### PR TITLE
fix(api): sanitize outbound text in inbox-bridge relay path

### DIFF
--- a/packages/api/src/plugins/inbox-bridge.ts
+++ b/packages/api/src/plugins/inbox-bridge.ts
@@ -16,6 +16,7 @@ import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { ChannelRegistry, OutgoingMessage } from '@omni/channel-sdk';
+import { sanitizeOutboundText } from '@omni/channel-sdk';
 import { createLogger } from '@omni/core';
 import type { Services } from '../services';
 
@@ -340,6 +341,10 @@ async function sendInboxMessage(
 
   if (!parsed.cleanText) return 'ok';
 
+  // Strip internal routing headers and agent directives before sending (GH #312)
+  const sanitizedText = sanitizeOutboundText(parsed.cleanText);
+  if (!sanitizedText) return 'ok';
+
   const plugin = channelRegistry.get(parsed.channel as Parameters<typeof channelRegistry.get>[0]);
   if (!plugin) {
     log.warn('Channel plugin not found', { channel: parsed.channel, team, inboxName });
@@ -350,7 +355,7 @@ async function sendInboxMessage(
     to: parsed.chat,
     threadId: parsed.thread,
     replyTo: parsed.replyTo,
-    content: { type: 'text', text: parsed.cleanText },
+    content: { type: 'text', text: sanitizedText },
   };
 
   try {


### PR DESCRIPTION
## Summary
- Apply `sanitizeOutboundText()` to inbox-bridge before forwarding agent replies to external channels
- Closes defense-in-depth gap from PR #311 review — all 3 outbound paths to `plugin.sendMessage()` now sanitize

## Test plan
- [x] 502 API tests pass, 0 fail
- [x] Lint clean

Closes #312