### PR TITLE
fix(ci): pass --output via args to git-cliff CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,9 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         with:
           config: cliff.toml
-          args: ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || '' }}
-          output: /tmp/release-notes.md
+          args: >-
+            ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || '' }}
+            --output /tmp/release-notes.md
         env:
           GITHUB_REPO: ${{ github.repository }}
 


### PR DESCRIPTION
The git-cliff GitHub Action v4.7.0 does not support `output` as an input parameter (only `version`, `config`, `args`, `github_token`).

**Fix:** Pass `--output /tmp/release-notes.md` via the `args` field, which is forwarded directly to the git-cliff CLI. This writes the changelog to a file without using env vars or shell argument expansion.

Previous attempts:
- #232: Used `printf` to write env var to file — env var still too large
- #233: Used `output:` input — not a valid action input  
- #234: Same fix, merged correctly but action ignores unknown inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal release workflow configuration for changelog generation. This is a technical infrastructure change with no impact on product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->