### PR TITLE
ci(version): tag v<version> (no -dev suffix)

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -79,7 +79,7 @@ jobs:
             git commit -m "[skip ci] version: ${VERSION}"
           fi
 
-          git tag "v${VERSION}-dev"
+          git tag "v${VERSION}"
           # When triggered via workflow_run we checkout by SHA (detached HEAD). Push the current commit to `dev`
           # explicitly so the version bump commit and its tag are both reachable from the branch.
-          git push --atomic origin HEAD:refs/heads/dev "refs/tags/v${VERSION}-dev"
+          git push --atomic origin HEAD:refs/heads/dev "refs/tags/v${VERSION}"


### PR DESCRIPTION
Version workflow now tags v<version> (semver v2.YYYYMMDD.N) instead of v<version>-dev. This supports a single continuous version stream.