### PR TITLE
docs: rewrite agent routing skill + multi-instance guide (#252 #240)

### DIFF
--- a/.agents/skills/omni-orchestrator/references/AGENT_ROUTING.md
+++ b/.agents/skills/omni-orchestrator/references/AGENT_ROUTING.md
@@ -1,90 +1,478 @@
 # Agent Routing Reference
 
-## Assign Provider
+Omni routes incoming messages to AI agents using a layered routing system. Routes can be scoped per-chat, per-user, or fall back to instance defaults. Access control rules determine who can interact with the bot.
 
-Set AI provider for an instance:
+## Route Resolution Order
 
-```bash
-omni instances update <id> --agent-routing '{"providerId":"<provider-id>","model":"gpt-5.3-codex"}'
+When a message arrives, Omni resolves the agent in this order:
+
+```
+1. Chat route   — matches the specific chat (group or DM)
+2. User route   — matches the specific person (sender)
+3. Instance default — the agent assigned to the instance
 ```
 
-Create a provider first:
+The first match wins. Higher-priority routes within the same scope are checked first.
+
+### Multi-Agent Pattern
+
+A single WhatsApp number (instance) can route different users to different agents:
+
+```
+Instance (1 WhatsApp number)
+  ├── Route: Felipe (user) → dev agent (debounce: off, ack: off)
+  ├── Route: Antonio (user) → test agent B
+  └── Default → production agent (instance defaults)
+```
+
+## Providers
+
+Providers connect Omni to AI backends. Create a provider before assigning agents.
+
+### Create a Provider
 
 ```bash
-omni providers create --name "openai" --type openai --api-key sk_xxx
+# Agno provider (hosted agents)
+omni providers create --name "my-agno" --schema agno --base-url https://api.agno.com --api-key sk_xxx
+
+# Claude Code provider (local)
+omni providers create --name "claude-local" --schema claude-code \
+  --project-path /home/user/my-project --permission-mode bypassPermissions
+
+# Genie provider (agent orchestration)
+omni providers create --name "my-genie" --schema genie \
+  --agent-name "omni-relay" \
+  --target-agent "sofia" \
+  --team-name "omni-{chat_id}"
+```
+
+### Test a Provider
+
+```bash
 omni providers test <provider-id>
+```
+
+### List and Inspect Providers
+
+```bash
+omni providers list
+omni providers get <provider-id>
+```
+
+### Genie Provider schemaConfig
+
+The genie provider schema supports these fields:
+
+| Field | Flag | Description |
+|-------|------|-------------|
+| `agentName` | `--agent-name` | Identity / "from" field for the agent sending messages |
+| `targetAgent` | `--target-agent` | Target agent inbox to deliver messages to |
+| `teamName` | `--team-name` | Team name template for session isolation |
+
+The `teamName` field supports placeholders:
+
+| Placeholder | Resolves to |
+|-------------|-------------|
+| `{chat_id}` | The chat UUID |
+| `{thread_id}` | The thread/topic UUID |
+| `{sender_id}` | The sender's person UUID |
+
+```bash
+# Example: each chat gets its own team
+omni providers create --name "genie-prod" --schema genie \
+  --agent-name "omni-relay" \
+  --target-agent "sofia" \
+  --team-name "omni-{chat_id}"
+
+# Update an existing provider's genie config
+omni providers update <id> --agent-name "new-relay" --target-agent "new-agent"
+
+# Or set raw schemaConfig as JSON
+omni providers update <id> --schema-config '{"agentName":"relay","targetAgent":"sofia","teamName":"omni-{chat_id}"}'
+```
+
+## Assigning an Agent to an Instance
+
+Set the default agent for an instance:
+
+```bash
+# By agent FK (references agents table)
+omni instances update <id> --agent-fk-id <agent-uuid>
+
+# By provider
+omni instances update <id> --agent-provider <provider-id>
+
+# Set agent type
+omni instances update <id> --agent-type agent    # or: team, workflow
+```
+
+### Agent Behavior Options
+
+```bash
+# Timeout (seconds before agent response times out)
+omni instances update <id> --agent-timeout 120
+
+# Streaming responses
+omni instances update <id> --agent-stream-mode
+omni instances update <id> --no-agent-stream-mode
+
+# Session strategy
+omni instances update <id> --agent-session-strategy per_user          # one session per sender
+omni instances update <id> --agent-session-strategy per_chat          # one session per chat
+omni instances update <id> --agent-session-strategy per_user_per_chat # one session per user+chat
+
+# Prefix sender name in messages (useful for group chats)
+omni instances update <id> --agent-prefix-sender-name
+omni instances update <id> --no-agent-prefix-sender-name
+
+# Wait for media processing before dispatching to agent
+omni instances update <id> --agent-wait-for-media
+omni instances update <id> --no-agent-wait-for-media
+
+# Include file path in formatted media text
+omni instances update <id> --agent-send-media-path
+omni instances update <id> --agent-send-media-path-types image,video,document
+```
+
+## Routes
+
+Routes override the instance default agent for specific chats or users.
+
+### Create a Route
+
+```bash
+# Route a specific user to a different agent
+omni routes create --instance <instance-id> \
+  --scope user --person <person-uuid> \
+  --agent <agent-uuid> \
+  --label "Felipe → dev agent"
+
+# Route a specific chat (group) to a different agent
+omni routes create --instance <instance-id> \
+  --scope chat --chat <chat-uuid> \
+  --agent <agent-uuid> \
+  --label "Support group → support agent"
+
+# Route with custom settings (override instance defaults)
+omni routes create --instance <instance-id> \
+  --scope user --person <person-uuid> \
+  --agent <agent-uuid> \
+  --timeout 300 \
+  --stream \
+  --no-prefix-sender \
+  --no-gate \
+  --priority 10 \
+  --label "Dev user — long timeout, no gate"
+```
+
+### Route Options
+
+Routes can override these instance-level settings:
+
+| Flag | Description |
+|------|-------------|
+| `--agent <uuid>` | Agent to route to |
+| `--timeout <seconds>` | Agent timeout override |
+| `--stream` / `--no-stream` | Streaming override |
+| `--prefix-sender` / `--no-prefix-sender` | Sender name prefix |
+| `--wait-media` / `--no-wait-media` | Wait for media processing |
+| `--send-media-path` / `--no-send-media-path` | Include file path in media text |
+| `--gate` / `--no-gate` | LLM response gate |
+| `--gate-model <model>` | Gate model override |
+| `--gate-prompt <prompt>` | Gate prompt override |
+| `--reply-filter-mode <mode>` | Reply filter: `all` or `filtered` |
+| `--priority <n>` | Higher number = higher priority |
+| `--label <text>` | Human-readable label |
+| `--inactive` | Create as inactive |
+
+### List Routes
+
+```bash
+# All routes for an instance
+omni routes list --instance <instance-id>
+
+# Filter by scope
+omni routes list --instance <instance-id> --scope user
+omni routes list --instance <instance-id> --scope chat
+
+# Active routes only
+omni routes list --instance <instance-id> --active
+```
+
+### Update a Route
+
+```bash
+# Change the target agent
+omni routes update <route-id> --agent <new-agent-uuid>
+
+# Deactivate a route (keeps config, stops matching)
+omni routes update <route-id> --inactive
+
+# Reactivate
+omni routes update <route-id> --active
+
+# Change priority
+omni routes update <route-id> --priority 20
+```
+
+### Delete a Route
+
+```bash
+omni routes delete <route-id>
+```
+
+### Test Route Resolution
+
+Debug which agent would handle a message for a given instance, chat, and person:
+
+```bash
+# Test what agent resolves for a specific person in a specific chat
+omni routes test --instance <instance-id> --chat <chat-uuid> --person <person-uuid>
+
+# Test just person-level routing
+omni routes test --instance <instance-id> --person <person-uuid>
+
+# Test just chat-level routing
+omni routes test --instance <instance-id> --chat <chat-uuid>
+```
+
+### Route Cache Metrics
+
+```bash
+omni routes metrics
+```
+
+## Access Control
+
+Access control determines who can interact with the bot. Rules use phone patterns or platform user IDs.
+
+### Access Modes
+
+Set the access control mode for an instance:
+
+```bash
+# Allowlist mode — only explicitly allowed contacts can interact
+omni access mode <instance-id> allowlist
+
+# Blocklist mode — everyone allowed except explicitly blocked contacts
+omni access mode <instance-id> blocklist
+
+# Disabled — no access control, everyone can interact
+omni access mode <instance-id> disabled
+
+# Check current mode
+omni access mode <instance-id>
+```
+
+### Create Access Rules
+
+```bash
+# Allow all Brazilian numbers
+omni access create --type allow --instance <instance-id> --phone "+55*"
+
+# Block a specific number
+omni access create --type deny --instance <instance-id> --phone "+5511999999999"
+
+# Block with a custom message sent to the blocked user
+omni access create --type deny --instance <instance-id> \
+  --phone "+1*" \
+  --action block \
+  --message "This service is not available in your region" \
+  --reason "Geo-restriction"
+
+# Silent block (no message sent)
+omni access create --type deny --instance <instance-id> \
+  --phone "+1*" \
+  --action silent_block
+
+# Rule for Discord user ID
+omni access create --type allow --instance <instance-id> --user "123456789"
+
+# Global rule (applies to all instances)
+omni access create --type deny --phone "+0*" --reason "Invalid numbers"
+
+# Set priority (higher = checked first)
+omni access create --type allow --instance <instance-id> --phone "+5511999999999" --priority 100
+```
+
+### List Access Rules
+
+```bash
+# All rules
+omni access list
+
+# Rules for a specific instance
+omni access list --instance <instance-id>
+
+# Filter by type
+omni access list --instance <instance-id> --type allow
+omni access list --instance <instance-id> --type deny
+```
+
+### Check Access
+
+```bash
+# Check if a user has access
+omni access check --instance <instance-id> --user "123456789" --channel discord
+```
+
+### Pairing Requests
+
+When access mode is `allowlist`, unknown users trigger a pairing request:
+
+```bash
+# List pending pairing requests
+omni access pending <instance-id>
+
+# Approve a request (adds user to allowlist)
+omni access approve <instance-id> <request-id>
+
+# Deny a request
+omni access deny <instance-id> <request-id>
+```
+
+### Delete an Access Rule
+
+```bash
+omni access delete <rule-id>
 ```
 
 ## Reply Filters
 
-Control which contacts the bot responds to.
-
-### Whitelist Mode
-
-Only respond to listed contacts:
+Control which messages the bot responds to:
 
 ```bash
-omni instances update <id> --reply-filter '{
-  "mode": "whitelist",
-  "contacts": ["5511999@s.whatsapp.net", "5511888@s.whatsapp.net"]
-}'
+# Respond to all messages
+omni instances update <id> --reply-filter-mode all
+
+# Filtered mode — only respond based on specific triggers
+omni instances update <id> --reply-filter-mode filtered
+
+# Configure filtered mode triggers
+omni instances update <id> --reply-filter-mode filtered \
+  --reply-on-dm \
+  --reply-on-mention \
+  --reply-on-reply \
+  --no-reply-on-name
+
+# Clear reply filter entirely
+omni instances update <id> --clear-reply-filter
 ```
 
-### Blacklist Mode
+### Filter Trigger Options
 
-Respond to everyone except listed contacts:
-
-```bash
-omni instances update <id> --reply-filter '{
-  "mode": "blacklist",
-  "contacts": ["5511777@s.whatsapp.net"]
-}'
-```
-
-### No Filter
-
-Remove all filters:
-
-```bash
-omni instances update <id> --reply-filter '{"mode": "none"}'
-```
+| Flag | Description |
+|------|-------------|
+| `--reply-on-dm` / `--no-reply-on-dm` | Reply to direct messages |
+| `--reply-on-mention` / `--no-reply-on-mention` | Reply when @mentioned |
+| `--reply-on-reply` / `--no-reply-on-reply` | Reply when message is a reply to bot |
+| `--reply-on-name` / `--no-reply-on-name` | Reply when bot name appears in text |
+| `--reply-name-patterns <p1,p2>` | Custom name patterns (comma-separated) |
 
 ## Debounce
 
-Prevent rapid-fire responses in group chats.
-
-### Group Debounce
-
-Wait for silence before responding:
+Debounce controls how long Omni waits before sending a message to the agent, batching rapid-fire messages together.
 
 ```bash
