### PR TITLE
fix(follow-up): guard arm/dispatch against NATS replay + missing agentId

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -2667,6 +2667,29 @@ const providerCache = new Map<string, IAgentProvider>();
 /** Shared OpenClaw WS clients keyed by provider DB ID (DEC-3: one connection per provider) */
 const openclawClientPool = new Map<string, OpenClawClient>();
 
+/**
+ * Pick the first non-empty agentId from instance → provider schemaConfig.
+ * Throws when neither is set so downstream code never hits upstream APIs
+ * with the literal string "default". The previous silent fallback could
+ * mask a mis-seeded instance as 404s on the upstream provider.
+ */
+function resolveRequiredAgentId(
+  instance: DispatchInstance,
+  schemaConfig: Record<string, unknown>,
+  providerId: string,
+  fieldName: 'agentId' | 'defaultAgentId' = 'agentId',
+): string {
+  const fromInstance = instance.agentInternalId;
+  const fromSchema = schemaConfig[fieldName];
+  const resolved = (fromInstance ?? fromSchema) as string | undefined | null;
+  if (!resolved || typeof resolved !== 'string' || resolved.trim() === '') {
+    throw new Error(
+      `agent-dispatcher: cannot resolve agentId for provider ${providerId} (instance.agentInternalId and schemaConfig.${fieldName} are both empty)`,
+    );
+  }
+  return resolved;
+}
+
 /** Create an OpenClaw-based agent provider */
 function createOpenClawProviderInstance(provider: AgentProvider, instance: DispatchInstance): IAgentProvider {
   // DEC-3: Reuse shared WS client per provider ID
@@ -2700,7 +2723,7 @@ function createOpenClawProviderInstance(provider: AgentProvider, instance: Dispa
 
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
   const providerConfig: OpenClawProviderConfig = {
-    defaultAgentId: (instance.agentInternalId ?? (schemaConfig.defaultAgentId as string) ?? 'default') as string,
+    defaultAgentId: resolveRequiredAgentId(instance, schemaConfig, provider.id, 'defaultAgentId'),
     agentTimeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 120) as number) * 1000,
     sendAckTimeoutMs: 10_000,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
@@ -2726,7 +2749,7 @@ function createAgnoProvider(provider: AgentProvider, instance: DispatchInstance)
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
 
   return new AgnoAgentProvider(provider.id, provider.name, client, {
-    agentId: (instance.agentInternalId ?? schemaConfig.agentId ?? 'default') as string,
+    agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
     agentType: (instance.agentType ?? 'agent') as 'agent' | 'team' | 'workflow',
     timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
@@ -2814,7 +2837,7 @@ function createAgUiProviderInstance(provider: AgentProvider, instance: DispatchI
   });
 
   return new AgUiAgentProvider(provider.id, provider.name, client, {
-    agentId: (instance.agentInternalId ?? schemaConfig.agentId ?? 'default') as string,
+    agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
     timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
@@ -2837,7 +2860,7 @@ function createA2AProviderInstance(provider: AgentProvider, instance: DispatchIn
   });
 
   return new A2AAgentProvider(provider.id, provider.name, client, {
-    agentId: (instance.agentInternalId ?? schemaConfig.agentId ?? 'default') as string,
+    agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
     timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,

--- a/packages/api/src/plugins/follow-up-hooks.ts
+++ b/packages/api/src/plugins/follow-up-hooks.ts
@@ -30,13 +30,6 @@ import type { Services } from '../services';
 const log = createLogger('follow-up-hooks');
 
 /**
- * Drop `message.sent` events older than this before they reach the lifecycle
- * service. Defends against NATS consumer replay re-arming historical chats
- * when weeks-old events get redelivered in a single burst.
- */
-const MAX_EVENT_AGE_MS = 5 * 60_000;
-
-/**
  * Resolve the DB chat UUID from a message event's external chat id.
  * Returns null when the chat has not been persisted yet — the follow-up row
  * can safely be skipped in that case.
@@ -67,17 +60,6 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
 
         const senderAgentId = payload.senderAgentId;
         if (!senderAgentId) return; // Only arm on agent-origin messages.
-
-        const ageMs = Date.now() - event.timestamp;
-        if (ageMs > MAX_EVENT_AGE_MS) {
-          log.warn('follow-up-hooks: dropping stale message.sent', {
-            instanceId,
-            chatId: payload.chatId,
-            ageMs,
-            maxAgeMs: MAX_EVENT_AGE_MS,
-          });
-          return;
-        }
 
         const chatId = await resolveChatId(services, instanceId, payload.chatId);
         if (!chatId) return;

--- a/packages/api/src/plugins/follow-up-hooks.ts
+++ b/packages/api/src/plugins/follow-up-hooks.ts
@@ -30,6 +30,13 @@ import type { Services } from '../services';
 const log = createLogger('follow-up-hooks');
 
 /**
+ * Drop `message.sent` events older than this before they reach the lifecycle
+ * service. Defends against NATS consumer replay re-arming historical chats
+ * when weeks-old events get redelivered in a single burst.
+ */
+const MAX_EVENT_AGE_MS = 5 * 60_000;
+
+/**
  * Resolve the DB chat UUID from a message event's external chat id.
  * Returns null when the chat has not been persisted yet — the follow-up row
  * can safely be skipped in that case.
@@ -60,6 +67,17 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
 
         const senderAgentId = payload.senderAgentId;
         if (!senderAgentId) return; // Only arm on agent-origin messages.
+
+        const ageMs = Date.now() - event.timestamp;
+        if (ageMs > MAX_EVENT_AGE_MS) {
+          log.warn('follow-up-hooks: dropping stale message.sent', {
+            instanceId,
+            chatId: payload.chatId,
+            ageMs,
+            maxAgeMs: MAX_EVENT_AGE_MS,
+          });
+          return;
+        }
 
         const chatId = await resolveChatId(services, instanceId, payload.chatId);
         if (!chatId) return;

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -43,13 +43,6 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 const log = createLogger('follow-up-lifecycle');
 
 /**
- * Refuse to arm a follow-up when the triggering message is older than this.
- * Guards against NATS redelivery / consumer replay from re-arming historical
- * chats long after the fact.
- */
-const MAX_ARM_MESSAGE_AGE_MS = 5 * 60_000;
-
-/**
  * Typed reads across the three storage locations — the resolver is DB-agnostic,
  * so the API service does the column/jsonb lookup here and hands plain
  * `FollowUpSequenceConfig | null | undefined` to the resolver.
@@ -110,19 +103,29 @@ export class FollowUpLifecycleService {
   async armForOutbound(input: Omit<ArmSequenceInput, 'config'> & { config?: FollowUpSequenceConfig }): Promise<void> {
     if (!this.eventBus) return;
 
-    const ageMs = Date.now() - input.lastAgentMessageAt.getTime();
-    if (ageMs > MAX_ARM_MESSAGE_AGE_MS) {
-      this.logger.warn('follow-up lifecycle: refusing to arm on stale message', {
-        chatId: input.chatId,
-        instanceId: input.instanceId,
-        ageMs,
-        maxAgeMs: MAX_ARM_MESSAGE_AGE_MS,
-      });
-      return;
-    }
-
     const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId ?? null));
     if (!config || config.enabled === false) return;
+
+    // Refuse to arm when the triggering message is already older than the
+    // first follow-up interval — the initial wait window has elapsed, so
+    // the sequence would fire immediately. Guards against NATS redelivery
+    // re-arming chats whose outbound happened long ago.
+    const firstIntervalMinutes =
+      config.schedule.kind === 'fixed' ? config.schedule.intervalsMinutes[0] : config.schedule.initialMinutes;
+    if (typeof firstIntervalMinutes === 'number' && firstIntervalMinutes > 0) {
+      const maxAgeMs = firstIntervalMinutes * 60_000;
+      const ageMs = Date.now() - input.lastAgentMessageAt.getTime();
+      if (ageMs > maxAgeMs) {
+        this.logger.warn('follow-up lifecycle: refusing to arm on stale message', {
+          chatId: input.chatId,
+          instanceId: input.instanceId,
+          ageMs,
+          maxAgeMs,
+          firstIntervalMinutes,
+        });
+        return;
+      }
+    }
 
     try {
       await armSequence(

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -43,6 +43,13 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 const log = createLogger('follow-up-lifecycle');
 
 /**
+ * Refuse to arm a follow-up when the triggering message is older than this.
+ * Guards against NATS redelivery / consumer replay from re-arming historical
+ * chats long after the fact.
+ */
+const MAX_ARM_MESSAGE_AGE_MS = 5 * 60_000;
+
+/**
  * Typed reads across the three storage locations — the resolver is DB-agnostic,
  * so the API service does the column/jsonb lookup here and hands plain
  * `FollowUpSequenceConfig | null | undefined` to the resolver.
@@ -102,6 +109,17 @@ export class FollowUpLifecycleService {
    */
   async armForOutbound(input: Omit<ArmSequenceInput, 'config'> & { config?: FollowUpSequenceConfig }): Promise<void> {
     if (!this.eventBus) return;
+
+    const ageMs = Date.now() - input.lastAgentMessageAt.getTime();
+    if (ageMs > MAX_ARM_MESSAGE_AGE_MS) {
+      this.logger.warn('follow-up lifecycle: refusing to arm on stale message', {
+        chatId: input.chatId,
+        instanceId: input.instanceId,
+        ageMs,
+        maxAgeMs: MAX_ARM_MESSAGE_AGE_MS,
+      });
+      return;
+    }
 
     const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId ?? null));
     if (!config || config.enabled === false) return;


### PR DESCRIPTION
## Summary

Three defense-in-depth fixes for an incident where redelivered `message.sent` events (weeks-old) re-armed historical chats and fired simultaneous follow-ups within a single minute.

- **Fix 1 — `packages/api/src/services/follow-up-lifecycle.ts`**: reject `armForOutbound` when `lastAgentMessageAt` is older than 5 minutes. Last-chance guard before the DB upsert.
- **Fix 2 — `packages/api/src/plugins/follow-up-hooks.ts`**: drop `message.sent` events whose `event.timestamp` is older than 5 minutes *before* they reach the lifecycle service. Prevents replay storms from entering the pipeline.
- **Fix 3 — `packages/api/src/plugins/agent-dispatcher.ts`**: replace `?? 'default'` agentId fallbacks in OpenClaw / Agno / AG-UI / A2A provider factories with `resolveRequiredAgentId()` which throws when neither `instance.agentInternalId` nor `schemaConfig[fieldName]` is set. The silent `'default'` fallback masked a mis-seeded instance and produced `agents/default` 404s upstream.

## Context

- Armed rows from the replay burst have already been disarmed and the idle follow-up automation was disabled pending this fix.
- Sweeper fail-fast on dispatch errors and NATS-consumer forensics are deferred follow-ups (not in this PR).

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run build` — green
- [x] `bun test` (pre-push hook) — **2964 pass / 0 fail / 252 skip** across 210 files
- [x] Follow-up specs (`follow-up-lifecycle`, `follow-up-e2e`, `follow-up-routes`, `follow-up-sweeper`, `agent-dispatcher-hooks`) — all green / DB-gated skips
- [x] Deploy bundle + restart API
- [ ] Smoke test: send a real message, verify arm + correct fire window
- [ ] Re-enable idle follow-up automation
- [ ] Monitor: no stale-arm warnings, no `agents/default` 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)