### PR TITLE
feat(media): add retry, circuit breaker, and health metrics

### DIFF
--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -21,7 +21,12 @@ import type { ChannelType, EventBus, MessageReceivedPayload } from '@omni/core';
 import { createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
 import { mediaContent, messages } from '@omni/db';
-import { type MediaProcessingService, createMediaProcessingService } from '@omni/media-processing';
+import {
+  type MediaProcessingService,
+  createMediaProcessingService,
+  getMediaHealthTracker,
+  setGlobalCircuitBreakerStateChangeCallback,
+} from '@omni/media-processing';
 import { eq } from 'drizzle-orm';
 import type { Services } from '../services';
 import { MediaStorageService } from '../services/media-storage';
@@ -336,20 +341,35 @@ async function processMessageMedia(
   });
 
   if (!result.success) {
-    log.warn('Media processing failed', { messageId: media.messageId, error: result.errorMessage });
+    const reason = result.errorMessage ?? 'unknown';
+    log.warn('Media processing failed', { messageId: media.messageId, error: reason });
 
     // Write error marker so consumers can detect failures via DB check
     const processingType = result.processingType ?? inferProcessingType(content.type);
     const errorColumn = getContentFieldForType(processingType, content.type);
     if (errorColumn) {
-      const marker = `[error: ${result.errorMessage ?? 'unknown'}]`;
+      const marker = `[media processing failed: ${reason}]`;
       await ctx.db
         .update(messages)
         .set({ [errorColumn]: marker })
         .where(eq(messages.id, media.messageId));
     }
 
-    // Publish failure event so dispatcher resolves immediately instead of waiting
+    // Publish media.processing.failed event (dedicated failure event)
+    await ctx.eventBus.publish(
+      'media.processing.failed',
+      {
+        eventId: eventId ?? media.messageId,
+        mediaId: media.messageId,
+        processingType,
+        error: reason,
+        provider: result.provider,
+        model: result.model,
+      },
+      { instanceId, channelType: metadata.channelType },
+    );
+
+    // Also publish media.processed with error so dispatcher resolves immediately
     await ctx.eventBus.publish(
       'media.processed',
       {
@@ -357,7 +377,7 @@ async function processMessageMedia(
         mediaId: media.messageId,
         processingType,
         content: '',
-        error: result.errorMessage ?? 'unknown',
+        error: reason,
       },
       { instanceId, channelType: metadata.channelType },
     );
@@ -457,16 +477,34 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
           error: String(error),
         });
 
