### PR TITLE
fix(channel-discord): plumb threadId through outbound send path

### DIFF
--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -520,6 +520,12 @@ export class DiscordPlugin extends BaseChannelPlugin {
     try {
       channelId = await resolveChannelId(client, channelId, this.logger);
 
+      // In Discord, threads are separate channel objects. If threadId is specified,
+      // override the channelId so the message is delivered to the correct thread.
+      if (message.threadId) {
+        channelId = message.threadId;
+      }
+
       // Journey timing: T10 (pluginSentAt) before platform call
       const correlationId = message.metadata?.correlationId as string | undefined;
       if (correlationId) this.captureT10(correlationId);


### PR DESCRIPTION
## Summary

- Fixes Discord not delivering messages to threads when `threadId` is provided via `POST /v2/messages/send`
- In Discord, threads are separate channel objects — routing to a thread means using the thread's channel ID
- One-line fix: override `channelId` with `message.threadId` before dispatching, after parent channel is resolved

## Root Cause

The `OutgoingMessage.threadId` field was correctly populated by the API route (for both text and media sends), and Telegram already handled it correctly via `message_thread_id`. Discord's `sendMessage()` simply never used it.

## Test plan
- [x] TypeScript type check passes (`bun run typecheck --filter=@omni/channel-discord`)
- [x] All 203 existing Discord tests pass
- [ ] Manual: send to a Discord thread via `POST /v2/messages/send` with `threadId` set — message should arrive in the thread, not the parent channel
- [ ] Verify `ThreadChannel` type already in `SendableChannel` union in `senders/text.ts` (it is)

Closes https://github.com/automagik-dev/omni/issues/161

🤖 Generated with [Claude Code](https://claude.com/claude-code)