### PR TITLE
fix(reactions): leave fromMe undefined when target missing, let plugin heuristic decide

### DIFF
--- a/packages/api/src/__tests__/messages-send-reaction.test.ts
+++ b/packages/api/src/__tests__/messages-send-reaction.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for POST /messages/send/reaction (#386).
+ *
+ * Specifically covers the fromMe resolution contract:
+ *   - target message found in DB → fromMe comes from messages.isFromMe
+ *   - target message NOT in DB (history gap / unsynced chat) → fromMe is left
+ *     undefined so the channel plugin applies its own heuristic. Previously
+ *     this forced fromMe=false, which broke bot-to-own-message reactions in
+ *     unsynced scenarios.
+ */
+
+import { afterAll, beforeAll, expect, mock, test } from 'bun:test';
+import { NotFoundError, OmniError } from '@omni/core';
+import type { Database, Instance } from '@omni/db';
+import { chats, instances, messages } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { createServices } from '../services';
+import type { AppVariables } from '../types';
+import { describeWithDb, getTestDb } from './db-helper';
+
+type SendMessageMock = ReturnType<typeof mock<(...args: unknown[]) => Promise<unknown>>>;
+
+function createMockPlugin(sendMessageMock: SendMessageMock) {
+  return {
+    capabilities: {
+      canSendText: true,
+      canSendMedia: true,
+      canSendReaction: true,
+      canSendTyping: true,
+      canReceiveReadReceipts: true,
+      canReceiveDeliveryReceipts: true,
+      canEditMessage: true,
+      canDeleteMessage: true,
+      canReplyToMessage: true,
+      canForwardMessage: true,
+      canSendContact: true,
+      canSendLocation: true,
+      canSendSticker: true,
+      canHandleGroups: true,
+      canHandleBroadcast: false,
+      maxMessageLength: 65536,
+      supportedMediaTypes: [],
+      maxFileSize: 100 * 1024 * 1024,
+    },
+    sendMessage: sendMessageMock,
+  };
+}
+
+function createMockChannelRegistry(plugin: ReturnType<typeof createMockPlugin> | null) {
+  return {
+    get: mock(() => plugin),
+    getAll: mock(() => (plugin ? [plugin] : [])),
+    has: mock(() => !!plugin),
+  };
+}
+
+describeWithDb('POST /messages/send/reaction — fromMe resolution (#386)', () => {
+  let db: Database;
+  let testInstance: Instance;
+  let testChat: { id: string; externalId: string };
+  let inboundMessage: { id: string; externalId: string };
+  let outboundMessage: { id: string; externalId: string };
+  const insertedInstanceIds: string[] = [];
+  const insertedChatIds: string[] = [];
+  const insertedMessageIds: string[] = [];
+
+  beforeAll(async () => {
+    db = getTestDb();
+
+    const [instance] = await db
+      .insert(instances)
+      .values({
+        name: `test-react-${Date.now()}`,
+        channel: 'whatsapp-baileys' as const,
+      })
+      .returning();
+    if (!instance) throw new Error('Failed to create test instance');
+    testInstance = instance;
+    insertedInstanceIds.push(instance.id);
+
+    const [chat] = await db
+      .insert(chats)
+      .values({
+        instanceId: testInstance.id,
+        externalId: '5511777777777@s.whatsapp.net',
+        chatType: 'dm',
+        channel: 'whatsapp-baileys',
+        name: 'React Test Chat',
+      })
+      .returning();
+    if (!chat) throw new Error('Failed to create test chat');
+    testChat = { id: chat.id, externalId: chat.externalId };
+    insertedChatIds.push(chat.id);
+
+    const [inbound] = await db
+      .insert(messages)
+      .values({
+        chatId: testChat.id,
+        externalId: `INBOUND-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Inbound message',
+        platformTimestamp: new Date(),
+        isFromMe: false,
+      })
+      .returning();
+    if (!inbound) throw new Error('Failed to create inbound message');
+    inboundMessage = { id: inbound.id, externalId: inbound.externalId };
+    insertedMessageIds.push(inbound.id);
+
+    const [outbound] = await db
+      .insert(messages)
+      .values({
+        chatId: testChat.id,
+        externalId: `OUTBOUND-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Outbound message',
+        platformTimestamp: new Date(),
+        isFromMe: true,
+      })
+      .returning();
+    if (!outbound) throw new Error('Failed to create outbound message');
+    outboundMessage = { id: outbound.id, externalId: outbound.externalId };
+    insertedMessageIds.push(outbound.id);
+  });
+
+  afterAll(async () => {
+    for (const id of insertedMessageIds) await db.delete(messages).where(eq(messages.id, id));
+    for (const id of insertedChatIds) await db.delete(chats).where(eq(chats.id, id));
+    for (const id of insertedInstanceIds) await db.delete(instances).where(eq(instances.id, id));
+  });
+
+  function createTestApp(sendMessageMock: SendMessageMock) {
+    const services = createServices(db, null);
+    const plugin = createMockPlugin(sendMessageMock);
+    const mockRegistry = createMockChannelRegistry(plugin);
+
+    const app = new Hono<{ Variables: AppVariables }>();
+
+    app.onError((error, c) => {
+      if (error instanceof NotFoundError) {
+        return c.json({ error: { code: 'NOT_FOUND', message: error.message } }, 404);
+      }
+      if (error instanceof OmniError) {
+        return c.json({ error: { code: error.code, message: error.message } }, 400);
+      }
+      return c.json({ error: { code: 'INTERNAL_ERROR', message: error.message } }, 500);
+    });
+
+    app.use('*', async (c, next) => {
+      c.set('services', services);
+      c.set('channelRegistry', mockRegistry as unknown as AppVariables['channelRegistry']);
+      c.set('apiKey', { id: 'test-key', name: 'test', scopes: ['*'], instanceIds: null, expiresAt: null });
+      await next();
+    });
+
+    const { messagesRoutes } = require('../routes/v2/messages');
+    app.route('/messages', messagesRoutes);
+
+    return { app };
+  }
+
+  test('target message found and inbound → fromMe=false (sourced from DB)', async () => {
+    const sendMessageMock = mock(async () => ({ success: true, messageId: 'REACT-1', timestamp: Date.now() }));
+    const { app } = createTestApp(sendMessageMock);
+
+    const res = await app.request('/messages/send/reaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testInstance.id,
+        to: testChat.externalId,
+        messageId: inboundMessage.externalId,
+        emoji: '👍',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const outgoing = (sendMessageMock.mock.calls[0] as unknown[])[1] as {
+      metadata?: { fromMe?: boolean };
+    };
+    expect(outgoing.metadata).toBeDefined();
+    expect(outgoing.metadata?.fromMe).toBe(false);
+  });
+
+  test('target message found and outbound → fromMe=true (sourced from DB)', async () => {
+    const sendMessageMock = mock(async () => ({ success: true, messageId: 'REACT-2', timestamp: Date.now() }));
+    const { app } = createTestApp(sendMessageMock);
+
+    const res = await app.request('/messages/send/reaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testInstance.id,
+        to: testChat.externalId,
+        messageId: outboundMessage.externalId,
+        emoji: '🔥',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const outgoing = (sendMessageMock.mock.calls[0] as unknown[])[1] as {
+      metadata?: { fromMe?: boolean };
+    };
+    expect(outgoing.metadata?.fromMe).toBe(true);
+  });
+
+  test('target message NOT in DB → fromMe is undefined so plugin heuristic decides (#386)', async () => {
+    const sendMessageMock = mock(async () => ({ success: true, messageId: 'REACT-3', timestamp: Date.now() }));
+    const { app } = createTestApp(sendMessageMock);
+
+    const res = await app.request('/messages/send/reaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testInstance.id,
+        to: testChat.externalId,
+        messageId: 'MISSING-MESSAGE-NOT-IN-DB',
+        emoji: '👍',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const outgoing = (sendMessageMock.mock.calls[0] as unknown[])[1] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(outgoing.metadata).toBeDefined();
+    expect('fromMe' in (outgoing.metadata ?? {})).toBe(false);
+    expect(outgoing.metadata?.fromMe).toBeUndefined();
+  });
+
+  test('target chat NOT in DB → fromMe is undefined, plugin still invoked', async () => {
+    const sendMessageMock = mock(async () => ({ success: true, messageId: 'REACT-4', timestamp: Date.now() }));
+    const { app } = createTestApp(sendMessageMock);
+
+    const res = await app.request('/messages/send/reaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testInstance.id,
+        to: '5519000000000@s.whatsapp.net',
+        messageId: 'SOME-MESSAGE-ID',
+        emoji: '✅',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const outgoing = (sendMessageMock.mock.calls[0] as unknown[])[1] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(outgoing.metadata?.fromMe).toBeUndefined();
+  });
+});

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1110,19 +1110,34 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
 
   // Look up the target message to determine fromMe (critical for WhatsApp reactions).
   // Baileys needs key.fromMe to locate the correct message — if wrong, the reaction
-  // is silently dropped by WhatsApp.
-  let fromMe = false; // Default: reacting to someone else's message
+  // is silently dropped by WhatsApp. When the target isn't in our DB (history gap
+  // or unsynced chat), we leave fromMe undefined and let the channel plugin's
+  // heuristic decide — forcing false here breaks bot-to-own-message reactions (#386).
+  let fromMe: boolean | undefined;
   const chat = await services.chats.findByExternalIdSmart(instanceId, resolvedTo);
   if (chat) {
     const target = await services.messages.getByExternalId(chat.id, messageId);
-    if (!target) {
-      log.warn('Target message not found in DB, sending reaction anyway', { messageId, chatId: chat.id });
-    } else {
+    if (target) {
       fromMe = target.isFromMe === true;
+    } else {
+      log.warn('Reaction target message not found in DB; deferring fromMe to channel plugin fallback (#386)', {
+        instanceId,
+        chatId: chat.id,
+        messageId,
+        fallback: 'plugin-heuristic',
+      });
     }
+  } else {
+    log.warn('Reaction target chat not found in DB; deferring fromMe to channel plugin fallback (#386)', {
+      instanceId,
+      resolvedTo,
+      messageId,
+      fallback: 'plugin-heuristic',
+    });
   }
 
-  // Build outgoing message for reaction
+  // Build outgoing message for reaction. When fromMe is undefined, omit it from
+  // metadata so the plugin applies its own fallback (defaults to true for Baileys).
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
     content: {
@@ -1130,7 +1145,7 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
       emoji,
       targetMessageId: messageId,
     } as OutgoingContent,
-    metadata: { fromMe },
+    metadata: fromMe === undefined ? {} : { fromMe },
   };
 
   // Send via channel plugin


### PR DESCRIPTION
## Summary

- When the target message isn't in our DB (history gap / unsynced chat), stop forcing `fromMe=false` in the reaction metadata. Leaving `fromMe` undefined lets the WhatsApp plugin apply its own heuristic (defaults to `true` in `dispatchReaction`), which is required for bot-to-own-message reactions in unsynced scenarios.
- Added structured `log.warn` with `fallback: 'plugin-heuristic'` on both miss paths (chat-not-found and message-not-found) so ops can observe frequency without a metrics dependency.
- New test suite `messages-send-reaction.test.ts` covers: target found inbound → `fromMe=false`; target found outbound → `fromMe=true`; target missing → `fromMe` omitted; chat missing → `fromMe` omitted.

## Why

Baileys silently drops a reaction whose `key.fromMe` is wrong. The previous default-to-false hid bot reactions to its own messages whenever the chat hadn't been synced yet. The plugin already had a heuristic for this — we were just overriding it from the API layer.

Closes #386

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on changed files — clean
- [x] `ENABLE_DB_TESTS=true bun test packages/api/src/__tests__/messages-send-reaction.test.ts` — 4/4 pass
- [x] Pre-push hook suite — 3240/3240 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)