### PR TITLE
fix(genie-client): stop overriding agent CWD with hardcoded ~/workspace

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -2658,7 +2658,8 @@ function createGenieProviderInstance(provider: AgentProvider, instance: Dispatch
   const teamName = typeof schemaConfig.teamName === 'string' ? schemaConfig.teamName : 'genie';
   const agentRole = typeof schemaConfig.agentRole === 'string' ? schemaConfig.agentRole : 'team-lead';
 
-  const client = createGenieClient({ teamName, agentName, targetAgent, agentRole });
+  const autoSpawnDir = typeof schemaConfig.autoSpawnDir === 'string' ? schemaConfig.autoSpawnDir : undefined;
+  const client = createGenieClient({ teamName, agentName, targetAgent, agentRole, autoSpawnDir });
 
   return new GenieAgentProvider(provider.id, provider.name, client, {
     prefixSenderName: instance.agentPrefixSenderName ?? true,

--- a/packages/core/src/providers/__tests__/genie-client-auto-spawn.test.ts
+++ b/packages/core/src/providers/__tests__/genie-client-auto-spawn.test.ts
@@ -141,6 +141,18 @@ describe('GenieClient auto-spawn on run()', () => {
     expect(args[3]).toBe('test-team');
   });
 
+  test('does not include --cwd when autoSpawnDir is not configured', async () => {
+    const client = new GenieClient(makeConfig());
+    await client.run(makeRequest());
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const genieCalls = getCallsFor('genie');
+    expect(genieCalls.length).toBe(1);
+    const args = genieCalls[0]?.[1] as string[];
+    expect(args).not.toContain('--cwd');
+  });
+
   test('includes --cwd flag with autoSpawnDir', async () => {
     const client = new GenieClient(makeConfig({ autoSpawnDir: '/my/workspace' }));
     await client.run(makeRequest());

--- a/packages/core/src/providers/genie-client.ts
+++ b/packages/core/src/providers/genie-client.ts
@@ -47,7 +47,7 @@ export interface GenieClientConfig {
   agentRole: string;
   /** Auto-spawn agent session if team doesn't exist yet (default: true) */
   autoSpawn?: boolean;
-  /** Working directory for auto-spawned agent session (default: ~/workspace) */
+  /** Working directory for auto-spawned agent session (default: agent's registered dir via genie dir) */
   autoSpawnDir?: string;
 }
 
@@ -118,7 +118,7 @@ export class GenieClient implements IAgentClient {
     this.targetAgentTemplate = config.targetAgent;
     this.agentRole = config.agentRole;
     this.autoSpawn = config.autoSpawn ?? true;
-    this.autoSpawnDir = config.autoSpawnDir ?? join(homedir(), 'workspace');
+    this.autoSpawnDir = config.autoSpawnDir ?? '';
 
     this.hasTemplates =
       /\{\w+\}/.test(this.teamNameTemplate) ||


### PR DESCRIPTION
## Summary

- Remove hardcoded `~/workspace` default from `GenieClient` constructor — when empty, `genie spawn` uses the agent's registered dir from `genie dir`
- Pass `autoSpawnDir` from `schemaConfig` through factory in `agent-dispatcher.ts` so explicit overrides still work
- Add test asserting spawn args do NOT include `--cwd` when `autoSpawnDir` is not configured

## Wish

`fix-genie-client-autospawn-cwd`

## Test plan

- [x] `bun test genie-client-auto-spawn.test.ts` passes
- [x] All 2457 tests pass (0 failures)
- [ ] Send a WhatsApp message to ClaudiA instance — agent spawns in its registered dir (not `~/workspace`)
- [ ] Provider with explicit `autoSpawnDir` in `schemaConfig` still overrides CWD correctly