### PR TITLE
fix(cli): resolve short route IDs to full UUIDs

### DIFF
--- a/packages/cli/src/commands/agent-routes.ts
+++ b/packages/cli/src/commands/agent-routes.ts
@@ -14,7 +14,7 @@ import type { UpdateAgentRoute } from '@omni/core';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
-import { resolveInstanceId } from '../resolve.js';
+import { resolveInstanceId, resolveRouteId } from '../resolve.js';
 
 type ReplyFilter =
   | { mode: string; conditions?: { onDm?: boolean; onMention?: boolean; onReply?: boolean } }
@@ -139,6 +139,7 @@ async function updateAgentRouteAction(
     }
 
     const instanceId = await resolveInstanceId(options.instance);
+    const resolvedRouteId = await resolveRouteId(instanceId, routeId);
 
     // Build update object with only provided options
     const updates: Partial<UpdateAgentRoute> = {};
@@ -163,7 +164,7 @@ async function updateAgentRouteAction(
       return;
     }
 
-    const route = await client.routes.update(instanceId, routeId, updates);
+    const route = await client.routes.update(instanceId, resolvedRouteId, updates);
 
     output.success('Route updated');
     output.data(route);
@@ -218,11 +219,12 @@ export function createRoutesCommand(): Command {
     .command('get <routeId>')
     .description('Get agent route details')
     .requiredOption('--instance <id>', 'Instance ID')
-    .action(async (routeId: string, options: { instance: string }) => {
+    .action(async (routeIdInput: string, options: { instance: string }) => {
       const client = getClient();
 
       try {
         const instanceId = await resolveInstanceId(options.instance);
+        const routeId = await resolveRouteId(instanceId, routeIdInput);
         const route = await client.routes.get(instanceId, routeId);
 
         output.data(route);
@@ -291,11 +293,12 @@ export function createRoutesCommand(): Command {
     .command('delete <routeId>')
     .description('Delete an agent route')
     .requiredOption('--instance <id>', 'Instance ID')
-    .action(async (routeId: string, options: { instance: string }) => {
+    .action(async (routeIdInput: string, options: { instance: string }) => {
       const client = getClient();
 
       try {
         const instanceId = await resolveInstanceId(options.instance);
+        const routeId = await resolveRouteId(instanceId, routeIdInput);
         await client.routes.delete(instanceId, routeId);
 
         output.success('Route deleted');

--- a/packages/cli/src/resolve.ts
+++ b/packages/cli/src/resolve.ts
@@ -323,3 +323,37 @@ export async function resolveBatchJobId(input: string): Promise<string> {
 
   output.error(`No batch job found matching "${input}"`);
 }
+
+/**
+ * Resolve an agent route identifier to a UUID.
+ *
+ * Routes are scoped to an instance, so instanceId must already be resolved.
+ *
+ * Matches in order:
+ *   1. Exact UUID match (skip API call)
+ *   2. UUID prefix match (minimum 2 hex chars)
+ *
+ * Routes don't have names, only IDs.
+ *
+ * Exits with error if no match or ambiguous.
+ */
+export async function resolveRouteId(instanceId: string, input: string): Promise<string> {
+  if (UUID_RE.test(input)) return input;
+
+  const client = getClient();
+  const routes = await client.routes.list(instanceId, {});
+
+  // Partial UUID prefix (at least 2 chars, looks hex-ish)
+  if (/^[0-9a-f]{2,}$/i.test(input)) {
+    const matches = routes.filter((r) => r.id.toLowerCase().startsWith(input.toLowerCase()));
+    if (matches.length === 1) return matches[0].id;
+    if (matches.length > 1) {
+      const ids = matches
+        .map((r) => `  ${r.id.slice(0, 8)}  ${r.scope} (${r.isActive ? 'active' : 'inactive'})`)
+        .join('\n');
+      output.error(`Ambiguous ID prefix "${input}" matches ${matches.length} routes:\n${ids}`);
+    }
+  }
+
+  output.error(`No route found matching "${input}"`);
+}


### PR DESCRIPTION
## Summary
- `omni routes list` truncates IDs to 8 chars, but `update`/`delete`/`get` passed them directly to the API which expects full PostgreSQL UUIDs — causing "invalid input syntax for type uuid" errors
- Added `resolveRouteId(instanceId, input)` to `resolve.ts` that prefix-matches short IDs against the instance's routes, consistent with all other CLI resolvers (instances, chats, persons, etc.)
- Applied the resolver in `get`, `update`, and `delete` route subcommands

Closes #298

## Test plan
- [ ] `omni routes list --instance <id>` still shows short IDs
- [ ] `omni routes get --instance <id> <short-id>` resolves and returns full route
- [ ] `omni routes update --instance <id> <short-id> --active` resolves and updates
- [ ] `omni routes delete --instance <id> <short-id>` resolves and deletes
- [ ] Full UUIDs still work (passthrough, no API call)
- [ ] Ambiguous prefix shows helpful error with matching routes