### PR TITLE
fix: address PR #211 review findings

### DIFF
--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -649,10 +649,11 @@ export class DiscordPlugin extends BaseChannelPlugin {
       doTyping();
     }, 8000);
 
-    // Failsafe: auto-clear after 60s to prevent leaked intervals
+    // Honor duration: use caller's duration if positive, otherwise 60s failsafe
+    const timeoutMs = duration && duration > 0 ? duration : 60000;
     const failsafe = setTimeout(() => {
       this.clearTypingInterval(key);
-    }, 60000);
+    }, timeoutMs);
 
     this.typingIntervals.set(key, { refresh, failsafe });
   }

--- a/packages/channel-telegram/src/plugin.ts
+++ b/packages/channel-telegram/src/plugin.ts
@@ -663,10 +663,11 @@ export class TelegramPlugin extends BaseChannelPlugin {
       doTyping();
     }, 4000);
 
-    // Failsafe: auto-clear after 60s to prevent leaked intervals
+    // Honor duration: use caller's duration if positive, otherwise 60s failsafe
+    const timeoutMs = duration && duration > 0 ? duration : 60000;
     const failsafe = setTimeout(() => {
       this.clearTypingInterval(key);
-    }, 60000);
+    }, timeoutMs);
 
     this.typingIntervals.set(key, { refresh, failsafe });
   }

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -301,6 +301,14 @@ async function handleUpdate(id: string, options: Record<string, unknown>): Promi
 
   const client = getClient();
   try {
+    // If updating individual schemaConfig fields (not raw --schema-config JSON),
+    // merge with the existing config to avoid dropping required fields.
+    if (body.schemaConfig && !options.schemaConfig) {
+      const existing = await client.providers.get(id);
+      const existingConfig = (existing.schemaConfig as Record<string, unknown>) ?? {};
+      body.schemaConfig = { ...existingConfig, ...(body.schemaConfig as Record<string, unknown>) };
+    }
+
     const provider = await client.providers.update(id, body);
     output.success(`Updated provider: ${provider.id}`);
     output.data(provider);


### PR DESCRIPTION
## Summary
- **P1 fix**: `providers update` now fetches the existing provider config before PATCHing, merging individual `schemaConfig` flags into the existing config instead of replacing it. This prevents dropping required fields like `agentName`/`targetAgent` when only updating e.g. `--team-name`.
- **P2 fix**: Discord `sendTyping` now honors the `duration` parameter — when a positive duration is passed, typing stops after that many ms instead of always running until the 60s failsafe.
- **P2 fix**: Telegram `sendTyping` — same fix as Discord, honoring the caller's duration.

## Test plan
- [x] `bun run typecheck` passes (all 18 packages)
- [x] CLI provider tests pass (20/20)
- [x] Discord channel tests pass (160/160)
- [x] Telegram channel tests pass (87/87)