### PR TITLE
fix(follow-up): terminal-disarm guard prevents tail messages re-arming

### DIFF
--- a/packages/api/src/__tests__/follow-up-lifecycle.test.ts
+++ b/packages/api/src/__tests__/follow-up-lifecycle.test.ts
@@ -284,4 +284,173 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     // Until G6 adds columns, all reads return undefined → resolver returns null.
     expect(result).toBeNull();
   });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Terminal-disarm guard (#419) — tail agent messages after a user-intent
+  // disarm must not re-arm the sequence until the customer returns.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test('#419 refuses re-arm after session_cleared when customer has not returned', async () => {
+    const armAt = new Date();
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: armAt,
+      config: config(),
+    });
+
+    // User clears the session → terminal disarm.
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'session_cleared' });
+    publishedEvents.length = 0;
+
+    // Tail stream chunk / redelivered message.sent fires armForOutbound.
+    // Wall-clock timestamp after the disarm, but the customer has NOT sent
+    // a message since — the sequence must stay disarmed.
+    const tailAt = new Date(armAt.getTime() + 2_000);
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: tailAt,
+      config: config(),
+    });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('session_cleared');
+    expect(row.nextFireAt).toBeNull();
+    expect(publishedEvents.map((e) => e.type)).not.toContain('follow_up.armed');
+  });
+
+  test('#419 allows re-arm after session_cleared once customer returns', async () => {
+    const armAt = new Date();
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: armAt,
+      config: config(),
+    });
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'session_cleared' });
+
+    // Customer returns with a new message.
+    const customerReturnAt = new Date(armAt.getTime() + 60_000);
+    await service.touchInboundTimestamp({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      at: customerReturnAt,
+    });
+
+    publishedEvents.length = 0;
+
+    // Agent replies to the returning customer — should arm fresh.
+    const newAgentReplyAt = new Date(customerReturnAt.getTime() + 1_000);
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: newAgentReplyAt,
+      config: config(),
+    });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBeNull();
+    expect(row.nextFireAt).not.toBeNull();
+    expect(publishedEvents.map((e) => e.type)).toContain('follow_up.armed');
+  });
+
+  test('#419 refuses re-arm after handoff / archived / window_expired (symmetric)', async () => {
+    for (const reason of ['handoff', 'archived', 'window_expired'] as const) {
+      await db.delete(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+
+      const armAt = new Date();
+      await service.armForOutbound({
+        chatId: testChatId,
+        instanceId: testInstanceId,
+        agentId: null,
+        lastAgentMessageAt: armAt,
+        config: config(),
+      });
+      await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason });
+      publishedEvents.length = 0;
+
+      await service.armForOutbound({
+        chatId: testChatId,
+        instanceId: testInstanceId,
+        agentId: null,
+        lastAgentMessageAt: new Date(armAt.getTime() + 2_000),
+        config: config(),
+      });
+
+      const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+      expect(row.disarmReason).toBe(reason);
+      expect(publishedEvents.map((e) => e.type)).not.toContain('follow_up.armed');
+    }
+  });
+
+  test('#419 customer_replied is NOT terminal — next agent message re-arms normally', async () => {
+    const armAt = new Date();
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: armAt,
+      config: config(),
+    });
+    // Normal customer reply flow: follow-up-hooks disarm + touchInbound.
+    const replyAt = new Date(armAt.getTime() + 30_000);
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'customer_replied',
+      lastInboundCustomerMessageAt: replyAt,
+    });
+    publishedEvents.length = 0;
+
+    // Agent replies to the customer — should arm a fresh sequence even
+    // without `touchInboundTimestamp` (customer_replied already set
+    // lastInboundCustomerMessageAt to replyAt).
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(replyAt.getTime() + 1_000),
+      config: config(),
+    });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBeNull();
+    expect(row.nextFireAt).not.toBeNull();
+    expect(publishedEvents.map((e) => e.type)).toContain('follow_up.armed');
+  });
+
+  test('touchInboundTimestamp updates lastInboundCustomerMessageAt even on terminally-disarmed rows', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'session_cleared' });
+
+    const returnAt = new Date(Date.now() + 60_000);
+    await service.touchInboundTimestamp({ chatId: testChatId, instanceId: testInstanceId, at: returnAt });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.lastInboundCustomerMessageAt?.getTime()).toBe(returnAt.getTime());
+    // Row stays terminally disarmed — touch must not clear the disarm reason.
+    expect(row.disarmReason).toBe('session_cleared');
+  });
+
+  test('touchInboundTimestamp on a missing row is a silent no-op', async () => {
+    await service.touchInboundTimestamp({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      at: new Date(),
+    });
+    const rows = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/packages/api/src/plugins/follow-up-hooks.ts
+++ b/packages/api/src/plugins/follow-up-hooks.ts
@@ -96,11 +96,21 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
         const chatId = await resolveChatId(services, instanceId, payload.chatId);
         if (!chatId) return;
 
+        const at = new Date(event.timestamp);
+
+        // Touch the inbound timestamp unconditionally — the disarm below is
+        // a no-op when the row is already terminally disarmed (e.g. by
+        // session_cleared), so without this the row's
+        // `lastInboundCustomerMessageAt` would never advance and the
+        // terminal-disarm guard in `armForOutbound` would refuse to re-arm
+        // even after the customer genuinely returns. See #419.
+        await services.followUpLifecycle.touchInboundTimestamp({ chatId, instanceId, at });
+
         await services.followUpLifecycle.disarm({
           chatId,
           instanceId,
           reason: 'customer_replied',
-          lastInboundCustomerMessageAt: new Date(event.timestamp),
+          lastInboundCustomerMessageAt: at,
         });
       },
       {

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -43,6 +43,26 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 const log = createLogger('follow-up-lifecycle');
 
 /**
+ * Disarm reasons that represent a terminal user/operator intent to stop the
+ * conversation. An agent-origin message received after one of these should
+ * NOT resurrect the sequence unless a customer message arrived in between
+ * (see `armForOutbound` re-arm guard). Tail-stream chunks, NATS redeliveries,
+ * or any agent activity that predates the disarm would otherwise re-arm a
+ * sequence the user explicitly terminated — that was #419.
+ *
+ * `customer_replied`, `sequence_complete`, `agent_error`, `send_failed` are
+ * *not* terminal intent: the former resumes on the very next agent reply
+ * (normal flow), the latter three mean the sequence ran its course or
+ * errored out and a brand-new agent reply can legitimately arm afresh.
+ */
+const TERMINAL_DISARM_REASONS: ReadonlySet<FollowUpDisarmReason> = new Set<FollowUpDisarmReason>([
+  'session_cleared',
+  'handoff',
+  'archived',
+  'window_expired',
+]);
+
+/**
  * Typed reads across the three storage locations — the resolver is DB-agnostic,
  * so the API service does the column/jsonb lookup here and hands plain
  * `FollowUpSequenceConfig | null | undefined` to the resolver.
@@ -127,6 +147,30 @@ export class FollowUpLifecycleService {
       }
     }
 
+    // Terminal-disarm guard (#419): if the chat was disarmed with a terminal
+    // intent (user cleared the session, operator took handoff, chat archived,
+    // or the messaging window expired), refuse to re-arm unless the customer
+    // has actually sent a new message since the disarm. Without this check,
+    // any agent-origin `message.sent` that lands after the disarm (tail stream
+    // chunks, split-message tails, NATS redelivery of in-flight events) will
+    // resurrect a sequence the user explicitly terminated.
+    const existing = await this.readExistingRow(input.chatId, input.instanceId);
+    if (existing?.disarmReason && TERMINAL_DISARM_REASONS.has(existing.disarmReason) && existing.disarmedAt) {
+      const lastInbound = existing.lastInboundCustomerMessageAt?.getTime() ?? 0;
+      const disarmedAt = existing.disarmedAt.getTime();
+      if (lastInbound <= disarmedAt) {
+        this.logger.info('follow-up lifecycle: refusing to arm — terminal disarm awaiting customer return', {
+          chatId: input.chatId,
+          instanceId: input.instanceId,
+          disarmReason: existing.disarmReason,
+          disarmedAt: existing.disarmedAt.toISOString(),
+          lastAgentMessageAt: input.lastAgentMessageAt.toISOString(),
+          lastInboundCustomerMessageAt: existing.lastInboundCustomerMessageAt?.toISOString() ?? null,
+        });
+        return;
+      }
+    }
+
     try {
       await armSequence(
         { repo: this.repo, eventBus: this.eventBus, logger: this.logger },
@@ -140,6 +184,29 @@ export class FollowUpLifecycleService {
       );
     } catch (err) {
       this.logger.error('follow-up lifecycle: arm failed', {
+        chatId: input.chatId,
+        instanceId: input.instanceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Record an inbound customer message timestamp on an existing row
+   * regardless of its disarm state. Used by the inbound hook so a
+   * terminally-disarmed row can be "reactivated" for arming when the
+   * customer genuinely returns (see `armForOutbound` terminal-disarm guard).
+   * No-op when no row exists yet — the first outbound agent message will
+   * create one.
+   */
+  async touchInboundTimestamp(input: { chatId: string; instanceId: string; at: Date }): Promise<void> {
+    try {
+      await this.db
+        .update(chatFollowUpState)
+        .set({ lastInboundCustomerMessageAt: input.at, updatedAt: input.at })
+        .where(and(eq(chatFollowUpState.chatId, input.chatId), eq(chatFollowUpState.instanceId, input.instanceId)));
+    } catch (err) {
+      this.logger.warn('follow-up lifecycle: touchInboundTimestamp failed', {
         chatId: input.chatId,
         instanceId: input.instanceId,
         error: err instanceof Error ? err.message : String(err),
@@ -214,6 +281,36 @@ export class FollowUpLifecycleService {
     const row = result[0];
     const created = row?.xmax === '0';
     return { created };
+  }
+
+  /**
+   * Read the minimum fields required by the terminal-disarm guard in
+   * `armForOutbound`. Returns `null` when no row exists yet.
+   */
+  private async readExistingRow(
+    chatId: string,
+    instanceId: string,
+  ): Promise<{
+    disarmReason: FollowUpDisarmReason | null;
+    disarmedAt: Date | null;
+    lastInboundCustomerMessageAt: Date | null;
+  } | null> {
+    const [row] = await this.db
+      .select({
+        disarmReason: chatFollowUpState.disarmReason,
+        disarmedAt: chatFollowUpState.disarmedAt,
+        lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
+      })
+      .from(chatFollowUpState)
+      .where(and(eq(chatFollowUpState.chatId, chatId), eq(chatFollowUpState.instanceId, instanceId)))
+      .limit(1);
+
+    if (!row) return null;
+    return {
+      disarmReason: (row.disarmReason ?? null) as FollowUpDisarmReason | null,
+      disarmedAt: row.disarmedAt ?? null,
+      lastInboundCustomerMessageAt: row.lastInboundCustomerMessageAt ?? null,
+    };
   }
 
   private async disarmActive(


### PR DESCRIPTION
## Summary

Fixes #419 — follow-up sequence kept firing after the user cleared the session via 🗑️. The disarm code from f7a19578 did run, but any agent-origin \`message.sent\` that landed AFTER the disarm (tail stream chunks, split-message tails, NATS redelivery) called \`armForOutbound\`, whose \`upsertArmed\` blindly resets \`disarm_reason\` to null and re-arms the sequence.

## Root cause

\`upsertArmed\` always wins over a prior disarm. So the race is:

1. \`T0\` agent replies → row armed
2. \`T0+5s\` user sends 🗑️ → session-cleaner disarms with \`session_cleared\`
3. \`T0+6s\` agent's tail chunk emits \`message.sent\` → \`armForOutbound\` → re-arm (bug)
4. \`T0+60s\` sweeper fires follow-up #0

## Fix

- Add \`TERMINAL_DISARM_REASONS\` set — \`session_cleared\`, \`handoff\`, \`archived\`, \`window_expired\` — these represent user/operator intent to stop.
- \`armForOutbound\` reads the existing row. If terminally disarmed and the customer has NOT sent a message since the disarm, the arm is refused (logged at info level).
- Expose \`touchInboundTimestamp\` — updates \`last_inbound_customer_message_at\` on any existing row regardless of disarm state. The repo's \`disarmActive\` guards on \`disarmReason IS NULL\`, so a terminally-disarmed row would otherwise never record the customer's return.
- \`follow-up-hooks\` inbound handler calls \`touchInboundTimestamp\` before the customer_replied disarm, so the next agent reply after a genuine customer return arms fresh.

\`customer_replied\`, \`sequence_complete\`, \`agent_error\`, \`send_failed\` are NOT terminal and continue to re-arm as before.

## Test plan

- [x] 16/16 follow-up-lifecycle tests pass (includes 5 new guards)
- [x] 18/18 follow-up-sweeper + e2e + routes tests pass
- [x] \`bun run typecheck\` clean across 19 packages
- [x] Biome lint clean (2 pre-existing warnings untouched)
- [ ] Manual QA on testonho — instance \`fdf0197d-1317-4e40-a537-80ea5a26c390\`, agent \`3a80f9ff-54c4-449e-b603-2b821920d4ab\`, config \`[1, 5, 30, 120, 1259]\`: converse → 🗑️ → verify no follow-up fires; then send new inbound → verify arm resumes.

Closes #419