### PR TITLE
feat(skills): full CLI ↔ skill parity — 28 commands, 14 skills

### DIFF
--- a/plugins/omni/skills/omni-chats/SKILL.md
+++ b/plugins/omni/skills/omni-chats/SKILL.md
@@ -13,6 +13,7 @@ allowed-tools: Bash(omni *), Bash(jq *)
 omni chats list --instance <id> --limit 50 --json
 omni chats list --instance <id> --unread --sort activity --verbose --json
 omni chats list --channel whatsapp-baileys --type group --json
+omni chats list --instance <id> --all --json
 omni chats get <chatId> --json
 ```
 
@@ -20,6 +21,7 @@ omni chats get <chatId> --json
 
 ```bash
 omni chats create --instance <id> --external-id "whatsapp:+5511999" --channel whatsapp-baileys --type private --name "Lead" --json
+omni chats create --instance <id> --external-id "..." --channel whatsapp-baileys --type group --name "Team" --description "Team chat" --json
 omni chats update <chatId> --name "New name" --description "Notes" --json
 omni chats delete <chatId> --json
 ```
@@ -44,6 +46,9 @@ omni chats messages <chatId> --limit 100 --json
 omni chats messages <chatId> --since 7d --search "invoice" --json
 omni chats messages <chatId> --audio-only --compact --truncate 120 --json
 omni chats messages <chatId> --images-only --before <cursor> --json
+omni chats messages <chatId> --videos-only --json
+omni chats messages <chatId> --docs-only --json
+omni chats messages <chatId> --after <cursor> --json
 ```
 
 ## Participants

--- a/plugins/omni/skills/omni-config/SKILL.md
+++ b/plugins/omni/skills/omni-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: omni-config
 description: |
-  Operate Omni configuration and access surfaces: CLI config/auth, providers, API keys, and server settings.
+  Operate Omni configuration and access surfaces: CLI config/auth, providers, API keys, server settings, service management, logs, dead letters, payloads, and shell completions.
 allowed-tools: Bash(omni *), Bash(jq *)
 ---
 
@@ -18,6 +18,15 @@ omni auth logout --json
 omni status --json
 ```
 
+## Auth recovery
+
+```bash
+# Recover API key when keyValid shows "no" (requires local PM2 access)
+omni auth recover --api-url http://localhost:8882 --json
+# Generate a new key instead of recovering the existing one
+omni auth recover --rotate --json
+```
+
 ## CLI config
 
 ```bash
@@ -30,9 +39,13 @@ omni config unset defaultInstance --json
 
 ## Providers
 
+Available schemas: `agno`, `webhook`, `openclaw`, `ag-ui`, `claude-code`
+
 ```bash
 omni providers list --json
 omni providers get <id> --json
+
+# openclaw provider
 omni providers create \
   --name "openclaw-prod" \
   --schema openclaw \
@@ -40,6 +53,21 @@ omni providers create \
   --api-key <key> \
   --default-agent-id <agentId> \
   --json
+
+# claude-code provider (runs Claude Code SDK locally)
+omni providers create \
+  --name "claude-dev" \
+  --schema claude-code \
+  --project-path /home/user/myproject \
+  --max-turns 10 \
+  --permission-mode acceptEdits \
+  --model claude-opus-4-5 \
+  --system-prompt "You are a helpful assistant." \
+  --json
+
+# agno / webhook / ag-ui providers (use --base-url and --api-key as needed)
+omni providers create --name "agno-prod" --schema agno --base-url https://api.agno.com --api-key <key> --json
+
 omni providers test <id> --json
 omni providers agents <id> --json
 omni providers teams <id> --json
@@ -67,7 +95,61 @@ omni settings get <key> --json
 omni settings set <key> <value> --reason "ops update" --json
 ```
 
+## Service management
+
+```bash
+omni start --json
+omni stop --json
+omni restart --json
+omni update -y --no-restart --json
+```
+
+## Logs
+
+```bash
+omni logs --json
+omni logs error --limit 50 --json
+omni logs --modules api,nats --follow --json
+omni logs --process nats --json
+```
+
+Flags: `[level]` (debug, info, warn, error), `--modules <modules>`, `--limit <n>` (default: 100), `--process [service]` (default: api), `--follow`
+
+## Dead letters
+
+```bash
+omni dead-letters list --status pending --limit 50 --json
+omni dead-letters get <id> --json
+omni dead-letters stats --json
+omni dead-letters retry <id> --json
+omni dead-letters resolve <id> --note "fixed manually" --json
+omni dead-letters abandon <id> --json
+```
+
+## Payloads
+
+```bash
+omni payloads list <eventId> --json
+omni payloads get <eventId> webhook_raw --json
+omni payloads get <eventId> agent_response --json
+omni payloads delete <eventId> --reason "cleanup" --json
+omni payloads config --json
+omni payloads config message.received --retention 30 --store-webhook true --json
+omni payloads stats --json
+```
+
+Payload stages: `webhook_raw`, `agent_request`, `agent_response`, `channel_send`, `error`
+
+## Shell completions
+
+```bash
+omni completions bash
+omni completions zsh
+omni completions fish
+```
+
 ## Notes
 
 - Prefer `--json` + `jq` for automation-safe parsing.
 - `omni providers setup` is interactive; avoid it in automated agent flows.
