### PR TITLE
fix(cli): include drizzle migrations in npm package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ cli-build:
 	bun run --cwd packages/cli build
 
 cli-build-full: ## Build CLI client + server bundles
-	cd packages/cli && bun run build && bun run build:server
+	cd packages/cli && bun run build && bun run build:server && bun run build:migrations
 
 cli-link: cli-build
 	cd packages/cli && bun link

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,8 @@
     "test:integration": "RUN_INTEGRATION_TESTS=1 bun test",
     "clean": "rm -rf dist",
     "build:server": "bun build ../api/src/index.ts --outfile dist/server/index.js --target bun",
-    "prepack": "bun run build && bun run build:server"
+    "build:migrations": "cp -r ../db/drizzle dist/drizzle",
+    "prepack": "bun run build && bun run build:server && bun run build:migrations"
   },
   "dependencies": {
     "chalk": "^5.4.0",


### PR DESCRIPTION
## Summary
- Copies `packages/db/drizzle/` into `packages/cli/dist/drizzle/` during build
- Fixes startup crash (`Can't find meta/_journal.json`) when running the published npm package
- Added `build:migrations` script to `packages/cli/package.json` and chained it in `prepack` and `Makefile`'s `cli-build-full`

## Test plan
- [x] `bun run build:migrations` copies files to `dist/drizzle/`
- [x] `dist/drizzle/meta/_journal.json` exists after build
- [x] `dist/drizzle/0000_closed_patriot.sql` exists after build
- [ ] `bun publish --dry-run` shows `dist/drizzle/` in tarball
- [ ] `omni start` no longer crashes on missing journal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI build and packaging processes to include database migration artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->