-omni instances update <id> --debounce '{"type":"group","delay":5000}'
+# Fixed delay — always wait this long
+omni instances update <id> --debounce-mode fixed --debounce-min 5000
+
+# Randomized delay — wait between min and max ms
+omni instances update <id> --debounce-mode randomized --debounce-min 3000 --debounce-max 8000
+
+# Disable debounce
+omni instances update <id> --debounce-mode disabled
+
+# Restart timer when user is still typing
+omni instances update <id> --debounce-restart-on-typing
+
+# Group chat debounce (separate from DM debounce)
+omni instances update <id> --debounce-group 10000
 ```
 
-### Delay Debounce
+## Response Gate
 
-Fixed delay per message:
+The response gate uses an LLM to evaluate whether the agent's response should be sent. Useful for safety filtering.
 
 ```bash
-omni instances update <id> --debounce '{"type":"delay","delay":2000}'
+# Enable gate with defaults
+omni instances update <id> --agent-gate
+
+# Custom gate model and prompt
+omni instances update <id> --agent-gate \
+  --agent-gate-model "claude-sonnet-4-20250514" \
+  --agent-gate-prompt "Only allow responses that are professional and on-topic"
+
+# Disable gate
+omni instances update <id> --no-agent-gate
 ```
 
-### No Debounce
+Routes can also override gate settings:
 
 ```bash