+- `omni auth recover` requires local PM2 access (run on the server hosting Omni).

--- a/plugins/omni/skills/omni-events/SKILL.md
+++ b/plugins/omni/skills/omni-events/SKILL.md
@@ -14,6 +14,8 @@ Use `omni events` for event streams and `omni journey` for per-message tracing.
 ```bash
 omni events list --since 24h --limit 100 --json
 omni events list --instance <id> --type message.received --json
+omni events list --chat-id <chatId> --since 24h --json
+omni events list --since 24h --until "2026-02-25" --json
 omni events search "error" --since 7d --limit 100 --json
 omni events timeline <personId> --limit 100 --json
 ```
@@ -33,6 +35,8 @@ omni events analytics --instance <id> --all-time --json
 omni events replay --start --since 7d --json
 omni events replay --start --since 24h --types message.received,message.sent --speed 2 --json
 omni events replay --start --since 7d --dry-run --json
+omni events replay --start --since 7d --until "2026-02-20" --json
+omni events replay --start --since 24h --instance <id> --json
 
 # Check / cancel
 omni events replay --status <sessionId> --json
@@ -48,5 +52,7 @@ omni journey summary --since 24h --json
 
 ## Notes
 
+- `events list` supports `--chat-id <id>` and `--until <time>` for precise time-range filtering.
+- `events replay --start` supports `--until <time>` and `--instance <id>`.
 - `events search` supports `--since` and `--limit` (no `--type` flag there).
 - Replay management is all through `omni events replay` flags.

--- a/plugins/omni/skills/omni-instances/SKILL.md
+++ b/plugins/omni/skills/omni-instances/SKILL.md
@@ -64,6 +64,8 @@ omni instances qr <id> --json
 
 ```bash
 omni instances sync <id> --type messages --depth 30d --download-media --json
+# Sync a specific chat (WhatsApp only)
+omni instances sync <id> --chat <jid> --json
 omni instances syncs <id> --limit 20 --json
 omni instances syncs <id> <jobId> --json
 
@@ -80,6 +82,49 @@ omni instances profile <id> <userId> --json
 omni instances check <id> +5511999 --json
 omni instances update-bio <id> "Available" --json
 omni instances privacy <id> --json
+
+# Profile pictures
+omni instances update-picture <id> --url "https://example.com/pic.jpg" --json
+omni instances update-picture <id> --base64 "<data>" --json
+omni instances remove-picture <id> --json
+omni instances group-update-picture <id> --group <groupJid> --url "https://example.com/pic.jpg" --json
+
+# Reject incoming call
+omni instances reject-call <id> --call-id <callId> --from <jid> --json
+```
+
+## Access control (`omni access`)
+
+Manage allow/deny lists per instance. Works with `accessMode` on the instance (`allowlist`, `blocklist`, or `disabled`).
+
+```bash
+# List rules (optionally filter by instance or type)
+omni access list --json
+omni access list --instance <id> --json
+omni access list --instance <id> --type allow --json
+
+# Create allow or deny rule
+omni access create --type allow --instance <id> --phone <number> --reason "description" --json
+omni access create --type deny --instance <id> --phone <number> --reason "description" --json
+# Options: --user <platformId>, --phone <pattern> (supports * wildcard, e.g. +55*),
+#          --priority <n>, --action block|silent_block|allow, --message "custom block msg", --disabled
+
+# Delete a rule
+omni access delete <ruleId> --json
+
+# Get or set access mode for an instance
+omni access mode <instanceId> --json              # get current mode
+omni access mode <instanceId> allowlist --json     # set to allowlist
+omni access mode <instanceId> blocklist --json     # set to blocklist
+omni access mode <instanceId> disabled --json      # disable access control
+
+# Check if a user has access
+omni access check --instance <id> --user <platformUserId> --json
+
+# Pairing requests (users requesting access)
+omni access pending <instanceId> --json
+omni access approve <instanceId> <requestId> --json   # adds user to allowlist
+omni access deny <instanceId> <requestId> --reason "not authorized" --json
 ```
 
 ## Moderation and group ops

