### PR TITLE
feat(plugin): add root marketplace manifest for GitHub discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "automagik-dev",
+  "description": "Omni v2 — Universal Event-Driven Omnichannel Platform plugins",
+  "owner": {
+    "name": "Automagik"
+  },
+  "plugins": [
+    {
+      "name": "omni",
+      "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
+      "version": "2.0.0",
+      "author": { "name": "Automagik" },
+      "source": "./plugins/omni",
+      "category": "development"
+    }
+  ]
+}


### PR DESCRIPTION
When installing via `claude plugin install automagik-dev/omni`, Claude Code clones the repo and looks for `.claude-plugin/marketplace.json` at the root. This manifest points to the omni plugin at `plugins/omni/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Omni plugin is now available in the Claude marketplace for easier discovery and installation.

* **Chores**
  * Added marketplace manifest configuration to enable plugin availability and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->