### PR TITLE
fix(skill): omni:chats auto-executes with --json + jq defaults

### DIFF
--- a/plugins/omni/commands/chats.md
+++ b/plugins/omni/commands/chats.md
@@ -1,8 +1,8 @@
 ---
-description: Chat browser — list, filter, archive, and view group metadata
+description: Chat browser — list, filter, archive, and view messages (compact JSON + jq by default)
 arguments:
   - name: args
-    description: Chat subcommand (e.g., list --instance <id> --unread, messages <chat-id>)
+    description: Free-form search query, chat-id, or explicit subcommand (list/messages/archive/participants...)
     required: false
 ---
 
@@ -10,15 +10,76 @@ arguments:
 
 Browse and manage conversations — list, filter, archive, pin, mute, and view participants.
 
-## Usage
+**Defaults you must honor as an agent:**
 
-$ARGUMENTS
+- **Never use table output.** Table rows pad to ~1000+ chars and blow the token budget.
+- **Always use `--json | jq -r`** with a compact selector. Select only the fields needed.
+- **Auto-execute** — when `$ARGUMENTS` contains content, run the best-matching subcommand directly instead of printing usage.
 
-## Examples
+---
+
+## How to dispatch `$ARGUMENTS`
+
+| Input shape | What to run |
+|-------------|-------------|
+| Empty | Print the one-liners below and wait for user input. |
+| Starts with `list`/`messages`/`archive`/`participants`/`create`/`update`/`delete`/`pin`/`mute`/`read`/`label`/`hide`/`disappearing` | Treat as explicit subcommand: run `omni chats $ARGUMENTS --json` and pipe through a `jq` selector that matches that subcommand. |
+| UUID (36 chars with dashes) or JID (`…@s.whatsapp.net` / `…@g.us` / `…@lid`) | Treat as a chat-id and run the `messages` template below. |
+| Anything else | Treat as a `list --search` query: run the search template below. |
+
+---
+
+## Templates (copy these verbatim, substitute `$ARGUMENTS`)
+
+### Search / list (default for free-form text)
 
 ```bash
-omni chats list --instance my-wa --unread --json | jq '.[] | {name, unreadCount}'
-omni chats messages <chat-id> --since 7d --search "keyword"
-omni chats archive <chat-id> --instance my-wa
-omni chats participants <chat-id> --instance my-wa
+omni chats list --search "$ARGUMENTS" --json \
+  | jq -r '.[] | "\(.id) \(.name // .externalId) | unread:\(.unreadCount // 0) | \((.lastMessagePreview // "") | .[:80])"'
 ```
