### PR TITLE
chore(surgeon): [benchmarker] remove redundant await in MessageService.create()

### DIFF
--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -377,7 +377,7 @@ export class MessageService {
    * Create a new message
    */
   async create(options: CreateMessageOptions): Promise<Message> {
-    return await this.db.transaction(async (tx) => {
+    return this.db.transaction(async (tx) => {
       // Insert message
       const [created] = await tx
         .insert(messages)


### PR DESCRIPTION
## Surgeon Thesis

| Field | Value |
|-------|-------|
| **Sweeper** | benchmarker |
| **Repo** | omni |
| **Date** | 2026-03-25 |
| **Finding** | Redundant `return await` outside try/catch in hot-path message creation |
| **Tool** | grep |

### What Changed
Removed unnecessary `await` from `return await this.db.transaction(...)` in `packages/api/src/services/messages.ts:380`. The `await` keyword is redundant here because the function is `async` and the `return await` is not inside a try/catch block.

### Why It's Faster
**Anti-pattern:** `return await promise` outside try/catch creates an unnecessary intermediate microtask — the runtime awaits the promise only to immediately re-wrap it in the function's implicit return promise.
**Replacement:** `return promise` passes the promise through directly, eliminating one microtask tick from the resolution chain.
**Path type:** HOT — `MessageService.create()` is called for every message stored in the system (all channels: WhatsApp, Telegram, Discord, Slack).

### Why It's Safe
- Mechanical replacement — per the JS specification, `return await expr` and `return expr` in an async function produce identical resolved/rejected values when not inside a try/catch block
- All 2549 tests pass identically before and after (0 failures)
- No change to function signature, return type, or side effects

### Quality Gates
- [x] `bun test` — 2549 tests, 0 failures
- [x] `biome check .` — 0 errors, 0 warnings
- [x] `bunx tsc --noEmit` — 0 errors (18/18 packages)

### Impact
| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Anti-patterns | 1 | 0 | -1 |
| Lines | 1 | 1 | 0 |

**Risk:** LOW — mechanical transformation with identical semantics per JS specification

### Attempt Log
| # | Finding | Result | Gate |
|---|---------|--------|------|
| 1 | `return await` in `MessageService.create()` | SHIPPED | all gates pass |
| 2 | — | SKIPPED | — |
| 3 | — | SKIPPED | — |