### PR TITLE
fix(channel-sdk): sanitize outbound messages — strip REPLY NOW directive

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -20,7 +20,13 @@
 import { unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { type AckHandle, type AckProvider, type ReactionAckConfig, startAck } from '@omni/channel-sdk';
+import {
+  type AckHandle,
+  type AckProvider,
+  type ReactionAckConfig,
+  sanitizeOutboundText,
+  startAck,
+} from '@omni/channel-sdk';
 import type { FetchHistoryResult, HistorySyncMessage } from '@omni/channel-sdk';
 import type { StreamSender } from '@omni/channel-sdk';
 import {
@@ -376,9 +382,13 @@ async function sendTextMessage(
   const plugin = await getPlugin(channel);
   if (!plugin) throw new Error(`Channel plugin not found: ${channel}`);
 
+  // Strip internal routing headers and agent directives (GH #300)
+  const sanitized = sanitizeOutboundText(text);
+  if (!sanitized) return; // Entire message was internal metadata — nothing to send
+
   await plugin.sendMessage(instanceId, {
     to: chatId,
-    content: { type: 'text', text },
+    content: { type: 'text', text: sanitized },
     replyTo,
     metadata: { messageFormatMode, correlationId, senderAgentId },
   });

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -36,6 +36,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { zValidator } from '@hono/zod-validator';
+import { sanitizeOutboundText } from '@omni/channel-sdk';
 import type { ChannelRegistry, OutgoingContent, OutgoingMessage } from '@omni/channel-sdk';
 import { ERROR_CODES, JOURNEY_STAGES, OmniError, createLogger, getJourneyTracker } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
@@ -862,7 +863,12 @@ messagesRoutes.post('/send', async (c) => {
     return c.json({ error: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } }, 400);
   }
 
-  const { instanceId, to, text, replyTo, threadId, mentions } = parsed.data;
+  const { instanceId, to, replyTo, threadId, mentions } = parsed.data;
+  // Strip internal routing headers and agent directives before sending (GH #300)
+  const text = sanitizeOutboundText(parsed.data.text);
+  if (!text) {
+    return c.json({ data: { messageId: '', status: 'filtered', instanceId, to } }, 200);
+  }
   const services = c.get('services');
   checkInstanceAccess(c.get('apiKey'), instanceId);
 

--- a/packages/channel-sdk/src/__tests__/sanitize.test.ts
+++ b/packages/channel-sdk/src/__tests__/sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { sanitizeMessage } from '../sanitize';
+import { sanitizeMessage, sanitizeOutboundText } from '../sanitize';
 
 function createMockLogger() {
   return {
@@ -144,5 +144,62 @@ describe('sanitizeMessage', () => {
     const avgMs = elapsed / iterations;
 
     expect(avgMs).toBeLessThan(1);
+  });
+});
+
+describe('sanitizeOutboundText', () => {
+  test('passes through clean text unchanged', () => {
+    expect(sanitizeOutboundText('Hello, how are you?')).toBe('Hello, how are you?');
+  });
+
+  test('strips routing header line', () => {
+    const input =
+      '[channel:whatsapp-baileys instance:abc123 chat:5511999@s.whatsapp.net msg:MSG1 from:John type:dm]\nHello there!';
+    expect(sanitizeOutboundText(input)).toBe('Hello there!');
+  });
+
+  test('strips routing header with subset of tags', () => {
+    const input = '[channel:telegram instance:xyz chat:123456]\nHi!';
+    expect(sanitizeOutboundText(input)).toBe('Hi!');
+  });
+
+  test('strips REPLY NOW directive', () => {
+    const input =
+      'Hello!\n⚡ REPLY NOW via SendMessage to "sofia-whatsapp". Include the routing header from the first line of this message in your reply. Do not proceed with other tasks until you respond.';
+    expect(sanitizeOutboundText(input)).toBe('Hello!');
+  });
+
+  test('strips both routing header and REPLY NOW from a full genie message', () => {
+    const input =
+      '[channel:whatsapp-baileys instance:abc chat:5511@s.whatsapp.net from:User type:dm]\nWhat is the weather today?\n⚡ REPLY NOW via SendMessage to "sofia". Include the routing header from the first line of this message in your reply.';
+    expect(sanitizeOutboundText(input)).toBe('What is the weather today?');
+  });
+
+  test('returns empty string when entire message is internal metadata', () => {
+    const input = '[channel:whatsapp-baileys instance:abc chat:xyz]\n⚡ REPLY NOW via SendMessage to "agent".';
+    expect(sanitizeOutboundText(input)).toBe('');
+  });
+
+  test('preserves emoji and international text', () => {
+    expect(sanitizeOutboundText('Olá! 👋 Como vai?')).toBe('Olá! 👋 Como vai?');
+  });
+
+  test('does not strip bracketed text that is not a routing header', () => {
+    const input = '[This is a note] Some message';
+    expect(sanitizeOutboundText(input)).toBe('[This is a note] Some message');
+  });
+
+  test('handles empty string', () => {
+    expect(sanitizeOutboundText('')).toBe('');
+  });
+
+  test('collapses excessive blank lines after stripping', () => {
+    const input = '[channel:whatsapp instance:x chat:y]\n\n\nActual message\n\n\n⚡ REPLY NOW directive';
+    expect(sanitizeOutboundText(input)).toBe('Actual message');
+  });
+
+  test('strips multiple routing headers in multiline message', () => {
+    const input = '[channel:whatsapp instance:a chat:b]\nFirst part\n[channel:discord instance:c chat:d]\nSecond part';
+    expect(sanitizeOutboundText(input)).toBe('First part\nSecond part');
   });
 });

--- a/packages/channel-sdk/src/index.ts
+++ b/packages/channel-sdk/src/index.ts
@@ -87,7 +87,7 @@ export type { DedupeCache, DedupeConfig, DedupeStats } from './dedupe';
 export { createThreadStarterCache } from './thread-cache';
 export type { ThreadStarterCache, ThreadStarterCacheConfig } from './thread-cache';
 
-export { sanitizeMessage, isValidInstanceId } from './sanitize';
+export { sanitizeMessage, sanitizeOutboundText, isValidInstanceId } from './sanitize';
 export type { SanitizeOptions, SanitizeResult } from './sanitize';
 
 export { createDownloadGuard, DownloadTooLargeError } from './download-guard';

--- a/packages/channel-sdk/src/sanitize.ts
+++ b/packages/channel-sdk/src/sanitize.ts
@@ -82,6 +82,33 @@ export function sanitizeMessage(
   return { ok: true, text: cleaned };
 }
 
+// ── Outbound sanitization ──
+// Strips internal agent directives and routing headers before messages reach external channels.
+// These patterns are injected by the genie provider (fire-and-forget model) and should
+// never be visible to end users. See GH #300.
+
+/** Routing header: [channel:whatsapp-baileys instance:abc chat:xyz@s.whatsapp.net ...] */
+const ROUTING_HEADER_RE =
+  /^\[(?:channel:\S+|instance:\S+|chat:\S+|thread:\S+|msg:\S+|from:\S+|type:\S+|replyTo:\S+)(?:\s+(?:channel:\S+|instance:\S+|chat:\S+|thread:\S+|msg:\S+|from:\S+|type:\S+|replyTo:\S+))*\]\s*/gm;
+
+/** ⚡ REPLY NOW directive injected by genie-client.ts */
+const REPLY_NOW_RE = /⚡\s*REPLY\s+NOW\b[^\n]*/g;
+
+/**
+ * Sanitize an outbound message before it reaches an external channel.
+ *
+ * Strips internal routing headers and agent directives that should never
+ * be visible to end users. Returns the cleaned text (may be empty if the
+ * entire message was internal metadata).
+ */
+export function sanitizeOutboundText(text: string): string {
+  let cleaned = text.replace(ROUTING_HEADER_RE, '');
+  cleaned = cleaned.replace(REPLY_NOW_RE, '');
+  // Collapse leftover blank lines from stripped content
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+  return cleaned.trim();
+}
+
 /**
  * Validate an instance ID format for cache keys.
  */


### PR DESCRIPTION
## Summary
- Adds `sanitizeOutboundText()` to `@omni/channel-sdk` that strips internal routing headers (`[channel:... instance:... chat:...]`) and `⚡ REPLY NOW` directives before messages reach external channels
- Integrates sanitizer at two outbound chokepoints: `agent-dispatcher.ts:sendTextMessage` (relay path) and `v2/messages.ts:/send` (public API path)
- Messages that are entirely internal metadata are silently dropped instead of being sent as blank messages

## Root Cause
The genie provider injects `⚡ REPLY NOW` directives into message body text (not metadata). When the agent relay loop processes responses, these raw directives and routing headers leak through to WhatsApp groups as visible messages.

## Test plan
- [x] 26 unit tests pass covering both inbound and outbound sanitization
- [x] Routing header stripping (full and partial tag sets)
- [x] REPLY NOW directive stripping
- [x] Combined header + directive stripping
- [x] Messages that are entirely metadata return empty (dropped)
- [x] Non-routing bracketed text preserved
- [x] Emoji and international text preserved
- [x] Excessive blank line collapse after stripping
- [x] Build passes, lint clean

Closes #300