### PR TITLE
fix(cli): add missing flushStdout to output module mock

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -17,7 +17,7 @@ import {
   type ServerConfig,
   isValidConfigKey,
   loadServerConfig,
-} from '../config';
+} from '../config.js';
 
 describe('Config Validation', () => {
   describe('isValidConfigKey', () => {

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -7,86 +7,70 @@
 
 import { describe, expect, test } from 'bun:test';
 
-import {
-  type OutputFormat,
-  areColorsEnabled,
-  data,
-  dim,
-  disableColors,
-  error,
-  flushStdout,
-  getCurrentFormat,
-  header,
-  info,
-  keyValue,
-  list,
-  raw,
-  success,
-  warn,
-} from '../output';
+import type { OutputFormat } from '../output.js';
+import * as output from '../output.js';
 
 describe('Output Module Exports', () => {
   test('exports color control functions', () => {
-    expect(typeof disableColors).toBe('function');
-    expect(typeof areColorsEnabled).toBe('function');
+    expect(typeof output.disableColors).toBe('function');
+    expect(typeof output.areColorsEnabled).toBe('function');
   });
 
   test('exports format function', () => {
-    expect(typeof getCurrentFormat).toBe('function');
+    expect(typeof output.getCurrentFormat).toBe('function');
   });
 
   test('exports output functions', () => {
-    expect(typeof success).toBe('function');
-    expect(typeof error).toBe('function');
-    expect(typeof warn).toBe('function');
-    expect(typeof info).toBe('function');
-    expect(typeof data).toBe('function');
-    expect(typeof list).toBe('function');
-    expect(typeof keyValue).toBe('function');
-    expect(typeof header).toBe('function');
-    expect(typeof dim).toBe('function');
-    expect(typeof raw).toBe('function');
+    expect(typeof output.success).toBe('function');
+    expect(typeof output.error).toBe('function');
+    expect(typeof output.warn).toBe('function');
+    expect(typeof output.info).toBe('function');
+    expect(typeof output.data).toBe('function');
+    expect(typeof output.list).toBe('function');
+    expect(typeof output.keyValue).toBe('function');
+    expect(typeof output.header).toBe('function');
+    expect(typeof output.dim).toBe('function');
+    expect(typeof output.raw).toBe('function');
+  });
+
+  test('exports flushStdout', () => {
+    expect(typeof output.flushStdout).toBe('function');
   });
 });
 
 describe('areColorsEnabled', () => {
   test('returns a boolean', () => {
-    const result = areColorsEnabled();
+    const result = output.areColorsEnabled();
     expect(typeof result).toBe('boolean');
   });
 });
 
 describe('getCurrentFormat', () => {
   test('returns human or json', () => {
-    const format = getCurrentFormat();
+    const format = output.getCurrentFormat();
     expect(['human', 'json']).toContain(format);
   });
 
   test('return type is OutputFormat', () => {
-    const format: OutputFormat = getCurrentFormat();
+    const format: OutputFormat = output.getCurrentFormat();
     expect(format).toBeDefined();
   });
 });
 
 describe('disableColors', () => {
   test('can be called without error', () => {
-    expect(() => disableColors()).not.toThrow();
+    expect(() => output.disableColors()).not.toThrow();
   });
 });
 
 describe('flushStdout', () => {
-  test('is exported as a function', () => {
-    expect(typeof flushStdout).toBe('function');
-  });
-
   test('returns a promise that resolves', async () => {
-    const result = flushStdout();
+    const result = output.flushStdout();
     expect(result).toBeInstanceOf(Promise);
     await expect(result).resolves.toBeUndefined();
   });
 
   test('resolves after pending writes', async () => {
-    // flushStdout should resolve without error even after writes
-    await expect(flushStdout()).resolves.toBeUndefined();
+    await expect(output.flushStdout()).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/src/__tests__/resolve.test.ts
+++ b/packages/cli/src/__tests__/resolve.test.ts
@@ -31,6 +31,7 @@ mock.module('../output.js', () => ({
   areColorsEnabled: () => true,
   setMaxCellWidth: mock(),
   getCurrentFormat: () => 'human',
+  flushStdout: () => Promise.resolve(),
 }));
 
 // Mock getClient


### PR DESCRIPTION
## Summary

- **Root cause:** `resolve.test.ts` mocks `../output.js` via bun's `mock.module()` without including `flushStdout`. When bun runs tests in parallel and `resolve.test.ts` loads first, the mock replaces the real module globally — making `flushStdout` undefined for `output.test.ts`.
- Added `flushStdout: () => Promise.resolve()` to the mock in `resolve.test.ts`
- Standardized test imports to use `.js` extensions and namespace imports matching production code patterns

## Test plan

- [x] `bun test packages/cli/src/__tests__/output.test.ts` passes (10/10)
- [x] `bun test packages/cli/src/__tests__/` passes (94/94, 0 fail)
- [x] Full test suite: 2492 pass, 229 skip, 0 fail, 0 error
- [x] `bun run typecheck` passes
- [x] `bunx biome check .` passes

Fixes #264