-omni instances update <id> --debounce '{"type":"none"}'
+omni routes create --instance <id> --scope user --person <person-uuid> \
+  --agent <agent-uuid> --no-gate --label "Trusted user — skip gate"
 ```
 
-## Access Modes
+## Reaction Acknowledgment
 
-| Mode | Behavior |
-|------|----------|
-| `public` | Anyone can interact with the bot |
-| `private` | Only whitelisted contacts |
-| `disabled` | Bot does not respond |
+Send a reaction emoji when the bot receives a message (visual feedback):
 
 ```bash
-omni instances update <id> --access-mode "public"
-omni instances update <id> --access-mode "private"
-omni instances update <id> --access-mode "disabled"
+# Enable reaction ack
+omni instances update <id> --reaction-ack on
+
+# Disable
+omni instances update <id> --reaction-ack off
+
+# Custom emoji per channel
+omni instances update <id> --reaction-ack on --reaction-ack-emoji '{"whatsapp":"⏳","discord":"👀"}'
+
+# Set ack timeout
+omni instances update <id> --ack-timeout 30000
+```
+
+## Complete Multi-Agent Setup Example
+
+Set up one WhatsApp number with different agents for different users:
+
+```bash
+# 1. Create providers
+omni providers create --name "genie-prod" --schema genie \
+  --agent-name "omni-relay" --target-agent "production-agent" \
+  --team-name "prod-{chat_id}"
+
+omni providers create --name "genie-dev" --schema genie \
+  --agent-name "omni-relay" --target-agent "dev-agent" \
+  --team-name "dev-{chat_id}"
+
+# 2. Assign default agent to the instance (production)
+omni instances update <instance-id> --agent-provider <prod-provider-id>
+
+# 3. Set instance defaults
+omni instances update <instance-id> \
+  --debounce-mode fixed --debounce-min 5000 \
+  --reaction-ack on \
+  --access-mode allowlist \
+  --agent-session-strategy per_user
+
+# 4. Create user routes for developers (skip debounce and ack via route overrides)
+omni routes create --instance <instance-id> \
+  --scope user --person <felipe-person-uuid> \
+  --agent <dev-agent-uuid> \
+  --no-gate \
+  --label "Felipe → dev agent"
+
+omni routes create --instance <instance-id> \
+  --scope user --person <antonio-person-uuid> \
+  --agent <test-agent-uuid> \
+  --label "Antonio → test agent"
+
+# 5. Allow specific contacts
+omni access create --type allow --instance <instance-id> --phone "+55*"
+
+# 6. Verify route resolution
+omni routes test --instance <instance-id> --person <felipe-person-uuid>
+omni routes test --instance <instance-id> --person <antonio-person-uuid>
+omni routes test --instance <instance-id> --person <random-person-uuid>
 ```

--- a/docs/guides/multi-instance.md
+++ b/docs/guides/multi-instance.md
@@ -1,0 +1,289 @@
+# Multi-Instance Deployment Guide
+
+Run multiple fully isolated Omni instances on the same machine. Each instance gets its own database, event bus, API port, and state directory.
+
+## When to Use Multi-Instance
+
+Use separate Omni instances when you need **full isolation** between environments:
+
+- Separate production and staging with different databases
+- Run multiple WhatsApp numbers with completely independent state
+- Isolate client deployments on shared infrastructure
+- Test migrations or upgrades without affecting production
+
+**If you only need per-user config differences on the same number** (different agents, different debounce settings), consider route-level overrides instead — see `omni routes create --help` and the [Agent Routing Reference](../../.agents/skills/omni-orchestrator/references/AGENT_ROUTING.md).
+
+## Architecture
+
+Each instance runs its own process tree managed by PM2:
+
+```
+Machine
+├── Instance A (production)
+│   ├── NATS server (port 4222)
+│   ├── API server (port 8882)
+│   └── pgserve (port 8432)
+│
+└── Instance B (staging)
+    ├── NATS server (port 4223)
+    ├── API server (port 8883)
+    └── pgserve (port 8433)
+```
+
+Isolation is achieved by giving each instance a different `HOME` directory, which separates:
+- PM2 process namespace (`~/.pm2/`)
+- Omni data directory (`~/.omni/`)
+- pgserve data directory (configured via `PGSERVE_DATA`)
+
+## PM2 Ecosystem Template
+
+Create one `ecosystem.config.cjs` per instance, or use a single file with namespaced process names. Below is a template for two isolated instances.
+
+### Per-Instance `.env` Files
+
+**`/opt/omni/production/.env`**:
+
+```bash
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:8432/omni
+PGSERVE_EMBEDDED=true
+PGSERVE_PORT=8432
+PGSERVE_DATA=/opt/omni/production/.pgserve-data
+
+# NATS
+NATS_URL=nats://localhost:4222
+NATS_MANAGED=true
+NATS_PORT=4222
+
+# API
+API_PORT=8882
+API_HOST=0.0.0.0
+API_MANAGED=true
+NODE_ENV=production
+```
+
+**`/opt/omni/staging/.env`**:
+
+```bash
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:8433/omni
+PGSERVE_EMBEDDED=true
+PGSERVE_PORT=8433
+PGSERVE_DATA=/opt/omni/staging/.pgserve-data
+
+# NATS
+NATS_URL=nats://localhost:4223
+NATS_MANAGED=true
+NATS_PORT=4223
+
+# API
+API_PORT=8883
+API_HOST=0.0.0.0
+API_MANAGED=true
+NODE_ENV=staging
+```
+
+### PM2 Ecosystem File
+
+**`/opt/omni/ecosystem.config.cjs`**:
+
+```javascript
+const path = require('node:path');
+
+const SHARED = {
+  autorestart: true,
+  watch: false,
+  max_restarts: 0,
+  exp_backoff_restart_delay: 100,
+  kill_timeout: 8000,
+  listen_timeout: 60000,
+  merge_logs: true,
+  log_date_format: 'YYYY-MM-DD HH:mm:ss.SSS',
+  combine_logs: true,
+};
+
+module.exports = {
+  apps: [
+    // ── Production ──────────────────────────────────────────
+    {
+      ...SHARED,
+      name: 'omni-prod-nats',
+      cwd: '/opt/omni/production',
+      script: '/opt/omni/production/bin/nats-server',
+      args: '-js -p 4222',
+      env: { HOME: '/opt/omni/production' },
+      max_memory_restart: '256M',
+    },
+    {
+      ...SHARED,
+      name: 'omni-prod-api',
+      cwd: '/opt/omni/production',
+      script: 'bun',
+      args: 'packages/api/src/index.ts',
+      env: {
+        HOME: '/opt/omni/production',
+        NODE_ENV: 'production',
+        OMNI_PACKAGES_DIR: '/opt/omni/production/packages',
+      },
+      env_file: '/opt/omni/production/.env',
+      max_memory_restart: '2G',
+      restart_delay: 1000,
+    },
+
+    // ── Staging ─────────────────────────────────────────────
+    {
+      ...SHARED,
+      name: 'omni-staging-nats',
+      cwd: '/opt/omni/staging',
+      script: '/opt/omni/staging/bin/nats-server',
+      args: '-js -p 4223',
+      env: { HOME: '/opt/omni/staging' },
+      max_memory_restart: '256M',
+    },
+    {
+      ...SHARED,
+      name: 'omni-staging-api',
+      cwd: '/opt/omni/staging',
+      script: 'bun',
+      args: 'packages/api/src/index.ts',
+      env: {
+        HOME: '/opt/omni/staging',
+        NODE_ENV: 'staging',
+        OMNI_PACKAGES_DIR: '/opt/omni/staging/packages',
+      },
+      env_file: '/opt/omni/staging/.env',
+      max_memory_restart: '2G',
+      restart_delay: 1000,
+    },
+  ],
+};
+```
+
+## Required Setup
+
+### 1. Clone Omni Per Instance
+
+Each instance needs its own copy of the Omni codebase (or at minimum, the `bin/` and `packages/` directories):
+
+```bash
+# Production
+git clone <omni-repo> /opt/omni/production
+cd /opt/omni/production && bun install
+
+# Staging
+git clone <omni-repo> /opt/omni/staging
+cd /opt/omni/staging && bun install
+```
+
+### 2. Install NATS Binary Per Instance
+
+Each HOME directory needs its own NATS binary because the ecosystem config references it by path:
+
+```bash
+cd /opt/omni/production && ./scripts/ensure-nats.sh
+cd /opt/omni/staging && ./scripts/ensure-nats.sh
+```
+
+### 3. Create `.env` Files
+
+Copy `.env.example` and adjust ports for each instance (see the env files above):
+
+```bash
+cp .env.example /opt/omni/production/.env
+cp .env.example /opt/omni/staging/.env
+# Edit each with unique PGSERVE_PORT, NATS_PORT, API_PORT
+```
+
+### 4. Start Services
+
+```bash
+# Load env and start all instances
+pm2 start /opt/omni/ecosystem.config.cjs
+
+# Or start individually
+set -a && . /opt/omni/production/.env && set +a
+pm2 start /opt/omni/ecosystem.config.cjs --only omni-prod-nats,omni-prod-api
+
+# Save for reboot persistence
+pm2 save
+```
+
+## CLI Usage Per Instance
+
+The `omni` CLI defaults to `http://localhost:8882`. When managing a non-default instance, specify the API URL and key:
+
+```bash
+# Talk to the staging instance
+omni instances list --api-url http://localhost:8883
+
+# Set a per-instance API key for auth
+omni instances list --api-url http://localhost:8883 --api-key <staging-key>
+
+# Tip: use shell aliases for convenience
+alias omni-prod='omni --api-url http://localhost:8882 --api-key $PROD_KEY'
+alias omni-staging='omni --api-url http://localhost:8883 --api-key $STAGING_KEY'
+
+# Then use naturally
+omni-staging instances list
+omni-prod routes list --instance <id>
+```
+
+## Environment Variable Reference
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://postgres:postgres@localhost:8432/omni` |
+| `PGSERVE_EMBEDDED` | Run PostgreSQL embedded in API process | `true` |
+| `PGSERVE_PORT` | Embedded PostgreSQL port | `8432` |
+| `PGSERVE_DATA` | pgserve data directory | `./.pgserve-data` |
+| `NATS_URL` | NATS server connection URL | `nats://localhost:4222` |
+| `NATS_MANAGED` | Let PM2 manage NATS server | `true` |
+| `NATS_PORT` | NATS server listen port | `4222` |
+| `API_PORT` | Omni API listen port | `8882` |
+| `API_HOST` | Omni API bind address | `0.0.0.0` |
+| `API_MANAGED` | Let PM2 manage API server | `true` |
+| `NODE_ENV` | Environment name | `development` |
+| `LOG_LEVEL` | Log verbosity | `debug` |
+
+## Known Limitations
+
+### Multi-Device Routing Unpredictability
+
+WhatsApp's multi-device architecture means messages may arrive on different linked devices with slightly different metadata. When the same WhatsApp number is connected through multiple Omni instances (not recommended), message routing can become unpredictable because:
+
+- WhatsApp may deliver the same message to multiple linked sessions
+- Session state (read receipts, typing indicators) may not sync between instances
+- Reconnection behavior after network issues varies per device
+
+**Recommendation:** Use one Omni instance per WhatsApp number. For different agent behavior per user or chat, use route-level overrides rather than separate instances.
+
+### Port Conflicts
+
+Each instance must use unique ports for `PGSERVE_PORT`, `NATS_PORT`, and `API_PORT`. Port conflicts will cause startup failures. Verify with:
+
+```bash
+# Check for port conflicts before starting
+lsof -i :8432 -i :8433 -i :4222 -i :4223 -i :8882 -i :8883
+```
+
+### Disk Space
+
+Each instance maintains its own PostgreSQL data directory and media downloads. Plan storage accordingly — media files accumulate in `~/.omni/data/media/`.
+
+## Monitoring
+
+```bash
+# PM2 status for all instances
+pm2 list
+
+# Logs for a specific service
+pm2 logs omni-prod-api --lines 100
+pm2 logs omni-staging-api --lines 100
+
+# Restart a specific instance
+pm2 restart omni-staging-api
+
+# Check instance health via CLI
+omni-prod instances status <id>
+omni-staging instances status <id>
+```


### PR DESCRIPTION
## Summary
- Rewrite AGENT_ROUTING.md with current `omni routes`/`omni access` CLI (470 lines)
- Create multi-instance deployment guide (289 lines)
- Documents route resolution, genie provider schemaConfig, multi-agent patterns

Wish: `omni-docs-cleanup`
Closes #252, closes #240