### PR TITLE
fix(media): wait for message persistence before media await

### DIFF
--- a/packages/api/src/plugins/__tests__/media-await.test.ts
+++ b/packages/api/src/plugins/__tests__/media-await.test.ts
@@ -123,17 +123,25 @@ describe('awaitMediaProcessing', () => {
     expect(result).toEqual(MEDIA_WAIT_NULL);
   });
 
-  it('returns MEDIA_WAIT_NULL when chat is not found', async () => {
-    const services = mockServices({ chat: null });
-    const result = await awaitMediaProcessing(services, 'inst-1', 'chat-ext-1', 'ext-msg-1', 'image');
-    expect(result).toEqual(MEDIA_WAIT_NULL);
-  });
+  it(
+    'returns MEDIA_WAIT_NULL when chat is not found after retries',
+    async () => {
+      const services = mockServices({ chat: null });
+      const result = await awaitMediaProcessing(services, 'inst-1', 'chat-ext-1', 'ext-msg-1', 'image');
+      expect(result).toEqual(MEDIA_WAIT_NULL);
+    },
+    { timeout: 10_000 },
+  );
 
-  it('returns MEDIA_WAIT_NULL when message is not found', async () => {
-    const services = mockServices({ message: null });
-    const result = await awaitMediaProcessing(services, 'inst-1', 'chat-ext-1', 'ext-msg-1', 'image');
-    expect(result).toEqual(MEDIA_WAIT_NULL);
-  });
+  it(
+    'returns MEDIA_WAIT_NULL when message is not found after retries',
+    async () => {
+      const services = mockServices({ message: null });
+      const result = await awaitMediaProcessing(services, 'inst-1', 'chat-ext-1', 'ext-msg-1', 'image');
+      expect(result).toEqual(MEDIA_WAIT_NULL);
+    },
+    { timeout: 10_000 },
+  );
 
   it('returns immediately when DB already has processed result (DB-already-done)', async () => {
     const services = mockServices({

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -563,6 +563,26 @@ function checkProcessedColumn(
 }
 
 /**
+ * Retry a DB lookup until it returns a non-null result or 5s elapses.
+ * Handles the race where message-persistence hasn't written the row yet.
+ */
+async function waitForRecord<T>(
+  fn: () => Promise<T | null | undefined>,
+  maxMs = 5_000,
+  pollMs = 250,
+): Promise<T | null> {
+  let result = await fn();
+  if (result) return result;
+  const deadline = Date.now() + maxMs;
+  while (Date.now() < deadline) {
+    await sleep(pollMs);
+    result = await fn();
+    if (result) return result;
+  }
+  return null;
+}
+
+/**
  * Await media processing via NATS event instead of DB polling.
  * Checks: DB first (already done) → event cache (arrived early) → await promise (NATS delivery).
  */
@@ -576,15 +596,18 @@ async function awaitMediaProcessing(
   const column = getProcessedColumn(contentType);
   if (!column) return MEDIA_WAIT_NULL;
 
-  const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+  // Wait briefly for message-persistence to create the DB rows (race condition:
+  // both media-processor and agent-dispatcher subscribe to message.received,
+  // and the dispatcher's debounce may fire before persistence completes).
+  const chat = await waitForRecord(() => services.chats.findByExternalIdSmart(instanceId, chatId));
   if (!chat) {
     log.warn('Chat not found for media wait', { instanceId, chatId });
     return MEDIA_WAIT_NULL;
   }
 
-  const msg = await services.messages.getByExternalId(chat.id, externalId);
+  const msg = await waitForRecord(() => services.messages.getByExternalId(chat.id, externalId));
   if (!msg) {
-    log.warn('Message not found for media wait', { instanceId, chatId, externalId });
+    log.warn('Message not found for media wait after retries', { instanceId, chatId, externalId });
     return MEDIA_WAIT_NULL;
   }
 


### PR DESCRIPTION
## Problem
`awaitMediaProcessing()` fails with `[media processing unavailable]` when the message row doesn't exist in DB yet — race condition where the dispatcher's debounce fires before message-persistence writes the row.

Found during live QA: image sent to Sofia processed successfully by Gemini Vision (10.8s), but dispatcher returned null because message row wasn't in DB at lookup time.

## Fix
Extract `waitForRecord()` helper with 5s retry loop (250ms poll) for both chat and message lookups. Matches the same pattern used in `media-processor.ts` `resolveMediaPath()`.

## Changes
- `agent-dispatcher.ts`: add `waitForRecord()`, use it in `awaitMediaProcessing()`
- `media-await.test.ts`: update "not found" tests with 10s timeout (retry takes 5s)

## Test results
2721 tests, 0 fail