### PR TITLE
feat(ci): enable Turborepo remote caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Turbo remote cache
+        uses: rharkor/caching-for-turbo@v2.2.1
+
       - name: Cache bun packages
         uses: actions/cache@v4
         with:
@@ -109,6 +112,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Turbo remote cache
+        uses: rharkor/caching-for-turbo@v2.2.1
 
       - name: Cache bun packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- Adds `rharkor/caching-for-turbo` to both quality-gate and smoke-test jobs
- Bridges Turbo's remote cache protocol to GitHub Actions' built-in cache — no Vercel account needed
- When the same code is already built/typechecked in a PR run, the merge-to-main run gets near-instant cache hits for `build` and `typecheck` turbo tasks

## How it works

The action starts a local cache server that Turbo connects to automatically via `TURBO_API`/`TURBO_TOKEN`/`TURBO_TEAM` env vars. Build artifacts are stored in GitHub's Actions cache and shared across workflow runs.

## Test plan

- [ ] PR CI run populates the turbo remote cache
- [ ] Subsequent run on same code shows `FULL TURBO` or `cache hit` for build/typecheck steps
- [ ] No regressions in quality-gate or smoke-test jobs