### PR TITLE
fix(ci): write git-cliff output to file, bypass env var entirely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772 # v4.7.0
-        id: cliff
         if: steps.exists.outputs.skip != 'true'
         with:
           config: cliff.toml
           args: ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || '' }}
+          output: /tmp/release-notes.md
         env:
           GITHUB_REPO: ${{ github.repository }}
 
@@ -65,10 +65,8 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          RELEASE_NOTES: ${{ steps.cliff.outputs.content }}
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
-          printf '%s' "$RELEASE_NOTES" > /tmp/release-notes.md
           gh release create "${TAG}" \
             --target "${{ github.sha }}" \
             --title "${TAG}" \


### PR DESCRIPTION
Previous attempts (#232, #233) failed because `RELEASE_NOTES` env var was still set from `steps.cliff.outputs.content`, exceeding OS ARG_MAX before bash can expand it.

**This fix removes the env var entirely:**
- Uses git-cliff's `output:` parameter to write directly to `/tmp/release-notes.md`
- Removes `RELEASE_NOTES` env var from the Create release step
- `gh release create` reads from `--notes-file`

No env var, no argument expansion, no ARG_MAX limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update refines internal release automation and workflow processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->