### PR TITLE
fix(inbox-bridge): resolve templated agent names when polling inboxes

### DIFF
--- a/packages/api/src/plugins/inbox-bridge.ts
+++ b/packages/api/src/plugins/inbox-bridge.ts
@@ -4,8 +4,9 @@
  * Internal API plugin that polls Claude Code team inboxes and forwards replies
  * back to the originating channel via the channel registry (no HTTP round-trip).
  *
- * - Discovers genie providers from DB every 60s to build agentName set
- * - Polls ~/.claude/teams/{team}/inboxes/{agentName}.json every 2s
+ * - Discovers genie providers from DB every 60s to build agent name patterns
+ * - For static names: polls ~/.claude/teams/{team}/inboxes/{agentName}.json
+ * - For templated names: scans inboxes/ directory for matching files
  * - Uses cursor file (~/.claude/bridge/state.json) to track lastIndex per inbox
  * - Sends via channelRegistry.get(channel) -> plugin.sendMessage() directly
  * - Never writes to the inbox files (read-only)
@@ -24,6 +25,8 @@ const CLAUDE_TEAMS_DIR = join(homedir(), '.claude', 'teams');
 const BRIDGE_STATE_PATH = join(homedir(), '.claude', 'bridge', 'state.json');
 const POLL_INTERVAL_MS = 2_000;
 const DISCOVERY_INTERVAL_MS = 60_000;
+/** Prune cursor entries older than 24h for dynamic inboxes that no longer exist */
+const CURSOR_TTL_MS = 24 * 60 * 60 * 1_000;
 
 // ============================================================================
 // Types
@@ -49,8 +52,30 @@ interface ParsedMetadata {
   cleanText: string;
 }
 
+interface CursorEntry {
+  lastIndex: number;
+  /** Timestamp of last successful read (for TTL-based pruning) */
+  lastSeen?: number;
+}
+
 interface BridgeState {
-  cursors: Record<string, { lastIndex: number }>;
+  cursors: Record<string, CursorEntry>;
+}
+
+/**
+ * An agent name pattern — either a static exact name or a template pattern
+ * that matches multiple dynamic inbox files.
+ */
+interface AgentPattern {
+  /** The raw config value (e.g. "omni" or "omni-{thread_id}") */
+  raw: string;
+  /** Whether the pattern contains template variables */
+  isTemplate: boolean;
+  /**
+   * For static names: the sanitized exact name (e.g. "omni")
+   * For templates: the static prefix before the first variable (e.g. "omni-")
+   */
+  prefix: string;
 }
 
 // ============================================================================
@@ -99,6 +124,98 @@ function parseMetadata(text: string): ParsedMetadata {
 }
 
 // ============================================================================
