### PR TITLE
chore: rolling promotion dev -> main

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "description": "Discord channel plugin for Omni v2 using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "description": "Slack channel plugin for Omni v2 using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "description": "Telegram channel plugin for Omni v2 using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "description": "WhatsApp channel plugin for Omni v2 using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "description": "LLM-optimized CLI for Omni v2",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "description": "Expose Omni v2 as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260223.1",
+  "version": "2.260223.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Rolling Promotion PR

Promotes `v2.260223.2` to main for npm publish.

Includes version bump fix (`%y` vs `%Y` in Version workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions from 2.260223.1 to 2.260223.2 across the platform. No functional changes or end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->