### PR TITLE
fix(api): walk full directory tree when finding monorepo root

### DIFF
--- a/packages/api/src/plugins/loader.ts
+++ b/packages/api/src/plugins/loader.ts
@@ -27,9 +27,8 @@ const logger = createLogger({ module: 'plugin-loader' });
  */
 function findMonorepoRoot(startDir: string): string | null {
   let current = startDir;
-  const root = dirname(current);
 
-  while (current !== root) {
+  while (current !== dirname(current)) {
     if (existsSync(join(current, 'turbo.json'))) {
       return current;
     }


### PR DESCRIPTION
## Summary
- `findMonorepoRoot` only checked one parent directory above `startDir`, so channel plugins failed to load when turbo ran the API from `packages/api/` (2 levels below `turbo.json`)
- Fix: use standard `current !== dirname(current)` loop to walk all the way to filesystem root

## Test plan
- [x] `make dev` — no more `ERROR api:plugins Failed to load channel plugins` 
- [x] `omni instances connect` works (WhatsApp connected successfully)