### PR TITLE
fix(api): replace explicit any types with proper interfaces

### DIFF
--- a/packages/api/src/pgserve.ts
+++ b/packages/api/src/pgserve.ts
@@ -28,8 +28,12 @@ export interface PgserveConfig {
   dataDir: string | null;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: pgserve has no type declarations
-let serverInstance: any | null = null;
+/** Minimal shape of the pgserve server instance (pgserve ships no type declarations). */
+interface PgserveInstance {
+  stop(): Promise<void>;
+}
+
+let serverInstance: PgserveInstance | null = null;
 
 /**
  * Read pgserve-related env vars and return a typed config object.
@@ -55,8 +59,7 @@ function buildDatabaseUrl(port: number): string {
   return `postgresql://postgres:postgres@localhost:${port}/omni`;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: pgserve has no type declarations
-type StartServerFn = (opts: Record<string, unknown>) => Promise<any>;
+type StartServerFn = (opts: Record<string, unknown>) => Promise<PgserveInstance>;
 
 async function tryStartOnPort(startFn: StartServerFn, port: number, config: PgserveConfig): Promise<string | null> {
   try {

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -39,6 +39,7 @@ import { zValidator } from '@hono/zod-validator';
 import type { ChannelRegistry, OutgoingContent, OutgoingMessage } from '@omni/channel-sdk';
 import { ERROR_CODES, JOURNEY_STAGES, OmniError, createLogger, getJourneyTracker } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
+import type { Database } from '@omni/db';
 import * as Sentry from '@sentry/bun';
 import { Hono } from 'hono';
 import { z } from 'zod';
@@ -511,10 +512,9 @@ const messageRefSchema = z.union([
 // Lazy singleton for MediaStorageService (same pattern as media.ts)
 let _mediaStorageForDownload: MediaStorageService | null = null;
 
-function getMediaStorageForDownload(db: unknown): MediaStorageService {
+function getMediaStorageForDownload(db: Database): MediaStorageService {
   if (!_mediaStorageForDownload) {
-    // biome-ignore lint/suspicious/noExplicitAny: db type bridging
-    _mediaStorageForDownload = new MediaStorageService(db as any);
+    _mediaStorageForDownload = new MediaStorageService(db);
   }
   return _mediaStorageForDownload;
 }


### PR DESCRIPTION
## Summary
- **pgserve.ts**: Replaced `any` with a `PgserveInstance` interface for the server instance variable and `StartServerFn` return type (pgserve ships no type declarations)
- **messages.ts**: Changed `getMediaStorageForDownload(db: unknown)` → `getMediaStorageForDownload(db: Database)`, eliminating the `as any` cast since `c.get('db')` already returns `Database` per `AppVariables`

Removes 3 `biome-ignore lint/suspicious/noExplicitAny` suppressions.

## Test plan
- [x] `bunx biome check packages/` — 0 errors
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — clean
- [x] `bun test` — 2548 pass, 229 skip, 0 related failures