### PR TITLE
fix(dispatcher): drop stale inbound messages via per-instance age guard

### DIFF
--- a/packages/api/src/__tests__/dispatcher-stale-inbound.test.ts
+++ b/packages/api/src/__tests__/dispatcher-stale-inbound.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the stale-inbound guard in the agent dispatcher.
+ *
+ * Defends against Baileys history-sync replays and NATS redelivery resurrecting
+ * old conversations after reconnect/restart. Drops inbound `message.received`
+ * events when the platform-native timestamp (e.g. WhatsApp `messageTimestamp`)
+ * is older than `instance.inboundMaxAgeMinutes` (default 10).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { isInboundTooStale } from '../plugins/agent-dispatcher';
+
+const NOW = new Date('2026-04-15T16:30:00Z').getTime();
+
+describe('isInboundTooStale', () => {
+  it('returns stale=false for a fresh message (seconds old)', () => {
+    const rawPayload = { messageTimestamp: Math.floor(NOW / 1000) - 5 };
+    const result = isInboundTooStale(rawPayload, 10, NOW);
+    expect(result.stale).toBe(false);
+    expect(result.ageMs).toBeLessThan(60_000);
+  });
+
+  it('returns stale=false right at the threshold boundary', () => {
+    const rawPayload = { messageTimestamp: Math.floor(NOW / 1000) - 10 * 60 };
+    const result = isInboundTooStale(rawPayload, 10, NOW);
+    expect(result.stale).toBe(false);
+    expect(result.ageMs).toBe(10 * 60_000);
+  });
+
+  it('returns stale=true when message is older than threshold', () => {
+    const rawPayload = { messageTimestamp: Math.floor(NOW / 1000) - 11 * 60 };
+    const result = isInboundTooStale(rawPayload, 10, NOW);
+    expect(result.stale).toBe(true);
+    expect(result.ageMs).toBeGreaterThan(10 * 60_000);
+  });
+
+  it('catches the incident case: 1h-old replay with default 10min threshold', () => {
+    // Mirrors the production replay: WA messageTimestamp ~1h old, redelivered
+    // by Baileys history-sync after reconnect.
+    const rawPayload = { messageTimestamp: Math.floor(NOW / 1000) - 60 * 60 };
+    const result = isInboundTooStale(rawPayload, 10, NOW);
+    expect(result.stale).toBe(true);
+  });
+
+  it('disables the guard when maxAgeMinutes=0', () => {
+    const rawPayload = { messageTimestamp: Math.floor(NOW / 1000) - 24 * 60 * 60 };
+    const result = isInboundTooStale(rawPayload, 0, NOW);
+    expect(result.stale).toBe(false);
+  });
+
+  it('disables the guard when maxAgeMinutes is negative', () => {
+    const rawPayload = { messageTimestamp: Math.floor(NOW / 1000) - 24 * 60 * 60 };
+    const result = isInboundTooStale(rawPayload, -1, NOW);
+    expect(result.stale).toBe(false);
+  });
+
+  it('treats missing rawPayload.messageTimestamp as fresh (fallback = now)', () => {
+    const result = isInboundTooStale(undefined, 10, NOW);
+    expect(result.stale).toBe(false);
+  });
+
+  it('treats rawPayload without messageTimestamp as fresh', () => {
+    const result = isInboundTooStale({ other: 'field' }, 10, NOW);
+    expect(result.stale).toBe(false);
+  });
+
+  it('handles WA protobuf Long timestamp format', () => {
+    // Baileys sometimes emits messageTimestamp as { low, high, unsigned }.
+    // Verify the helper doesn't crash and treats unparseable timestamps as
+    // fresh (fallback to `now`) rather than dropping valid messages.
+    const rawPayload = {
+      messageTimestamp: { low: Math.floor(NOW / 1000) - 30, high: 0, unsigned: true },
+    };
+    const result = isInboundTooStale(rawPayload, 10, NOW);
+    expect(result.stale).toBe(false);
+  });
+
+  it('accepts messageTimestamp as a string (seconds)', () => {
+    const rawPayload = { messageTimestamp: String(Math.floor(NOW / 1000) - 30) };
+    const result = isInboundTooStale(rawPayload, 10, NOW);
+    expect(result.stale).toBe(false);
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -88,6 +88,7 @@ import {
   type DispatchMetadata,
   MessageDebouncer,
 } from './message-debouncer';
+import { extractPlatformTimestamp } from './message-persistence';
 import { createSessionStorage } from './session-storage';
 
 const log = createLogger('agent-dispatcher');
@@ -3458,6 +3459,29 @@ function needsLidMentionCheck(messageContext: MessageContext, instance: Instance
   return !messageContext.mentionsBot && !messageContext.isDirectMessage && !!instance.ownerIdentifier;
 }
 
+/**
+ * True when the inbound message's platform-native timestamp
+ * (e.g. WhatsApp `messageTimestamp`) is older than `maxAgeMinutes`.
+ *
+ * Exported so unit tests can exercise the threshold boundary without
+ * wiring up the full dispatcher pipeline. `maxAgeMinutes <= 0` disables
+ * the guard entirely (useful for instances that genuinely want to replay
+ * backlog after a long outage).
+ */
+export function isInboundTooStale(
+  rawPayload: Record<string, unknown> | undefined,
+  maxAgeMinutes: number,
+  now: number = Date.now(),
+): { stale: boolean; ageMs: number; maxAgeMs: number } {
+  const maxAgeMs = maxAgeMinutes * 60_000;
+  if (maxAgeMinutes <= 0) {
+    return { stale: false, ageMs: 0, maxAgeMs };
+  }
+  const platformTs = extractPlatformTimestamp(rawPayload, now);
+  const ageMs = now - platformTs.getTime();
+  return { stale: ageMs > maxAgeMs, ageMs, maxAgeMs };
+}
+
 async function shouldProcessMessage(
   agentRunner: Services['agentRunner'],
   accessService: Services['access'],
@@ -3496,6 +3520,22 @@ async function shouldProcessMessage(
   const instance = await agentRunner.getInstanceWithProvider(metadata.instanceId);
   if (!instance?.agentId) {
     log.debug('Instance has no agentId', { instanceId: metadata.instanceId });
+    return null;
+  }
+
+  // Drop events whose platform-native timestamp is older than the instance's
+  // configured threshold. Defends against Baileys history-sync replays and
+  // NATS redelivery resurrecting stale conversations after reconnect/restart.
+  const staleness = isInboundTooStale(payload.rawPayload, instance.inboundMaxAgeMinutes);
+  if (staleness.stale) {
+    log.warn('Dropping stale inbound message', {
+      instanceId: instance.id,
+      chatId: payload.chatId,
+      externalId: payload.externalId,
+      ageMs: staleness.ageMs,
+      maxAgeMs: staleness.maxAgeMs,
+      maxAgeMinutes: instance.inboundMaxAgeMinutes,
+    });
     return null;
   }
 

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -152,7 +152,7 @@ function findLongStrings(obj: unknown, prefix = '', minLength = 200): Record<str
 /**
  * Extract platform timestamp from raw payload
  */
-function extractPlatformTimestamp(rawPayload: Record<string, unknown> | undefined, fallback: number): Date {
+export function extractPlatformTimestamp(rawPayload: Record<string, unknown> | undefined, fallback: number): Date {
   if (!rawPayload?.messageTimestamp) return new Date(fallback);
 
   const ts = rawPayload.messageTimestamp;

--- a/packages/db/drizzle/0023_dispatcher_inbound_age.sql
+++ b/packages/db/drizzle/0023_dispatcher_inbound_age.sql
@@ -1,0 +1,8 @@
+-- Add `inbound_max_age_minutes` to `instances`. Drops inbound
+-- `message.received` events for the agent dispatcher when the platform-native
+-- timestamp (e.g. WhatsApp `messageTimestamp`) is older than this value.
+--
+-- Guards against history-sync replays and NATS redelivery of stale messages
+-- after reconnect/restart. Default: 10 minutes.
+
+ALTER TABLE "instances" ADD COLUMN "inbound_max_age_minutes" integer DEFAULT 10 NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1776500100000,
       "tag": "0022_idle_follow_up_prompt_v2",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1776528000000,
+      "tag": "0023_dispatcher_inbound_age",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -670,6 +670,13 @@ export const instances = pgTable(
     triggerMode: varchar('trigger_mode', { length: 20 }).notNull().default('round-trip'),
     /** Max triggers per user per channel per minute (rate limiting) */
     triggerRateLimit: integer('trigger_rate_limit').notNull().default(5),
+    /**
+     * Drop inbound `message.received` events when the platform-native timestamp
+     * (e.g. WhatsApp `messageTimestamp`) is older than this many minutes.
+     * Guards the agent dispatcher against history-sync replays and NATS
+     * redelivery of stale messages after reconnect/restart. Default: 10.
+     */
+    inboundMaxAgeMinutes: integer('inbound_max_age_minutes').notNull().default(10),
 
     // ---- Profile Information (populated from channel) ----
     profileName: varchar('profile_name', { length: 255 }),


### PR DESCRIPTION
## Summary

Defense-in-depth for the agent dispatcher against the same replay vulnerability that PR #414 closed on the follow-up side. Baileys history-sync and NATS redelivery can resurface `message.received` events hours after the original WhatsApp timestamp, triggering the agent to reply to long-ended conversations on restart/reconnect.

## Changes

- **`packages/db/src/schema.ts`** + **`packages/db/drizzle/0023_dispatcher_inbound_age.sql`** — new column `instances.inbound_max_age_minutes` (integer, default 10).
- **`packages/api/src/plugins/agent-dispatcher.ts`** — new `isInboundTooStale()` helper + guard in `shouldProcessMessage()` that reads `rawPayload.messageTimestamp` (WhatsApp seconds-since-epoch) and drops events older than the instance threshold.
- **`packages/api/src/plugins/message-persistence.ts`** — export existing `extractPlatformTimestamp()` for reuse.
- **`packages/api/src/__tests__/dispatcher-stale-inbound.test.ts`** — 10 new unit tests covering the threshold boundary, disabled-guard (`<= 0`), missing-timestamp fallback, Baileys protobuf Long format, string-encoded timestamps.

## Behavior

- `inboundMaxAgeMinutes > 0`: drop if `now - rawPayload.messageTimestamp > threshold` (logs `warn` with `ageMs` / `maxAgeMs` for observability).
- `inboundMaxAgeMinutes <= 0`: guard disabled (for instances that genuinely need backlog replay).
- Missing/unparseable `messageTimestamp`: fallback to `now` → treated as fresh, never drops legitimate messages.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run build` — green
- [x] `bun test` (pre-push hook) — **3226 pass / 0 fail / 252 skip** across 211 files
- [x] New specs `dispatcher-stale-inbound` — 10/10 pass
- [ ] Deploy bundle + restart API
- [ ] Verify stale-inbound drops are logged on reconnect, and fresh messages still dispatch
- [ ] Monitor: no agent replies to hours-old conversations after next restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)