### PR TITLE
docs(skills): sync omni skills with current CLI surface

### DIFF
--- a/plugins/omni/skills/omni-agents/SKILL.md
+++ b/plugins/omni/skills/omni-agents/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: omni-agents
+description: |
+  Manage AI agent entities: list with filtering, get details, create with provider/model/type, and soft-delete agents.
+allowed-tools: Bash(omni *), Bash(jq *)
+---
+
+# Omni Agents
+
+## List agents
+
+```bash
+omni agents list --json
+omni agents list --provider claude --json
+omni agents list --provider agno --json
+omni agents list --provider openai --json
+omni agents list --provider gemini --json
+omni agents list --provider custom --json
+omni agents list --provider omni-internal --json
+omni agents list --inactive-only --json
+omni agents list --limit 10 --json
+omni agents list --provider claude --limit 5 --json
+```
+
+### List options
+
+| Flag | Description |
+|------|-------------|
+| `--provider <provider>` | Filter by provider: `claude`, `agno`, `openai`, `gemini`, `custom`, `omni-internal` |
+| `--inactive-only` | Show only inactive (soft-deleted) agents |
+| `--limit <n>` | Max results (default: 50) |
+
+## Get agent details
+
+```bash
+omni agents get <id> --json
+```
+
+Returns full agent record including name, provider, model, type, active status, and linked provider configuration.
+
+## Create agent
+
+```bash
+# Basic assistant agent
+omni agents create --name "Support Bot" --provider claude --model claude-sonnet-4-6 --json
+
+# Specify agent type
+omni agents create --name "Router" --provider claude --model claude-sonnet-4-6 --type assistant --json
+omni agents create --name "Pipeline" --provider agno --model gpt-4o --type workflow --json
+omni agents create --name "Squad" --provider agno --model gpt-4o --type team --json
+omni agents create --name "Toolbox" --provider custom --model custom-v1 --type tool --json
+
+# Link to an agent provider configuration
+omni agents create --name "My Agent" --provider claude --model claude-sonnet-4-6 --agent-provider <providerId> --json
+```
+
+### Create options
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | Agent name |
+| `--provider <provider>` | AI provider: `claude`, `agno`, `openai`, `gemini`, `custom`, `omni-internal` |
+| `--model <model>` | Model identifier (e.g. `claude-sonnet-4-6`, `gpt-4o`) |
+| `--type <type>` | Agent type: `assistant` (default), `workflow`, `team`, `tool` |
+| `--agent-provider <agentProviderId>` | Link to an agent provider configuration |
+
+## Delete agent
+
+```bash
+omni agents delete <id> --json
+```
+
+Soft-deletes the agent (sets inactive). The agent record is preserved but will no longer appear in default listings. Use `--inactive-only` on list to see deleted agents.
+
+## Notes
+
+- Agents are the identity layer — they represent an AI entity that can be assigned to routes and instances.
+- Providers (see `omni providers`) define *how* to reach the underlying AI service; agents define *who* is responding.
+- Deleting an agent is a soft-delete: the record stays but is marked inactive.
+- Use `omni routes create --agent <agentId>` to assign an agent to a specific chat or user.
+- Use `omni instances update <id> --agent <agentId>` to set a default agent on an instance.

--- a/plugins/omni/skills/omni-chats/SKILL.md
+++ b/plugins/omni/skills/omni-chats/SKILL.md
@@ -13,9 +13,39 @@ allowed-tools: Bash(omni *), Bash(jq *)
 omni chats list --instance <id> --limit 50 --json
 omni chats list --instance <id> --unread --sort activity --verbose --json
 omni chats list --channel whatsapp-baileys --type group --json
