### PR TITLE
fix(cli): await stdout drain to prevent 64KB pipe truncation on --json

### DIFF
--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -97,8 +97,11 @@ describe('stdout pipe truncation (issue #402)', () => {
 
     try {
       const outputModulePath = join(import.meta.dir, '..', 'output.ts');
+      // Normalize backslashes on Windows so they don't become escape sequences
+      // when embedded in the single-quoted import literal below.
+      const importPath = outputModulePath.replace(/\\/g, '/').replace(/'/g, "\\'");
       const script = `
-import { list, flushStdout } from '${outputModulePath.replace(/'/g, "\\'")}';
+import { list, flushStdout } from '${importPath}';
 
 const items = Array.from({ length: 2000 }, (_, i) => ({
   id: 'msg-' + i,
@@ -144,6 +147,67 @@ await flushStdout();
       const parsed = JSON.parse(readFileSync(outputPath, 'utf8'));
       expect(Array.isArray(parsed)).toBe(true);
       expect(parsed).toHaveLength(2000);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  // Non-JSON (human) output is also subject to 64KB pipe truncation because
+  // tables, key/value pairs, and info lines all end up on stdout. Prior to
+  // this fix, `flushStdout` only awaited JSON/raw writes, so piping a large
+  // human-formatted table to a slow reader lost trailing rows at 64KB.
+  test('emits >100KB human-format table through slow pipe without truncation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'omni-402-human-'));
+    const scriptPath = join(tempDir, 'emit.ts');
+    const outputPath = join(tempDir, 'out.txt');
+
+    try {
+      const outputModulePath = join(import.meta.dir, '..', 'output.ts');
+      const importPath = outputModulePath.replace(/\\/g, '/').replace(/'/g, "\\'");
+      const script = `
+import { list, flushStdout } from '${importPath}';
+
+const items = Array.from({ length: 2000 }, (_, i) => ({
+  id: 'msg-' + i,
+  text: 'a long message body '.repeat(10),
+  ts: new Date().toISOString(),
+}));
+list(items);
+await flushStdout();
+`;
+      writeFileSync(scriptPath, script);
+
+      const bytes = await new Promise<number>((resolve, reject) => {
+        const child = spawn('bun', [scriptPath], {
+          stdio: ['ignore', 'pipe', 'inherit'],
+          // Force human format + no colors so we count raw bytes deterministically.
+          env: { ...process.env, OMNI_FORMAT: 'human', NO_COLOR: '1' },
+        });
+
+        // Same slow-reader scenario: pause, let the kernel pipe fill, then drain.
+        child.stdout.pause();
+
+        const chunks: Buffer[] = [];
+        child.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+        child.stdout.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          writeFileSync(outputPath, buf);
+          resolve(buf.byteLength);
+        });
+        child.on('error', reject);
+
+        setTimeout(() => child.stdout.resume(), 100);
+      });
+
+      expect(bytes).toBeGreaterThan(100_000);
+      expect(bytes).not.toBe(65_537);
+      expect(bytes).not.toBe(65_536);
+
+      // Ensure every row made it out — the last item is `msg-1999`.
+      const text = readFileSync(outputPath, 'utf8');
+      expect(text).toContain('msg-1999');
+      // And the header row survived the slow pipe (it's the first emission).
+      expect(text).toMatch(/^ID\s/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -6,6 +6,10 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import type { OutputFormat } from '../output.js';
 import * as output from '../output.js';
@@ -73,4 +77,75 @@ describe('flushStdout', () => {
   test('resolves after pending writes', async () => {
     await expect(output.flushStdout()).resolves.toBeUndefined();
   });
+});
+
+/**
+ * Regression test for automagik-dev/omni#402.
+ *
+ * When stdout is piped to a slow consumer and the payload exceeds the 64KB
+ * Linux kernel pipe buffer, the old flushStdout implementation let Bun exit
+ * before the internal stream buffer drained, truncating output at exactly
+ * 65537 bytes. This test spawns a child process that emits a >100KB JSON
+ * payload via `output.list` and pipes it through a slow reader, asserting
+ * the full payload survives the round-trip.
+ */
+describe('stdout pipe truncation (issue #402)', () => {
+  test('emits >100KB JSON payload through slow pipe without truncation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'omni-402-'));
+    const scriptPath = join(tempDir, 'emit.ts');
+    const outputPath = join(tempDir, 'out.json');
+
+    try {
+      const outputModulePath = join(import.meta.dir, '..', 'output.ts');
+      const script = `
+import { list, flushStdout } from '${outputModulePath.replace(/'/g, "\\'")}';
+
+const items = Array.from({ length: 2000 }, (_, i) => ({
+  id: 'msg-' + i,
+  text: 'a long message body '.repeat(10),
+  ts: new Date().toISOString(),
+}));
+list(items, { rawData: items });
+await flushStdout();
+`;
+      writeFileSync(scriptPath, script);
+
+      const bytes = await new Promise<number>((resolve, reject) => {
+        const child = spawn('bun', [scriptPath], {
+          stdio: ['ignore', 'pipe', 'inherit'],
+          env: { ...process.env, OMNI_FORMAT: 'json' },
+        });
+
+        // Hold the reader idle for 100ms to let the kernel pipe buffer fill
+        // (64KB on Linux) and force the child's write to return false. Then
+        // drain normally. Without the fix, the child exits before its internal
+        // buffer flushes and the payload truncates at exactly 65537 bytes.
+        child.stdout.pause();
+
+        const chunks: Buffer[] = [];
+        child.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+        child.stdout.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          writeFileSync(outputPath, buf);
+          resolve(buf.byteLength);
+        });
+        child.on('error', reject);
+
+        setTimeout(() => child.stdout.resume(), 100);
+      });
+
+      // Payload is deterministic: 2000 items × ~230 bytes JSON-pretty > 400KB
+      expect(bytes).toBeGreaterThan(100_000);
+      // Specifically assert we are NOT truncated at the 64KB pipe boundary.
+      expect(bytes).not.toBe(65_537);
+      expect(bytes).not.toBe(65_536);
+
+      // And the payload parses as valid JSON with all items present.
+      const parsed = JSON.parse(readFileSync(outputPath, 'utf8'));
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2000);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -7,6 +7,29 @@
 import chalk from 'chalk';
 import { getOutputFormat } from './config.js';
 
+/**
+ * Pending write promises for end-of-process flush.
+ * When stdout is a pipe (e.g., `--json | cat > file`), writes above the kernel
+ * pipe buffer (64KB on Linux) trigger backpressure and get buffered in the
+ * stream's internal queue. `write(chunk, cb)` fires its callback only after
+ * the chunk is actually drained, so we retain those promises and await them
+ * before the process exits to prevent 64KB truncation.
+ */
+const pendingStdoutWrites = new Set<Promise<void>>();
+
+/**
+ * Write a line to stdout using the callback form so we can await drain.
+ * `console.log` doesn't expose a completion signal, so large JSON payloads
+ * can be lost when the process exits before the pipe drains.
+ */
+function writeStdoutLine(text: string): void {
+  const promise = new Promise<void>((resolve) => {
+    process.stdout.write(`${text}\n`, () => resolve());
+  });
+  pendingStdoutWrites.add(promise);
+  promise.finally(() => pendingStdoutWrites.delete(promise));
+}
+
 /** Global color control */
 let colorsEnabled = true;
 
@@ -42,8 +65,7 @@ export function success(message: string, data?: unknown): void {
   const format = getCurrentFormat();
 
   if (format === 'json') {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(JSON.stringify({ success: true, message, data }, null, 2));
+    writeStdoutLine(JSON.stringify({ success: true, message, data }, null, 2));
   } else {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.log(c().green('✓'), message);
@@ -106,8 +128,7 @@ export function data(value: unknown): void {
   const format = getCurrentFormat();
 
   if (format === 'json') {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(JSON.stringify(value, null, 2));
+    writeStdoutLine(JSON.stringify(value, null, 2));
   } else {
     if (Array.isArray(value)) {
       printTable(value);
@@ -133,8 +154,7 @@ export function list<T>(items: T[], options?: { emptyMessage?: string; rawData?:
   const format = getCurrentFormat();
 
   if (format === 'json') {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(JSON.stringify(options?.rawData ?? items, null, 2));
+    writeStdoutLine(JSON.stringify(options?.rawData ?? items, null, 2));
     return;
   }
 
@@ -241,8 +261,7 @@ export function keyValue(key: string, value: unknown): void {
   const format = getCurrentFormat();
 
   if (format === 'json') {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(JSON.stringify({ [key]: value }, null, 2));
+    writeStdoutLine(JSON.stringify({ [key]: value }, null, 2));
   } else {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.log(`${c().cyan(key)}: ${formatValue(value)}`);
@@ -265,22 +284,24 @@ export function dim(text: string): void {
   }
 }
 
-/** Raw console.log (for custom formatting) */
+/** Raw stdout line (for custom formatting) */
 export function raw(text: string): void {
-  // biome-ignore lint/suspicious/noConsole: CLI output
-  console.log(text);
+  writeStdoutLine(text);
 }
 
 /**
- * Flush stdout to ensure all buffered data is written.
- * When stdout is a pipe (e.g., `--json | jq`), writes are buffered.
- * Without explicit flushing, the process can exit before all data is written,
- * causing truncated output.
+ * Flush stdout to ensure all buffered data is written before exit.
+ * When stdout is a pipe (e.g., `--json | cat > file`), writes above the kernel
+ * pipe buffer (64KB on Linux) trigger backpressure and get queued in Bun's
+ * internal stream buffer. If the process exits before those bytes drain,
+ * output is truncated at exactly 64KB boundaries.
+ *
+ * JSON/raw output paths use `process.stdout.write(chunk, cb)` which fires its
+ * callback only after the chunk is actually drained. We track those promises
+ * in `pendingStdoutWrites` and await them here.
  */
-export function flushStdout(): Promise<void> {
-  return new Promise((resolve) => {
-    // Writing an empty string queues behind all pending data.
-    // The callback fires once all prior writes have been flushed.
-    process.stdout.write('', () => resolve());
-  });
+export async function flushStdout(): Promise<void> {
+  while (pendingStdoutWrites.size > 0) {
+    await Promise.all([...pendingStdoutWrites]);
+  }
 }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -67,11 +67,9 @@ export function success(message: string, data?: unknown): void {
   if (format === 'json') {
     writeStdoutLine(JSON.stringify({ success: true, message, data }, null, 2));
   } else {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(c().green('✓'), message);
+    writeStdoutLine(`${c().green('✓')} ${message}`);
     if (data !== undefined) {
-      // biome-ignore lint/suspicious/noConsole: CLI output
-      console.log(c().dim(JSON.stringify(data, null, 2)));
+      writeStdoutLine(c().dim(JSON.stringify(data, null, 2)));
     }
   }
 }
@@ -104,8 +102,7 @@ export function warn(message: string): void {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.error(JSON.stringify({ warning: message }));
   } else {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(c().yellow('⚠'), message);
+    writeStdoutLine(`${c().yellow('⚠')} ${message}`);
   }
 }
 
@@ -118,8 +115,7 @@ export function info(message: string): void {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.error(JSON.stringify({ info: message }));
   } else {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(c().blue('ℹ'), message);
+    writeStdoutLine(`${c().blue('ℹ')} ${message}`);
   }
 }
 
@@ -135,8 +131,7 @@ export function data(value: unknown): void {
     } else if (typeof value === 'object' && value !== null) {
       printObject(value as Record<string, unknown>);
     } else {
-      // biome-ignore lint/suspicious/noConsole: CLI output
-      console.log(value);
+      writeStdoutLine(String(value));
     }
   }
 }
@@ -159,8 +154,7 @@ export function list<T>(items: T[], options?: { emptyMessage?: string; rawData?:
   }
 
   if (items.length === 0) {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(c().dim(options?.emptyMessage ?? 'No items found.'));
+    writeStdoutLine(c().dim(options?.emptyMessage ?? 'No items found.'));
     return;
   }
 
@@ -174,8 +168,7 @@ function printTable<T>(items: T[]): void {
   const first = items[0];
   if (typeof first !== 'object' || first === null) {
     for (const item of items) {
-      // biome-ignore lint/suspicious/noConsole: CLI output
-      console.log(item);
+      writeStdoutLine(String(item));
     }
     return;
   }
@@ -197,18 +190,15 @@ function printTable<T>(items: T[]): void {
   }
 
   const header = keys.map((k) => k.toUpperCase().padEnd(widths[k])).join('  ');
-  // biome-ignore lint/suspicious/noConsole: CLI output
-  console.log(c().bold(header));
+  writeStdoutLine(c().bold(header));
 
   const separator = keys.map((k) => '-'.repeat(widths[k])).join('  ');
-  // biome-ignore lint/suspicious/noConsole: CLI output
-  console.log(c().dim(separator));
+  writeStdoutLine(c().dim(separator));
 
   for (const item of items) {
     const obj = item as Record<string, unknown>;
     const row = keys.map((k) => formatCellValue(obj[k]).padEnd(widths[k])).join('  ');
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(row);
+    writeStdoutLine(row);
   }
 }
 
@@ -237,8 +227,7 @@ function printObject(obj: Record<string, unknown>): void {
   for (const [key, value] of Object.entries(obj)) {
     const label = key.padEnd(maxKeyLen);
     const formattedValue = formatValue(value);
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(`${c().cyan(label)}  ${formattedValue}`);
+    writeStdoutLine(`${c().cyan(label)}  ${formattedValue}`);
   }
 }
 
@@ -263,24 +252,21 @@ export function keyValue(key: string, value: unknown): void {
   if (format === 'json') {
     writeStdoutLine(JSON.stringify({ [key]: value }, null, 2));
   } else {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(`${c().cyan(key)}: ${formatValue(value)}`);
+    writeStdoutLine(`${c().cyan(key)}: ${formatValue(value)}`);
   }
 }
 
 /** Print a section header */
 export function header(title: string): void {
   if (getCurrentFormat() === 'human') {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(`\n${c().bold.underline(title)}`);
+    writeStdoutLine(`\n${c().bold.underline(title)}`);
   }
 }
 
 /** Print dimmed/secondary text */
 export function dim(text: string): void {
   if (getCurrentFormat() === 'human') {
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(c().dim(text));
+    writeStdoutLine(c().dim(text));
   }
 }
 
@@ -296,12 +282,19 @@ export function raw(text: string): void {
  * internal stream buffer. If the process exits before those bytes drain,
  * output is truncated at exactly 64KB boundaries.
  *
- * JSON/raw output paths use `process.stdout.write(chunk, cb)` which fires its
- * callback only after the chunk is actually drained. We track those promises
- * in `pendingStdoutWrites` and await them here.
+ * All output paths in this module route through `writeStdoutLine`, which uses
+ * `process.stdout.write(chunk, cb)`. The callback fires only after the chunk
+ * is actually drained; we track those promises in `pendingStdoutWrites` and
+ * await them here.
+ *
+ * A trailing empty-write drain gives any stdout bytes written outside this
+ * module (e.g., direct `process.stdout.write` calls) a final chance to drain.
  */
 export async function flushStdout(): Promise<void> {
   while (pendingStdoutWrites.size > 0) {
     await Promise.all([...pendingStdoutWrites]);
   }
+  await new Promise<void>((resolve) => {
+    process.stdout.write('', () => resolve());
+  });
 }


### PR DESCRIPTION
## Summary

- `omni chats messages <id> --json | cat > file` truncated at exactly 65537 bytes (64KB kernel pipe buffer).
- Switched JSON/raw output to `process.stdout.write(chunk, cb)` and await the callback through a `pendingStdoutWrites` set; `flushStdout()` now drains that set before exit.
- Added a regression test that spawns a child bun process, holds the reader idle for 100ms to trigger pipe backpressure, and asserts the full >100KB payload round-trips without truncation.

## Why this happened

`console.log` exposes no completion signal, and the previous `flushStdout()` called `process.stdout.write('', cb)` — in Bun the callback for an empty write can fire before the prior buffered data actually drains to the kernel, so the process exited with >64KB still sitting in Bun's internal stream buffer.

## Verification

- Before: `omni chats messages <large-id> --since 14d --json 2>/dev/null | cat > /tmp/b.json` → 65536 bytes; `| dd of=file` → 65536 bytes.
- After: same commands → 241040 bytes (complete), `jq length` parses to 100 messages.
- `make typecheck`, `make lint` (clean on changed files), `bun test` 263/263 pass in `@automagik/omni`, 3235/3235 repo-wide.

## Test plan

- [x] `bun test output.test` passes (11/11 including new regression test)
- [x] `bun test` repo-wide passes (3235/3235, pre-push hook)
- [x] Manual: `omni chats messages <large-id> --since 14d --json | wc -c` matches direct-redirect byte count
- [x] Manual: `omni chats messages <large-id> --since 14d --json | cat > /tmp/b.json && jq length /tmp/b.json` returns correct count

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)