### PR TITLE
fix(claude-code): set supportsImages true and forward file paths to provider

### DIFF
--- a/packages/api/src/routes/v2/providers.ts
+++ b/packages/api/src/routes/v2/providers.ts
@@ -49,7 +49,10 @@ const createProviderSchema = z.object({
   defaultStream: z.boolean().default(true).describe('Default streaming setting'),
   defaultTimeout: z.number().int().positive().default(60).describe('Default timeout in seconds'),
   supportsStreaming: z.boolean().default(true).describe('Provider supports streaming'),
-  supportsImages: z.boolean().default(false).describe('Provider supports image inputs'),
+  supportsImages: z
+    .boolean()
+    .optional()
+    .describe('Provider supports image inputs (defaults to true for claude-code, false otherwise)'),
   supportsAudio: z.boolean().default(false).describe('Provider supports audio inputs'),
   supportsDocuments: z.boolean().default(false).describe('Provider supports document inputs'),
   description: z.string().optional().describe('Provider description'),
@@ -103,7 +106,13 @@ providersRoutes.post('/', zValidator('json', createProviderSchema), async (c) =>
   const data = c.req.valid('json');
   const services = c.get('services');
 
-  const provider = await services.providers.create(data);
+  // Apply schema-specific capability defaults (claude-code supports images via vision)
+  const createData = {
+    ...data,
+    supportsImages: data.supportsImages ?? data.schema === 'claude-code',
+  };
+
+  const provider = await services.providers.create(createData);
 
   return c.json(
     {

--- a/packages/api/src/schemas/openapi/providers.ts
+++ b/packages/api/src/schemas/openapi/providers.ts
@@ -83,7 +83,10 @@ export const CreateProviderSchema = z.object({
   defaultStream: z.boolean().default(true).openapi({ description: 'Default streaming' }),
   defaultTimeout: z.number().int().positive().default(60).openapi({ description: 'Default timeout' }),
   supportsStreaming: z.boolean().default(true).openapi({ description: 'Supports streaming' }),
-  supportsImages: z.boolean().default(false).openapi({ description: 'Supports images' }),
+  supportsImages: z
+    .boolean()
+    .optional()
+    .openapi({ description: 'Supports images (defaults to true for claude-code, false otherwise)' }),
   supportsAudio: z.boolean().default(false).openapi({ description: 'Supports audio' }),
   supportsDocuments: z.boolean().default(false).openapi({ description: 'Supports documents' }),
   description: z.string().optional().openapi({ description: 'Description' }),

--- a/packages/core/src/providers/__tests__/claude-code-client.test.ts
+++ b/packages/core/src/providers/__tests__/claude-code-client.test.ts
@@ -288,6 +288,50 @@ describe('ClaudeCodeAgentProvider', () => {
 
     expect(provider).toBeDefined();
   });
+
+  it('includes attached file paths in message for image forwarding', () => {
+    const provider = new ClaudeCodeAgentProvider('test-id', 'Test', { projectPath: '/test' }, mockSessionStorage, {
+      prefixSenderName: false,
+    });
+
+    const buildMessage = (context: AnyRecord) => (provider as unknown as AnyRecord).buildMessage(context) as string;
+
+    const trigger: AnyRecord = {
+      content: {
+        text: 'Look at this image',
+        files: [
+          { path: '/tmp/uploads/photo.jpg', mimeType: 'image/jpeg' },
+          { path: '/tmp/uploads/doc.pdf', mimeType: 'application/pdf' },
+        ],
+      },
+      sender: { displayName: undefined },
+      source: {},
+    };
+
+    const message = buildMessage(trigger);
+    expect(message).toContain('Look at this image');
+    expect(message).toContain('Attached files:');
+    expect(message).toContain('/tmp/uploads/photo.jpg [image/jpeg]');
+    expect(message).toContain('/tmp/uploads/doc.pdf [application/pdf]');
+  });
+
+  it('does not add attached files section when no files present', () => {
+    const provider = new ClaudeCodeAgentProvider('test-id', 'Test', { projectPath: '/test' }, mockSessionStorage, {
+      prefixSenderName: false,
+    });
+
+    const buildMessage = (context: AnyRecord) => (provider as unknown as AnyRecord).buildMessage(context) as string;
+
+    const trigger: AnyRecord = {
+      content: { text: 'Hello' },
+      sender: { displayName: undefined },
+      source: {},
+    };
+
+    const message = buildMessage(trigger);
+    expect(message).toBe('Hello');
+    expect(message).not.toContain('Attached files');
+  });
 });
 
 describe('createClaudeCodeClient', () => {

--- a/packages/core/src/providers/claude-code-provider.ts
+++ b/packages/core/src/providers/claude-code-provider.ts
@@ -102,6 +102,13 @@ export class ClaudeCodeAgentProvider implements IAgentProvider {
       message = `[${context.sender.displayName}]: ${message}`;
     }
 
+    // Append file path references so Claude Code can read images and documents via its tools.
+    // Claude Sonnet/Haiku support vision — the Read tool can handle image files directly.
+    if (context.content.files && context.content.files.length > 0) {
+      const fileList = context.content.files.map((f) => `- ${f.path} [${f.mimeType}]`).join('\n');
+      message += `\n\nAttached files:\n${fileList}`;
+    }
+
     // Prepend context messages (message history since last bot response)
     if (context.contextMessages && context.contextMessages.length > 0) {
       const boundedContext = boundContextMessages(context.contextMessages);


### PR DESCRIPTION
## Summary

- Fixes the contradiction where claude-code provider had `supportsImages: false` but instances could be configured with `processImages: true`
- Claude Sonnet/Haiku support vision — the claude-code schema now correctly defaults `supportsImages` to `true`
- File paths are appended to messages in `buildMessage()` so Claude Code can read images/documents via its Read tool
- `supportsImages` is now optional in provider create schema; the route handler applies correct per-schema defaults

## Changes

- `packages/api/src/routes/v2/providers.ts` — apply `supportsImages: true` default for `claude-code` schema
- `packages/api/src/schemas/openapi/providers.ts` — make `supportsImages` optional in OpenAPI schema
- `packages/core/src/providers/claude-code-provider.ts` — append attached file paths to message in `buildMessage()`
- `packages/core/src/providers/__tests__/claude-code-client.test.ts` — add tests for file forwarding

## Test plan

- [x] All 25 existing + new unit tests pass
- [x] TypeCheck clean (18/18 packages)
- [x] Biome lint clean

Closes NAM-66

🤖 Generated with [Claude Code](https://claude.com/claude-code)