### PR TITLE
ci(version): base bumps on dev

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,7 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'dev' }}
+          # This workflow always writes to `dev`. To avoid non-fast-forward races when triggered by workflow_run
+          # (which checks out by SHA / detached HEAD), always base version bumps on the latest `dev`.
+          ref: dev
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fix Version workflow race: always checkout dev (workflow writes to dev), avoiding non-fast-forward atomic push failures when triggered by workflow_run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved version management reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->