### PR TITLE
feat(api): API Key Management CRUD routes + CLI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,9 +131,11 @@
         "chalk": "^5.4.0",
         "commander": "^13.1.0",
         "ora": "^8.1.1",
+        "qrcode-terminal": "^0.12.0",
       },
       "devDependencies": {
         "@types/node": "^22.10.3",
+        "@types/qrcode-terminal": "^0.12.2",
         "typescript": "^5.7.3",
       },
     },

--- a/packages/api/src/routes/v2/index.ts
+++ b/packages/api/src/routes/v2/index.ts
@@ -15,6 +15,7 @@ import { deadLettersRoutes } from './dead-letters';
 import { eventOpsRoutes } from './event-ops';
 import { eventsRoutes } from './events';
 import { instancesRoutes } from './instances';
+import { keysRoutes } from './keys';
 import { logsRoutes } from './logs';
 import { mediaRoutes } from './media';
 import { messagesRoutes } from './messages';
@@ -43,6 +44,7 @@ v2Routes.route('/metrics', metricsRoutes);
 v2Routes.route('/chats', chatsRoutes); // Unified chat model - must be before root mounts with /:id
 v2Routes.route('/media', mediaRoutes); // Media file serving - must be before root mounts with /:id
 v2Routes.route('/batch-jobs', batchJobsRoutes); // Batch job routes - must be before root mounts with /:id