+// Agent pattern helpers
+// ============================================================================
+
+/** Sanitize a string for use in file paths — same logic as genie-client.ts */
+function sanitize(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '');
+}
+
+/**
+ * Extract the static prefix from a template string.
+ * "omni-{thread_id}" → "omni-"
+ * "{channel}-{thread_id}" → "" (empty — matches everything)
+ * "omni" → "omni" (no template — exact match)
+ */
+function extractStaticPrefix(template: string): string {
+  const firstBrace = template.indexOf('{');
+  if (firstBrace === -1) return sanitize(template);
+  // Sanitize only the portion before the first template variable
+  return sanitize(template.substring(0, firstBrace));
+}
+
+/**
+ * Build AgentPattern from a raw config value.
+ */
+function buildPattern(raw: string): AgentPattern {
+  const isTemplate = /\{\w+\}/.test(raw);
+  return {
+    raw,
+    isTemplate,
+    prefix: isTemplate ? extractStaticPrefix(raw) : sanitize(raw),
+  };
+}
+
+/** Check if a filename (without .json) matches any of the template prefixes */
+function matchesAnyPrefix(baseName: string, prefixes: string[]): boolean {
+  for (const prefix of prefixes) {
+    // Empty prefix means the entire name is templated — match everything
+    if (prefix === '' || baseName.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/** Separate patterns into static names and template prefixes */
+function partitionPatterns(patterns: AgentPattern[]): { staticNames: string[]; templatePrefixes: string[] } {
+  const staticNames: string[] = [];
+  const templatePrefixes: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.isTemplate) {
+      templatePrefixes.push(pattern.prefix);
+    } else if (pattern.prefix) {
+      staticNames.push(pattern.prefix);
+    }
+  }
+  return { staticNames, templatePrefixes };
+}
+
+/** Scan an inboxes directory for .json files matching any template prefix */
+async function scanInboxDir(inboxDir: string, prefixes: string[]): Promise<string[]> {
+  const matched: string[] = [];
+  try {
+    const entries = await readdir(inboxDir);
+    for (const entry of entries) {
+      if (!entry.endsWith('.json') || entry.endsWith('.tmp') || entry.endsWith('.lock')) continue;
+      const baseName = entry.slice(0, -5); // strip .json
+      if (baseName && matchesAnyPrefix(baseName, prefixes)) {
+        matched.push(baseName);
+      }
+    }
+  } catch {
+    // Directory doesn't exist yet — fine, no inboxes to poll
+  }
+  return matched;
+}
+
+/**
+ * Given a set of patterns and an inboxes directory, resolve the actual inbox
+ * file names we should poll. Static patterns produce exact names; template
+ * patterns scan the directory and match by prefix.
+ */
+async function resolveInboxNames(patterns: AgentPattern[], inboxDir: string): Promise<string[]> {
+  const { staticNames, templatePrefixes } = partitionPatterns(patterns);
+  const names = new Set<string>(staticNames);
+
+  if (templatePrefixes.length > 0) {
+    const dynamicNames = await scanInboxDir(inboxDir, templatePrefixes);
+    for (const name of dynamicNames) names.add(name);
+  }
+
+  return [...names];
+}
+
+// ============================================================================
 // State management
 // ============================================================================
 
@@ -116,13 +233,35 @@ async function saveState(state: BridgeState): Promise<void> {
   await writeFile(BRIDGE_STATE_PATH, JSON.stringify(state, null, 2), 'utf-8');
 }
 
+/**
+ * Prune cursor entries that haven't been seen in CURSOR_TTL_MS.
+ * Dynamic inboxes come and go — without pruning, state.json grows unbounded.
+ */
+function pruneStaleCursors(state: BridgeState): boolean {
+  const now = Date.now();
+  let pruned = false;
+  for (const key of Object.keys(state.cursors)) {
+    const entry = state.cursors[key];
+    if (entry?.lastSeen && now - entry.lastSeen > CURSOR_TTL_MS) {
+      delete state.cursors[key];
+      pruned = true;
+    }
+  }
+  return pruned;
+}
+
 // ============================================================================
 // Agent discovery
 // ============================================================================
 
-async function discoverAgentNames(services: Services): Promise<Set<string>> {
+/**
+ * Discover agent patterns from active genie providers.
+ * Returns patterns that may be static names or template patterns.
+ */
+async function discoverAgentPatterns(services: Services): Promise<AgentPattern[]> {
   const providers = await services.providers.list({ active: true });
-  const names = new Set<string>();
+  const patterns: AgentPattern[] = [];
+  const seen = new Set<string>();
 
   for (const provider of providers) {
     if (provider.schema !== 'genie') continue;
@@ -130,11 +269,18 @@ async function discoverAgentNames(services: Services): Promise<Set<string>> {
       typeof provider.schemaConfig === 'object' && provider.schemaConfig !== null
         ? (provider.schemaConfig as Record<string, unknown>)
         : {};
-    const agentName = typeof config.agentName === 'string' ? config.agentName.replace(/[^a-zA-Z0-9_-]/g, '') : null;
-    if (agentName) names.add(agentName);
+    const agentName = typeof config.agentName === 'string' ? config.agentName : null;
+    if (!agentName || seen.has(agentName)) continue;
+    seen.add(agentName);
+
+    const pattern = buildPattern(agentName);
+    // Skip patterns that resolve to empty prefix with no template
+    // (e.g. someone stored agentName = "!!!" → sanitize → "")
+    if (!pattern.isTemplate && !pattern.prefix) continue;
+    patterns.push(pattern);
   }
 
-  return names;
+  return patterns;
 }
 
 // ============================================================================
@@ -150,20 +296,45 @@ async function listTeams(): Promise<string[]> {
   }
 }
 
+/**
+ * Check if a message sender matches any of the configured agent patterns.
+ * Used for echo prevention — we skip messages that the agent itself sent.
+ *
+ * For static configs: msg.from === "omni" matches pattern prefix "omni"
+ * For template configs: msg.from === "omni-123" matches pattern prefix "omni-"
+ */
+function isSelfMessage(from: string, inboxName: string, patterns: AgentPattern[]): boolean {
+  // Direct match: the message sender is the inbox owner
+  if (from === inboxName) return true;
+
+  // Pattern match: sender matches any configured agent pattern
+  for (const pattern of patterns) {
+    if (pattern.isTemplate) {
+      // For templates, the sender's name starts with the same prefix
+      if (pattern.prefix === '' || from.startsWith(pattern.prefix)) return true;
+    } else {
+      if (from === pattern.prefix) return true;
+    }
+  }
+
+  return false;
+}
+
 /** Send one inbox message to the appropriate channel plugin. Returns 'retry' on exception. */
 async function sendInboxMessage(
   msg: InboxMessage,
-  agentName: string,
+  inboxName: string,
   team: string,
   channelRegistry: ChannelRegistry,
+  patterns: AgentPattern[],
 ): Promise<'ok' | 'retry'> {
   // Skip messages from the agent itself (echo prevention)
-  if (msg.from === agentName) return 'ok';
+  if (isSelfMessage(msg.from, inboxName, patterns)) return 'ok';
 
   const parsed = parseMetadata(msg.text);
 
   if (!parsed.instance || !parsed.chat || !parsed.channel) {
-    log.debug('Skipping message — missing routing metadata', { team, agentName, from: msg.from });
+    log.debug('Skipping message — missing routing metadata', { team, inboxName, from: msg.from });
     return 'ok';
   }
 
@@ -171,7 +342,7 @@ async function sendInboxMessage(
 
   const plugin = channelRegistry.get(parsed.channel as Parameters<typeof channelRegistry.get>[0]);
   if (!plugin) {
-    log.warn('Channel plugin not found', { channel: parsed.channel, team, agentName });
+    log.warn('Channel plugin not found', { channel: parsed.channel, team, inboxName });
     return 'ok';
   }
 
@@ -187,7 +358,7 @@ async function sendInboxMessage(
     if (result.success) {
       log.info('Forwarded reply', {
         team,
-        agentName,
+        inboxName,
         channel: parsed.channel,
         instance: parsed.instance,
         chat: parsed.chat,
@@ -195,13 +366,13 @@ async function sendInboxMessage(
         messageId: result.messageId,
       });
     } else {
-      log.error('sendMessage failed', { team, agentName, channel: parsed.channel, error: result.error });
+      log.error('sendMessage failed', { team, inboxName, channel: parsed.channel, error: result.error });
     }
     // sendMessage returned false (not a throw): advance cursor anyway to avoid an infinite
     // retry loop on persistently failing channels. The error is logged above.
     return 'ok';
   } catch (err) {
-    log.error('sendMessage threw', { team, agentName, error: String(err) });
+    log.error('sendMessage threw', { team, inboxName, error: String(err) });
     return 'retry'; // Don't advance cursor — retry on next poll
   }
 }
@@ -211,13 +382,14 @@ async function sendInboxMessage(
  * On first encounter, initializes cursor to current inbox length (skips history).
  */
 async function processInbox(
-  agentName: string,
+  inboxName: string,
   team: string,
   state: BridgeState,
   channelRegistry: ChannelRegistry,
+  patterns: AgentPattern[],
 ): Promise<boolean> {
-  const inboxPath = join(CLAUDE_TEAMS_DIR, team, 'inboxes', `${agentName}.json`);
-  const cursorKey = `${team}/${agentName}`;
+  const inboxPath = join(CLAUDE_TEAMS_DIR, team, 'inboxes', `${inboxName}.json`);
+  const cursorKey = `${team}/${inboxName}`;
 
   let inbox: InboxMessage[];
   try {
@@ -228,32 +400,51 @@ async function processInbox(
     return false; // File doesn't exist or invalid — skip
   }
 
+  const now = Date.now();
+
   // First time seeing this inbox: set cursor to current length (skip history)
   if (!(cursorKey in state.cursors)) {
-    state.cursors[cursorKey] = { lastIndex: inbox.length };
+    state.cursors[cursorKey] = { lastIndex: inbox.length, lastSeen: now };
     return true;
   }
 
-  const { lastIndex } = state.cursors[cursorKey] ?? { lastIndex: 0 };
-  if (lastIndex >= inbox.length) return false; // No new messages
+  const entry = state.cursors[cursorKey] ?? { lastIndex: 0 };
+  let { lastIndex } = entry;
+
+  // Edge case: inbox was truncated/rotated — reset cursor to avoid being stuck forever
+  if (lastIndex > inbox.length) {
+    log.warn('Inbox shrank (truncated/rotated), resetting cursor', {
+      team,
+      inboxName,
+      oldCursor: lastIndex,
+      newLength: inbox.length,
+    });
+    lastIndex = 0;
+  }
+
+  if (lastIndex >= inbox.length) {
+    // No new messages, but update lastSeen for TTL tracking
+    state.cursors[cursorKey] = { lastIndex, lastSeen: now };
+    return false;
+  }
 
   let processed = 0;
   for (const msg of inbox.slice(lastIndex)) {
-    const sendResult = await sendInboxMessage(msg, agentName, team, channelRegistry);
+    const sendResult = await sendInboxMessage(msg, inboxName, team, channelRegistry, patterns);
     if (sendResult === 'retry') break; // Don't advance cursor — retry on next poll
     processed++;
   }
 
   if (processed > 0) {
-    state.cursors[cursorKey] = { lastIndex: lastIndex + processed };
+    state.cursors[cursorKey] = { lastIndex: lastIndex + processed, lastSeen: now };
     return true;
   }
 
   return false;
 }
 
-async function pollInboxes(agentNames: Set<string>, channelRegistry: ChannelRegistry): Promise<void> {
-  if (agentNames.size === 0) return;
+async function pollInboxes(patterns: AgentPattern[], channelRegistry: ChannelRegistry): Promise<void> {
+  if (patterns.length === 0) return;
 
   const teams = await listTeams();
   if (teams.length === 0) return;
@@ -261,12 +452,21 @@ async function pollInboxes(agentNames: Set<string>, channelRegistry: ChannelRegi
   const state = await loadState();
   let stateChanged = false;
 
-  for (const agentName of agentNames) {
-    for (const team of teams) {
-      if (await processInbox(agentName, team, state, channelRegistry)) {
+  for (const team of teams) {
+    const inboxDir = join(CLAUDE_TEAMS_DIR, team, 'inboxes');
+    // Resolve dynamic inbox names by scanning the directory for template patterns
+    const inboxNames = await resolveInboxNames(patterns, inboxDir);
+
+    for (const inboxName of inboxNames) {
+      if (await processInbox(inboxName, team, state, channelRegistry, patterns)) {
         stateChanged = true;
       }
     }
+  }
+
+  // Periodically prune stale cursor entries from deleted dynamic inboxes
+  if (pruneStaleCursors(state)) {
+    stateChanged = true;
   }
 
   if (stateChanged) {
@@ -282,12 +482,14 @@ export async function setupInboxBridge(
   services: Services,
   channelRegistry: ChannelRegistry,
 ): Promise<() => Promise<void>> {
-  let agentNames: Set<string> = new Set();
+  let patterns: AgentPattern[] = [];
 
   // Initial discovery
   try {
-    agentNames = await discoverAgentNames(services);
-    log.info('Inbox bridge started', { agents: [...agentNames] });
+    patterns = await discoverAgentPatterns(services);
+    log.info('Inbox bridge started', {
+      patterns: patterns.map((p) => ({ raw: p.raw, isTemplate: p.isTemplate, prefix: p.prefix })),
+    });
   } catch (err) {
     log.warn('Initial agent discovery failed', { error: String(err) });
   }
@@ -295,8 +497,10 @@ export async function setupInboxBridge(
   // Discovery refresh timer
   const discoveryTimer = setInterval(async () => {
     try {
-      agentNames = await discoverAgentNames(services);
-      log.debug('Agent names refreshed', { agents: [...agentNames] });
+      patterns = await discoverAgentPatterns(services);
+      log.debug('Agent patterns refreshed', {
+        patterns: patterns.map((p) => ({ raw: p.raw, isTemplate: p.isTemplate, prefix: p.prefix })),
+      });
     } catch (err) {
       log.warn('Agent discovery refresh failed', { error: String(err) });
     }
@@ -309,7 +513,7 @@ export async function setupInboxBridge(
     if (polling) return;
     polling = true;
     try {
-      await pollInboxes(agentNames, channelRegistry);
+      await pollInboxes(patterns, channelRegistry);
     } catch (err) {
       log.error('Poll cycle error', { error: String(err) });
     } finally {

--- a/packages/core/src/providers/__tests__/genie-client-auto-spawn.test.ts
+++ b/packages/core/src/providers/__tests__/genie-client-auto-spawn.test.ts
@@ -18,8 +18,8 @@ import type { ProviderRequest } from '../types';
 // Mocks
 // ============================================================================
 
-// Mock child_process.exec to capture auto-spawn calls
-const execMock = mock((_cmd: string, cb: (error: Error | null) => void) => {
+// Mock child_process.execFile to capture auto-spawn calls
+const execFileMock = mock((_file: string, _args: string[], cb: (error: Error | null) => void) => {
   cb(null);
 });
 
@@ -27,7 +27,7 @@ const execMock = mock((_cmd: string, cb: (error: Error | null) => void) => {
 const TEST_DIR = '/tmp/genie-client-auto-spawn-test';
 
 mock.module('node:child_process', () => ({
-  exec: execMock,
+  execFile: execFileMock,
 }));
 
 mock.module('node:os', () => ({
@@ -65,7 +65,7 @@ function makeConfig(overrides?: Partial<GenieClientConfig>): GenieClientConfig {
 beforeEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
   mkdirSync(TEST_DIR, { recursive: true });
-  execMock.mockClear();
+  execFileMock.mockClear();
 });
 
 afterEach(() => {
@@ -122,9 +122,13 @@ describe('GenieClient auto-spawn on run()', () => {
     // Give fire-and-forget stat() a tick to resolve
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(execMock).toHaveBeenCalledTimes(1);
-    const cmd = execMock.mock.calls[0]?.[0] as string;
-    expect(cmd).toContain('genie team ensure test-team');
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const file = execFileMock.mock.calls[0]?.[0] as string;
+    const args = execFileMock.mock.calls[0]?.[1] as string[];
+    expect(file).toBe('genie');
+    expect(args).toContain('team');
+    expect(args).toContain('ensure');
+    expect(args).toContain('test-team');
   });
 
   test('includes --dir flag with autoSpawnDir', async () => {
@@ -133,9 +137,10 @@ describe('GenieClient auto-spawn on run()', () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(execMock).toHaveBeenCalledTimes(1);
-    const cmd = execMock.mock.calls[0]?.[0] as string;
-    expect(cmd).toContain('--dir "/my/workspace"');
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const args = execFileMock.mock.calls[0]?.[1] as string[];
+    expect(args).toContain('--dir');
+    expect(args).toContain('/my/workspace');
   });
 
   test('does not call exec when team config already exists', async () => {
@@ -149,7 +154,7 @@ describe('GenieClient auto-spawn on run()', () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   test('does not call exec when autoSpawn is disabled', async () => {
@@ -158,7 +163,7 @@ describe('GenieClient auto-spawn on run()', () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   test('caches known teams and skips filesystem check on second call', async () => {
@@ -168,15 +173,15 @@ describe('GenieClient auto-spawn on run()', () => {
     await client.run(makeRequest());
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
 
-    execMock.mockClear();
+    execFileMock.mockClear();
 
     // Second call: team should be cached (exec succeeded), no new exec
     await client.run(makeRequest('second message'));
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   test('caches known teams after finding config on disk', async () => {
@@ -198,11 +203,11 @@ describe('GenieClient auto-spawn on run()', () => {
     await client.run(makeRequest('second'));
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   test('does not block response even if exec fails', async () => {
-    execMock.mockImplementation((_cmd: string, cb: (error: Error | null) => void) => {
+    execFileMock.mockImplementation((_file: string, _args: string[], cb: (error: Error | null) => void) => {
       cb(new Error('genie not found'));
     });
 

--- a/packages/core/src/providers/genie-client.ts
+++ b/packages/core/src/providers/genie-client.ts
@@ -6,7 +6,7 @@
  * No outbox, no polling.
  */
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -90,6 +90,8 @@ export class GenieClient implements IAgentClient {
 
   /** Cache of teams known to exist (avoids repeated filesystem checks) */
   private readonly knownTeams = new Set<string>();
+  /** Teams currently being spawned (prevents duplicate exec calls during bursts) */
+  private readonly pendingTeams = new Set<string>();
 
   constructor(config: GenieClientConfig) {
     this.teamNameTemplate = config.teamName ?? 'genie';
@@ -127,6 +129,28 @@ export class GenieClient implements IAgentClient {
       targetAgent = sanitize(this.targetAgentTemplate);
     }
 
+    // Fail fast if template variables resolved to empty strings.
+    // Without this, we'd write to paths like "inboxes/.json" or merge
+    // unrelated conversations into the same inbox file.
+    if (!teamName) {
+      throw new ProviderError(
+        `Team name resolved to empty string (template: "${this.teamNameTemplate}"). Ensure the template variable (e.g. {thread_id}) is populated in the request.`,
+        'INVALID_RESPONSE',
+      );
+    }
+    if (!agentName) {
+      throw new ProviderError(
+        `Agent name resolved to empty string (template: "${this.agentNameTemplate}"). Ensure the template variable is populated in the request.`,
+        'INVALID_RESPONSE',
+      );
+    }
+    if (!targetAgent) {
+      throw new ProviderError(
+        `Target agent resolved to empty string (template: "${this.targetAgentTemplate}"). Ensure the template variable is populated in the request.`,
+        'INVALID_RESPONSE',
+      );
+    }
+
     const inboxDir = join(homedir(), '.claude', 'teams', teamName, 'inboxes');
     const inboxPath = join(inboxDir, `${targetAgent}.json`);
 
@@ -137,24 +161,32 @@ export class GenieClient implements IAgentClient {
    * Fire-and-forget: ensure team-lead exists for the given team.
    * Checks if ~/.claude/teams/<team>/config.json exists; if not,
    * spawns `genie team ensure` in background without blocking.
+   *
+   * Uses pendingTeams set to coalesce concurrent requests for the same team,
+   * preventing process storms during traffic bursts.
    */
   private ensureTeamExists(teamName: string): void {
     if (!this.autoSpawn) return;
     if (this.knownTeams.has(teamName)) return;
+    if (this.pendingTeams.has(teamName)) return; // Already checking/spawning
 
+    this.pendingTeams.add(teamName);
     const configPath = join(homedir(), '.claude', 'teams', teamName, 'config.json');
 
     stat(configPath)
       .then(() => {
         // Team exists — cache it
         this.knownTeams.add(teamName);
+        this.pendingTeams.delete(teamName);
       })
       .catch(() => {
         // Team doesn't exist — spawn team-lead in background
-        const cmd = `genie team ensure ${teamName} --dir "${this.autoSpawnDir}"`;
-        log.info('Auto-spawning team-lead', { teamName, cmd });
+        // Use execFile instead of exec to avoid shell injection via teamName
+        const args = ['team', 'ensure', teamName, '--dir', this.autoSpawnDir];
+        log.info('Auto-spawning team-lead', { teamName, args });
 
-        exec(cmd, (error) => {
+        execFile('genie', args, (error) => {
+          this.pendingTeams.delete(teamName);
           if (error) {
             log.warn('Auto-spawn failed (genie CLI may not be installed)', {
               teamName,


### PR DESCRIPTION
## Summary

Fixes the P1 bug flagged by Codex in PR #176 where the inbox-bridge silently drops all replies from templated Genie providers.

**Root cause:** `discoverAgentNames()` sanitized raw template strings (e.g. `omni-{thread_id}` → `omni-thread_id`) and polled that literal filename. Meanwhile, `GenieClient.resolveConfig()` interpolated templates per-request (e.g. `omni-123`), writing replies to dynamic inbox files. The bridge never found those files — replies vanished silently.

**The fix replaces static name discovery with pattern-based resolution:**

- **Template patterns** → scan `inboxes/` directory, match files by static prefix (e.g. `omni-*`)
- **Static names** → exact filename match (unchanged behavior)
- **Cursor TTL pruning** → stale entries from deleted dynamic inboxes are cleaned up after 24h
- **Inbox shrink detection** → cursor resets instead of getting stuck forever when file is truncated
- **Echo prevention** → works correctly with both static and templated agent names

**Also fixes in `genie-client.ts` (edge cases from Codex/CodeRabbit reviews):**

- Validate resolved names are non-empty → fail fast when template vars are missing
- Deduplicate auto-spawn with `pendingTeams` set → prevents process storms during bursts
- Use `execFile` instead of `exec` → avoids shell injection via teamName

## Edge cases covered

| Scenario | Before | After |
|---|---|---|
| `agentName: "omni-{thread_id}"` with thread 123 | Bridge polls `omni-thread_id.json` (wrong) | Bridge scans dir, finds `omni-123.json` ✅ |
| `agentName: "{channel}-{thread_id}"` (all template) | Bridge polls `channel-thread_id.json` | Bridge scans dir, matches ALL `.json` files ✅ |
| Template var is undefined → resolves to `""` | Writes to `inboxes/.json` (corrupt path) | Throws `ProviderError` immediately ✅ |
| Inbox file truncated/rotated | Cursor stuck, bridge stops reading | Cursor resets to 0, resumes ✅ |
| 100 dynamic inboxes deleted | 100 stale cursor entries forever | Pruned after 24h ✅ |
| 50 concurrent `run()` calls for new team | 50 `exec` processes spawned | 1 `execFile` process (deduplicated) ✅ |

## Test plan

- [x] 108 existing provider tests pass (0 failures)
- [x] TypeScript compiles cleanly (`tsc --noEmit` for core + api)
- [x] Biome lint passes with 0 errors
- [x] Auto-spawn tests updated for `execFile` API