+omni chats list --instance <id> --search "client name" --json
 omni chats list --instance <id> --all --json
 omni chats get <chatId> --json
 ```
+
+### List flags reference
+
+| Flag | Description |
+|------|-------------|
+| `--instance <id>` | Filter by instance ID |
+| `--channel <type>` | Filter by channel type (whatsapp-baileys, discord, etc.) |
+| `--search <query>` | Search chats by name |
+| `--type <type>` | Filter by chat type: `dm`, `group`, `channel`. When omitted, all types are shown (no filtering). |
+| `--limit <n>` | Limit number of results |
+| `--sort <field>` | Sort by: `activity` (default), `unread`, `name` |
+| `--unread` | Only show chats with unread messages |
+| `--archived` | Include archived chats |
+| `--all` | Include newsletters and broadcasts |
+| `--verbose` | Show full details (ID, channel, archived status) |
+| `--pending` | Only show chats pending a reply (last message is not from me AND has unreads) |
+| `--attention` | Show chats needing attention (combines: unread + pending reply + follow-up labeled) |
+| `--label <name>` | Filter chats by label (e.g., `follow-up`, `todo`, `vip`) |
+| `--hidden` | Include hidden chats in the listing (hidden chats are excluded by default) |
+
+### Pagination
+
+The `list` command displays pagination metadata after the table:
+
+```
+ℹ Showing 3 of 3 chats
+```
+
+When `--limit` truncates results, this shows how many were returned vs. total matching.
 
 ## Attention and pending
 

--- a/plugins/omni/skills/omni-config/SKILL.md
+++ b/plugins/omni/skills/omni-config/SKILL.md
@@ -37,24 +37,33 @@ omni config set format json --json
 omni config unset defaultInstance --json
 ```
 
-## Providers
+## Provider schemas (quick reference)
 
 Available schemas: `agno`, `webhook`, `openclaw`, `claude-code`, `genie`, `a2a`, `ag-ui`
 
+> For full provider management (list, get, create, update, delete, setup, test), see the **omni-providers** skill.
+
+### genie
+
+Connects Omni to a Claude Code team inbox (Automagik Genie orchestrator).
+
 ```bash
-omni providers list --json
-omni providers get <id> --json
-
-# openclaw provider
 omni providers create \
-  --name "openclaw-prod" \
-  --schema openclaw \
-  --base-url wss://gateway.example/ws \
-  --api-key <key> \
-  --default-agent-id <agentId> \
+  --name "genie-prod" \
+  --schema genie \
+  --agent-name "omni-agent" \
+  --target-agent "team-lead" \
+  --team-name "omni-{chat_id}" \
   --json
+```
 
-# claude-code provider (runs Claude Code SDK locally)
+Flags: `--agent-name` (required), `--target-agent` (required), `--team-name` (template with `{chat_id}`, `{thread_id}`, `{sender_id}`; default: `omni-{chat_id}`)
+
+### claude-code
+
+Runs Claude Code SDK locally as an agent backend.
+
+```bash
 omni providers create \
   --name "claude-dev" \
   --schema claude-code \
@@ -64,15 +73,45 @@ omni providers create \
   --model claude-opus-4-5 \
   --system-prompt "You are a helpful assistant." \
   --json
+```
 
-# agno / webhook providers (use --base-url and --api-key as needed)
+Flags: `--project-path` (required), `--max-turns`, `--permission-mode` (default|acceptEdits|bypassPermissions|plan), `--model`, `--system-prompt`
+
+### a2a
+
+Agent-to-Agent protocol provider (Google A2A standard).
+
+```bash
+omni providers create \
+  --name "a2a-agent" \
+  --schema a2a \
+  --base-url https://a2a-server.example/api \
+  --api-key <key> \
+  --json
+```
+
+### ag-ui
+
+Agent-UI protocol provider (CopilotKit AG-UI standard).
+
+```bash
+omni providers create \
+  --name "agui-agent" \
+  --schema ag-ui \
+  --base-url https://agui-server.example/api \
+  --api-key <key> \
+  --json
+```
+
+### openclaw / agno / webhook
+
+```bash
+# openclaw (WebSocket gateway)
+omni providers create --name "openclaw-prod" --schema openclaw \
+  --base-url wss://gateway.example/ws --api-key <key> --default-agent-id <agentId> --json
+
+# agno / webhook (HTTP API)
 omni providers create --name "agno-prod" --schema agno --base-url https://api.agno.com --api-key <key> --json
-
-omni providers test <id> --json
-omni providers agents <id> --json
-omni providers teams <id> --json
-omni providers workflows <id> --json
-omni providers delete <id> --force --json
 ```
 
 ## API keys

