### PR TITLE
fix(api,cli): instance PATCH + CLI expose messageSplitDelay* fields

### DIFF
--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -108,6 +108,28 @@ const createInstanceSchema = z.object({
     .nullable()
     .default(null)
     .describe('Debounce delay for group chats in milliseconds (null = use messageDebounceMinMs)'),
+  messageSplitDelayMode: z
+    .enum(['disabled', 'fixed', 'randomized'])
+    .default('randomized')
+    .describe('Between-chunk delay when agent responses are split into multiple messages'),
+  messageSplitDelayFixedMs: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe('Fixed delay between split chunks in milliseconds (used when messageSplitDelayMode="fixed")'),
+  messageSplitDelayMinMs: z
+    .number()
+    .int()
+    .min(0)
+    .default(300)
+    .describe('Minimum delay between split chunks in milliseconds (used when messageSplitDelayMode="randomized")'),
+  messageSplitDelayMaxMs: z
+    .number()
+    .int()
+    .min(0)
+    .default(1000)
+    .describe('Maximum delay between split chunks in milliseconds (used when messageSplitDelayMode="randomized")'),
   agentGateEnabled: z.boolean().default(false).describe('Enable LLM response gate (pre-filter before agent dispatch)'),
   agentGateModel: z
     .string()
@@ -197,6 +219,12 @@ const updateInstanceSchema = createInstanceSchema.partial().extend({
   reactionAckEmoji: z.record(z.string()).nullable().optional(),
   ackTimeoutMs: z.number().int().min(0).max(120_000).optional(),
   agentStalledTimeoutMs: z.number().int().min(0).optional(),
+  // Split-delay fields are NOT NULL in DB — override to strip defaults so a
+  // PATCH that omits them doesn't reset the stored values on the row.
+  messageSplitDelayMode: z.enum(['disabled', 'fixed', 'randomized']).optional(),
+  messageSplitDelayFixedMs: z.number().int().min(0).optional(),
+  messageSplitDelayMinMs: z.number().int().min(0).optional(),
+  messageSplitDelayMaxMs: z.number().int().min(0).optional(),
 });
 
 /**

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -88,6 +88,14 @@ function applyDebounceFields(body: Record<string, unknown>, opts: Record<string,
   if (opts.debounceGroup !== undefined) body.messageDebounceGroupMs = opts.debounceGroup;
 }
 
+/** Extract split-delay fields from CLI options into body */
+function applySplitDelayFields(body: Record<string, unknown>, opts: Record<string, unknown>): void {
+  setVal(body, 'messageSplitDelayMode', opts.splitDelayMode);
+  if (opts.splitDelayFixed !== undefined) body.messageSplitDelayFixedMs = opts.splitDelayFixed;
+  if (opts.splitDelayMin !== undefined) body.messageSplitDelayMinMs = opts.splitDelayMin;
+  if (opts.splitDelayMax !== undefined) body.messageSplitDelayMaxMs = opts.splitDelayMax;
+}
+
 /** Extract agent gate fields from CLI options into body */
 function applyGateFields(body: Record<string, unknown>, opts: Record<string, unknown>): void {
   setBool(body, 'agentGateEnabled', opts.agentGate);
@@ -144,6 +152,7 @@ function buildInstanceBody(opts: Record<string, unknown>): Record<string, unknow
   applyReplyFilter(body, opts);
   applyFormatFields(body, opts);
   applyDebounceFields(body, opts);
+  applySplitDelayFields(body, opts);
   applyGateFields(body, opts);
   applyMiscFields(body, opts);
   applyAckFields(body, opts);
@@ -297,6 +306,11 @@ export function createInstancesCommand(): Command {
     .option('--debounce-max <ms>', 'Maximum debounce delay in ms', (v) => Number.parseInt(v, 10))
     .option('--debounce-restart-on-typing', 'Restart debounce timer on typing')
     .option('--debounce-group <ms>', 'Group chat debounce in ms', (v) => Number.parseInt(v, 10))
+    // Split delay (between agent-reply chunks)
+    .option('--split-delay-mode <mode>', 'Split delay mode: disabled, fixed, or randomized')
+    .option('--split-delay-fixed <ms>', 'Fixed delay between split chunks in ms', (v) => Number.parseInt(v, 10))
+    .option('--split-delay-min <ms>', 'Minimum delay between split chunks in ms', (v) => Number.parseInt(v, 10))
+    .option('--split-delay-max <ms>', 'Maximum delay between split chunks in ms', (v) => Number.parseInt(v, 10))
     // Agent gate
     .option('--agent-gate', 'Enable LLM response gate')
     .option('--agent-gate-model <model>', 'Model for response gate')
@@ -770,6 +784,11 @@ export function createInstancesCommand(): Command {
     .option('--debounce-group <ms>', 'Group chat debounce in ms (use "null" to inherit)', (v) =>
       v === 'null' ? null : Number.parseInt(v, 10),
     )
+    // Split delay (between agent-reply chunks)
+    .option('--split-delay-mode <mode>', 'Split delay mode: disabled, fixed, or randomized')
+    .option('--split-delay-fixed <ms>', 'Fixed delay between split chunks in ms', (v) => Number.parseInt(v, 10))
+    .option('--split-delay-min <ms>', 'Minimum delay between split chunks in ms', (v) => Number.parseInt(v, 10))
+    .option('--split-delay-max <ms>', 'Maximum delay between split chunks in ms', (v) => Number.parseInt(v, 10))
     // Agent gate
     .option('--agent-gate', 'Enable LLM response gate')
     .option('--no-agent-gate', 'Disable LLM response gate')


### PR DESCRIPTION
## Summary

Fixes #373 — the DB schema has \`messageSplitDelayMode/FixedMs/MinMs/MaxMs\` and the dispatcher honors them at runtime, but the \`PATCH /instances/:id\` zod schema doesn't list them and \`omni instances update\` has no flags for them. Configuring split delays required direct DB updates.

## Changes

- **\`packages/api/src/routes/v2/instances.ts\`** — add the 4 fields to \`createInstanceSchema\` (with DB defaults: mode=randomized, fixed=0, min=300, max=1000); extend \`updateInstanceSchema\` to strip defaults on PATCH so an omitted field doesn't silently reset a live instance back to defaults (same pattern as readReceipts/reactionAck).
- **\`packages/cli/src/commands/instances.ts\`** — new \`applySplitDelayFields\` helper mirroring the debounce helper, wired into \`buildInstanceBody\`. Four new flags on both \`create\` and \`update\`:
  - \`--split-delay-mode <disabled|fixed|randomized>\`
  - \`--split-delay-fixed <ms>\`
  - \`--split-delay-min <ms>\`
  - \`--split-delay-max <ms>\`

## Test plan

- [x] \`bun run typecheck\` clean across 19 packages
- [x] Biome lint clean
- [ ] Manual verify: \`omni instances update <id> --split-delay-mode fixed --split-delay-fixed 500\` persists to DB
- [ ] Manual verify: omitting the fields on PATCH does NOT reset live instance back to defaults

Note on test coverage: this is a mechanical schema-expansion on top of columns that already exist in the DB with NOT NULL defaults. Drizzle's typed \`update()\` call ensures type-safety down-stack. No new runtime behavior — the dispatcher side already reads these columns today.

Closes #373