-        // Publish failure event for unexpected crashes so dispatcher doesn't wait forever
+        // Publish failure events for unexpected crashes so dispatcher doesn't wait forever
         try {
+          const crashProcessingType = inferProcessingType(content.type);
+          const crashReason = `unexpected: ${String(error)}`;
+
+          // Dedicated failure event
+          await ctx.eventBus.publish(
+            'media.processing.failed',
+            {
+              eventId: event.id,
+              mediaId: payload.externalId,
+              processingType: crashProcessingType,
+              error: crashReason,
+              provider: 'unknown',
+              model: 'unknown',
+            },
+            { instanceId: metadata.instanceId, channelType: metadata.channelType },
+          );
+
+          // Also publish media.processed for backward compatibility
           await ctx.eventBus.publish(
             'media.processed',
             {
               eventId: event.id,
               mediaId: payload.externalId,
-              processingType: inferProcessingType(content.type),
+              processingType: crashProcessingType,
               content: '',
-              error: `unexpected: ${String(error)}`,
+              error: crashReason,
             },
             { instanceId: metadata.instanceId, channelType: metadata.channelType },
           );
@@ -483,6 +521,37 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
       retryDelayMs: 1000,
       startFrom: 'first',
       concurrency: 5, // Process up to 5 media files in parallel
+    },
+  );
+
+  // Set up circuit breaker state change logging
+  setGlobalCircuitBreakerStateChangeCallback((name, from, to) => {
+    log.warn('Circuit breaker state change', { provider: name, from, to });
+  });
+
+  // Subscribe to media.health requests and respond with health report
+  await eventBus.subscribePattern(
+    'media.health.request',
+    async (event) => {
+      const tracker = getMediaHealthTracker();
+      const report = tracker.getReport();
+      const correlationId = event.metadata?.correlationId ?? event.id;
+
+      await eventBus.publishGeneric(
+        'system.media.health.response',
+        { correlationId, report },
+        { source: 'media-processor' },
+      );
+
+      log.debug('Published media health report', {
+        correlationId,
+        totalRequests: report.overall.totalRequests,
+        successRate: report.overall.successRate,
+      });
+    },
+    {
+      durable: 'media-health-responder',
+      queue: 'media-health-responder',
     },
   );
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -27,6 +27,7 @@ export const CORE_EVENT_TYPES = [
   // Media processing
   'media.received',
   'media.processed',
+  'media.processing.failed',
   // Identity management
   'identity.created',
   'identity.linked',
@@ -302,6 +303,17 @@ export interface MediaProcessedPayload {
   tokensUsed?: number;
   /** Set when processing failed — content will be empty string */
   error?: string;
+}
+
+export interface MediaProcessingFailedPayload {
+  eventId: string;
+  mediaId: string;
+  processingType: 'transcription' | 'description' | 'extraction';
+  error: string;
+  provider?: string;
+  model?: string;
+  /** Number of retry attempts made before giving up */
+  retryAttempts?: number;
 }
 
 /**
@@ -639,6 +651,7 @@ export interface EventPayloadMap {
   'message.poll_vote': MessagePollVotePayload;
   'media.received': MediaReceivedPayload;
   'media.processed': MediaProcessedPayload;
+  'media.processing.failed': MediaProcessingFailedPayload;
   'identity.created': IdentityCreatedPayload;
   'identity.linked': IdentityLinkedPayload;
   'identity.merged': IdentityMergedPayload;

--- a/packages/media-processing/__tests__/circuit-breaker.test.ts
+++ b/packages/media-processing/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for circuit breaker module
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { CircuitBreaker, CircuitOpenError, getCircuitBreaker, resetAllCircuitBreakers } from '../src/circuit-breaker';
+
+describe('CircuitBreaker', () => {
+  afterEach(() => {
+    resetAllCircuitBreakers();
+  });
+
+  describe('initial state', () => {
+    it('starts in closed state', () => {
+      const breaker = new CircuitBreaker({ name: 'test' });
+      expect(breaker.getState()).toBe('closed');
+    });
+
+    it('has zero failures and successes initially', () => {
+      const breaker = new CircuitBreaker({ name: 'test' });
+      const stats = breaker.getStats();
+      expect(stats.failures).toBe(0);
+      expect(stats.successes).toBe(0);
+      expect(stats.state).toBe('closed');
+      expect(stats.name).toBe('test');
+    });
+  });
+
+  describe('closed state', () => {
+    it('executes functions normally', async () => {
+      const breaker = new CircuitBreaker({ name: 'test' });
+      const result = await breaker.execute(() => Promise.resolve('ok'));
+      expect(result).toBe('ok');
+    });
+
+    it('tracks successes', async () => {
+      const breaker = new CircuitBreaker({ name: 'test' });
+      await breaker.execute(() => Promise.resolve('ok'));
+      await breaker.execute(() => Promise.resolve('ok'));
+      expect(breaker.getStats().successes).toBe(2);
+    });
+
+    it('tracks failures without opening below threshold', async () => {
+      const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 5 });
+
+      for (let i = 0; i < 4; i++) {
+        try {
+          await breaker.execute(() => Promise.reject(new Error('fail')));
+        } catch {
+          // expected
+        }
+      }
+
+      expect(breaker.getState()).toBe('closed');
+      expect(breaker.getStats().failures).toBe(4);
+    });
+  });
+
+  describe('opening the circuit', () => {
+    it('opens after failureThreshold failures', async () => {
+      const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 3 });
+
+      for (let i = 0; i < 3; i++) {
+        try {
+          await breaker.execute(() => Promise.reject(new Error('fail')));
+        } catch {
+          // expected
+        }
+      }
+
+      expect(breaker.getState()).toBe('open');
+    });
+
+    it('rejects immediately when open', async () => {
+      const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1 });
+
+      try {
+        await breaker.execute(() => Promise.reject(new Error('fail')));
+      } catch {
+        // expected
+      }
+
+      expect(breaker.getState()).toBe('open');
+
+      try {
+        await breaker.execute(() => Promise.resolve('should not run'));
+        expect.unreachable('Should have thrown CircuitOpenError');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CircuitOpenError);
+        expect((error as Error).message).toContain('test');
+      }
+    });
+  });
+
+  describe('half-open state', () => {
+    it('transitions to half-open after resetTimeout', async () => {
+      const breaker = new CircuitBreaker({
+        name: 'test',
+        failureThreshold: 1,
+        resetTimeoutMs: 50, // Very short for testing
+      });
+
+      // Trip the breaker
+      try {
+        await breaker.execute(() => Promise.reject(new Error('fail')));
+      } catch {
+        // expected
+      }
+      expect(breaker.getState()).toBe('open');
+
+      // Wait for reset timeout
+      await new Promise((r) => setTimeout(r, 60));
+
+      expect(breaker.getState()).toBe('half-open');
+    });
+
+    it('closes on successful probe', async () => {
+      const breaker = new CircuitBreaker({
+        name: 'test',
+        failureThreshold: 1,
+        resetTimeoutMs: 50,
+      });
+
+      // Trip the breaker
+      try {
+        await breaker.execute(() => Promise.reject(new Error('fail')));
+      } catch {
+        // expected
+      }
+
+      // Wait for reset timeout
+      await new Promise((r) => setTimeout(r, 60));
+
+      // Successful probe
+      const result = await breaker.execute(() => Promise.resolve('recovered'));
+      expect(result).toBe('recovered');
+      expect(breaker.getState()).toBe('closed');
+    });
+
+    it('re-opens on failed probe', async () => {
+      const breaker = new CircuitBreaker({
+        name: 'test',
+        failureThreshold: 1,
+        resetTimeoutMs: 50,
+      });
+
+      // Trip the breaker
+      try {
+        await breaker.execute(() => Promise.reject(new Error('fail1')));
+      } catch {
+        // expected
+      }
+
+      // Wait for reset timeout
+      await new Promise((r) => setTimeout(r, 60));
+
+      // Failed probe
+      try {
+        await breaker.execute(() => Promise.reject(new Error('still failing')));
+      } catch {
+        // expected
+      }
+
+      expect(breaker.getState()).toBe('open');
+    });
+  });
+
+  describe('rolling window', () => {
+    it('forgets old failures outside the window', async () => {
+      const breaker = new CircuitBreaker({
+        name: 'test',
+        failureThreshold: 3,
+        windowMs: 100, // Very short window for testing
+      });
+
+      // Add 2 failures
+      for (let i = 0; i < 2; i++) {
+        try {
+          await breaker.execute(() => Promise.reject(new Error('fail')));
+        } catch {
+          // expected
+        }
+      }
+
+      // Wait for window to expire
+      await new Promise((r) => setTimeout(r, 150));
+
+      // Add 2 more failures — should still be closed because old ones expired
+      for (let i = 0; i < 2; i++) {
+        try {
+          await breaker.execute(() => Promise.reject(new Error('fail')));
+        } catch {
+          // expected
+        }
+      }
+
+      expect(breaker.getState()).toBe('closed');
+    });
+  });
+
+  describe('reset', () => {
+    it('resets breaker to closed state', async () => {
+      const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1 });
+
+      try {
+        await breaker.execute(() => Promise.reject(new Error('fail')));
+      } catch {
+        // expected
+      }
+      expect(breaker.getState()).toBe('open');
+
+      breaker.reset();
+      expect(breaker.getState()).toBe('closed');
+      expect(breaker.getStats().failures).toBe(0);
+      expect(breaker.getStats().successes).toBe(0);
+    });
+  });
+
+  describe('getCircuitBreaker registry', () => {
+    it('returns the same instance for the same name', () => {
+      const breaker1 = getCircuitBreaker('groq');
+      const breaker2 = getCircuitBreaker('groq');
+      expect(breaker1).toBe(breaker2);
+    });
+
+    it('returns different instances for different names', () => {
+      const groq = getCircuitBreaker('groq');
+      const openai = getCircuitBreaker('openai');
+      expect(groq).not.toBe(openai);
+    });
+  });
+
+  describe('resetAllCircuitBreakers', () => {
+    it('clears the registry', () => {
+      const breaker1 = getCircuitBreaker('test1');
+      resetAllCircuitBreakers();
+      const breaker2 = getCircuitBreaker('test1');
+      expect(breaker1).not.toBe(breaker2);
+    });
+  });
+});

--- a/packages/media-processing/__tests__/retry.test.ts
+++ b/packages/media-processing/__tests__/retry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for retry module
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { calculateBackoffDelay, isTransientError, withRetry } from '../src/retry';
+
+describe('retry', () => {
+  describe('isTransientError', () => {
+    it('detects rate limit errors (429)', () => {
+      expect(isTransientError(new Error('Request failed with status 429'))).toBe(true);
+      expect(isTransientError(new Error('rate limit exceeded'))).toBe(true);
+      expect(isTransientError(new Error('Too Many Requests'))).toBe(true);
+    });
+
+    it('detects resource exhausted errors', () => {
+      expect(isTransientError(new Error('RESOURCE_EXHAUSTED: quota exceeded'))).toBe(true);
+      expect(isTransientError(new Error('resource exhausted'))).toBe(true);
+    });
+
+    it('detects timeout errors', () => {
+      expect(isTransientError(new Error('Request timed out'))).toBe(true);
+      expect(isTransientError(new Error('Operation timeout'))).toBe(true);
+      expect(isTransientError(new Error('Connection aborted'))).toBe(true);
+
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      expect(isTransientError(abortError)).toBe(true);
+    });
+
+    it('detects network errors', () => {
+      expect(isTransientError(new Error('ECONNRESET'))).toBe(true);
+      expect(isTransientError(new Error('ECONNREFUSED'))).toBe(true);
+      expect(isTransientError(new Error('ENOTFOUND'))).toBe(true);
+      expect(isTransientError(new Error('ETIMEDOUT'))).toBe(true);
+      expect(isTransientError(new Error('fetch failed'))).toBe(true);
+      expect(isTransientError(new Error('socket hang up'))).toBe(true);
+    });
+
+    it('detects server errors (5xx)', () => {
+      expect(isTransientError(new Error('Request failed with status 500'))).toBe(true);
+      expect(isTransientError(new Error('502 Bad Gateway'))).toBe(true);
+      expect(isTransientError(new Error('503 Service Unavailable'))).toBe(true);
+      expect(isTransientError(new Error('504 Gateway Timeout'))).toBe(true);
+      expect(isTransientError(new Error('Internal Server Error'))).toBe(true);
+    });
+
+    it('does not detect non-transient errors', () => {
+      expect(isTransientError(new Error('Invalid API key'))).toBe(false);
+      expect(isTransientError(new Error('Not Found (404)'))).toBe(false);
+      expect(isTransientError(new Error('Bad Request'))).toBe(false);
+      expect(isTransientError(new Error('Unauthorized'))).toBe(false);
+    });
+
+    it('returns false for non-Error values', () => {
+      expect(isTransientError('some string')).toBe(false);
+      expect(isTransientError(null)).toBe(false);
+      expect(isTransientError(undefined)).toBe(false);
+      expect(isTransientError(42)).toBe(false);
+    });
+  });
+
+  describe('calculateBackoffDelay', () => {
+    it('calculates exponential delay', () => {
+      // With jitter, delay is between base and base*1.25
+      const delay0 = calculateBackoffDelay(0, 1000, 10000);
+      expect(delay0).toBeGreaterThanOrEqual(1000);
+      expect(delay0).toBeLessThanOrEqual(1250);
+
+      const delay1 = calculateBackoffDelay(1, 1000, 10000);
+      expect(delay1).toBeGreaterThanOrEqual(2000);
+      expect(delay1).toBeLessThanOrEqual(2500);
+
+      const delay2 = calculateBackoffDelay(2, 1000, 10000);
+      expect(delay2).toBeGreaterThanOrEqual(4000);
+      expect(delay2).toBeLessThanOrEqual(5000);
+    });
+
+    it('respects maximum delay', () => {
+      const delay = calculateBackoffDelay(10, 1000, 5000);
+      expect(delay).toBeGreaterThanOrEqual(5000);
+      expect(delay).toBeLessThanOrEqual(6250); // 5000 + 25% jitter
+    });
+  });
+
+  describe('withRetry', () => {
+    it('returns result on first success', async () => {
+      const result = await withRetry(() => Promise.resolve('ok'));
+      expect(result).toBe('ok');
+    });
+
+    it('retries on transient error and succeeds', async () => {
+      let calls = 0;
+      const result = await withRetry(
+        () => {
+          calls++;
+          if (calls < 3) {
+            throw new Error('429 rate limit');
+          }
+          return Promise.resolve('recovered');
+        },
+        { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 50 },
+      );
+      expect(result).toBe('recovered');
+      expect(calls).toBe(3);
+    });
+
+    it('does not retry on non-transient error', async () => {
+      let calls = 0;
+      try {
+        await withRetry(
+          () => {
+            calls++;
+            throw new Error('Invalid API key');
+          },
+          { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 50 },
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect((error as Error).message).toBe('Invalid API key');
+        expect(calls).toBe(1); // Only one attempt, no retries
+      }
+    });
+
+    it('throws after all retries exhausted', async () => {
+      let calls = 0;
+      try {
+        await withRetry(
+          () => {
+            calls++;
+            throw new Error('503 Service Unavailable');
+          },
+          { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 },
+        );
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect((error as Error).message).toBe('503 Service Unavailable');
+        expect(calls).toBe(3); // 1 initial + 2 retries
+      }
+    });
+
+    it('calls onRetry callback', async () => {
+      const retryAttempts: number[] = [];
+      try {
+        await withRetry(
+          () => {
+            throw new Error('ECONNRESET');
+          },
+          {
+            maxRetries: 2,
+            baseDelayMs: 10,
+            maxDelayMs: 50,
+            onRetry: (attempt) => retryAttempts.push(attempt),
+          },
+        );
+      } catch {
+        // expected
+      }
+      expect(retryAttempts).toEqual([1, 2]);
+    });
+
+    it('respects per-attempt timeout', async () => {
+      try {
+        await withRetry(() => new Promise((resolve) => setTimeout(resolve, 5000)), { maxRetries: 0, timeoutMs: 50 });
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect((error as Error).message).toContain('timed out');
+      }
+    });
+  });
+});

--- a/packages/media-processing/src/circuit-breaker.ts
+++ b/packages/media-processing/src/circuit-breaker.ts
@@ -1,0 +1,317 @@
+/**
+ * Circuit Breaker
+ *
+ * Prevents cascading failures by tracking provider health and short-circuiting
+ * requests when a provider is unhealthy. Each provider (groq, openai, gemini)
+ * gets its own CircuitBreaker instance.
+ *
+ * States:
+ * - CLOSED: Normal operation. Track failures in a rolling window.
+ * - OPEN: After failureThreshold failures in windowMs, reject immediately for resetTimeoutMs.
+ * - HALF-OPEN: After cooldown, allow one probe request. Success -> CLOSED, failure -> OPEN.
+ */
+
+import { createLogger } from '@omni/core';
+
+const log = createLogger('media-processing:circuit-breaker');
+
+/**
+ * Circuit breaker state
+ */
+export type CircuitBreakerState = 'closed' | 'open' | 'half-open';
+
+/**
+ * Callback invoked when the circuit breaker transitions between states.
+ */
+export type CircuitBreakerStateChangeCallback = (
+  name: string,
+  from: CircuitBreakerState,
+  to: CircuitBreakerState,
+) => void;
+
+/**
+ * Configuration for the circuit breaker
+ */
+export interface CircuitBreakerOptions {
+  /** Name of the provider (for logging) */
+  name: string;
+  /** Number of failures within windowMs to trip the breaker (default 5) */
+  failureThreshold: number;
+  /** Time in ms to keep the circuit open before allowing a probe (default 300000 = 5 min) */
+  resetTimeoutMs: number;
+  /** Rolling window in ms to track failures (default 600000 = 10 min) */
+  windowMs: number;
+  /** Optional callback for state transitions */
+  onStateChange?: CircuitBreakerStateChangeCallback;
+}
+
+/**
+ * Default circuit breaker options
+ */
+export const DEFAULT_CIRCUIT_BREAKER_OPTIONS: Omit<CircuitBreakerOptions, 'name'> = {
+  failureThreshold: 5,
+  resetTimeoutMs: 300_000, // 5 minutes
+  windowMs: 600_000, // 10 minutes
+};
+
+/**
+ * Statistics about the circuit breaker state
+ */
+export interface CircuitBreakerStats {
+  /** Current number of failures in the window */
+  failures: number;
+  /** Current number of successes in the window */
+  successes: number;
+  /** Current state */
+  state: CircuitBreakerState;
+  /** Provider name */
+  name: string;
+}
+
+/**
+ * Error thrown when the circuit breaker is open
+ */
+export class CircuitOpenError extends Error {
+  constructor(name: string) {
+    super(`Circuit breaker is open for provider "${name}" — requests are being rejected`);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+/**
+ * Circuit breaker implementation with rolling window failure tracking.
+ */
+export class CircuitBreaker {
+  private readonly name: string;
+  private readonly failureThreshold: number;
+  private readonly resetTimeoutMs: number;
+  private readonly windowMs: number;
+  private onStateChangeCallback?: CircuitBreakerStateChangeCallback;
+
+  private state: CircuitBreakerState = 'closed';
+  private failureTimestamps: number[] = [];
+  private successCount = 0;
+  private lastFailureTime = 0;
+  private halfOpenInFlight = false;
+
+  constructor(options: Partial<CircuitBreakerOptions> & { name: string }) {
+    this.name = options.name;
+    this.failureThreshold = options.failureThreshold ?? DEFAULT_CIRCUIT_BREAKER_OPTIONS.failureThreshold;
+    this.resetTimeoutMs = options.resetTimeoutMs ?? DEFAULT_CIRCUIT_BREAKER_OPTIONS.resetTimeoutMs;
+    this.windowMs = options.windowMs ?? DEFAULT_CIRCUIT_BREAKER_OPTIONS.windowMs;
+    this.onStateChangeCallback = options.onStateChange;
+  }
+
+  /**
+   * Set a callback to be invoked on state transitions.
+   * Replaces any previously set callback.
+   */
+  setOnStateChange(callback: CircuitBreakerStateChangeCallback | undefined): void {
+    this.onStateChangeCallback = callback;
+  }
+
+  /**
+   * Execute a function through the circuit breaker.
+   *
+   * - CLOSED: Execute normally, track failures.
+   * - OPEN: Reject immediately with CircuitOpenError.
+   * - HALF-OPEN: Allow one probe request; success closes, failure re-opens.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    const currentState = this.evaluateState();
+
+    if (currentState === 'open') {
+      throw new CircuitOpenError(this.name);
+    }
+
+    if (currentState === 'half-open') {
+      // Only allow one concurrent probe
+      if (this.halfOpenInFlight) {
+        throw new CircuitOpenError(this.name);
+      }
+      this.halfOpenInFlight = true;
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess(currentState);
+      return result;
+    } catch (error) {
+      this.onFailure(currentState);
+      throw error;
+    }
+  }
+
+  /**
+   * Get the current state of the circuit breaker.
+   */
+  getState(): CircuitBreakerState {
+    return this.evaluateState();
+  }
+
+  /**
+   * Get statistics about the circuit breaker.
+   */
+  getStats(): CircuitBreakerStats {
+    this.pruneOldFailures();
+    return {
+      failures: this.failureTimestamps.length,
+      successes: this.successCount,
+      state: this.evaluateState(),
+      name: this.name,
+    };
+  }
+
+  /**
+   * Manually reset the circuit breaker to closed state.
+   */
+  reset(): void {
+    this.state = 'closed';
+    this.failureTimestamps = [];
+    this.successCount = 0;
+    this.lastFailureTime = 0;
+    this.halfOpenInFlight = false;
+    log.info('Circuit breaker manually reset', { name: this.name });
+  }
+
+  /**
+   * Evaluate the current state, checking if OPEN should transition to HALF-OPEN.
+   */
+  private evaluateState(): CircuitBreakerState {
+    if (this.state === 'open') {
+      const timeSinceLastFailure = Date.now() - this.lastFailureTime;
+      if (timeSinceLastFailure >= this.resetTimeoutMs) {
+        const from = this.state;
+        this.state = 'half-open';
+        this.halfOpenInFlight = false;
+        log.info('Circuit breaker transitioning to half-open', { name: this.name });
+        this.emitStateChange(from, 'half-open');
+      }
+    }
+    return this.state;
+  }
+
+  /**
+   * Handle a successful execution.
+   */
+  private onSuccess(stateAtExecution: CircuitBreakerState): void {
+    this.successCount++;
+    this.halfOpenInFlight = false;
+
+    if (stateAtExecution === 'half-open') {
+      // Probe succeeded — close the circuit
+      this.state = 'closed';
+      this.failureTimestamps = [];
+      log.info('Circuit breaker closed after successful probe', { name: this.name });
+      this.emitStateChange('half-open', 'closed');
+    }
+  }
+
+  /**
+   * Handle a failed execution.
+   */
+  private onFailure(stateAtExecution: CircuitBreakerState): void {
+    this.halfOpenInFlight = false;
+    const now = Date.now();
+    this.lastFailureTime = now;
+
+    if (stateAtExecution === 'half-open') {
+      // Probe failed — re-open the circuit
+      this.state = 'open';
+      log.warn('Circuit breaker re-opened after failed probe', { name: this.name });
+      this.emitStateChange('half-open', 'open');
+      return;
+    }
+
+    // Track failure in rolling window
+    this.failureTimestamps.push(now);
+    this.pruneOldFailures();
+
+    if (this.failureTimestamps.length >= this.failureThreshold) {
+      const from = stateAtExecution;
+      this.state = 'open';
+      log.warn('Circuit breaker opened', {
+        name: this.name,
+        failures: this.failureTimestamps.length,
+        threshold: this.failureThreshold,
+      });
+      this.emitStateChange(from, 'open');
+    }
+  }
+
+  /**
+   * Emit a state change notification via the callback.
+   */
+  private emitStateChange(from: CircuitBreakerState, to: CircuitBreakerState): void {
+    if (this.onStateChangeCallback) {
+      try {
+        this.onStateChangeCallback(this.name, from, to);
+      } catch (err) {
+        log.warn('onStateChange callback error', { name: this.name, error: String(err) });
+      }
+    }
+  }
+
+  /**
+   * Remove failure timestamps outside the rolling window.
+   */
+  private pruneOldFailures(): void {
+    const cutoff = Date.now() - this.windowMs;
+    this.failureTimestamps = this.failureTimestamps.filter((ts) => ts > cutoff);
+  }
+}
+
+/**
+ * Registry of circuit breakers keyed by provider name.
+ * Ensures each provider gets exactly one circuit breaker instance.
+ */
+const circuitBreakerRegistry = new Map<string, CircuitBreaker>();
+
+/**
+ * Global state change listener applied to all circuit breakers created via the registry.
+ */
+let globalStateChangeCallback: CircuitBreakerStateChangeCallback | undefined;
+
+/**
+ * Set a global callback that will be invoked whenever any registered circuit breaker
+ * transitions between states. Also retroactively applies to existing breakers.
+ */
+export function setGlobalCircuitBreakerStateChangeCallback(
+  callback: CircuitBreakerStateChangeCallback | undefined,
+): void {
+  globalStateChangeCallback = callback;
+  // Apply to already-registered breakers
+  for (const breaker of circuitBreakerRegistry.values()) {
+    breaker.setOnStateChange(callback);
+  }
+}
+
+/**
+ * Get or create a circuit breaker for a provider.
+ *
+ * @param name - Provider name (e.g. 'groq', 'openai', 'gemini')
+ * @param options - Optional configuration overrides
+ * @returns The circuit breaker instance for this provider
+ */
+export function getCircuitBreaker(
+  name: string,
+  options?: Partial<Omit<CircuitBreakerOptions, 'name'>>,
+): CircuitBreaker {
+  let breaker = circuitBreakerRegistry.get(name);
+  if (!breaker) {
+    breaker = new CircuitBreaker({ name, onStateChange: globalStateChangeCallback, ...options });
+    circuitBreakerRegistry.set(name, breaker);
+    log.debug('Circuit breaker created', { name });
+  }
+  return breaker;
+}
+
+/**
+ * Reset all circuit breakers. Useful for testing.
+ */
+export function resetAllCircuitBreakers(): void {
+  for (const breaker of circuitBreakerRegistry.values()) {
+    breaker.reset();
+  }
+  circuitBreakerRegistry.clear();
+}

--- a/packages/media-processing/src/health.ts
+++ b/packages/media-processing/src/health.ts
@@ -1,0 +1,203 @@
+/**
+ * Media Health Tracker
+ *
+ * Tracks per-processor, per-provider metrics for media processing operations.
+ * Provides health reports with success rates, latencies, and circuit breaker states.
+ *
+ * Usage:
+ *   const tracker = getMediaHealthTracker();
+ *   tracker.recordSuccess('audio', 'groq', 150);
+ *   tracker.recordFailure('audio', 'groq', 'rate limit exceeded');
+ *   const report = tracker.getReport();
+ */
+
+import { createLogger } from '@omni/core';
+import { type CircuitBreakerState, getCircuitBreaker } from './circuit-breaker';
+
+const log = createLogger('media-processing:health');
+
+/**
+ * Per-provider, per-processor metrics
+ */
+export interface ProviderMetrics {
+  provider: string;
+  processor: string; // 'audio' | 'image' | 'video' | 'document'
+  successCount: number;
+  failureCount: number;
+  totalLatencyMs: number;
+  avgLatencyMs: number;
+  successRate: number; // 0-1
+  circuitState: CircuitBreakerState;
+  lastFailure?: string; // error message
+  lastFailureAt?: number; // timestamp
+}
+
+/**
+ * Overall media health report
+ */
+export interface MediaHealthReport {
+  timestamp: number;
+  processors: ProviderMetrics[];
+  overall: {
+    totalRequests: number;
+    successRate: number;
+    avgLatencyMs: number;
+  };
+}
+
+/**
+ * Internal mutable metrics for a processor+provider pair
+ */
+interface MetricsEntry {
+  provider: string;
+  processor: string;
+  successCount: number;
+  failureCount: number;
+  totalLatencyMs: number;
+  lastFailure?: string;
+  lastFailureAt?: number;
+}
+
+/**
+ * Build a composite key for the metrics map
+ */
+function metricsKey(processor: string, provider: string): string {
+  return `${processor}:${provider}`;
+}
+
+/**
+ * Tracks health metrics for media processing operations.
+ *
+ * Thread-safe for single-threaded Node/Bun runtimes (no concurrent writes).
+ * Metrics accumulate until reset() is called.
+ */
+export class MediaHealthTracker {
+  private readonly metrics = new Map<string, MetricsEntry>();
+
+  /**
+   * Record a successful provider call
+   */
+  recordSuccess(processor: string, provider: string, latencyMs: number): void {
+    const entry = this.getOrCreate(processor, provider);
+    entry.successCount++;
+    entry.totalLatencyMs += latencyMs;
+  }
+
+  /**
+   * Record a failed provider call
+   */
+  recordFailure(processor: string, provider: string, error: string): void {
+    const entry = this.getOrCreate(processor, provider);
+    entry.failureCount++;
+    entry.lastFailure = error;
+    entry.lastFailureAt = Date.now();
+  }
+
+  /**
+   * Generate a full health report with computed metrics
+   */
+  getReport(): MediaHealthReport {
+    const processors: ProviderMetrics[] = [];
+    let totalRequests = 0;
+    let totalSuccesses = 0;
+    let totalLatencyMs = 0;
+
+    for (const entry of this.metrics.values()) {
+      const total = entry.successCount + entry.failureCount;
+      const avgLatencyMs = entry.successCount > 0 ? Math.round(entry.totalLatencyMs / entry.successCount) : 0;
+      const successRate = total > 0 ? entry.successCount / total : 0;
+
+      // Look up circuit breaker state for this provider
+      let circuitState: CircuitBreakerState = 'closed';
+      try {
+        const breaker = getCircuitBreaker(entry.provider);
+        circuitState = breaker.getState();
+      } catch {
+        // No breaker registered — default to closed
+      }
+
+      processors.push({
+        provider: entry.provider,
+        processor: entry.processor,
+        successCount: entry.successCount,
+        failureCount: entry.failureCount,
+        totalLatencyMs: entry.totalLatencyMs,
+        avgLatencyMs,
+        successRate: Math.round(successRate * 1000) / 1000, // 3 decimal places
+        circuitState,
+        lastFailure: entry.lastFailure,
+        lastFailureAt: entry.lastFailureAt,
+      });
+
+      totalRequests += total;
+      totalSuccesses += entry.successCount;
+      totalLatencyMs += entry.totalLatencyMs;
+    }
+
+    const overallSuccessRate = totalRequests > 0 ? totalSuccesses / totalRequests : 0;
+    const overallAvgLatency = totalSuccesses > 0 ? Math.round(totalLatencyMs / totalSuccesses) : 0;
+
+    return {
+      timestamp: Date.now(),
+      processors,
+      overall: {
+        totalRequests,
+        successRate: Math.round(overallSuccessRate * 1000) / 1000,
+        avgLatencyMs: overallAvgLatency,
+      },
+    };
+  }
+
+  /**
+   * Reset all metrics
+   */
+  reset(): void {
+    this.metrics.clear();
+    log.info('Health metrics reset');
+  }
+
+  /**
+   * Get or create a metrics entry for a processor+provider pair
+   */
+  private getOrCreate(processor: string, provider: string): MetricsEntry {
+    const key = metricsKey(processor, provider);
+    let entry = this.metrics.get(key);
+    if (!entry) {
+      entry = {
+        provider,
+        processor,
+        successCount: 0,
+        failureCount: 0,
+        totalLatencyMs: 0,
+      };
+      this.metrics.set(key, entry);
+    }
+    return entry;
+  }
+}
+
+/**
+ * Singleton health tracker instance.
+ * Shared across all processors within the same process.
+ */
+let globalTracker: MediaHealthTracker | null = null;
+
+/**
+ * Get the singleton MediaHealthTracker instance.
+ */
+export function getMediaHealthTracker(): MediaHealthTracker {
+  if (!globalTracker) {
+    globalTracker = new MediaHealthTracker();
+  }
+  return globalTracker;
+}
+
+/**
+ * Reset the global tracker (useful for testing).
+ */
+export function resetMediaHealthTracker(): void {
+  if (globalTracker) {
+    globalTracker.reset();
+  }
+  globalTracker = null;
+}

--- a/packages/media-processing/src/index.ts
+++ b/packages/media-processing/src/index.ts
@@ -11,6 +11,30 @@ export { MediaProcessingService, createMediaProcessingService } from './service'
 // Processors
 export { BaseProcessor, AudioProcessor, ImageProcessor, DocumentProcessor } from './processors';
 
+// Retry
+export { withRetry, isTransientError, calculateBackoffDelay, DEFAULT_RETRY_OPTIONS } from './retry';
+export type { RetryOptions } from './retry';
+
+// Circuit Breaker
+export {
+  CircuitBreaker,
+  CircuitOpenError,
+  getCircuitBreaker,
+  resetAllCircuitBreakers,
+  setGlobalCircuitBreakerStateChangeCallback,
+  DEFAULT_CIRCUIT_BREAKER_OPTIONS,
+} from './circuit-breaker';
+export type {
+  CircuitBreakerOptions,
+  CircuitBreakerState,
+  CircuitBreakerStateChangeCallback,
+  CircuitBreakerStats,
+} from './circuit-breaker';
+
+// Health
+export { MediaHealthTracker, getMediaHealthTracker, resetMediaHealthTracker } from './health';
+export type { ProviderMetrics, MediaHealthReport } from './health';
+
 // Types
 export type {
   ProcessingResult,
@@ -20,7 +44,9 @@ export type {
   PricingUnit,
   PricingRate,
   MediaContentInput,
+  MediaTimeoutConfig,
 } from './types';
+export { DEFAULT_MEDIA_TIMEOUTS, getMediaTimeouts } from './types';
 
 // Models
 export { GEMINI_MODEL, OPENAI_VISION_MODEL, OPENAI_WHISPER_MODEL, GROQ_WHISPER_MODEL } from './models';

--- a/packages/media-processing/src/processors/audio.ts
+++ b/packages/media-processing/src/processors/audio.ts
@@ -3,6 +3,8 @@
  *
  * Transcribes audio using Groq Whisper (primary) with OpenAI fallback.
  * Groq's Whisper is extremely fast (216x real-time) and cost-effective.
+ *
+ * Uses centralized retry + circuit breaker for resilience.
  */
 
 import { createReadStream, statSync } from 'node:fs';
@@ -13,9 +15,8 @@ import type { Uploadable } from 'openai/uploads';
 import { GROQ_WHISPER_MODEL, OPENAI_WHISPER_MODEL } from '../models';
 import { calculateCost } from '../pricing';
 import type { ProcessOptions, ProcessingResult } from '../types';
+import { getMediaTimeouts } from '../types';
 import { BaseProcessor } from './base';
-
-const MAX_RETRIES = 3;
 
 /**
  * Audio processor using Groq Whisper with OpenAI fallback
@@ -101,7 +102,7 @@ export class AudioProcessor extends BaseProcessor {
   }
 
   /**
-   * Transcribe using Groq Whisper API with retry on rate limits
+   * Transcribe using Groq Whisper API with retry + circuit breaker
    */
   private async transcribeWithGroq(filePath: string, language: string): Promise<ProcessingResult> {
     const client = this.getGroqClient();
@@ -109,54 +110,47 @@ export class AudioProcessor extends BaseProcessor {
       return this.createFailedResult('Groq client not configured (missing API key)', 'groq', GROQ_WHISPER_MODEL);
     }
 
-    let lastError: Error | null = null;
+    const timeouts = getMediaTimeouts();
 
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        // Use ReadStream which is compatible with the SDK
-        const fileStream = createReadStream(filePath);
+    try {
+      const text = await this.executeWithResilience(
+        'groq',
+        async () => {
+          const fileStream = createReadStream(filePath);
 
-        const transcription = await client.audio.transcriptions.create({
-          file: fileStream as unknown as Uploadable,
-          model: GROQ_WHISPER_MODEL,
-          language,
-          response_format: 'text',
-        });
+          const transcription = await client.audio.transcriptions.create({
+            file: fileStream as unknown as Uploadable,
+            model: GROQ_WHISPER_MODEL,
+            language,
+            response_format: 'text',
+          });
 
-        // Groq returns text directly when response_format="text"
-        const text =
-          typeof transcription === 'string' ? transcription : ((transcription as { text?: string }).text ?? '');
+          return typeof transcription === 'string' ? transcription : ((transcription as { text?: string }).text ?? '');
+        },
+        { timeoutMs: timeouts.audioTimeoutMs },
+      );
 
-        return {
-          success: true,
-          content: text.trim(),
-          contentFormat: 'text',
-          processingType: 'transcription',
-          provider: 'groq',
-          model: GROQ_WHISPER_MODEL,
-          processingTimeMs: 0,
-          language,
-          costCents: 0,
-        };
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-
-        if (this.isRateLimitError(error)) {
-          this.log.warn(`Groq rate limit hit (attempt ${attempt + 1}/${MAX_RETRIES}), retrying...`);
-          await this.sleep(attempt);
-        } else {
-          // Non-rate-limit error, don't retry
-          this.log.error('Groq transcription error', { error: lastError.message });
-          break;
-        }
-      }
+      return {
+        success: true,
+        content: text.trim(),
+        contentFormat: 'text',
+        processingType: 'transcription',
+        provider: 'groq',
+        model: GROQ_WHISPER_MODEL,
+        processingTimeMs: 0,
+        language,
+        costCents: 0,
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      const isCircuit = this.isCircuitOpen(error);
+      this.log.error('Groq transcription error', { error: errorMsg, circuitOpen: isCircuit });
+      return this.createFailedResult(errorMsg, 'groq', GROQ_WHISPER_MODEL);
     }
-
-    return this.createFailedResult(lastError?.message ?? 'Transcription failed', 'groq', GROQ_WHISPER_MODEL);
   }
 
   /**
-   * Transcribe using OpenAI Whisper API (fallback)
+   * Transcribe using OpenAI Whisper API (fallback) with retry + circuit breaker
    */
   private async transcribeWithOpenAI(filePath: string, language: string): Promise<ProcessingResult> {
     const client = this.getOpenAIClient();
@@ -164,19 +158,25 @@ export class AudioProcessor extends BaseProcessor {
       return this.createFailedResult('OpenAI client not configured (missing API key)', 'openai', OPENAI_WHISPER_MODEL);
     }
 
+    const timeouts = getMediaTimeouts();
+
     try {
-      // Use ReadStream which is compatible with the SDK
-      const fileStream = createReadStream(filePath);
+      const text = await this.executeWithResilience(
+        'openai',
+        async () => {
+          const fileStream = createReadStream(filePath);
 
-      const transcription = await client.audio.transcriptions.create({
-        file: fileStream,
-        model: OPENAI_WHISPER_MODEL,
-        language,
-        response_format: 'text',
-      });
+          const transcription = await client.audio.transcriptions.create({
+            file: fileStream,
+            model: OPENAI_WHISPER_MODEL,
+            language,
+            response_format: 'text',
+          });
 
-      const text =
-        typeof transcription === 'string' ? transcription : ((transcription as { text?: string }).text ?? '');
+          return typeof transcription === 'string' ? transcription : ((transcription as { text?: string }).text ?? '');
+        },
+        { timeoutMs: timeouts.audioTimeoutMs },
+      );
 
       return {
         success: true,
@@ -192,7 +192,6 @@ export class AudioProcessor extends BaseProcessor {
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.log.error('OpenAI transcription error', { error: errorMsg });
-
       return this.createFailedResult(errorMsg, 'openai', OPENAI_WHISPER_MODEL);
     }
   }

--- a/packages/media-processing/src/processors/base.ts
+++ b/packages/media-processing/src/processors/base.ts
@@ -2,9 +2,13 @@
  * Base Processor
  *
  * Abstract base class for all media processors.
+ * Provides retry with exponential backoff and circuit breaker integration.
  */
 
 import { createLogger } from '@omni/core';
+import { type CircuitBreaker, CircuitOpenError, getCircuitBreaker } from '../circuit-breaker';
+import { getMediaHealthTracker } from '../health';
+import { type RetryOptions, isTransientError, withRetry } from '../retry';
 import type { ProcessOptions, ProcessingResult, Processor, ProcessorConfig } from '../types';
 
 /**
@@ -86,7 +90,76 @@ export abstract class BaseProcessor implements Processor {
   }
 
   /**
+   * Check if an error is transient (rate limits, timeouts, network, 5xx)
+   */
+  protected isTransientError(error: unknown): boolean {
+    return isTransientError(error);
+  }
+
+  /**
+   * Get or create a circuit breaker for a provider
+   */
+  protected getCircuitBreaker(providerName: string): CircuitBreaker {
+    return getCircuitBreaker(providerName);
+  }
+
+  /**
+   * Execute a provider call with circuit breaker and retry logic.
+   *
+   * This replaces the manual retry loops in individual processors.
+   * The circuit breaker short-circuits if a provider is unhealthy.
+   * The retry wrapper handles transient errors with exponential backoff.
+   *
+   * @param providerName - Provider identifier for circuit breaker (e.g. 'groq', 'openai', 'gemini')
+   * @param fn - The async function to execute
+   * @param retryOptions - Optional retry configuration overrides
+   */
+  protected async executeWithResilience<T>(
+    providerName: string,
+    fn: () => Promise<T>,
+    retryOptions?: Partial<RetryOptions>,
+  ): Promise<T> {
+    const breaker = this.getCircuitBreaker(providerName);
+    const tracker = getMediaHealthTracker();
+    const startTime = performance.now();
+
+    try {
+      const result = await breaker.execute(() =>
+        withRetry(fn, {
+          maxRetries: 3,
+          baseDelayMs: 1000,
+          maxDelayMs: 10000,
+          timeoutMs: 0,
+          onRetry: (attempt, error) => {
+            this.log.warn(`Retry attempt ${attempt} for ${providerName}`, {
+              error: error.message,
+            });
+          },
+          ...retryOptions,
+        }),
+      );
+
+      const latencyMs = Math.round(performance.now() - startTime);
+      tracker.recordSuccess(this.name, providerName, latencyMs);
+      return result;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      tracker.recordFailure(this.name, providerName, errorMsg);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if an error is a circuit breaker open error.
+   * Useful for processors to decide whether to try a fallback provider.
+   */
+  protected isCircuitOpen(error: unknown): boolean {
+    return error instanceof CircuitOpenError;
+  }
+
+  /**
    * Sleep with exponential backoff
+   * @deprecated Use executeWithResilience() instead. Kept for backwards compatibility.
    */
   protected async sleep(attempt: number, baseMs = 2000, maxMs = 30000): Promise<void> {
     const delay = Math.min(baseMs * 2 ** attempt, maxMs);

--- a/packages/media-processing/src/processors/document.ts
+++ b/packages/media-processing/src/processors/document.ts
@@ -9,6 +9,8 @@
  * - Excel: exceljs (local, xlsx/xlsm only)
  * - Text/Markdown/JSON: direct read
  * - Scanned PDFs: Gemini Vision (fallback)
+ *
+ * Uses centralized retry + circuit breaker for Gemini OCR calls.
  */
 
 import { readFileSync } from 'node:fs';
@@ -18,6 +20,7 @@ import { GEMINI_MODEL } from '../models';
 import { calculateCost } from '../pricing';
 import { DOCUMENT_OCR_PROMPT } from '../prompts';
 import type { ProcessOptions, ProcessingResult } from '../types';
+import { getMediaTimeouts } from '../types';
 import { BaseProcessor } from './base';
 
 /** Minimum text length to consider extraction successful (below this, assume scanned PDF) */
@@ -425,7 +428,7 @@ export class DocumentProcessor extends BaseProcessor {
   }
 
   /**
-   * Process document with Gemini OCR (for scanned PDFs)
+   * Process document with Gemini OCR (for scanned PDFs) with retry + circuit breaker
    */
   private async processWithGeminiOcr(filePath: string, ocrPrompt: string): Promise<ProcessingResult> {
     const model = this.getGeminiModel();
@@ -433,25 +436,35 @@ export class DocumentProcessor extends BaseProcessor {
       return this.createFailedResult('Gemini not configured for OCR fallback (missing API key)', 'local', 'pdf-parse');
     }
 
+    const timeouts = getMediaTimeouts();
+
     try {
-      const pdfData = readFileSync(filePath);
+      const { text, inputTokens, outputTokens } = await this.executeWithResilience(
+        'gemini',
+        async () => {
+          const pdfData = readFileSync(filePath);
 
-      const result = await model.generateContent([
-        {
-          inlineData: {
-            mimeType: 'application/pdf',
-            data: pdfData.toString('base64'),
-          },
+          const result = await model.generateContent([
+            {
+              inlineData: {
+                mimeType: 'application/pdf',
+                data: pdfData.toString('base64'),
+              },
+            },
+            { text: ocrPrompt },
+          ]);
+
+          const response = result.response;
+          const usageMetadata = response.usageMetadata;
+
+          return {
+            text: response.text(),
+            inputTokens: usageMetadata?.promptTokenCount ?? 0,
+            outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
+          };
         },
-        { text: ocrPrompt },
-      ]);
-
-      const response = result.response;
-      const text = response.text();
-      const usageMetadata = response.usageMetadata;
-
-      const inputTokens = usageMetadata?.promptTokenCount ?? 0;
-      const outputTokens = usageMetadata?.candidatesTokenCount ?? 0;
+        { timeoutMs: timeouts.documentTimeoutMs },
+      );
 
       const costCents = calculateCost('gemini_vision', GEMINI_MODEL, {
         inputTokens,

--- a/packages/media-processing/src/processors/image.ts
+++ b/packages/media-processing/src/processors/image.ts
@@ -2,6 +2,8 @@
  * Image Processor
  *
  * Generates descriptions for images using Gemini Vision (primary) with OpenAI fallback.
+ *
+ * Uses centralized retry + circuit breaker for resilience.
  */
 
 import { readFileSync } from 'node:fs';
@@ -12,9 +14,8 @@ import { GEMINI_MODEL, OPENAI_VISION_MODEL } from '../models';
 import { calculateCost } from '../pricing';
 import { IMAGE_DESCRIPTION_PROMPT } from '../prompts';
 import type { ProcessOptions, ProcessingResult } from '../types';
+import { getMediaTimeouts } from '../types';
 import { BaseProcessor } from './base';
-
-const MAX_RETRIES = 3;
 
 /**
  * Image processor using Gemini Vision with OpenAI fallback
@@ -100,7 +101,7 @@ export class ImageProcessor extends BaseProcessor {
   }
 
   /**
-   * Describe image using Gemini Vision API
+   * Describe image using Gemini Vision API with retry + circuit breaker
    */
   private async describeWithGemini(imageData: Buffer, mimeType: string, prompt: string): Promise<ProcessingResult> {
     const model = this.getGeminiModel();
@@ -108,62 +109,61 @@ export class ImageProcessor extends BaseProcessor {
       return this.createFailedResult('Gemini not configured (missing API key)', 'google', GEMINI_MODEL);
     }
 
-    let lastError: Error | null = null;
+    const timeouts = getMediaTimeouts();
 
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        const result = await model.generateContent([
-          {
-            inlineData: {
-              mimeType: this.normalizeGeminiMimeType(mimeType),
-              data: imageData.toString('base64'),
+    try {
+      const { text, inputTokens, outputTokens } = await this.executeWithResilience(
+        'gemini',
+        async () => {
+          const result = await model.generateContent([
+            {
+              inlineData: {
+                mimeType: this.normalizeGeminiMimeType(mimeType),
+                data: imageData.toString('base64'),
+              },
             },
-          },
-          { text: prompt },
-        ]);
+            { text: prompt },
+          ]);
 
-        const response = result.response;
-        const text = response.text();
-        const usageMetadata = response.usageMetadata;
+          const response = result.response;
+          const usageMetadata = response.usageMetadata;
 
-        const inputTokens = usageMetadata?.promptTokenCount ?? 0;
-        const outputTokens = usageMetadata?.candidatesTokenCount ?? 0;
+          return {
+            text: response.text(),
+            inputTokens: usageMetadata?.promptTokenCount ?? 0,
+            outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
+          };
+        },
+        { timeoutMs: timeouts.imageTimeoutMs },
+      );
 
-        const costCents = calculateCost('gemini_vision', GEMINI_MODEL, {
-          inputTokens,
-          outputTokens,
-        });
+      const costCents = calculateCost('gemini_vision', GEMINI_MODEL, {
+        inputTokens,
+        outputTokens,
+      });
 
-        return {
-          success: true,
-          content: text.trim(),
-          contentFormat: 'text',
-          processingType: 'description',
-          provider: 'google',
-          model: GEMINI_MODEL,
-          processingTimeMs: 0,
-          inputTokens,
-          outputTokens,
-          costCents,
-        };
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-
-        if (this.isRateLimitError(error)) {
-          this.log.warn(`Gemini rate limit hit (attempt ${attempt + 1}/${MAX_RETRIES}), retrying...`);
-          await this.sleep(attempt);
-        } else {
-          this.log.error('Gemini description error', { error: lastError.message });
-          break;
-        }
-      }
+      return {
+        success: true,
+        content: text.trim(),
+        contentFormat: 'text',
+        processingType: 'description',
+        provider: 'google',
+        model: GEMINI_MODEL,
+        processingTimeMs: 0,
+        inputTokens,
+        outputTokens,
+        costCents,
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      const isCircuit = this.isCircuitOpen(error);
+      this.log.error('Gemini description error', { error: errorMsg, circuitOpen: isCircuit });
+      return this.createFailedResult(errorMsg, 'google', GEMINI_MODEL);
     }
-
-    return this.createFailedResult(lastError?.message ?? 'Description failed', 'google', GEMINI_MODEL);
   }
 
   /**
-   * Describe image using OpenAI Vision API (fallback)
+   * Describe image using OpenAI Vision API (fallback) with retry + circuit breaker
    */
   private async describeWithOpenAI(imageData: Buffer, mimeType: string, prompt: string): Promise<ProcessingResult> {
     const client = this.getOpenAIClient();
@@ -171,33 +171,43 @@ export class ImageProcessor extends BaseProcessor {
       return this.createFailedResult('OpenAI client not configured (missing API key)', 'openai', OPENAI_VISION_MODEL);
     }
 
-    try {
-      const base64Data = imageData.toString('base64');
-      const dataUrl = `data:${mimeType};base64,${base64Data}`;
+    const timeouts = getMediaTimeouts();
 
-      const response = await client.chat.completions.create({
-        model: OPENAI_VISION_MODEL,
-        messages: [
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: prompt },
+    try {
+      const { text, inputTokens, outputTokens } = await this.executeWithResilience(
+        'openai',
+        async () => {
+          const base64Data = imageData.toString('base64');
+          const dataUrl = `data:${mimeType};base64,${base64Data}`;
+
+          const response = await client.chat.completions.create({
+            model: OPENAI_VISION_MODEL,
+            messages: [
               {
-                type: 'image_url',
-                image_url: {
-                  url: dataUrl,
-                  detail: 'high',
-                },
+                role: 'user',
+                content: [
+                  { type: 'text', text: prompt },
+                  {
+                    type: 'image_url',
+                    image_url: {
+                      url: dataUrl,
+                      detail: 'high',
+                    },
+                  },
+                ],
               },
             ],
-          },
-        ],
-        max_tokens: 1024,
-      });
+            max_tokens: 1024,
+          });
 
-      const text = response.choices[0]?.message?.content ?? '';
-      const inputTokens = response.usage?.prompt_tokens ?? 0;
-      const outputTokens = response.usage?.completion_tokens ?? 0;
+          return {
+            text: response.choices[0]?.message?.content ?? '',
+            inputTokens: response.usage?.prompt_tokens ?? 0,
+            outputTokens: response.usage?.completion_tokens ?? 0,
+          };
+        },
+        { timeoutMs: timeouts.imageTimeoutMs },
+      );
 
       const costCents = calculateCost('openai_vision', OPENAI_VISION_MODEL, {
         inputTokens,
@@ -219,7 +229,6 @@ export class ImageProcessor extends BaseProcessor {
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.log.error('OpenAI description error', { error: errorMsg });
-
       return this.createFailedResult(errorMsg, 'openai', OPENAI_VISION_MODEL);
     }
   }

--- a/packages/media-processing/src/processors/video.ts
+++ b/packages/media-processing/src/processors/video.ts
@@ -4,6 +4,8 @@
  * Generates descriptions for videos using Gemini Flash.
  * Supports video understanding including scene description, action detection,
  * and audio transcription for videos with speech.
+ *
+ * Uses centralized retry + circuit breaker for resilience.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -13,9 +15,9 @@ import { GEMINI_MODEL } from '../models';
 import { calculateCost } from '../pricing';
 import { VIDEO_DESCRIPTION_PROMPT } from '../prompts';
 import type { ProcessOptions, ProcessingResult } from '../types';
+import { getMediaTimeouts } from '../types';
 import { BaseProcessor } from './base';
 
-const MAX_RETRIES = 3;
 const MAX_VIDEO_SIZE_MB = 20; // Gemini inline limit
 
 /**
@@ -97,7 +99,7 @@ export class VideoProcessor extends BaseProcessor {
   }
 
   /**
-   * Describe video using Gemini Flash API
+   * Describe video using Gemini Flash API with retry + circuit breaker
    */
   private async describeWithGemini(videoData: Buffer, mimeType: string, prompt: string): Promise<ProcessingResult> {
     const model = this.getGeminiModel();
@@ -105,58 +107,57 @@ export class VideoProcessor extends BaseProcessor {
       return this.createFailedResult('Gemini not configured (missing API key)', 'google', GEMINI_MODEL);
     }
 
-    let lastError: Error | null = null;
+    const timeouts = getMediaTimeouts();
 
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        const result = await model.generateContent([
-          {
-            inlineData: {
-              mimeType: this.normalizeVideoMimeType(mimeType),
-              data: videoData.toString('base64'),
+    try {
+      const { text, inputTokens, outputTokens } = await this.executeWithResilience(
+        'gemini',
+        async () => {
+          const result = await model.generateContent([
+            {
+              inlineData: {
+                mimeType: this.normalizeVideoMimeType(mimeType),
+                data: videoData.toString('base64'),
+              },
             },
-          },
-          { text: prompt },
-        ]);
+            { text: prompt },
+          ]);
 
-        const response = result.response;
-        const text = response.text();
-        const usageMetadata = response.usageMetadata;
+          const response = result.response;
+          const usageMetadata = response.usageMetadata;
 
-        const inputTokens = usageMetadata?.promptTokenCount ?? 0;
-        const outputTokens = usageMetadata?.candidatesTokenCount ?? 0;
+          return {
+            text: response.text(),
+            inputTokens: usageMetadata?.promptTokenCount ?? 0,
+            outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
+          };
+        },
+        { timeoutMs: timeouts.videoTimeoutMs },
+      );
 
-        const costCents = calculateCost('gemini_video', GEMINI_MODEL, {
-          inputTokens,
-          outputTokens,
-        });
+      const costCents = calculateCost('gemini_video', GEMINI_MODEL, {
+        inputTokens,
+        outputTokens,
+      });
 
-        return {
-          success: true,
-          content: text.trim(),
-          contentFormat: 'text',
-          processingType: 'description',
-          provider: 'google',
-          model: GEMINI_MODEL,
-          processingTimeMs: 0,
-          inputTokens,
-          outputTokens,
-          costCents,
-        };
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-
-        if (this.isRateLimitError(error)) {
-          this.log.warn(`Gemini rate limit hit (attempt ${attempt + 1}/${MAX_RETRIES}), retrying...`);
-          await this.sleep(attempt);
-        } else {
-          this.log.error('Gemini video description error', { error: lastError.message });
-          break;
-        }
-      }
+      return {
+        success: true,
+        content: text.trim(),
+        contentFormat: 'text',
+        processingType: 'description',
+        provider: 'google',
+        model: GEMINI_MODEL,
+        processingTimeMs: 0,
+        inputTokens,
+        outputTokens,
+        costCents,
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      const isCircuit = this.isCircuitOpen(error);
+      this.log.error('Gemini video description error', { error: errorMsg, circuitOpen: isCircuit });
+      return this.createFailedResult(errorMsg, 'google', GEMINI_MODEL);
     }
-
-    return this.createFailedResult(lastError?.message ?? 'Video description failed', 'google', GEMINI_MODEL);
   }
 
   /**

--- a/packages/media-processing/src/retry.ts
+++ b/packages/media-processing/src/retry.ts
@@ -1,0 +1,211 @@
+/**
+ * Retry with Exponential Backoff
+ *
+ * Generic retry wrapper for async operations with exponential backoff,
+ * jitter, per-attempt timeout, and transient error detection.
+ */
+
+import { createLogger } from '@omni/core';
+
+const log = createLogger('media-processing:retry');
+
+/**
+ * Options for the retry wrapper
+ */
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default 3) */
+  maxRetries: number;
+  /** Base delay in ms before first retry (default 1000) */
+  baseDelayMs: number;
+  /** Maximum delay in ms between retries (default 10000) */
+  maxDelayMs: number;
+  /** Per-attempt timeout in ms (0 = no timeout) */
+  timeoutMs: number;
+  /** Optional callback invoked before each retry */
+  onRetry?: (attempt: number, error: Error) => void;
+}
+
+/**
+ * Default retry options
+ */
+export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 10000,
+  timeoutMs: 0,
+};
+
+/**
+ * Patterns that indicate a transient error (case-insensitive matching against error message).
+ */
+const TRANSIENT_MESSAGE_PATTERNS = [
+  // Rate limits
+  '429',
+  'rate limit',
+  'too many requests',
+  'resource exhausted',
+  'resource_exhausted',
+  // Timeouts
+  'timeout',
+  'timed out',
+  'aborted',
+  // Network errors
+  'econnreset',
+  'econnrefused',
+  'epipe',
+  'enotfound',
+  'etimedout',
+  'network',
+  'fetch failed',
+  'socket hang up',
+  // Server errors (5xx)
+  '500',
+  '502',
+  '503',
+  '504',
+  'internal server error',
+  'service unavailable',
+  'bad gateway',
+];
+
+/**
+ * Error names that indicate a transient error.
+ */
+const TRANSIENT_ERROR_NAMES = ['aborterror', 'timeouterror'];
+
+/**
+ * Check if an error message matches any transient pattern.
+ */
+function matchesTransientPattern(msg: string): boolean {
+  return TRANSIENT_MESSAGE_PATTERNS.some((pattern) => msg.includes(pattern));
+}
+
+/**
+ * Check if an error is transient and should be retried.
+ *
+ * Detects: rate limits (429), timeouts, network errors, server errors (5xx).
+ */
+export function isTransientError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const msg = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+
+  if (TRANSIENT_ERROR_NAMES.includes(name)) {
+    return true;
+  }
+
+  return matchesTransientPattern(msg);
+}
+
+/**
+ * Calculate delay with exponential backoff and jitter.
+ *
+ * Formula: min(baseDelay * 2^attempt, maxDelay) + random jitter (0-25% of delay)
+ */
+export function calculateBackoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const exponentialDelay = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+  // Add jitter: 0-25% of the delay
+  const jitter = Math.random() * exponentialDelay * 0.25;
+  return Math.round(exponentialDelay + jitter);
+}
+
+/**
+ * Wrap a promise with a timeout.
+ *
+ * Returns a promise that rejects with a timeout error if the original
+ * promise does not resolve within the given time.
+ */
+function withTimeout<T>(fn: () => Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs <= 0) {
+    return fn();
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Operation timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    fn()
+      .then((result) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(result);
+        }
+      })
+      .catch((error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(error);
+        }
+      });
+  });
+}
+
+/**
+ * Normalize an error to an Error instance.
+ */
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Determine whether a failed attempt should be retried.
+ */
+function shouldRetry(error: Error, attempt: number, maxRetries: number): boolean {
+  if (attempt >= maxRetries) {
+    return false;
+  }
+  return isTransientError(error);
+}
+
+/**
+ * Execute an async function with retry logic, exponential backoff, and per-attempt timeout.
+ *
+ * Only retries on transient errors (rate limits, timeouts, network errors, 5xx).
+ * Non-transient errors (auth, validation, 4xx) are thrown immediately.
+ *
+ * @param fn - The async function to execute
+ * @param options - Retry configuration (uses defaults for missing fields)
+ * @returns The result of the function
+ * @throws The last error if all retries are exhausted
+ */
+export async function withRetry<T>(fn: () => Promise<T>, options?: Partial<RetryOptions>): Promise<T> {
+  const opts: RetryOptions = { ...DEFAULT_RETRY_OPTIONS, ...options };
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      return await withTimeout(fn, opts.timeoutMs);
+    } catch (error) {
+      lastError = toError(error);
+
+      if (!shouldRetry(lastError, attempt, opts.maxRetries)) {
+        break;
+      }
+
+      const delay = calculateBackoffDelay(attempt, opts.baseDelayMs, opts.maxDelayMs);
+
+      log.debug('Retrying after transient error', {
+        attempt: attempt + 1,
+        maxRetries: opts.maxRetries,
+        delayMs: delay,
+        error: lastError.message,
+      });
+
+      opts.onRetry?.(attempt + 1, lastError);
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError ?? new Error('withRetry failed with no error captured');
+}

--- a/packages/media-processing/src/types.ts
+++ b/packages/media-processing/src/types.ts
@@ -112,6 +112,42 @@ export interface PricingRate {
 }
 
 /**
+ * Timeout configuration for media processors (env-configurable)
+ */
+export interface MediaTimeoutConfig {
+  /** Audio processing timeout in ms (env: MEDIA_AUDIO_TIMEOUT_MS, default 30000) */
+  audioTimeoutMs: number;
+  /** Image processing timeout in ms (env: MEDIA_IMAGE_TIMEOUT_MS, default 15000) */
+  imageTimeoutMs: number;
+  /** Video processing timeout in ms (env: MEDIA_VIDEO_TIMEOUT_MS, default 60000) */
+  videoTimeoutMs: number;
+  /** Document processing timeout in ms (env: MEDIA_DOCUMENT_TIMEOUT_MS, default 30000) */
+  documentTimeoutMs: number;
+}
+
+/**
+ * Default timeout values for media processors
+ */
+export const DEFAULT_MEDIA_TIMEOUTS: MediaTimeoutConfig = {
+  audioTimeoutMs: 30_000,
+  imageTimeoutMs: 15_000,
+  videoTimeoutMs: 60_000,
+  documentTimeoutMs: 30_000,
+};
+
+/**
+ * Read timeout configuration from environment variables with defaults.
+ */
+export function getMediaTimeouts(): MediaTimeoutConfig {
+  return {
+    audioTimeoutMs: Number(process.env.MEDIA_AUDIO_TIMEOUT_MS) || DEFAULT_MEDIA_TIMEOUTS.audioTimeoutMs,
+    imageTimeoutMs: Number(process.env.MEDIA_IMAGE_TIMEOUT_MS) || DEFAULT_MEDIA_TIMEOUTS.imageTimeoutMs,
+    videoTimeoutMs: Number(process.env.MEDIA_VIDEO_TIMEOUT_MS) || DEFAULT_MEDIA_TIMEOUTS.videoTimeoutMs,
+    documentTimeoutMs: Number(process.env.MEDIA_DOCUMENT_TIMEOUT_MS) || DEFAULT_MEDIA_TIMEOUTS.documentTimeoutMs,
+  };
+}
+
+/**
  * Media content row shape (for DB storage)
  */
 export interface MediaContentInput {


### PR DESCRIPTION
## Summary
- **Retry wrapper** with exponential backoff, per-attempt timeout, and jitter for all media processor API calls
- **Circuit breaker** per provider (Groq, OpenAI, Gemini) — opens after 5 failures in 10min, 5min cooldown
- **Configurable timeouts** via env vars: `MEDIA_AUDIO_TIMEOUT_MS` (30s), `MEDIA_IMAGE_TIMEOUT_MS` (15s), `MEDIA_VIDEO_TIMEOUT_MS` (60s), `MEDIA_DOCUMENT_TIMEOUT_MS` (30s)
- **Provider failover** enhanced with circuit-breaker-aware fallback: Groq→OpenAI (audio), Gemini→OpenAI (vision)
- **`media.processing.failed`** core event emitted when all retries exhausted
- **Health metrics tracker** — per-processor/per-provider success rate, avg latency, failure count
- **NATS `media.health` subject** for health report requests
- **Circuit breaker state change logging** at warn level

## New Files
- `packages/media-processing/src/retry.ts` — `withRetry()` wrapper
- `packages/media-processing/src/circuit-breaker.ts` — `CircuitBreaker` class + registry
- `packages/media-processing/src/health.ts` — `MediaHealthTracker` singleton
- `packages/media-processing/__tests__/retry.test.ts` — 16 tests
- `packages/media-processing/__tests__/circuit-breaker.test.ts` — 14 tests

## Test plan
- [x] 85 media-processing tests pass (55 existing + 30 new)
- [x] 2522 total monorepo tests pass, 0 failures
- [x] Biome lint clean (816 files checked)
- [x] TypeScript typecheck passes (turbo typecheck, 18/18 packages)

Wish: omni-media-resilience