### PR TITLE
fix(access): resolve LID to phone number before allowlist/blocklist check (GH#178)

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -494,6 +494,95 @@ describe('agent-dispatcher', () => {
       expect(services.agentRunner.run).not.toHaveBeenCalled();
     });
 
+    it('allows LID sender when resolvedSenderPhone matches allowlist rule', async () => {
+      const eventBus = createMockEventBus();
+      // Access check: deny LID ID but allow phone number (simulates allowlist with phone rule)
+      const checkAccess = mock(async (_instance: unknown, id: string) => {
+        if (id === '5511999000001') return { allowed: true, reason: 'Phone matched allowlist' };
+        return { allowed: false, reason: 'No rule matched', mode: 'allowlist' };
+      });
+      const services = createMockServices({
+        access: { checkAccess, requestPairing: mock(async () => {}) },
+      });
+
+      cleanup = await setupAgentDispatcher(eventBus as unknown as import('@omni/core').EventBus, services, mockDb);
+
+      // LID sender with resolvedSenderPhone annotated by channel-whatsapp
+      const event = createMessageEvent({
+        payload: {
+          externalId: 'ext-lid-allowlist',
+          chatId: '100000001@lid',
+          from: '100000001', // LID ID — no rule matches this
+          content: { type: 'text', text: 'Hello from LID sender' },
+          rawPayload: { resolvedSenderPhone: '5511999000001' }, // phone resolved from LID cache
+        },
+      });
+
+      await eventBus.fire('message.received', event);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Should have been called 3 times: once for LID, once fallback (no participantAlt), once for resolvedSenderPhone
+      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '100000001', expect.anything());
+      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '5511999000001', expect.anything());
+      // Message should have reached agent (allowed via phone number)
+      expect(services.agentRunner.getSenderName).toHaveBeenCalled();
+    });
+
+    it('denies LID sender when resolvedSenderPhone is also not in allowlist', async () => {
+      const eventBus = createMockEventBus();
+      const checkAccess = mock(async () => ({ allowed: false, reason: 'No rule matched', mode: 'allowlist' }));
+      const services = createMockServices({
+        access: { checkAccess, requestPairing: mock(async () => {}) },
+      });
+
+      cleanup = await setupAgentDispatcher(eventBus as unknown as import('@omni/core').EventBus, services, mockDb);
+
+      const event = createMessageEvent({
+        payload: {
+          externalId: 'ext-lid-denied',
+          chatId: '100000002@lid',
+          from: '100000002',
+          content: { type: 'text', text: 'Hello, blocked' },
+          rawPayload: { resolvedSenderPhone: '5511999000002' },
+        },
+      });
+
+      await eventBus.fire('message.received', event);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(services.agentRunner.run).not.toHaveBeenCalled();
+    });
+
+    it('allows LID group sender via participantAlt when resolvedSenderPhone is absent', async () => {
+      const eventBus = createMockEventBus();
+      const checkAccess = mock(async (_instance: unknown, id: string) => {
+        if (id === '5511999000003') return { allowed: true, reason: 'Phone matched allowlist' };
+        return { allowed: false, reason: 'No rule matched', mode: 'allowlist' };
+      });
+      const services = createMockServices({
+        access: { checkAccess, requestPairing: mock(async () => {}) },
+      });
+
+      cleanup = await setupAgentDispatcher(eventBus as unknown as import('@omni/core').EventBus, services, mockDb);
+
+      // Group message: participantAlt in key (existing fallback path), no resolvedSenderPhone
+      const event = createMessageEvent({
+        payload: {
+          externalId: 'ext-group-lid',
+          chatId: '5511group@g.us',
+          from: '100000003',
+          content: { type: 'text', text: 'Group msg from LID sender' },
+          rawPayload: { key: { participantAlt: '5511999000003@s.whatsapp.net' } },
+        },
+      });
+
+      await eventBus.fire('message.received', event);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '5511999000003', expect.anything());
+      expect(services.agentRunner.getSenderName).toHaveBeenCalled();
+    });
+
     it('rate limits when too many messages from same user', async () => {
       const eventBus = createMockEventBus();
       // Instance with rate limit of 2

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3292,6 +3292,7 @@ async function shouldProcessMessage(
 
 /**
  * Check access using primary sender ID, falling back to participantAlt for Baileys LID addressing.
+ * Also tries resolvedSenderPhone annotated by the WhatsApp channel when the sender is a LID.
  * Returns true if access is denied (caller should return null).
  */
 async function checkAccessWithFallback(
@@ -3300,10 +3301,15 @@ async function checkAccessWithFallback(
   payload: { from: string; chatId: string; rawPayload?: unknown },
   channel: ChannelType,
 ): Promise<boolean> {
-  const rawKey = (payload.rawPayload as Record<string, unknown>)?.key as Record<string, unknown> | undefined;
+  const rawPayload = payload.rawPayload as Record<string, unknown> | undefined;
+  const rawKey = rawPayload?.key as Record<string, unknown> | undefined;
   const rawParticipantAlt = (rawKey?.participantAlt as string)?.replace(/@.*$/, '');
   // Validate participantAlt looks like a real phone number (Baileys LID fallback)
   const participantAlt = rawParticipantAlt && /^\d{7,15}$/.test(rawParticipantAlt) ? rawParticipantAlt : undefined;
+  // resolvedSenderPhone is annotated by channel-whatsapp when it resolves a LID sender to phone
+  // via participantAlt, remoteJidAlt, or the in-memory LID mapping cache.
+  const rawResolvedPhone = rawPayload?.resolvedSenderPhone as string | undefined;
+  const resolvedSenderPhone = rawResolvedPhone && /^\d{7,15}$/.test(rawResolvedPhone) ? rawResolvedPhone : undefined;
   const primaryId = payload.from ?? '';
 
   let accessResult = await accessService.checkAccess(instance, primaryId, channel);
@@ -3315,6 +3321,20 @@ async function checkAccessWithFallback(
       chatId: payload.chatId,
     });
     accessResult = await accessService.checkAccess(instance, participantAlt, channel);
+  }
+  if (
+    !accessResult.allowed &&
+    resolvedSenderPhone &&
+    resolvedSenderPhone !== primaryId &&
+    resolvedSenderPhone !== participantAlt
+  ) {
+    log.debug('Access fallback to resolvedSenderPhone (LID→phone)', {
+      instanceId: instance.id,
+      primaryId,
+      resolvedSenderPhone,
+      chatId: payload.chatId,
+    });
+    accessResult = await accessService.checkAccess(instance, resolvedSenderPhone, channel);
   }
   if (accessResult.allowed) return false;
 

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -734,6 +734,39 @@ function annotateSenderLidStatus(msg: WAMessage, senderJid: string): void {
 }
 
 /**
+ * Resolve a LID sender to their phone number and annotate the message.
+ *
+ * In LID-first mode, access rules are phone-based but the sender identity is
+ * a LID. This resolves the phone using (1) participantAlt from the message key
+ * (group messages), (2) remoteJidAlt from the message key (DM messages), or
+ * (3) the in-memory LID mapping cache built from prior messages.
+ *
+ * The resolved phone is stored as `resolvedSenderPhone` on the raw message so
+ * it flows through rawPayload to the access check in agent-dispatcher.
+ */
+function annotateSenderResolvedPhone(
+  msg: WAMessage,
+  senderJid: string,
+  plugin: WhatsAppPlugin,
+  instanceId: string,
+): void {
+  if (!isLidJid(senderJid)) return;
+
+  const participantAlt = (msg.key as Record<string, unknown>).participantAlt as string | undefined;
+  const remoteJidAlt = (msg.key as Record<string, unknown>).remoteJidAlt as string | undefined;
+  const lidCache = plugin.getLidMappingCache(instanceId);
+
+  // resolveToPhoneJidLegacy tries: (1) the provided alt JID, then (2) the LID cache
+  const altJid = participantAlt || remoteJidAlt;
+  const resolvedPhoneJid = resolveToPhoneJidLegacy(senderJid, altJid, lidCache);
+
+  if (resolvedPhoneJid !== senderJid && isUserJid(resolvedPhoneJid)) {
+    const { id: resolvedPhone } = fromJid(resolvedPhoneJid);
+    (msg as unknown as Record<string, unknown>).resolvedSenderPhone = resolvedPhone;
+  }
+}
+
+/**
  * Extract platform timestamp (T0) in milliseconds.
  */
 function getPlatformTimestamp(msg: WAMessage): number {
@@ -800,6 +833,11 @@ async function processMessage(
   // but individual participants can still be @lid. Downstream identity resolution
   // uses this flag to skip phone extraction for LID sender IDs.
   annotateSenderLidStatus(msg, senderJid);
+
+  // Resolve LID sender to phone for access rule checks (LID-first mode).
+  // Access rules match phone numbers, so we need the phone even when the
+  // sender is addressed as @lid. Stores resolvedSenderPhone on rawPayload.
+  annotateSenderResolvedPhone(msg, senderJid, plugin, instanceId);
 
   // Extract platform timestamp (T0) — WhatsApp sends seconds since epoch
   const platformTimestamp = getPlatformTimestamp(msg);


### PR DESCRIPTION
## Summary

- **Bug**: When WhatsApp LID-first mode is enabled, sender identities are LIDs (e.g., `100000001`) instead of phone numbers. Access rules match phone numbers, so LID-addressed senders were incorrectly denied or unmatched even when a valid phone rule existed.
- **Root cause**: `checkAccessWithFallback` only checked the raw LID ID and `participantAlt` from the message key (only available for group messages), never consulting the in-memory LID mapping cache or `remoteJidAlt` for DMs.
- **Fix**: Two-part change:
  1. `channel-whatsapp/src/handlers/messages.ts` — added `annotateSenderResolvedPhone` which resolves LID → phone using `participantAlt` (groups), `remoteJidAlt` (DMs), or the LID mapping cache, then writes `resolvedSenderPhone` onto the raw message so it flows through `rawPayload`.
  2. `api/src/plugins/agent-dispatcher.ts` — `checkAccessWithFallback` now uses `rawPayload.resolvedSenderPhone` as a third fallback when both primary LID ID and `participantAlt` fail the access check.

Fallback behaviour for **unresolvable LIDs is unchanged** (deny on allowlist, allow on blocklist).

## Test plan

- [x] `allows LID sender when resolvedSenderPhone matches allowlist rule` — verifies the fix path
- [x] `denies LID sender when resolvedSenderPhone is also not in allowlist` — verifies deny still works
- [x] `allows LID group sender via participantAlt when resolvedSenderPhone is absent` — verifies existing group fallback unaffected
- [x] All 2214 existing tests pass (CI full suite)

Closes: #178
NAM-54