### PR TITLE
fix(api): guard against empty sender ID in responder pairing path

### DIFF
--- a/packages/api/src/plugins/agent-responder.ts
+++ b/packages/api/src/plugins/agent-responder.ts
@@ -565,8 +565,8 @@ async function processIncomingMessage(
 
     // Trigger pairing flow for unknown senders in allowlist mode (no explicit rule matched).
     // Fire-and-forget: pairing request creation must not block message processing.
-    if (accessResult.mode === 'allowlist' && !accessResult.rule) {
-      accessService.requestPairing(instance.id, payload.from ?? '', { channelType: instance.channel }).catch((err) => {
+    if (accessResult.mode === 'allowlist' && !accessResult.rule && payload.from) {
+      accessService.requestPairing(instance.id, payload.from, { channelType: instance.channel }).catch((err) => {
         log.warn('Failed to create pairing request', {
           instanceId: instance.id,
           from: payload.from,


### PR DESCRIPTION
One-line fix: add `&& payload.from` guard to match dispatcher path. Prevents degenerate pairing entries.

Caught by CodeRabbit on PR #321.