### PR TITLE
fix(cli): bundle channel plugins in npm package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@hono/swagger-ui": "^0.4.1",
         "@hono/zod-validator": "^0.4.3",
@@ -82,7 +82,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -98,7 +98,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -109,7 +109,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -126,7 +126,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -142,7 +142,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -162,7 +162,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -173,6 +173,12 @@
         "qrcode-terminal": "^0.12.0",
       },
       "devDependencies": {
+        "@omni/api": "workspace:*",
+        "@omni/channel-discord": "workspace:*",
+        "@omni/channel-sdk": "workspace:*",
+        "@omni/channel-slack": "workspace:*",
+        "@omni/channel-telegram": "workspace:*",
+        "@omni/channel-whatsapp": "workspace:*",
         "@omni/core": "workspace:*",
         "@omni/sdk": "workspace:*",
         "@types/node": "^22.10.3",
@@ -182,7 +188,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.39",
         "croner": "^9.1.0",
@@ -197,7 +203,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -211,7 +217,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -229,7 +235,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -237,7 +243,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.20260221.1",
+      "version": "2.260223.4",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },

--- a/packages/api/src/plugins/loader.ts
+++ b/packages/api/src/plugins/loader.ts
@@ -95,11 +95,37 @@ export interface LoadPluginsResult {
  * Load and initialize all channel plugins
  */
 export async function loadChannelPlugins(options: LoadPluginsOptions): Promise<LoadPluginsResult> {
-  const { packagesDir = getMonorepoPackagesDir(), eventBus, db } = options;
+  const { eventBus, db } = options;
 
   // Set database for persistent storage BEFORE creating plugin contexts
   setStorageDatabase(db);
 
+  // Import the singleton registry from channel-sdk
+  const { channelRegistry } = await import('@omni/channel-sdk');
+
+  // Check if channels were pre-registered (bundled npm distribution)
+  const preRegistered = channelRegistry.getAll();
+  if (preRegistered.length > 0) {
+    logger.info('Using pre-registered channel plugins', { count: preRegistered.length });
+    for (const plugin of preRegistered) {
+      try {
+        const context = createPluginContext({ pluginId: plugin.id, eventBus, db });
+        await channelRegistry.initialize(plugin.id, context);
+        logger.info(`Initialized channel: ${plugin.id}`, { name: plugin.name, version: plugin.version });
+      } catch (error) {
+        logger.error(`Failed to initialize channel: ${plugin.id}`, { error: String(error) });
+      }
+    }
+    return {
+      registry: channelRegistry,
+      loaded: preRegistered.length,
+      failed: 0,
+      pluginIds: preRegistered.map((p) => p.id),
+    };
+  }
+
+  // Filesystem discovery fallback (monorepo dev mode)
+  const packagesDir = options.packagesDir ?? getMonorepoPackagesDir();
   logger.info('Starting channel plugin discovery', { packagesDir });
 
   // Discover and register plugins
@@ -118,9 +144,6 @@ export async function loadChannelPlugins(options: LoadPluginsOptions): Promise<L
   for (const failure of discoveryResult.failed) {
     logger.error('Failed to load plugin', { path: failure.path, error: failure.error });
   }
-
-  // Import the singleton registry from channel-sdk
-  const { channelRegistry } = await import('@omni/channel-sdk');
 
   // Initialize all registered plugins with context
   for (const plugin of discoveryResult.registered) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "test": "bun test",
     "test:integration": "RUN_INTEGRATION_TESTS=1 bun test",
     "clean": "rm -rf dist",
-    "build:server": "bun build ../api/src/index.ts --outfile dist/server/index.js --target bun",
+    "build:server": "bun build src/bundled-server-entry.ts --outfile dist/server/index.js --target bun",
     "build:migrations": "cp -r ../db/drizzle dist/drizzle",
     "prepack": "bun run build && bun run build:server && bun run build:migrations"
   },
@@ -31,6 +31,12 @@
     "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
+    "@omni/api": "workspace:*",
+    "@omni/channel-discord": "workspace:*",
+    "@omni/channel-sdk": "workspace:*",
+    "@omni/channel-slack": "workspace:*",
+    "@omni/channel-telegram": "workspace:*",
+    "@omni/channel-whatsapp": "workspace:*",
     "@omni/core": "workspace:*",
     "@omni/sdk": "workspace:*",
     "@types/node": "^22.10.3",

--- a/packages/cli/src/bundled-server-entry.ts
+++ b/packages/cli/src/bundled-server-entry.ts
@@ -1,0 +1,25 @@
+/**
+ * Bundled server entry point
+ *
+ * Pre-registers all channel plugins before starting the API server.
+ * This ensures npm-installed omni ships with channels available
+ * without needing monorepo filesystem discovery.
+ */
+
+import { type ChannelPlugin, channelRegistry } from '@omni/channel-sdk';
+
+import discordPlugin from '@omni/channel-discord';
+import slackPlugin from '@omni/channel-slack';
+import telegramPlugin from '@omni/channel-telegram';
+import whatsappPlugin from '@omni/channel-whatsapp';
+
+// Pre-register all bundled channel plugins
+// Type assertion needed: channel plugins implement ChannelPlugin but
+// some have narrower parameter types (e.g. Discord's fetchContacts)
+for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin] as ChannelPlugin[]) {
+  channelRegistry.register(plugin);
+}
+
+// Start the API server — must be a dynamic import to guarantee
+// registration happens before the server reads the registry
+await import('@omni/api');

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -261,6 +261,7 @@ function buildApiRuntimeEnv(cfg: WizardConfig): Record<string, string> {
     DATABASE_URL: cfg.databaseUrl,
     OMNI_API_KEY: cfg.apiKey,
     MEDIA_STORAGE_PATH: join(cfg.dataDir, 'media'),
+    OMNI_PACKAGES_DIR: join(cfg.dataDir, 'packages'),
     PGSERVE_EMBEDDED: 'true',
     PGSERVE_DATA: join(cfg.dataDir, 'pglite'),
     NATS_URL: 'nats://localhost:4222',

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -37,6 +37,7 @@ function buildApiRuntimeEnv(): Record<string, string> {
     DATABASE_URL: serverConfig.databaseUrl,
     OMNI_API_KEY: config.apiKey ?? '',
     MEDIA_STORAGE_PATH: join(serverConfig.dataDir, 'media'),
+    OMNI_PACKAGES_DIR: join(serverConfig.dataDir, 'packages'),
     PGSERVE_EMBEDDED: 'true',
     PGSERVE_DATA: join(serverConfig.dataDir, 'pglite'),
     NATS_URL: 'nats://localhost:4222',

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -16,5 +16,5 @@
     "types": ["bun-types", "node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/bundled-server-entry.ts"]
 }


### PR DESCRIPTION
## Summary

- **New entry point** (`bundled-server-entry.ts`) that statically imports all 4 channel plugins (telegram, discord, whatsapp, slack) and pre-registers them with `channelRegistry` before starting the API server
- **Plugin loader detects pre-registered channels** and skips filesystem discovery — falls back to monorepo discovery only in dev mode
- **`build:server`** now bundles from the new entry point (15MB bundle, 2569 modules — all channel SDKs included)
- **`OMNI_PACKAGES_DIR`** added to PM2 runtime env in both `install` and `start` commands as safety fallback

## Problem

When `@automagik/omni` is installed via npm, `omni install` starts the API via PM2. The server calls `loadChannelPlugins()` → `getMonorepoPackagesDir()` which walks up the filesystem looking for `turbo.json`. In an npm install there's no monorepo, so it throws `Could not find monorepo root` and the channel registry never initializes — all `instances connect` calls return 503.

## Test plan

- [ ] `cd packages/cli && bun run build:server` produces bundle (~15MB)
- [ ] `bun run prepack` completes successfully
- [ ] `bun pack` includes `dist/server/index.js` with bundled channels
- [ ] Monorepo dev mode still works (API discovers plugins via filesystem)
- [ ] `make typecheck` passes (16/16 packages)
- [ ] `make lint` passes