### PR TITLE
fix(cli): add sender fields to chat messages JSON + fix send error handling

### DIFF
--- a/packages/cli/src/commands/chats.ts
+++ b/packages/cli/src/commands/chats.ts
@@ -32,6 +32,7 @@ interface ExtendedChat extends Chat {
 
 interface ExtendedMessage extends Message {
   senderDisplayName?: string | null;
+  senderPlatformUserId?: string | null;
   hasMedia?: boolean;
   mediaMimeType?: string | null;
   mediaMetadata?: { filename?: string; size?: number; duration?: number } | null;
@@ -203,11 +204,19 @@ function formatRichMessages(
 /**
  * Format messages for standard display
  */
-function formatStandardMessages(
-  messages: ExtendedMessage[],
-): { id: string; type: string; content: string; fromMe: string; timestamp: string | null }[] {
+function formatStandardMessages(messages: ExtendedMessage[]): {
+  id: string;
+  from: string;
+  senderId: string;
+  type: string;
+  content: string;
+  fromMe: string;
+  timestamp: string | null;
+}[] {
   return messages.map((m) => ({
     id: m.id,
+    from: formatSender(m),
+    senderId: m.senderPlatformUserId ?? '-',
     type: m.messageType,
     content: _truncateMax > 0 ? truncate(m.textContent, _truncateMax) : (m.textContent ?? '-'),
     fromMe: m.isFromMe ? 'yes' : 'no',


### PR DESCRIPTION
## Bug Fixes

### Bug 1: Missing sender field in JSON output
`omni chats messages` with JSON format now includes:
- `from` — sender display name  
- `senderId` — platform user ID

Previously group messages only showed `fromMe: yes/no` without identifying the actual sender. Agents consuming WhatsApp group history can now attribute messages to specific participants.

### Bug 2: `omni send` failing silently  
**Root cause:** `OmniApiError.from()` in the SDK didn't handle:
- `{ error: "string message" }` format (returned undefined message)
- `{ message: "..." }` without error wrapper

**Fix:** 
- Extracted `parseErrorObject()` helper for robust error parsing
- `send.ts` now surfaces `OmniApiError` details (code, status, details) in error output

### Files Changed
- `packages/cli/src/commands/chats.ts` — added from/senderId to standard format
- `packages/cli/src/commands/send.ts` — OmniApiError-aware catch block  
- `packages/sdk/src/errors.ts` — robust error parsing

### Quality
- ✅ SDK typecheck clean
- ✅ CLI typecheck clean  
- ✅ Lint clean (1 pre-existing warning in send.ts complexity)
- ⚠️ UI typecheck has pre-existing Dashboard.tsx errors (unrelated)