### PR TITLE
fix(whatsapp): group read receipts require participant in message key

### DIFF
--- a/packages/api/src/__tests__/messages-read.test.ts
+++ b/packages/api/src/__tests__/messages-read.test.ts
@@ -21,7 +21,12 @@ import { describeWithDb, getTestDb } from './db-helper';
 function createMockPlugin(
   overrides: Partial<{
     canReceiveReadReceipts: boolean;
-    markAsRead: (instanceId: string, chatId: string, messageIds: string[]) => Promise<void>;
+    markAsRead: (
+      instanceId: string,
+      chatId: string,
+      messageIds: string[],
+      messageData?: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }>,
+    ) => Promise<void>;
     markChatAsRead: (instanceId: string, chatId: string) => Promise<void>;
   }> = {},
 ) {
@@ -64,7 +69,9 @@ describeWithDb('Read Receipt Endpoints', () => {
   let db: Database;
   let testInstance: Instance;
   let testChat: { id: string; externalId: string };
+  let testDmChat: { id: string; externalId: string };
   let testMessage: { id: string; externalId: string };
+  let testDmMessage: { id: string; externalId: string };
   const insertedInstanceIds: string[] = [];
   const insertedChatIds: string[] = [];
   const insertedMessageIds: string[] = [];
@@ -103,7 +110,7 @@ describeWithDb('Read Receipt Endpoints', () => {
     testChat = { id: chat.id, externalId: chat.externalId };
     insertedChatIds.push(chat.id);
 
-    // Create a test message
+    // Create a test message (with rawPayload containing participant for group read receipts)
     const [message] = await db
       .insert(messages)
       .values({
@@ -114,6 +121,7 @@ describeWithDb('Read Receipt Endpoints', () => {
         textContent: 'Test message',
         platformTimestamp: new Date(),
         isFromMe: false,
+        rawPayload: { key: { participant: '5511999999999@s.whatsapp.net' } },
       })
       .returning();
     if (!message) {
@@ -121,6 +129,39 @@ describeWithDb('Read Receipt Endpoints', () => {
     }
     testMessage = { id: message.id, externalId: message.externalId };
     insertedMessageIds.push(message.id);
+
+    // Create a DM chat (non-group — no participant needed)
+    const [dmChat] = await db
+      .insert(chats)
+      .values({
+        instanceId: testInstance.id,
+        externalId: '5511888888888@s.whatsapp.net',
+        chatType: 'dm',
+        channel: 'whatsapp-baileys',
+        name: 'DM Chat',
+      })
+      .returning();
+    if (!dmChat) throw new Error('Failed to create DM chat');
+    testDmChat = { id: dmChat.id, externalId: dmChat.externalId };
+    insertedChatIds.push(dmChat.id);
+
+    // Create a DM message (no participant in rawPayload)
+    const [dmMsg] = await db
+      .insert(messages)
+      .values({
+        chatId: testDmChat.id,
+        externalId: `BAE5DM${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'DM test message',
+        platformTimestamp: new Date(),
+        isFromMe: false,
+        rawPayload: { key: { remoteJid: '5511888888888@s.whatsapp.net', fromMe: false } },
+      })
+      .returning();
+    if (!dmMsg) throw new Error('Failed to create DM message');
+    testDmMessage = { id: dmMsg.id, externalId: dmMsg.externalId };
+    insertedMessageIds.push(dmMsg.id);
   });
 
   afterAll(async () => {
@@ -189,7 +230,13 @@ describeWithDb('Read Receipt Endpoints', () => {
       expect(body.data.messageId).toBe(testMessage.id);
       expect(body.data.externalMessageId).toBe(testMessage.externalId);
       expect(markAsReadMock).toHaveBeenCalledTimes(1);
-      expect(markAsReadMock).toHaveBeenCalledWith(testInstance.id, testChat.externalId, [testMessage.externalId]);
+      // Plugin receives messageData with rawPayload so it can extract channel-specific keys
+      expect(markAsReadMock).toHaveBeenCalledWith(
+        testInstance.id,
+        testChat.externalId,
+        [testMessage.externalId],
+        [{ externalId: testMessage.externalId, rawPayload: { key: { participant: '5511999999999@s.whatsapp.net' } } }],
+      );
     });
 
     test('returns error when channel does not support read receipts', async () => {
@@ -277,7 +324,36 @@ describeWithDb('Read Receipt Endpoints', () => {
       expect(body.success).toBe(true);
       expect(body.data.messageCount).toBe(3);
       expect(markAsReadMock).toHaveBeenCalledTimes(1);
-      expect(markAsReadMock).toHaveBeenCalledWith(testInstance.id, testChat.externalId, messageIds);
+      // messageIds don't exist in DB → messageData is empty array
+      expect(markAsReadMock).toHaveBeenCalledWith(testInstance.id, testChat.externalId, messageIds, []);
+    });
+
+    test('batch resolves messageData from DB for existing messages', async () => {
+      const markAsReadMock = mock(async () => {});
+      const mockPlugin = createMockPlugin({ markAsRead: markAsReadMock });
+      const { app } = createTestApp(mockPlugin);
+
+      const res = await app.request('/messages/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instanceId: testInstance.id,
+          chatId: testChat.externalId,
+          messageIds: [testMessage.externalId], // real message in DB
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(markAsReadMock).toHaveBeenCalledTimes(1);
+      // Plugin receives messageData with rawPayload containing participant
+      const callArgs = markAsReadMock.mock.calls[0] as unknown[];
+      expect(callArgs[0]).toBe(testInstance.id);
+      expect(callArgs[1]).toBe(testChat.externalId);
+      expect(callArgs[2]).toEqual([testMessage.externalId]);
+      const messageData = callArgs[3] as Array<{ externalId: string; rawPayload: Record<string, unknown> }>;
+      expect(messageData).toHaveLength(1);
+      expect(messageData[0]?.externalId).toBe(testMessage.externalId);
+      expect(messageData[0]?.rawPayload).toEqual({ key: { participant: '5511999999999@s.whatsapp.net' } });
     });
 
     test('successfully marks batch using internal chat UUID', async () => {
@@ -302,7 +378,7 @@ describeWithDb('Read Receipt Endpoints', () => {
       expect(body.success).toBe(true);
       // Should resolve to external ID
       expect(body.data.chatId).toBe(testChat.externalId);
-      expect(markAsReadMock).toHaveBeenCalledWith(testInstance.id, testChat.externalId, messageIds);
+      expect(markAsReadMock).toHaveBeenCalledWith(testInstance.id, testChat.externalId, messageIds, []);
     });
 
     test('returns error when channel does not support read receipts', async () => {
@@ -389,6 +465,56 @@ describeWithDb('Read Receipt Endpoints', () => {
       const body = (await res.json()) as { error: { code: string; message: string } };
       expect(body.error.code).toBe('VALIDATION');
       expect(body.error.message).toContain('Instance ID does not match');
+    });
+  });
+
+  describe('DM (non-group) read receipts', () => {
+    test('single DM message passes messageData without participant', async () => {
+      const markAsReadMock = mock(async () => {});
+      const mockPlugin = createMockPlugin({ markAsRead: markAsReadMock });
+      const { app } = createTestApp(mockPlugin);
+
+      const res = await app.request(`/messages/${testDmMessage.id}/read`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instanceId: testInstance.id }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(markAsReadMock).toHaveBeenCalledTimes(1);
+      const callArgs = markAsReadMock.mock.calls[0] as unknown[];
+      // DM rawPayload has no participant field
+      expect(callArgs[3]).toEqual([
+        {
+          externalId: testDmMessage.externalId,
+          rawPayload: { key: { remoteJid: '5511888888888@s.whatsapp.net', fromMe: false } },
+        },
+      ]);
+    });
+
+    test('batch DM passes messageData from DB', async () => {
+      const markAsReadMock = mock(async () => {});
+      const mockPlugin = createMockPlugin({ markAsRead: markAsReadMock });
+      const { app } = createTestApp(mockPlugin);
+
+      const res = await app.request('/messages/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instanceId: testInstance.id,
+          chatId: testDmChat.externalId,
+          messageIds: [testDmMessage.externalId],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(markAsReadMock).toHaveBeenCalledTimes(1);
+      const callArgs = markAsReadMock.mock.calls[0] as unknown[];
+      const messageData = callArgs[3] as Array<{ externalId: string; rawPayload: { key: Record<string, unknown> } }>;
+      expect(messageData).toHaveLength(1);
+      expect(messageData[0]?.externalId).toBe(testDmMessage.externalId);
+      // rawPayload has no participant — plugin won't try to set one
+      expect(messageData[0]?.rawPayload.key.participant).toBeUndefined();
     });
   });
 

--- a/packages/api/src/routes/v2/chats.ts
+++ b/packages/api/src/routes/v2/chats.ts
@@ -576,7 +576,14 @@ chatsRoutes.post('/:id/read', zValidator('json', markChatReadSchema), async (c) 
   } else if ('markAsRead' in plugin && typeof plugin.markAsRead === 'function') {
     // Fall back to markAsRead with 'all' marker (WhatsApp style)
     await (
-      plugin as { markAsRead: (instanceId: string, chatId: string, messageIds: string[]) => Promise<void> }
+      plugin as {
+        markAsRead: (
+          instanceId: string,
+          chatId: string,
+          messageIds: string[],
+          messageData?: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }>,
+        ) => Promise<void>;
+      }
     ).markAsRead(instanceId, chat.externalId, ['all']);
   } else {
     throw new OmniError({

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1781,10 +1781,19 @@ messagesRoutes.post('/:id/read', zValidator('json', markMessageReadSchema), asyn
     });
   }
 
-  // Call plugin with external message ID
+  // Pass message data so the plugin can build channel-specific keys (e.g., group participant)
+  const messageData = [{ externalId: message.externalId, rawPayload: message.rawPayload ?? null }];
+
   await (
-    plugin as { markAsRead: (instanceId: string, chatId: string, messageIds: string[]) => Promise<void> }
-  ).markAsRead(instanceId, chat.externalId, [message.externalId]);
+    plugin as {
+      markAsRead: (
+        instanceId: string,
+        chatId: string,
+        messageIds: string[],
+        messageData?: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }>,
+      ) => Promise<void>;
+    }
+  ).markAsRead(instanceId, chat.externalId, [message.externalId], messageData);
 
   return c.json({
     success: true,
@@ -1827,6 +1836,7 @@ messagesRoutes.post('/read', zValidator('json', markBatchReadSchema), async (c) 
   // chatId can be either external chat ID or internal UUID
   // Try to resolve as UUID first, fall back to external ID
   let externalChatId = chatId;
+  let internalChatId: string | undefined;
   const UUID_REGEX_LOCAL = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   if (UUID_REGEX_LOCAL.test(chatId)) {
     const chat = await services.chats.getById(chatId);
@@ -1839,11 +1849,30 @@ messagesRoutes.post('/read', zValidator('json', markBatchReadSchema), async (c) 
       });
     }
     externalChatId = chat.externalId;
+    internalChatId = chat.id;
+  }
+
+  // Fetch message data so the plugin can build channel-specific keys (e.g., group participant)
+  if (!internalChatId) {
+    const chat = await services.chats.findByExternalIdSmart(instanceId, externalChatId);
+    if (chat) internalChatId = chat.id;
+  }
+  let messageData: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }> | undefined;
+  if (internalChatId) {
+    const msgs = await services.messages.getByExternalIds(internalChatId, messageIds);
+    messageData = msgs.map((m) => ({ externalId: m.externalId, rawPayload: m.rawPayload ?? null }));
   }
 
   await (
-    plugin as { markAsRead: (instanceId: string, chatId: string, messageIds: string[]) => Promise<void> }
-  ).markAsRead(instanceId, externalChatId, messageIds);
+    plugin as {
+      markAsRead: (
+        instanceId: string,
+        chatId: string,
+        messageIds: string[],
+        messageData?: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }>,
+      ) => Promise<void>;
+    }
+  ).markAsRead(instanceId, externalChatId, messageIds, messageData);
 
   return c.json({
     success: true,

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -367,6 +367,15 @@ export class MessageService {
     return result ?? null;
   }
 
+  /** Get multiple messages by external IDs in a single query */
+  async getByExternalIds(chatId: string, externalIds: string[]): Promise<Message[]> {
+    if (externalIds.length === 0) return [];
+    return this.db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.chatId, chatId), inArray(messages.externalId, externalIds)));
+  }
+
   /**
    * Create a new message
    */

--- a/packages/channel-sdk/src/types/plugin.ts
+++ b/packages/channel-sdk/src/types/plugin.ts
@@ -192,8 +192,14 @@ export interface ChannelPlugin {
    * @param instanceId - Instance to mark messages read for
    * @param chatId - Chat ID containing the messages
    * @param messageIds - Array of message IDs to mark as read, or ['all'] to mark entire chat
+   * @param messageData - Optional message records from DB (plugins use these to build channel-specific keys)
    */
-  markAsRead?(instanceId: string, chatId: string, messageIds: string[]): Promise<void>;
+  markAsRead?(
+    instanceId: string,
+    chatId: string,
+    messageIds: string[],
+    messageData?: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }>,
+  ): Promise<void>;
 
   /**
    * Mark entire chat as read

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -24,7 +24,7 @@ import { WHATSAPP_CAPABILITIES } from './capabilities';
 import { setupAllEventHandlers } from './handlers/all-events';
 import { resetConnectionState, seedAuthenticated, setupConnectionHandlers } from './handlers/connection';
 import { setupMessageHandlers, tryDownloadMedia } from './handlers/messages';
-import { fromJid, isUserJid, toJid } from './jid';
+import { fromJid, isLidJid, isUserJid, toJid } from './jid';
 import { buildMessageContent } from './senders/builders';
 import { sendReaction } from './senders/reaction';
 import { WhatsAppStreamSender } from './senders/stream';
@@ -1317,7 +1317,12 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    * @param chatId - Chat ID (JID or phone number)
    * @param messageIds - Array of message IDs, or ['all'] to mark entire chat as read
    */
-  async markAsRead(instanceId: string, chatId: string, messageIds: string[]): Promise<void> {
+  async markAsRead(
+    instanceId: string,
+    chatId: string,
+    messageIds: string[],
+    messageData?: Array<{ externalId: string; rawPayload?: Record<string, unknown> | null }>,
+  ): Promise<void> {
     const sock = this.getSocket(instanceId);
     const jid = toJid(chatId);
 
@@ -1327,11 +1332,43 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       return;
     }
 
-    const keys = messageIds.map((id) => ({
-      remoteJid: jid,
-      id,
-      fromMe: false,
-    }));
+    const isGroup = jid.endsWith('@g.us');
+
+    // Build a lookup from messageData for group key construction
+    const dataByExternalId = new Map((messageData ?? []).map((m) => [m.externalId, m.rawPayload]));
+
+    const lidCache = isGroup ? this.getLidMappingCache(instanceId) : undefined;
+    let missingParticipants = 0;
+
+    const keys = messageIds.map((id) => {
+      const raw = dataByExternalId.get(id) as { key?: { participant?: string; fromMe?: boolean } } | null | undefined;
+      const fromMe = raw?.key?.fromMe ?? false;
+      let participant = raw?.key?.participant;
+
+      // Resolve LID participant to phone JID if mapping exists
+      if (participant && isLidJid(participant) && lidCache) {
+        participant = lidCache.get(participant) ?? participant;
+      }
+
+      if (isGroup && !participant) missingParticipants++;
+
+      return {
+        remoteJid: jid,
+        id,
+        fromMe,
+        // Groups require participant (sender JID) for read receipts — without it WhatsApp silently ignores
+        ...(isGroup && participant ? { participant } : {}),
+      };
+    });
+
+    if (missingParticipants > 0) {
+      this.logger.warn('Group read receipt missing participant for some messages', {
+        instanceId,
+        chatId: jid,
+        total: messageIds.length,
+        missingParticipants,
+      });
+    }
 
     await sock.readMessages(keys);
   }


### PR DESCRIPTION
## Summary

- WhatsApp silently ignores read receipts for group messages when `participant` (sender JID) is missing from the message key. This adds participant resolution to `markAsRead` so group read receipts work.
- SDK interface accepts optional `messageData` (channel-agnostic — no WhatsApp logic in API layer)
- WhatsApp plugin extracts `participant` + `fromMe` from rawPayload, resolves LID JIDs, logs warning when participant is missing
- Batch route uses `findByExternalIdSmart` for LID chat resolution + `getByExternalIds` single bulk query
- 18 tests (was 15): group with real DB data, DM single + batch

## Test plan

- [x] `bun test packages/api/src/__tests__/messages-read.test.ts` — 18/18 pass
- [x] `bun test packages/channel-whatsapp/` — 266/266 pass
- [x] `bunx biome check .` — clean
- [x] `turbo typecheck` — 16/16 pass
- [ ] Manual: mark group message as read via API, verify blue ticks appear