--- a/plugins/omni/skills/omni-events/SKILL.md
+++ b/plugins/omni/skills/omni-events/SKILL.md
@@ -28,7 +28,9 @@ omni events analytics --since 7d --json
 omni events analytics --instance <id> --all-time --json
 ```
 
-## Replay sessions
+## Replay sessions (event replay)
+
+Re-process historical events through the event pipeline. Useful for rerunning automations or backfilling analytics.
 
 ```bash
 # Start
@@ -43,6 +45,22 @@ omni events replay --status <sessionId> --json
 omni events replay --cancel <sessionId> --json
 ```
 
+## Message replay (standalone command)
+
+`omni replay` is a **separate, standalone command** (not under `omni events`). It replays missed inbound messages for a specific agent instance — useful when an agent was offline and needs to catch up.
+
+```bash
+# Replay missed messages since instance's lastSeenAt (default, max 24h)
+omni replay <instanceId>
+
+# Replay messages received after a specific timestamp
+omni replay wa-main --since 2026-02-27T10:00:00Z
+```
+
+Flags: `--since <timestamp>` (ISO 8601; default: instance's `lastSeenAt`, max 24h ago)
+
+> **Key difference:** `omni events replay` re-processes events through the event bus (analytics, automations). `omni replay` re-delivers missed inbound messages to an agent instance.
+
 ## Journey tracing
 
 ```bash
@@ -55,4 +73,5 @@ omni journey summary --since 24h --json
 - `events list` supports `--chat-id <id>` and `--until <time>` for precise time-range filtering.
 - `events replay --start` supports `--until <time>` and `--instance <id>`.
 - `events search` supports `--since` and `--limit` (no `--type` flag there).
-- Replay management is all through `omni events replay` flags.
+- Event replay management is all through `omni events replay` flags.
+- For replaying missed agent messages, use `omni replay <instanceId>` (standalone command).

--- a/plugins/omni/skills/omni-instances/SKILL.md
+++ b/plugins/omni/skills/omni-instances/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: omni-instances
 description: |
-  Operate Omni channel instances: lifecycle, QR/pairing, sync jobs, contacts/groups, profile/privacy, and history backfill via resync.
+  Operate Omni channel instances: lifecycle, QR/pairing, sync jobs, contacts/groups, profile/privacy, history backfill via resync, auto-ack, debounce, and agent dispatch options.
 allowed-tools: Bash(omni *), Bash(jq *)
 ---
 
