### PR TITLE
fix(api): add null check for instance in sendMessage wrapper

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -298,6 +298,7 @@ async function setupEventBusServices(
     await services.automations.startEngine({
       sendMessage: async (instanceId, to, content) => {
         const instance = await services.instances.getById(instanceId);
+        if (!instance) throw new Error(`Instance not found: ${instanceId}`);
         const plugin = await getPlugin(instance.channel);
         if (!plugin) throw new Error(`No plugin for channel: ${instance.channel}`);
         await plugin.sendMessage(instanceId, { to, content: { type: 'text', text: content } });


### PR DESCRIPTION
## Summary
Adds missing null check on `instance` before accessing `.channel` in the automation engine's `sendMessage` callback. Prevents TypeError on invalid/deleted instanceId.

Follow-up to #326 — caught by Gemini Code Assist review.

## Test plan
- [x] `bun test` — 2570 pass
- [x] One-line guard, no behavior change for valid instances