### PR TITLE
feat(whatsapp): groupCreate + fix mentions

### DIFF
--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -2200,6 +2200,42 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   }
 
   /**
+   * Create a new WhatsApp group
+   *
+   * @param instanceId - Instance ID
+   * @param subject - Group name/subject (max 100 chars)
+   * @param participants - Array of phone numbers or JIDs to add
+   * @returns Group metadata including JID, subject, participants
+   */
+  async groupCreate(
+    instanceId: string,
+    subject: string,
+    participants: string[],
+  ): Promise<{
+    id: string;
+    subject: string;
+    owner: string | undefined;
+    creation: number | undefined;
+    participants: Array<{ id: string; admin: string | null }>;
+  }> {
+    const sock = this.getSocket(instanceId);
+    const participantJids = participants.map((p) => toJid(p));
+    this.logger.info('Creating group', { instanceId, subject, participantCount: participantJids.length });
+    const metadata = await sock.groupCreate(subject, participantJids);
+    this.logger.info('Group created', { instanceId, groupId: metadata.id, subject: metadata.subject });
+    return {
+      id: metadata.id,
+      subject: metadata.subject,
+      owner: metadata.owner,
+      creation: metadata.creation,
+      participants: metadata.participants.map((p) => ({
+        id: p.id,
+        admin: p.admin ?? null,
+      })),
+    };
+  }
+
+  /**
    * C4: Fetch the blocklist for the connected account
    *
   /**

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -845,6 +845,37 @@ export function createInstancesCommand(): Command {
     });
 
   // ============================================================================
+  // Group Create
+  // ============================================================================
+
+  // omni instances group-create <id> --subject "Name" --participants "+55..." "+55..."
+  instances
+    .command('group-create <id>')
+    .description('Create a new WhatsApp group')
+    .requiredOption('--subject <name>', 'Group name/subject')
+    .requiredOption('--participants <phones...>', 'Phone numbers or JIDs to add (space-separated)')
+    .action(async (id: string, opts: { subject: string; participants: string[] }) => {
+      try {
+        const result = (await apiCall(`instances/${id}/groups`, 'POST', {
+          subject: opts.subject,
+          participants: opts.participants,
+        })) as {
+          data: {
+            id: string;
+            subject: string;
+            owner: string | undefined;
+            creation: number | undefined;
+            participants: Array<{ id: string; admin: string | null }>;
+          };
+        };
+        output.success(`Group created: ${result.data.id}`, result.data);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        output.error(`Failed to create group: ${msg}`);
+      }
+    });
+
+  // ============================================================================
   // C3: Group Invite Links
   // ============================================================================
 


### PR DESCRIPTION
## Summary

### Group Create (Helena's request)
- **Plugin:** `groupCreate(instanceId, subject, participants)` → calls `sock.groupCreate()`, returns GroupMetadata
- **API:** `POST /instances/:id/groups` with `{ subject, participants }` → 201 with group data
- **CLI:** `omni instances group-create <id> --subject 'Name' --participants '+55...' '+55...'`
- Phone numbers auto-converted to JIDs
- Instance access check enforced via `instanceAccess` middleware

### Fix Mentions (Felipe's homework)
- **Stop prepending** `@phone` to message text — caller controls mention placement
- **Shared helper** `extractMentionJids()` extracted from buildText
- **Image/video captions** now support mentions (was text-only)

### Quality
- Typecheck: ✅ (10/10 packages)
- Lint: ✅ (454 files, 0 issues)  
- Tests: 751 pass, 40 fail (all pre-existing, 0 regressions)

Closes wish: `.wishes/group-create/group-create-wish.md`