### PR TITLE
feat(channel-linkedin): add LinkedIn as first-class social channel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@hono/swagger-ui": "^0.4.1",
         "@hono/zod-validator": "^0.4.3",
@@ -83,7 +83,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "0.1.0",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -99,7 +99,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -115,7 +115,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "0.1.0",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -128,9 +128,26 @@
         "typescript": "^5.0.0",
       },
     },
+    "packages/channel-linkedin": {
+      "name": "@omni/channel-linkedin",
+      "version": "2.260309.1",
+      "dependencies": {
+        "@omni/channel-sdk": "workspace:*",
+        "@omni/core": "workspace:*",
+        "@omni/db": "workspace:*",
+        "playwright": "^1.49.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.3",
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -141,7 +158,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -159,7 +176,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -175,7 +192,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -195,7 +212,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -222,7 +239,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -237,7 +254,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -251,7 +268,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -269,7 +286,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -277,7 +294,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260228.1",
+      "version": "2.260304.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -596,6 +613,8 @@
     "@omni/channel-discord": ["@omni/channel-discord@workspace:packages/channel-discord"],
 
     "@omni/channel-internal": ["@omni/channel-internal@workspace:packages/channel-internal"],
+
+    "@omni/channel-linkedin": ["@omni/channel-linkedin@workspace:packages/channel-linkedin"],
 
     "@omni/channel-sdk": ["@omni/channel-sdk@workspace:packages/channel-sdk"],
 
@@ -1263,7 +1282,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "fstream": ["fstream@1.0.12", "", { "dependencies": { "graceful-fs": "^4.1.2", "inherits": "~2.0.0", "mkdirp": ">=0.5 0", "rimraf": "2" } }, "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg=="],
 
@@ -1643,6 +1662,10 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -1961,6 +1984,14 @@
 
     "@nuxtjs/opencollective/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@omni/channel-linkedin/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@omni/channel-sdk/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "@omni/core/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "@omni/db/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
     "@omni/ui/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@openapitools/openapi-generator-cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -2091,11 +2122,15 @@
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "unzipper/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2150,6 +2185,14 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@nuxtjs/opencollective/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "@omni/channel-linkedin/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "@omni/channel-sdk/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "@omni/core/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "@omni/db/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@omni/ui/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2295,6 +2338,14 @@
 
     "zip-stream/archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "@omni/channel-linkedin/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "@omni/channel-sdk/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@omni/core/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@omni/db/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@redocly/openapi-core/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -2310,6 +2361,8 @@
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
+
+    "@omni/channel-linkedin/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/channel-linkedin/package.json
+++ b/packages/channel-linkedin/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@omni/channel-linkedin",
+  "version": "2.260309.1",
+  "description": "LinkedIn channel plugin for Omni v2 using Playwright browser automation",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --noEmit",
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
+  "dependencies": {
+    "@omni/channel-sdk": "workspace:*",
+    "@omni/core": "workspace:*",
+    "@omni/db": "workspace:*",
+    "playwright": "^1.49.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/channel-linkedin/src/actions/comment.ts
+++ b/packages/channel-linkedin/src/actions/comment.ts
@@ -1,0 +1,151 @@
+/**
+ * Comment Action — NEW (no Python equivalent)
+ *
+ * Posts a comment on a LinkedIn post. Follows the same fill->click->verify
+ * pattern established in reply.py.
+ *
+ * Flow:
+ * 1. Click the comment button on the post
+ * 2. Wait for comment input to appear
+ * 3. Type comment using typeText() (character-by-character)
+ * 4. Submit comment
+ * 5. Return structured result
+ */
+
+import type { ElementHandle, Page } from 'playwright';
+import type { RateLimiter } from '../browser/humanizer';
+import { humanDelay, typeText } from '../browser/humanizer';
+import { SELECTORS, findElement } from '../browser/selectors';
+import type { ActionResult, CommentResult } from '../types';
+
+// Pre-extract selector entries
+const commentButtonSel = SELECTORS.feed.commentButton;
+
+/** Selector for the comment input field within a post's comment section */
+const COMMENT_INPUT = {
+  primary: '.ql-editor[data-placeholder]',
+  fallbacks: [
+    '.comments-comment-box__form .ql-editor',
+    '[role="textbox"][aria-label*="comment" i]',
+    '.comments-comment-texteditor .ql-editor',
+  ],
+};
+
+/** Selector for the comment submit button */
+const COMMENT_SUBMIT = {
+  primary: '.comments-comment-box__submit-button',
+  fallbacks: ['button.comments-comment-box__submit-button--cr', '.comments-comment-box button[type="submit"]'],
+};
+
+/**
+ * Post a comment on a LinkedIn post.
+ *
+ * @param page - Playwright Page instance
+ * @param rateLimiter - RateLimiter instance to check commentsPerHour
+ * @param postElement - ElementHandle for the post container (.feed-shared-update-v2)
+ * @param text - Comment text
+ * @param postId - External post identifier (for result tracking)
+ */
+export async function postComment(
+  page: Page,
+  rateLimiter: RateLimiter,
+  postElement: ElementHandle,
+  text: string,
+  postId: string,
+): Promise<ActionResult<CommentResult>> {
+  // Check rate limit before proceeding
+  if (!rateLimiter.canPerform('commentsPerHour')) {
+    return {
+      success: false,
+      error: 'Rate limit exceeded for commentsPerHour',
+    };
+  }
+
+  // Step 1: Click the comment button on the post
+  let clickedComment = false;
+  const commentBtn = await postElement.$(commentButtonSel.primary);
+  if (commentBtn) {
+    await commentBtn.click();
+    clickedComment = true;
+  } else {
+    for (const fallback of commentButtonSel.fallbacks) {
+      const btn = await postElement.$(fallback);
+      if (btn) {
+        await btn.click();
+        clickedComment = true;
+        break;
+      }
+    }
+  }
+
+  if (!clickedComment) {
+    return {
+      success: false,
+      error: 'Comment button not found on post',
+    };
+  }
+
+  await humanDelay('postClick');
+
+  // Step 2: Wait for comment input to appear
+  const commentInput = await findElement(page, COMMENT_INPUT, {
+    timeout: 5000,
+  });
+  if (!commentInput) {
+    return {
+      success: false,
+      error: 'Comment input field not found',
+    };
+  }
+
+  // Step 3: Type comment using typeText for human-like input
+  const inputSelector = await resolveWorkingSelector(page, COMMENT_INPUT);
+  if (!inputSelector) {
+    return {
+      success: false,
+      error: 'Could not resolve comment input selector',
+    };
+  }
+  await typeText(page, inputSelector, text);
+  await humanDelay('postClick');
+
+  // Step 4: Submit comment
+  const submitBtn = await findElement(page, COMMENT_SUBMIT, {
+    timeout: 3000,
+  });
+  if (!submitBtn) {
+    // Fallback: press Enter to submit
+    await page.keyboard.press('Enter');
+  } else {
+    await submitBtn.click();
+  }
+
+  await humanDelay('postClick');
+
+  // Record the action after success
+  rateLimiter.record('commentsPerHour');
+
+  // Step 5: Return result
+  return {
+    success: true,
+    data: {
+      commentText: text,
+      postId,
+    },
+  };
+}
+
+/**
+ * Resolve the first working CSS selector from a SelectorEntry.
+ */
+async function resolveWorkingSelector(
+  page: Page,
+  entry: { primary: string; fallbacks: string[] },
+): Promise<string | null> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+  for (const selector of allSelectors) {
+    const el = await page.$(selector);
+    if (el) return selector;
+  }
+  return null;
+}

--- a/packages/channel-linkedin/src/actions/connect.ts
+++ b/packages/channel-linkedin/src/actions/connect.ts
@@ -1,0 +1,297 @@
+/**
+ * Connection Actions — NEW (no Python equivalent)
+ *
+ * Send connection requests and accept pending invitations on LinkedIn.
+ * Follows the same fill->click->verify pattern from reply.py.
+ */
+
+import type { ElementHandle, Page } from 'playwright';
+import type { RateLimiter } from '../browser/humanizer';
+import { humanDelay, typeText } from '../browser/humanizer';
+import { findElement } from '../browser/selectors';
+import type { ActionResult, ConnectResult } from '../types';
+
+// ---------------------------------------------------------------------------
+// Selectors for connection actions
+// ---------------------------------------------------------------------------
+
+/** Connect button on a profile page */
+const CONNECT_BUTTON = {
+  primary: 'button[aria-label*="Connect" i]',
+  fallbacks: ['.pvs-profile-actions button:has-text("Connect")', 'button.pv-s-profile-actions--connect'],
+};
+
+/** "Add a note" button in the connection invite dialog */
+const ADD_NOTE_BUTTON = {
+  primary: 'button[aria-label*="Add a note" i]',
+  fallbacks: ['.send-invite button:has-text("Add a note")', '.artdeco-modal button:has-text("Add a note")'],
+};
+
+/** Note textarea in the connection invite dialog */
+const NOTE_INPUT = {
+  primary: 'textarea[name="message"]',
+  fallbacks: ['.send-invite textarea', '#custom-message', '.artdeco-modal textarea'],
+};
+
+/** Send invite / Send now button */
+const SEND_INVITE_BUTTON = {
+  primary: 'button[aria-label*="Send" i]',
+  fallbacks: ['.artdeco-modal button:has-text("Send")', '.send-invite button[type="submit"]'],
+};
+
+/** Profile name element on a profile page */
+const PROFILE_NAME = {
+  primary: '.text-heading-xlarge',
+  fallbacks: ['h1.inline', '.pv-top-card--list li:first-child'],
+};
+
+/** Pending invite accept button in invitation card */
+const ACCEPT_BUTTON = {
+  primary: 'button[aria-label*="Accept" i]',
+  fallbacks: ['.invitation-card__action-btn:has-text("Accept")', 'button.artdeco-button--secondary:has-text("Accept")'],
+};
+
+/** Invitation card element */
+const INVITATION_CARD = {
+  primary: '.invitation-card',
+  fallbacks: ['.mn-invitation-list li', '[data-test-invitation-card]'],
+};
+
+/** Invitation card name */
+const INVITATION_NAME = {
+  primary: '.invitation-card__title',
+  fallbacks: ['.invitation-card__tvm-title', '.mn-invitation-list .artdeco-entity-lockup__title'],
+};
+
+// ---------------------------------------------------------------------------
+// Send Connection Request
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a connection request to a LinkedIn profile.
+ *
+ * @param page - Playwright Page instance
+ * @param rateLimiter - RateLimiter instance to check connectionsPerDay
+ * @param profileUrl - Full LinkedIn profile URL to connect with
+ * @param message - Optional personalized note to include with the request
+ */
+export async function sendConnectionRequest(
+  page: Page,
+  rateLimiter: RateLimiter,
+  profileUrl: string,
+  message?: string,
+): Promise<ActionResult<ConnectResult>> {
+  // Check rate limit before proceeding
+  if (!rateLimiter.canPerform('connectionsPerDay')) {
+    return {
+      success: false,
+      error: 'Rate limit exceeded for connectionsPerDay',
+    };
+  }
+
+  // Step 1: Navigate to the profile
+  try {
+    await page.goto(profileUrl, { waitUntil: 'domcontentloaded' });
+    await humanDelay('navigation');
+  } catch {
+    return {
+      success: false,
+      error: `Failed to navigate to profile: ${profileUrl}`,
+    };
+  }
+
+  // Get the profile name for the result
+  const nameEl = await findElement(page, PROFILE_NAME, { timeout: 5000 });
+  const profileName = nameEl ? (await nameEl.innerText()).trim() : profileUrl;
+
+  // Step 2: Click Connect button
+  const connectBtn = await findElement(page, CONNECT_BUTTON, { timeout: 5000 });
+  if (!connectBtn) {
+    return {
+      success: false,
+      error: 'Connect button not found on profile page (may already be connected)',
+    };
+  }
+
+  await connectBtn.click();
+  await humanDelay('postClick');
+
+  // Step 3: Optionally add a personalized message
+  if (message) {
+    const addNoteBtn = await findElement(page, ADD_NOTE_BUTTON, { timeout: 3000 });
+    if (addNoteBtn) {
+      await addNoteBtn.click();
+      await humanDelay('postClick');
+
+      // Find and fill the note textarea
+      const noteSelector = await resolveWorkingSelector(page, NOTE_INPUT);
+      if (noteSelector) {
+        await typeText(page, noteSelector, message);
+        await humanDelay('postClick');
+      }
+    }
+  }
+
+  // Step 4: Click Send
+  const sendBtn = await findElement(page, SEND_INVITE_BUTTON, { timeout: 3000 });
+  if (!sendBtn) {
+    return {
+      success: false,
+      error: 'Send invite button not found in dialog',
+    };
+  }
+
+  await sendBtn.click();
+  await humanDelay('postClick');
+
+  // Record the action after success
+  rateLimiter.record('connectionsPerDay');
+
+  return {
+    success: true,
+    data: {
+      profileName,
+      action: 'sent',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Accept Connection Request
+// ---------------------------------------------------------------------------
+
+/**
+ * Query multiple elements using primary selector with fallbacks.
+ * Returns the first non-empty result set.
+ */
+async function queryAllWithFallbacks(
+  container: Page | ElementHandle,
+  entry: { primary: string; fallbacks: string[] },
+): Promise<ElementHandle[]> {
+  const results = await container.$$(entry.primary);
+  if (results.length > 0) return results;
+  for (const fallback of entry.fallbacks) {
+    const fbResults = await container.$$(fallback);
+    if (fbResults.length > 0) return fbResults;
+  }
+  return [];
+}
+
+/**
+ * Query a single element using primary selector with fallbacks.
+ */
+async function queryWithFallbacks(
+  container: ElementHandle,
+  entry: { primary: string; fallbacks: string[] },
+): Promise<ElementHandle | null> {
+  const el = await container.$(entry.primary);
+  if (el) return el;
+  for (const fallback of entry.fallbacks) {
+    const fbEl = await container.$(fallback);
+    if (fbEl) return fbEl;
+  }
+  return null;
+}
+
+/**
+ * Navigate to the invitation manager page.
+ * Returns an error message on failure, or null on success.
+ */
+async function navigateToInvitations(page: Page): Promise<string | null> {
+  try {
+    await page.goto('https://www.linkedin.com/mynetwork/invitation-manager/', {
+      waitUntil: 'domcontentloaded',
+    });
+    await humanDelay('navigation');
+    return null;
+  } catch {
+    return 'Failed to navigate to invitation manager';
+  }
+}
+
+/**
+ * Scroll the page to load more invitation cards.
+ */
+async function scrollToLoadInvitations(page: Page): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await page.evaluate('window.scrollBy(0, 500)');
+    await humanDelay('scroll');
+  }
+}
+
+/**
+ * Accept a pending connection request by name.
+ *
+ * Uses case-insensitive substring matching (same pattern as reply.py and archive_batch.py).
+ *
+ * @param page - Playwright Page instance
+ * @param rateLimiter - RateLimiter instance to check connectionsPerDay
+ * @param name - Name of the person whose invite to accept (case-insensitive substring)
+ */
+export async function acceptConnectionRequest(
+  page: Page,
+  rateLimiter: RateLimiter,
+  name: string,
+): Promise<ActionResult<ConnectResult>> {
+  if (!rateLimiter.canPerform('connectionsPerDay')) {
+    return { success: false, error: 'Rate limit exceeded for connectionsPerDay' };
+  }
+
+  const navError = await navigateToInvitations(page);
+  if (navError) {
+    return { success: false, error: navError };
+  }
+
+  await scrollToLoadInvitations(page);
+
+  const cards = await queryAllWithFallbacks(page, INVITATION_CARD);
+
+  for (const card of cards) {
+    const result = await tryAcceptCard(card, name, rateLimiter);
+    if (result) return result;
+  }
+
+  return { success: false, error: `No pending invitation from '${name}' found` };
+}
+
+/**
+ * Attempt to accept a single invitation card if it matches the target name.
+ * Returns an ActionResult if the card matches (success or failure), or null to skip.
+ */
+async function tryAcceptCard(
+  card: ElementHandle,
+  name: string,
+  rateLimiter: RateLimiter,
+): Promise<ActionResult<ConnectResult> | null> {
+  const cardNameEl = await queryWithFallbacks(card, INVITATION_NAME);
+  if (!cardNameEl) return null;
+
+  const cardName = (await cardNameEl.innerText()).trim();
+  if (!cardName.toLowerCase().includes(name.toLowerCase())) return null;
+
+  const acceptBtn = await queryWithFallbacks(card, ACCEPT_BUTTON);
+  if (!acceptBtn) {
+    return { success: false, error: `Found invitation from '${cardName}' but Accept button not found` };
+  }
+
+  await acceptBtn.click();
+  await humanDelay('postClick');
+  rateLimiter.record('connectionsPerDay');
+
+  return { success: true, data: { profileName: cardName, action: 'accepted' } };
+}
+
+/**
+ * Resolve the first working CSS selector from a SelectorEntry.
+ */
+async function resolveWorkingSelector(
+  page: Page,
+  entry: { primary: string; fallbacks: string[] },
+): Promise<string | null> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+  for (const selector of allSelectors) {
+    const el = await page.$(selector);
+    if (el) return selector;
+  }
+  return null;
+}

--- a/packages/channel-linkedin/src/actions/create-post.ts
+++ b/packages/channel-linkedin/src/actions/create-post.ts
@@ -1,0 +1,128 @@
+/**
+ * Create Post Action — NEW (no Python equivalent)
+ *
+ * Flow:
+ * 1. Navigate to feed if not already there
+ * 2. Click "Start a post" button
+ * 3. Wait for post editor to appear
+ * 4. Type text using typeText() (character-by-character)
+ * 5. Click Post button
+ * 6. Return structured result
+ */
+
+import type { Page } from 'playwright';
+import type { RateLimiter } from '../browser/humanizer';
+import { humanDelay, typeText } from '../browser/humanizer';
+import { SELECTORS, findElement } from '../browser/selectors';
+import type { ActionResult, CreatePostResult } from '../types';
+
+// Pre-extract selector entries to avoid index-signature optionality issues
+const startPostButtonSel = SELECTORS.compose.startPostButton;
+const postEditorSel = SELECTORS.compose.postEditor;
+const postButtonSel = SELECTORS.compose.postButton;
+
+/**
+ * Create a new LinkedIn post.
+ *
+ * @param page - Playwright Page instance
+ * @param rateLimiter - RateLimiter instance to check postsPerDay
+ * @param text - Post content text
+ */
+export async function createPost(
+  page: Page,
+  rateLimiter: RateLimiter,
+  text: string,
+): Promise<ActionResult<CreatePostResult>> {
+  // Check rate limit before proceeding
+  if (!rateLimiter.canPerform('postsPerDay')) {
+    return {
+      success: false,
+      error: 'Rate limit exceeded for postsPerDay',
+    };
+  }
+
+  // Step 1: Ensure we are on the feed page
+  const currentUrl = page.url();
+  if (!currentUrl.includes('/feed')) {
+    await page.goto('https://www.linkedin.com/feed/', {
+      waitUntil: 'domcontentloaded',
+    });
+    await humanDelay('navigation');
+  }
+
+  // Step 2: Click "Start a post" button
+  const startPostBtn = await findElement(page, startPostButtonSel, {
+    timeout: 5000,
+  });
+  if (!startPostBtn) {
+    return {
+      success: false,
+      error: 'Start a post button not found',
+    };
+  }
+
+  await startPostBtn.click();
+  await humanDelay('postClick');
+
+  // Step 3: Wait for post editor to appear
+  const editor = await findElement(page, postEditorSel, {
+    timeout: 5000,
+  });
+  if (!editor) {
+    return {
+      success: false,
+      error: 'Post editor not found after clicking Start a post',
+    };
+  }
+
+  // Step 4: Type text using typeText for human-like input
+  const editorSelector = await resolveWorkingSelector(page, postEditorSel);
+  if (!editorSelector) {
+    return {
+      success: false,
+      error: 'Could not resolve post editor selector',
+    };
+  }
+  await typeText(page, editorSelector, text);
+  await humanDelay('postClick');
+
+  // Step 5: Click Post button
+  const postBtn = await findElement(page, postButtonSel, {
+    timeout: 5000,
+  });
+  if (!postBtn) {
+    return {
+      success: false,
+      error: 'Post submit button not found',
+    };
+  }
+
+  await postBtn.click();
+  await humanDelay('navigation');
+
+  // Record the action after success
+  rateLimiter.record('postsPerDay');
+
+  // Step 6: Return result
+  return {
+    success: true,
+    data: {
+      postUrl: undefined, // URL not easily extractable right after posting
+    },
+  };
+}
+
+/**
+ * Resolve the first working CSS selector from a SelectorEntry.
+ */
+async function resolveWorkingSelector(
+  page: Page,
+  entry: { primary: string; fallbacks: string[] },
+): Promise<string | null> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+  for (const selector of allSelectors) {
+    const el = await page.$(selector);
+    if (el) return selector;
+  }
+  return null;
+}

--- a/packages/channel-linkedin/src/actions/index.ts
+++ b/packages/channel-linkedin/src/actions/index.ts
@@ -1,0 +1,12 @@
+/**
+ * LinkedIn Actions — barrel exports
+ *
+ * Actions that mutate state on LinkedIn: send message, create post,
+ * comment, react, and manage connections.
+ */
+
+export { sendMessage } from './send-message';
+export { createPost } from './create-post';
+export { postComment } from './comment';
+export { reactToPost } from './react';
+export { sendConnectionRequest, acceptConnectionRequest } from './connect';

--- a/packages/channel-linkedin/src/actions/react.ts
+++ b/packages/channel-linkedin/src/actions/react.ts
@@ -1,0 +1,149 @@
+/**
+ * React Action — NEW (no Python equivalent)
+ *
+ * Reacts to a LinkedIn post with a specified reaction type.
+ * Follows the same fill->click->verify pattern from reply.py.
+ *
+ * Flow:
+ * 1. Hover over the reaction button on the post
+ * 2. Wait for reaction picker to appear
+ * 3. Click the appropriate reaction
+ * 4. Return structured result
+ */
+
+import type { ElementHandle, Page } from 'playwright';
+import type { RateLimiter } from '../browser/humanizer';
+import { humanDelay } from '../browser/humanizer';
+import { SELECTORS, findElement } from '../browser/selectors';
+import type { ActionResult, LinkedInReactionType, ReactResult } from '../types';
+
+// Pre-extract selector entry
+const reactionButtonSel = SELECTORS.feed.reactionButton;
+
+/**
+ * Maps reaction types to their selectors in the LinkedIn reaction picker popup.
+ * LinkedIn renders reactions as buttons with descriptive aria-labels.
+ */
+const REACTION_SELECTORS: Record<LinkedInReactionType, { primary: string; fallbacks: string[] }> = {
+  like: {
+    primary: 'button[aria-label*="Like" i]',
+    fallbacks: ['.reactions-menu button:nth-child(1)', '[data-reaction-type="LIKE"]'],
+  },
+  celebrate: {
+    primary: 'button[aria-label*="Celebrate" i]',
+    fallbacks: ['.reactions-menu button:nth-child(2)', '[data-reaction-type="PRAISE"]'],
+  },
+  support: {
+    primary: 'button[aria-label*="Support" i]',
+    fallbacks: ['.reactions-menu button:nth-child(3)', '[data-reaction-type="EMPATHY"]'],
+  },
+  love: {
+    primary: 'button[aria-label*="Love" i]',
+    fallbacks: ['.reactions-menu button:nth-child(4)', '[data-reaction-type="INTEREST"]'],
+  },
+  insightful: {
+    primary: 'button[aria-label*="Insightful" i]',
+    fallbacks: ['.reactions-menu button:nth-child(5)', '[data-reaction-type="APPRECIATION"]'],
+  },
+  funny: {
+    primary: 'button[aria-label*="Funny" i]',
+    fallbacks: ['.reactions-menu button:nth-child(6)', '[data-reaction-type="ENTERTAINMENT"]'],
+  },
+};
+
+/** Selector for the reaction picker popup */
+const REACTION_PICKER = {
+  primary: '.reactions-menu',
+  fallbacks: ['[data-test-reactions-menu]', '.reactions-react-button__reaction-picker'],
+};
+
+/**
+ * React to a LinkedIn post with a specific reaction type.
+ *
+ * @param page - Playwright Page instance
+ * @param rateLimiter - RateLimiter instance to check reactionsPerHour
+ * @param postElement - ElementHandle for the post container (.feed-shared-update-v2)
+ * @param reactionType - Reaction to apply (like, celebrate, support, love, insightful, funny)
+ * @param postId - External post identifier (for result tracking)
+ */
+export async function reactToPost(
+  page: Page,
+  rateLimiter: RateLimiter,
+  postElement: ElementHandle,
+  reactionType: LinkedInReactionType,
+  postId: string,
+): Promise<ActionResult<ReactResult>> {
+  // Check rate limit before proceeding
+  if (!rateLimiter.canPerform('reactionsPerHour')) {
+    return {
+      success: false,
+      error: 'Rate limit exceeded for reactionsPerHour',
+    };
+  }
+
+  // Step 1: Find and hover over the reaction button to trigger the picker
+  let hovered = false;
+  const reactionBtn = await postElement.$(reactionButtonSel.primary);
+  if (reactionBtn) {
+    await reactionBtn.hover();
+    hovered = true;
+  } else {
+    for (const fallback of reactionButtonSel.fallbacks) {
+      const btn = await postElement.$(fallback);
+      if (btn) {
+        await btn.hover();
+        hovered = true;
+        break;
+      }
+    }
+  }
+
+  if (!hovered) {
+    return {
+      success: false,
+      error: 'Reaction button not found on post',
+    };
+  }
+
+  await humanDelay('postClick');
+
+  // Step 2: Wait for the reaction picker popup to appear
+  const picker = await findElement(page, REACTION_PICKER, {
+    timeout: 3000,
+  });
+  if (!picker) {
+    return {
+      success: false,
+      error: 'Reaction picker did not appear after hovering',
+    };
+  }
+
+  await humanDelay('postClick');
+
+  // Step 3: Click the appropriate reaction
+  const reactionEntry = REACTION_SELECTORS[reactionType];
+  const reactionEl = await findElement(page, reactionEntry, {
+    timeout: 3000,
+  });
+  if (!reactionEl) {
+    return {
+      success: false,
+      error: `Reaction '${reactionType}' button not found in picker`,
+    };
+  }
+
+  await reactionEl.click();
+  await humanDelay('postClick');
+
+  // Record the action after success
+  rateLimiter.record('reactionsPerHour');
+
+  // Step 4: Return result
+  return {
+    success: true,
+    data: {
+      reactionType,
+      postId,
+    },
+  };
+}

--- a/packages/channel-linkedin/src/actions/send-message.ts
+++ b/packages/channel-linkedin/src/actions/send-message.ts
@@ -1,0 +1,148 @@
+/**
+ * Send Message Action — ported from linkedin-agent/reply.py
+ *
+ * Flow (exact match to reply.py):
+ * 1. Scroll conversation list to find target by name (case-insensitive substring)
+ * 2. Click the matching conversation
+ * 3. Wait for message input to appear
+ * 4. Fill input using typeText() (character-by-character typing)
+ * 5. Locate send button (.msg-form__send-button, fallback button[type='submit'])
+ * 6. Click send
+ * 7. Return structured result
+ */
+
+import type { Page } from 'playwright';
+import type { RateLimiter } from '../browser/humanizer';
+import { CONVERSATION_SCROLL_MAX, humanDelay, typeText } from '../browser/humanizer';
+import { SELECTORS, findElement } from '../browser/selectors';
+import type { ActionResult, SendMessageResult } from '../types';
+
+// Pre-extract selector entries to avoid index-signature optionality issues
+const conversationListSel = SELECTORS.inbox.conversationList;
+const conversationItemSel = SELECTORS.inbox.conversationItem;
+const participantNamesSel = SELECTORS.inbox.participantNames;
+const messageInputSel = SELECTORS.inbox.messageInput;
+const sendButtonSel = SELECTORS.inbox.sendButton;
+
+/**
+ * Scroll the conversation list to load more conversations.
+ * Ported from reply.py lines 31-41.
+ */
+async function scrollConversationList(page: Page): Promise<void> {
+  const convList = await findElement(page, conversationListSel);
+  if (!convList) return;
+
+  let prevCount = 0;
+  for (let i = 0; i < CONVERSATION_SCROLL_MAX; i++) {
+    const items = await page.$$(conversationItemSel.primary);
+    const currentCount = items.length;
+    if (currentCount === prevCount) break;
+    prevCount = currentCount;
+    await convList.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await humanDelay('scroll');
+  }
+}
+
+/**
+ * Find a conversation item by recipient name (case-insensitive substring match).
+ * Returns the matching item and the displayed name, or null if not found.
+ */
+async function findConversationByName(
+  page: Page,
+  recipientName: string,
+): Promise<{ item: import('playwright').ElementHandle; name: string } | null> {
+  const items = await page.$$(conversationItemSel.primary);
+  for (const item of items) {
+    const nameEl = await item.$(participantNamesSel.primary);
+    if (!nameEl) continue;
+    const name = (await nameEl.innerText()).trim();
+    if (name.toLowerCase().includes(recipientName.toLowerCase())) {
+      return { item, name };
+    }
+  }
+  return null;
+}
+
+/**
+ * Fill the message input and click send in the active conversation.
+ * Returns an error string on failure, or null on success.
+ */
+async function fillAndSendMessage(page: Page, text: string): Promise<string | null> {
+  const inputEl = await findElement(page, messageInputSel, { timeout: 5000 });
+  if (!inputEl) return 'Message input field not found after clicking conversation';
+
+  const inputSelector = await resolveWorkingSelector(page, messageInputSel);
+  if (!inputSelector) return 'Could not resolve message input selector';
+
+  await typeText(page, inputSelector, text);
+  await humanDelay('postClick');
+
+  const sendBtn = await findElement(page, sendButtonSel, { timeout: 3000 });
+  if (!sendBtn) return 'Send button not found';
+
+  await sendBtn.click();
+  await humanDelay('postClick');
+  return null;
+}
+
+/**
+ * Send a message to a LinkedIn conversation by recipient name.
+ *
+ * Ported from reply.py — uses the same scroll->find->click->fill->send flow.
+ * Name matching is case-insensitive substring (same as reply.py line 51).
+ *
+ * @param page - Playwright Page (must already be on messaging page)
+ * @param rateLimiter - RateLimiter instance to check messagesPerHour
+ * @param recipientName - Name to search for (case-insensitive substring match)
+ * @param text - Message text to send
+ */
+export async function sendMessage(
+  page: Page,
+  rateLimiter: RateLimiter,
+  recipientName: string,
+  text: string,
+): Promise<ActionResult<SendMessageResult>> {
+  if (!rateLimiter.canPerform('messagesPerHour')) {
+    return { success: false, error: 'Rate limit exceeded for messagesPerHour' };
+  }
+
+  await scrollConversationList(page);
+
+  const match = await findConversationByName(page, recipientName);
+  if (!match) {
+    return { success: false, error: `Conversation with '${recipientName}' not found` };
+  }
+
+  await match.item.click();
+  await humanDelay('messageLoad');
+
+  const sendError = await fillAndSendMessage(page, text);
+  if (sendError) {
+    return { success: false, error: sendError };
+  }
+
+  rateLimiter.record('messagesPerHour');
+
+  return {
+    success: true,
+    data: { sentTo: match.name, message: text },
+  };
+}
+
+/**
+ * Resolve the first working CSS selector from a SelectorEntry.
+ * Returns the selector string (not the element) so it can be passed to typeText.
+ */
+async function resolveWorkingSelector(
+  page: Page,
+  entry: { primary: string; fallbacks: string[] },
+): Promise<string | null> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+  for (const selector of allSelectors) {
+    const el = await page.$(selector);
+    if (el) return selector;
+  }
+  return null;
+}

