### PR TITLE
fix(whatsapp): history-push sync tracking + absolute media URLs

### DIFF
--- a/packages/api/src/__tests__/history-push-guard.test.ts
+++ b/packages/api/src/__tests__/history-push-guard.test.ts
@@ -1,0 +1,279 @@
+/**
+ * History-Push Sync Guard Tests
+ *
+ * Tests that manual per-chat sync (POST /instances/:id/sync with type 'messages'
+ * or chatJids, and POST /instances/:id/resync) returns 409 when a history-push
+ * job is active for the instance.
+ *
+ * Profile/contacts/groups sync types should NOT be blocked.
+ */
+
+import { afterAll, beforeAll, expect, mock, test } from 'bun:test';
+import { NotFoundError } from '@omni/core';
+import type { Database, Instance } from '@omni/db';
+import { instances, syncJobs } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { instancesRoutes } from '../routes/v2/instances';
+import { createServices } from '../services';
+import type { Services } from '../services';
+import type { AppVariables } from '../types';
+import { describeWithDb, getTestDb } from './db-helper';
+
+describeWithDb('History-Push Sync Guard', () => {
+  let db: Database;
+  let services: Services;
+  let testInstance: Instance;
+  const insertedInstanceIds: string[] = [];
+
+  beforeAll(async () => {
+    db = getTestDb();
+    services = createServices(db, null);
+
+    const [inst] = await db
+      .insert(instances)
+      .values({
+        name: `test-guard-${Date.now()}`,
+        channel: 'whatsapp-baileys' as const,
+      })
+      .returning();
+    if (!inst) throw new Error('Failed to create test instance');
+    testInstance = inst;
+    insertedInstanceIds.push(inst.id);
+  });
+
+  afterAll(async () => {
+    // Clean up sync jobs first (foreign key)
+    for (const id of insertedInstanceIds) {
+      await db.delete(syncJobs).where(eq(syncJobs.instanceId, id));
+      await db.delete(instances).where(eq(instances.id, id));
+    }
+  });
+
+  function createTestApp() {
+    const mockRegistry = {
+      get: mock(() => ({ capabilities: {} })),
+      getAll: mock(() => []),
+      has: mock(() => true),
+    };
+
+    const mockEventBus = {
+      subscribe: mock(async () => {}),
+      publish: mock(async () => ({ id: 'test-event-id', sequence: 1 })),
+      publishGeneric: mock(async () => ({ id: 'test-event-id', sequence: 1 })),
+      close: mock(async () => {}),
+    };
+
+    const app = new Hono<{ Variables: AppVariables }>();
+
+    app.onError((error, c) => {
+      if (error instanceof NotFoundError) {
+        return c.json({ error: { code: 'NOT_FOUND', message: error.message } }, 404);
+      }
+      return c.json({ error: { code: 'INTERNAL_ERROR', message: error.message } }, 500);
+    });
+
+    app.use('*', async (c, next) => {
+      c.set('services', services);
+      c.set('db', db);
+      c.set('channelRegistry', mockRegistry as unknown as AppVariables['channelRegistry']);
+      c.set('eventBus', mockEventBus as unknown as AppVariables['eventBus']);
+      c.set('apiKey', { id: 'test-key', name: 'test', scopes: ['*'], instanceIds: null, expiresAt: null });
+      await next();
+    });
+
+    app.route('/instances', instancesRoutes);
+
+    return app;
+  }
+
+  /** Insert a history-push sync job with the given status */
+  async function insertHistoryPushJob(status: 'pending' | 'running' | 'completed' | 'failed') {
+    const rows = await db
+      .insert(syncJobs)
+      .values({
+        instanceId: testInstance.id,
+        channel: 'whatsapp-baileys',
+        type: 'history-push' as const,
+        status,
+        config: {},
+        progress: { fetched: 0, stored: 0, duplicates: 0, mediaDownloaded: 0 },
+      })
+      .returning();
+    return rows[0];
+  }
+
+  /** Clean up all sync jobs for the test instance */
+  async function cleanSyncJobs() {
+    await db.delete(syncJobs).where(eq(syncJobs.instanceId, testInstance.id));
+  }
+
+  // ============================================================================
+  // POST /instances/:id/sync guards
+  // ============================================================================
+
+  test('POST /instances/:id/sync with type "messages" returns 409 when history-push is running', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('running');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'messages' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('history push sync is in progress');
+  });
+
+  test('POST /instances/:id/sync with chatJids returns 409 when history-push is running', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('running');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'messages', chatJids: ['test@s.whatsapp.net'] }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('history push sync is in progress');
+  });
+
+  test('POST /instances/:id/sync with type "messages" works when history-push is completed', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('completed');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'messages' }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  test('POST /instances/:id/sync with type "messages" works when no history-push job exists', async () => {
+    await cleanSyncJobs();
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'messages' }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  test('POST /instances/:id/sync with type "contacts" is NOT blocked by active history-push', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('running');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'contacts' }),
+    });
+
+    // Should not be 409 - contacts sync is allowed
+    expect(res.status).not.toBe(409);
+  });
+
+  test('POST /instances/:id/sync with type "groups" is NOT blocked by active history-push', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('running');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'groups' }),
+    });
+
+    // Should not be 409 - groups sync is allowed
+    expect(res.status).not.toBe(409);
+  });
+
+  test('POST /instances/:id/sync with type "profile" is NOT blocked by active history-push', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('running');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'profile' }),
+    });
+
+    // Profile sync redirects to internal handler; should not be 409
+    expect(res.status).not.toBe(409);
+  });
+
+  // ============================================================================
+  // POST /instances/:id/resync guards
+  // ============================================================================
+
+  test('POST /instances/:id/resync returns 409 when history-push is running', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('running');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/resync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ since: '2h' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('history push sync is in progress');
+  });
+
+  test('POST /instances/:id/resync works when history-push is completed', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('completed');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/resync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ since: '2h' }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /instances/:id/resync works when no history-push job exists', async () => {
+    await cleanSyncJobs();
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/resync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ since: '2h' }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /instances/:id/sync with type "messages" returns 409 when history-push is pending', async () => {
+    await cleanSyncJobs();
+    await insertHistoryPushJob('pending');
+    const app = createTestApp();
+
+    const res = await app.request(`/instances/${testInstance.id}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'messages' }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -34,6 +34,7 @@ import {
   setupConnectionListener,
   setupContactNamesListener,
   setupEventPersistence,
+  setupHistoryPushTracker,
   setupLidMappingListener,
   setupMediaProcessor,
   setupMessageListener,
@@ -282,6 +283,13 @@ async function setupEventBusServices(
     } catch (error) {
       log.error('Failed to set up sync worker', { error: String(error) });
     }
+  }
+
+  // History-push tracker (creates sync jobs on connect, tracks Baileys push progress)
+  try {
+    await setupHistoryPushTracker(eventBus, services);
+  } catch (error) {
+    log.error('Failed to set up history-push tracker', { error: String(error) });
   }
 }
 

--- a/packages/api/src/plugins/index.ts
+++ b/packages/api/src/plugins/index.ts
@@ -32,7 +32,7 @@ export { setupMediaProcessor } from './media-processor';
 export { setupAgentResponder } from './agent-dispatcher';
 
 // Sync worker (processes sync jobs)
-export { setupSyncWorker } from './sync-worker';
+export { setupHistoryPushTracker, setupSyncWorker } from './sync-worker';
 
 // Session cleaner (clears agent sessions on trash emoji)
 export { setupSessionCleaner } from './session-cleaner';

--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -848,3 +848,163 @@ async function processGroupsSync(
     updated,
   });
 }
+
+const historyPushLog = createLogger('history-push-tracker');
+
+/**
+ * Set up history-push sync tracker
+ *
+ * - Subscribes to `instance.connected` to auto-create a `history-push` sync job
+ * - Subscribes to `sync.progress` (jobType=history-push) to update sync job progress
+ * - Subscribes to `sync.completed` (jobType=history-push) to mark sync job completed
+ */
+export async function setupHistoryPushTracker(eventBus: EventBus, services: Services): Promise<void> {
+  try {
+    // 1. Create history-push sync job when an instance connects
+    await eventBus.subscribe(
+      'instance.connected',
+      async (event) => {
+        const { instanceId, channelType } = event.payload;
+
+        try {
+          // Create a running history-push sync job
+          const job = await services.syncJobs.create({
+            instanceId,
+            channelType,
+            type: 'history-push',
+          });
+
+          // Immediately start the job (set status to running)
+          await services.syncJobs.start(job.id);
+
+          historyPushLog.info('Created history-push sync job', {
+            jobId: job.id,
+            instanceId,
+            channel: channelType,
+          });
+        } catch (error) {
+          historyPushLog.error('Failed to create history-push sync job', {
+            instanceId,
+            error: String(error),
+          });
+        }
+      },
+      {
+        durable: 'history-push-creator',
+        startFrom: 'new',
+      },
+    );
+
+    // 2. Update history-push sync job progress from WhatsApp plugin events
+    await eventBus.subscribePattern(
+      'sync.progress.>',
+      async (event) => {
+        const payload = event.payload as {
+          instanceId?: string;
+          jobType?: string;
+          fetched?: number;
+          progress?: number;
+        };
+
+        // Only handle history-push progress events (from WhatsApp plugin)
+        if (payload.jobType !== 'history-push' || !payload.instanceId) return;
+
+        try {
+          // Find the active history-push job for this instance
+          const activeJobs = await services.syncJobs.getActiveForInstance(payload.instanceId);
+          const historyPushJob = activeJobs.find((j) => j.type === 'history-push');
+
+          if (!historyPushJob) {
+            historyPushLog.debug('No active history-push job found for progress update', {
+              instanceId: payload.instanceId,
+            });
+            return;
+          }
+
+          await services.syncJobs.updateProgress(historyPushJob.id, {
+            fetched: payload.fetched ?? 0,
+            stored: 0,
+            duplicates: 0,
+            mediaDownloaded: 0,
+            totalEstimated: payload.progress ? Math.round((payload.fetched ?? 0) / (payload.progress / 100)) : 0,
+          });
+
+          historyPushLog.debug('Updated history-push progress', {
+            jobId: historyPushJob.id,
+            instanceId: payload.instanceId,
+            fetched: payload.fetched,
+            progress: payload.progress,
+          });
+        } catch (error) {
+          historyPushLog.warn('Failed to update history-push progress', {
+            instanceId: payload.instanceId,
+            error: String(error),
+          });
+        }
+      },
+      {
+        durable: 'history-push-tracker',
+        startFrom: 'new',
+      },
+    );
+
+    // 3. Complete history-push sync job when WhatsApp signals completion
+    await eventBus.subscribePattern(
+      'sync.completed.>',
+      async (event) => {
+        const payload = event.payload as {
+          instanceId?: string;
+          jobType?: string;
+          totalFetched?: number;
+        };
+
+        // Only handle history-push completed events (from WhatsApp plugin)
+        if (payload.jobType !== 'history-push' || !payload.instanceId) return;
+
+        try {
+          // Find the active history-push job for this instance
+          const activeJobs = await services.syncJobs.getActiveForInstance(payload.instanceId);
+          const historyPushJob = activeJobs.find((j) => j.type === 'history-push');
+
+          if (!historyPushJob) {
+            historyPushLog.debug('No active history-push job found for completion', {
+              instanceId: payload.instanceId,
+            });
+            return;
+          }
+
+          // Update final progress
+          await services.syncJobs.updateProgress(historyPushJob.id, {
+            fetched: payload.totalFetched ?? 0,
+            stored: 0,
+            duplicates: 0,
+            mediaDownloaded: 0,
+          });
+
+          // Mark completed
+          await services.syncJobs.complete(historyPushJob.id);
+
+          historyPushLog.info('History-push sync completed', {
+            jobId: historyPushJob.id,
+            instanceId: payload.instanceId,
+            totalFetched: payload.totalFetched,
+          });
+        } catch (error) {
+          historyPushLog.warn('Failed to complete history-push sync job', {
+            instanceId: payload.instanceId,
+            error: String(error),
+          });
+        }
+      },
+      {
+        durable: 'history-push-completer',
+        startFrom: 'new',
+      },
+    );
+
+    historyPushLog.info('History-push tracker initialized');
+  } catch (error) {
+    historyPushLog.error('Failed to set up history-push tracker', { error: String(error) });
+    throw error;
+  }
+}

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -5,6 +5,7 @@
 import { zValidator } from '@hono/zod-validator';
 import type { ChannelPlugin, ChannelRegistry } from '@omni/channel-sdk';
 import { AccessModeSchema, ChannelTypeSchema, NotFoundError, createLogger } from '@omni/core';
+import type { SyncJobType } from '@omni/db';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { accessCache } from '../../cache/cache-keys';
@@ -1097,6 +1098,30 @@ instancesRoutes.put(
   },
 );
 
+/** Validate chatJids + history-push guard for message sync. Returns error tuple [message, status] or null. */
+async function validateMessageSyncPreconditions(
+  services: { syncJobs: { hasActiveJob: (id: string, type: SyncJobType) => Promise<boolean> } },
+  instanceId: string,
+  channel: string,
+  type: string,
+  chatJids?: string[],
+): Promise<{ error: string | { code: string; message: string }; status: 400 | 409 } | null> {
+  if (chatJids?.length && !channel.startsWith('whatsapp')) {
+    return {
+      error: { code: 'VALIDATION_ERROR', message: 'chatJids is only supported for WhatsApp instances' },
+      status: 400,
+    };
+  }
+  if ((type === 'messages' || chatJids?.length) && (await services.syncJobs.hasActiveJob(instanceId, 'history-push'))) {
+    return {
+      error:
+        'Cannot start manual sync while history push sync is in progress. Wait for the push sync to complete or check progress with GET /instances/:id/sync.',
+      status: 409,
+    };
+  }
+  return null;
+}
+
 /**
  * POST /instances/:id/sync - Request a sync operation
  *
@@ -1159,13 +1184,9 @@ instancesRoutes.post('/:id/sync', instanceAccess, zValidator('json', syncRequest
     });
   }
 
-  // chatJids is only supported for WhatsApp instances
-  if (chatJids?.length && !instance.channel.startsWith('whatsapp')) {
-    return c.json(
-      { error: { code: 'VALIDATION_ERROR', message: 'chatJids is only supported for WhatsApp instances' } },
-      400,
-    );
-  }
+  // Validate chatJids support + history-push guard
+  const preconditionError = await validateMessageSyncPreconditions(services, id, instance.channel, type, chatJids);
+  if (preconditionError) return c.json({ error: preconditionError.error }, preconditionError.status);
 
   // For other sync types, check for existing active job
   const hasActiveJob = await services.syncJobs.hasActiveJob(id, type);
@@ -2301,6 +2322,10 @@ instancesRoutes.post('/:id/resync', instanceAccess, zValidator('json', resyncSch
   if (!channelRegistry || !eventBus) {
     return c.json({ error: { code: 'NOT_AVAILABLE', message: 'Channel registry or event bus not available' } }, 503);
   }
+
+  // Guard: block resync while a history-push job is active
+  const guardError = await validateMessageSyncPreconditions(services, id, instance.channel, 'messages');
+  if (guardError) return c.json({ error: guardError.error }, guardError.status);
 
   const sinceDate = parseSince(since);
   const untilDate = until ? new Date(until) : new Date();

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -538,12 +538,16 @@ const MEDIA_BASE_PATH = process.env.MEDIA_STORAGE_PATH || './data/media';
  * Download media from a message and return the API-serving URL.
  *
  * Stores at: data/media/{instanceId}/{YYYY-MM}/{externalId}.{ext}
- * Returns:   /api/v2/media/{instanceId}/{YYYY-MM}/{externalId}.{ext}
+ * Returns:   {apiBaseUrl}/api/v2/media/{instanceId}/{YYYY-MM}/{externalId}.{ext}
+ *
+ * When apiBaseUrl is provided, returns an absolute URL (e.g. http://host:port/api/v2/media/...).
+ * This is required for downstream consumers like the media processor that use fetch().
  */
 export async function tryDownloadMedia(
   msg: WAMessage,
   instanceId: string,
   externalId: string,
+  apiBaseUrl?: string,
 ): Promise<{ mediaUrl: string; mediaLocalPath: string; mimeType: string; size: number } | null> {
   const mediaInfo = detectMediaType(msg);
   if (!mediaInfo) return null;
@@ -591,8 +595,9 @@ export async function tryDownloadMedia(
 
     log.debug('Downloaded media', { externalId, path: relativePath, size: result.buffer.length });
 
+    const mediaPath = `/api/v2/media/${relativePath}`;
     return {
-      mediaUrl: `/api/v2/media/${relativePath}`,
+      mediaUrl: apiBaseUrl ? `${apiBaseUrl}${mediaPath}` : mediaPath,
       mediaLocalPath: relativePath,
       mimeType: result.mimeType,
       size: result.buffer.length,
@@ -780,7 +785,7 @@ async function processMessage(
   }
 
   // Download media if present (non-blocking on failure)
-  const mediaResult = await tryDownloadMedia(msg, instanceId, externalId);
+  const mediaResult = await tryDownloadMedia(msg, instanceId, externalId, plugin.getApiBaseUrl());
   if (mediaResult) {
     content.mediaUrl = mediaResult.mediaUrl;
     content.mediaLocalPath = mediaResult.mediaLocalPath;

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -227,6 +227,9 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     }
   >();
 
+  /** Tracks total messages fetched during initial history push (no explicit sync job) per instance */
+  private historyPushFetchCount = new Map<string, number>();
+
   /** Cached contacts from sync events per instance */
   private contactsCache = new Map<string, Map<string, SyncContact>>();
 
@@ -422,6 +425,14 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    */
   getMeJid(instanceId: string): string | undefined {
     return this.sockets.get(instanceId)?.user?.id;
+  }
+
+  /**
+   * Get the API base URL (e.g., "http://localhost:8881") for constructing absolute media URLs.
+   * Used by message handlers so that tryDownloadMedia() returns fetch-able URLs.
+   */
+  getApiBaseUrl(): string {
+    return this.config.apiBaseUrl;
   }
 
   /**
@@ -3321,7 +3332,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     }
 
     // Download media if present (same as realtime messages)
-    const mediaResult = await tryDownloadMedia(msg, instanceId, msg.key.id);
+    const mediaResult = await tryDownloadMedia(msg, instanceId, msg.key.id, this.config.apiBaseUrl);
     if (mediaResult) {
       content.mediaUrl = mediaResult.mediaUrl;
       // Note: content doesn't have mediaLocalPath field, but mediaUrl is enough for storage
@@ -3428,9 +3439,37 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     isLatest: boolean | undefined,
     messageCount: number,
   ): void {
-    // Report progress
+    // Report progress via sync state callbacks (explicit sync jobs)
     if (syncState?.onProgress && progress !== undefined && progress !== null) {
       syncState.onProgress(syncState.totalFetched, progress);
+    }
+
+    // Track and publish history-push progress via NATS (initial connection push)
+    if (!syncState) {
+      const prevCount = this.historyPushFetchCount.get(instanceId) ?? 0;
+      const totalFetched = prevCount + messageCount;
+      this.historyPushFetchCount.set(instanceId, totalFetched);
+
+      const meta = { instanceId, channelType: this.id };
+
+      // Publish sync.progress event
+      this.eventBus
+        .publishGeneric(
+          'sync.progress' as const,
+          { instanceId, jobType: 'history-push', fetched: totalFetched, progress: progress ?? 0 },
+          meta,
+        )
+        .catch((err) => this.logger.warn('Failed to publish sync.progress for history-push', { error: String(err) }));
+
+      // Publish sync.completed when Baileys signals completion
+      if (isLatest || progress === 100) {
+        this.eventBus
+          .publishGeneric('sync.completed' as const, { instanceId, jobType: 'history-push', totalFetched }, meta)
+          .catch((err) =>
+            this.logger.warn('Failed to publish sync.completed for history-push', { error: String(err) }),
+          );
+        this.historyPushFetchCount.delete(instanceId);
+      }
     }
 
     // Check if sync is complete

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -387,7 +387,7 @@ export interface SyncJobProgress {
   totalEstimated?: number;
 }
 
-export type SyncJobType = 'profile' | 'messages' | 'contacts' | 'groups' | 'all';
+export type SyncJobType = 'profile' | 'messages' | 'contacts' | 'groups' | 'all' | 'history-push';
 
 export interface SyncStartedPayload {
   jobId: string;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1314,7 +1314,7 @@ export const batchJobs = pgTable(
 // SYNC JOBS
 // ============================================================================
 
-export const syncJobTypes = ['profile', 'messages', 'contacts', 'groups', 'all'] as const;
+export const syncJobTypes = ['profile', 'messages', 'contacts', 'groups', 'all', 'history-push'] as const;
 export type SyncJobType = (typeof syncJobTypes)[number];
 
 /**


### PR DESCRIPTION
## Summary
- **Auto-create `history-push` sync job** on every `instance.connected` — tracks Baileys push progress via NATS `sync.progress`/`sync.completed` events with native `progress`/`isLatest` signals
- **Fix `tryDownloadMedia()` to return absolute URLs** — prepends `apiBaseUrl` from plugin context, fixing `ERR_INVALID_URL` in media processor
- **Guard manual per-chat sync** with 409 Conflict when a history-push job is still running

## Test plan
- [ ] Delete existing WhatsApp instance, recreate, pair, and verify `omni instances syncs <id>` shows a `history-push` job with real-time progress
- [ ] Confirm sync job transitions to `completed` when Baileys finishes pushing history
- [ ] Verify media from history sync downloads successfully (no `ERR_INVALID_URL` in logs)
- [ ] Attempt manual sync while push is running — expect 409 response
- [ ] Attempt manual sync after push completes — expect success
- [ ] Verify profile/contacts/groups sync types are NOT blocked by the guard
- [ ] Run `bun test src/__tests__/history-push-guard.test.ts` — 11 tests pass

Wish: `whatsapp-reconnect-bugs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)