### PR TITLE
fix(slack): enrich rawPayload with sender identity

### DIFF
--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -67,8 +67,8 @@ export class SlackPlugin extends BaseChannelPlugin {
   /** Plugin-specific config per instance */
   private slackConfigs = new Map<string, SlackConfig>();
 
-  /** Cached user display names per instance: Map<`${instanceId}:${userId}`, displayName> */
-  private userNameCache = new Map<string, string>();
+  /** Cached user display names per instance: Map<`${instanceId}:${userId}`, displayName | null> (null = failed lookup) */
+  private userNameCache = new Map<string, string | null>();
 
   /**
    * Plugin-specific initialization
@@ -398,12 +398,14 @@ export class SlackPlugin extends BaseChannelPlugin {
 
   /**
    * Resolve user display name with caching.
-   * Falls back to undefined if the Slack API call fails.
+   * Caches both successful and failed lookups to avoid repeated API calls
+   * (prevents rate-limit storms when users.info consistently fails for a user).
    */
   private async resolveUserDisplayName(instanceId: string, userId: string): Promise<string | undefined> {
     const cacheKey = `${instanceId}:${userId}`;
-    const cached = this.userNameCache.get(cacheKey);
-    if (cached) return cached;
+    if (this.userNameCache.has(cacheKey)) {
+      return this.userNameCache.get(cacheKey) ?? undefined;
+    }
 
     try {
       const profile = await this.fetchUserProfile(instanceId, userId);
@@ -414,6 +416,8 @@ export class SlackPlugin extends BaseChannelPlugin {
     } catch {
       // fetchUserProfile already logs the warning
     }
+    // Cache the failure (null sentinel) so we don't retry on every message
+    this.userNameCache.set(cacheKey, null);
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- Slack messages arrived without `pushName`/`displayName` fields in `rawPayload`, causing all users to show as "gateway-client" in the AI agent
- Adds a cached `resolveUserDisplayName()` method that calls the existing `fetchUserProfile()` (Slack `users.info` API) and caches results per `instanceId:userId`
- Enriches `rawPayload` in the `onMessage` callback with `displayName`, `pushName`, `chatName`, and `isGroup` — matching the cross-channel identity contract used by Discord, Telegram, and WhatsApp
- Cache is cleared on instance disconnect and plugin destroy

## Test plan

- [x] `make typecheck` — passes (16/16)
- [x] `make lint` — passes (698 files, no issues)
- [x] `bun test packages/channel-slack` — 108 tests pass
- [ ] Manual: Send messages from 2+ Slack users → verify agent sees distinct sender names
- [ ] Verify DB: `SELECT "senderDisplayName" FROM messages` shows actual names instead of null