+
+Useful flag additions:
+
+- `--instance <id>` — scope to one channel instance
+- `--unread` — only chats with unread messages
+- `--attention` — unread + pending + follow-up
+- `--type dm|group|channel` — filter chat type
+- `--limit <n>` — cap result count
+
+### Messages (when `$ARGUMENTS` is a chat-id)
+
+```bash
+omni chats messages "$ARGUMENTS" --since 7d --json \
+  | jq -r '.[] | "\(.timestamp[11:16]) \(.senderDisplayName // "?"): \((.textContent // "[media]") | .[:200])"'
+```
+
+For noisy group chats, add `--search "<keyword>"` or `--audio-only` / `--images-only` / `--docs-only`.
+
+### Archive / participants / read / pin / mute
+
+Pass `$ARGUMENTS` through and pipe JSON when the subcommand returns structured data:
+
+```bash
+omni chats participants <chat-id> --instance <inst> --json \
+  | jq -r '.[] | "\(.platformUserId) \(.displayName // "-") [\(.role // "member")]"'
+```
+
+Mutations (`archive`, `delete`, `read`, `pin`, `mute`, `label`) typically return a terse status — run them with `--json` and log the result line.
+
+---
+
+## Output-shape cheat sheet
+
+`chats list` JSON items expose: `id`, `name`, `externalId`, `unreadCount`, `lastMessageAt`, `lastMessagePreview`, `messageCount`, `isGroup`, `instanceId`, `channelType`, `canonicalId`.
+
+`chats messages` JSON items expose: `id`, `timestamp`, `textContent`, `senderDisplayName`, `senderPlatformUserId`, `hasMedia`, `mediaMimeType`, `transcription`, `imageDescription`, `videoDescription`, `documentExtraction`, `isFromMe`.
+
+Select only what you need; skip the rest.
+
+---
+
+## Known caveats
+
+- **Large message streams**: `omni chats messages` JSON output has been observed to truncate at ~64 KB when piped (see issue #402). If your `jq` errors with "Unfinished string at EOF", redirect to a file first: `omni … --json > /tmp/out.json && jq … /tmp/out.json`.
+- **Groups without names**: fall back to `.externalId` (ends in `@g.us`).
+- **LID JIDs**: use `.canonicalId` when present — it resolves the phone JID for anonymized linked-identity chats.

--- a/plugins/omni/commands/chats.md
+++ b/plugins/omni/commands/chats.md
@@ -60,7 +60,7 @@ For noisy group chats, add `--search "<keyword>"` or `--audio-only` / `--images-
 Pass `$ARGUMENTS` through and pipe JSON when the subcommand returns structured data:
 
 ```bash
-omni chats participants <chat-id> --instance <inst> --json \
+omni chats participants <chat-id> --json \
   | jq -r '.[] | "\(.platformUserId) \(.displayName // "-") [\(.role // "member")]"'
 ```
 

--- a/plugins/omni/commands/chats.md
+++ b/plugins/omni/commands/chats.md
@@ -50,7 +50,7 @@ Useful flag additions:
 
 ```bash
 omni chats messages "$ARGUMENTS" --since 7d --json \
-  | jq -r '.[] | "\(.timestamp[11:16]) \(.senderDisplayName // "?"): \((.textContent // "[media]") | .[:200])"'
+  | jq -r '.[] | "\(.platformTimestamp[11:16]) \(.senderDisplayName // "?"): \((.textContent // "[media]") | .[:200])"'
 ```
 
 For noisy group chats, add `--search "<keyword>"` or `--audio-only` / `--images-only` / `--docs-only`.
@@ -61,7 +61,7 @@ Pass `$ARGUMENTS` through and pipe JSON when the subcommand returns structured d
 
 ```bash
 omni chats participants <chat-id> --json \
-  | jq -r '.[] | "\(.platformUserId) \(.displayName // "-") [\(.role // "member")]"'
+  | jq -r '.[] | "\(.userId) \(.name // "-") [\(.role // "member")]"'
 ```
 
 Mutations (`archive`, `delete`, `read`, `pin`, `mute`, `label`) typically return a terse status — run them with `--json` and log the result line.
@@ -70,9 +70,9 @@ Mutations (`archive`, `delete`, `read`, `pin`, `mute`, `label`) typically return
 
 ## Output-shape cheat sheet
 
-`chats list` JSON items expose: `id`, `name`, `externalId`, `unreadCount`, `lastMessageAt`, `lastMessagePreview`, `messageCount`, `isGroup`, `instanceId`, `channelType`, `canonicalId`.
+`chats list` JSON items expose: `id`, `name`, `externalId`, `unreadCount`, `lastMessageAt`, `lastMessagePreview`, `messageCount`, `isGroup`, `instanceId`, `chatType`, `canonicalId`.
 
-`chats messages` JSON items expose: `id`, `timestamp`, `textContent`, `senderDisplayName`, `senderPlatformUserId`, `hasMedia`, `mediaMimeType`, `transcription`, `imageDescription`, `videoDescription`, `documentExtraction`, `isFromMe`.
+`chats messages` JSON items expose: `id`, `platformTimestamp`, `textContent`, `senderDisplayName`, `senderPlatformUserId`, `hasMedia`, `mediaMimeType`, `transcription`, `imageDescription`, `videoDescription`, `documentExtraction`, `isFromMe`.
 
 Select only what you need; skip the rest.
 


### PR DESCRIPTION
## Summary

- Replaces the usage-dump `/omni:chats` skill with a dispatcher that routes `\$ARGUMENTS` to `list` / `messages` / explicit subcommands based on input shape
- Mandates \`--json | jq -r\` with compact selectors — never table output
- Documents output field shape for \`list\` and \`messages\` so selectors stay focused
- Flags the known 64 KB pipe-truncation caveat (#402)

## Why

Table rows pad to ~1000+ chars each, blowing the agent token budget every time a chat listing is pulled. Compact \`jq\` selectors keep each row under ~200 chars and make the skill usable for agent-driven triage.

## Test plan

- [x] Skill file syntactically valid (front-matter + markdown preserved)
- [ ] Manual: \`/omni:chats nmstx leadership\` auto-runs \`list --search … --json | jq …\`
- [ ] Manual: \`/omni:chats <chat-uuid>\` auto-runs \`messages <id> --since 7d --json | jq …\`

Closes #367