### PR TITLE
fix(cli): produce valid JSON from --json flag

### DIFF
--- a/packages/cli/src/commands/messages.ts
+++ b/packages/cli/src/commands/messages.ts
@@ -120,8 +120,9 @@ async function fetchSearchResults(params: URLSearchParams): Promise<ExtendedMess
   });
 
   if (!resp.ok) {
-    const err = (await resp.json()) as { error?: string };
-    throw new Error(err?.error ?? `API error: ${resp.status}`);
+    const err = (await resp.json()) as { error?: unknown };
+    const errorMsg = typeof err?.error === 'string' ? err.error : `API error: ${resp.status}`;
+    throw new Error(errorMsg);
   }
 
   const data = (await resp.json()) as { items?: ExtendedMessage[] };

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -73,26 +73,28 @@ export function error(message: string, details?: unknown, exitCode = 1): never {
   process.exit(exitCode);
 }
 
-/** Output warning message */
+/** Output warning message. In JSON mode, writes to stderr to keep stdout as valid JSON. */
 export function warn(message: string): void {
   const format = getCurrentFormat();
 
   if (format === 'json') {
+    // Write to stderr so --json stdout remains valid, parseable JSON
     // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(JSON.stringify({ warning: message }, null, 2));
+    console.error(JSON.stringify({ warning: message }));
   } else {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.log(c().yellow('⚠'), message);
   }
 }
 
-/** Output info message */
+/** Output info message. In JSON mode, writes to stderr to keep stdout as valid JSON. */
 export function info(message: string): void {
   const format = getCurrentFormat();
 
   if (format === 'json') {
+    // Write to stderr so --json stdout remains valid, parseable JSON
     // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(JSON.stringify({ info: message }, null, 2));
+    console.error(JSON.stringify({ info: message }));
   } else {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.log(c().blue('ℹ'), message);


### PR DESCRIPTION
## Summary

- **`output.info()` and `output.warn()` now write to stderr in JSON mode** instead of stdout. Previously, commands like `omni chats list --json` would output a valid JSON array followed by `{"info":"Showing 5 of 10 chats"}` — two root JSON objects on stdout, which is invalid JSON. Now the info/warning metadata goes to stderr, keeping stdout as a single valid JSON value that `jq`, `python3 -c "json.load()"`, and agent parsers can consume directly.
- **Fixed `[object Object]` in message search errors** — when the API returns a non-string `error` field (e.g. an object), the CLI now falls back to `API error: <status>` instead of coercing the object to `[object Object]`.

Closes #269

## Changed files

- `packages/cli/src/output.ts` — `info()` and `warn()`: `console.log` → `console.error` in JSON mode
- `packages/cli/src/commands/messages.ts` — `fetchSearchResults`: type-check `err.error` before using as message

## Test plan

- [ ] Run `omni chats list --json | jq .` — should parse without errors
- [ ] Run `omni chats list --json 2>/dev/null | jq .` — should show only the JSON array
- [ ] Run `omni messages search "test" --json | jq .` — should produce valid JSON
- [ ] Verify info/warning messages appear on stderr: `omni chats list --json 2>&1 1>/dev/null` should show the pagination info