### PR TITLE
fix(cli,api): omni agents create expose provider-agent-id / config-path / metadata flags (#372)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -508,6 +508,119 @@ describe('CLI Integration Tests', () => {
       testAgentId = body.data.id;
     });
 
+    test('agents create exposes --provider-agent-id, --config-path, --metadata (#372)', async () => {
+      // Locate the JSON data block from the two-block output (success + data).
+      // We parse the tail JSON object, which is the agent payload.
+      const result = await runCli(
+        [
+          'agents',
+          'create',
+          '--name',
+          `agno-seller-${Date.now()}`,
+          '--provider',
+          'agno',
+          '--provider-agent-id',
+          'eugenia-seller',
+          '--config-path',
+          '/tmp/eugenia.yaml',
+          '--metadata',
+          JSON.stringify({ team: 'sales', tier: 'premium' }),
+        ],
+        { OMNI_FORMAT: 'json' },
+      );
+      assertSuccess(result, 'agents create with new flags');
+
+      const blocks = result.stdout
+        .split(/\n(?=\{)/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const last = blocks[blocks.length - 1] ?? '';
+      const parsed = JSON.parse(last);
+      const agent = parsed.data ?? parsed;
+
+      expect(agent.configPath).toBe('/tmp/eugenia.yaml');
+      expect(agent.metadata).toEqual({
+        team: 'sales',
+        tier: 'premium',
+        providerAgentId: 'eugenia-seller',
+      });
+
+      // Cleanup
+      if (agent.id) {
+        await fetch(`${MOCK_URL}/api/v2/agents/${agent.id}`, {
+          method: 'DELETE',
+          headers: { 'x-api-key': MOCK_API_KEY },
+        });
+      }
+    });
+
+    test('agents create rejects invalid JSON in --metadata', async () => {
+      const result = await runCli([
+        'agents',
+        'create',
+        '--name',
+        'bad-meta',
+        '--provider',
+        'agno',
+        '--metadata',
+        'not-json',
+      ]);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--metadata is not valid JSON');
+    });
+
+    test('agents create rejects non-object JSON in --metadata', async () => {
+      const result = await runCli([
+        'agents',
+        'create',
+        '--name',
+        'bad-meta-array',
+        '--provider',
+        'agno',
+        '--metadata',
+        '[1,2,3]',
+      ]);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--metadata must be a JSON object');
+    });
+
+    test('agents create --provider-agent-id overrides providerAgentId in --metadata', async () => {
+      const result = await runCli(
+        [
+          'agents',
+          'create',
+          '--name',
+          `override-${Date.now()}`,
+          '--provider',
+          'agno',
+          '--metadata',
+          JSON.stringify({ providerAgentId: 'from-metadata', keep: true }),
+          '--provider-agent-id',
+          'from-flag',
+        ],
+        { OMNI_FORMAT: 'json' },
+      );
+      assertSuccess(result, 'agents create flag overrides metadata');
+
+      const blocks = result.stdout
+        .split(/\n(?=\{)/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const parsed = JSON.parse(blocks[blocks.length - 1] ?? '{}');
+      const agent = parsed.data ?? parsed;
+
+      expect(agent.metadata).toEqual({ providerAgentId: 'from-flag', keep: true });
+
+      if (agent.id) {
+        await fetch(`${MOCK_URL}/api/v2/agents/${agent.id}`, {
+          method: 'DELETE',
+          headers: { 'x-api-key': MOCK_API_KEY },
+        });
+      }
+    });
+
     test('agents update patches model and preserves UUID', async () => {
       if (!testAgentId) return;
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -699,6 +699,122 @@ describe('CLI Integration Tests', () => {
       expect(result.stdout).toContain('--provider');
       expect(result.stdout).toContain('--active');
       expect(result.stdout).toContain('--inactive');
+      expect(result.stdout).toContain('--provider-agent-id');
+      expect(result.stdout).toContain('--config-path');
+      expect(result.stdout).toContain('--metadata');
+    });
+
+    test('agents update rejects invalid JSON in --metadata (#372)', async () => {
+      if (!testAgentId) return;
+
+      const result = await runCli(['agents', 'update', testAgentId, '--metadata', 'not-json']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--metadata is not valid JSON');
+    });
+
+    test('agents update rejects non-object JSON in --metadata (#372)', async () => {
+      if (!testAgentId) return;
+
+      const result = await runCli(['agents', 'update', testAgentId, '--metadata', '[1,2,3]']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--metadata must be a JSON object');
+    });
+
+    test('agents update --config-path sets configPath (#372)', async () => {
+      if (!testAgentId) return;
+
+      const result = await runCli(['agents', 'update', testAgentId, '--config-path', '/tmp/agent-config.yaml'], {
+        OMNI_FORMAT: 'json',
+      });
+
+      assertSuccess(result, 'agents update --config-path');
+      const parsed = JSON.parse(result.stdout);
+      const agent = parsed.data ?? parsed;
+      expect(agent.configPath).toBe('/tmp/agent-config.yaml');
+    });
+
+    test('agents update --metadata merges into existing metadata (#372)', async () => {
+      if (!testAgentId) return;
+
+      // Seed existing metadata via raw PATCH so we can verify the merge behavior
+      const seed = await fetch(`${MOCK_URL}/api/v2/agents/${testAgentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'x-api-key': MOCK_API_KEY },
+        body: JSON.stringify({ metadata: { keepMe: 'original', tier: 'standard' } }),
+      });
+      expect(seed.ok).toBe(true);
+
+      const result = await runCli(
+        ['agents', 'update', testAgentId, '--metadata', JSON.stringify({ tier: 'premium', added: true })],
+        { OMNI_FORMAT: 'json' },
+      );
+
+      assertSuccess(result, 'agents update --metadata merge');
+      const parsed = JSON.parse(result.stdout);
+      const agent = parsed.data ?? parsed;
+      expect(agent.metadata).toEqual({
+        keepMe: 'original', // preserved
+        tier: 'premium', // overwritten
+        added: true, // added
+      });
+    });
+
+    test('agents update --provider-agent-id wins over --metadata providerAgentId (#372)', async () => {
+      if (!testAgentId) return;
+
+      // Reset metadata to a known state
+      await fetch(`${MOCK_URL}/api/v2/agents/${testAgentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'x-api-key': MOCK_API_KEY },
+        body: JSON.stringify({ metadata: { keep: 'yes' } }),
+      });
+
+      const result = await runCli(
+        [
+          'agents',
+          'update',
+          testAgentId,
+          '--metadata',
+          JSON.stringify({ providerAgentId: 'from-metadata' }),
+          '--provider-agent-id',
+          'from-flag',
+        ],
+        { OMNI_FORMAT: 'json' },
+      );
+
+      assertSuccess(result, 'agents update provider-agent-id precedence');
+      const parsed = JSON.parse(result.stdout);
+      const agent = parsed.data ?? parsed;
+      expect(agent.metadata).toEqual({
+        keep: 'yes', // preserved from existing
+        providerAgentId: 'from-flag', // flag wins
+      });
+    });
+
+    test('agents update --provider-agent-id only preserves existing metadata (#372)', async () => {
+      if (!testAgentId) return;
+
+      // Seed with keys we must not clobber
+      await fetch(`${MOCK_URL}/api/v2/agents/${testAgentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'x-api-key': MOCK_API_KEY },
+        body: JSON.stringify({ metadata: { team: 'sales', region: 'BR' } }),
+      });
+
+      const result = await runCli(['agents', 'update', testAgentId, '--provider-agent-id', 'eugenia-seller'], {
+        OMNI_FORMAT: 'json',
+      });
+
+      assertSuccess(result, 'agents update --provider-agent-id only');
+      const parsed = JSON.parse(result.stdout);
+      const agent = parsed.data ?? parsed;
+      expect(agent.metadata).toEqual({
+        team: 'sales',
+        region: 'BR',
+        providerAgentId: 'eugenia-seller',
+      });
     });
 
     test('agents delete removes agent', async () => {

--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -117,6 +117,7 @@ let dynamicAgents: Array<{
   agentType: string;
   capabilities: string[];
   agentProviderId: string | null;
+  configPath: string | null;
   isInternal: boolean;
   isActive: boolean;
   metadata: Record<string, unknown> | null;
@@ -128,7 +129,14 @@ function makeAgent(
   id: string,
   name: string,
   provider: string,
-  opts?: { model?: string; agentType?: string; agentProviderId?: string | null; isActive?: boolean },
+  opts?: {
+    model?: string;
+    agentType?: string;
+    agentProviderId?: string | null;
+    configPath?: string | null;
+    isActive?: boolean;
+    metadata?: Record<string, unknown> | null;
+  },
 ) {
   return {
     id,
@@ -138,9 +146,10 @@ function makeAgent(
     agentType: opts?.agentType ?? 'assistant',
     capabilities: [],
     agentProviderId: opts?.agentProviderId ?? null,
+    configPath: opts?.configPath ?? null,
     isInternal: false,
     isActive: opts?.isActive ?? true,
-    metadata: null,
+    metadata: opts?.metadata ?? null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
@@ -153,14 +162,18 @@ async function handleCreateAgent(req: Request): Promise<Response> {
     model?: string;
     agentType?: string;
     agentProviderId?: string;
+    configPath?: string;
     isActive?: boolean;
+    metadata?: Record<string, unknown>;
   };
   const id = crypto.randomUUID();
   const agent = makeAgent(id, body.name ?? 'unnamed', body.provider ?? 'claude', {
     model: body.model,
     agentType: body.agentType,
     agentProviderId: body.agentProviderId,
+    configPath: body.configPath ?? null,
     isActive: body.isActive,
+    metadata: body.metadata ?? null,
   });
   dynamicAgents.push(agent);
   return json({ data: agent }, 201);

--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -199,6 +199,8 @@ async function handleUpdateAgent(req: Request, path: string): Promise<Response> 
   if (body.agentType !== undefined) found.agentType = body.agentType as string;
   if (body.agentProviderId !== undefined) found.agentProviderId = body.agentProviderId as string | null;
   if (body.isActive !== undefined) found.isActive = body.isActive as boolean;
+  if (body.configPath !== undefined) found.configPath = body.configPath as string | null;
+  if (body.metadata !== undefined) found.metadata = body.metadata as Record<string, unknown> | null;
   found.updatedAt = new Date().toISOString();
   return json({ data: found });
 }

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -6,6 +6,7 @@
  * omni agents create --name <name> --provider <provider> [--agent-provider <id>] [--model <model>] [--type <type>]
  *                  [--provider-agent-id <id>] [--config-path <path>] [--metadata <json>]
  * omni agents update <id> [--name <name>] [--model <model>] [--provider <provider>] [--agent-provider <id>] [--type <type>] [--active|--inactive]
+ *                  [--provider-agent-id <id>] [--config-path <path>] [--metadata <json>]
  * omni agents delete <id>
  */
 
@@ -27,6 +28,9 @@ interface UpdateAgentOptions {
   type?: string;
   active?: boolean;
   inactive?: boolean;
+  providerAgentId?: string;
+  configPath?: string;
+  metadata?: string;
 }
 
 interface UpdateAgentBody {
@@ -36,6 +40,8 @@ interface UpdateAgentBody {
   agentProviderId?: string;
   agentType?: AgentType;
   isActive?: boolean;
+  configPath?: string;
+  metadata?: Record<string, unknown>;
 }
 
 interface CreateAgentOptions {
@@ -50,33 +56,36 @@ interface CreateAgentOptions {
 }
 
 /**
- * Parse a metadata JSON string and merge providerAgentId (flag wins over embedded value).
- * Calls output.error (which exits) on invalid JSON or non-object payloads.
+ * Parse a --metadata JSON string into a plain object. Exits with a CLI error on
+ * invalid JSON or non-object payloads. Returns undefined when raw is omitted.
  */
-function parseCreateMetadata(raw: string | undefined, providerAgentId?: string): Record<string, unknown> | undefined {
-  let metadata: Record<string, unknown> | undefined;
+function parseMetadataJson(raw: string | undefined): Record<string, unknown> | undefined {
+  if (raw === undefined) return undefined;
 
-  if (raw !== undefined) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      output.error(`--metadata is not valid JSON: ${message}`);
-    }
-
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      output.error('--metadata must be a JSON object.');
-    }
-
-    metadata = parsed as Record<string, unknown>;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    output.error(`--metadata is not valid JSON: ${message}`);
   }
 
-  if (providerAgentId !== undefined) {
-    metadata = { ...(metadata ?? {}), providerAgentId };
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    output.error('--metadata must be a JSON object.');
   }
 
-  return metadata;
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Compose metadata for create: parse --metadata (may be undefined) and merge
+ * --provider-agent-id on top (flag wins over any providerAgentId embedded in
+ * --metadata).
+ */
+function composeCreateMetadata(raw: string | undefined, providerAgentId?: string): Record<string, unknown> | undefined {
+  const parsed = parseMetadataJson(raw);
+  if (providerAgentId !== undefined) return { ...(parsed ?? {}), providerAgentId };
+  return parsed;
 }
 
 /**
@@ -102,7 +111,7 @@ function buildCreateAgentBody(options: CreateAgentOptions): {
     output.error(`Invalid type: ${options.type}. Valid: ${VALID_TYPES.join(', ')}`);
   }
 
-  const metadata = parseCreateMetadata(options.metadata, options.providerAgentId);
+  const metadata = composeCreateMetadata(options.metadata, options.providerAgentId);
 
   return {
     name: options.name,
@@ -243,7 +252,8 @@ export function createAgentsCommand(): Command {
       }
     });
 
-  // omni agents update <id> [--name <name>] [--model <model>] [--provider <provider>] [--agent-provider <id>] [--type <type>] [--active|--inactive]
+  // omni agents update <id> [--name <name>] [--model <model>] [--provider <provider>] [--agent-provider <id>] [--type <type>]
+  //                        [--active|--inactive] [--provider-agent-id <id>] [--config-path <path>] [--metadata <json>]
   agents
     .command('update <id>')
     .description('Update an existing agent (partial patch; omitted fields are preserved)')
@@ -254,17 +264,42 @@ export function createAgentsCommand(): Command {
     .option('--type <type>', `Agent type (${VALID_TYPES.join(', ')})`)
     .option('--active', 'Mark agent as active')
     .option('--inactive', 'Mark agent as inactive')
+    .option(
+      '--provider-agent-id <id>',
+      'Provider-internal agent identifier (e.g. agno agent name). Merged into metadata.providerAgentId; wins over any value in --metadata.',
+    )
+    .option('--config-path <path>', 'Path to the agent config file (DB column config_path)')
+    .option(
+      '--metadata <json>',
+      'Additional metadata as JSON object. Merged shallowly into existing metadata; omitted keys are preserved. --provider-agent-id wins if both set providerAgentId.',
+    )
     .action(async (id: string, options: UpdateAgentOptions) => {
       const body = buildUpdateAgentBody(options);
+      if (options.configPath !== undefined) body.configPath = options.configPath;
 
-      if (Object.keys(body).length === 0) {
-        output.error(
-          'No fields to update. Pass at least one of --name, --model, --provider, --agent-provider, --type, --active, --inactive.',
-        );
-      }
+      // Validate --metadata JSON up front (fails fast before any network call).
+      const parsedMetadata = parseMetadataJson(options.metadata);
+      const client = getClient();
 
       try {
-        const agent = await getClient().agents.update(id, body);
+        // Metadata is stored as a single JSONB column server-side; to avoid
+        // clobbering keys the user didn't pass, fetch-then-merge whenever
+        // --metadata or --provider-agent-id is supplied.
+        if (parsedMetadata !== undefined || options.providerAgentId !== undefined) {
+          const existing = await client.agents.get(id);
+          const existingMetadata = (existing.metadata ?? {}) as Record<string, unknown>;
+          const merged: Record<string, unknown> = { ...existingMetadata, ...(parsedMetadata ?? {}) };
+          if (options.providerAgentId !== undefined) merged.providerAgentId = options.providerAgentId;
+          body.metadata = merged;
+        }
+
+        if (Object.keys(body).length === 0) {
+          output.error(
+            'No fields to update. Pass at least one of --name, --model, --provider, --agent-provider, --type, --active, --inactive, --config-path, --metadata, --provider-agent-id.',
+          );
+        }
+
+        const agent = await client.agents.update(id, body);
         output.data(agent);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -4,6 +4,7 @@
  * omni agents list [--provider <p>] [--inactive-only] [--limit <n>]
  * omni agents get <id>
  * omni agents create --name <name> --provider <provider> [--agent-provider <id>] [--model <model>] [--type <type>]
+ *                  [--provider-agent-id <id>] [--config-path <path>] [--metadata <json>]
  * omni agents update <id> [--name <name>] [--model <model>] [--provider <provider>] [--agent-provider <id>] [--type <type>] [--active|--inactive]
  * omni agents delete <id>
  */
@@ -35,6 +36,86 @@ interface UpdateAgentBody {
   agentProviderId?: string;
   agentType?: AgentType;
   isActive?: boolean;
+}
+
+interface CreateAgentOptions {
+  name: string;
+  provider: string;
+  model?: string;
+  type?: string;
+  agentProvider?: string;
+  providerAgentId?: string;
+  configPath?: string;
+  metadata?: string;
+}
+
+/**
+ * Parse a metadata JSON string and merge providerAgentId (flag wins over embedded value).
+ * Calls output.error (which exits) on invalid JSON or non-object payloads.
+ */
+function parseCreateMetadata(raw: string | undefined, providerAgentId?: string): Record<string, unknown> | undefined {
+  let metadata: Record<string, unknown> | undefined;
+
+  if (raw !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      output.error(`--metadata is not valid JSON: ${message}`);
+    }
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      output.error('--metadata must be a JSON object.');
+    }
+
+    metadata = parsed as Record<string, unknown>;
+  }
+
+  if (providerAgentId !== undefined) {
+    metadata = { ...(metadata ?? {}), providerAgentId };
+  }
+
+  return metadata;
+}
+
+/**
+ * Validate enums for create and return a typed body. Calls output.error on invalid input.
+ */
+function buildCreateAgentBody(options: CreateAgentOptions): {
+  name: string;
+  provider: AgentProvider;
+  model?: string;
+  agentType: AgentType;
+  agentProviderId?: string;
+  configPath?: string;
+  metadata?: Record<string, unknown>;
+  capabilities: string[];
+  isInternal: boolean;
+  isActive: boolean;
+} {
+  if (!VALID_PROVIDERS.includes(options.provider as AgentProvider)) {
+    output.error(`Invalid provider: ${options.provider}. Valid: ${VALID_PROVIDERS.join(', ')}`);
+  }
+
+  if (options.type && !VALID_TYPES.includes(options.type as AgentType)) {
+    output.error(`Invalid type: ${options.type}. Valid: ${VALID_TYPES.join(', ')}`);
+  }
+
+  const metadata = parseCreateMetadata(options.metadata, options.providerAgentId);
+
+  return {
+    name: options.name,
+    provider: options.provider as AgentProvider,
+    model: options.model,
+    agentType: (options.type ?? 'assistant') as AgentType,
+    agentProviderId: options.agentProvider,
+    configPath: options.configPath,
+    metadata,
+    capabilities: [],
+    isInternal: false,
+    isActive: true,
+  };
 }
 
 /**
@@ -140,44 +221,27 @@ export function createAgentsCommand(): Command {
     .option('--model <model>', 'Model identifier (e.g. claude-sonnet-4-6)')
     .option('--type <type>', `Agent type (${VALID_TYPES.join(', ')})`, 'assistant')
     .option('--agent-provider <agentProviderId>', 'Link to an agent provider configuration')
-    .action(
-      async (options: {
-        name: string;
-        provider: string;
-        model?: string;
-        type?: string;
-        agentProvider?: string;
-      }) => {
-        const client = getClient();
+    .option(
+      '--provider-agent-id <id>',
+      'Provider-internal agent identifier (e.g. agno agent name). Stored at metadata.providerAgentId; used by the dispatcher to resolve agentInternalId.',
+    )
+    .option('--config-path <path>', 'Path to the agent config file (DB column config_path)')
+    .option(
+      '--metadata <json>',
+      'Additional metadata as JSON string. Merged into metadata; --provider-agent-id takes precedence if both provide providerAgentId.',
+    )
+    .action(async (options: CreateAgentOptions) => {
+      const body = buildCreateAgentBody(options);
 
-        if (!VALID_PROVIDERS.includes(options.provider as AgentProvider)) {
-          output.error(`Invalid provider: ${options.provider}. Valid: ${VALID_PROVIDERS.join(', ')}`);
-        }
-
-        if (options.type && !VALID_TYPES.includes(options.type as AgentType)) {
-          output.error(`Invalid type: ${options.type}. Valid: ${VALID_TYPES.join(', ')}`);
-        }
-
-        try {
-          const agent = await client.agents.create({
-            name: options.name,
-            provider: options.provider as AgentProvider,
-            model: options.model,
-            agentType: (options.type ?? 'assistant') as AgentType,
-            agentProviderId: options.agentProvider,
-            capabilities: [],
-            isInternal: false,
-            isActive: true,
-          });
-
-          output.success(`Agent created: ${agent.id}`);
-          output.data(agent);
-        } catch (err) {
-          const message = err instanceof Error ? err.message : 'Unknown error';
-          output.error(`Failed to create agent: ${message}`);
-        }
-      },
-    );
+      try {
+        const agent = await getClient().agents.create(body);
+        output.success(`Agent created: ${agent.id}`);
+        output.data(agent);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to create agent: ${message}`);
+      }
+    });
 
   // omni agents update <id> [--name <name>] [--model <model>] [--provider <provider>] [--agent-provider <id>] [--type <type>] [--active|--inactive]
   agents


### PR DESCRIPTION
## Summary
- Add `--provider-agent-id`, `--config-path`, and `--metadata` flags to `omni agents create` so the provider-internal agent identifier can be set from the CLI
- Wire values through to the existing API fields (`metadata.providerAgentId`, `configPath`, `metadata`) that the dispatcher already reads
- Extract `buildCreateAgentBody` / `parseCreateMetadata` helpers to keep the action handler under the Biome cognitive-complexity limit

## Why
The dispatcher (`packages/api/src/plugins/agent-dispatcher.ts`) resolves `agentInternalId` from `agentRow.metadata?.providerAgentId ?? agentRow.configPath`. Without a CLI surface for these fields, `agentInternalId` fell back to `"default"` and provider dispatch (e.g. agno → `eugenia-seller`) failed. The API zod schema and SDK types already accepted `configPath` and `metadata`; this PR is the missing CLI wiring.

Precedence: if both `--metadata` (carrying its own `providerAgentId`) and `--provider-agent-id` are supplied, the flag wins and the rest of the metadata object is preserved.

Closes #372

## Test plan
- [x] `bun run typecheck` — all 19 packages pass
- [x] `bun test packages/cli` — 266 pass, 0 fail (4 new tests for #372)
- [x] `bun test packages/api/src/services/__tests__/agents.test.ts` — 13 pass, 0 fail
- [x] Pre-push full suite — 2986 pass, 0 fail
- [x] Biome lint — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)