### PR TITLE
fix(chats): derive and expose isGroup on chat list/get responses

### DIFF
--- a/packages/api/src/__tests__/chats-service.test.ts
+++ b/packages/api/src/__tests__/chats-service.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Database } from '@omni/db';
 import type { Chat } from '@omni/db';
-import { ChatService } from '../services/chats';
+import { ChatService, isChatGroup, withIsGroup } from '../services/chats';
 
 // Helper to create a mock chat with all required fields
 function createMockChat(overrides: Partial<Chat>): Chat {
@@ -348,5 +348,46 @@ describe('ChatService regression tests', () => {
     expect(result?.id).toBe('545f8ecb-f485-4283-88f1-a4bec20f66be');
     expect(result?.externalId).toBe(lidJid);
     expect(result?.canonicalId).toBe(phoneJid);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// #403 — derived `isGroup` flag on chat responses
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('isChatGroup / withIsGroup', () => {
+  test('returns true for chatType=group regardless of externalId', () => {
+    expect(isChatGroup({ chatType: 'group', externalId: 'anything' })).toBe(true);
+  });
+
+  test('returns true for chatType=community', () => {
+    expect(isChatGroup({ chatType: 'community', externalId: 'x@s.whatsapp.net' })).toBe(true);
+  });
+
+  test('returns true for legacy WhatsApp group still classified as dm (fallback)', () => {
+    // Older rows / migration edge cases may have chatType='dm' despite @g.us.
+    // Fallback keeps consumers working until the row is reclassified.
+    expect(isChatGroup({ chatType: 'dm', externalId: '120363042@g.us' })).toBe(true);
+  });
+
+  test('returns false for WhatsApp DM', () => {
+    expect(isChatGroup({ chatType: 'dm', externalId: '5511999999@s.whatsapp.net' })).toBe(false);
+  });
+
+  test('returns false for Discord channel', () => {
+    expect(isChatGroup({ chatType: 'channel', externalId: 'disc-ch-1' })).toBe(false);
+  });
+
+  test('returns false for broadcast (not multi-party in the WhatsApp sense)', () => {
+    expect(isChatGroup({ chatType: 'broadcast', externalId: 'status@broadcast' })).toBe(false);
+  });
+
+  test('withIsGroup preserves every input field and adds the derived flag', () => {
+    const chat = createMockChat({ chatType: 'group', externalId: '120363042@g.us', name: 'Team Chat' });
+    const augmented = withIsGroup(chat);
+    expect(augmented.isGroup).toBe(true);
+    expect(augmented.id).toBe(chat.id);
+    expect(augmented.externalId).toBe(chat.externalId);
+    expect(augmented.name).toBe('Team Chat');
   });
 });

--- a/packages/api/src/services/chats.ts
+++ b/packages/api/src/services/chats.ts
@@ -27,6 +27,28 @@ const log = createLogger('chats');
 /** Label that triggers the "attention" state when present on a chat */
 const ATTENTION_LABEL = 'follow-up';
 
+/** Chat types that represent a multi-party conversation (vs a 1:1 DM). */
+const GROUP_CHAT_TYPES = new Set<ChatType>(['group', 'community']);
+
+/**
+ * True when the chat is a multi-party conversation.
+ *
+ * Derives from `chatType` first (channel-agnostic, already correctly set for
+ * modern rows). Falls back to a WhatsApp JID suffix check for legacy rows
+ * classified as `dm` despite having a `@g.us` externalId — see #403.
+ */
+export function isChatGroup(chat: Pick<Chat, 'chatType' | 'externalId'>): boolean {
+  if (GROUP_CHAT_TYPES.has(chat.chatType)) return true;
+  return typeof chat.externalId === 'string' && chat.externalId.endsWith('@g.us');
+}
+
+export type ChatWithIsGroup<T extends Pick<Chat, 'chatType' | 'externalId'>> = T & { isGroup: boolean };
+
+/** Augment a chat row with the derived `isGroup` flag. */
+export function withIsGroup<T extends Pick<Chat, 'chatType' | 'externalId'>>(chat: T): ChatWithIsGroup<T> {
+  return { ...chat, isGroup: isChatGroup(chat) };
+}
+
 export interface ChatWithParticipants extends Chat {
   participants: ChatParticipant[];
 }
@@ -177,7 +199,7 @@ export class ChatService {
    * List chats with filtering and pagination
    */
   async list(options: ListChatsOptions = {}): Promise<{
-    items: Chat[];
+    items: ChatWithIsGroup<Chat>[];
     hasMore: boolean;
     cursor?: string;
     total: number;
@@ -218,7 +240,10 @@ export class ChatService {
 
     const lastItem = items[items.length - 1];
     return {
-      items,
+      // Derive `isGroup` at the serialization boundary — the DB doesn't store
+      // it explicitly, but clients need a single boolean to filter groups vs
+      // DMs without hard-coding WhatsApp JID suffixes. See #403.
+      items: items.map(withIsGroup),
       hasMore,
       cursor: lastItem?.lastMessageAt?.toISOString(),
       total: items.length + (hasMore ? 1 : 0),
@@ -351,7 +376,7 @@ export class ChatService {
   /**
    * Get chat by ID
    */
-  async getById(id: string, options?: { includeHidden?: boolean }): Promise<Chat> {
+  async getById(id: string, options?: { includeHidden?: boolean }): Promise<ChatWithIsGroup<Chat>> {
     const [result] = await this.db.select().from(chats).where(eq(chats.id, id)).limit(1);
 
     if (!result) {
@@ -362,7 +387,7 @@ export class ChatService {
       throw new NotFoundError('Chat', id);
     }
 
-    return result;
+    return withIsGroup(result);
   }
 
   /**

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -48,6 +48,12 @@ export interface Chat {
   name?: string | null;
   description?: string | null;
   avatarUrl?: string | null;
+  /**
+   * Derived flag: true when the chat is a multi-party conversation
+   * (chatType group/community, or WhatsApp `@g.us` externalId). Computed
+   * server-side so clients can filter groups without platform-specific checks.
+   */
+  isGroup?: boolean;
   isArchived: boolean;
   settings?: ChatSettings | null;
   createdAt: string;


### PR DESCRIPTION
## Summary

Fixes #403 — \`omni chats list --json\` consumers had no way to filter groups vs DMs without regex-matching \`externalId\` for \`@g.us\`. The \`isGroup\` field existed on the Contact SDK type but NOT on Chat, and the chats table has no \`is_group\` column either — so the flag wasn't surfaced anywhere on the chat response.

## Fix

- \`isChatGroup(chat)\` helper: \`chatType ∈ {group, community}\` with a \`@g.us\`-suffix fallback for legacy rows still classified as \`dm\`.
- \`withIsGroup(chat)\` decorator preserves every field, appends the derived flag.
- \`ChatService.list()\` and \`ChatService.getById()\` now return \`ChatWithIsGroup<Chat>\`.
- SDK Chat interface gets optional \`isGroup?: boolean\`.

No DB migration. The flag is computed at the serialization boundary.

## Proposed backfill (out of scope of this PR)

For any legacy rows where \`chatType='dm'\` despite \`@g.us\`:

\`\`\`sql
UPDATE chats
   SET chat_type = 'group', updated_at = NOW()
 WHERE external_id LIKE '%@g.us'
   AND chat_type = 'dm';
\`\`\`

Deliberately not bundled — the fallback in \`isChatGroup\` keeps consumers working today, and a data-hygiene sweep is a separate concern that should be reviewed per environment.

## Test plan

- [x] 14/14 chats-service tests pass (7 new isChatGroup/withIsGroup tests)
- [x] \`bun run typecheck\` clean across 19 packages
- [x] Biome lint clean
- [ ] Manual verify on testonho: \`omni chats list --json | jq '.[] | select(.isGroup)' | head\` returns group entries only

Closes #403