### PR TITLE
feat: add ingestMode metadata + expose whatsapp connect options

### DIFF
--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -528,6 +528,12 @@ instancesRoutes.post('/:id/pair', instanceAccess, zValidator('json', pairingCode
 const connectInstanceSchema = z.object({
   token: z.string().optional().describe('Bot token for Discord instances'),
   forceNewQr: z.boolean().optional().describe('Force new QR code for WhatsApp (re-authentication)'),
+  whatsapp: z
+    .object({
+      syncFullHistory: z.boolean().optional().describe('Sync full message history on connect (default: true)'),
+    })
+    .optional()
+    .describe('WhatsApp-specific connection options'),
 });
 
 /**
@@ -561,6 +567,9 @@ instancesRoutes.post(
     }
     if (instance.channel === 'telegram') {
       connectionOptions.telegramReactionLevel = instance.telegramReactionLevel;
+    }
+    if (body.whatsapp) {
+      connectionOptions.whatsapp = body.whatsapp;
     }
 
     // Trigger connection via channel plugin

--- a/packages/channel-sdk/src/base/BaseChannelPlugin.ts
+++ b/packages/channel-sdk/src/base/BaseChannelPlugin.ts
@@ -344,6 +344,7 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
         instanceId: params.instanceId,
         channelType: this.id,
         source: `channel:${this.id}`,
+        ingestMode: params.isHistorySync ? 'history-sync' : 'realtime',
         timings: params.timings,
       },
     );

--- a/packages/channel-sdk/src/helpers/events.ts
+++ b/packages/channel-sdk/src/helpers/events.ts
@@ -45,6 +45,13 @@ export interface EmitMessageReceivedParams {
 
   /** Journey timing checkpoints (T0, T1, etc.) to include in event metadata */
   timings?: Record<string, number>;
+
+  /**
+   * Whether this message originates from a history sync (Baileys messaging-history.set).
+   * When true, the event ingestMode is set to 'history-sync' so downstream consumers
+   * (e.g. external bots) can skip replaying old messages on restart.
+   */
+  isHistorySync?: boolean;
 }
 
 /**

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -2976,6 +2976,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
           mimeType: content.mimeType,
         },
         rawPayload,
+        isHistorySync: true,
       });
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,10 +8,7 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "bin"
-  ],
+  "files": ["dist", "bin"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/events/nats/client.ts
+++ b/packages/core/src/events/nats/client.ts
@@ -205,6 +205,8 @@ export class NatsEventBus implements EventBus {
         platformIdentityId: metadata?.platformIdentityId,
         traceId: metadata?.traceId ?? eventId,
         source: metadata?.source ?? this.config.serviceName,
+        ingestMode: metadata?.ingestMode,
+        timings: metadata?.timings,
       },
     };
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -131,6 +131,13 @@ export interface EventMetadata {
   platformIdentityId?: string;
   traceId?: string;
   source?: string;
+  /**
+   * How the message entered the system.
+   * - 'realtime': a live message received from the platform
+   * - 'history-sync': a historical message replayed on reconnect (e.g. Baileys messaging-history.set)
+   * Consumers (e.g. bots) should skip 'history-sync' messages to avoid replaying old messages.
+   */
+  ingestMode?: 'realtime' | 'history-sync';
   /** NATS stream sequence number (set by subscription handler, not by publisher) */
   streamSequence?: number;
   /** Journey timing checkpoints: checkpoint name → Unix ms timestamp */

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -757,6 +757,11 @@ export interface SendEmbedBody {
 export interface ConnectInstanceBody {
   token?: string;
   forceNewQr?: boolean;
+  /** WhatsApp-specific connection options */
+  whatsapp?: {
+    /** Sync full message history on connect (default: true) */
+    syncFullHistory?: boolean;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `ingestMode` field to `EventMetadata` (`'realtime' | 'history-sync'`) to distinguish live messages from Baileys history-sync replays
- Propagate `ingestMode` and `timings` through `publishInternal` (they were silently dropped because metadata is constructed field-by-field)
- Expose `whatsapp.syncFullHistory` option in the connect API schema so consumers can control history sync per-instance

## Test plan

- [ ] Connect WhatsApp instance with `{ whatsapp: { syncFullHistory: false } }` — no history flood
- [ ] Verify `ingestMode: "realtime"` appears on new incoming messages
- [ ] Verify `ingestMode: "history-sync"` appears on history-sync messages (when syncFullHistory is true)
- [ ] Verify `source` field still contains channel identifier (e.g. `channel:whatsapp-baileys`)