### PR TITLE
fix(build): typecheck depends on ^build — fixes UI typecheck errors

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["dist/**"]
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"],
+      "dependsOn": ["^build", "^typecheck"],
       "outputs": []
     },
     "lint": {


### PR DESCRIPTION
## Problem

`make typecheck` fails with 4 errors in `apps/ui/src/pages/Dashboard.tsx`:
- `EventAnalytics` and `EventMetrics` types not found in `@omni/sdk`
- `events.analytics()` method not found
- `bucket` parameter has implicit `any`

This blocks ALL git pushes (husky pre-push runs `make typecheck`).

## Root Cause

`turbo.json` had `typecheck` depending only on `^typecheck`, not `^build`. The UI resolves `@omni/sdk` via `dist/` (package.json exports), but the SDK's `dist/` was never built before typechecking — stale types were missing the newer exports.

## Fix

One line in `turbo.json`:
```diff
-"dependsOn": ["^typecheck"]
+"dependsOn": ["^build", "^typecheck"]
```

This ensures SDK `dist/` is rebuilt before UI typechecks.

## Verification

- ✅ `make typecheck` — 14/14 tasks pass (11 typecheck + 3 builds)
- ✅ `make lint` — 0 errors
- ✅ `git push` works without `--no-verify`
- ✅ FULL TURBO cache on subsequent runs (162ms)