--- a/plugins/omni/skills/omni-persons/SKILL.md
+++ b/plugins/omni/skills/omni-persons/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: omni-persons
+description: |
+  Search and inspect contacts in the Omni person directory: search by name/phone, get full profile, and check online presence.
+allowed-tools: Bash(omni *), Bash(jq *)
+---
+
+# Omni Persons
+
+## Search
+
+```bash
+omni persons search "Felipe" --json
+omni persons search "+5511999" --limit 5 --json
+omni persons search "partial name" --limit 50 --json
+```
+
+## Get details
+
+```bash
+omni persons get <personId> --json
+```
+
+## Presence check
+
+```bash
+omni persons presence <personId> --json
+```
+
+## Notes
+
+- Persons are auto-created from incoming messages; no manual creation needed.
+- Search supports partial name and phone number matches.
+- `--limit` defaults to 20; increase for broader results.
+- Presence returns online status and last activity info for the person.

--- a/plugins/omni/skills/omni-prompts/SKILL.md
+++ b/plugins/omni/skills/omni-prompts/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: omni-prompts
+description: |
+  View and override LLM prompt templates used for media description (image/video/document) and gating decisions.
+allowed-tools: Bash(omni *), Bash(jq *)
+---
+
+# Omni Prompts
+
+## List prompts
+
+```bash
+omni prompts list --json
+```
+
+## Get prompt
+
+```bash
+omni prompts get image --json
+omni prompts get video --json
+omni prompts get document --json
+omni prompts get gate --json
+```
+
+## Set custom prompt
+
+```bash
+# Set inline
+omni prompts set image "Describe this image in detail, including any text visible." --reason "More detail needed" --json
+
+# Set from a file using stdin (for multiline prompts)
+omni prompts set document < /path/to/prompt.txt --json
+
+# Set gate prompt
+omni prompts set gate "Reply YES if the message is a support request, NO otherwise." --json
+```
+
+## Reset to default
+
+```bash
+omni prompts reset image --json
+omni prompts reset video --json
+omni prompts reset document --json
+omni prompts reset gate --json
+```
+
+## Notes
+
+- Prompts control how Omni describes media attachments to LLMs and how gate decisions are made.
+- Valid prompt names are: `image`, `video`, `document`, `gate`.
+- `reset` clears the override and reverts to the built-in code default.
+- `set` reads from stdin if no inline value is provided, enabling multiline prompt editing.
+- `--reason` documents why the prompt was changed (stored for audit purposes).

--- a/plugins/omni/skills/omni-routes/SKILL.md
+++ b/plugins/omni/skills/omni-routes/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: omni-routes
+description: |
+  Manage agent routing rules: create per-chat or per-user routes to specific providers/agents, test route resolution, and view routing metrics.
+allowed-tools: Bash(omni *), Bash(jq *)
+---
+
+# Omni Routes
+
+## List routes
+
+```bash
+omni routes list --instance <id> --json
+omni routes list --instance <id> --active --json
+omni routes list --instance <id> --scope chat --json
+omni routes list --instance <id> --scope user --json
+```
+
+## Get route
+
+```bash
+omni routes get <routeId> --instance <id> --json
+```
+
+## Create route
+
+```bash
+# Route a specific chat to an agent
+omni routes create --instance <id> --scope chat --chat <chatId> --provider <providerId> --agent <agentId> --label "Support bot" --priority 10 --json
+
+# Route all conversations from a person to an agent
+omni routes create --instance <id> --scope user --person <personId> --provider <providerId> --agent <agentId> --json
+
+# Create with gate and streaming options
+omni routes create --instance <id> --scope chat --chat <chatId> --provider <providerId> --agent <agentId> --gate --gate-model <model> --gate-prompt "Only reply if relevant" --stream --timeout 60 --json
+
+# Create as inactive (not yet active)
+omni routes create --instance <id> --scope chat --chat <chatId> --provider <providerId> --agent <agentId> --inactive --json
+```
+
+## Update route
+
+```bash
+omni routes update <routeId> --instance <id> --label "New label" --priority 20 --json
+omni routes update <routeId> --instance <id> --active --json
+omni routes update <routeId> --instance <id> --inactive --json
+omni routes update <routeId> --instance <id> --agent <newAgentId> --timeout 120 --json
+omni routes update <routeId> --instance <id> --no-gate --no-stream --json
+```
+
+## Delete route
+
+```bash
+omni routes delete <routeId> --instance <id> --json
+```
+
+## Test resolution
+
+```bash
+# Test which route would be applied for a given chat
+omni routes test --instance <id> --chat <chatId> --json
+
+# Test for a specific person
+omni routes test --instance <id> --person <personId> --json
+
+# Test for both chat and person
+omni routes test --instance <id> --chat <chatId> --person <personId> --json
+```
+
+## Metrics
+
+```bash
+omni routes metrics --json
+```
+
+## Notes
+
+- Routes override instance-level agent config for matched chats or persons.
+- Scope "chat" targets a specific conversation; "user" targets all conversations from a person.
+- Higher `--priority` value wins when multiple routes could match.
+- `--gate` enables an LLM-based filter that decides whether the agent should reply.
+- `--reply-filter-mode` accepts `all` or `filtered`.
+- `--agent-type` accepts `agent`, `team`, or `workflow` (default: `agent`).

