### PR TITLE
fix(openapi): correct /messages/media path to /messages/send/media

### DIFF
--- a/packages/api/src/schemas/openapi/messages.ts
+++ b/packages/api/src/schemas/openapi/messages.ts
@@ -200,7 +200,7 @@ export function registerMessageSchemas(registry: OpenAPIRegistry): void {
 
   registry.registerPath({
     method: 'post',
-    path: '/messages/media',
+    path: '/messages/send/media',
     operationId: 'sendMediaMessage',
     tags: ['Messages'],
     summary: 'Send media message',

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -376,7 +376,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/messages/media": {
+    "/messages/send/media": {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## 🐛 Bug Fix: OpenAPI path mismatch for /messages/media

### Problem
`omni send --media` returned 404. The OpenAPI spec declared the send-media endpoint as `/messages/media` but the actual Hono route is `/messages/send/media`. The auto-generated SDK (and CLI) called the wrong path.

### Fix
- **File:** `packages/api/src/schemas/openapi/messages.ts` line 203
- **Change:** `path: '/messages/media'` → `path: '/messages/send/media'`
- SDK regenerated with correct path

### Quality
- ✅ Typecheck: 14/14 passed
- ✅ Lint: passed
- 2 files changed, 2 insertions, 2 deletions