+v2Routes.route('/keys', keysRoutes); // API key management
 v2Routes.route('/', payloadsRoutes); // Payloads routes at /api/v2/events/:id/payloads and /api/v2/payload-config
 v2Routes.route('/', webhooksRoutes); // Webhook routes at /api/v2/webhooks/:source, /api/v2/webhook-sources, /api/v2/events/trigger
 v2Routes.route('/automations', automationsRoutes); // Automation routes at /api/v2/automations

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -1,0 +1,184 @@
+/**
+ * API Key Management Routes
+ *
+ * CRUD operations for API keys with scope-based authorization.
+ * Keys are used to authenticate agents and services with specific permissions.
+ */
+
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { requireScope } from '../../middleware/auth';
+import type { AppVariables } from '../../types';
+
+export const keysRoutes = new Hono<{ Variables: AppVariables }>();
+
+// ============================================================================
+// SCHEMAS
+// ============================================================================
+
+const createKeySchema = z.object({
+  name: z.string().min(1).max(255).describe('Human-readable key name'),
+  description: z.string().optional().describe('Key description'),
+  scopes: z.array(z.string()).min(1).describe('Permission scopes (e.g. messages:read, instances:write)'),
+  instanceIds: z.array(z.string().uuid()).optional().describe('Restrict key to specific instance IDs'),
+  rateLimit: z.number().int().positive().optional().describe('Rate limit in requests per minute'),
+  expiresAt: z.string().datetime().optional().describe('Expiration timestamp (ISO 8601)'),
+});
+
+const updateKeySchema = z.object({
+  name: z.string().min(1).max(255).optional().describe('Human-readable key name'),
+  description: z.string().nullable().optional().describe('Key description'),
+  scopes: z.array(z.string()).min(1).optional().describe('Permission scopes'),
+  instanceIds: z.array(z.string().uuid()).nullable().optional().describe('Instance ID restrictions (null = all)'),
+  rateLimit: z.number().int().positive().nullable().optional().describe('Rate limit (null = default)'),
+  expiresAt: z.string().datetime().nullable().optional().describe('Expiration timestamp (null = never)'),
+});
+
+const revokeKeySchema = z.object({
+  reason: z.string().optional().describe('Reason for revocation'),
+  revokedBy: z.string().optional().describe('Who revoked the key'),
+});
+
+const listQuerySchema = z.object({
+  status: z.enum(['active', 'revoked', 'expired']).optional().describe('Filter by status'),
+  limit: z.coerce.number().int().min(1).max(100).default(50).describe('Max results'),
+});
+
+// ============================================================================
+// ROUTES
+// ============================================================================
+
+/**
+ * POST /keys - Create a new API key
+ * Returns the plaintext key ONLY in this response.
+ */
+keysRoutes.post('/', requireScope('keys:write'), zValidator('json', createKeySchema), async (c) => {
+  const data = c.req.valid('json');
+  const services = c.get('services');
+
+  const result = await services.apiKeys.create({
+    name: data.name,
+    description: data.description,
+    scopes: data.scopes,
+    instanceIds: data.instanceIds,
+    rateLimit: data.rateLimit,
+    expiresAt: data.expiresAt ? new Date(data.expiresAt) : undefined,
+    createdBy: c.get('apiKey')?.name,
+  });
+
+  return c.json(
+    {
+      data: {
+        ...result.key,
+        plainTextKey: result.plainTextKey,
+      },
+    },
+    201,
+  );
+});
+
+/**
+ * GET /keys - List all API keys
+ */
+keysRoutes.get('/', requireScope('keys:read'), zValidator('query', listQuerySchema), async (c) => {
+  const { status, limit } = c.req.valid('query');
+  const services = c.get('services');
+
+  let items = await services.apiKeys.list();
+
+  if (status) {
+    items = items.filter((k) => k.status === status);
+  }
+
+  items = items.slice(0, limit);
+
+  return c.json({
+    items,
+    meta: {
+      total: items.length,
+    },
+  });
+});
+
+/**
+ * GET /keys/:id - Get a single API key
+ */
+keysRoutes.get('/:id', requireScope('keys:read'), async (c) => {
+  const id = c.req.param('id');
+  const services = c.get('services');
+
+  const key = await services.apiKeys.getById(id);
+  if (!key) {
+    return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+  }
+
+  return c.json({ data: key });
+});
+
+/**
+ * PATCH /keys/:id - Update an API key
+ */
+keysRoutes.patch('/:id', requireScope('keys:write'), zValidator('json', updateKeySchema), async (c) => {
+  const id = c.req.param('id');
+  const data = c.req.valid('json');
+  const services = c.get('services');
+
+  try {
+    const updated = await services.apiKeys.update(id, {
+      ...data,
+      expiresAt: data.expiresAt === null ? null : data.expiresAt ? new Date(data.expiresAt) : undefined,
+    });
+
+    if (!updated) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+    }
+
+    return c.json({ data: updated });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    if (message.includes('Cannot rename primary')) {
+      return c.json({ error: { code: 'FORBIDDEN', message } }, 403);
+    }
+    throw error;
+  }
+});
+
+/**
+ * POST /keys/:id/revoke - Revoke an API key
+ */
+keysRoutes.post('/:id/revoke', requireScope('keys:write'), zValidator('json', revokeKeySchema), async (c) => {
+  const id = c.req.param('id');
+  const data = c.req.valid('json');
+  const services = c.get('services');
+
+  const revoked = await services.apiKeys.revoke(id, data.reason, data.revokedBy ?? c.get('apiKey')?.name);
+
+  if (!revoked) {
+    return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+  }
+
+  return c.json({ data: revoked });
+});
+
+/**
+ * DELETE /keys/:id - Permanently delete an API key
+ */
+keysRoutes.delete('/:id', requireScope('keys:write'), async (c) => {
+  const id = c.req.param('id');
+  const services = c.get('services');
+
+  try {
+    const deleted = await services.apiKeys.delete(id);
+    if (!deleted) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+    }
+    return c.json({ data: { deleted: true } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    if (message.includes('Cannot delete primary')) {
+      return c.json({ error: { code: 'FORBIDDEN', message } }, 403);
+    }
+    throw error;
+  }
+});

--- a/packages/cli/src/commands/keys.ts
+++ b/packages/cli/src/commands/keys.ts
@@ -1,0 +1,255 @@
+/**
+ * API Key Management Commands
+ *
+ * Create, list, update, revoke, and delete API keys.
+ */
+
+import type { ApiKeyRecord, ApiKeyStatus, OmniClient } from '@omni/sdk';
+import { Command } from 'commander';
+import { getClient } from '../client.js';
+import * as output from '../output.js';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface CreateOptions {
+  name: string;
+  scopes: string;
+  instances?: string;
+  description?: string;
+  rateLimit?: number;
+  expires?: string;
+}
+
+interface ListOptions {
+  status?: ApiKeyStatus;
+  limit?: number;
+}
+
+interface UpdateOptions {
+  name?: string;
+  description?: string;
+  scopes?: string;
+  instances?: string;
+  rateLimit?: number;
+  expires?: string;
+}
+
+interface RevokeOptions {
+  reason?: string;
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function formatKeyRow(key: ApiKeyRecord): Record<string, string> {
+  return {
+    id: key.id.slice(0, 8),
+    name: key.name,
+    status: key.status,
+    scopes: key.scopes.join(', '),
+    instances: key.instanceIds ? `${key.instanceIds.length} restricted` : 'all',
+    created: new Date(key.createdAt).toLocaleDateString(),
+    lastUsed: key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleDateString() : 'never',
+  };
+}
+
+function parseCommaSeparated(value: string): string[] {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+// ============================================================================
+// HANDLERS
+// ============================================================================
+
+async function handleCreate(client: OmniClient, options: CreateOptions): Promise<void> {
+  const scopes = parseCommaSeparated(options.scopes);
+  const instanceIds = options.instances ? parseCommaSeparated(options.instances) : undefined;
+
+  const result = await client.keys.create({
+    name: options.name,
+    description: options.description,
+    scopes,
+    instanceIds,
+    rateLimit: options.rateLimit,
+    expiresAt: options.expires,
+  });
+
+  output.success(`API key created: ${result.name}`);
+
+  // biome-ignore lint/suspicious/noConsole: CLI output — plaintext key display
+  console.log(`\n  API Key (save this — it will NOT be shown again):\n\n  ${result.plainTextKey}\n`);
+
+  output.info(`ID: ${result.id}`);
+  output.info(`Scopes: ${result.scopes.join(', ')}`);
+  if (result.instanceIds) {
+    output.info(`Instances: ${result.instanceIds.join(', ')}`);
+  }
+  if (result.expiresAt) {
+    output.info(`Expires: ${result.expiresAt}`);
+  }
+}
+
+async function handleList(client: OmniClient, options: ListOptions): Promise<void> {
+  const result = await client.keys.list({
+    status: options.status,
+    limit: options.limit,
+  });
+
+  if (result.items.length === 0) {
+    output.info('No API keys found.');
+    return;
+  }
+
+  const rows = result.items.map(formatKeyRow);
+  output.list(rows);
+}
+
+async function handleGet(client: OmniClient, id: string): Promise<void> {
+  const key = await client.keys.get(id);
+  output.data(key);
+}
+
+async function handleUpdate(client: OmniClient, id: string, options: UpdateOptions): Promise<void> {
+  const body: Record<string, unknown> = {};
+  if (options.name !== undefined) body.name = options.name;
+  if (options.description !== undefined) body.description = options.description;
+  if (options.scopes !== undefined) body.scopes = parseCommaSeparated(options.scopes);
+  if (options.instances !== undefined) {
+    body.instanceIds = options.instances === '' ? null : parseCommaSeparated(options.instances);
+  }
+  if (options.rateLimit !== undefined) body.rateLimit = options.rateLimit;
+  if (options.expires !== undefined) body.expiresAt = options.expires === '' ? null : options.expires;
+
+  if (Object.keys(body).length === 0) {
+    output.warn('No fields to update. Use --name, --scopes, --instances, etc.');
+    return;
+  }
+
+  const updated = await client.keys.update(id, body);
+  output.success(`API key updated: ${updated.name}`);
+  output.data(updated);
+}
+
+async function handleRevoke(client: OmniClient, id: string, options: RevokeOptions): Promise<void> {
+  const revoked = await client.keys.revoke(id, {
+    reason: options.reason,
+  });
+  output.success(`API key revoked: ${revoked.name}`);
+  if (options.reason) {
+    output.info(`Reason: ${options.reason}`);
+  }
+}
+
+async function handleDelete(client: OmniClient, id: string): Promise<void> {
+  await client.keys.delete(id);
+  output.success(`API key deleted: ${id}`);
+}
+
+// ============================================================================
+// COMMAND
+// ============================================================================
+
+export function createKeysCommand(): Command {
+  const keys = new Command('keys').description('Manage API keys');
+
+  keys
+    .command('create')
+    .description('Create a new API key')
+    .requiredOption('--name <name>', 'Key name')
+    .requiredOption('--scopes <scopes>', 'Comma-separated scopes (e.g. messages:read,instances:write)')
+    .option('--instances <ids>', 'Comma-separated instance IDs to restrict access')
+    .option('--description <desc>', 'Key description')
+    .option('--rate-limit <n>', 'Rate limit (requests/minute)', Number.parseInt)
+    .option('--expires <date>', 'Expiration date (ISO 8601)')
+    .action(async (options: CreateOptions) => {
+      const client = getClient();
+      try {
+        await handleCreate(client, options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to create key: ${message}`);
+      }
+    });
+
+  keys
+    .command('list')
+    .description('List API keys')
+    .option('--status <status>', 'Filter by status (active, revoked, expired)')
+    .option('--limit <n>', 'Max results', Number.parseInt)
+    .action(async (options: ListOptions) => {
+      const client = getClient();
+      try {
+        await handleList(client, options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to list keys: ${message}`);
+      }
+    });
+
+  keys
+    .command('get <id>')
+    .description('Get API key details')
+    .action(async (id: string) => {
+      const client = getClient();
+      try {
+        await handleGet(client, id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to get key: ${message}`);
+      }
+    });
+
+  keys
+    .command('update <id>')
+    .description('Update an API key')
+    .option('--name <name>', 'New key name')
+    .option('--description <desc>', 'New description')
+    .option('--scopes <scopes>', 'New scopes (comma-separated)')
+    .option('--instances <ids>', 'New instance IDs (comma-separated, empty string to unrestrict)')
+    .option('--rate-limit <n>', 'New rate limit', Number.parseInt)
+    .option('--expires <date>', 'New expiration (ISO 8601, empty string to clear)')
+    .action(async (id: string, options: UpdateOptions) => {
+      const client = getClient();
+      try {
+        await handleUpdate(client, id, options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to update key: ${message}`);
+      }
+    });
+
+  keys
+    .command('revoke <id>')
+    .description('Revoke an API key')
+    .option('--reason <reason>', 'Reason for revocation')
+    .action(async (id: string, options: RevokeOptions) => {
+      const client = getClient();
+      try {
+        await handleRevoke(client, id, options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to revoke key: ${message}`);
+      }
+    });
+
+  keys
+    .command('delete <id>')
+    .description('Permanently delete an API key')
+    .action(async (id: string) => {
+      const client = getClient();
+      try {
+        await handleDelete(client, id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to delete key: ${message}`);
+      }
+    });
+
+  return keys;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { createConfigCommand } from './commands/config.js';
 import { createDeadLettersCommand } from './commands/dead-letters.js';
 import { createEventsCommand } from './commands/events.js';
 import { createInstancesCommand } from './commands/instances.js';
+import { createKeysCommand } from './commands/keys.js';
 import { createLogsCommand } from './commands/logs.js';
 import { createMessagesCommand } from './commands/messages.js';
 import { createPayloadsCommand } from './commands/payloads.js';
@@ -97,6 +98,12 @@ const COMMANDS: CommandDef[] = [
     category: 'core',
     helpGroup: 'Management',
     helpDescription: 'AI/LLM providers configuration',
+  },
+  {
+    create: createKeysCommand,
+    category: 'core',
+    helpGroup: 'Management',
+    helpDescription: 'API key management',
   },
   {
     create: createAccessCommand,


### PR DESCRIPTION
## Summary

Adds full API key management so each OpenClaw agent can have its own scoped API key with restricted `instanceIds` and `scopes`.

### Changes (643 lines, 7 files)

**API Routes** (`packages/api/src/routes/v2/keys.ts`):
- `POST /api/v2/keys` — Create API key with scopes + instanceIds
- `GET /api/v2/keys` — List all keys (masked)
- `GET /api/v2/keys/:id` — Get key details
- `PATCH /api/v2/keys/:id` — Update key (scopes, instanceIds, name)
- `POST /api/v2/keys/:id/revoke` — Revoke a key
- `DELETE /api/v2/keys/:id` — Delete a key

**Service Layer** (`packages/api/src/services/api-keys.ts`):
- Extended with `update()` and `listAll()` methods

**SDK** (`packages/sdk/src/client.ts`):
- Added `client.keys` namespace with all CRUD operations

**CLI** (`packages/cli/src/commands/keys.ts`):
- `omni keys create --name <name> --scopes <scopes> [--instances <ids>]`
- `omni keys list`
- `omni keys get <id>`
- `omni keys revoke <id>`
- `omni keys delete <id>`

### Use Case

Each OpenClaw agent (Cegonha, Stefani, etc.) gets a scoped API key:
```bash
omni keys create --name cegonha --scopes 'messages:send,messages:read,instances:read' --instances 07a5178e-fb07-4d93-885b-1d361fbd5d6b
```

### Notes
- Pre-existing CLI typecheck errors (unrelated to this PR) — `@omni/sdk` module resolution + implicit `any` types
- Based on existing wishes: `.wishes/api-key-security/` and `.wishes/api-key-audit/`
