### PR TITLE
fix(channel-sdk): remove dead buildSubject assignments in BaseChannelPlugin (#89)

### DIFF
--- a/packages/channel-sdk/src/base/BaseChannelPlugin.ts
+++ b/packages/channel-sdk/src/base/BaseChannelPlugin.ts
@@ -10,7 +10,6 @@
 
 import { generateCorrelationId } from '@omni/core';
 import type { EventBus } from '@omni/core/events';
-import { buildSubject } from '@omni/core/events/nats';
 import { JOURNEY_STAGES, getJourneyTracker } from '@omni/core/tracing';
 import type { ChannelType } from '@omni/core/types';
 import type {
@@ -325,7 +324,6 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    * });
    */
   protected async emitMessageReceived(params: EmitMessageReceivedParams): Promise<string> {
-    const _subject = buildSubject('message.received', this.id, params.instanceId);
     const correlationId = generateCorrelationId('evt');
 
     await this.eventBus.publish(
@@ -358,8 +356,6 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    * Emit message.sent event with hierarchical subject
    */
   protected async emitMessageSent(params: EmitMessageSentParams): Promise<void> {
-    const _subject = buildSubject('message.sent', this.id, params.instanceId);
-
     await this.eventBus.publish(
       'message.sent',
       {
@@ -386,8 +382,6 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    * Emit message.failed event
    */
   protected async emitMessageFailed(params: EmitMessageFailedParams): Promise<void> {
-    const _subject = buildSubject('message.failed', this.id, params.instanceId);
-
     await this.eventBus.publish(
       'message.failed',
       {
@@ -530,8 +524,6 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    * Emit message.button_click event
    */
   protected async emitButtonClick(params: EmitButtonClickParams): Promise<void> {
-    const _subject = buildSubject('message.button_click', this.id, params.instanceId);
-
     await this.eventBus.publish(
       'message.button_click',
       {
@@ -563,8 +555,6 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    * Emit message.poll event
    */
   protected async emitPoll(params: EmitPollParams): Promise<void> {
-    const _subject = buildSubject('message.poll', this.id, params.instanceId);
-
     await this.eventBus.publish(
       'message.poll',
       {
@@ -596,8 +586,6 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    * Emit message.poll_vote event
    */
   protected async emitPollVote(params: EmitPollVoteParams): Promise<void> {
-    const _subject = buildSubject('message.poll_vote', this.id, params.instanceId);
-
     await this.eventBus.publish(
       'message.poll_vote',
       {


### PR DESCRIPTION
## Summary

- Removes 6 unused `const _subject = buildSubject(...)` assignments from `BaseChannelPlugin` — return value was never read in any of the 6 emit methods
- Removes the now-unused `buildSubject` import from `BaseChannelPlugin.ts`
- `buildSubject` itself remains: still used by the NATS client internally and re-exported via `@omni/channel-sdk` for downstream consumers

Closes #89

## Acceptance Criteria

- [x] All 6 dead `_subject` assignments removed (`emitMessageReceived`, `emitMessageSent`, `emitMessageFailed`, `emitButtonClick`, `emitPoll`, `emitPollVote`)
- [x] `buildSubject` import removed from `BaseChannelPlugin.ts`
- [x] `make check` green (typecheck + biome pass; 1 pre-existing test failure in `cli/config.test.ts` due to local `DATABASE_URL` env var on port 8432 — unrelated to this change)

## Test plan

- [x] `bunx biome check .` — no issues
- [x] `turbo typecheck` — all 16 packages pass
- [x] Verified pre-existing test failure exists on `main` with no changes (env-specific, not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discord Components v2 support with builders for text displays, files, sections, media galleries, separators, and containers.
  * Introduced thread management capabilities: create threads, forum posts, archive threads, and add thread members.
  * Added entity select menu builders for user, role, channel, and mentionable selections.
  * Implemented role-based interaction authorization for Discord component interactions.
  * Added component lifecycle management with TTL support and automatic cleanup.

* **Chores**
  * Updated package versions across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->