### PR TITLE
fix(api): add per_thread to instance schema validation

### DIFF
--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -61,7 +61,7 @@ const createInstanceSchema = z.object({
   agentStreamMode: z.boolean().default(false).describe('Enable streaming responses'),
   agentReplyFilter: agentReplyFilterSchema.optional().nullable().describe('When agent should reply'),
   agentSessionStrategy: z
-    .enum(['per_user', 'per_chat'])
+    .enum(['per_user', 'per_chat', 'per_thread'])
     .default('per_chat')
     .describe('Session strategy for agent memory'),
   agentPrefixSenderName: z.boolean().default(true).describe('Prefix messages with sender name'),


### PR DESCRIPTION
## Summary
- Add `per_thread` to the `agentSessionStrategy` Zod enum in the instance create/update schema
- Without this fix, the API rejects `per_thread` with a 400 even though the DB schema and agent-dispatcher already support it

## Test plan
- [x] `curl -X PATCH ... -d '{"agentSessionStrategy":"per_thread"}'` returns 200
- [x] Biome lint passes
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)