@@ -24,6 +24,90 @@ omni instances disconnect <id> --json
 omni instances restart <id> --force-new-qr --json
 omni instances logout <id> --json
 ```
+
+## Auto-ack (reaction acknowledgement)
+
+Acknowledge incoming messages with a reaction before the agent responds. Gives users instant feedback that their message was received.
+
+```bash
+# Enable reaction ack
+omni instances update <id> --reaction-ack on --json
+
+# Disable reaction ack
+omni instances update <id> --reaction-ack off --json
+
+# Custom per-channel emoji map (JSON object)
+omni instances update <id> --reaction-ack on --reaction-ack-emoji '{"whatsapp":"⏳","discord":"⏳","telegram":"⏳","slack":"eyes"}' --json
+
+# Set ack timeout (ms) — remove reaction after agent responds
+omni instances update <id> --ack-timeout 30000 --json
+```
+
+Flags (available on `create` and `update`):
+- `--reaction-ack <on|off>` — enable/disable reaction acknowledgement
+- `--reaction-ack-emoji <json>` — per-channel emoji map as JSON (e.g., `{"whatsapp":"⏳"}`)
+- `--ack-timeout <ms>` — timeout in milliseconds before ack reaction is removed
+
+The `agentAckMessage` field (set via API) sends a text auto-reply before agent dispatch — e.g., "Thinking..." — as a fire-and-forget pre-dispatch message.
+
+## Agent session strategy
+
+Controls how the agent groups conversation context.
+
+```bash
+# One session per user per chat (default for group chats)
+omni instances update <id> --agent-session-strategy per_user_per_chat --json
+
+# One session per user (across all chats)
+omni instances update <id> --agent-session-strategy per_user --json
+
+# One session per chat (all users share context)
+omni instances update <id> --agent-session-strategy per_chat --json
+```
+
+Flag: `--agent-session-strategy <per_user|per_chat|per_user_per_chat>`
+
+## Message format mode
+
+Controls how messages are formatted before being sent to the agent.
+
+```bash
+# Convert markdown/formatting to channel-native format (default)
+omni instances update <id> --message-format-mode convert --json
+
+# Pass raw message through without conversion
+omni instances update <id> --message-format-mode passthrough --json
+```
+
+Flag: `--message-format-mode <convert|passthrough>`
+
+## Debounce
+
+Group rapid successive messages into a single agent dispatch. Useful for users who send multiple short messages in sequence.
+
+```bash
+# Enable fixed debounce (wait 3s after last message)
+omni instances update <id> --debounce-mode fixed --debounce-min 3000 --json
+
+# Randomized debounce (between min and max)
+omni instances update <id> --debounce-mode randomized --debounce-min 2000 --debounce-max 5000 --json
+
+# Separate debounce for group chats
+omni instances update <id> --debounce-mode fixed --debounce-min 3000 --debounce-group 5000 --json
+
+# Restart debounce timer when user is typing
+omni instances update <id> --debounce-mode fixed --debounce-min 3000 --debounce-restart-on-typing --json
+
+# Disable debounce
+omni instances update <id> --debounce-mode disabled --json
+```
+
+Flags (available on `create` and `update`):
+- `--debounce-mode <disabled|fixed|randomized>` — debounce strategy
+- `--debounce-min <ms>` — minimum debounce delay in milliseconds
+- `--debounce-max <ms>` — maximum debounce delay (for `randomized` mode)
+- `--debounce-group <ms>` — override debounce for group chats (use `"null"` to inherit)
+- `--debounce-restart-on-typing` / `--no-debounce-restart-on-typing` — restart timer on typing indicator
 
 ## WhatsApp connect
 

--- a/plugins/omni/skills/omni-providers/SKILL.md
+++ b/plugins/omni/skills/omni-providers/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: omni-providers
+description: |
+  Manage AI/agent providers: list, get, create (genie, claude-code, a2a, ag-ui, agno, openclaw, webhook schemas), update, delete, setup wizards, health test, and Agno resource listing.
+allowed-tools: Bash(omni *), Bash(jq *)
+---
+
+# Omni Providers
+
+## List providers
+
+```bash
+omni providers list --json
+omni providers list --active --json
+```
+
+### List options
+
+| Flag | Description |
+|------|-------------|
+| `--active` | Show only active providers |
+
+## Get provider details
+
+```bash
+omni providers get <id> --json
+```
+
+Returns full provider record including schema, config, active status, and linked agents.
+
+## Create provider
+
+Each provider has a `--schema` that determines which options apply.
+
+### Agno provider
+
+```bash
+omni providers create --name "agno-prod" --schema agno \
+  --base-url https://app.agno.com/v1/playground/agents \
+  --api-key <key> --json
+```
+
+### Webhook provider
+
+```bash
+omni providers create --name "my-webhook" --schema webhook \
+  --base-url https://api.example.com/chat \
+  --api-key <key> --timeout 30 --stream --json
+```
+
+### OpenClaw provider
+
+```bash
+omni providers create --name "openclaw-agent" --schema openclaw \
+  --base-url wss://gateway.openclaw.dev \
+  --api-key <token> --default-agent-id <agentId> --json
+```
+
+### A2A provider
+
+```bash
+omni providers create --name "a2a-service" --schema a2a \
+  --base-url https://a2a.example.com \
+  --api-key <key> --timeout 120 --json
+```
+
+### AG-UI provider
+
+```bash
+omni providers create --name "ag-ui-service" --schema ag-ui \
+  --base-url https://ag-ui.example.com \
+  --api-key <key> --stream --json
+```
+
+### Claude Code provider
+
+```bash
+omni providers create --name "claude-code-local" --schema claude-code \
+  --project-path /home/user/my-project \
+  --max-turns 10 --permission-mode bypassPermissions \
+  --model claude-sonnet-4-6 --system-prompt "You are a helpful assistant" --json
+
+# API key is optional if ANTHROPIC_API_KEY env var is set
+omni providers create --name "claude-code-keyed" --schema claude-code \
+  --project-path /home/user/project --api-key <key> --json
+```
+
+### Genie provider
+
+```bash
+omni providers create --name "genie-teamlead" --schema genie \
+  --agent-name "omni-agent" --target-agent "team-lead" \
+  --team-name "omni-{chat_id}" --json
+```
+
+### Create options (all schemas)
+
+| Flag | Schema | Description |
+|------|--------|-------------|
+| `--name <name>` | all | Provider name (unique) |
+| `--schema <schema>` | all | `agno`, `webhook`, `openclaw`, `ag-ui`, `claude-code`, `a2a`, `genie` |
+| `--base-url <url>` | all except genie | API base URL (`ws://` or `wss://` for openclaw) |
+| `--api-key <key>` | all | API key (optional for claude-code if env var set) |
+| `--description <desc>` | all | Provider description |
+| `--timeout <seconds>` | all | Default timeout in seconds (default: 60) |
+| `--stream` | all | Enable streaming by default |
+| `--default-agent-id <id>` | openclaw | Default agent ID (required) |
+| `--project-path <path>` | claude-code | Project directory path (required) |
+| `--max-turns <number>` | claude-code | Max conversation turns |
+| `--permission-mode <mode>` | claude-code | `default`, `acceptEdits`, `bypassPermissions`, `plan` |
+| `--model <model>` | claude-code | Model override |
+| `--system-prompt <prompt>` | claude-code | System prompt prepended to agent |
+| `--agent-name <name>` | genie | Agent identity / "from" field (required) |
+| `--target-agent <name>` | genie | Target agent inbox to deliver to (required) |
+| `--team-name <template>` | genie | Team name template, supports `{chat_id}`, `{thread_id}`, `{sender_id}` (default: `omni-{chat_id}`) |
+
+## Update provider
+
+```bash
+omni providers update <id> --name "new-name" --json
+omni providers update <id> --base-url https://new.url --api-key <newKey> --json
+omni providers update <id> --timeout 120 --stream --json
+omni providers update <id> --no-stream --json
+omni providers update <id> --active --json
+omni providers update <id> --no-active --json
+
+# Update genie-specific options
+omni providers update <id> --agent-name "new-agent" --target-agent "new-target" --team-name "custom-{chat_id}" --json
+
+# Update claude-code-specific options
+omni providers update <id> --project-path /new/path --max-turns 20 --permission-mode plan --model claude-sonnet-4-6 --json
+
+# Raw schema config override (advanced)
+omni providers update <id> --schema-config '{"projectPath":"/custom","maxTurns":5}' --json
+```
+
+### Update options
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | Provider name |
+| `--base-url <url>` | API base URL |
+| `--api-key <key>` | API key |
+| `--description <desc>` | Provider description |
+| `--timeout <seconds>` | Default timeout in seconds |
+| `--stream` / `--no-stream` | Enable/disable streaming |
+| `--active` / `--no-active` | Set provider active/inactive |
+| `--agent-name <name>` | Agent identity (genie) |
+| `--target-agent <name>` | Target agent inbox (genie) |
+| `--team-name <template>` | Team name template (genie) |
+| `--project-path <path>` | Project directory path (claude-code) |
+| `--max-turns <number>` | Max conversation turns (claude-code) |
+| `--permission-mode <mode>` | Permission mode (claude-code) |
+| `--model <model>` | Model override (claude-code) |
+| `--system-prompt <prompt>` | System prompt (claude-code) |
+| `--schema-config <json>` | Raw schemaConfig as JSON (overrides individual schema flags) |
+
+## Delete provider
+
+```bash
+omni providers delete <id> --json
+omni providers delete <id> --force --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Skip confirmation prompt |
+
+## Setup wizards
+
+Interactive wizards that guide you through provider configuration.
+
+### OpenClaw setup
+
+```bash
+omni providers setup openclaw
+omni providers setup openclaw --gateway-url wss://gateway.openclaw.dev \
+  --gateway-token <token> --agent-id <agentId> --name "my-openclaw" \
+  --instance-id <uuid> --non-interactive
+```
+
+| Flag | Description |
+|------|-------------|
+| `--gateway-url <url>` | Gateway WebSocket URL |
+| `--gateway-token <token>` | Gateway authentication token |
+| `--agent-id <agentId>` | Default agent ID |
+| `--name <name>` | Provider name (default: `openclaw-<agent-id>`) |
+| `--instance-id <uuid>` | Omni instance UUID for the openclaw channel account |
+| `--account-name <name>` | Account name in openclaw.json (default: agent-id) |
+| `--plugin-path <path>` | Path to omni.ts plugin entry (auto-detected from CWD) |
+| `--skip-openclaw-config` | Skip openclaw.json updates entirely |
+| `--non-interactive` | Error on missing required flags instead of prompting |
+
+### Genie setup
+
+```bash
+omni providers setup genie
+omni providers setup genie --agent-name "omni-agent" --target-agent "team-lead" \
+  --team-name "omni-{chat_id}" --instance-id <uuid> --non-interactive
+```
+
+| Flag | Description |
+|------|-------------|
+| `--agent-name <name>` | Agent identity / "from" field |
+| `--target-agent <name>` | Target agent inbox to deliver messages to |
+| `--team-name <template>` | Team name template (supports `{chat_id}`, `{thread_id}`, etc.) |
+| `--agent-role <role>` | Registered genie dir agent name (default: `team-lead`) |
+| `--name <name>` | Provider name (default: `genie-<agent-name>`) |
+| `--base-url <url>` | Base URL (default: `file:///home/genie/.claude/teams`) |
+| `--instance-id <uuid>` | Omni instance UUID to auto-assign provider |
+| `--non-interactive` | Error on missing required flags instead of prompting |
+
+## Test provider health
+
+```bash
+omni providers test <id> --json
+```
+
+Sends a health-check request to the provider and reports whether it is reachable and responding correctly.
+
+## Agno resource listing
+
+For Agno-schema providers, list remote resources:
+
+```bash
+# List agents registered in the Agno platform
+omni providers agents <id> --json
+
+# List teams
+omni providers teams <id> --json
+
+# List workflows
+omni providers workflows <id> --json
+```
+
+## Notes
+
+- Providers define *how* to reach an AI service. Agents (see `omni agents`) define *who* is responding.
+- Each provider has a schema that determines its configuration shape (connection params, auth, etc.).
+- The `genie` schema enables Claude Code team inbox integration — messages are delivered to a named agent via the genie orchestrator.
+- The `claude-code` schema runs a local Claude Code subprocess with a configured project path and permission mode.
+- The `a2a` schema implements the Agent-to-Agent protocol for inter-agent communication.
+- The `ag-ui` schema implements the AG-UI protocol for agent-UI communication.
+- Use `omni providers setup` for guided, interactive provider creation.
+- Use `omni providers test <id>` to verify connectivity before assigning to routes or instances.

