### PR TITLE
fix(debounce): typing events now reset timer in fixed mode

### DIFF
--- a/packages/api/src/plugins/__tests__/message-debouncer.test.ts
+++ b/packages/api/src/plugins/__tests__/message-debouncer.test.ts
@@ -251,6 +251,67 @@ describe('MessageDebouncer', () => {
     });
   });
 
+  describe('typing resets timer in fixed mode', () => {
+    it('onUserTyping force-restarts the fixed-mode timer', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+
+      const typingFixedConfig: DebounceConfig = {
+        mode: 'fixed',
+        minMs: 100,
+        maxMs: 100,
+        restartOnTyping: true,
+        groupMs: null,
+      };
+
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+      });
+
+      // Buffer a message — starts a 100ms fixed timer
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg1'), typingFixedConfig);
+
+      // At 60ms, user starts typing — should reset the 100ms timer
+      await wait(60);
+      debouncer.onUserTyping('inst-1', 'chat-1', typingFixedConfig);
+
+      // At 110ms from start (50ms after typing reset), the ORIGINAL timer
+      // would have fired. If the reset worked, it should NOT have flushed yet.
+      await wait(50);
+      expect(flushCalls.length).toBe(0);
+
+      // Wait for the restarted timer to fire (100ms from the typing event)
+      await wait(80);
+      expect(flushCalls.length).toBe(1);
+      expect(flushCalls[0]!.length).toBe(1);
+    });
+
+    it('typing does NOT reset timer when restartOnTyping is false', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+
+      const noTypingConfig: DebounceConfig = {
+        mode: 'fixed',
+        minMs: 100,
+        maxMs: 100,
+        restartOnTyping: false,
+        groupMs: null,
+      };
+
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+      });
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg1'), noTypingConfig);
+
+      // Typing event should be ignored when restartOnTyping is false
+      await wait(60);
+      debouncer.onUserTyping('inst-1', 'chat-1', noTypingConfig);
+
+      // Original timer fires at 100ms — should flush normally
+      await wait(80);
+      expect(flushCalls.length).toBe(1);
+    });
+  });
+
   describe('clear()', () => {
     it('clears all internal state including inFlight', async () => {
       debouncer = new MessageDebouncer(async () => {

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -83,16 +83,18 @@ export class MessageDebouncer {
     if (this.inFlight.has(chatKey)) return;
     if (config.restartOnTyping && this.buffers.has(chatKey)) {
       log.debug('Restarting debounce timer on user typing', { chatKey });
-      this.restartTimer(chatKey, config);
+      this.restartTimer(chatKey, config, true);
     }
   }
 
-  private restartTimer(chatKey: string, config: DebounceConfig): void {
+  private restartTimer(chatKey: string, config: DebounceConfig, force = false): void {
     const existing = this.timers.get(chatKey);
 
     // In 'fixed' mode, the timer is a fixed collection window from the first
     // message — do NOT restart it when subsequent messages arrive.
-    if (config.mode === 'fixed' && existing) return;
+    // However, typing events force-restart even in fixed mode so the user
+    // has time to finish composing before the agent is dispatched.
+    if (config.mode === 'fixed' && existing && !force) return;
 
     if (existing) clearTimeout(existing);
 

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -923,6 +923,12 @@ export function setupMessageHandlers(
 ): void {
   const cache = dedupeCache ?? fallbackDedupeCache;
 
+  // Track JIDs we've already subscribed to for presence updates.
+  // Baileys requires an explicit presenceSubscribe(jid) before typing
+  // indicators are delivered for DM chats. We only need to call it once
+  // per JID per connection lifecycle.
+  const presenceSubscribed = new Set<string>();
+
   sock.ev.on('messages.upsert', async (upsert: { messages: WAMessage[]; type: MessageUpsertType }) => {
     // Log all message types to diagnose missing messages
     log.debug('messages.upsert received', {
@@ -942,6 +948,17 @@ export function setupMessageHandlers(
     // 'append' = outgoing messages sent from this device
     // We need both to capture all conversation activity
     for (const msg of upsert.messages) {
+      // Subscribe to presence updates for DM chats so Baileys delivers
+      // typing indicators (composing/recording). Without this, the WA
+      // server never pushes chatstate nodes for 1-on-1 conversations.
+      const chatJid = msg.key.remoteJid;
+      if (chatJid && isUserJid(chatJid) && !presenceSubscribed.has(chatJid)) {
+        presenceSubscribed.add(chatJid);
+        sock
+          .presenceSubscribe(chatJid)
+          .catch((err) => log.debug('presenceSubscribe failed (non-fatal)', { chatJid, error: String(err) }));
+      }
+
       if (shouldProcessMessage(plugin, instanceId, msg)) {
         await processMessage(plugin, instanceId, msg, cache);
       }


### PR DESCRIPTION
## Summary
- **Bug 1 (debouncer):** `restartTimer()` had a fixed-mode guard that blocked ALL timer restarts — including those from `onUserTyping()`. Added a `force` parameter so typing events bypass the guard while normal message buffering behavior is unchanged.
- **Bug 2 (presence):** Baileys requires explicit `presenceSubscribe(jid)` before delivering typing indicators for 1-on-1 DM chats. Added auto-subscription on first message from each DM JID, with a per-connection `Set` to avoid redundant network calls.
- Adds 2 regression tests for the debouncer fix (fixed-mode typing reset + config flag respected).

## Root cause
In `message-debouncer.ts:95`, the guard `if (config.mode === 'fixed' && existing) return;` was designed to prevent new messages from restarting the fixed collection window. However, it also blocked `onUserTyping()` from resetting the timer — meaning the agent was dispatched while the user was still composing.

Separately, `presenceSubscribe(jid)` was never called for DM chats in `messages.ts`, so Baileys never received typing indicators from the WhatsApp server for 1-on-1 conversations — making the debouncer's typing feature effectively dead for the most common interaction pattern.

## Changes
| File | Change |
|------|--------|
| `packages/api/src/plugins/message-debouncer.ts` | Add `force` param to `restartTimer()`, call with `true` from `onUserTyping()` |
| `packages/channel-whatsapp/src/handlers/messages.ts` | Auto-subscribe to presence on first DM message per JID |
| `packages/api/src/plugins/__tests__/message-debouncer.test.ts` | 2 new tests: typing resets fixed timer + respects config flag |

## Test plan
- [x] All 13 message-debouncer tests pass (including 2 new regression tests)
- [x] Full test suite: 2764 pass, 0 fail, 229 skip
- [x] Typecheck passes across all 17 packages
- [x] Biome lint passes
- [ ] Manual: send messages with `restartOnTyping: true` + `fixed` mode, verify typing resets the timer
- [ ] Manual: verify DM typing indicators appear in `presence.typing` events