### PR TITLE
feat(genie-client): pass --session to genie spawn for isolated tmux sessions

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -2659,7 +2659,8 @@ function createGenieProviderInstance(provider: AgentProvider, instance: Dispatch
   const agentRole = typeof schemaConfig.agentRole === 'string' ? schemaConfig.agentRole : 'team-lead';
 
   const autoSpawnDir = typeof schemaConfig.autoSpawnDir === 'string' ? schemaConfig.autoSpawnDir : undefined;
-  const client = createGenieClient({ teamName, agentName, targetAgent, agentRole, autoSpawnDir });
+  const sessionName = typeof schemaConfig.sessionName === 'string' ? schemaConfig.sessionName : undefined;
+  const client = createGenieClient({ teamName, agentName, targetAgent, agentRole, autoSpawnDir, sessionName });
 
   return new GenieAgentProvider(provider.id, provider.name, client, {
     prefixSenderName: instance.agentPrefixSenderName ?? true,

--- a/packages/core/src/providers/__tests__/genie-client-auto-spawn.test.ts
+++ b/packages/core/src/providers/__tests__/genie-client-auto-spawn.test.ts
@@ -218,6 +218,25 @@ describe('GenieClient auto-spawn on run()', () => {
     expect(response.content).toBe('');
   });
 
+  test('does not include --session when sessionName is not configured', async () => {
+    const client = new GenieClient(makeConfig());
+    await client.run(makeRequest());
+    await new Promise((r) => setTimeout(r, 100));
+    const genieCalls = getCallsFor('genie');
+    const args = genieCalls[0]?.[1] as string[];
+    expect(args).not.toContain('--session');
+  });
+
+  test('includes --session flag with sessionName', async () => {
+    const client = new GenieClient(makeConfig({ sessionName: 'claudia-whatsapp' }));
+    await client.run(makeRequest());
+    await new Promise((r) => setTimeout(r, 100));
+    const genieCalls = getCallsFor('genie');
+    const args = genieCalls[0]?.[1] as string[];
+    expect(args).toContain('--session');
+    expect(args).toContain('claudia-whatsapp');
+  });
+
   test('still delivers message to inbox regardless of auto-spawn', async () => {
     const client = new GenieClient(makeConfig());
     const response = await client.run(makeRequest('hello world'));

--- a/packages/core/src/providers/genie-client.ts
+++ b/packages/core/src/providers/genie-client.ts
@@ -49,6 +49,8 @@ export interface GenieClientConfig {
   autoSpawn?: boolean;
   /** Working directory for auto-spawned agent session (default: agent's registered dir via genie dir) */
   autoSpawnDir?: string;
+  /** Tmux session name for spawned agents — groups all chats under one session */
+  sessionName?: string;
 }
 
 /** Variables available for template interpolation at runtime */
@@ -104,6 +106,7 @@ export class GenieClient implements IAgentClient {
   /** Auto-spawn agent session when team doesn't exist */
   private readonly autoSpawn: boolean;
   private readonly autoSpawnDir: string;
+  private readonly sessionName: string;
   /** Registered agent name in genie dir — used as spawn target */
   private readonly agentRole: string;
 
@@ -119,6 +122,7 @@ export class GenieClient implements IAgentClient {
     this.agentRole = config.agentRole;
     this.autoSpawn = config.autoSpawn ?? true;
     this.autoSpawnDir = config.autoSpawnDir ?? '';
+    this.sessionName = config.sessionName ?? '';
 
     this.hasTemplates =
       /\{\w+\}/.test(this.teamNameTemplate) ||
@@ -231,12 +235,15 @@ export class GenieClient implements IAgentClient {
 
   /**
    * Spawn agent session via genie CLI.
-   * Calls: genie spawn <agentRole> --team <teamName> [--cwd <autoSpawnDir>]
+   * Calls: genie spawn <agentRole> --team <teamName> [--cwd <autoSpawnDir>] [--session <sessionName>]
    */
   private async spawnAgentSession(teamName: string): Promise<void> {
     const args = ['spawn', this.agentRole, '--team', teamName];
     if (this.autoSpawnDir) {
       args.push('--cwd', this.autoSpawnDir);
+    }
+    if (this.sessionName) {
+      args.push('--session', this.sessionName);
     }
 
     log.info('Auto-spawning agent session', { teamName, agentRole: this.agentRole, args });


### PR DESCRIPTION
## Summary

- Add `sessionName` field to `GenieClientConfig` interface and pass `--session <name>` to `genie spawn` when configured
- Extract `sessionName` from `schemaConfig` in the agent dispatcher factory
- Add tests for both `--session` presence and absence in spawn args

## Wish

`genie-session-passthrough` — [Issue #239](https://github.com/automagik-dev/omni/issues/239)

## Test plan

- [x] Unit test: `--session` is NOT included when `sessionName` is not configured
- [x] Unit test: `--session claudia-whatsapp` IS included when `sessionName` is configured
- [x] All 2458 existing tests pass (0 failures)
- [ ] Manual: Configure `sessionName: "claudia-whatsapp"` in provider schemaConfig, verify agent spawns in dedicated tmux session