--- a/plugins/omni/skills/omni-send/SKILL.md
+++ b/plugins/omni/skills/omni-send/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: omni-send
 description: |
-  Send outbound messages with Omni CLI: text, media, TTS, reactions, stickers, contacts, locations, polls, embeds, presence, and forwards.
+  Send outbound messages with Omni CLI: text, media, TTS, reactions, stickers, contacts, locations, polls, embeds, presence, forwards, and media browsing/download.
 allowed-tools: Bash(omni *), Bash(jq *)
 ---
 
@@ -43,10 +43,14 @@ omni send --to <recipient> --location --lat -23.55 --lng -46.63 --address "São 
 
 # Discord poll / embed
 omni send --to <channel> --poll "Lunch?" --options "Pizza,Sushi" --duration 24 --instance <id> --json
+omni send --to <channel> --poll "Vote?" --options "Yes,No" --multi-select --duration 24 --instance <id> --json
 omni send --to <channel> --embed --title "Alert" --description "Details" --color "#00ff00" --url https://x --instance <id> --json
 
-# Presence + forward
+# Presence (with optional recording simulation delay)
 omni send --to <recipient> --presence typing --instance <id> --json
+omni send --to <recipient> --tts "Hello" --voice-id <voiceId> --presence-delay 3000 --instance <id> --json
+
+# Forward
 omni send --to <recipient> --forward --message <messageId> --from-chat <chatId> --instance <id> --json
 ```
 
@@ -56,7 +60,24 @@ omni send --to <recipient> --forward --message <messageId> --from-chat <chatId> 
 omni tts voices --json
 ```
 
+## Media browsing
+
+```bash
+# List media across an instance (audio, image, video, document)
+omni media list --instance <id> --type audio,image --since 2025-01-01 --limit 50 --json
+omni media list --chat <chatId> --remote-only --json
+
+# Download a specific media item
+omni media download --message <uuid> --output ./file.jpg --json
+omni media download --chat <uuid> --external <externalId> --json
+```
+
+Flags for `media list`: `--instance <id>`, `--chat <id>`, `--since <datetime>`, `--until <datetime>`, `--type <types>` (audio,image,video,document), `--limit <n>` (default: 20, max: 100), `--remote-only`, `--cached-only`, `--full`
+
+Flags for `media download`: `--message <uuid>`, `--chat <uuid>`, `--external <id>`, `--output <path>`
+
 ## Notes
 
 - `--to` accepts phone/JID or Omni UUIDs (chat/person).
+- `--presence-delay <ms>` on `omni send --tts` simulates a typing/recording presence before delivering the TTS voice note.
 - Add small delays in loops to avoid rate-limit spikes.

--- a/plugins/omni/skills/omni-webhooks/SKILL.md
+++ b/plugins/omni/skills/omni-webhooks/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: omni-webhooks
+description: |
+  Manage webhook event sources: create, update, and delete webhook endpoints, and trigger custom events for testing automations.
+allowed-tools: Bash(omni *), Bash(jq *)
+---
+
+# Omni Webhooks
+
+## List webhooks
+
+```bash
+omni webhooks list --json
+omni webhooks list --enabled --json
+omni webhooks list --disabled --json
+```
+
+## Get webhook
+
+```bash
+omni webhooks get <id> --json
+```
+
+## Create webhook
+
+```bash
+omni webhooks create --name "My Webhook" --description "Receives external events" --json
+
+# Create with expected headers for validation
+omni webhooks create --name "Secure Hook" --headers '{"X-Secret": true}' --json
+
+# Create in disabled state
+omni webhooks create --name "Draft Hook" --disabled --json
+```
+
+## Update webhook
+
+```bash
+omni webhooks update <id> --name "Renamed Hook" --json
+omni webhooks update <id> --description "Updated description" --json
+omni webhooks update <id> --enable --json
+omni webhooks update <id> --disable --json
+```
+
+## Delete webhook
+
+```bash
+omni webhooks delete <id> --json
+```
+
+## Trigger events
+
+```bash
+# Trigger a custom event for testing
+omni webhooks trigger --type "custom.event" --payload '{"key": "value"}' --instance <id> --json
+
+# Trigger with a correlation ID for tracing
+omni webhooks trigger --type "order.created" --payload '{"orderId": "123"}' --instance <id> --correlation-id "req-abc" --json
+```
+
+## Notes
+
+- Webhooks provide external event injection into Omni's event bus.
+- Use `trigger` to test automations with custom payloads without an external caller.
+- `--headers` defines expected request headers (used for webhook validation/security).
+- Disabled webhooks will not process incoming events until enabled.