--- a/plugins/omni/skills/omni-send/SKILL.md
+++ b/plugins/omni/skills/omni-send/SKILL.md
@@ -76,8 +76,49 @@ Flags for `media list`: `--instance <id>`, `--chat <chatId>`, `--since <datetime
 
 Flags for `media download`: `--message <uuid>`, `--chat <chatId>`, `--external <externalId>`, `--output <path>`
 
+## Recipient resolution (`--to`)
+
+The `--to` flag supports multiple identifier formats with smart resolution:
+
+```bash
+# Phone number — passed through directly
+omni send --to +5511999887766 --text "Hi" --instance <id> --json
+
+# WhatsApp JID — passed through directly
+omni send --to 5511999887766@s.whatsapp.net --text "Hi" --instance <id> --json
+
+# Full Omni UUID (chat or person)
+omni send --to 550e8400-e29b-41d4-a716-446655440000 --text "Hi" --instance <id> --json
+
+# Short ID prefix — resolves to full UUID (same as omni chats messages)
+omni send --to c14b05ff --text "Hi" --instance <id> --json
+
+# Chat name — resolves by exact or substring match (case-insensitive)
+omni send --to "Felipe" --text "Hi" --instance <id> --json
+```
+
+Short ID resolution: any hex string (2+ chars) that isn't a phone number is treated as a UUID prefix. The CLI fetches the chat list and matches the prefix. If ambiguous (multiple matches), it prints the candidates and exits with an error.
+
+## @name mention auto-resolution (WhatsApp)
+
+When sending text to WhatsApp, `@name` patterns in the message body are automatically resolved to WhatsApp JID mentions. The resolver matches contact names from the instance's contact list.
+
+```bash
+# @Felipe is resolved to the contact's JID and rendered as a clickable mention
+omni send --to <group-jid> --text "Hey @Felipe, check this out" --instance <id> --json
+
+# Multiple mentions
+omni send --to <group-jid> --text "@Ana and @Carlos please review" --instance <id> --json
+```
+
+Resolution rules:
+- Exact match first (case-insensitive): `@felipe` matches contact named "Felipe"
+- Prefix match fallback: `@Fel` matches "Felipe" if no exact match exists
+- Unresolved names are left as literal text (no error)
+- Only works on WhatsApp instances — other channels ignore `@name` syntax
+
 ## Notes
 
-- `--to` accepts phone/JID or Omni UUIDs (chat/person).
+- `--to` accepts phone/JID, Omni UUIDs (chat/person), short ID prefixes, or chat names.
 - `--presence-delay <ms>` on `omni send --tts` simulates a typing/recording presence before delivering the TTS voice note.
 - Add small delays in loops to avoid rate-limit spikes.


### PR DESCRIPTION
## Summary
- **New:** `omni-agents` skill — covers `omni agents list|get|create|delete`
- **New:** `omni-providers` skill — covers `omni providers list|get|create|update|delete|setup|test` with all provider schemas (genie, a2a, ag-ui, claude-code, openclaw, webhook)
- **Updated:** `omni-chats` — attention system: `--pending`, `--attention`, `--label`, `--hidden` flags + `hide/unhide/label/unlabel` commands + pagination metadata
- **Updated:** `omni-instances` — auto-ack options (`--agent-ack-message`, `--reaction-ack`, `--ack-timeout`), debounce config, `--message-format-mode`, session strategies
- **Updated:** `omni-send` — `@name` mention auto-resolution on WhatsApp, short ID resolution for `--to`
- **Updated:** `omni-config` — references genie/a2a/ag-ui/claude-code provider schemas, cross-references `omni-providers` skill
- **Updated:** `omni-events` — clarifies `omni replay` as standalone command

Wish: omni-skills-sync

## Test plan
- [ ] Verify all new skill files exist and contain documented commands
- [ ] Spot-check `omni agents --help` and `omni providers --help` match skill docs
- [ ] Confirm attention system flags in omni-chats skill
- [ ] Confirm auto-ack and debounce options in omni-instances skill
- [ ] Confirm @mention and short ID docs in omni-send skill