### PR TITLE
fix(dispatcher): treat null agent_reply_filter as allow-all (#371)

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -72,6 +72,10 @@ POST   /api/v2/instances                      # Create instance
         agentSessionStrategy?, agentPrefixSenderName?,
         enableAutoSplit?, isDefault?, token?, ttsVoiceId?, ttsModelId?
 
+  Note: `agentReplyFilter` defaults to `null`, which means **reply to all**
+  inbound messages (see #371). Set `{ mode: 'filtered', conditions: {...} }`
+  to restrict agent responses to DMs / mentions / replies / name matches.
+
 PATCH  /api/v2/instances/:id                  # Update instance
   Body: (same as create, all optional)
 

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1290,12 +1290,12 @@ describe('agent-dispatcher', () => {
       expect(agentRunner.getSenderName).toHaveBeenCalled();
     });
 
-    it('skips messages when reply filter is null (no agent response)', async () => {
+    it('processes messages when reply filter is null (allow-all default — #371)', async () => {
       const eventBus = createMockEventBus();
       const agentRunner = {
         getInstanceWithProvider: mock(async () =>
           createMockInstance({
-            agentReplyFilter: null, // No filter = no reply
+            agentReplyFilter: null, // No filter = allow all (documented new default)
           }),
         ),
         getSenderName: mock(async () => 'User'),
@@ -1311,7 +1311,8 @@ describe('agent-dispatcher', () => {
       await eventBus.fire('message.received', createMessageEvent());
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      expect(agentRunner.run).not.toHaveBeenCalled();
+      // Null filter should pass the reply-filter gate and reach agent dispatch.
+      expect(agentRunner.getSenderName).toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3466,6 +3466,10 @@ async function resolveEffectiveReplyFilter(
   return (route?.agentReplyFilter as Instance['agentReplyFilter']) ?? defaultFilter;
 }
 
+// Tracks instances we've already logged a "no reply filter configured" warning for,
+// so operators see the notice once per process lifetime instead of per message.
+const nullFilterWarnedInstances = new Set<string>();
+
 /** Slack: resolve isReplyToBot by checking if the bot has sent a message in this thread */
 async function resolveSlackThreadReply(
   chatsService: Services['chats'],
@@ -3620,8 +3624,18 @@ async function shouldProcessMessage(
     instance.agentReplyFilter,
   );
 
+  // #371: null filter now means "allow all" instead of silently dropping every
+  // message. Surface a one-time warning so operators know they're running without
+  // explicit gating and can configure a filter if that's not what they want.
+  if (!effectiveReplyFilter && !nullFilterWarnedInstances.has(instance.id)) {
+    nullFilterWarnedInstances.add(instance.id);
+    log.warn('instance has no agent_reply_filter configured — allowing all inbound messages', {
+      instanceId: instance.id,
+    });
+  }
+
   if (!shouldAgentReply(effectiveReplyFilter, messageContext)) {
-    log.debug('Message did not pass reply filter', {
+    log.info('Message did not pass reply filter', {
       instanceId: instance.id,
       chatId: payload.chatId,
       messageContext,

--- a/packages/api/src/services/__tests__/agent-reply-thread.test.ts
+++ b/packages/api/src/services/__tests__/agent-reply-thread.test.ts
@@ -11,6 +11,44 @@ import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../message-con
 import { MessageService } from '../messages';
 
 // ============================================================================
+// shouldAgentReply – null filter default (#371)
+// ============================================================================
+
+describe('shouldAgentReply – null filter', () => {
+  const baseContext: MessageContext = {
+    isDirectMessage: false,
+    mentionsBot: false,
+    isReplyToBot: false,
+    text: 'hello',
+  };
+
+  test('returns true when filter is null (allow-all default)', () => {
+    expect(shouldAgentReply(null, baseContext)).toBe(true);
+  });
+
+  test('returns true when filter is undefined (allow-all default)', () => {
+    expect(shouldAgentReply(undefined, baseContext)).toBe(true);
+  });
+
+  test("returns true when filter.mode is 'all' regardless of context", () => {
+    const allFilter = {
+      mode: 'all' as const,
+      conditions: { onDm: false, onMention: false, onReply: false, onNameMatch: false },
+    };
+    expect(shouldAgentReply(allFilter, baseContext)).toBe(true);
+  });
+
+  test("'filtered' mode still enforces conditions (unchanged)", () => {
+    const dmOnly = {
+      mode: 'filtered' as const,
+      conditions: { onDm: true, onMention: false, onReply: false, onNameMatch: false },
+    };
+    expect(shouldAgentReply(dmOnly, { ...baseContext, isDirectMessage: false })).toBe(false);
+    expect(shouldAgentReply(dmOnly, { ...baseContext, isDirectMessage: true })).toBe(true);
+  });
+});
+
+// ============================================================================
 // shouldAgentReply – onReply condition
 // ============================================================================
 

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -126,8 +126,9 @@ function matchesNamePattern(text: string, patterns?: string[]): boolean {
  * Determine if the agent should reply based on filter configuration
  */
 export function shouldAgentReply(filter: AgentReplyFilter | null | undefined, context: MessageContext): boolean {
-  // No filter configured = no agent response
-  if (!filter) return false;
+  // No filter configured = reply to all (safe default for new instances).
+  // Callers are expected to log/notify when operating without an explicit filter.
+  if (!filter) return true;
 
   // 'all' mode = always reply
   if (filter.mode === 'all') return true;


### PR DESCRIPTION
## Summary

- `shouldAgentReply(null | undefined, ...)` now returns `true` instead of `false`. A newly-provisioned instance with no reply filter configured will receive every inbound message (matches operator expectation).
- Dispatcher emits a **one-time `warn` log per instance** when operating without a filter, so "no filter configured" is visible instead of silent.
- Rejected-filter path bumped from `debug` → `info` so routine drops surface in prod logs.
- Tests updated to assert the new behavior; new unit tests cover null/undefined filters.
- Docs (`docs/api/endpoints.md`) call out the default on `POST /api/v2/instances`.

Closes #371.

## ⚠️ BEHAVIOR CHANGE — reviewer attention required

Live instances whose `agentReplyFilter` column is `null` will now start dispatching messages to their agent. Before this fix, those instances silently dropped every message.

- If any production instance was relying on the implicit drop (i.e., "no filter" meant "mute the agent"), this change will wake the bot up. Those instances need an explicit filter (e.g., `{ mode: 'filtered', conditions: {...} }` with conservative conditions) before merge, OR an ops-side verification that no instance is in this state.
- The one-time `warn` log is the operator's signal — grep prod logs for `instance has no agent_reply_filter configured` after deploy to see which instances are affected.

## Test plan

- [x] `bun test packages/api/src/services/__tests__/agent-reply-thread.test.ts` — 18 pass (includes 4 new null-filter unit tests)
- [x] `bun test packages/api/src/plugins/__tests__/agent-dispatcher.test.ts` — 50 pass (existing null-filter test flipped to assert dispatch proceeds)
- [x] `bun test packages/api/src` — 581 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] Pre-push full suite — 2,986 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)