### PR TITLE
fix(api): add JID-based fallback for null group names

### DIFF
--- a/packages/api/src/services/chats.ts
+++ b/packages/api/src/services/chats.ts
@@ -243,6 +243,10 @@ export class ChatService {
       const groupName = nameMap.get(chat.externalId);
       if (groupName) {
         chat.name = groupName;
+      } else {
+        // Fallback: derive a name from the JID when group metadata is not synced (GH #309)
+        const jidPrefix = chat.externalId.split('@')[0];
+        chat.name = jidPrefix ? `Group ${jidPrefix.slice(0, 15)}${jidPrefix.length > 15 ? '…' : ''}` : 'Unknown Group';
       }
     }
   }


### PR DESCRIPTION
## Summary
- When `enrichGroupNames()` can't find a group in `omni_groups`, derive name from JID prefix
- No more blank group names in `omni chats list`

Closes #309

## Test plan
- [x] 502 API tests pass, 0 fail
- [x] Lint clean