--- a/plugins/omni/skills/omni/SKILL.md
+++ b/plugins/omni/skills/omni/SKILL.md
@@ -12,11 +12,16 @@ If running → use `--json` by default for agent consumption. Verify instance/ch
 ## Keyword → skill routing
 
 - install, setup, fresh install, server not running, not installed → `omni-install/SKILL.md`
-- send, message, text, TTS, voice, media, image, reaction, sticker, poll, embed → `omni-send/SKILL.md`
+- send, message, text, TTS, voice, media, image, browse media, download media, reaction, sticker, poll, embed → `omni-send/SKILL.md`
 - search messages, read messages, star, delete message → `omni-messages/SKILL.md`
 - chats, conversations, list chats, chat history, participants, groups → `omni-chats/SKILL.md`
 - events, analytics, replay, timeline, journey, latency, debug flow → `omni-events/SKILL.md`
-- instances, connect, disconnect, QR, sync, agent routing, reply filter, WhatsApp, Telegram, Discord → `omni-instances/SKILL.md`
+- instances, connect, disconnect, QR, sync, resync, backfill, agent routing, reply filter, WhatsApp, Telegram, Discord → `omni-instances/SKILL.md`
+- access, allowlist, blocklist, allow, deny, pairing requests, access control → `omni-instances/SKILL.md`
 - automations, triggers, workflows → `omni-automations/SKILL.md`
 - batch, transcribe, extract, audio, document → `omni-batch/SKILL.md`
-- auth, config, providers, API key, default instance, webhooks → `omni-config/SKILL.md`
+- auth, config, keys, API keys, providers, default instance, dead letters, payloads, logs, completions, service management, start, stop, restart, update → `omni-config/SKILL.md`
+- persons, contacts, person search, contact directory, presence → `omni-persons/SKILL.md`
+- routes, routing, agent route, route resolution, route metrics → `omni-routes/SKILL.md`
+- webhooks, webhook source, custom event, trigger event, event injection → `omni-webhooks/SKILL.md`
+- prompts, LLM prompt, image prompt, gate prompt, prompt override → `omni-prompts/SKILL.md`


### PR DESCRIPTION
## Summary

- QA'd every `omni` CLI command (28 total, including 4 debug) against existing skill documentation
- Fixed 5 existing skills with missing flags, subcommands, and entire command groups
- Created 4 new skills for previously undocumented command groups
- Updated router skill to cover all 14 skills with accurate keyword routing

### Existing skills fixed
- **omni-send** — added `omni media list/download`, `--presence-delay`, `--multi-select`
- **omni-config** — added auth recover, all provider schemas (agno/webhook/openclaw/ag-ui/claude-code), service management, logs, dead-letters, payloads, completions
- **omni-instances** — added update-picture, remove-picture, group-update-picture, reject-call, sync --chat
- **omni-events** — added --chat-id, --until, --instance flags to list/replay
- **omni-chats** — added --all, --videos-only, --docs-only, --after, create --description

### New skills created
- **omni-persons** — persons search, get, presence (3 subcommands)
- **omni-routes** — routes list, get, create, update, delete, test, metrics (7 subcommands)
- **omni-webhooks** — webhooks list, get, create, update, delete, trigger (6 subcommands)
- **omni-prompts** — prompts list, get, set, reset (4 subcommands)

### Router updated
- 13 routing entries (was 9) covering all non-router skills
- Fixed keywords: removed stale "webhooks" from omni-config, added proper entries for all new skills

## Test plan
- [x] All 14 skills exist and are non-empty
- [x] All 13 non-router skills appear in router
- [x] All 28 CLI commands have skill coverage (verified with `grep`)
- [x] `--help` verified for every command and subcommand
- [x] Zero stale skill references (no docs pointing to non-existent CLI commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)