### PR TITLE
fix: SDK endpoints + media base64 handling

### DIFF
--- a/packages/channel-whatsapp/src/senders/builders.ts
+++ b/packages/channel-whatsapp/src/senders/builders.ts
@@ -93,12 +93,19 @@ const buildText: ContentBuilder = (message) => {
 
 /**
  * Build image message content
+ *
+ * Supports URL and base64. Priority: base64 > URL
  */
-const buildImage: ContentBuilder = (message) => ({
-  image: { url: message.content.mediaUrl || '' },
-  caption: message.content.caption,
-  mimetype: message.content.mimeType,
-});
+const buildImage: ContentBuilder = (message) => {
+  const base64 = message.metadata?.base64 as string | undefined;
+  const source = base64 ? Buffer.from(base64, 'base64') : { url: message.content.mediaUrl || '' };
+
+  return {
+    image: source,
+    caption: message.content.caption,
+    mimetype: message.content.mimeType,
+  };
+};
 
 /**
  * Build audio message content
@@ -130,28 +137,49 @@ const buildAudio: ContentBuilder = (message) => {
 
 /**
  * Build video message content
+ *
+ * Supports URL and base64. Priority: base64 > URL
  */
-const buildVideo: ContentBuilder = (message) => ({
-  video: { url: message.content.mediaUrl || '' },
-  caption: message.content.caption,
-  mimetype: message.content.mimeType,
-});
+const buildVideo: ContentBuilder = (message) => {
+  const base64 = message.metadata?.base64 as string | undefined;
+  const source = base64 ? Buffer.from(base64, 'base64') : { url: message.content.mediaUrl || '' };
+
+  return {
+    video: source,
+    caption: message.content.caption,
+    mimetype: message.content.mimeType,
+  };
+};
 
 /**
  * Build document message content
+ *
+ * Supports URL and base64. Priority: base64 > URL
  */
-const buildDocument: ContentBuilder = (message) => ({
-  document: { url: message.content.mediaUrl || '' },
-  mimetype: message.content.mimeType || 'application/octet-stream',
-  fileName: message.content.filename || 'document',
-});
+const buildDocument: ContentBuilder = (message) => {
+  const base64 = message.metadata?.base64 as string | undefined;
+  const source = base64 ? Buffer.from(base64, 'base64') : { url: message.content.mediaUrl || '' };
+
+  return {
+    document: source,
+    mimetype: message.content.mimeType || 'application/octet-stream',
+    fileName: message.content.filename || 'document',
+  };
+};
 
 /**
  * Build sticker message content
+ *
+ * Supports URL and base64. Priority: base64 > URL
  */
-const buildSticker: ContentBuilder = (message) => ({
-  sticker: { url: message.content.mediaUrl || '' },
-});
+const buildSticker: ContentBuilder = (message) => {
+  const base64 = message.metadata?.base64 as string | undefined;
+  const source = base64 ? Buffer.from(base64, 'base64') : { url: message.content.mediaUrl || '' };
+
+  return {
+    sticker: source,
+  };
+};
 
 /**
  * Build location message content

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1444,61 +1444,91 @@ export function createOmniClient(config: OmniClientConfig) {
        * Send a text message
        */
       async send(body: SendMessageBody): Promise<{ messageId: string; status: string }> {
-        const { data, error, response } = await client.POST('/messages', { body });
-        throwIfError(response, error);
-        return data?.data ?? { messageId: '', status: 'sent' };
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+        const json = (await resp.json()) as { data?: { messageId: string; status: string } };
+        return json?.data ?? { messageId: '', status: 'sent' };
       },
 
       /**
        * Send a media message
        */
       async sendMedia(body: SendMediaBody): Promise<{ messageId: string; status: string }> {
-        const { data, error, response } = await client.POST('/messages/media', { body });
-        throwIfError(response, error);
-        return data?.data ?? { messageId: '', status: 'sent' };
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/media`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+        const json = (await resp.json()) as { data?: { messageId: string; status: string } };
+        return json?.data ?? { messageId: '', status: 'sent' };
       },
 
       /**
        * Send a reaction
        */
       async sendReaction(body: SendReactionBody): Promise<{ messageId?: string; success: boolean }> {
-        const { data, error, response } = await client.POST('/messages/reaction', { body });
-        throwIfError(response, error);
-        return data ?? { success: true };
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/reaction`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+        const json = (await resp.json()) as { success?: boolean; data?: { messageId?: string } };
+        return { success: json?.success ?? true, messageId: json?.data?.messageId };
       },
 
       /**
        * Send a sticker
        */
       async sendSticker(body: SendStickerBody): Promise<{ messageId: string; status: string }> {
-        const { data, error, response } = await client.POST('/messages/sticker', { body });
-        throwIfError(response, error);
-        return data?.data ?? { messageId: '', status: 'sent' };
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/sticker`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+        const json = (await resp.json()) as { data?: { messageId: string; status: string } };
+        return json?.data ?? { messageId: '', status: 'sent' };
       },
 
       /**
        * Send a contact card
        */
       async sendContact(body: SendContactBody): Promise<{ messageId: string; status: string }> {
-        const { data, error, response } = await client.POST('/messages/contact', { body });
-        throwIfError(response, error);
-        return data?.data ?? { messageId: '', status: 'sent' };
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/contact`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+        const json = (await resp.json()) as { data?: { messageId: string; status: string } };
+        return json?.data ?? { messageId: '', status: 'sent' };
       },
 
       /**
        * Send a location
        */
       async sendLocation(body: SendLocationBody): Promise<{ messageId: string; status: string }> {
-        const { data, error, response } = await client.POST('/messages/location', { body });
-        throwIfError(response, error);
-        return data?.data ?? { messageId: '', status: 'sent' };
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/location`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+        const json = (await resp.json()) as { data?: { messageId: string; status: string } };
+        return json?.data ?? { messageId: '', status: 'sent' };
       },
 
       /**
        * Send a poll (Discord only)
        */
       async sendPoll(body: SendPollBody): Promise<{ messageId: string; status: string }> {
-        const resp = await apiFetch(`${baseUrl}/api/v2/messages/poll`, {
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/poll`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -1512,7 +1542,7 @@ export function createOmniClient(config: OmniClientConfig) {
        * Send an embed (Discord only)
        */
       async sendEmbed(body: SendEmbedBody): Promise<{ messageId: string; status: string }> {
-        const resp = await apiFetch(`${baseUrl}/api/v2/messages/embed`, {
+        const resp = await apiFetch(`${baseUrl}/api/v2/messages/send/embed`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- **SDK client endpoints fixed**: All message send methods (`send`, `sendMedia`, `sendReaction`, `sendSticker`, `sendContact`, `sendLocation`, `sendPoll`, `sendEmbed`) were POSTing to stale endpoints (e.g., `/messages` instead of `/messages/send`), causing 404s for all CLI send operations. Switched from typed `client.POST()` (which relied on stale generated types) to `apiFetch()` with correct paths.
- **WhatsApp media base64 support**: `buildImage`, `buildVideo`, `buildDocument`, and `buildSticker` now handle base64 data from `metadata.base64`, following the same `base64 > URL` fallback pattern that `buildAudio` already used. Previously, passing base64 without a URL sent an empty string to Baileys, which tried to read it as a file path → EISDIR error.

## Test plan
- [x] `make typecheck` — all 10 packages pass
- [x] `make lint` — 453 files checked, no issues
- [ ] Manual: `omni send text` via CLI should succeed (was 404)
- [ ] Manual: `omni send media --base64 <data>` for image/video/doc should work without EISDIR
- [ ] Verify `sendPresence`, `markRead`, `batchMarkRead` still work (unchanged, already correct)

Fixes: omni-5nt, omni-u9f, omni-hu7

🤖 Generated with [Claude Code](https://claude.com/claude-code)