### PR TITLE
fix(api): prevent debounce typing race causing message double-dispatch

### DIFF
--- a/packages/api/src/plugins/__tests__/message-debouncer.test.ts
+++ b/packages/api/src/plugins/__tests__/message-debouncer.test.ts
@@ -208,6 +208,49 @@ describe('MessageDebouncer', () => {
     });
   });
 
+  describe('typing during in-flight does not cause double dispatch', () => {
+    it('onUserTyping is ignored while flush is in-flight', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+      let resolveFirstFlush: (() => void) | null = null;
+
+      const typingConfig: DebounceConfig = {
+        mode: 'fixed',
+        minMs: 100,
+        maxMs: 100,
+        restartOnTyping: true,
+        groupMs: null,
+      };
+
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+        if (flushCalls.length === 1) {
+          await new Promise<void>((resolve) => {
+            resolveFirstFlush = resolve;
+          });
+        }
+      });
+
+      // Buffer a message and wait for the fixed window to fire
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg1'), typingConfig);
+      await wait(150);
+      expect(flushCalls.length).toBe(1);
+
+      // While in-flight: buffer a late message AND fire a typing event
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg2'), typingConfig);
+      debouncer.onUserTyping('inst-1', 'chat-1', typingConfig);
+
+      // Release first flush
+      resolveFirstFlush!();
+      await wait(50);
+
+      // Should have exactly 2 flushes — the re-flush from finally picked up msg2.
+      // Without the inFlight guard in onUserTyping, a third flush could fire from
+      // the typing-restarted timer racing the finally-block re-flush.
+      expect(flushCalls.length).toBe(2);
+      expect(flushCalls[1]!.length).toBe(1);
+    });
+  });
+
   describe('clear()', () => {
     it('clears all internal state including inFlight', async () => {
       debouncer = new MessageDebouncer(async () => {

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -77,6 +77,10 @@ export class MessageDebouncer {
 
   onUserTyping(instanceId: string, chatId: string, config: DebounceConfig): void {
     const chatKey = this.getChatKey(instanceId, chatId);
+    // Don't restart the timer if this chat is currently being flushed — the
+    // finally-block re-flush will pick up any pending messages.  Restarting
+    // here would race with that re-flush and could cause a double-dispatch.
+    if (this.inFlight.has(chatKey)) return;
     if (config.restartOnTyping && this.buffers.has(chatKey)) {
       log.debug('Restarting debounce timer on user typing', { chatKey });
       this.restartTimer(chatKey, config);


### PR DESCRIPTION
## Summary
- `onUserTyping()` in `MessageDebouncer` did not check the `inFlight` set before restarting the debounce timer
- A typing event arriving while flush was processing could restart the timer, racing with the `finally`-block re-flush and potentially dispatching buffered messages twice (duplicate replies to user)
- Added `inFlight` guard to `onUserTyping()`, matching the guard already present in `buffer()`

## Root Cause
The `MessageDebouncer` tracks in-flight flushes to prevent `buffer()` from starting competing timers. However, `onUserTyping()` bypassed this guard and could restart the timer during processing. The restarted timer would fire and flush the same pending messages that the `finally`-block re-flush was about to process.

## Test plan
- [x] New test: "onUserTyping is ignored while flush is in-flight" — verifies exactly 2 flushes (not 3) when typing event fires during processing
- [x] All 11 debouncer tests pass
- [x] Full test suite: 2561 pass, 0 fail
- [x] Lint clean

Ref: omni#45 (fix-debounce-message-drops)