--- a/packages/channel-linkedin/src/browser/humanizer.ts
+++ b/packages/channel-linkedin/src/browser/humanizer.ts
@@ -1,0 +1,258 @@
+/**
+ * Humanized Delays & Rate Limiter for LinkedIn automation.
+ *
+ * Timing constants are derived from the linkedin-agent Python scripts
+ * (scan_raw.py, reply.py, read_full.py) and randomized within a range
+ * to avoid detection patterns.
+ *
+ * Rate limiter tracks action counts per time window and blocks when
+ * configurable limits are exceeded.
+ */
+
+import type { Page } from 'playwright';
+import type { ActiveHoursConfig, RateLimitsConfig } from '../types';
+import { DEFAULT_RATE_LIMITS } from '../types';
+
+// ---------------------------------------------------------------------------
+// Timing Constants — baseline from linkedin-agent, randomized around center
+// ---------------------------------------------------------------------------
+
+/**
+ * Delay ranges in milliseconds. Each range is centered around the
+ * value used in the linkedin-agent Python scripts.
+ */
+export const TIMING = {
+  /** Page navigation wait — scan_raw.py: page.wait_for_timeout(3000) */
+  navigation: { min: 2000, max: 4000 },
+  /** Message list load — scan_raw.py: page.wait_for_timeout(2500) */
+  messageLoad: { min: 2000, max: 3500 },
+  /** Scroll iteration pause — scan_raw.py: page.wait_for_timeout(1500) */
+  scroll: { min: 800, max: 1500 },
+  /** Post-click settle time — scan_raw.py: page.wait_for_timeout(1000) */
+  postClick: { min: 700, max: 1300 },
+  /** Per-character typing delay — simulates human typing speed */
+  typing: { min: 30, max: 80 },
+  /** Pause between sending separate messages */
+  betweenMessages: { min: 3000, max: 8000 },
+  /** Pause between feed actions (like, comment) */
+  betweenFeedActions: { min: 5000, max: 15000 },
+  /** Pause between navigating to different pages */
+  betweenPageViews: { min: 2000, max: 5000 },
+} as const;
+
+export type TimingKey = keyof typeof TIMING;
+
+// ---------------------------------------------------------------------------
+// Navigation Constants — from linkedin-agent
+// ---------------------------------------------------------------------------
+
+/** scan_raw.py: 3 attempts for navigation retry */
+export const NAV_RETRY_ATTEMPTS = 3;
+/** scan_raw.py: 2s between retries */
+export const NAV_RETRY_DELAY = 2000;
+/** scan_raw.py: 20 scroll iterations to load conversation list */
+export const CONVERSATION_SCROLL_MAX = 20;
+/** read_full.py: 5 scroll-up iterations for full message history */
+export const HISTORY_SCROLL_UP = 5;
+
+// ---------------------------------------------------------------------------
+// Delay Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a random integer between min and max (inclusive).
+ */
+function randomInRange(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+/**
+ * Wait for a humanized random duration within the specified timing range.
+ *
+ * @param type - Key from TIMING constants
+ * @returns Promise that resolves after the random delay
+ */
+export async function humanDelay(type: TimingKey): Promise<void> {
+  const range = TIMING[type];
+  const ms = randomInRange(range.min, range.max);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wait for a specific number of milliseconds.
+ * Prefer humanDelay() for most cases — use this only for exact waits.
+ */
+export async function exactDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Type text character by character with humanized per-key delays.
+ * Simulates realistic typing speed to avoid bot detection.
+ *
+ * @param page - Playwright Page instance
+ * @param selector - CSS selector for the input element
+ * @param text - Text to type
+ */
+export async function typeText(page: Page, selector: string, text: string): Promise<void> {
+  await page.click(selector);
+  for (const char of text) {
+    await page.keyboard.type(char, {
+      delay: randomInRange(TIMING.typing.min, TIMING.typing.max),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rate Limiter
+// ---------------------------------------------------------------------------
+
+type RateLimitAction = keyof RateLimitsConfig;
+
+interface ActionRecord {
+  timestamps: number[];
+}
+
+/**
+ * Tracks action counts per time window and blocks when limits are exceeded.
+ * Each action type has an independent counter and configurable limit.
+ */
+export class RateLimiter {
+  private readonly limits: RateLimitsConfig;
+  private readonly actions: Map<RateLimitAction, ActionRecord> = new Map();
+
+  constructor(limits?: Partial<RateLimitsConfig>) {
+    this.limits = { ...DEFAULT_RATE_LIMITS, ...limits };
+  }
+
+  /**
+   * Get the time window in milliseconds for a given action.
+   * Actions ending in "PerDay" use a 24h window; others use 1h.
+   */
+  private getWindowMs(action: RateLimitAction): number {
+    if (action.includes('PerDay')) {
+      return 24 * 60 * 60 * 1000;
+    }
+    return 60 * 60 * 1000;
+  }
+
+  /**
+   * Prune timestamps older than the time window for an action.
+   */
+  private prune(action: RateLimitAction): number[] {
+    const record = this.actions.get(action);
+    if (!record) return [];
+
+    const windowMs = this.getWindowMs(action);
+    const cutoff = Date.now() - windowMs;
+    record.timestamps = record.timestamps.filter((t) => t > cutoff);
+    return record.timestamps;
+  }
+
+  /**
+   * Check if the action can be performed without exceeding the rate limit.
+   *
+   * @param action - The rate limit action key
+   * @returns true if within limits, false if limit would be exceeded
+   */
+  canPerform(action: RateLimitAction): boolean {
+    const recent = this.prune(action);
+    const limit = this.limits[action];
+    return recent.length < limit;
+  }
+
+  /**
+   * Record that an action was performed. Call this AFTER the action succeeds.
+   *
+   * @param action - The rate limit action key
+   */
+  record(action: RateLimitAction): void {
+    let record = this.actions.get(action);
+    if (!record) {
+      record = { timestamps: [] };
+      this.actions.set(action, record);
+    }
+    record.timestamps.push(Date.now());
+  }
+
+  /**
+   * Check if an action can be performed; if yes, record it and return true.
+   * If limit is exceeded, return false without recording.
+   *
+   * @param action - The rate limit action key
+   * @returns true if the action was allowed and recorded
+   */
+  tryPerform(action: RateLimitAction): boolean {
+    if (!this.canPerform(action)) {
+      return false;
+    }
+    this.record(action);
+    return true;
+  }
+
+  /**
+   * Get the number of remaining allowed actions in the current window.
+   *
+   * @param action - The rate limit action key
+   * @returns Number of remaining actions
+   */
+  remaining(action: RateLimitAction): number {
+    const recent = this.prune(action);
+    const limit = this.limits[action];
+    return Math.max(0, limit - recent.length);
+  }
+
+  /**
+   * Reset all tracked action counts.
+   */
+  reset(): void {
+    this.actions.clear();
+  }
+
+  /**
+   * Get a summary of all action counts and limits.
+   */
+  getSummary(): Record<RateLimitAction, { used: number; limit: number; remaining: number }> {
+    const summary = {} as Record<RateLimitAction, { used: number; limit: number; remaining: number }>;
+    for (const action of Object.keys(this.limits) as RateLimitAction[]) {
+      const recent = this.prune(action);
+      const limit = this.limits[action];
+      summary[action] = {
+        used: recent.length,
+        limit,
+        remaining: Math.max(0, limit - recent.length),
+      };
+    }
+    return summary;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Active Hours Check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the current time falls within the configured active hours.
+ * Used to avoid LinkedIn activity during unusual hours that might trigger
+ * bot detection.
+ *
+ * @param config - Active hours configuration with start, end, and timezone
+ * @returns true if current time is within active hours
+ */
+export function isActiveHours(config: ActiveHoursConfig): boolean {
+  // Get current hour in the configured timezone
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    hour12: false,
+    timeZone: config.timezone,
+  });
+  const currentHour = Number.parseInt(formatter.format(now), 10);
+
+  if (config.start <= config.end) {
+    // Simple range, e.g. 8-22
+    return currentHour >= config.start && currentHour < config.end;
+  }
+  // Wraps midnight, e.g. 22-6
+  return currentHour >= config.start || currentHour < config.end;
+}

--- a/packages/channel-linkedin/src/browser/index.ts
+++ b/packages/channel-linkedin/src/browser/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Browser automation layer for LinkedIn.
+ *
+ * Re-exports the BrowserManager, selector registry, and humanizer utilities.
+ */
+
+export { BrowserManager } from './manager';
+export type { BrowserConfig } from './manager';
+
+export {
+  SELECTORS,
+  findElement,
+  combinedSelector,
+  selectorExists,
+} from './selectors';
+export type { SelectorEntry, InboxSelectorGroup, FeedSelectorGroup, ComposeSelectorGroup } from './selectors';
+
+export {
+  TIMING,
+  NAV_RETRY_ATTEMPTS,
+  NAV_RETRY_DELAY,
+  CONVERSATION_SCROLL_MAX,
+  HISTORY_SCROLL_UP,
+  humanDelay,
+  exactDelay,
+  typeText,
+  RateLimiter,
+  isActiveHours,
+} from './humanizer';
+export type { TimingKey } from './humanizer';

--- a/packages/channel-linkedin/src/browser/manager.ts
+++ b/packages/channel-linkedin/src/browser/manager.ts
@@ -1,0 +1,211 @@
+/**
+ * BrowserManager — Chromium lifecycle management for LinkedIn automation.
+ *
+ * Ported from linkedin-agent/scan_raw.py launch_persistent_context() pattern.
+ * Uses Playwright's persistent context to preserve LinkedIn session cookies
+ * across restarts.
+ *
+ * Key design decisions (from linkedin-agent):
+ * - Persistent user data dir keeps session cookies alive
+ * - headless: true for server deployment
+ * - viewport: 1280x900 (same as linkedin-agent)
+ * - locale: 'pt-BR' (same as linkedin-agent)
+ * - Navigation retry: 3 attempts with 2s backoff (scan_raw.py lines 14-24)
+ */
+
+import { chromium } from 'playwright';
+import type { BrowserContext, Page } from 'playwright';
+import { NAV_RETRY_ATTEMPTS, NAV_RETRY_DELAY, exactDelay, humanDelay } from './humanizer';
+
+// ---------------------------------------------------------------------------
+// Default browser configuration (from linkedin-agent)
+// ---------------------------------------------------------------------------
+
+export interface BrowserConfig {
+  /** Path to persistent Chromium user data directory */
+  browserDataPath: string;
+  /** Run in headless mode (default: true) — scan_raw.py: headless=True */
+  headless?: boolean;
+  /** Viewport width (default: 1280) — scan_raw.py: width=1280 */
+  viewportWidth?: number;
+  /** Viewport height (default: 900) — scan_raw.py: height=900 */
+  viewportHeight?: number;
+  /** Browser locale (default: 'pt-BR') — scan_raw.py: locale='pt-BR' */
+  locale?: string;
+}
+
+const DEFAULTS: Required<Omit<BrowserConfig, 'browserDataPath'>> = {
+  headless: true,
+  viewportWidth: 1280,
+  viewportHeight: 900,
+  locale: 'pt-BR',
+};
+
+// ---------------------------------------------------------------------------
+// LinkedIn URLs
+// ---------------------------------------------------------------------------
+
+const LINKEDIN_MESSAGING_URL = 'https://www.linkedin.com/messaging/';
+const LINKEDIN_FEED_URL = 'https://www.linkedin.com/feed/';
+
+// ---------------------------------------------------------------------------
+// BrowserManager
+// ---------------------------------------------------------------------------
+
+export class BrowserManager {
+  private context: BrowserContext | null = null;
+  private page: Page | null = null;
+  private readonly config: Required<BrowserConfig>;
+
+  constructor(config: BrowserConfig) {
+    this.config = {
+      ...DEFAULTS,
+      ...config,
+    } as Required<BrowserConfig>;
+  }
+
+  /**
+   * Launch a persistent Chromium context.
+   * Ported from scan_raw.py: p.chromium.launch_persistent_context(...)
+   *
+   * Uses persistent user data dir so LinkedIn session cookies survive restarts.
+   * If pages already exist in the context (restored session), reuses the first.
+   * Otherwise creates a new page — same pattern as scan_raw.py line 67.
+   */
+  async launch(): Promise<void> {
+    if (this.context) {
+      throw new Error('Browser already launched. Call close() first.');
+    }
+
+    this.context = await chromium.launchPersistentContext(this.config.browserDataPath, {
+      headless: this.config.headless,
+      viewport: {
+        width: this.config.viewportWidth,
+        height: this.config.viewportHeight,
+      },
+      locale: this.config.locale,
+    });
+
+    // Reuse existing page or create new one — scan_raw.py line 67
+    const pages = this.context.pages();
+    this.page = pages.length > 0 ? (pages[0] as Page) : await this.context.newPage();
+  }
+
+  /**
+   * Navigate to LinkedIn Messaging with retry.
+   * Ported from scan_raw.py goto_messaging() — lines 14-24.
+   *
+   * 3 attempts, 2s backoff between retries.
+   * Uses 'domcontentloaded' wait strategy (not 'load') for faster navigation.
+   *
+   * @throws Error if all retry attempts fail
+   */
+  async navigateToMessaging(): Promise<void> {
+    const page = this.requirePage();
+
+    for (let attempt = 0; attempt < NAV_RETRY_ATTEMPTS; attempt++) {
+      try {
+        await page.goto(LINKEDIN_MESSAGING_URL, {
+          waitUntil: 'domcontentloaded',
+        });
+        // scan_raw.py: page.wait_for_timeout(3000) after navigation
+        await humanDelay('navigation');
+        return;
+      } catch (error) {
+        const _message = error instanceof Error ? error.message : String(error);
+        if (attempt < NAV_RETRY_ATTEMPTS - 1) {
+          await exactDelay(NAV_RETRY_DELAY);
+        }
+      }
+    }
+
+    throw new Error(`Failed to navigate to LinkedIn Messaging after ${NAV_RETRY_ATTEMPTS} attempts`);
+  }
+
+  /**
+   * Navigate to LinkedIn Feed.
+   * Same retry pattern as navigateToMessaging().
+   *
+   * @throws Error if all retry attempts fail
+   */
+  async navigateToFeed(): Promise<void> {
+    const page = this.requirePage();
+
+    for (let attempt = 0; attempt < NAV_RETRY_ATTEMPTS; attempt++) {
+      try {
+        await page.goto(LINKEDIN_FEED_URL, {
+          waitUntil: 'domcontentloaded',
+        });
+        await humanDelay('navigation');
+        return;
+      } catch (error) {
+        const _message = error instanceof Error ? error.message : String(error);
+        if (attempt < NAV_RETRY_ATTEMPTS - 1) {
+          await exactDelay(NAV_RETRY_DELAY);
+        }
+      }
+    }
+
+    throw new Error(`Failed to navigate to LinkedIn Feed after ${NAV_RETRY_ATTEMPTS} attempts`);
+  }
+
+  /**
+   * Get the current Playwright Page instance.
+   *
+   * @throws Error if browser not launched
+   */
+  getPage(): Page {
+    return this.requirePage();
+  }
+
+  /**
+   * Check if the browser is still connected and the page is usable.
+   */
+  isConnected(): boolean {
+    if (!this.context || !this.page) return false;
+    try {
+      // Check if the page is still open (not closed)
+      return !this.page.isClosed();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check if the LinkedIn session is authenticated.
+   * Ported from scan_raw.py lines 74-77: checks URL for 'login' or 'checkpoint'.
+   *
+   * @returns true if the page URL does not indicate a login/checkpoint redirect
+   */
+  isAuthenticated(): boolean {
+    if (!this.page || this.page.isClosed()) return false;
+    const url = this.page.url();
+    return !url.includes('login') && !url.includes('checkpoint');
+  }
+
+  /**
+   * Close the browser context and release resources.
+   * Ported from scan_raw.py: context.close()
+   */
+  async close(): Promise<void> {
+    if (this.context) {
+      try {
+        await this.context.close();
+      } catch {
+        // Context may already be closed
+      }
+      this.context = null;
+      this.page = null;
+    }
+  }
+
+  /**
+   * Internal: ensure page is available or throw.
+   */
+  private requirePage(): Page {
+    if (!this.page || this.page.isClosed()) {
+      throw new Error('Browser not launched or page closed. Call launch() first.');
+    }
+    return this.page;
+  }
+}

--- a/packages/channel-linkedin/src/browser/selectors.ts
+++ b/packages/channel-linkedin/src/browser/selectors.ts
@@ -1,0 +1,245 @@
+/**
+ * Centralized Selector Registry for LinkedIn DOM elements.
+ *
+ * Primary selectors are sourced from the proven linkedin-agent Python scripts.
+ * Each entry includes the source file reference and 1-2 fallback alternatives
+ * using aria-roles or data-attribute patterns.
+ *
+ * When LinkedIn updates their DOM, update the primary selector and shift the
+ * old primary into fallbacks. This keeps the fallback chain historically aware.
+ */
+
+import type { ElementHandle, Page } from 'playwright';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SelectorEntry {
+  /** The proven selector from linkedin-agent scripts */
+  primary: string;
+  /** Fallback selectors (aria-role, data-attribute, structural alternatives) */
+  fallbacks: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Typed selector groups (explicit properties, no index signature)
+// ---------------------------------------------------------------------------
+
+export interface InboxSelectorGroup {
+  conversationList: SelectorEntry;
+  conversationItem: SelectorEntry;
+  participantNames: SelectorEntry;
+  messageContent: SelectorEntry;
+  messageInput: SelectorEntry;
+  sendButton: SelectorEntry;
+  tabRow: SelectorEntry;
+}
+
+export interface FeedSelectorGroup {
+  postContainer: SelectorEntry;
+  postContent: SelectorEntry;
+  postAuthor: SelectorEntry;
+  reactionButton: SelectorEntry;
+  commentButton: SelectorEntry;
+  likeCount: SelectorEntry;
+  commentCount: SelectorEntry;
+}
+
+export interface ComposeSelectorGroup {
+  startPostButton: SelectorEntry;
+  postEditor: SelectorEntry;
+  postButton: SelectorEntry;
+}
+
+// ---------------------------------------------------------------------------
+// Inbox Selectors — sourced from scan_raw.py, reply.py, list_names.py, read_full.py
+// ---------------------------------------------------------------------------
+
+const inbox: InboxSelectorGroup = {
+  /** Scrollable conversation list container — scan_raw.py line 28 */
+  conversationList: {
+    primary: '.msg-conversations-container__conversations-list',
+    fallbacks: ['[data-test-conversations-list]', '.msg-conversations-container ul'],
+  },
+
+  /** Individual conversation item — scan_raw.py line 33 */
+  conversationItem: {
+    primary: 'li.msg-conversation-listitem',
+    fallbacks: ['[data-test-conversation-item]', '.msg-conversations-container li'],
+  },
+
+  /** Participant name(s) inside conversation item — scan_raw.py line 94 */
+  participantNames: {
+    primary: '.msg-conversation-listitem__participant-names',
+    fallbacks: ['[data-test-participant-names]', '.msg-conversation-card__participant-names'],
+  },
+
+  /** Message list content area (thread body) — scan_raw.py line 50 */
+  messageContent: {
+    primary: '.msg-s-message-list-content',
+    fallbacks: ['.msg-thread', '[data-test-message-list]'],
+  },
+
+  /** Message input field — reply.py line 59 */
+  messageInput: {
+    primary: '.msg-form__contenteditable',
+    fallbacks: ['[role="textbox"]', '.msg-form [contenteditable="true"]'],
+  },
+
+  /** Send button — reply.py line 64 */
+  sendButton: {
+    primary: '.msg-form__send-button',
+    fallbacks: ['button[type="submit"]', '.msg-form__send-btn'],
+  },
+
+  /** Tab navigation row — list_names.py line 22 */
+  tabRow: {
+    primary: '.msg-conversations-container__title-row',
+    fallbacks: ['[data-test-tab-row]', '.msg-tab-container'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Feed Selectors — NEW (no Python equivalent)
+// ---------------------------------------------------------------------------
+
+const feed: FeedSelectorGroup = {
+  /** Individual post container */
+  postContainer: {
+    primary: '.feed-shared-update-v2',
+    fallbacks: ['[data-test-feed-post]'],
+  },
+
+  /** Post text content */
+  postContent: {
+    primary: '.feed-shared-update-v2__description',
+    fallbacks: ['.update-components-text'],
+  },
+
+  /** Post author name */
+  postAuthor: {
+    primary: '.update-components-actor__name',
+    fallbacks: ['.feed-shared-actor__name'],
+  },
+
+  /** Reaction (like) button */
+  reactionButton: {
+    primary: '.reactions-react-button',
+    fallbacks: ['[data-test-react-button]'],
+  },
+
+  /** Comment button */
+  commentButton: {
+    primary: '.comment-button',
+    fallbacks: ['[data-test-comment-button]'],
+  },
+
+  /** Like/reaction count */
+  likeCount: {
+    primary: '.social-details-social-counts__reactions-count',
+    fallbacks: ['[data-test-like-count]'],
+  },
+
+  /** Comment count */
+  commentCount: {
+    primary: '.social-details-social-counts__comments',
+    fallbacks: ['[data-test-comment-count]'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Compose Selectors — NEW (no Python equivalent)
+// ---------------------------------------------------------------------------
+
+const compose: ComposeSelectorGroup = {
+  /** "Start a post" trigger button */
+  startPostButton: {
+    primary: '.share-box-feed-entry__trigger',
+    fallbacks: ['[data-test-share-box]'],
+  },
+
+  /** Rich text editor for post content */
+  postEditor: {
+    primary: '.ql-editor',
+    fallbacks: ['[data-test-post-editor]', '[role="textbox"]'],
+  },
+
+  /** "Post" submit button */
+  postButton: {
+    primary: '.share-actions__primary-action',
+    fallbacks: ['button[data-test-post-button]'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Consolidated Registry
+// ---------------------------------------------------------------------------
+
+export const SELECTORS = {
+  inbox,
+  feed,
+  compose,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Selector Resolution Helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Try the primary selector first, then each fallback in order.
+ * Returns the first matching ElementHandle, or null if none match.
+ *
+ * @param page - Playwright Page instance
+ * @param entry - SelectorEntry with primary + fallbacks
+ * @param options - Optional timeout for waiting (default: no wait, immediate check)
+ */
+export async function findElement(
+  page: Page,
+  entry: SelectorEntry,
+  options?: { timeout?: number },
+): Promise<ElementHandle | null> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+
+  for (const selector of allSelectors) {
+    try {
+      if (options?.timeout) {
+        const locator = page.locator(selector);
+        await locator.waitFor({ state: 'visible', timeout: options.timeout });
+        const handle = await locator.elementHandle();
+        if (handle) return handle;
+      } else {
+        const handle = await page.$(selector);
+        if (handle) return handle;
+      }
+    } catch {
+      // Selector didn't match or timed out, try next
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build a combined CSS selector string from a SelectorEntry (primary + fallbacks).
+ * Useful for Playwright's locator() which accepts comma-separated selectors.
+ *
+ * @param entry - SelectorEntry with primary + fallbacks
+ * @returns Comma-separated selector string
+ */
+export function combinedSelector(entry: SelectorEntry): string {
+  return [entry.primary, ...entry.fallbacks].join(', ');
+}
+
+/**
+ * Check if any selector in the entry matches an element on the page.
+ * Non-blocking — returns immediately.
+ *
+ * @param page - Playwright Page instance
+ * @param entry - SelectorEntry to check
+ * @returns true if at least one selector matches
+ */
+export async function selectorExists(page: Page, entry: SelectorEntry): Promise<boolean> {
+  const el = await findElement(page, entry);
+  return el !== null;
+}

--- a/packages/channel-linkedin/src/index.ts
+++ b/packages/channel-linkedin/src/index.ts
@@ -1,0 +1,119 @@
+/**
+ * LinkedIn Channel Plugin for Omni v2
+ *
+ * Provides LinkedIn messaging, feed management, and social interactions
+ * via Playwright browser automation.
+ *
+ * @example
+ * ```typescript
+ * import linkedInPlugin from '@omni/channel-linkedin';
+ *
+ * // Plugin is auto-discovered by channel-sdk scanner
+ * // Or manually register:
+ * registry.register(linkedInPlugin);
+ * ```
+ */
+
+import { LinkedInPlugin } from './plugin';
+
+// Export the plugin instance (default export for auto-discovery)
+const plugin = new LinkedInPlugin();
+export default plugin;
+
+// Named exports for the plugin class
+export { LinkedInPlugin } from './plugin';
+
+// Sync engine
+export {
+  diffByExternalId,
+  FeedPoller,
+  InboxPoller,
+} from './sync';
+
+export type {
+  DiffResult,
+  FeedPollerConfig,
+  FeedPollerDataAccess,
+  InboxPollerConfig,
+} from './sync';
+
+// Browser automation layer
+export {
+  BrowserManager,
+  SELECTORS,
+  findElement,
+  combinedSelector,
+  selectorExists,
+  TIMING,
+  NAV_RETRY_ATTEMPTS,
+  NAV_RETRY_DELAY,
+  CONVERSATION_SCROLL_MAX,
+  HISTORY_SCROLL_UP,
+  humanDelay,
+  exactDelay,
+  typeText,
+  RateLimiter,
+  isActiveHours,
+} from './browser';
+
+export type {
+  BrowserConfig,
+  SelectorEntry,
+  InboxSelectorGroup,
+  FeedSelectorGroup,
+  ComposeSelectorGroup,
+  TimingKey,
+} from './browser';
+
+// Actions (mutate state on LinkedIn)
+export {
+  sendMessage,
+  createPost,
+  postComment,
+  reactToPost,
+  sendConnectionRequest,
+  acceptConnectionRequest,
+} from './actions';
+
+// DOM Scrapers
+export {
+  scrapeConversations,
+  scrapeFullConversation,
+  listConversationNames,
+  switchTab,
+  scrapeFeedPosts,
+  scrapePostComments,
+  scrapeProfile,
+  scrapeConnections,
+  scrapePendingInvites,
+} from './scrapers';
+
+export type {
+  ScrapeConversationsOptions,
+  ScrapeFullConversationOptions,
+  InboxTab,
+  ScrapeFeedPostsOptions,
+} from './scrapers';
+
+// LinkedIn types
+export { DEFAULT_RATE_LIMITS } from './types';
+
+export type {
+  LinkedInInstanceConfig,
+  LinkedInPost,
+  LinkedInComment,
+  LinkedInConnection,
+  LinkedInConversation,
+  LinkedInMessage,
+  LinkedInProfile,
+  LinkedInReactionType,
+  RateLimitsConfig,
+  ActiveHoursConfig,
+  SyncIntervalsConfig,
+  ActionResult,
+  SendMessageResult,
+  CreatePostResult,
+  ReactResult,
+  CommentResult,
+  ConnectResult,
+} from './types';

--- a/packages/channel-linkedin/src/plugin.ts
+++ b/packages/channel-linkedin/src/plugin.ts
@@ -1,0 +1,885 @@
+/**
+ * LinkedInPlugin — main plugin class for the LinkedIn channel.
+ *
+ * Extends SocialChannelPlugin from channel-sdk and wires together:
+ * - BrowserManager for Playwright-based automation
+ * - RateLimiter for humanized rate limiting
+ * - FeedPoller for periodic feed sync
+ * - InboxPoller for periodic inbox sync
+ * - All scrapers and actions from Groups B-D
+ *
+ * Plugin metadata:
+ * - id: 'linkedin'
+ * - name: 'LinkedIn'
+ * - channelType: 'linkedin'
+ */
+
+import { SocialChannelPlugin } from '@omni/channel-sdk';
+import type {
+  ChannelCapabilities,
+  ConnectionStatus,
+  CreatePostInput,
+  CreatePostResult,
+  FeedPost,
+  GetCommentsResult,
+  GetConnectionsResult,
+  GetFeedOptions,
+  GetFeedResult,
+  HealthCheck,
+  InstanceConfig,
+  OutgoingMessage,
+  PostComment,
+  SendResult,
+  SocialConnection,
+} from '@omni/channel-sdk';
+import { DEFAULT_CAPABILITIES } from '@omni/channel-sdk';
+import type { ChannelType } from '@omni/core/types';
+
+import {
+  createPost as createPostAction,
+  reactToPost as reactToPostAction,
+  sendMessage as sendMessageAction,
+} from './actions';
+import { BrowserManager, RateLimiter, SELECTORS, isActiveHours, selectorExists } from './browser';
+import type { BrowserConfig } from './browser';
+import { scrapeConnections, scrapeFeedPosts, scrapePendingInvites, scrapePostComments } from './scrapers';
+import { FeedPoller } from './sync/feed-poller';
+import type { FeedPollerDataAccess } from './sync/feed-poller';
+import { InboxPoller } from './sync/inbox-poller';
+import type {
+  ActiveHoursConfig,
+  LinkedInComment,
+  LinkedInInstanceConfig,
+  LinkedInPost,
+  LinkedInReactionType,
+  RateLimitsConfig,
+  SyncIntervalsConfig,
+} from './types';
+import { DEFAULT_RATE_LIMITS } from './types';
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+const LINKEDIN_CAPABILITIES: ChannelCapabilities = {
+  ...DEFAULT_CAPABILITIES,
+  canSendText: true,
+  canCreatePost: true,
+  canReadFeed: true,
+  canComment: true,
+  canHandleConnections: true,
+  canHandleDMs: true,
+  maxMessageLength: 8000,
+};
+
+// ---------------------------------------------------------------------------
+// Default configuration
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SYNC_INTERVALS: SyncIntervalsConfig = {
+  feed: 15 * 60 * 1000, // 15 minutes
+  inbox: 5 * 60 * 1000, // 5 minutes
+  connections: 60 * 60 * 1000, // 1 hour
+  engagement: 30 * 60 * 1000, // 30 minutes
+};
+
+const DEFAULT_ACTIVE_HOURS: ActiveHoursConfig = {
+  start: 8,
+  end: 22,
+  timezone: 'America/Sao_Paulo',
+};
+
+// ---------------------------------------------------------------------------
+// Per-instance state
+// ---------------------------------------------------------------------------
+
+interface InstanceState {
+  browser: BrowserManager;
+  rateLimiter: RateLimiter;
+  feedPoller: FeedPoller | null;
+  inboxPoller: InboxPoller | null;
+  config: LinkedInInstanceConfig;
+}
+
+// ---------------------------------------------------------------------------
+// LinkedInPlugin
+// ---------------------------------------------------------------------------
+
+export class LinkedInPlugin extends SocialChannelPlugin {
+  readonly id = 'linkedin' as ChannelType;
+  readonly name = 'LinkedIn';
+  readonly version = '1.0.0';
+  readonly capabilities = LINKEDIN_CAPABILITIES;
+
+  private instanceStates = new Map<string, InstanceState>();
+
+  // ─────────────────────────────────────────────────────────────
+  // Lifecycle
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Connect a LinkedIn instance.
+   *
+   * 1. Parse instance config for LinkedIn-specific settings
+   * 2. Launch BrowserManager with persistent Chromium context
+   * 3. Verify authentication (check for login redirect)
+   * 4. Start feed and inbox pollers
+   * 5. Emit instance.connected event
+   */
+  async connect(instanceId: string, config: InstanceConfig): Promise<void> {
+    if (this.instanceStates.has(instanceId)) {
+      throw new Error(`LinkedIn instance '${instanceId}' already connected`);
+    }
+
+    const linkedInConfig = this.parseConfig(config);
+
+    this.instances.setInstance(instanceId, config, {
+      state: 'connecting',
+      since: new Date(),
+      message: 'Launching browser...',
+    });
+
+    // Create browser manager
+    const browserConfig: BrowserConfig = {
+      browserDataPath: linkedInConfig.browserDataPath,
+      headless: linkedInConfig.headless,
+      viewportWidth: linkedInConfig.viewportWidth,
+      viewportHeight: linkedInConfig.viewportHeight,
+      locale: linkedInConfig.locale,
+    };
+
+    const browser = new BrowserManager(browserConfig);
+    const rateLimiter = new RateLimiter(linkedInConfig.rateLimits);
+
+    try {
+      // Launch browser
+      await browser.launch();
+      this.logger.info('Browser launched', { instanceId });
+
+      // Navigate to messaging to verify auth
+      await browser.navigateToMessaging();
+
+      // Check authentication
+      if (!browser.isAuthenticated()) {
+        this.instances.setInstance(instanceId, config, {
+          state: 'error',
+          since: new Date(),
+          message: 'Authentication required - please log in to LinkedIn in the browser',
+          error: {
+            code: 'AUTH_REQUIRED',
+            message: 'LinkedIn session not authenticated. Log in via the persistent browser profile.',
+            retryable: true,
+          },
+        });
+        await this.emitInstanceDisconnected(instanceId, 'auth_expired');
+        return;
+      }
+
+      // Create data access layer for feed poller
+      const dataAccess = this.createDataAccess(instanceId);
+
+      // Create and start feed poller
+      const feedPoller = new FeedPoller({
+        page: browser.getPage(),
+        dataAccess,
+        logger: this.logger,
+        onPostReceived: async (post) => {
+          await this.emitPostReceived({
+            instanceId,
+            externalId: post.externalId,
+            authorPlatformUserId: post.authorProfileUrl ?? post.authorName,
+            authorDisplayName: post.authorName,
+            postType: 'text',
+            textContent: post.content,
+            mediaUrls: post.mediaUrls,
+            hashtags: post.hashtags,
+            likeCount: post.likeCount,
+            commentCount: post.commentCount,
+            repostCount: post.repostCount,
+          });
+        },
+        onPostUpdated: async (_oldPost, newPost, changedFields) => {
+          await this.emitPostUpdated({
+            instanceId,
+            externalId: newPost.externalId,
+            changedFields,
+            likeCount: newPost.likeCount,
+            commentCount: newPost.commentCount,
+            repostCount: newPost.repostCount,
+          });
+        },
+        onPostDeleted: async (post) => {
+          await this.emitPostDeleted({
+            instanceId,
+            externalId: post.externalId,
+            reason: 'not_found_in_feed',
+          });
+        },
+        onCommentReceived: async (comment) => {
+          await this.emitCommentReceived({
+            instanceId,
+            externalId: comment.externalId,
+            postExternalId: comment.postId,
+            parentCommentExternalId: comment.parentCommentId,
+            authorPlatformUserId: comment.authorProfileUrl ?? comment.authorName,
+            authorDisplayName: comment.authorName,
+            textContent: comment.content,
+          });
+        },
+      });
+
+      // Create and start inbox poller
+      const inboxPoller = new InboxPoller({
+        page: browser.getPage(),
+        instanceId,
+        logger: this.logger,
+        onMessageReceived: async (message, conversation) => {
+          await this.emitMessageReceived({
+            instanceId,
+            externalId: message.externalId,
+            chatId: conversation.externalId,
+            from: message.senderName,
+            content: {
+              type: 'text',
+              text: message.body,
+            },
+          });
+        },
+      });
+
+      // Store instance state
+      const state: InstanceState = {
+        browser,
+        rateLimiter,
+        feedPoller,
+        inboxPoller,
+        config: linkedInConfig,
+      };
+      this.instanceStates.set(instanceId, state);
+
+      // Start pollers (respecting active hours)
+      if (isActiveHours(linkedInConfig.activeHours)) {
+        feedPoller.start(linkedInConfig.syncIntervals.feed);
+        inboxPoller.start(linkedInConfig.syncIntervals.inbox);
+      } else {
+        this.logger.info('Outside active hours, pollers will start when active hours begin', { instanceId });
+      }
+
+      // Update instance status
+      this.instances.setInstance(instanceId, config, {
+        state: 'connected',
+        since: new Date(),
+        message: 'LinkedIn connected via persistent browser session',
+      });
+
+      await this.emitInstanceConnected(instanceId, {
+        profileName: 'LinkedIn User',
+      });
+
+      this.logger.info('LinkedIn instance connected', { instanceId });
+    } catch (error) {
+      await browser.close();
+      const message = error instanceof Error ? error.message : String(error);
+
+      this.instances.setInstance(instanceId, config, {
+        state: 'error',
+        since: new Date(),
+        message: `Connection failed: ${message}`,
+        error: {
+          code: 'CONNECTION_FAILED',
+          message,
+          retryable: true,
+        },
+      });
+
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect a LinkedIn instance.
+   *
+   * 1. Stop pollers
+   * 2. Close browser
+   * 3. Emit instance.disconnected event
+   */
+  async disconnect(instanceId: string): Promise<void> {
+    const state = this.instanceStates.get(instanceId);
+    if (!state) {
+      this.logger.warn('Disconnect called for unknown instance', { instanceId });
+      return;
+    }
+
+    // Stop pollers
+    state.feedPoller?.stop();
+    state.inboxPoller?.stop();
+
+    // Close browser
+    await state.browser.close();
+
+    // Clean up
+    this.instanceStates.delete(instanceId);
+    this.instances.setInstance(
+      instanceId,
+      { instanceId, credentials: {} },
+      {
+        state: 'disconnected',
+        since: new Date(),
+        message: 'Disconnected',
+      },
+    );
+
+    await this.emitInstanceDisconnected(instanceId);
+    this.logger.info('LinkedIn instance disconnected', { instanceId });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Messaging
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Send a message to a LinkedIn conversation.
+   */
+  async sendMessage(instanceId: string, message: OutgoingMessage): Promise<SendResult> {
+    const state = this.requireState(instanceId);
+    const page = state.browser.getPage();
+    const text = message.content.text ?? '';
+
+    if (!text) {
+      return {
+        success: false,
+        error: 'Message text is required',
+        timestamp: Date.now(),
+      };
+    }
+
+    // Navigate to messaging if needed
+    const currentUrl = page.url();
+    if (!currentUrl.includes('/messaging')) {
+      await state.browser.navigateToMessaging();
+    }
+
+    const result = await sendMessageAction(page, state.rateLimiter, message.to, text);
+
+    if (result.success && result.data) {
+      await this.emitMessageSent({
+        instanceId,
+        externalId: `msg-${Date.now()}`,
+        chatId: message.to,
+        to: message.to,
+        content: { type: 'text', text },
+      });
+    }
+
+    return {
+      success: result.success,
+      messageId: result.success ? `msg-${Date.now()}` : undefined,
+      error: result.error,
+      timestamp: Date.now(),
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Social methods (SocialChannelPlugin abstract implementations)
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Create a post on LinkedIn.
+   */
+  async createPost(instanceId: string, post: CreatePostInput): Promise<CreatePostResult> {
+    const state = this.requireState(instanceId);
+    const page = state.browser.getPage();
+    const text = post.textContent ?? '';
+
+    if (!text) {
+      return { success: false, error: 'Post text content is required' };
+    }
+
+    // Navigate to feed if needed
+    const currentUrl = page.url();
+    if (!currentUrl.includes('/feed')) {
+      await state.browser.navigateToFeed();
+    }
+
+    const result = await createPostAction(page, state.rateLimiter, text);
+
+    if (result.success) {
+      await this.emitPostCreated({
+        instanceId,
+        externalId: `post-${Date.now()}`,
+        postType: 'text',
+        textContent: text,
+        visibility: post.visibility,
+      });
+    }
+
+    return {
+      success: result.success,
+      externalId: result.success ? `post-${Date.now()}` : undefined,
+      error: result.error,
+    };
+  }
+
+  /**
+   * Get feed posts. Live scrapes from LinkedIn.
+   */
+  async getFeed(instanceId: string, options?: GetFeedOptions): Promise<GetFeedResult> {
+    const state = this.requireState(instanceId);
+    const page = state.browser.getPage();
+
+    // Navigate to feed if needed
+    const currentUrl = page.url();
+    if (!currentUrl.includes('/feed')) {
+      await state.browser.navigateToFeed();
+    }
+
+    const posts = await scrapeFeedPosts(page, {
+      limit: options?.limit ?? 10,
+    });
+
+    const feedPosts: FeedPost[] = posts.map((p) => ({
+      externalId: p.externalId,
+      authorPlatformUserId: p.authorProfileUrl ?? p.authorName,
+      authorDisplayName: p.authorName,
+      postType: 'text',
+      textContent: p.content,
+      mediaUrls: p.mediaUrls,
+      hashtags: p.hashtags,
+      likeCount: p.likeCount,
+      commentCount: p.commentCount,
+      repostCount: p.repostCount,
+    }));
+
+    return {
+      posts: feedPosts,
+      hasMore: feedPosts.length >= (options?.limit ?? 10),
+    };
+  }
+
+  /**
+   * Get comments on a specific post.
+   */
+  async getComments(instanceId: string, postExternalId: string): Promise<GetCommentsResult> {
+    const state = this.requireState(instanceId);
+    const page = state.browser.getPage();
+
+    // Find the post element by its externalId (data-urn)
+    const postElements = await page.$$('.feed-shared-update-v2, [data-test-feed-post]');
+    let matchedEl = null;
+
+    for (const el of postElements) {
+      const dataUrn = await el.getAttribute('data-urn');
+      if (dataUrn === postExternalId) {
+        matchedEl = el;
+        break;
+      }
+    }
+
+    if (!matchedEl) {
+      return { comments: [], hasMore: false };
+    }
+
+    const scrapedComments = await scrapePostComments(matchedEl);
+
+    const comments: PostComment[] = scrapedComments.map((c) => ({
+      externalId: c.externalId,
+      postExternalId: c.postId,
+      parentCommentExternalId: c.parentCommentId,
+      authorPlatformUserId: c.authorProfileUrl ?? c.authorName,
+      authorDisplayName: c.authorName,
+      textContent: c.content,
+      likeCount: c.likeCount,
+    }));
+
+    return {
+      comments,
+      hasMore: false,
+    };
+  }
+
+  /**
+   * React to a LinkedIn post.
+   */
+  async reactToPost(instanceId: string, postExternalId: string, reactionType: string): Promise<void> {
+    const state = this.requireState(instanceId);
+    const page = state.browser.getPage();
+
+    // Find the post element
+    const postElements = await page.$$('.feed-shared-update-v2, [data-test-feed-post]');
+    let matchedEl = null;
+
+    for (const el of postElements) {
+      const dataUrn = await el.getAttribute('data-urn');
+      if (dataUrn === postExternalId) {
+        matchedEl = el;
+        break;
+      }
+    }
+
+    if (!matchedEl) {
+      throw new Error(`Post '${postExternalId}' not found on current page`);
+    }
+
+    const result = await reactToPostAction(
+      page,
+      state.rateLimiter,
+      matchedEl,
+      reactionType as LinkedInReactionType,
+      postExternalId,
+    );
+
+    if (!result.success) {
+      throw new Error(result.error ?? 'Failed to react to post');
+    }
+  }
+
+  /**
+   * Get connections list.
+   */
+  async getConnections(instanceId: string): Promise<GetConnectionsResult> {
+    const state = this.requireState(instanceId);
+    const page = state.browser.getPage();
+
+    const connections = await scrapeConnections(page);
+    const pendingInvites = await scrapePendingInvites(page);
+
+    const all: SocialConnection[] = [
+      ...connections.map((c) => ({
+        platformUserId: c.externalId,
+        displayName: c.name,
+        connectionType: 'connect',
+        status: c.status,
+        connectedAt: c.connectedAt ? new Date(c.connectedAt) : undefined,
+      })),
+      ...pendingInvites.map((c) => ({
+        platformUserId: c.externalId,
+        displayName: c.name,
+        connectionType: 'connect',
+        status: c.status,
+      })),
+    ];
+
+    return {
+      connections: all,
+      hasMore: false,
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Status & Health
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Get connection status for an instance.
+   */
+  override async getStatus(instanceId: string): Promise<ConnectionStatus> {
+    const state = this.instanceStates.get(instanceId);
+
+    if (!state) {
+      return {
+        state: 'disconnected',
+        since: new Date(),
+        message: 'Instance not found',
+      };
+    }
+
+    if (!state.browser.isConnected()) {
+      return {
+        state: 'error',
+        since: new Date(),
+        message: 'Browser connection lost',
+        error: {
+          code: 'BROWSER_DISCONNECTED',
+          message: 'The Chromium browser is no longer connected',
+          retryable: true,
+        },
+      };
+    }
+
+    if (!state.browser.isAuthenticated()) {
+      return {
+        state: 'error',
+        since: new Date(),
+        message: 'LinkedIn authentication expired',
+        error: {
+          code: 'AUTH_EXPIRED',
+          message: 'LinkedIn session has expired. Please re-authenticate.',
+          retryable: true,
+        },
+      };
+    }
+
+    return {
+      state: 'connected',
+      since: new Date(),
+      message: 'Connected',
+    };
+  }
+
+  /**
+   * Custom health checks including selector verification.
+   */
+  protected override async getHealthChecks(): Promise<HealthCheck[]> {
+    const checks = await super.getHealthChecks();
+
+    // Check selector health for each connected instance
+    for (const [instanceId, state] of this.instanceStates) {
+      try {
+        const page = state.browser.getPage();
+
+        // Check if key selectors are resolvable
+        const inboxConvListExists = await selectorExists(page, SELECTORS.inbox.conversationList);
+        const feedPostExists = await selectorExists(page, SELECTORS.feed.postContainer);
+
+        if (inboxConvListExists || feedPostExists) {
+          checks.push({
+            name: `selectors:${instanceId}`,
+            status: 'pass',
+            message: 'Critical DOM selectors found',
+            data: {
+              inboxConversationList: inboxConvListExists,
+              feedPostContainer: feedPostExists,
+            },
+          });
+        } else {
+          checks.push({
+            name: `selectors:${instanceId}`,
+            status: 'warn',
+            message: 'No critical selectors matched - LinkedIn DOM may have changed',
+            data: {
+              inboxConversationList: false,
+              feedPostContainer: false,
+            },
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        checks.push({
+          name: `selectors:${instanceId}`,
+          status: 'fail',
+          message: `Selector health check failed: ${message}`,
+        });
+      }
+
+      // Rate limiter summary
+      checks.push({
+        name: `rate-limiter:${instanceId}`,
+        status: 'pass',
+        message: 'Rate limiter summary',
+        data: state.rateLimiter.getSummary() as unknown as Record<string, unknown>,
+      });
+    }
+
+    return checks;
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Data Access Layer
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Create a FeedPollerDataAccess implementation for a given instance.
+   *
+   * Uses the PluginDatabase interface (db.execute) to avoid direct drizzle-orm
+   * imports, which cause duplicate package resolution issues in monorepos.
+   */
+  private createDataAccess(instanceId: string): FeedPollerDataAccess {
+    const db = this.db;
+
+    return {
+      loadExistingPosts: async (): Promise<LinkedInPost[]> => {
+        const rows = await db.execute<{
+          external_id: string;
+          author_display_name: string | null;
+          text_content: string | null;
+          like_count: number;
+          comment_count: number;
+          repost_count: number;
+          media_urls: string[] | null;
+          hashtags: string[] | null;
+          last_synced_at: string | null;
+          created_at: string;
+        }>(
+          `SELECT external_id, author_display_name, text_content, like_count,
+                  comment_count, repost_count, media_urls, hashtags,
+                  last_synced_at, created_at
+           FROM social_posts
+           WHERE instance_id = $1 AND status = 'active'`,
+          [instanceId],
+        );
+
+        return rows.map((row) => ({
+          externalId: row.external_id,
+          authorName: row.author_display_name ?? '',
+          content: row.text_content ?? '',
+          likeCount: row.like_count,
+          commentCount: row.comment_count,
+          repostCount: row.repost_count,
+          mediaUrls: row.media_urls ?? undefined,
+          hashtags: row.hashtags ?? undefined,
+          scrapedAt: row.last_synced_at ? new Date(row.last_synced_at).getTime() : new Date(row.created_at).getTime(),
+        }));
+      },
+
+      insertPost: async (post: LinkedInPost): Promise<void> => {
+        await db.execute(
+          `INSERT INTO social_posts
+            (instance_id, external_id, channel, author_display_name,
+             author_platform_user_id, post_type, text_content, media_urls,
+             hashtags, like_count, comment_count, repost_count,
+             last_synced_at, platform_timestamp)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW(),
+                   ${post.postedAt ? '$13' : 'NULL'})`,
+          [
+            instanceId,
+            post.externalId,
+            'linkedin',
+            post.authorName,
+            post.authorProfileUrl ?? post.authorName,
+            'text',
+            post.content,
+            post.mediaUrls ? JSON.stringify(post.mediaUrls) : null,
+            post.hashtags ?? null,
+            post.likeCount ?? 0,
+            post.commentCount ?? 0,
+            post.repostCount ?? 0,
+            ...(post.postedAt ? [new Date(post.postedAt).toISOString()] : []),
+          ],
+        );
+      },
+
+      updatePost: async (externalId: string, post: LinkedInPost): Promise<void> => {
+        await db.execute(
+          `UPDATE social_posts
+           SET like_count = $1, comment_count = $2, repost_count = $3,
+               text_content = $4, last_synced_at = NOW(), updated_at = NOW()
+           WHERE instance_id = $5 AND external_id = $6`,
+          [post.likeCount ?? 0, post.commentCount ?? 0, post.repostCount ?? 0, post.content, instanceId, externalId],
+        );
+      },
+
+      markPostDeleted: async (externalId: string): Promise<void> => {
+        await db.execute(
+          `UPDATE social_posts
+           SET status = 'deleted', updated_at = NOW()
+           WHERE instance_id = $1 AND external_id = $2`,
+          [instanceId, externalId],
+        );
+      },
+
+      insertEngagementSnapshot: async (externalId: string, post: LinkedInPost): Promise<void> => {
+        await db.execute(
+          `INSERT INTO social_engagement_snapshots (post_id, like_count, comment_count, repost_count)
+           SELECT id, $1, $2, $3
+           FROM social_posts
+           WHERE instance_id = $4 AND external_id = $5
+           LIMIT 1`,
+          [post.likeCount ?? 0, post.commentCount ?? 0, post.repostCount ?? 0, instanceId, externalId],
+        );
+      },
+
+      loadExistingComments: async (postExternalId: string): Promise<LinkedInComment[]> => {
+        const rows = await db.execute<{
+          external_id: string;
+          author_display_name: string | null;
+          text_content: string | null;
+          like_count: number;
+          parent_comment_id: string | null;
+        }>(
+          `SELECT sc.external_id, sc.author_display_name, sc.text_content,
+                  sc.like_count, sc.parent_comment_id
+           FROM social_comments sc
+           JOIN social_posts sp ON sc.post_id = sp.id
+           WHERE sp.instance_id = $1 AND sp.external_id = $2`,
+          [instanceId, postExternalId],
+        );
+
+        return rows.map((row) => ({
+          externalId: row.external_id,
+          postId: postExternalId,
+          parentCommentId: row.parent_comment_id ?? undefined,
+          authorName: row.author_display_name ?? '',
+          content: row.text_content ?? '',
+          likeCount: row.like_count,
+        }));
+      },
+
+      insertComment: async (postExternalId: string, comment: LinkedInComment): Promise<void> => {
+        // Resolve parent comment ID if this is a reply
+        let parentClause = 'NULL';
+        const params: unknown[] = [
+          postExternalId,
+          instanceId,
+          comment.externalId,
+          comment.authorName,
+          comment.authorProfileUrl ?? comment.authorName,
+          comment.content,
+          comment.likeCount ?? 0,
+        ];
+
+        if (comment.parentCommentId) {
+          parentClause = `(SELECT sc2.id FROM social_comments sc2
+                           JOIN social_posts sp2 ON sc2.post_id = sp2.id
+                           WHERE sp2.instance_id = $8 AND sp2.external_id = $9
+                             AND sc2.external_id = $10
+                           LIMIT 1)`;
+          params.push(instanceId, postExternalId, comment.parentCommentId);
+        }
+
+        await db.execute(
+          `INSERT INTO social_comments
+            (post_id, parent_comment_id, external_id, author_display_name,
+             author_platform_user_id, text_content, like_count, last_synced_at)
+           SELECT sp.id, ${parentClause}, $3, $4, $5, $6, $7, NOW()
+           FROM social_posts sp
+           WHERE sp.instance_id = $2 AND sp.external_id = $1
+           LIMIT 1`,
+          params,
+        );
+      },
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Internals
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Parse InstanceConfig into LinkedInInstanceConfig with defaults.
+   */
+  private parseConfig(config: InstanceConfig): LinkedInInstanceConfig {
+    const opts = config.options ?? {};
+    const creds = config.credentials ?? {};
+
+    return {
+      browserDataPath: (creds.browserDataPath as string) ?? (opts.browserDataPath as string) ?? '.browser_data',
+      syncIntervals: {
+        ...DEFAULT_SYNC_INTERVALS,
+        ...(opts.syncIntervals as Partial<SyncIntervalsConfig> | undefined),
+      },
+      rateLimits: {
+        ...DEFAULT_RATE_LIMITS,
+        ...(opts.rateLimits as Partial<RateLimitsConfig> | undefined),
+      },
+      activeHours: {
+        ...DEFAULT_ACTIVE_HOURS,
+        ...(opts.activeHours as Partial<ActiveHoursConfig> | undefined),
+      },
+      headless: (opts.headless as boolean | undefined) ?? true,
+      viewportWidth: (opts.viewportWidth as number | undefined) ?? 1280,
+      viewportHeight: (opts.viewportHeight as number | undefined) ?? 900,
+      locale: (opts.locale as string | undefined) ?? 'pt-BR',
+    };
+  }
+
+  /**
+   * Get instance state or throw if not connected.
+   */
+  private requireState(instanceId: string): InstanceState {
+    const state = this.instanceStates.get(instanceId);
+    if (!state) {
+      throw new Error(`LinkedIn instance '${instanceId}' is not connected`);
+    }
+    return state;
+  }
+}

--- a/packages/channel-linkedin/src/scrapers/comments.ts
+++ b/packages/channel-linkedin/src/scrapers/comments.ts
@@ -1,0 +1,179 @@
+/**
+ * Comments Scraper — extracts threaded comments from LinkedIn posts.
+ *
+ * NEW scraper (no Python equivalent). Follows the same DOM parsing patterns
+ * established in the inbox scraper (scan_raw.py port).
+ *
+ * All DOM queries go through findElement() / SELECTORS from the centralized
+ * selector registry. All waits use humanDelay() from the humanizer.
+ */
+
+import type { ElementHandle } from 'playwright';
+import { humanDelay } from '../browser/humanizer';
+import { SELECTORS } from '../browser/selectors';
+import type { LinkedInComment } from '../types';
+
+// ---------------------------------------------------------------------------
+// Selectors for comments (structural, not in registry since comment DOM
+// is nested within post elements)
+// ---------------------------------------------------------------------------
+
+const COMMENT_SELECTORS = {
+  /** Top-level comment container */
+  commentItem: '.comments-comment-item',
+  /** Comment author name */
+  commentAuthor: '.comments-post-meta__name-text',
+  /** Comment body text */
+  commentBody: '.comments-comment-item__main-content',
+  /** Reply container (nested under a comment) */
+  replyItem: '.comments-reply-item',
+  /** Reply body text */
+  replyBody: '.comments-reply-item__main-content',
+  /** Like count on a comment */
+  commentLikes: '.comments-comment-social-bar__reactions-count',
+  /** Author profile link */
+  commentAuthorLink: '.comments-post-meta__name-text a',
+  /** "Show more replies" / "Load more comments" button */
+  loadMoreComments: 'button.comments-comments-list__load-more-comments-button',
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const EVAL_INNER_TEXT = (el: { innerText?: string }) => el.innerText?.trim() ?? '';
+
+// ---------------------------------------------------------------------------
+// Internal: extract a single comment element
+// ---------------------------------------------------------------------------
+
+async function extractComment(
+  commentEl: ElementHandle,
+  postId: string,
+  index: number,
+  parentCommentId?: string,
+): Promise<LinkedInComment | null> {
+  try {
+    // Author name
+    const authorEl = await commentEl.$(COMMENT_SELECTORS.commentAuthor);
+    const authorName = authorEl ? await authorEl.evaluate(EVAL_INNER_TEXT) : '';
+
+    // Author profile URL
+    let authorProfileUrl: string | undefined;
+    const authorLink = await commentEl.$(COMMENT_SELECTORS.commentAuthorLink);
+    if (authorLink) {
+      authorProfileUrl = (await authorLink.getAttribute('href')) ?? undefined;
+    }
+
+    // Comment body
+    const bodySelector = parentCommentId ? COMMENT_SELECTORS.replyBody : COMMENT_SELECTORS.commentBody;
+    const bodyEl = await commentEl.$(bodySelector);
+    const content = bodyEl ? await bodyEl.evaluate(EVAL_INNER_TEXT) : '';
+
+    if (!content && !authorName) return null;
+
+    // Like count
+    let likeCount: number | undefined;
+    const likeEl = await commentEl.$(COMMENT_SELECTORS.commentLikes);
+    if (likeEl) {
+      const likeText = await likeEl.evaluate(EVAL_INNER_TEXT);
+      const parsed = Number.parseInt(likeText.replace(/[^\d]/g, ''), 10);
+      if (!Number.isNaN(parsed)) likeCount = parsed;
+    }
+
+    // External ID
+    const dataUrn = await commentEl.getAttribute('data-urn');
+    const externalId = dataUrn ?? `${postId}-comment-${index}`;
+
+    return {
+      externalId,
+      postId,
+      parentCommentId,
+      authorName,
+      authorProfileUrl,
+      content,
+      likeCount,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// scrapePostComments
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract comments from a LinkedIn post, including threaded replies.
+ *
+ * Expects that the comment section is already expanded (i.e., the comment
+ * button has been clicked on the post). Will attempt to load more comments
+ * by clicking "Load more" buttons.
+ *
+ * @param postElement - The post's ElementHandle (the .feed-shared-update-v2 container)
+ * @returns Array of comments with parent references for threading
+ */
+/**
+ * Expand the comment section by clicking the comment button and loading more comments.
+ */
+async function expandComments(postElement: ElementHandle): Promise<void> {
+  const commentBtnEntry = SELECTORS.feed.commentButton;
+  const commentBtn = await postElement.$(commentBtnEntry.primary);
+  if (commentBtn) {
+    await commentBtn.click();
+    await humanDelay('postClick');
+  }
+
+  const loadMoreBtn = await postElement.$(COMMENT_SELECTORS.loadMoreComments);
+  if (!loadMoreBtn) return;
+  try {
+    await loadMoreBtn.click();
+    await humanDelay('messageLoad');
+  } catch {
+    // Button may not be clickable
+  }
+}
+
+/**
+ * Extract a top-level comment and its threaded replies.
+ */
+async function extractCommentWithReplies(
+  commentEl: ElementHandle,
+  postId: string,
+  index: number,
+): Promise<LinkedInComment[]> {
+  const results: LinkedInComment[] = [];
+  const comment = await extractComment(commentEl, postId, index);
+  if (!comment) return results;
+
+  results.push(comment);
+
+  const replyEls = await commentEl.$$(COMMENT_SELECTORS.replyItem);
+  for (let j = 0; j < replyEls.length; j++) {
+    const replyEl = replyEls[j] as ElementHandle;
+    const reply = await extractComment(replyEl, postId, j, comment.externalId);
+    if (reply) {
+      results.push(reply);
+    }
+  }
+
+  return results;
+}
+
+export async function scrapePostComments(postElement: ElementHandle): Promise<LinkedInComment[]> {
+  const dataUrn = await postElement.getAttribute('data-urn');
+  const postId = dataUrn ?? `post-${Date.now()}`;
+
+  await expandComments(postElement);
+
+  const commentEls = await postElement.$$(COMMENT_SELECTORS.commentItem);
+  const results: LinkedInComment[] = [];
+
+  for (let i = 0; i < commentEls.length; i++) {
+    const commentEl = commentEls[i] as ElementHandle;
+    const commentResults = await extractCommentWithReplies(commentEl, postId, i);
+    results.push(...commentResults);
+  }
+
+  return results;
+}

--- a/packages/channel-linkedin/src/scrapers/connections.ts
+++ b/packages/channel-linkedin/src/scrapers/connections.ts
@@ -1,0 +1,268 @@
+/**
+ * Connections Scraper — extracts connections list and pending invites.
+ *
+ * NEW scraper (no Python equivalent). Follows the same DOM parsing patterns
+ * established in the inbox scraper (scan_raw.py port).
+ *
+ * All waits use humanDelay() from the humanizer.
+ */
+
+import type { ElementHandle, Page } from 'playwright';
+import { humanDelay } from '../browser/humanizer';
+import type { LinkedInConnection } from '../types';
+
+// ---------------------------------------------------------------------------
+// Connections DOM selectors
+// ---------------------------------------------------------------------------
+
+interface ConnectionSelectorEntry {
+  primary: string;
+  fallbacks: string[];
+}
+
+interface ConnectionSelectors {
+  connectionCard: ConnectionSelectorEntry;
+  connectionName: ConnectionSelectorEntry;
+  connectionHeadline: ConnectionSelectorEntry;
+  connectionLink: ConnectionSelectorEntry;
+  connectionAvatar: ConnectionSelectorEntry;
+  inviteCard: ConnectionSelectorEntry;
+  inviteName: ConnectionSelectorEntry;
+  inviteHeadline: ConnectionSelectorEntry;
+}
+
+const CONNECTION_SELECTORS: ConnectionSelectors = {
+  connectionCard: {
+    primary: '.mn-connection-card',
+    fallbacks: ['.scaffold-finite-scroll__content li', '[data-test-connection-card]'],
+  },
+  connectionName: {
+    primary: '.mn-connection-card__name',
+    fallbacks: ['.mn-connection-card__details a span:first-child'],
+  },
+  connectionHeadline: {
+    primary: '.mn-connection-card__occupation',
+    fallbacks: ['.mn-connection-card__details .t-14'],
+  },
+  connectionLink: {
+    primary: '.mn-connection-card__link',
+    fallbacks: ['.mn-connection-card a[href*="/in/"]'],
+  },
+  connectionAvatar: {
+    primary: '.mn-connection-card__profile-image',
+    fallbacks: ['.mn-connection-card img.EntityPhoto-circle-4'],
+  },
+  inviteCard: {
+    primary: '.invitation-card',
+    fallbacks: ['.mn-invitation-card', '[data-test-invite-card]'],
+  },
+  inviteName: {
+    primary: '.invitation-card__title',
+    fallbacks: ['.mn-invitation-card__name'],
+  },
+  inviteHeadline: {
+    primary: '.invitation-card__subtitle',
+    fallbacks: ['.mn-invitation-card__occupation'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// URLs
+// ---------------------------------------------------------------------------
+
+const CONNECTIONS_URL = 'https://www.linkedin.com/mynetwork/invite-connect/connections/';
+const INVITATIONS_URL = 'https://www.linkedin.com/mynetwork/invitation-manager/';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const EVAL_INNER_TEXT = (el: { innerText?: string }) => el.innerText?.trim() ?? '';
+
+async function tryExtractText(container: ElementHandle, entry: ConnectionSelectorEntry): Promise<string> {
+  const all = [entry.primary, ...entry.fallbacks];
+  for (const sel of all) {
+    try {
+      const child = await container.$(sel);
+      if (child) {
+        const text = await child.evaluate(EVAL_INNER_TEXT);
+        if (text) return text;
+      }
+    } catch {
+      // Try next
+    }
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Internal: extract external ID from a profile URL
+// ---------------------------------------------------------------------------
+
+function extractExternalIdFromUrl(profileUrl: string | undefined, fallback: string): string {
+  if (!profileUrl) return fallback;
+  const match = profileUrl.match(/\/in\/([^/?]+)/);
+  return match ? (match[1] as string) : fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: extract attribute using fallback selectors
+// ---------------------------------------------------------------------------
+
+async function tryExtractAttribute(
+  container: ElementHandle,
+  entry: ConnectionSelectorEntry,
+  attribute: string,
+): Promise<string | undefined> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+  for (const sel of allSelectors) {
+    const el = await container.$(sel);
+    if (el) {
+      const value = (await el.getAttribute(attribute)) ?? undefined;
+      if (value) return value;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: extract a single connection card
+// ---------------------------------------------------------------------------
+
+async function extractConnectionCard(card: ElementHandle, index: number): Promise<LinkedInConnection | null> {
+  const name = await tryExtractText(card, CONNECTION_SELECTORS.connectionName);
+  if (!name) return null;
+
+  const headline = await tryExtractText(card, CONNECTION_SELECTORS.connectionHeadline);
+  const profileUrl = await tryExtractAttribute(card, CONNECTION_SELECTORS.connectionLink, 'href');
+  const externalId = extractExternalIdFromUrl(profileUrl, `connection-${index}`);
+  const avatarUrl = await tryExtractAttribute(card, CONNECTION_SELECTORS.connectionAvatar, 'src');
+
+  return {
+    externalId,
+    name,
+    headline: headline || undefined,
+    profileUrl,
+    avatarUrl,
+    status: 'connected',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: extract a single invite card
+// ---------------------------------------------------------------------------
+
+async function extractInviteCard(card: ElementHandle, index: number): Promise<LinkedInConnection | null> {
+  const name = await tryExtractText(card, CONNECTION_SELECTORS.inviteName);
+  if (!name) return null;
+
+  const headline = await tryExtractText(card, CONNECTION_SELECTORS.inviteHeadline);
+
+  let profileUrl: string | undefined;
+  const linkEl = await card.$('a[href*="/in/"]');
+  if (linkEl) {
+    profileUrl = (await linkEl.getAttribute('href')) ?? undefined;
+  }
+
+  const externalId = extractExternalIdFromUrl(profileUrl, `invite-${index}`);
+
+  return {
+    externalId,
+    name,
+    headline: headline || undefined,
+    profileUrl,
+    status: 'pending_received',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// scrapeConnections
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigate to the connections page and extract the visible connections list.
+ *
+ * Scrolls the page to load more connections, then extracts structured data
+ * from each connection card.
+ *
+ * @param page - Playwright Page instance
+ * @param options - Optional limit and scroll settings
+ * @returns Array of connections
+ */
+export async function scrapeConnections(
+  page: Page,
+  options?: { limit?: number; scrollIterations?: number },
+): Promise<LinkedInConnection[]> {
+  const limit = options?.limit ?? 50;
+  const scrollIterations = options?.scrollIterations ?? 5;
+
+  // Navigate to connections page
+  await page.goto(CONNECTIONS_URL, { waitUntil: 'domcontentloaded' });
+  await humanDelay('navigation');
+
+  // Scroll to load more connections
+  const cardEntry = CONNECTION_SELECTORS.connectionCard;
+  for (let i = 0; i < scrollIterations; i++) {
+    const cards = await page.$$(cardEntry.primary);
+    if (cards.length >= limit) break;
+
+    await page.evaluate('window.scrollBy(0, window.innerHeight)');
+    await humanDelay('scroll');
+  }
+
+  // Extract connections
+  const allSelectors = [cardEntry.primary, ...cardEntry.fallbacks];
+
+  let cardElements: Awaited<ReturnType<Page['$$']>> = [];
+  for (const sel of allSelectors) {
+    cardElements = await page.$$(sel);
+    if (cardElements.length > 0) break;
+  }
+
+  const total = Math.min(cardElements.length, limit);
+  const results: LinkedInConnection[] = [];
+
+  for (let i = 0; i < total; i++) {
+    const card = cardElements[i] as ElementHandle;
+    const connection = await extractConnectionCard(card, i);
+    if (connection) results.push(connection);
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// scrapePendingInvites
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigate to the invitations page and extract pending connection requests.
+ *
+ * @param page - Playwright Page instance
+ * @returns Array of pending connections
+ */
+export async function scrapePendingInvites(page: Page): Promise<LinkedInConnection[]> {
+  // Navigate to invitations page
+  await page.goto(INVITATIONS_URL, { waitUntil: 'domcontentloaded' });
+  await humanDelay('navigation');
+
+  // Find invite cards
+  const inviteEntry = CONNECTION_SELECTORS.inviteCard;
+  const allSelectors = [inviteEntry.primary, ...inviteEntry.fallbacks];
+
+  let inviteElements: Awaited<ReturnType<Page['$$']>> = [];
+  for (const sel of allSelectors) {
+    inviteElements = await page.$$(sel);
+    if (inviteElements.length > 0) break;
+  }
+
+  const results: LinkedInConnection[] = [];
+
+  for (let i = 0; i < inviteElements.length; i++) {
+    const card = inviteElements[i] as ElementHandle;
+    const invite = await extractInviteCard(card, i);
+    if (invite) results.push(invite);
+  }
+
+  return results;
+}

--- a/packages/channel-linkedin/src/scrapers/feed.ts
+++ b/packages/channel-linkedin/src/scrapers/feed.ts
@@ -1,0 +1,196 @@
+/**
+ * Feed Scraper — extracts structured post data from the LinkedIn feed.
+ *
+ * NEW scraper (no Python equivalent). Follows the same DOM parsing patterns
+ * established in the inbox scraper (scan_raw.py port).
+ *
+ * All DOM queries go through findElement() / SELECTORS from the centralized
+ * selector registry. All waits use humanDelay() from the humanizer.
+ */
+
+import type { ElementHandle, Page } from 'playwright';
+import { humanDelay } from '../browser/humanizer';
+import { SELECTORS, combinedSelector } from '../browser/selectors';
+import type { LinkedInPost } from '../types';
+
+// ---------------------------------------------------------------------------
+// Shorthand references
+// ---------------------------------------------------------------------------
+
+const SEL = {
+  postContainer: SELECTORS.feed.postContainer,
+  postContent: SELECTORS.feed.postContent,
+  postAuthor: SELECTORS.feed.postAuthor,
+  likeCount: SELECTORS.feed.likeCount,
+  commentCount: SELECTORS.feed.commentCount,
+};
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface ScrapeFeedPostsOptions {
+  /** Maximum number of posts to scrape (default: 10) */
+  limit?: number;
+  /** Number of scroll iterations to load more posts (default: 5) */
+  scrollIterations?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const EVAL_INNER_TEXT = (el: { innerText?: string }) => el.innerText?.trim() ?? '';
+
+async function tryExtractText(container: ElementHandle, primary: string, fallbacks: string[]): Promise<string> {
+  const el = await container.$(primary);
+  if (el) {
+    const text = await el.evaluate(EVAL_INNER_TEXT);
+    if (text) return text;
+  }
+  for (const fb of fallbacks) {
+    const fbEl = await container.$(fb);
+    if (fbEl) {
+      const text = await fbEl.evaluate(EVAL_INNER_TEXT);
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers for post extraction
+// ---------------------------------------------------------------------------
+
+/** Parse a numeric count from an element's inner text. */
+async function extractCount(postEl: ElementHandle, selector: string): Promise<number | undefined> {
+  const el = await postEl.$(selector);
+  if (!el) return undefined;
+  const text = await el.evaluate(EVAL_INNER_TEXT);
+  const parsed = Number.parseInt(text.replace(/[^\d]/g, ''), 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** Extract src attributes from multiple matching elements. */
+async function extractSrcAttributes(postEl: ElementHandle, selector: string): Promise<string[]> {
+  const elements = await postEl.$$(selector);
+  const urls: string[] = [];
+  for (const el of elements) {
+    const src = await el.getAttribute('src');
+    if (src) urls.push(src);
+  }
+  return urls;
+}
+
+/** Extract a single attribute from the first matching element. */
+async function extractAttribute(
+  postEl: ElementHandle,
+  selector: string,
+  attribute: string,
+): Promise<string | undefined> {
+  const el = await postEl.$(selector);
+  if (!el) return undefined;
+  return (await el.getAttribute(attribute)) ?? undefined;
+}
+
+/** Resolve the external ID from data-urn, post URL, or fallback index. */
+async function resolveExternalId(postEl: ElementHandle, postUrl: string | undefined, index: number): Promise<string> {
+  const dataUrn = await postEl.getAttribute('data-urn');
+  if (dataUrn) return dataUrn;
+  if (postUrl) return postUrl;
+  return `feed-post-${index}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: extract a single post from its DOM element
+// ---------------------------------------------------------------------------
+
+async function extractPost(postEl: ElementHandle, index: number): Promise<LinkedInPost | null> {
+  try {
+    const authorName = await tryExtractText(postEl, SEL.postAuthor.primary, SEL.postAuthor.fallbacks);
+    const content = await tryExtractText(postEl, SEL.postContent.primary, SEL.postContent.fallbacks);
+    if (!content && !authorName) return null;
+
+    const hashtags = content.match(/#[\w\u00C0-\u024F]+/g) ?? [];
+    const likeCount = await extractCount(postEl, SEL.likeCount.primary);
+    const commentCount = await extractCount(postEl, SEL.commentCount.primary);
+
+    const imgUrls = await extractSrcAttributes(postEl, 'img[src*="media"]');
+    const videoUrls = await extractSrcAttributes(postEl, 'video source');
+    const mediaUrls = [...imgUrls, ...videoUrls];
+
+    const authorProfileUrl = await extractAttribute(
+      postEl,
+      '.update-components-actor__name a, .feed-shared-actor__name a',
+      'href',
+    );
+    const authorAvatarUrl = await extractAttribute(
+      postEl,
+      '.update-components-actor__image img, .feed-shared-actor__avatar img',
+      'src',
+    );
+    const postUrl = await extractAttribute(postEl, 'a[href*="/feed/update/"]', 'href');
+    const externalId = await resolveExternalId(postEl, postUrl, index);
+
+    return {
+      externalId,
+      authorName,
+      authorProfileUrl,
+      authorAvatarUrl,
+      content,
+      mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+      hashtags: hashtags.length > 0 ? hashtags : undefined,
+      postUrl,
+      likeCount,
+      commentCount,
+      scrapedAt: Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// scrapeFeedPosts
+// ---------------------------------------------------------------------------
+
+/**
+ * Scrape posts from the LinkedIn feed.
+ *
+ * Scrolls the feed page to load more posts, then extracts structured data
+ * from each post element including author, content, media, engagement counts,
+ * and hashtags.
+ *
+ * @param page - Playwright Page (must already be on /feed/)
+ * @param options - Scraping options
+ * @returns Array of structured post data
+ */
+export async function scrapeFeedPosts(page: Page, options?: ScrapeFeedPostsOptions): Promise<LinkedInPost[]> {
+  const limit = options?.limit ?? 10;
+  const scrollIterations = options?.scrollIterations ?? 5;
+
+  // Scroll feed to load more posts (same pattern as inbox scroll)
+  for (let i = 0; i < scrollIterations; i++) {
+    const posts = await page.$$(combinedSelector(SEL.postContainer));
+    if (posts.length >= limit) break;
+
+    await page.evaluate('window.scrollBy(0, window.innerHeight)');
+    await humanDelay('scroll');
+  }
+
+  // Extract posts
+  const postElements = await page.$$(combinedSelector(SEL.postContainer));
+  const total = Math.min(postElements.length, limit);
+
+  const results: LinkedInPost[] = [];
+
+  for (let i = 0; i < total; i++) {
+    const postEl = postElements[i] as ElementHandle;
+    const post = await extractPost(postEl, i);
+    if (post) {
+      results.push(post);
+    }
+  }
+
+  return results;
+}

--- a/packages/channel-linkedin/src/scrapers/inbox.ts
+++ b/packages/channel-linkedin/src/scrapers/inbox.ts
@@ -1,0 +1,405 @@
+/**
+ * Inbox Scraper — ported from linkedin-agent Python scripts.
+ *
+ * Sources:
+ * - scan_raw.py: scroll_conversation_list(), read_conversation(), main loop
+ * - read_full.py: full conversation history via scroll-up
+ * - list_names.py: tab handling (Focused, InMail, Other)
+ *
+ * All DOM queries go through findElement() / SELECTORS from the centralized
+ * selector registry. All waits use humanDelay() from the humanizer.
+ */
+
+import type { Page } from 'playwright';
+import { CONVERSATION_SCROLL_MAX, HISTORY_SCROLL_UP, exactDelay, humanDelay } from '../browser/humanizer';
+import { SELECTORS, combinedSelector, findElement } from '../browser/selectors';
+import type { LinkedInConversation, LinkedInMessage } from '../types';
+
+// ---------------------------------------------------------------------------
+// Shorthand references to avoid repeated index access
+// ---------------------------------------------------------------------------
+
+const SEL = {
+  conversationList: SELECTORS.inbox.conversationList,
+  conversationItem: SELECTORS.inbox.conversationItem,
+  participantNames: SELECTORS.inbox.participantNames,
+  messageContent: SELECTORS.inbox.messageContent,
+};
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface ScrapeConversationsOptions {
+  /** Maximum number of conversations to read (default: 20) */
+  limit?: number;
+  /** Maximum number of recent message lines to keep per conversation (default: 15) */
+  maxMessagesPerConvo?: number;
+}
+
+export interface ScrapeFullConversationOptions {
+  /** Number of scroll-up iterations to load older messages (default: 5) */
+  scrollUpIterations?: number;
+}
+
+export type InboxTab = 'Focused' | 'InMail' | 'Other';
+
+// ---------------------------------------------------------------------------
+// Internal: inline helper for evaluate() — extracts innerText in browser ctx
+// ---------------------------------------------------------------------------
+
+/** Evaluate expression to extract innerText. Pass to ElementHandle.evaluate(). */
+const EVAL_INNER_TEXT = (el: { innerText?: string }) => el.innerText?.trim() ?? '';
+
+// ---------------------------------------------------------------------------
+// Internal: scroll conversation list — ported from scan_raw.py line 27-39
+// ---------------------------------------------------------------------------
+
+/**
+ * Scroll the conversation sidebar to load more items.
+ * Ported from scan_raw.py scroll_conversation_list().
+ *
+ * Scrolls up to CONVERSATION_SCROLL_MAX (20) iterations, stopping early
+ * if the item count stops growing or reaches targetCount.
+ */
+async function scrollConversationList(page: Page, targetCount: number): Promise<void> {
+  const convList = await findElement(page, SEL.conversationList);
+  if (!convList) return;
+
+  let prevCount = 0;
+
+  for (let i = 0; i < CONVERSATION_SCROLL_MAX; i++) {
+    const items = await page.$$(combinedSelector(SEL.conversationItem));
+    const current = items.length;
+
+    if (current >= targetCount || current === prevCount) {
+      break;
+    }
+
+    prevCount = current;
+
+    // scan_raw.py: conv_list.first.evaluate("el => el.scrollTop = el.scrollHeight")
+    await convList.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    await humanDelay('scroll');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: read a single conversation — ported from scan_raw.py line 42-58
+// ---------------------------------------------------------------------------
+
+/**
+ * Click a conversation item, extract message text, return it.
+ * Ported from scan_raw.py read_conversation().
+ *
+ * Flow: scroll into view → click → wait 2500ms → extract inner text →
+ * take last N lines.
+ */
+async function readConversation(page: Page, item: Awaited<ReturnType<Page['$']>>, maxLines: number): Promise<string> {
+  if (!item) return '';
+
+  // scan_raw.py: item.scroll_into_view_if_needed()
+  await item.evaluate((el) => el.scrollIntoView({ block: 'center', behavior: 'instant' }));
+  await exactDelay(500);
+
+  // scan_raw.py: item.click()
+  await item.click();
+
+  // scan_raw.py: page.wait_for_timeout(2500)
+  await humanDelay('messageLoad');
+
+  // scan_raw.py: try multiple selectors for message content
+  const messageContent = await findElement(page, SEL.messageContent);
+  if (!messageContent) return '';
+
+  const fullText: string = await messageContent.evaluate(EVAL_INNER_TEXT);
+
+  if (!fullText) return '';
+
+  // scan_raw.py: lines[-15:]
+  const lines = fullText
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  return lines.slice(-maxLines).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Internal: extract participant name from a conversation item
+// ---------------------------------------------------------------------------
+
+async function extractParticipantName(item: Awaited<ReturnType<Page['$']>>): Promise<string> {
+  if (!item) return '';
+
+  // Try primary selector first
+  const nameEl = await item.$(SEL.participantNames.primary);
+  if (nameEl) {
+    const text = await nameEl.evaluate(EVAL_INNER_TEXT);
+    if (text) return text;
+  }
+
+  // Try fallbacks
+  for (const fb of SEL.participantNames.fallbacks) {
+    const fbEl = await item.$(fb);
+    if (fbEl) {
+      const text = await fbEl.evaluate(EVAL_INNER_TEXT);
+      if (text) return text;
+    }
+  }
+
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// scrapeConversations — ported from scan_raw.py main()
+// ---------------------------------------------------------------------------
+
+/**
+ * Scrape conversations from the LinkedIn messaging inbox.
+ * Ported from scan_raw.py main loop.
+ *
+ * Flow (matches scan_raw.py exactly):
+ * 1. Scroll conversation list (20 iterations) to load items
+ * 2. For each conversation:
+ *    a. Extract sender name from DOM
+ *    b. Click conversation item
+ *    c. Wait for messages to load
+ *    d. Extract last 15 lines of text
+ *    e. Check if list is still visible; if not, navigate back
+ *
+ * @param page - Playwright Page (must already be on /messaging/)
+ * @param options - Scraping options
+ * @returns Array of conversations with sender and message text
+ */
+export async function scrapeConversations(
+  page: Page,
+  options?: ScrapeConversationsOptions,
+): Promise<LinkedInConversation[]> {
+  const limit = options?.limit ?? 20;
+  const maxLines = options?.maxMessagesPerConvo ?? 15;
+
+  // Step 1: Scroll to load conversations — scan_raw.py line 79
+  await scrollConversationList(page, limit);
+
+  // Step 2: Get all conversation items — scan_raw.py line 81-82
+  let items = await page.$$(combinedSelector(SEL.conversationItem));
+  const total = Math.min(items.length, limit);
+
+  const results: LinkedInConversation[] = [];
+
+  // Step 3: Iterate and read each conversation — scan_raw.py lines 88-118
+  for (let i = 0; i < total; i++) {
+    // Re-query items each iteration (DOM may have changed) — scan_raw.py line 89
+    items = await page.$$(combinedSelector(SEL.conversationItem));
+    if (i >= items.length) break;
+
+    const item = items[i] as Awaited<ReturnType<Page['$']>>;
+
+    // Extract sender name — scan_raw.py lines 94-97
+    const sender = await extractParticipantName(item);
+    if (!sender) continue;
+
+    // Read conversation messages — scan_raw.py line 99
+    const message = await readConversation(page, item, maxLines);
+
+    results.push({
+      externalId: String(i),
+      participantNames: [sender],
+      lastMessagePreview: message || undefined,
+    });
+
+    // Check if conversation list is still visible — scan_raw.py lines 113-118
+    const convList = await findElement(page, SEL.conversationList);
+    if (!convList) {
+      // List disappeared, need to go back
+      // scan_raw.py: goto_messaging(page) + scroll_conversation_list(page, LIMIT)
+      await page.goto('https://www.linkedin.com/messaging/', {
+        waitUntil: 'domcontentloaded',
+      });
+      await humanDelay('navigation');
+      await scrollConversationList(page, limit);
+    } else {
+      const box = await convList.boundingBox();
+      const isVisible = box !== null;
+      if (!isVisible) {
+        await page.goto('https://www.linkedin.com/messaging/', {
+          waitUntil: 'domcontentloaded',
+        });
+        await humanDelay('navigation');
+        await scrollConversationList(page, limit);
+      }
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// scrapeFullConversation — ported from read_full.py
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a conversation by name and load full message history.
+ * Ported from read_full.py.
+ *
+ * Flow:
+ * 1. Scroll conversation list to load items
+ * 2. Find conversation by case-insensitive substring match on participant name
+ * 3. Click to open
+ * 4. Scroll message thread upward (5 iterations) to load older messages
+ * 5. Extract all text
+ *
+ * @param page - Playwright Page (must already be on /messaging/)
+ * @param name - Target participant name (case-insensitive substring match)
+ * @param options - Scroll options
+ * @returns Array of messages extracted from the conversation
+ */
+export async function scrapeFullConversation(
+  page: Page,
+  name: string,
+  options?: ScrapeFullConversationOptions,
+): Promise<LinkedInMessage[]> {
+  const scrollIterations = options?.scrollUpIterations ?? HISTORY_SCROLL_UP;
+  const lowerName = name.toLowerCase();
+
+  // Scroll to load conversations — read_full.py lines 30-40
+  await scrollConversationList(page, 100);
+
+  // Find and click target conversation — read_full.py lines 42-51
+  const items = await page.$$(combinedSelector(SEL.conversationItem));
+
+  let targetItem: Awaited<ReturnType<Page['$']>> = null;
+  let matchedName = '';
+
+  for (const item of items) {
+    const participantName = await extractParticipantName(item);
+    if (!participantName) continue;
+
+    // read_full.py: target.lower() not in name.lower() → case-insensitive substring
+    if (participantName.toLowerCase().includes(lowerName)) {
+      targetItem = item;
+      matchedName = participantName;
+      break;
+    }
+  }
+
+  if (!targetItem) {
+    return [];
+  }
+
+  // Click to open conversation — read_full.py line 50
+  await targetItem.click();
+  await humanDelay('navigation');
+
+  // Scroll up to load full history — read_full.py lines 53-58
+  const thread = await findElement(page, SEL.messageContent);
+  if (thread) {
+    for (let i = 0; i < scrollIterations; i++) {
+      // read_full.py: thread.first.evaluate("el => el.scrollTop = 0")
+      await thread.evaluate((el) => {
+        el.scrollTop = 0;
+      });
+      await humanDelay('postClick');
+    }
+  }
+
+  // Extract all text — read_full.py lines 60-67
+  const messageContent = await findElement(page, SEL.messageContent);
+  if (!messageContent) {
+    return [];
+  }
+
+  const fullText: string = await messageContent.evaluate(EVAL_INNER_TEXT);
+
+  if (!fullText) {
+    return [];
+  }
+
+  // Parse lines into messages
+  const lines = fullText
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  const messages: LinkedInMessage[] = lines.map((line, idx) => ({
+    externalId: `${matchedName}-${idx}`,
+    conversationId: matchedName,
+    senderName: matchedName,
+    body: line,
+  }));
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// listConversationNames — ported from list_names.py
+// ---------------------------------------------------------------------------
+
+/**
+ * List all visible conversation names in the current inbox tab.
+ * Ported from list_names.py lines 29-34.
+ *
+ * @param page - Playwright Page (must already be on /messaging/)
+ * @returns Array of conversation participant names
+ */
+export async function listConversationNames(page: Page): Promise<string[]> {
+  const items = await page.$$(combinedSelector(SEL.conversationItem));
+  const names: string[] = [];
+
+  for (const item of items) {
+    const name = await extractParticipantName(item);
+    if (name) {
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// switchTab — ported from list_names.py tab handling
+// ---------------------------------------------------------------------------
+
+/**
+ * Switch between messaging tabs (Focused, InMail, Other).
+ * Ported from list_names.py tab detection logic.
+ *
+ * Looks for button/link elements within the messaging container that
+ * match the target tab name (case-insensitive).
+ *
+ * @param page - Playwright Page (must already be on /messaging/)
+ * @param tab - Target tab name
+ * @returns true if the tab was found and clicked
+ */
+export async function switchTab(page: Page, tab: InboxTab): Promise<boolean> {
+  const lowerTab = tab.toLowerCase();
+
+  // list_names.py: looks in .msg-conversations-container, .msg-focused-inbox,
+  // .scaffold-layout__sidebar for button/link elements
+  const tabSelectors = [
+    '.msg-conversations-container button',
+    '.msg-conversations-container a',
+    '.msg-focused-inbox button',
+    '.msg-focused-inbox a',
+    '.scaffold-layout__sidebar button',
+    '.scaffold-layout__sidebar a',
+  ];
+
+  for (const sel of tabSelectors) {
+    const elements = await page.$$(sel);
+    for (const el of elements) {
+      const text = await el.evaluate(EVAL_INNER_TEXT);
+      if (text.toLowerCase().includes(lowerTab)) {
+        await el.click();
+        await humanDelay('navigation');
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/channel-linkedin/src/scrapers/index.ts
+++ b/packages/channel-linkedin/src/scrapers/index.ts
@@ -1,0 +1,35 @@
+/**
+ * LinkedIn DOM Scrapers — barrel exports.
+ *
+ * Inbox scraper: ported from linkedin-agent Python scripts (scan_raw.py,
+ * read_full.py, list_names.py).
+ *
+ * Feed, comments, profile, connections scrapers: NEW implementations
+ * following the same DOM parsing patterns.
+ */
+
+// Inbox (ported from scan_raw.py, read_full.py, list_names.py)
+export {
+  scrapeConversations,
+  scrapeFullConversation,
+  listConversationNames,
+  switchTab,
+} from './inbox';
+export type {
+  ScrapeConversationsOptions,
+  ScrapeFullConversationOptions,
+  InboxTab,
+} from './inbox';
+
+// Feed (NEW)
+export { scrapeFeedPosts } from './feed';
+export type { ScrapeFeedPostsOptions } from './feed';
+
+// Comments (NEW)
+export { scrapePostComments } from './comments';
+
+// Profile (NEW)
+export { scrapeProfile } from './profile';
+
+// Connections (NEW)
+export { scrapeConnections, scrapePendingInvites } from './connections';

--- a/packages/channel-linkedin/src/scrapers/profile.ts
+++ b/packages/channel-linkedin/src/scrapers/profile.ts
@@ -1,0 +1,158 @@
+/**
+ * Profile Scraper — extracts the connected user's profile information.
+ *
+ * NEW scraper (no Python equivalent). Follows the same DOM parsing patterns
+ * established in the inbox scraper (scan_raw.py port).
+ *
+ * All waits use humanDelay() from the humanizer.
+ */
+
+import type { Page } from 'playwright';
+import { humanDelay } from '../browser/humanizer';
+import type { LinkedInProfile } from '../types';
+
+// ---------------------------------------------------------------------------
+// Profile DOM selectors (structural — not in the centralized registry
+// since profile pages have a distinct layout from feed/messaging)
+// ---------------------------------------------------------------------------
+
+interface ProfileSelectorEntry {
+  primary: string;
+  fallbacks: string[];
+}
+
+interface ProfileSelectors {
+  name: ProfileSelectorEntry;
+  headline: ProfileSelectorEntry;
+  currentPosition: ProfileSelectorEntry;
+  location: ProfileSelectorEntry;
+  avatar: ProfileSelectorEntry;
+  connectionCount: ProfileSelectorEntry;
+}
+
+const PROFILE_SELECTORS: ProfileSelectors = {
+  /** Profile name (h1 on profile page) */
+  name: {
+    primary: 'h1.text-heading-xlarge',
+    fallbacks: ['.pv-text-details--left-aligned h1', '.top-card-layout__title'],
+  },
+  /** Headline / tagline */
+  headline: {
+    primary: '.text-body-medium.break-words',
+    fallbacks: ['.pv-text-details--left-aligned .text-body-medium', '.top-card-layout__headline'],
+  },
+  /** Current position */
+  currentPosition: {
+    primary: '.pv-text-details--right-panel .inline-show-more-text',
+    fallbacks: ['.experience-item__title'],
+  },
+  /** Location */
+  location: {
+    primary: '.pv-text-details--left-aligned .text-body-small:last-child',
+    fallbacks: ['.top-card-layout__first-subline'],
+  },
+  /** Profile photo */
+  avatar: {
+    primary: '.pv-top-card-profile-picture__image',
+    fallbacks: ['.profile-photo-edit__preview', 'img.top-card-layout__entity-image'],
+  },
+  /** Connection count */
+  connectionCount: {
+    primary: '.pv-top-card--list .t-bold',
+    fallbacks: ['[data-test-connection-count]'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const EVAL_INNER_TEXT = (el: { innerText?: string }) => el.innerText?.trim() ?? '';
+
+async function extractText(page: Page, entry: ProfileSelectorEntry): Promise<string | undefined> {
+  const allSelectors = [entry.primary, ...entry.fallbacks];
+
+  for (const sel of allSelectors) {
+    try {
+      const el = await page.$(sel);
+      if (el) {
+        const text = await el.evaluate(EVAL_INNER_TEXT);
+        if (text) return text;
+      }
+    } catch {
+      // Selector didn't match, try next
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// scrapeProfile
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the connected user's profile information from the current page.
+ *
+ * The page should already be navigated to a LinkedIn profile URL
+ * (e.g., https://www.linkedin.com/in/username/).
+ *
+ * @param page - Playwright Page (must already be on a profile page)
+ * @returns Structured profile data
+ */
+export async function scrapeProfile(page: Page): Promise<LinkedInProfile> {
+  // Wait for profile content to load
+  await humanDelay('navigation');
+
+  // Extract profile URL from the current page
+  const profileUrl = page.url();
+  const urlMatch = profileUrl.match(/\/in\/([^/]+)/);
+  const externalId = urlMatch ? (urlMatch[1] as string) : profileUrl;
+
+  // Name
+  const name = (await extractText(page, PROFILE_SELECTORS.name)) ?? '';
+
+  // Headline
+  const headline = await extractText(page, PROFILE_SELECTORS.headline);
+
+  // Current position
+  const currentPosition = await extractText(page, PROFILE_SELECTORS.currentPosition);
+
+  // Location
+  const location = await extractText(page, PROFILE_SELECTORS.location);
+
+  // Avatar URL
+  let avatarUrl: string | undefined;
+  const avatarEntry = PROFILE_SELECTORS.avatar;
+  const allAvatarSelectors = [avatarEntry.primary, ...avatarEntry.fallbacks];
+  for (const sel of allAvatarSelectors) {
+    try {
+      const img = await page.$(sel);
+      if (img) {
+        avatarUrl = (await img.getAttribute('src')) ?? undefined;
+        if (avatarUrl) break;
+      }
+    } catch {
+      // Try next
+    }
+  }
+
+  // Connection count
+  let connectionCount: number | undefined;
+  const connText = await extractText(page, PROFILE_SELECTORS.connectionCount);
+  if (connText) {
+    const parsed = Number.parseInt(connText.replace(/[^\d]/g, ''), 10);
+    if (!Number.isNaN(parsed)) connectionCount = parsed;
+  }
+
+  return {
+    externalId,
+    name,
+    headline,
+    avatarUrl,
+    profileUrl,
+    currentPosition,
+    location,
+    connectionCount,
+  };
+}

--- a/packages/channel-linkedin/src/sync/differ.ts
+++ b/packages/channel-linkedin/src/sync/differ.ts
@@ -1,0 +1,90 @@
+/**
+ * Generic Diff Engine for sync operations.
+ *
+ * Compares scraped data against existing DB records by externalId to detect
+ * additions, updates, removals, and unchanged entities. Used by both the
+ * feed poller and inbox poller for DB-backed diffing.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of diffing two entity lists.
+ *
+ * @typeParam T - Entity type (must have an externalId string field)
+ */
+export interface DiffResult<T> {
+  /** Entities present in scraped but not in existing */
+  added: T[];
+  /** Entities present in both but with changed data */
+  updated: { old: T; new: T }[];
+  /** Entities present in existing but not in scraped (potentially removed) */
+  removed: T[];
+  /** Entities present in both with no changes */
+  unchanged: T[];
+}
+
+// ---------------------------------------------------------------------------
+// Core diff function
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff two arrays of entities by their externalId field.
+ *
+ * Builds a map of existing entities keyed by externalId, then iterates
+ * the scraped list to classify each entity as added, updated, or unchanged.
+ * Any existing entities not seen in the scraped list are classified as removed.
+ *
+ * @param existing - Entities currently in the DB
+ * @param scraped - Entities freshly scraped from LinkedIn
+ * @param hasChanged - Comparator function that returns true if the entity changed
+ * @returns Classification of all entities into added/updated/removed/unchanged
+ */
+export function diffByExternalId<T extends { externalId: string }>(
+  existing: T[],
+  scraped: T[],
+  hasChanged: (old: T, new_: T) => boolean,
+): DiffResult<T> {
+  const result: DiffResult<T> = {
+    added: [],
+    updated: [],
+    removed: [],
+    unchanged: [],
+  };
+
+  // Build lookup map from existing entities
+  const existingMap = new Map<string, T>();
+  for (const item of existing) {
+    existingMap.set(item.externalId, item);
+  }
+
+  // Track which existing entities we've seen in the scraped data
+  const seenIds = new Set<string>();
+
+  for (const scrapedItem of scraped) {
+    const existingItem = existingMap.get(scrapedItem.externalId);
+    seenIds.add(scrapedItem.externalId);
+
+    if (!existingItem) {
+      // New entity not in DB
+      result.added.push(scrapedItem);
+    } else if (hasChanged(existingItem, scrapedItem)) {
+      // Entity exists but data changed
+      result.updated.push({ old: existingItem, new: scrapedItem });
+    } else {
+      // Entity exists and data unchanged
+      result.unchanged.push(scrapedItem);
+    }
+  }
+
+  // Entities in DB but not in scraped data are considered removed
+  for (const item of existing) {
+    if (!seenIds.has(item.externalId)) {
+      result.removed.push(item);
+    }
+  }
+
+  return result;
+}

--- a/packages/channel-linkedin/src/sync/feed-poller.ts
+++ b/packages/channel-linkedin/src/sync/feed-poller.ts
@@ -1,0 +1,291 @@
+/**
+ * Feed Poller — periodic feed sync with DB-backed diffing.
+ *
+ * On each tick:
+ * 1. Scrape feed posts via scrapeFeedPosts()
+ * 2. Load existing posts from DB via data access callbacks
+ * 3. Diff scraped vs DB using diffByExternalId
+ * 4. NEW posts: persist via callback, emit post.received
+ * 5. UPDATED posts (engagement changed): update via callback, emit post.updated,
+ *    record engagement snapshots
+ * 6. REMOVED posts: mark as deleted via callback, emit post.deleted
+ * 7. For posts with changed comment counts: sync comments
+ */
+
+import type { Page } from 'playwright';
+
+import type { Logger } from '@omni/channel-sdk';
+import { scrapePostComments } from '../scrapers/comments';
+import { scrapeFeedPosts } from '../scrapers/feed';
+import type { LinkedInComment, LinkedInPost } from '../types';
+import { diffByExternalId } from './differ';
+
+// ---------------------------------------------------------------------------
+// Data access interface — avoids direct drizzle-orm imports
+// ---------------------------------------------------------------------------
+
+/**
+ * Data access callbacks for the feed poller.
+ * Implemented by the plugin using Drizzle ORM internally.
+ */
+export interface FeedPollerDataAccess {
+  /** Load active posts from DB for this instance */
+  loadExistingPosts(): Promise<LinkedInPost[]>;
+  /** Insert a new post into DB */
+  insertPost(post: LinkedInPost): Promise<void>;
+  /** Update an existing post in DB */
+  updatePost(externalId: string, post: LinkedInPost): Promise<void>;
+  /** Mark a post as deleted in DB */
+  markPostDeleted(externalId: string): Promise<void>;
+  /** Insert an engagement snapshot for a post */
+  insertEngagementSnapshot(externalId: string, post: LinkedInPost): Promise<void>;
+  /** Load existing comments for a post (by external post ID) */
+  loadExistingComments(postExternalId: string): Promise<LinkedInComment[]>;
+  /** Insert a new comment into DB */
+  insertComment(postExternalId: string, comment: LinkedInComment): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FeedPollerConfig {
+  /** Playwright Page instance (must be on /feed/) */
+  page: Page;
+  /** Data access callbacks */
+  dataAccess: FeedPollerDataAccess;
+  /** Logger instance */
+  logger: Logger;
+  /** Callback for emitting post.received events */
+  onPostReceived?: (post: LinkedInPost) => Promise<void>;
+  /** Callback for emitting post.updated events */
+  onPostUpdated?: (oldPost: LinkedInPost, newPost: LinkedInPost, changedFields: string[]) => Promise<void>;
+  /** Callback for emitting post.deleted events */
+  onPostDeleted?: (post: LinkedInPost) => Promise<void>;
+  /** Callback for emitting comment.received events */
+  onCommentReceived?: (comment: LinkedInComment) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether engagement counts changed between two scraped post snapshots.
+ */
+function postHasChanged(old: LinkedInPost, new_: LinkedInPost): boolean {
+  return (
+    old.likeCount !== new_.likeCount ||
+    old.commentCount !== new_.commentCount ||
+    old.repostCount !== new_.repostCount ||
+    old.content !== new_.content
+  );
+}
+
+/**
+ * Compute which fields changed between two post snapshots.
+ */
+function getChangedFields(old: LinkedInPost, new_: LinkedInPost): string[] {
+  const fields: string[] = [];
+  if (old.likeCount !== new_.likeCount) fields.push('likeCount');
+  if (old.commentCount !== new_.commentCount) fields.push('commentCount');
+  if (old.repostCount !== new_.repostCount) fields.push('repostCount');
+  if (old.content !== new_.content) fields.push('content');
+  return fields;
+}
+
+function commentHasChanged(old: LinkedInComment, new_: LinkedInComment): boolean {
+  return old.likeCount !== new_.likeCount || old.content !== new_.content;
+}
+
+// ---------------------------------------------------------------------------
+// FeedPoller
+// ---------------------------------------------------------------------------
+
+export class FeedPoller {
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private readonly config: FeedPollerConfig;
+  private running = false;
+
+  constructor(config: FeedPollerConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Start periodic feed polling.
+   *
+   * @param intervalMs - Polling interval in milliseconds (default: 15 min)
+   */
+  start(intervalMs = 15 * 60 * 1000): void {
+    if (this.intervalHandle) {
+      this.config.logger.warn('FeedPoller already running, skipping start');
+      return;
+    }
+
+    this.config.logger.info('FeedPoller started', { intervalMs });
+
+    // Run immediately on start, then on interval
+    void this.tick();
+    this.intervalHandle = setInterval(() => void this.tick(), intervalMs);
+  }
+
+  /**
+   * Stop the periodic polling.
+   */
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+      this.config.logger.info('FeedPoller stopped');
+    }
+  }
+
+  /**
+   * Whether the poller is currently running.
+   */
+  isRunning(): boolean {
+    return this.intervalHandle !== null;
+  }
+
+  /**
+   * Handle newly added posts: persist and emit events.
+   */
+  private async handleAddedPosts(posts: LinkedInPost[]): Promise<void> {
+    for (const post of posts) {
+      await this.config.dataAccess.insertPost(post);
+      if (this.config.onPostReceived) {
+        await this.config.onPostReceived(post);
+      }
+    }
+  }
+
+  /**
+   * Handle a single updated post: persist, snapshot engagement, and emit event.
+   */
+  private async handleUpdatedPost(oldPost: LinkedInPost, newPost: LinkedInPost): Promise<void> {
+    const changedFields = getChangedFields(oldPost, newPost);
+    await this.config.dataAccess.updatePost(newPost.externalId, newPost);
+
+    const hasEngagementChange =
+      changedFields.includes('likeCount') ||
+      changedFields.includes('commentCount') ||
+      changedFields.includes('repostCount');
+
+    if (hasEngagementChange) {
+      await this.config.dataAccess.insertEngagementSnapshot(newPost.externalId, newPost);
+    }
+
+    if (this.config.onPostUpdated) {
+      await this.config.onPostUpdated(oldPost, newPost, changedFields);
+    }
+  }
+
+  /**
+   * Handle removed posts: mark deleted and emit events.
+   */
+  private async handleRemovedPosts(posts: LinkedInPost[]): Promise<void> {
+    for (const post of posts) {
+      await this.config.dataAccess.markPostDeleted(post.externalId);
+      if (this.config.onPostDeleted) {
+        await this.config.onPostDeleted(post);
+      }
+    }
+  }
+
+  /**
+   * Execute a single sync cycle.
+   */
+  private async tick(): Promise<void> {
+    if (this.running) {
+      this.config.logger.debug('FeedPoller tick skipped (previous tick still running)');
+      return;
+    }
+
+    this.running = true;
+    const start = Date.now();
+
+    try {
+      this.config.logger.debug('FeedPoller tick starting');
+
+      const scraped = await scrapeFeedPosts(this.config.page, { limit: 20 });
+      const existingPosts = await this.config.dataAccess.loadExistingPosts();
+      const diff = diffByExternalId(existingPosts, scraped, postHasChanged);
+
+      await this.handleAddedPosts(diff.added);
+
+      for (const { old: oldPost, new: newPost } of diff.updated) {
+        await this.handleUpdatedPost(oldPost, newPost);
+      }
+
+      await this.handleRemovedPosts(diff.removed);
+
+      const postsWithCommentChanges = diff.updated
+        .filter(({ old: o, new: n }) => o.commentCount !== n.commentCount)
+        .map(({ new: n }) => n);
+      await this.syncComments(postsWithCommentChanges);
+
+      const elapsed = Date.now() - start;
+      this.config.logger.info('FeedPoller tick complete', {
+        added: diff.added.length,
+        updated: diff.updated.length,
+        removed: diff.removed.length,
+        unchanged: diff.unchanged.length,
+        elapsedMs: elapsed,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.config.logger.error('FeedPoller tick failed', { error: message });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /**
+   * Find the DOM element for a post by matching its data-urn attribute.
+   */
+  private async findPostElement(post: LinkedInPost): Promise<import('playwright').ElementHandle | null> {
+    const postElements = await this.config.page.$$('.feed-shared-update-v2, [data-test-feed-post]');
+    for (const el of postElements) {
+      const dataUrn = await el.getAttribute('data-urn');
+      if (dataUrn === post.externalId) return el;
+    }
+    return null;
+  }
+
+  /**
+   * Sync comments for a single post element.
+   */
+  private async syncPostComments(post: LinkedInPost, postEl: import('playwright').ElementHandle): Promise<void> {
+    const scrapedComments = await scrapePostComments(postEl);
+    if (scrapedComments.length === 0) return;
+
+    const existingComments = await this.config.dataAccess.loadExistingComments(post.externalId);
+    const commentDiff = diffByExternalId(existingComments, scrapedComments, commentHasChanged);
+
+    for (const comment of commentDiff.added) {
+      await this.config.dataAccess.insertComment(post.externalId, comment);
+      if (this.config.onCommentReceived) {
+        await this.config.onCommentReceived(comment);
+      }
+    }
+  }
+
+  /**
+   * Sync comments for posts where commentCount changed.
+   */
+  private async syncComments(posts: LinkedInPost[]): Promise<void> {
+    for (const post of posts) {
+      try {
+        const matchedEl = await this.findPostElement(post);
+        if (!matchedEl) continue;
+        await this.syncPostComments(post, matchedEl);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.config.logger.warn('Comment sync failed for post', {
+          postId: post.externalId,
+          error: message,
+        });
+      }
+    }
+  }
+}

--- a/packages/channel-linkedin/src/sync/inbox-poller.ts
+++ b/packages/channel-linkedin/src/sync/inbox-poller.ts
@@ -1,0 +1,197 @@
+/**
+ * Inbox Poller — periodic inbox sync with in-memory diffing.
+ *
+ * Replaces scan_raw.py's manual polling with automated continuous sync.
+ *
+ * On each tick:
+ * 1. Scrape conversations via scrapeConversations()
+ * 2. Diff against previously known conversations (in-memory cache)
+ * 3. For NEW messages: emit message.received events
+ * 4. Update the in-memory cache
+ */
+
+import type { Logger } from '@omni/channel-sdk';
+import type { Page } from 'playwright';
+import { scrapeConversations } from '../scrapers/inbox';
+import type { LinkedInConversation, LinkedInMessage } from '../types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InboxPollerConfig {
+  /** Playwright Page instance (must be navigable to /messaging/) */
+  page: Page;
+  /** Instance ID */
+  instanceId: string;
+  /** Logger instance */
+  logger: Logger;
+  /** Callback for emitting message.received events */
+  onMessageReceived?: (message: LinkedInMessage, conversation: LinkedInConversation) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// InboxPoller
+// ---------------------------------------------------------------------------
+
+export class InboxPoller {
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private readonly config: InboxPollerConfig;
+  private running = false;
+
+  /**
+   * In-memory cache of last known conversation previews, keyed by
+   * participant name(s) concatenated. Used for diffing to detect new messages.
+   */
+  private lastKnown = new Map<string, string>();
+
+  constructor(config: InboxPollerConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Start periodic inbox polling.
+   *
+   * @param intervalMs - Polling interval in milliseconds (default: 5 min)
+   */
+  start(intervalMs = 5 * 60 * 1000): void {
+    if (this.intervalHandle) {
+      this.config.logger.warn('InboxPoller already running, skipping start');
+      return;
+    }
+
+    this.config.logger.info('InboxPoller started', { intervalMs });
+
+    // Run immediately on start, then on interval
+    void this.tick();
+    this.intervalHandle = setInterval(() => void this.tick(), intervalMs);
+  }
+
+  /**
+   * Stop the periodic polling.
+   */
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+      this.config.logger.info('InboxPoller stopped');
+    }
+  }
+
+  /**
+   * Whether the poller is currently running.
+   */
+  isRunning(): boolean {
+    return this.intervalHandle !== null;
+  }
+
+  /**
+   * Ensure the page is on the messaging URL, navigating if needed.
+   */
+  private async ensureOnMessaging(): Promise<void> {
+    const currentUrl = this.config.page.url();
+    if (currentUrl.includes('/messaging')) return;
+
+    await this.config.page.goto('https://www.linkedin.com/messaging/', {
+      waitUntil: 'domcontentloaded',
+    });
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+
+  /**
+   * Extract new lines from a conversation preview compared to the cached version.
+   */
+  private extractNewLines(currentPreview: string, previousPreview: string): string[] {
+    const previousLines = new Set(
+      previousPreview
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean),
+    );
+    const currentLines = currentPreview
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    return currentLines.filter((line) => !previousLines.has(line));
+  }
+
+  /**
+   * Diff a single conversation against the cache and emit new messages.
+   * Returns the number of new messages emitted.
+   */
+  private async diffConversation(convo: LinkedInConversation): Promise<number> {
+    const key = convo.participantNames.join(', ');
+    const currentPreview = convo.lastMessagePreview ?? '';
+    const previousPreview = this.lastKnown.get(key);
+
+    // First run: seed the cache without emitting events
+    if (previousPreview === undefined) {
+      this.lastKnown.set(key, currentPreview);
+      return 0;
+    }
+
+    if (currentPreview === previousPreview || currentPreview.length === 0) return 0;
+
+    const newLines = this.extractNewLines(currentPreview, previousPreview);
+    if (newLines.length === 0) return 0;
+
+    for (let i = 0; i < newLines.length; i++) {
+      const line = newLines[i] as string;
+      const message: LinkedInMessage = {
+        externalId: `${key}-${Date.now()}-${i}`,
+        conversationId: convo.externalId,
+        senderName: convo.participantNames[0] ?? 'Unknown',
+        body: line,
+        timestamp: Date.now(),
+        isOutgoing: false,
+      };
+
+      if (this.config.onMessageReceived) {
+        await this.config.onMessageReceived(message, convo);
+      }
+    }
+
+    this.lastKnown.set(key, currentPreview);
+    return newLines.length;
+  }
+
+  /**
+   * Execute a single sync cycle.
+   */
+  private async tick(): Promise<void> {
+    if (this.running) {
+      this.config.logger.debug('InboxPoller tick skipped (previous tick still running)');
+      return;
+    }
+
+    this.running = true;
+    const start = Date.now();
+
+    try {
+      this.config.logger.debug('InboxPoller tick starting');
+      await this.ensureOnMessaging();
+
+      const conversations = await scrapeConversations(this.config.page, {
+        limit: 20,
+        maxMessagesPerConvo: 15,
+      });
+
+      let newMessageCount = 0;
+      for (const convo of conversations) {
+        newMessageCount += await this.diffConversation(convo);
+      }
+
+      const elapsed = Date.now() - start;
+      this.config.logger.info('InboxPoller tick complete', {
+        conversationsScanned: conversations.length,
+        newMessages: newMessageCount,
+        elapsedMs: elapsed,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.config.logger.error('InboxPoller tick failed', { error: message });
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/packages/channel-linkedin/src/sync/index.ts
+++ b/packages/channel-linkedin/src/sync/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Sync engine — barrel exports.
+ *
+ * Provides the diff engine, feed poller, and inbox poller for
+ * automated LinkedIn data synchronization.
+ */
+
+export { diffByExternalId } from './differ';
+export type { DiffResult } from './differ';
+
+export { FeedPoller } from './feed-poller';
+export type { FeedPollerConfig, FeedPollerDataAccess } from './feed-poller';
+
+export { InboxPoller } from './inbox-poller';
+export type { InboxPollerConfig } from './inbox-poller';

--- a/packages/channel-linkedin/src/types.ts
+++ b/packages/channel-linkedin/src/types.ts
@@ -1,0 +1,225 @@
+/**
+ * LinkedIn-specific types for the channel-linkedin plugin.
+ *
+ * These types represent LinkedIn entities as scraped from the DOM
+ * and stored in the social DB tables.
+ */
+
+// ---------------------------------------------------------------------------
+// Rate Limits
+// ---------------------------------------------------------------------------
+
+export interface RateLimitsConfig {
+  messagesPerHour: number;
+  profileViewsPerHour: number;
+  connectionsPerDay: number;
+  postsPerDay: number;
+  commentsPerHour: number;
+  reactionsPerHour: number;
+}
+
+export const DEFAULT_RATE_LIMITS: RateLimitsConfig = {
+  messagesPerHour: 20,
+  profileViewsPerHour: 50,
+  connectionsPerDay: 25,
+  postsPerDay: 5,
+  commentsPerHour: 15,
+  reactionsPerHour: 30,
+};
+
+// ---------------------------------------------------------------------------
+// Active Hours
+// ---------------------------------------------------------------------------
+
+export interface ActiveHoursConfig {
+  /** Hour of day to start (0-23) */
+  start: number;
+  /** Hour of day to stop (0-23) */
+  end: number;
+  /** IANA timezone, e.g. 'America/Sao_Paulo' */
+  timezone: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sync Intervals (ms)
+// ---------------------------------------------------------------------------
+
+export interface SyncIntervalsConfig {
+  feed: number;
+  inbox: number;
+  connections: number;
+  engagement: number;
+}
+
+// ---------------------------------------------------------------------------
+// Instance Configuration
+// ---------------------------------------------------------------------------
+
+export interface LinkedInInstanceConfig {
+  /** Path to persistent Chromium user data directory */
+  browserDataPath: string;
+  /** Polling intervals in milliseconds */
+  syncIntervals: SyncIntervalsConfig;
+  /** Per-action rate limits */
+  rateLimits: RateLimitsConfig;
+  /** Operating window to avoid off-hours activity */
+  activeHours: ActiveHoursConfig;
+  /** Run browser in headless mode (default: true) */
+  headless?: boolean;
+  /** Browser viewport width (default: 1280) */
+  viewportWidth?: number;
+  /** Browser viewport height (default: 900) */
+  viewportHeight?: number;
+  /** Browser locale (default: 'pt-BR') */
+  locale?: string;
+}
+
+// ---------------------------------------------------------------------------
+// LinkedIn Entities
+// ---------------------------------------------------------------------------
+
+export type LinkedInReactionType = 'like' | 'celebrate' | 'support' | 'love' | 'insightful' | 'funny';
+
+export interface LinkedInProfile {
+  /** LinkedIn profile URL slug or ID */
+  externalId: string;
+  /** Display name */
+  name: string;
+  /** Headline / tagline */
+  headline?: string;
+  /** Profile picture URL */
+  avatarUrl?: string;
+  /** Profile page URL */
+  profileUrl?: string;
+  /** Current company / position */
+  currentPosition?: string;
+  /** Location string */
+  location?: string;
+  /** Number of connections */
+  connectionCount?: number;
+}
+
+export interface LinkedInConversation {
+  /** Internal index or identifier from DOM */
+  externalId: string;
+  /** Participant display names */
+  participantNames: string[];
+  /** Last message preview text */
+  lastMessagePreview?: string;
+  /** Whether the conversation has unread messages */
+  isUnread?: boolean;
+  /** Timestamp of the last activity */
+  lastActivityAt?: number;
+}
+
+export interface LinkedInMessage {
+  /** Unique identifier (constructed from conversation + index) */
+  externalId: string;
+  /** The conversation this message belongs to */
+  conversationId: string;
+  /** Sender display name */
+  senderName: string;
+  /** Message body text */
+  body: string;
+  /** Timestamp if extractable */
+  timestamp?: number;
+  /** Whether this message was sent by the connected account */
+  isOutgoing?: boolean;
+}
+
+export interface LinkedInPost {
+  /** Post URN or unique DOM identifier */
+  externalId: string;
+  /** Author display name */
+  authorName: string;
+  /** Author profile URL */
+  authorProfileUrl?: string;
+  /** Author avatar URL */
+  authorAvatarUrl?: string;
+  /** Post body text */
+  content: string;
+  /** Media attachments (image/video URLs) */
+  mediaUrls?: string[];
+  /** Hashtags extracted from content */
+  hashtags?: string[];
+  /** Post URL */
+  postUrl?: string;
+  /** Engagement counts */
+  likeCount?: number;
+  commentCount?: number;
+  repostCount?: number;
+  /** Timestamp */
+  postedAt?: number;
+  /** Scraped timestamp */
+  scrapedAt: number;
+}
+
+export interface LinkedInComment {
+  /** Comment identifier */
+  externalId: string;
+  /** Parent post ID */
+  postId: string;
+  /** Parent comment ID (for threaded replies) */
+  parentCommentId?: string;
+  /** Author display name */
+  authorName: string;
+  /** Author profile URL */
+  authorProfileUrl?: string;
+  /** Comment body text */
+  content: string;
+  /** Like count */
+  likeCount?: number;
+  /** Timestamp */
+  postedAt?: number;
+}
+
+export interface LinkedInConnection {
+  /** Profile identifier */
+  externalId: string;
+  /** Display name */
+  name: string;
+  /** Headline */
+  headline?: string;
+  /** Profile URL */
+  profileUrl?: string;
+  /** Avatar URL */
+  avatarUrl?: string;
+  /** Connection status */
+  status: 'connected' | 'pending_sent' | 'pending_received';
+  /** When the connection was established */
+  connectedAt?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Action Results
+// ---------------------------------------------------------------------------
+
+export interface ActionResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface SendMessageResult {
+  sentTo: string;
+  message: string;
+}
+
+export interface CreatePostResult {
+  postUrl?: string;
+}
+
+export interface ReactResult {
+  reactionType: LinkedInReactionType;
+  postId: string;
+}
+
+export interface CommentResult {
+  commentText: string;
+  postId: string;
+}
+
+export interface ConnectResult {
+  profileName: string;
+  action: 'sent' | 'accepted' | 'rejected';
+}

--- a/packages/channel-linkedin/tsconfig.json
+++ b/packages/channel-linkedin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/channel-sdk/src/base/SocialChannelPlugin.ts
+++ b/packages/channel-sdk/src/base/SocialChannelPlugin.ts
@@ -1,0 +1,446 @@
+/**
+ * Social channel plugin base class
+ *
+ * Extends BaseChannelPlugin with social-specific functionality:
+ * - Abstract methods for social operations (createPost, getFeed, etc.)
+ * - Event emission helpers for social events (post.*, comment.*, connection.*, mention.*)
+ *
+ * Social channels (LinkedIn, Twitter/X, Instagram) should extend this class
+ * instead of BaseChannelPlugin directly.
+ *
+ * @example
+ * ```typescript
+ * export class LinkedInPlugin extends SocialChannelPlugin {
+ *   readonly id = 'linkedin' as const;
+ *   readonly name = 'LinkedIn';
+ *   readonly version = '1.0.0';
+ *   readonly capabilities = {
+ *     ...DEFAULT_CAPABILITIES,
+ *     canCreatePost: true,
+ *     canReadFeed: true,
+ *     canComment: true,
+ *     canHandleConnections: true,
+ *   };
+ *
+ *   async createPost(instanceId, post) { ... }
+ *   async getFeed(instanceId, options) { ... }
+ *   // ... other abstract methods
+ * }
+ * ```
+ */
+
+import { generateCorrelationId } from '@omni/core';
+import type {
+  EmitCommentReceivedParams,
+  EmitCommentSentParams,
+  EmitConnectionAcceptedParams,
+  EmitConnectionReceivedParams,
+  EmitMentionReceivedParams,
+  EmitPostCreatedParams,
+  EmitPostDeletedParams,
+  EmitPostReceivedParams,
+  EmitPostUpdatedParams,
+} from '../helpers/social-events';
+import { BaseChannelPlugin } from './BaseChannelPlugin';
+
+// ─────────────────────────────────────────────────────────────
+// Social method types
+// ─────────────────────────────────────────────────────────────
+
+/** Input for creating a social post */
+export interface CreatePostInput {
+  /** Text content of the post */
+  textContent?: string;
+  /** Media URLs to attach */
+  mediaUrls?: string[];
+  /** Link URL to include */
+  linkUrl?: string;
+  /** Post visibility (public, connections, etc.) */
+  visibility?: string;
+}
+
+/** Result of creating a social post */
+export interface CreatePostResult {
+  success: boolean;
+  /** Platform-assigned post ID */
+  externalId?: string;
+  error?: string;
+}
+
+/** Options for fetching the social feed */
+export interface GetFeedOptions {
+  /** Maximum number of posts to fetch */
+  limit?: number;
+  /** Cursor or offset for pagination */
+  cursor?: string;
+}
+
+/** A post from the social feed */
+export interface FeedPost {
+  externalId: string;
+  authorPlatformUserId: string;
+  authorDisplayName?: string;
+  postType: string;
+  textContent?: string;
+  mediaUrls?: string[];
+  linkUrl?: string;
+  likeCount?: number;
+  commentCount?: number;
+  repostCount?: number;
+  impressionCount?: number;
+  hashtags?: string[];
+  platformTimestamp?: Date;
+  rawPayload?: Record<string, unknown>;
+}
+
+/** Result of fetching the social feed */
+export interface GetFeedResult {
+  posts: FeedPost[];
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
+/** A comment on a social post */
+export interface PostComment {
+  externalId: string;
+  postExternalId: string;
+  parentCommentExternalId?: string;
+  authorPlatformUserId: string;
+  authorDisplayName?: string;
+  textContent: string;
+  mediaUrl?: string;
+  likeCount?: number;
+  replyCount?: number;
+  platformTimestamp?: Date;
+  rawPayload?: Record<string, unknown>;
+}
+
+/** Result of fetching comments on a post */
+export interface GetCommentsResult {
+  comments: PostComment[];
+  hasMore: boolean;
+}
+
+/** A connection/follower on the social platform */
+export interface SocialConnection {
+  platformUserId: string;
+  displayName?: string;
+  connectionType: string;
+  status: string;
+  message?: string;
+  connectedAt?: Date;
+  requestedAt?: Date;
+}
+
+/** Result of fetching connections */
+export interface GetConnectionsResult {
+  connections: SocialConnection[];
+  hasMore: boolean;
+}
+
+/**
+ * Abstract base class for social channel plugins
+ *
+ * Extends BaseChannelPlugin with social-specific abstract methods
+ * and event emission helpers for post, comment, connection, and mention events.
+ */
+export abstract class SocialChannelPlugin extends BaseChannelPlugin {
+  // ─────────────────────────────────────────────────────────────
+  // Abstract social methods - must be implemented by subclasses
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Create a post on the social platform
+   */
+  abstract createPost(instanceId: string, post: CreatePostInput): Promise<CreatePostResult>;
+
+  /**
+   * Fetch the social feed
+   */
+  abstract getFeed(instanceId: string, options?: GetFeedOptions): Promise<GetFeedResult>;
+
+  /**
+   * Fetch comments on a specific post
+   */
+  abstract getComments(instanceId: string, postExternalId: string): Promise<GetCommentsResult>;
+
+  /**
+   * React to a social post
+   *
+   * @param instanceId - Instance to react from
+   * @param postExternalId - Platform post ID to react to
+   * @param reactionType - Reaction type (like, celebrate, support, etc.)
+   */
+  abstract reactToPost(instanceId: string, postExternalId: string, reactionType: string): Promise<void>;
+
+  /**
+   * Fetch connections/followers
+   */
+  abstract getConnections(instanceId: string): Promise<GetConnectionsResult>;
+
+  // ─────────────────────────────────────────────────────────────
+  // Social Event Emission Helpers
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Emit post.received event
+   */
+  protected async emitPostReceived(params: EmitPostReceivedParams): Promise<void> {
+    await this.eventBus.publish(
+      'post.received',
+      {
+        externalId: params.externalId,
+        authorPlatformUserId: params.authorPlatformUserId,
+        authorDisplayName: params.authorDisplayName,
+        postType: params.postType,
+        textContent: params.textContent,
+        mediaUrls: params.mediaUrls,
+        linkUrl: params.linkUrl,
+        likeCount: params.likeCount,
+        commentCount: params.commentCount,
+        repostCount: params.repostCount,
+        hashtags: params.hashtags,
+        rawPayload: params.rawPayload,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted post.received', {
+      instanceId: params.instanceId,
+      externalId: params.externalId,
+    });
+  }
+
+  /**
+   * Emit post.created event
+   */
+  protected async emitPostCreated(params: EmitPostCreatedParams): Promise<void> {
+    await this.eventBus.publish(
+      'post.created',
+      {
+        externalId: params.externalId,
+        postType: params.postType,
+        textContent: params.textContent,
+        mediaUrls: params.mediaUrls,
+        linkUrl: params.linkUrl,
+        visibility: params.visibility,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted post.created', {
+      instanceId: params.instanceId,
+      externalId: params.externalId,
+    });
+  }
+
+  /**
+   * Emit post.updated event
+   */
+  protected async emitPostUpdated(params: EmitPostUpdatedParams): Promise<void> {
+    await this.eventBus.publish(
+      'post.updated',
+      {
+        externalId: params.externalId,
+        changedFields: params.changedFields,
+        likeCount: params.likeCount,
+        commentCount: params.commentCount,
+        repostCount: params.repostCount,
+        impressionCount: params.impressionCount,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted post.updated', {
+      instanceId: params.instanceId,
+      externalId: params.externalId,
+      changedFields: params.changedFields,
+    });
+  }
+
+  /**
+   * Emit post.deleted event
+   */
+  protected async emitPostDeleted(params: EmitPostDeletedParams): Promise<void> {
+    await this.eventBus.publish(
+      'post.deleted',
+      {
+        externalId: params.externalId,
+        reason: params.reason,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted post.deleted', {
+      instanceId: params.instanceId,
+      externalId: params.externalId,
+    });
+  }
+
+  /**
+   * Emit comment.received event
+   */
+  protected async emitCommentReceived(params: EmitCommentReceivedParams): Promise<void> {
+    await this.eventBus.publish(
+      'comment.received',
+      {
+        externalId: params.externalId,
+        postExternalId: params.postExternalId,
+        parentCommentExternalId: params.parentCommentExternalId,
+        authorPlatformUserId: params.authorPlatformUserId,
+        authorDisplayName: params.authorDisplayName,
+        textContent: params.textContent,
+        mediaUrl: params.mediaUrl,
+        rawPayload: params.rawPayload,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted comment.received', {
+      instanceId: params.instanceId,
+      externalId: params.externalId,
+      postExternalId: params.postExternalId,
+    });
+  }
+
+  /**
+   * Emit comment.sent event
+   */
+  protected async emitCommentSent(params: EmitCommentSentParams): Promise<void> {
+    await this.eventBus.publish(
+      'comment.sent',
+      {
+        externalId: params.externalId,
+        postExternalId: params.postExternalId,
+        parentCommentExternalId: params.parentCommentExternalId,
+        textContent: params.textContent,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted comment.sent', {
+      instanceId: params.instanceId,
+      externalId: params.externalId,
+      postExternalId: params.postExternalId,
+    });
+  }
+
+  /**
+   * Emit connection.received event
+   */
+  protected async emitConnectionReceived(params: EmitConnectionReceivedParams): Promise<void> {
+    await this.eventBus.publish(
+      'connection.received',
+      {
+        platformUserId: params.platformUserId,
+        displayName: params.displayName,
+        connectionType: params.connectionType,
+        message: params.message,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted connection.received', {
+      instanceId: params.instanceId,
+      platformUserId: params.platformUserId,
+    });
+  }
+
+  /**
+   * Emit connection.accepted event
+   */
+  protected async emitConnectionAccepted(params: EmitConnectionAcceptedParams): Promise<void> {
+    await this.eventBus.publish(
+      'connection.accepted',
+      {
+        platformUserId: params.platformUserId,
+        displayName: params.displayName,
+        connectionType: params.connectionType,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted connection.accepted', {
+      instanceId: params.instanceId,
+      platformUserId: params.platformUserId,
+    });
+  }
+
+  /**
+   * Emit mention.received event
+   */
+  protected async emitMentionReceived(params: EmitMentionReceivedParams): Promise<void> {
+    await this.eventBus.publish(
+      'mention.received',
+      {
+        mentionContext: params.mentionContext,
+        sourceExternalId: params.sourceExternalId,
+        mentionedByPlatformUserId: params.mentionedByPlatformUserId,
+        mentionedByDisplayName: params.mentionedByDisplayName,
+        textContent: params.textContent,
+        rawPayload: params.rawPayload,
+      },
+      {
+        correlationId: generateCorrelationId('evt'),
+        instanceId: params.instanceId,
+        channelType: this.id,
+        source: `channel:${this.id}`,
+      },
+    );
+
+    this.instances.recordActivity(params.instanceId);
+    this.logger.debug('Emitted mention.received', {
+      instanceId: params.instanceId,
+      mentionContext: params.mentionContext,
+      sourceExternalId: params.sourceExternalId,
+    });
+  }
+}

--- a/packages/channel-sdk/src/base/index.ts
+++ b/packages/channel-sdk/src/base/index.ts
@@ -3,6 +3,18 @@
  */
 
 export { BaseChannelPlugin } from './BaseChannelPlugin';
+export { SocialChannelPlugin } from './SocialChannelPlugin';
+export type {
+  CreatePostInput,
+  CreatePostResult,
+  GetFeedOptions,
+  FeedPost,
+  GetFeedResult,
+  PostComment,
+  GetCommentsResult,
+  SocialConnection,
+  GetConnectionsResult,
+} from './SocialChannelPlugin';
 export { ChannelRegistry, channelRegistry } from './ChannelRegistry';
 export type { RegistryEntry } from './ChannelRegistry';
 export { HealthChecker, aggregateHealthChecks, createHealthCheck } from './HealthChecker';

--- a/packages/channel-sdk/src/helpers/social-events.ts
+++ b/packages/channel-sdk/src/helpers/social-events.ts
@@ -1,0 +1,221 @@
+/**
+ * Social event emitter parameter types
+ *
+ * These types define the parameters for SocialChannelPlugin's emit* methods.
+ * Follows the same pattern as events.ts for messaging events.
+ */
+
+/**
+ * Parameters for emitPostReceived
+ */
+export interface EmitPostReceivedParams {
+  /** Instance that received the post */
+  instanceId: string;
+
+  /** Platform-assigned post ID */
+  externalId: string;
+
+  /** Post author (platform user ID) */
+  authorPlatformUserId: string;
+
+  /** Author display name */
+  authorDisplayName?: string;
+
+  /** Post type (text, article, image, video, poll, etc.) */
+  postType: string;
+
+  /** Text content of the post */
+  textContent?: string;
+
+  /** Media URLs attached to the post */
+  mediaUrls?: string[];
+
+  /** Link URL if post contains a link */
+  linkUrl?: string;
+
+  /** Engagement counts at time of receipt */
+  likeCount?: number;
+  commentCount?: number;
+  repostCount?: number;
+
+  /** Hashtags found in the post */
+  hashtags?: string[];
+
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for emitPostCreated
+ */
+export interface EmitPostCreatedParams {
+  /** Instance that created the post */
+  instanceId: string;
+
+  /** Platform-assigned post ID (after creation) */
+  externalId: string;
+
+  /** Post type */
+  postType: string;
+
+  /** Text content */
+  textContent?: string;
+
+  /** Media URLs attached */
+  mediaUrls?: string[];
+
+  /** Link URL */
+  linkUrl?: string;
+
+  /** Visibility setting */
+  visibility?: string;
+}
+
+/**
+ * Parameters for emitPostUpdated
+ */
+export interface EmitPostUpdatedParams {
+  /** Instance that detected the update */
+  instanceId: string;
+
+  /** Platform-assigned post ID */
+  externalId: string;
+
+  /** Which fields changed */
+  changedFields: string[];
+
+  /** Updated engagement counts */
+  likeCount?: number;
+  commentCount?: number;
+  repostCount?: number;
+  impressionCount?: number;
+}
+
+/**
+ * Parameters for emitPostDeleted
+ */
+export interface EmitPostDeletedParams {
+  /** Instance that detected the deletion */
+  instanceId: string;
+
+  /** Platform-assigned post ID */
+  externalId: string;
+
+  /** Reason for deletion (if known) */
+  reason?: string;
+}
+
+/**
+ * Parameters for emitCommentReceived
+ */
+export interface EmitCommentReceivedParams {
+  /** Instance that received the comment */
+  instanceId: string;
+
+  /** Platform-assigned comment ID */
+  externalId: string;
+
+  /** Post this comment belongs to (platform post ID) */
+  postExternalId: string;
+
+  /** Parent comment ID for threaded replies */
+  parentCommentExternalId?: string;
+
+  /** Comment author (platform user ID) */
+  authorPlatformUserId: string;
+
+  /** Author display name */
+  authorDisplayName?: string;
+
+  /** Comment text */
+  textContent: string;
+
+  /** Media URL if comment has media */
+  mediaUrl?: string;
+
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for emitCommentSent
+ */
+export interface EmitCommentSentParams {
+  /** Instance that sent the comment */
+  instanceId: string;
+
+  /** Platform-assigned comment ID */
+  externalId: string;
+
+  /** Post this comment belongs to */
+  postExternalId: string;
+
+  /** Parent comment ID for threaded replies */
+  parentCommentExternalId?: string;
+
+  /** Comment text */
+  textContent: string;
+}
+
+/**
+ * Parameters for emitConnectionReceived
+ */
+export interface EmitConnectionReceivedParams {
+  /** Instance that received the connection request */
+  instanceId: string;
+
+  /** Platform user ID of person who sent the request */
+  platformUserId: string;
+
+  /** Display name */
+  displayName?: string;
+
+  /** Connection type (connect, follow, etc.) */
+  connectionType: string;
+
+  /** Optional message included with the request */
+  message?: string;
+}
+
+/**
+ * Parameters for emitConnectionAccepted
+ */
+export interface EmitConnectionAcceptedParams {
+  /** Instance that accepted the connection */
+  instanceId: string;
+
+  /** Platform user ID of the connection */
+  platformUserId: string;
+
+  /** Display name */
+  displayName?: string;
+
+  /** Connection type */
+  connectionType: string;
+}
+
+/**
+ * Parameters for emitMentionReceived
+ */
+export interface EmitMentionReceivedParams {
+  /** Instance that received the mention */
+  instanceId: string;
+
+  /** Where the mention occurred: 'post' or 'comment' */
+  mentionContext: 'post' | 'comment';
+
+  /** External ID of the post or comment containing the mention */
+  sourceExternalId: string;
+
+  /** Platform user ID of the person who mentioned us */
+  mentionedByPlatformUserId: string;
+
+  /** Display name of the person who mentioned us */
+  mentionedByDisplayName?: string;
+
+  /** Text content of the post/comment containing the mention */
+  textContent?: string;
+
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}

--- a/packages/channel-sdk/src/index.ts
+++ b/packages/channel-sdk/src/index.ts
@@ -139,6 +139,15 @@ export type {
   InstanceConnectedPayload,
   InstanceDisconnectedPayload,
   InstanceQrCodePayload,
+  PostReceivedPayload,
+  PostCreatedPayload,
+  PostUpdatedPayload,
+  PostDeletedPayload,
+  CommentReceivedPayload,
+  CommentSentPayload,
+  ConnectionReceivedPayload,
+  ConnectionAcceptedPayload,
+  MentionReceivedPayload,
 } from '@omni/core/events';
 
 // Channel types from core

--- a/packages/channel-sdk/src/types/capabilities.ts
+++ b/packages/channel-sdk/src/types/capabilities.ts
@@ -98,6 +98,22 @@ export interface ChannelCapabilities {
   canStreamResponse?: boolean;
 
   // ─────────────────────────────────────────────────────────────
+  // Social channel capabilities (LinkedIn, Twitter, Instagram, etc.)
+  // ─────────────────────────────────────────────────────────────
+
+  /** Can create posts on a social feed */
+  canCreatePost?: boolean;
+
+  /** Can read/scrape the social feed */
+  canReadFeed?: boolean;
+
+  /** Can post comments on social posts */
+  canComment?: boolean;
+
+  /** Can handle connection/follow requests */
+  canHandleConnections?: boolean;
+
+  // ─────────────────────────────────────────────────────────────
   // Limits
   // ─────────────────────────────────────────────────────────────
 
@@ -168,6 +184,12 @@ export const DEFAULT_CAPABILITIES: ChannelCapabilities = {
   canCreateWebhooks: false,
   canSendViaWebhook: false,
   canHandleVoice: false,
+
+  // Social (disabled by default)
+  canCreatePost: false,
+  canReadFeed: false,
+  canComment: false,
+  canHandleConnections: false,
 
   // Limits
   maxMessageLength: 0,

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -81,6 +81,16 @@ export const CORE_EVENT_TYPES = [
   'conversation.created',
   'conversation.updated',
   'conversation.deleted',
+  // Social channel events
+  'post.received',
+  'post.created',
+  'post.updated',
+  'post.deleted',
+  'comment.received',
+  'comment.sent',
+  'connection.received',
+  'connection.accepted',
+  'mention.received',
 ] as const;
 
 export type CoreEventType = (typeof CORE_EVENT_TYPES)[number];
@@ -623,6 +633,141 @@ export interface AgentTaskCancelledPayload {
   chatId: string;
 }
 
+// ─── Social Channel Events ─────────────────────────────────
+
+/** Canonical event: social post received from platform */
+export interface PostReceivedPayload {
+  /** Platform-assigned post ID */
+  externalId: string;
+  /** Post author (platform user ID) */
+  authorPlatformUserId: string;
+  /** Author display name */
+  authorDisplayName?: string;
+  /** Post type (text, article, image, video, poll, etc.) */
+  postType: string;
+  /** Text content of the post */
+  textContent?: string;
+  /** Media URLs attached to the post */
+  mediaUrls?: string[];
+  /** Link URL if post contains a link */
+  linkUrl?: string;
+  /** Engagement counts at time of receipt */
+  likeCount?: number;
+  commentCount?: number;
+  repostCount?: number;
+  /** Hashtags found in the post */
+  hashtags?: string[];
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
+/** Canonical event: social post created by us */
+export interface PostCreatedPayload {
+  /** Platform-assigned post ID (after creation) */
+  externalId: string;
+  /** Post type */
+  postType: string;
+  /** Text content */
+  textContent?: string;
+  /** Media URLs attached */
+  mediaUrls?: string[];
+  /** Link URL */
+  linkUrl?: string;
+  /** Visibility setting */
+  visibility?: string;
+}
+
+/** Canonical event: social post updated (content or engagement change) */
+export interface PostUpdatedPayload {
+  /** Platform-assigned post ID */
+  externalId: string;
+  /** Which fields changed */
+  changedFields: string[];
+  /** Updated engagement counts */
+  likeCount?: number;
+  commentCount?: number;
+  repostCount?: number;
+  impressionCount?: number;
+}
+
+/** Canonical event: social post deleted */
+export interface PostDeletedPayload {
+  /** Platform-assigned post ID */
+  externalId: string;
+  /** Reason for deletion (if known) */
+  reason?: string;
+}
+
+/** Canonical event: comment received on a social post */
+export interface CommentReceivedPayload {
+  /** Platform-assigned comment ID */
+  externalId: string;
+  /** Post this comment belongs to (platform post ID) */
+  postExternalId: string;
+  /** Parent comment ID for threaded replies */
+  parentCommentExternalId?: string;
+  /** Comment author (platform user ID) */
+  authorPlatformUserId: string;
+  /** Author display name */
+  authorDisplayName?: string;
+  /** Comment text */
+  textContent: string;
+  /** Media URL if comment has media */
+  mediaUrl?: string;
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
+/** Canonical event: comment sent by us */
+export interface CommentSentPayload {
+  /** Platform-assigned comment ID */
+  externalId: string;
+  /** Post this comment belongs to */
+  postExternalId: string;
+  /** Parent comment ID for threaded replies */
+  parentCommentExternalId?: string;
+  /** Comment text */
+  textContent: string;
+}
+
+/** Canonical event: connection/follow request received */
+export interface ConnectionReceivedPayload {
+  /** Platform user ID of person who sent the request */
+  platformUserId: string;
+  /** Display name */
+  displayName?: string;
+  /** Connection type (connect, follow, etc.) */
+  connectionType: string;
+  /** Optional message included with the request */
+  message?: string;
+}
+
+/** Canonical event: connection/follow request accepted */
+export interface ConnectionAcceptedPayload {
+  /** Platform user ID of the connection */
+  platformUserId: string;
+  /** Display name */
+  displayName?: string;
+  /** Connection type */
+  connectionType: string;
+}
+
+/** Canonical event: mention received in a post or comment */
+export interface MentionReceivedPayload {
+  /** Where the mention occurred: 'post' or 'comment' */
+  mentionContext: 'post' | 'comment';
+  /** External ID of the post or comment containing the mention */
+  sourceExternalId: string;
+  /** Platform user ID of the person who mentioned us */
+  mentionedByPlatformUserId: string;
+  /** Display name of the person who mentioned us */
+  mentionedByDisplayName?: string;
+  /** Text content of the post/comment containing the mention */
+  textContent?: string;
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
 /**
  * Event type map for type-safe event handling (core events only)
  */
@@ -678,6 +823,16 @@ export interface EventPayloadMap {
   'conversation.created': { conversationId: string; title: string | null };
   'conversation.updated': { conversationId: string; title: string | null };
   'conversation.deleted': { conversationId: string };
+  // Social channel events
+  'post.received': PostReceivedPayload;
+  'post.created': PostCreatedPayload;
+  'post.updated': PostUpdatedPayload;
+  'post.deleted': PostDeletedPayload;
+  'comment.received': CommentReceivedPayload;
+  'comment.sent': CommentSentPayload;
+  'connection.received': ConnectionReceivedPayload;
+  'connection.accepted': ConnectionAcceptedPayload;
+  'mention.received': MentionReceivedPayload;
 }
 
 /**

--- a/packages/core/src/types/channel.ts
+++ b/packages/core/src/types/channel.ts
@@ -10,6 +10,7 @@ export const CHANNEL_TYPES = [
   'telegram',
   'a2a',
   'internal',
+  'linkedin',
 ] as const;
 export type ChannelType = (typeof CHANNEL_TYPES)[number];
 

--- a/packages/db/drizzle/0008_abandoned_vance_astro.sql
+++ b/packages/db/drizzle/0008_abandoned_vance_astro.sql
@@ -1,0 +1,118 @@
+CREATE TABLE "social_comments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"parent_comment_id" uuid,
+	"external_id" varchar(255) NOT NULL,
+	"author_person_id" uuid,
+	"author_platform_identity_id" uuid,
+	"author_platform_user_id" varchar(255),
+	"author_display_name" varchar(255),
+	"text_content" text,
+	"media_url" text,
+	"mentions" jsonb,
+	"like_count" integer DEFAULT 0 NOT NULL,
+	"reply_count" integer DEFAULT 0 NOT NULL,
+	"reactions" jsonb,
+	"status" varchar(20) DEFAULT 'active' NOT NULL,
+	"platform_timestamp" timestamp,
+	"last_synced_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"raw_payload" jsonb
+);
+--> statement-breakpoint
+CREATE TABLE "social_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"instance_id" uuid NOT NULL,
+	"person_id" uuid,
+	"platform_identity_id" uuid,
+	"platform_user_id" varchar(255) NOT NULL,
+	"display_name" varchar(255),
+	"connection_type" varchar(50) NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"message" text,
+	"connected_at" timestamp,
+	"requested_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_engagement_snapshots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"like_count" integer DEFAULT 0 NOT NULL,
+	"comment_count" integer DEFAULT 0 NOT NULL,
+	"repost_count" integer DEFAULT 0 NOT NULL,
+	"impression_count" integer DEFAULT 0 NOT NULL,
+	"snapshot_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_posts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"instance_id" uuid NOT NULL,
+	"external_id" varchar(255) NOT NULL,
+	"channel" varchar(50) NOT NULL,
+	"author_person_id" uuid,
+	"author_platform_identity_id" uuid,
+	"author_platform_user_id" varchar(255),
+	"author_display_name" varchar(255),
+	"post_type" varchar(50) DEFAULT 'text' NOT NULL,
+	"text_content" text,
+	"media_urls" jsonb,
+	"link_url" text,
+	"link_preview" jsonb,
+	"shared_post_id" uuid,
+	"shared_external_id" varchar(255),
+	"like_count" integer DEFAULT 0 NOT NULL,
+	"comment_count" integer DEFAULT 0 NOT NULL,
+	"repost_count" integer DEFAULT 0 NOT NULL,
+	"impression_count" integer DEFAULT 0 NOT NULL,
+	"reactions" jsonb,
+	"status" varchar(20) DEFAULT 'active' NOT NULL,
+	"visibility" varchar(50),
+	"is_pinned" boolean DEFAULT false NOT NULL,
+	"hashtags" text[],
+	"mentions" jsonb,
+	"platform_timestamp" timestamp,
+	"last_synced_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"raw_payload" jsonb,
+	"platform_metadata" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "social_comments" ADD CONSTRAINT "social_comments_post_id_social_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."social_posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_comments" ADD CONSTRAINT "social_comments_parent_comment_id_social_comments_id_fk" FOREIGN KEY ("parent_comment_id") REFERENCES "public"."social_comments"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_comments" ADD CONSTRAINT "social_comments_author_person_id_persons_id_fk" FOREIGN KEY ("author_person_id") REFERENCES "public"."persons"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_comments" ADD CONSTRAINT "social_comments_author_platform_identity_id_platform_identities_id_fk" FOREIGN KEY ("author_platform_identity_id") REFERENCES "public"."platform_identities"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_connections" ADD CONSTRAINT "social_connections_instance_id_instances_id_fk" FOREIGN KEY ("instance_id") REFERENCES "public"."instances"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_connections" ADD CONSTRAINT "social_connections_person_id_persons_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."persons"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_connections" ADD CONSTRAINT "social_connections_platform_identity_id_platform_identities_id_fk" FOREIGN KEY ("platform_identity_id") REFERENCES "public"."platform_identities"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_engagement_snapshots" ADD CONSTRAINT "social_engagement_snapshots_post_id_social_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."social_posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD CONSTRAINT "social_posts_instance_id_instances_id_fk" FOREIGN KEY ("instance_id") REFERENCES "public"."instances"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD CONSTRAINT "social_posts_author_person_id_persons_id_fk" FOREIGN KEY ("author_person_id") REFERENCES "public"."persons"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD CONSTRAINT "social_posts_author_platform_identity_id_platform_identities_id_fk" FOREIGN KEY ("author_platform_identity_id") REFERENCES "public"."platform_identities"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD CONSTRAINT "social_posts_shared_post_id_social_posts_id_fk" FOREIGN KEY ("shared_post_id") REFERENCES "public"."social_posts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "social_comments_post_idx" ON "social_comments" USING btree ("post_id");--> statement-breakpoint
+CREATE INDEX "social_comments_parent_idx" ON "social_comments" USING btree ("parent_comment_id");--> statement-breakpoint
+CREATE INDEX "social_comments_author_person_idx" ON "social_comments" USING btree ("author_person_id");--> statement-breakpoint
+CREATE INDEX "social_comments_author_pi_idx" ON "social_comments" USING btree ("author_platform_identity_id");--> statement-breakpoint
+CREATE INDEX "social_comments_status_idx" ON "social_comments" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "social_comments_platform_ts_idx" ON "social_comments" USING btree ("platform_timestamp");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_comments_post_external_idx" ON "social_comments" USING btree ("post_id","external_id");--> statement-breakpoint
+CREATE INDEX "social_connections_instance_idx" ON "social_connections" USING btree ("instance_id");--> statement-breakpoint
+CREATE INDEX "social_connections_person_idx" ON "social_connections" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "social_connections_pi_idx" ON "social_connections" USING btree ("platform_identity_id");--> statement-breakpoint
+CREATE INDEX "social_connections_status_idx" ON "social_connections" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_connections_instance_user_type_idx" ON "social_connections" USING btree ("instance_id","platform_user_id","connection_type");--> statement-breakpoint
+CREATE INDEX "social_engagement_snapshots_post_idx" ON "social_engagement_snapshots" USING btree ("post_id");--> statement-breakpoint
+CREATE INDEX "social_engagement_snapshots_at_idx" ON "social_engagement_snapshots" USING btree ("snapshot_at");--> statement-breakpoint
+CREATE INDEX "social_engagement_snapshots_post_at_idx" ON "social_engagement_snapshots" USING btree ("post_id","snapshot_at");--> statement-breakpoint
+CREATE INDEX "social_posts_instance_idx" ON "social_posts" USING btree ("instance_id");--> statement-breakpoint
+CREATE INDEX "social_posts_channel_idx" ON "social_posts" USING btree ("channel");--> statement-breakpoint
+CREATE INDEX "social_posts_author_person_idx" ON "social_posts" USING btree ("author_person_id");--> statement-breakpoint
+CREATE INDEX "social_posts_author_pi_idx" ON "social_posts" USING btree ("author_platform_identity_id");--> statement-breakpoint
+CREATE INDEX "social_posts_status_idx" ON "social_posts" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "social_posts_platform_ts_idx" ON "social_posts" USING btree ("platform_timestamp");--> statement-breakpoint
+CREATE INDEX "social_posts_created_at_idx" ON "social_posts" USING btree ("created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_posts_instance_external_idx" ON "social_posts" USING btree ("instance_id","external_id");

--- a/packages/db/drizzle/meta/0008_snapshot.json
+++ b/packages/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,7658 @@
+{
+  "id": "9434cff1-1613-4dc7-a107-57155f616b20",
+  "prevId": "58ba1b1d-5925-4503-9244-fac1e95950e7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_rules": {
+      "name": "access_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_type": {
+          "name": "rule_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_pattern": {
+          "name": "phone_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "block_message": {
+          "name": "block_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_rules_instance_idx": {
+          "name": "access_rules_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_rules_phone_idx": {
+          "name": "access_rules_phone_idx",
+          "columns": [
+            {
+              "expression": "phone_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_rules_type_idx": {
+          "name": "access_rules_type_idx",
+          "columns": [
+            {
+              "expression": "rule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_rules_unique_idx": {
+          "name": "access_rules_unique_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_rules_pairing": {
+          "name": "idx_access_rules_pairing",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_rules_instance_id_instances_id_fk": {
+          "name": "access_rules_instance_id_instances_id_fk",
+          "tableFrom": "access_rules",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_rules_person_id_persons_id_fk": {
+          "name": "access_rules_person_id_persons_id_fk",
+          "tableFrom": "access_rules",
+          "tableTo": "persons",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_providers": {
+      "name": "agent_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agno'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_config": {
+          "name": "schema_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_stream": {
+          "name": "default_stream",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_timeout": {
+          "name": "default_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "supports_images": {
+          "name": "supports_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supports_audio": {
+          "name": "supports_audio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supports_documents": {
+          "name": "supports_documents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_status": {
+          "name": "last_health_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_error": {
+          "name": "last_health_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_providers_name_idx": {
+          "name": "agent_providers_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_providers_schema_idx": {
+          "name": "agent_providers_schema_idx",
+          "columns": [
+            {
+              "expression": "schema",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_providers_active_idx": {
+          "name": "agent_providers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_providers_name_unique": {
+          "name": "agent_providers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_routes": {
+      "name": "agent_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_timeout": {
+          "name": "agent_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_stream_mode": {
+          "name": "agent_stream_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_reply_filter": {
+          "name": "agent_reply_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_strategy": {
+          "name": "agent_session_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_prefix_sender_name": {
+          "name": "agent_prefix_sender_name",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_wait_for_media": {
+          "name": "agent_wait_for_media",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_send_media_path": {
+          "name": "agent_send_media_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_send_media_path_types": {
+          "name": "agent_send_media_path_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_gate_enabled": {
+          "name": "agent_gate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_gate_model": {
+          "name": "agent_gate_model",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_gate_prompt": {
+          "name": "agent_gate_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_routes_unique_chat_route": {
+          "name": "agent_routes_unique_chat_route",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_routes_unique_user_route": {
+          "name": "agent_routes_unique_user_route",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_routes_instance_idx": {
+          "name": "agent_routes_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_routes_chat_idx": {
+          "name": "agent_routes_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_routes_person_idx": {
+          "name": "agent_routes_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_routes_active_idx": {
+          "name": "agent_routes_active_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_routes_agent_id_idx": {
+          "name": "agent_routes_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_routes_instance_id_instances_id_fk": {
+          "name": "agent_routes_instance_id_instances_id_fk",
+          "tableFrom": "agent_routes",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_routes_chat_id_chats_id_fk": {
+          "name": "agent_routes_chat_id_chats_id_fk",
+          "tableFrom": "agent_routes",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_routes_person_id_persons_id_fk": {
+          "name": "agent_routes_person_id_persons_id_fk",
+          "tableFrom": "agent_routes",
+          "tableTo": "persons",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_routes_agent_id_agents_id_fk": {
+          "name": "agent_routes_agent_id_agents_id_fk",
+          "tableFrom": "agent_routes",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scope_check": {
+          "name": "scope_check",
+          "value": "(scope = 'chat' AND chat_id IS NOT NULL AND person_id IS NULL) OR (scope = 'user' AND person_id IS NOT NULL AND chat_id IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_data": {
+          "name": "provider_session_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_instance_key_idx": {
+          "name": "agent_sessions_instance_key_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_expires_idx": {
+          "name": "agent_sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_last_used_idx": {
+          "name": "agent_sessions_last_used_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_instance_id_instances_id_fk": {
+          "name": "agent_sessions_instance_id_instances_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tasks": {
+      "name": "agent_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_task_id": {
+          "name": "parent_task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtask_count": {
+          "name": "subtask_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_subtask_count": {
+          "name": "completed_subtask_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tasks_agent_id_idx": {
+          "name": "agent_tasks_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_chat_id_idx": {
+          "name": "agent_tasks_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_conversation_id_idx": {
+          "name": "agent_tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_parent_task_id_idx": {
+          "name": "agent_tasks_parent_task_id_idx",
+          "columns": [
+            {
+              "expression": "parent_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_status_idx": {
+          "name": "agent_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_agent_chat_idx": {
+          "name": "agent_tasks_agent_chat_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_tasks_agent_status_idx": {
+          "name": "agent_tasks_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tasks_agent_id_agents_id_fk": {
+          "name": "agent_tasks_agent_id_agents_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_chat_id_chats_id_fk": {
+          "name": "agent_tasks_chat_id_chats_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_conversation_id_conversations_id_fk": {
+          "name": "agent_tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_message_id_messages_id_fk": {
+          "name": "agent_tasks_message_id_messages_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_tasks_parent_task_id_agent_tasks_id_fk": {
+          "name": "agent_tasks_parent_task_id_agent_tasks_id_fk",
+          "tableFrom": "agent_tasks",
+          "tableTo": "agent_tasks",
+          "columnsFrom": ["parent_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'assistant'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider_id": {
+          "name": "agent_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_path": {
+          "name": "config_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_card": {
+          "name": "agent_card",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_name_idx": {
+          "name": "agents_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_owner_idx": {
+          "name": "agents_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_provider_idx": {
+          "name": "agents_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_active_idx": {
+          "name": "agents_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_persons_id_fk": {
+          "name": "agents_owner_id_persons_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "persons",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_agent_provider_id_agent_providers_id_fk": {
+          "name": "agents_agent_provider_id_agent_providers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "agent_providers",
+          "columnsFrom": ["agent_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key_audit_logs": {
+      "name": "api_key_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_audit_logs_api_key_idx": {
+          "name": "api_key_audit_logs_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_audit_logs_timestamp_idx": {
+          "name": "api_key_audit_logs_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_audit_logs_path_idx": {
+          "name": "api_key_audit_logs_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_audit_logs_api_key_id_api_keys_id_fk": {
+          "name": "api_key_audit_logs_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_key_audit_logs",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_ids": {
+          "name": "instance_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_prefix_idx": {
+          "name": "api_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_status_idx": {
+          "name": "api_keys_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_expires_at_idx": {
+          "name": "api_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_logs": {
+      "name": "automation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions_matched": {
+          "name": "conditions_matched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions_executed": {
+          "name": "actions_executed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_time_ms": {
+          "name": "execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_logs_automation_idx": {
+          "name": "automation_logs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_logs_event_id_idx": {
+          "name": "automation_logs_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_logs_status_idx": {
+          "name": "automation_logs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_logs_created_at_idx": {
+          "name": "automation_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_logs_automation_id_automations_id_fk": {
+          "name": "automation_logs_automation_id_automations_id_fk",
+          "tableFrom": "automation_logs",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_type": {
+          "name": "trigger_event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_conditions": {
+          "name": "trigger_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_logic": {
+          "name": "condition_logic",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'and'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debounce": {
+          "name": "debounce",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automations_name_idx": {
+          "name": "automations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_trigger_idx": {
+          "name": "automations_trigger_idx",
+          "columns": [
+            {
+              "expression": "trigger_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_enabled_idx": {
+          "name": "automations_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_priority_idx": {
+          "name": "automations_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batch_jobs": {
+      "name": "batch_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "request_params": {
+          "name": "request_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_items": {
+          "name": "processed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_item": {
+          "name": "current_item",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "numeric(15, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batch_jobs_status_idx": {
+          "name": "batch_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batch_jobs_instance_idx": {
+          "name": "batch_jobs_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batch_jobs_created_at_idx": {
+          "name": "batch_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_jobs_instance_id_instances_id_fk": {
+          "name": "batch_jobs_instance_id_instances_id_fk",
+          "tableFrom": "batch_jobs",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_id_mappings": {
+      "name": "chat_id_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lid_id": {
+          "name": "lid_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_id": {
+          "name": "phone_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discovered_from": {
+          "name": "discovered_from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_id_mappings_instance_lid_idx": {
+          "name": "chat_id_mappings_instance_lid_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_id_mappings_instance_phone_idx": {
+          "name": "chat_id_mappings_instance_phone_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_id_mappings_instance_id_instances_id_fk": {
+          "name": "chat_id_mappings_instance_id_instances_id_fk",
+          "tableFrom": "chat_id_mappings",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_participants": {
+      "name": "chat_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_identity_id": {
+          "name": "platform_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platform_metadata": {
+          "name": "platform_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_participants_chat_user_idx": {
+          "name": "chat_participants_chat_user_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_participants_chat_idx": {
+          "name": "chat_participants_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_participants_person_idx": {
+          "name": "chat_participants_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_participants_platform_identity_idx": {
+          "name": "chat_participants_platform_identity_idx",
+          "columns": [
+            {
+              "expression": "platform_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_participants_role_idx": {
+          "name": "chat_participants_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_participants_chat_id_chats_id_fk": {
+          "name": "chat_participants_chat_id_chats_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_participants_person_id_persons_id_fk": {
+          "name": "chat_participants_person_id_persons_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "persons",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_participants_platform_identity_id_platform_identities_id_fk": {
+          "name": "chat_participants_platform_identity_id_platform_identities_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "platform_identities",
+          "columnsFrom": ["platform_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_metadata": {
+          "name": "platform_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chats_instance_external_idx": {
+          "name": "chats_instance_external_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_canonical_id_idx": {
+          "name": "chats_canonical_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_instance_canonical_unique_idx": {
+          "name": "chats_instance_canonical_unique_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chats\".\"canonical_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_type_idx": {
+          "name": "chats_type_idx",
+          "columns": [
+            {
+              "expression": "chat_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_channel_idx": {
+          "name": "chats_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_parent_idx": {
+          "name": "chats_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_last_message_idx": {
+          "name": "chats_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_conversation_id_idx": {
+          "name": "chats_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_instance_id_instances_id_fk": {
+          "name": "chats_instance_id_instances_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_conversation_id_conversations_id_fk": {
+          "name": "chats_conversation_id_conversations_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumer_offsets": {
+      "name": "consumer_offsets",
+      "schema": "",
+      "columns": {
+        "consumer_name": {
+          "name": "consumer_name",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stream_name": {
+          "name": "stream_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sequence": {
+          "name": "last_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_updated_at_idx": {
+          "name": "conversations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dead_letter_events": {
+      "name": "dead_letter_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_retry_count": {
+          "name": "auto_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "manual_retry_count": {
+          "name": "manual_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_auto_retry_at": {
+          "name": "next_auto_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dead_letter_events_event_id_idx": {
+          "name": "dead_letter_events_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dead_letter_events_event_type_idx": {
+          "name": "dead_letter_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dead_letter_events_status_idx": {
+          "name": "dead_letter_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dead_letter_events_created_at_idx": {
+          "name": "dead_letter_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dead_letter_events_next_retry_idx": {
+          "name": "dead_letter_events_next_retry_idx",
+          "columns": [
+            {
+              "expression": "next_auto_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_payloads": {
+      "name": "event_payloads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_compressed": {
+          "name": "payload_compressed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_size_original": {
+          "name": "payload_size_original",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_size_compressed": {
+          "name": "payload_size_compressed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "contains_media": {
+          "name": "contains_media",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "contains_base64": {
+          "name": "contains_base64",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_payloads_event_id_idx": {
+          "name": "event_payloads_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_payloads_event_type_idx": {
+          "name": "event_payloads_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_payloads_stage_idx": {
+          "name": "event_payloads_stage_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_payloads_timestamp_idx": {
+          "name": "event_payloads_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_payloads_deleted_at_idx": {
+          "name": "event_payloads_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_payloads_event_stage_idx": {
+          "name": "event_payloads_event_stage_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_settings": {
+      "name": "global_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_rules": {
+          "name": "validation_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "global_settings_key_idx": {
+          "name": "global_settings_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "global_settings_category_idx": {
+          "name": "global_settings_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_settings_key_unique": {
+          "name": "global_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instances": {
+      "name": "instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_bot_token": {
+          "name": "discord_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_client_id": {
+          "name": "discord_client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_guild_ids": {
+          "name": "discord_guild_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_default_channel_id": {
+          "name": "discord_default_channel_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_voice_enabled": {
+          "name": "discord_voice_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "discord_slash_commands_enabled": {
+          "name": "discord_slash_commands_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "discord_webhook_url": {
+          "name": "discord_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_permissions": {
+          "name": "discord_permissions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guild_config_overrides": {
+          "name": "guild_config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_presence": {
+          "name": "discord_presence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_bot_token": {
+          "name": "slack_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_app_token": {
+          "name": "slack_app_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_signing_secret": {
+          "name": "slack_signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_reaction_level": {
+          "name": "telegram_reaction_level",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_timeout": {
+          "name": "agent_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "agent_stream_mode": {
+          "name": "agent_stream_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_reply_filter": {
+          "name": "agent_reply_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_strategy": {
+          "name": "agent_session_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'per_chat'"
+        },
+        "agent_prefix_sender_name": {
+          "name": "agent_prefix_sender_name",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"message.received\"]'::jsonb"
+        },
+        "trigger_reactions": {
+          "name": "trigger_reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_mention_patterns": {
+          "name": "trigger_mention_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round-trip'"
+        },
+        "trigger_rate_limit": {
+          "name": "trigger_rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "profile_name": {
+          "name": "profile_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_pic_url": {
+          "name": "profile_pic_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_bio": {
+          "name": "profile_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_metadata": {
+          "name": "profile_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_synced_at": {
+          "name": "profile_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_identifier": {
+          "name": "owner_identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_media_on_sync": {
+          "name": "download_media_on_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_auto_split": {
+          "name": "enable_auto_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "message_format_mode": {
+          "name": "message_format_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'convert'"
+        },
+        "disable_username_prefix": {
+          "name": "disable_username_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "process_media_on_blocked": {
+          "name": "process_media_on_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blocklist'"
+        },
+        "message_debounce_mode": {
+          "name": "message_debounce_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "message_debounce_min_ms": {
+          "name": "message_debounce_min_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_debounce_group_ms": {
+          "name": "message_debounce_group_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_debounce_max_ms": {
+          "name": "message_debounce_max_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_debounce_restart_on_typing": {
+          "name": "message_debounce_restart_on_typing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_gate_enabled": {
+          "name": "agent_gate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_gate_model": {
+          "name": "agent_gate_model",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_gate_prompt": {
+          "name": "agent_gate_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_split_delay_mode": {
+          "name": "message_split_delay_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'randomized'"
+        },
+        "message_split_delay_fixed_ms": {
+          "name": "message_split_delay_fixed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_split_delay_min_ms": {
+          "name": "message_split_delay_min_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "message_split_delay_max_ms": {
+          "name": "message_split_delay_max_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "tts_voice_id": {
+          "name": "tts_voice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tts_model_id": {
+          "name": "tts_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_ack": {
+          "name": "reaction_ack",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "reaction_ack_emoji": {
+          "name": "reaction_ack_emoji",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack_timeout_ms": {
+          "name": "ack_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "session_reset": {
+          "name": "session_reset",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process_audio": {
+          "name": "process_audio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "process_images": {
+          "name": "process_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "process_video": {
+          "name": "process_video",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "process_documents": {
+          "name": "process_documents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_wait_for_media": {
+          "name": "agent_wait_for_media",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_send_media_path": {
+          "name": "agent_send_media_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_send_media_path_types": {
+          "name": "agent_send_media_path_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_receipts": {
+          "name": "read_receipts",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on'"
+        },
+        "group_history_size": {
+          "name": "group_history_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_enabled": {
+          "name": "replay_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_chain_to_instance_id": {
+          "name": "agent_chain_to_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_mode": {
+          "name": "chain_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instances_name_idx": {
+          "name": "instances_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instances_channel_idx": {
+          "name": "instances_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instances_is_active_idx": {
+          "name": "instances_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instances_is_default_idx": {
+          "name": "instances_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instances_agent_id_idx": {
+          "name": "instances_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instances_agent_id_agents_id_fk": {
+          "name": "instances_agent_id_agents_id_fk",
+          "tableFrom": "instances",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "instances_agent_chain_to_instance_id_instances_id_fk": {
+          "name": "instances_agent_chain_to_instance_id_instances_id_fk",
+          "tableFrom": "instances",
+          "tableTo": "instances",
+          "columnsFrom": ["agent_chain_to_instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instances_name_unique": {
+          "name": "instances_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "instances_chain_mode_check": {
+          "name": "instances_chain_mode_check",
+          "value": "\"instances\".\"chain_mode\" IN ('off', 'forward', 'bidirectional')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_content": {
+      "name": "media_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_type": {
+          "name": "processing_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(15, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_job_id": {
+          "name": "batch_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_time_ms": {
+          "name": "processing_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_content_event_idx": {
+          "name": "media_content_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_content_media_idx": {
+          "name": "media_content_media_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_content_batch_job_idx": {
+          "name": "media_content_batch_job_idx",
+          "columns": [
+            {
+              "expression": "batch_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_content_event_id_omni_events_id_fk": {
+          "name": "media_content_event_id_omni_events_id_fk",
+          "tableFrom": "media_content",
+          "tableTo": "omni_events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_content_batch_job_id_batch_jobs_id_fk": {
+          "name": "media_content_batch_job_id_batch_jobs_id_fk",
+          "tableFrom": "media_content",
+          "tableTo": "batch_jobs",
+          "columnsFrom": ["batch_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_person_id": {
+          "name": "sender_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_platform_identity_id": {
+          "name": "sender_platform_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_platform_user_id": {
+          "name": "sender_platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_from_me": {
+          "name": "is_from_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sender_agent_id": {
+          "name": "sender_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription": {
+          "name": "transcription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_description": {
+          "name": "image_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_description": {
+          "name": "video_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_extraction": {
+          "name": "document_extraction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "media_mime_type": {
+          "name": "media_mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_local_path": {
+          "name": "media_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_metadata": {
+          "name": "media_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quoted_sender_name": {
+          "name": "quoted_sender_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forwarded_from_message_id": {
+          "name": "forwarded_from_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forwarded_from_external_id": {
+          "name": "forwarded_from_external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forward_count": {
+          "name": "forward_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_forwarded": {
+          "name": "is_forwarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'sent'"
+        },
+        "edit_count": {
+          "name": "edit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edit_history": {
+          "name": "edit_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_counts": {
+          "name": "reaction_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_event_id": {
+          "name": "original_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_timestamp": {
+          "name": "platform_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_external_idx": {
+          "name": "messages_chat_external_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_chat_idx": {
+          "name": "messages_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_person_idx": {
+          "name": "messages_sender_person_idx",
+          "columns": [
+            {
+              "expression": "sender_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_platform_identity_idx": {
+          "name": "messages_sender_platform_identity_idx",
+          "columns": [
+            {
+              "expression": "sender_platform_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_agent_idx": {
+          "name": "messages_sender_agent_idx",
+          "columns": [
+            {
+              "expression": "sender_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_source_idx": {
+          "name": "messages_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_type_idx": {
+          "name": "messages_type_idx",
+          "columns": [
+            {
+              "expression": "message_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_status_idx": {
+          "name": "messages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_timestamp_idx": {
+          "name": "messages_platform_timestamp_idx",
+          "columns": [
+            {
+              "expression": "platform_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_reply_to_idx": {
+          "name": "messages_reply_to_idx",
+          "columns": [
+            {
+              "expression": "reply_to_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_reply_to_external_idx": {
+          "name": "messages_reply_to_external_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reply_to_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_from_me",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_has_media_idx": {
+          "name": "messages_has_media_idx",
+          "columns": [
+            {
+              "expression": "has_media",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_original_event_idx": {
+          "name": "messages_original_event_idx",
+          "columns": [
+            {
+              "expression": "original_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_person_id_persons_id_fk": {
+          "name": "messages_sender_person_id_persons_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "persons",
+          "columnsFrom": ["sender_person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_sender_platform_identity_id_platform_identities_id_fk": {
+          "name": "messages_sender_platform_identity_id_platform_identities_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platform_identities",
+          "columnsFrom": ["sender_platform_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_sender_agent_id_agents_id_fk": {
+          "name": "messages_sender_agent_id_agents_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "agents",
+          "columnsFrom": ["sender_agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.omni_events": {
+      "name": "omni_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_identity_id": {
+          "name": "platform_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbound'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription": {
+          "name": "transcription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_description": {
+          "name": "image_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_extraction": {
+          "name": "document_extraction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_mime_type": {
+          "name": "media_mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_size": {
+          "name": "media_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_duration": {
+          "name": "media_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_event_id": {
+          "name": "reply_to_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_chat_id": {
+          "name": "canonical_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_uuid": {
+          "name": "chat_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stage": {
+          "name": "error_stage",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_time_ms": {
+          "name": "processing_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_latency_ms": {
+          "name": "agent_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_latency_ms": {
+          "name": "total_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_request": {
+          "name": "agent_request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_response": {
+          "name": "agent_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "omni_events_external_id_idx": {
+          "name": "omni_events_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_channel_idx": {
+          "name": "omni_events_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_instance_idx": {
+          "name": "omni_events_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_person_idx": {
+          "name": "omni_events_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_type_idx": {
+          "name": "omni_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_status_idx": {
+          "name": "omni_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_received_at_idx": {
+          "name": "omni_events_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_chat_id_idx": {
+          "name": "omni_events_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_canonical_chat_idx": {
+          "name": "omni_events_canonical_chat_idx",
+          "columns": [
+            {
+              "expression": "canonical_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_agent_id_idx": {
+          "name": "omni_events_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_chat_uuid_idx": {
+          "name": "omni_events_chat_uuid_idx",
+          "columns": [
+            {
+              "expression": "chat_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_events_conversation_id_idx": {
+          "name": "omni_events_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "omni_events_instance_id_instances_id_fk": {
+          "name": "omni_events_instance_id_instances_id_fk",
+          "tableFrom": "omni_events",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "omni_events_person_id_persons_id_fk": {
+          "name": "omni_events_person_id_persons_id_fk",
+          "tableFrom": "omni_events",
+          "tableTo": "persons",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "omni_events_platform_identity_id_platform_identities_id_fk": {
+          "name": "omni_events_platform_identity_id_platform_identities_id_fk",
+          "tableFrom": "omni_events",
+          "tableTo": "platform_identities",
+          "columnsFrom": ["platform_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "omni_events_chat_uuid_chats_id_fk": {
+          "name": "omni_events_chat_uuid_chats_id_fk",
+          "tableFrom": "omni_events",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_uuid"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "omni_events_agent_id_agents_id_fk": {
+          "name": "omni_events_agent_id_agents_id_fk",
+          "tableFrom": "omni_events",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "omni_events_conversation_id_conversations_id_fk": {
+          "name": "omni_events_conversation_id_conversations_id_fk",
+          "tableFrom": "omni_events",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.omni_groups": {
+      "name": "omni_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_community": {
+          "name": "is_community",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_metadata": {
+          "name": "platform_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "omni_groups_instance_external_idx": {
+          "name": "omni_groups_instance_external_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_groups_instance_idx": {
+          "name": "omni_groups_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_groups_channel_idx": {
+          "name": "omni_groups_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "omni_groups_name_idx": {
+          "name": "omni_groups_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "omni_groups_instance_id_instances_id_fk": {
+          "name": "omni_groups_instance_id_instances_id_fk",
+          "tableFrom": "omni_groups",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_storage_config": {
+      "name": "payload_storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_webhook_raw": {
+          "name": "store_webhook_raw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "store_agent_request": {
+          "name": "store_agent_request",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "store_agent_response": {
+          "name": "store_agent_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "store_channel_send": {
+          "name": "store_channel_send",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "store_error": {
+          "name": "store_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_storage_config_event_type_idx": {
+          "name": "payload_storage_config_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payload_storage_config_event_type_unique": {
+          "name": "payload_storage_config_event_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["event_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.persons": {
+      "name": "persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_phone": {
+          "name": "primary_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persons_phone_idx": {
+          "name": "persons_phone_idx",
+          "columns": [
+            {
+              "expression": "primary_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "persons_email_idx": {
+          "name": "persons_email_idx",
+          "columns": [
+            {
+              "expression": "primary_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "persons_name_idx": {
+          "name": "persons_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_identities": {
+      "name": "platform_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_username": {
+          "name": "platform_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_pic_url": {
+          "name": "profile_pic_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_data": {
+          "name": "profile_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linked_by": {
+          "name": "linked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "link_reason": {
+          "name": "link_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_identities_person_idx": {
+          "name": "platform_identities_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_identities_agent_idx": {
+          "name": "platform_identities_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_identities_channel_idx": {
+          "name": "platform_identities_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_identities_instance_idx": {
+          "name": "platform_identities_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_identities_platform_user_idx": {
+          "name": "platform_identities_platform_user_idx",
+          "columns": [
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_identities_channel_user_idx": {
+          "name": "platform_identities_channel_user_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_identities_person_id_persons_id_fk": {
+          "name": "platform_identities_person_id_persons_id_fk",
+          "tableFrom": "platform_identities",
+          "tableTo": "persons",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "platform_identities_agent_id_agents_id_fk": {
+          "name": "platform_identities_agent_id_agents_id_fk",
+          "tableFrom": "platform_identities",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "platform_identities_instance_id_instances_id_fk": {
+          "name": "platform_identities_instance_id_instances_id_fk",
+          "tableFrom": "platform_identities",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_identities_actor_xor": {
+          "name": "platform_identities_actor_xor",
+          "value": "NOT (person_id IS NOT NULL AND agent_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plugin_storage": {
+      "name": "plugin_storage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_storage_plugin_key_idx": {
+          "name": "plugin_storage_plugin_key_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_storage_plugin_idx": {
+          "name": "plugin_storage_plugin_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_storage_expires_at_idx": {
+          "name": "plugin_storage_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setting_change_history": {
+      "name": "setting_change_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "setting_id": {
+          "name": "setting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "change_reason": {
+          "name": "change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "setting_change_history_setting_idx": {
+          "name": "setting_change_history_setting_idx",
+          "columns": [
+            {
+              "expression": "setting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setting_change_history_changed_at_idx": {
+          "name": "setting_change_history_changed_at_idx",
+          "columns": [
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setting_change_history_setting_id_global_settings_id_fk": {
+          "name": "setting_change_history_setting_id_global_settings_id_fk",
+          "tableFrom": "setting_change_history",
+          "tableTo": "global_settings",
+          "columnsFrom": ["setting_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_comments": {
+      "name": "social_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_person_id": {
+          "name": "author_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_platform_identity_id": {
+          "name": "author_platform_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_platform_user_id": {
+          "name": "author_platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "platform_timestamp": {
+          "name": "platform_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "social_comments_post_idx": {
+          "name": "social_comments_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_comments_parent_idx": {
+          "name": "social_comments_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_comments_author_person_idx": {
+          "name": "social_comments_author_person_idx",
+          "columns": [
+            {
+              "expression": "author_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_comments_author_pi_idx": {
+          "name": "social_comments_author_pi_idx",
+          "columns": [
+            {
+              "expression": "author_platform_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_comments_status_idx": {
+          "name": "social_comments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_comments_platform_ts_idx": {
+          "name": "social_comments_platform_ts_idx",
+          "columns": [
+            {
+              "expression": "platform_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_comments_post_external_idx": {
+          "name": "social_comments_post_external_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_comments_post_id_social_posts_id_fk": {
+          "name": "social_comments_post_id_social_posts_id_fk",
+          "tableFrom": "social_comments",
+          "tableTo": "social_posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_comments_parent_comment_id_social_comments_id_fk": {
+          "name": "social_comments_parent_comment_id_social_comments_id_fk",
+          "tableFrom": "social_comments",
+          "tableTo": "social_comments",
+          "columnsFrom": ["parent_comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_comments_author_person_id_persons_id_fk": {
+          "name": "social_comments_author_person_id_persons_id_fk",
+          "tableFrom": "social_comments",
+          "tableTo": "persons",
+          "columnsFrom": ["author_person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_comments_author_platform_identity_id_platform_identities_id_fk": {
+          "name": "social_comments_author_platform_identity_id_platform_identities_id_fk",
+          "tableFrom": "social_comments",
+          "tableTo": "platform_identities",
+          "columnsFrom": ["author_platform_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_connections": {
+      "name": "social_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_identity_id": {
+          "name": "platform_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_connections_instance_idx": {
+          "name": "social_connections_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_connections_person_idx": {
+          "name": "social_connections_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_connections_pi_idx": {
+          "name": "social_connections_pi_idx",
+          "columns": [
+            {
+              "expression": "platform_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_connections_status_idx": {
+          "name": "social_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_connections_instance_user_type_idx": {
+          "name": "social_connections_instance_user_type_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_connections_instance_id_instances_id_fk": {
+          "name": "social_connections_instance_id_instances_id_fk",
+          "tableFrom": "social_connections",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_connections_person_id_persons_id_fk": {
+          "name": "social_connections_person_id_persons_id_fk",
+          "tableFrom": "social_connections",
+          "tableTo": "persons",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_connections_platform_identity_id_platform_identities_id_fk": {
+          "name": "social_connections_platform_identity_id_platform_identities_id_fk",
+          "tableFrom": "social_connections",
+          "tableTo": "platform_identities",
+          "columnsFrom": ["platform_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_engagement_snapshots": {
+      "name": "social_engagement_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repost_count": {
+          "name": "repost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "impression_count": {
+          "name": "impression_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_engagement_snapshots_post_idx": {
+          "name": "social_engagement_snapshots_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_engagement_snapshots_at_idx": {
+          "name": "social_engagement_snapshots_at_idx",
+          "columns": [
+            {
+              "expression": "snapshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_engagement_snapshots_post_at_idx": {
+          "name": "social_engagement_snapshots_post_at_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_engagement_snapshots_post_id_social_posts_id_fk": {
+          "name": "social_engagement_snapshots_post_id_social_posts_id_fk",
+          "tableFrom": "social_engagement_snapshots",
+          "tableTo": "social_posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_person_id": {
+          "name": "author_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_platform_identity_id": {
+          "name": "author_platform_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_platform_user_id": {
+          "name": "author_platform_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_type": {
+          "name": "post_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_preview": {
+          "name": "link_preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_post_id": {
+          "name": "shared_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_external_id": {
+          "name": "shared_external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repost_count": {
+          "name": "repost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "impression_count": {
+          "name": "impression_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_timestamp": {
+          "name": "platform_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_metadata": {
+          "name": "platform_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "social_posts_instance_idx": {
+          "name": "social_posts_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_channel_idx": {
+          "name": "social_posts_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_author_person_idx": {
+          "name": "social_posts_author_person_idx",
+          "columns": [
+            {
+              "expression": "author_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_author_pi_idx": {
+          "name": "social_posts_author_pi_idx",
+          "columns": [
+            {
+              "expression": "author_platform_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_platform_ts_idx": {
+          "name": "social_posts_platform_ts_idx",
+          "columns": [
+            {
+              "expression": "platform_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_instance_external_idx": {
+          "name": "social_posts_instance_external_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_posts_instance_id_instances_id_fk": {
+          "name": "social_posts_instance_id_instances_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_author_person_id_persons_id_fk": {
+          "name": "social_posts_author_person_id_persons_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "persons",
+          "columnsFrom": ["author_person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_posts_author_platform_identity_id_platform_identities_id_fk": {
+          "name": "social_posts_author_platform_identity_id_platform_identities_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "platform_identities",
+          "columnsFrom": ["author_platform_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_posts_shared_post_id_social_posts_id_fk": {
+          "name": "social_posts_shared_post_id_social_posts_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "social_posts",
+          "columnsFrom": ["shared_post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_jobs_instance_idx": {
+          "name": "sync_jobs_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_jobs_status_idx": {
+          "name": "sync_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_jobs_type_idx": {
+          "name": "sync_jobs_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_jobs_created_at_idx": {
+          "name": "sync_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_jobs_instance_id_instances_id_fk": {
+          "name": "sync_jobs_instance_id_instances_id_fk",
+          "tableFrom": "sync_jobs",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_logs": {
+      "name": "trigger_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded": {
+          "name": "responded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_logs_instance_idx": {
+          "name": "trigger_logs_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_logs_trace_idx": {
+          "name": "trigger_logs_trace_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_logs_fired_at_idx": {
+          "name": "trigger_logs_fired_at_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_logs_event_type_idx": {
+          "name": "trigger_logs_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_logs_instance_id_instances_id_fk": {
+          "name": "trigger_logs_instance_id_instances_id_fk",
+          "tableFrom": "trigger_logs",
+          "tableTo": "instances",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_logs_provider_id_agent_providers_id_fk": {
+          "name": "trigger_logs_provider_id_agent_providers_id_fk",
+          "tableFrom": "trigger_logs",
+          "tableTo": "agent_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trigger_logs_route_id_agent_routes_id_fk": {
+          "name": "trigger_logs_route_id_agent_routes_id_fk",
+          "tableFrom": "trigger_logs",
+          "tableTo": "agent_routes",
+          "columnsFrom": ["route_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_sources": {
+      "name": "webhook_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_headers": {
+          "name": "expected_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_received": {
+          "name": "total_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_sources_name_idx": {
+          "name": "webhook_sources_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_sources_enabled_idx": {
+          "name": "webhook_sources_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_sources_name_unique": {
+          "name": "webhook_sources_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772485979658,
       "tag": "0007_clumsy_nick_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1773108301748,
+      "tag": "0008_abandoned_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -40,6 +40,7 @@ export const channelTypes = [
   'telegram',
   'a2a',
   'internal',
+  'linkedin',
 ] as const;
 export type ChannelType = (typeof channelTypes)[number];
 
@@ -2474,5 +2475,298 @@ export const agentTasksRelations = relations(agentTasks, ({ one, many }) => ({
   }),
   subtasks: many(agentTasks, {
     relationName: 'parentChild',
+  }),
+}));
+
+// ============================================================================
+// SOCIAL POSTS
+// ============================================================================
+
+/**
+ * Social post - channel-agnostic representation of a social media post.
+ * Used by LinkedIn, Twitter/X, Instagram, and other social channels.
+ *
+ * @see linkedin-channel wish — Group A
+ */
+export const socialPosts = pgTable(
+  'social_posts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    instanceId: uuid('instance_id')
+      .notNull()
+      .references(() => instances.id, { onDelete: 'cascade' }),
+    externalId: varchar('external_id', { length: 255 }).notNull(),
+    channel: varchar('channel', { length: 50 }).notNull().$type<ChannelType>(),
+
+    // ---- Author ----
+    authorPersonId: uuid('author_person_id').references(() => persons.id, { onDelete: 'set null' }),
+    authorPlatformIdentityId: uuid('author_platform_identity_id').references(() => platformIdentities.id, {
+      onDelete: 'set null',
+    }),
+    authorPlatformUserId: varchar('author_platform_user_id', { length: 255 }),
+    authorDisplayName: varchar('author_display_name', { length: 255 }),
+
+    // ---- Content ----
+    postType: varchar('post_type', { length: 50 }).notNull().default('text'), // text, article, image, video, poll, etc.
+    textContent: text('text_content'),
+    mediaUrls: jsonb('media_urls').$type<string[]>(),
+    linkUrl: text('link_url'),
+    linkPreview: jsonb('link_preview').$type<Record<string, unknown>>(),
+
+    // ---- Sharing ----
+    sharedPostId: uuid('shared_post_id').references((): AnyPgColumn => socialPosts.id, { onDelete: 'set null' }),
+    sharedExternalId: varchar('shared_external_id', { length: 255 }),
+
+    // ---- Engagement ----
+    likeCount: integer('like_count').notNull().default(0),
+    commentCount: integer('comment_count').notNull().default(0),
+    repostCount: integer('repost_count').notNull().default(0),
+    impressionCount: integer('impression_count').notNull().default(0),
+    reactions: jsonb('reactions').$type<Record<string, number>>(), // e.g. { like: 10, celebrate: 3 }
+
+    // ---- Meta ----
+    status: varchar('status', { length: 20 }).notNull().default('active'), // active, deleted, hidden
+    visibility: varchar('visibility', { length: 50 }), // public, connections, private
+    isPinned: boolean('is_pinned').notNull().default(false),
+    hashtags: text('hashtags').array(),
+    mentions: jsonb('mentions').$type<Array<{ platformUserId: string; displayName?: string }>>(),
+
+    // ---- Timestamps ----
+    platformTimestamp: timestamp('platform_timestamp'),
+    lastSyncedAt: timestamp('last_synced_at'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+
+    // ---- Raw ----
+    rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>(),
+    platformMetadata: jsonb('platform_metadata').$type<Record<string, unknown>>(),
+  },
+  (table) => ({
+    instanceIdx: index('social_posts_instance_idx').on(table.instanceId),
+    channelIdx: index('social_posts_channel_idx').on(table.channel),
+    authorPersonIdx: index('social_posts_author_person_idx').on(table.authorPersonId),
+    authorPlatformIdentityIdx: index('social_posts_author_pi_idx').on(table.authorPlatformIdentityId),
+    statusIdx: index('social_posts_status_idx').on(table.status),
+    platformTimestampIdx: index('social_posts_platform_ts_idx').on(table.platformTimestamp),
+    createdAtIdx: index('social_posts_created_at_idx').on(table.createdAt),
+    instanceExternalIdx: uniqueIndex('social_posts_instance_external_idx').on(table.instanceId, table.externalId),
+  }),
+);
+
+export type SocialPost = typeof socialPosts.$inferSelect;
+export type NewSocialPost = typeof socialPosts.$inferInsert;
+
+export const socialPostsRelations = relations(socialPosts, ({ one, many }) => ({
+  instance: one(instances, {
+    fields: [socialPosts.instanceId],
+    references: [instances.id],
+  }),
+  authorPerson: one(persons, {
+    fields: [socialPosts.authorPersonId],
+    references: [persons.id],
+  }),
+  authorPlatformIdentity: one(platformIdentities, {
+    fields: [socialPosts.authorPlatformIdentityId],
+    references: [platformIdentities.id],
+  }),
+  sharedPost: one(socialPosts, {
+    fields: [socialPosts.sharedPostId],
+    references: [socialPosts.id],
+    relationName: 'sharedPosts',
+  }),
+  comments: many(socialComments),
+  engagementSnapshots: many(socialEngagementSnapshots),
+}));
+
+// ============================================================================
+// SOCIAL COMMENTS
+// ============================================================================
+
+/**
+ * Social comment - channel-agnostic representation of a comment on a social post.
+ * Supports threaded replies via parentCommentId self-reference.
+ */
+export const socialComments = pgTable(
+  'social_comments',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    postId: uuid('post_id')
+      .notNull()
+      .references(() => socialPosts.id, { onDelete: 'cascade' }),
+    parentCommentId: uuid('parent_comment_id').references((): AnyPgColumn => socialComments.id, {
+      onDelete: 'set null',
+    }),
+    externalId: varchar('external_id', { length: 255 }).notNull(),
+
+    // ---- Author ----
+    authorPersonId: uuid('author_person_id').references(() => persons.id, { onDelete: 'set null' }),
+    authorPlatformIdentityId: uuid('author_platform_identity_id').references(() => platformIdentities.id, {
+      onDelete: 'set null',
+    }),
+    authorPlatformUserId: varchar('author_platform_user_id', { length: 255 }),
+    authorDisplayName: varchar('author_display_name', { length: 255 }),
+
+    // ---- Content ----
+    textContent: text('text_content'),
+    mediaUrl: text('media_url'),
+    mentions: jsonb('mentions').$type<Array<{ platformUserId: string; displayName?: string }>>(),
+
+    // ---- Engagement ----
+    likeCount: integer('like_count').notNull().default(0),
+    replyCount: integer('reply_count').notNull().default(0),
+    reactions: jsonb('reactions').$type<Record<string, number>>(),
+
+    // ---- Meta ----
+    status: varchar('status', { length: 20 }).notNull().default('active'),
+
+    // ---- Timestamps ----
+    platformTimestamp: timestamp('platform_timestamp'),
+    lastSyncedAt: timestamp('last_synced_at'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+
+    // ---- Raw ----
+    rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>(),
+  },
+  (table) => ({
+    postIdx: index('social_comments_post_idx').on(table.postId),
+    parentCommentIdx: index('social_comments_parent_idx').on(table.parentCommentId),
+    authorPersonIdx: index('social_comments_author_person_idx').on(table.authorPersonId),
+    authorPlatformIdentityIdx: index('social_comments_author_pi_idx').on(table.authorPlatformIdentityId),
+    statusIdx: index('social_comments_status_idx').on(table.status),
+    platformTimestampIdx: index('social_comments_platform_ts_idx').on(table.platformTimestamp),
+    postExternalIdx: uniqueIndex('social_comments_post_external_idx').on(table.postId, table.externalId),
+  }),
+);
+
+export type SocialComment = typeof socialComments.$inferSelect;
+export type NewSocialComment = typeof socialComments.$inferInsert;
+
+export const socialCommentsRelations = relations(socialComments, ({ one, many }) => ({
+  post: one(socialPosts, {
+    fields: [socialComments.postId],
+    references: [socialPosts.id],
+  }),
+  parentComment: one(socialComments, {
+    fields: [socialComments.parentCommentId],
+    references: [socialComments.id],
+    relationName: 'commentThreads',
+  }),
+  replies: many(socialComments, {
+    relationName: 'commentThreads',
+  }),
+  authorPerson: one(persons, {
+    fields: [socialComments.authorPersonId],
+    references: [persons.id],
+  }),
+  authorPlatformIdentity: one(platformIdentities, {
+    fields: [socialComments.authorPlatformIdentityId],
+    references: [platformIdentities.id],
+  }),
+}));
+
+// ============================================================================
+// SOCIAL CONNECTIONS
+// ============================================================================
+
+/**
+ * Social connection - represents a connection/follow relationship on a social platform.
+ * Channel-agnostic: works for LinkedIn connections, Twitter follows, Instagram follows, etc.
+ */
+export const socialConnections = pgTable(
+  'social_connections',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    instanceId: uuid('instance_id')
+      .notNull()
+      .references(() => instances.id, { onDelete: 'cascade' }),
+    personId: uuid('person_id').references(() => persons.id, { onDelete: 'set null' }),
+    platformIdentityId: uuid('platform_identity_id').references(() => platformIdentities.id, {
+      onDelete: 'set null',
+    }),
+    platformUserId: varchar('platform_user_id', { length: 255 }).notNull(),
+    displayName: varchar('display_name', { length: 255 }),
+
+    // ---- Connection details ----
+    connectionType: varchar('connection_type', { length: 50 }).notNull(), // connect, follow, etc.
+    status: varchar('status', { length: 20 }).notNull().default('pending'), // pending, accepted, rejected, blocked
+    message: text('message'), // Optional message with connection request
+
+    // ---- Timestamps ----
+    connectedAt: timestamp('connected_at'),
+    requestedAt: timestamp('requested_at'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => ({
+    instanceIdx: index('social_connections_instance_idx').on(table.instanceId),
+    personIdx: index('social_connections_person_idx').on(table.personId),
+    platformIdentityIdx: index('social_connections_pi_idx').on(table.platformIdentityId),
+    statusIdx: index('social_connections_status_idx').on(table.status),
+    instancePlatformUserTypeIdx: uniqueIndex('social_connections_instance_user_type_idx').on(
+      table.instanceId,
+      table.platformUserId,
+      table.connectionType,
+    ),
+  }),
+);
+
+export type SocialConnectionRecord = typeof socialConnections.$inferSelect;
+export type NewSocialConnection = typeof socialConnections.$inferInsert;
+
+export const socialConnectionsRelations = relations(socialConnections, ({ one }) => ({
+  instance: one(instances, {
+    fields: [socialConnections.instanceId],
+    references: [instances.id],
+  }),
+  person: one(persons, {
+    fields: [socialConnections.personId],
+    references: [persons.id],
+  }),
+  platformIdentity: one(platformIdentities, {
+    fields: [socialConnections.platformIdentityId],
+    references: [platformIdentities.id],
+  }),
+}));
+
+// ============================================================================
+// SOCIAL ENGAGEMENT SNAPSHOTS
+// ============================================================================
+
+/**
+ * Social engagement snapshot - time-series record of a post's engagement metrics.
+ * Allows tracking how likes, comments, reposts, and impressions change over time.
+ */
+export const socialEngagementSnapshots = pgTable(
+  'social_engagement_snapshots',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    postId: uuid('post_id')
+      .notNull()
+      .references(() => socialPosts.id, { onDelete: 'cascade' }),
+
+    // ---- Engagement counts ----
+    likeCount: integer('like_count').notNull().default(0),
+    commentCount: integer('comment_count').notNull().default(0),
+    repostCount: integer('repost_count').notNull().default(0),
+    impressionCount: integer('impression_count').notNull().default(0),
+
+    // ---- Timestamp ----
+    snapshotAt: timestamp('snapshot_at').notNull().defaultNow(),
+  },
+  (table) => ({
+    postIdx: index('social_engagement_snapshots_post_idx').on(table.postId),
+    snapshotAtIdx: index('social_engagement_snapshots_at_idx').on(table.snapshotAt),
+    postSnapshotIdx: index('social_engagement_snapshots_post_at_idx').on(table.postId, table.snapshotAt),
+  }),
+);
+
+export type SocialEngagementSnapshot = typeof socialEngagementSnapshots.$inferSelect;
+export type NewSocialEngagementSnapshot = typeof socialEngagementSnapshots.$inferInsert;
+
+export const socialEngagementSnapshotsRelations = relations(socialEngagementSnapshots, ({ one }) => ({
+  post: one(socialPosts, {
+    fields: [socialEngagementSnapshots.postId],
+    references: [socialPosts.id],
   }),
 }));


### PR DESCRIPTION
## Summary

- Adds LinkedIn as a first-class channel in Omni v2 via Playwright browser automation
- Introduces `SocialChannelPlugin` abstraction in channel-sdk for future social channels (Twitter/X, Instagram)
- Creates 4 new channel-agnostic DB tables for social content tracking
- Ports proven selectors, timing, and navigation flows from the linkedin-agent Python scripts

## What's included

### SDK Foundation
- `SocialChannelPlugin` abstract class extending `BaseChannelPlugin` with social methods (createPost, getFeed, getComments, reactToPost, getConnections)
- 9 social event types: `post.received`, `post.created`, `post.updated`, `post.deleted`, `comment.received`, `comment.sent`, `connection.received`, `connection.accepted`, `mention.received`
- 4 social capabilities: `canCreatePost`, `canReadFeed`, `canComment`, `canHandleConnections`

### Database
- `socialPosts` — posts, articles, reposts with engagement tracking
- `socialComments` — threaded comments on posts
- `socialConnections` — network relationships (connections, followers, following)
- `socialEngagementSnapshots` — engagement curves over time
- Drizzle migration included

### channel-linkedin package
- **Browser layer**: Playwright persistent Chromium profile, centralized selector registry with fallbacks, humanized delays + rate limiter
- **Scrapers**: inbox (ported from scan_raw.py), feed, comments, profile, connections
- **Actions**: send message (ported from reply.py), create post, comment, react, connect
- **Sync engine**: feed/inbox pollers with diff-based DB persistence and event emission
- **LinkedInPlugin**: wires everything together, extends SocialChannelPlugin

### Anti-bot protection
- Humanized delays (randomized around linkedin-agent baseline values)
- Rate limiting per operation type (messages/hour, posts/day, etc.)
- Active hours window (configurable)
- Selector health checks with `instance.degraded` events

## Test plan

- [x] `bun run build` passes (17 packages, 0 errors)
- [x] `bunx biome check .` passes (0 lint errors)
- [x] Typecheck passes for `@omni/channel-linkedin`
- [ ] Manual: connect LinkedIn account via persistent browser profile
- [ ] Manual: scrape inbox conversations
- [ ] Manual: send a DM
- [ ] Manual: scrape feed posts
- [ ] Manual: create a post

## Design docs

- Brainstorm: `.genie/brainstorms/linkedin-channel/DESIGN.md`
- Wish: `.genie/wishes/linkedin-channel/WISH.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched LinkedIn channel plugin with comprehensive social media automation: send messages, create posts, comment, react to posts, and manage connections
  * Implemented feed and inbox real-time synchronization with periodic polling
  * Added social event framework for post, comment, connection, and mention notifications
  * Introduced LinkedIn support to core channel types

* **Chores**
  * Added social data schema to database for storing posts, comments, connections, and engagement metrics
  * Extended channel SDK with social channel plugin base abstractions and event payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->