### PR TITLE
fix(agent-dispatcher): enable context messages for DM conversations

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -1516,7 +1516,7 @@ function formatMediaContent(msg: {
 }
 
 /**
- * Build context messages from recent chat history for group conversations
+ * Build context messages from recent chat history for group and DM conversations.
  * Returns messages since the last bot response, formatted as "[Name - time] message"
  */
 async function buildContextMessages(
@@ -1530,10 +1530,9 @@ async function buildContextMessages(
     const historyLimit = Math.min(Math.max(instance.groupHistorySize ?? 50, 0), 200);
     if (historyLimit === 0) return [];
 
-    // Only provide context for group chats (not DMs)
     // chatId here is the external JID, not internal UUID
     const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
-    if (!chat || chat.chatType !== 'group') {
+    if (!chat) {
       return [];
     }
 
@@ -1661,7 +1660,7 @@ async function dispatchViaProvider(
   const rawThreadId = extractThreadId(messages);
   const sessionId = computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
 
-  // Build context messages for group conversations (messages since last bot response)
+  // Build context messages for group and DM conversations (messages since last bot response)
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
   const dbContextMessages = await buildContextMessages(services, instance, chatId, currentMessageIds);
   const allContextMessages = mergeContextMessages(extraContextMessages, dbContextMessages);


### PR DESCRIPTION
## Summary

- Removes the `chat.chatType !== 'group'` guard in `buildContextMessages()` that was silently returning empty context for all DM conversations
- DMs now receive the same conversation history context as group chats
- Uses the existing `groupHistorySize` limit (default 50, max 200) — no new configuration needed

## Root Cause

The `buildContextMessages()` function had an explicit early-return for non-group chats:
```ts
if (!chat || chat.chatType !== 'group') {
  return [];
}
```
This meant agents responding in DMs had zero conversation history context, causing them to treat every message as if it were the first.

## Changes

- `packages/api/src/plugins/agent-dispatcher.ts`: remove `chatType !== 'group'` guard; update comments

## Test Plan

- [x] `bun run build` — clean
- [x] `bun run lint` — clean
- [x] Full test suite: 2130 pass, 0 fail
- [ ] Manual verify: WhatsApp DM response includes prior messages in agent context

Closes NAM-67