### PR TITLE
fix(ci): use HEAD in changelog range for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         with:
           config: cliff.toml
-          args: ${{ steps.prev.outputs.tag && format('{0}..v{1}', steps.prev.outputs.tag, steps.pkg.outputs.version) || '' }}
+          args: ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || '' }}
         env:
           GITHUB_REPO: ${{ github.repository }}
 


### PR DESCRIPTION
## Summary

- Release workflow failed because git-cliff tried to resolve tag `v2.260223.1` before it was created
- Changed changelog range from `{prev_tag}..v{new_version}` to `{prev_tag}..HEAD` — the tag doesn't exist until the next step creates it
- Also includes the tighter version regex fix from coderabbit review

## Context

Release run [#22311323039](https://github.com/automagik-dev/omni/actions/runs/22311323039) failed with:
```
Error: SetCommitRangeError("v2.20260221.1..v2.260223.1", revspec 'v2.260223.1' not found)
```

## Test plan

- [ ] Merge this PR and verify release workflow succeeds
- [ ] GitHub release `v2.260223.1` is created with changelog
- [ ] npm publish succeeds