### PR TITLE
fix(ops): guard pgserve against wrong-cwd data dir swap on restart

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -22,9 +22,22 @@
  */
 
 const path = require('node:path');
+const os = require('node:os');
 
 const natsManaged = process.env.NATS_MANAGED === 'true';
 const apiManaged = process.env.API_MANAGED === 'true';
+
+// ---------------------------------------------------------------------------
+// Canonical absolute PGSERVE_DATA.
+//
+// #412 incident: PM2's persisted cwd drifted to an unrelated workspace on
+// restart; the relative `./.pgserve-data` convention then resolved to a
+// different filesystem location and the embedded PostgreSQL silently
+// initdb'd a fresh, empty cluster. Force an absolute default so the data
+// dir is cwd-independent. An operator-set PGSERVE_DATA still wins.
+// ---------------------------------------------------------------------------
+const PGSERVE_DATA_DEFAULT = path.join(os.homedir(), '.omni', 'data', 'pgserve');
+const pgserveData = process.env.PGSERVE_DATA || PGSERVE_DATA_DEFAULT;
 
 // ---------------------------------------------------------------------------
 // Shared defaults — production-grade self-healing
@@ -86,6 +99,8 @@ if (apiManaged) {
     env: {
       NODE_ENV: process.env.NODE_ENV || 'development',
       OMNI_PACKAGES_DIR: path.join(__dirname, 'packages'),
+      // Absolute path — see PGSERVE_DATA_DEFAULT block above for rationale.
+      PGSERVE_DATA: pgserveData,
     },
     max_memory_restart: '2G',
     // Dependency: wait 1s to let nats bind its port first

--- a/packages/api/src/__tests__/pgserve.test.ts
+++ b/packages/api/src/__tests__/pgserve.test.ts
@@ -17,12 +17,17 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  PgserveDataDirMissingError,
   PgserveInternalPortConflict,
+  PgserveRelativeDataPathError,
   type SystemCalls,
   ensureInternalPortFree,
   findProcessOnPort,
+  isPopulatedPgserveDir,
   killOrphanedPostgres,
   killPostgresByPid,
+  resolvePgserveConfig,
+  validatePgserveDataDir,
 } from '../pgserve';
 
 /**
@@ -406,5 +411,203 @@ describe('killOrphanedPostgres — postmaster.pid path (preserved legacy behavio
     // Only the liveness probe (signal 0) should have fired — never SIGTERM
     const termSent = sentSignals.some((s) => s.signal === 'SIGTERM' || s.signal === 'SIGKILL');
     expect(termSent).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #412 — PGSERVE_DATA path + require-existing guards
+// ---------------------------------------------------------------------------
+
+describe('resolvePgserveConfig — #412 env surface', () => {
+  const saved: Record<string, string | undefined> = {};
+  const keys = ['PGSERVE_DATA', 'PGSERVE_REQUIRE_EXISTING', 'PGSERVE_ALLOW_RELATIVE_DATA'];
+
+  beforeEach(() => {
+    for (const k of keys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('defaults requireExisting and allowRelativeData to false', () => {
+    const cfg = resolvePgserveConfig();
+    expect(cfg.requireExisting).toBe(false);
+    expect(cfg.allowRelativeData).toBe(false);
+  });
+
+  test('reads PGSERVE_REQUIRE_EXISTING=true', () => {
+    process.env.PGSERVE_REQUIRE_EXISTING = 'true';
+    expect(resolvePgserveConfig().requireExisting).toBe(true);
+  });
+
+  test('reads PGSERVE_ALLOW_RELATIVE_DATA=true', () => {
+    process.env.PGSERVE_ALLOW_RELATIVE_DATA = 'true';
+    expect(resolvePgserveConfig().allowRelativeData).toBe(true);
+  });
+});
+
+describe('validatePgserveDataDir — relative path rejection (#412)', () => {
+  test('accepts absolute path and returns resolved value', () => {
+    const result = validatePgserveDataDir({
+      enabled: true,
+      port: 8432,
+      dataDir: '/tmp/pg-abs',
+      requireExisting: false,
+      allowRelativeData: false,
+    });
+    expect(result).toBe('/tmp/pg-abs');
+  });
+
+  test('throws PgserveRelativeDataPathError when path is relative and opt-in is off', () => {
+    let caught: PgserveRelativeDataPathError | undefined;
+    try {
+      validatePgserveDataDir({
+        enabled: true,
+        port: 8432,
+        dataDir: './.pgserve-data',
+        requireExisting: false,
+        allowRelativeData: false,
+      });
+    } catch (err) {
+      caught = err as PgserveRelativeDataPathError;
+    }
+
+    expect(caught).toBeInstanceOf(PgserveRelativeDataPathError);
+    expect(caught?.rawPath).toBe('./.pgserve-data');
+    expect(caught?.message).toContain('PGSERVE_ALLOW_RELATIVE_DATA=true');
+    expect(caught?.message).toContain('#412');
+  });
+
+  test('allows relative path when PGSERVE_ALLOW_RELATIVE_DATA escape hatch is set', () => {
+    const result = validatePgserveDataDir({
+      enabled: true,
+      port: 8432,
+      dataDir: './.pgserve-data',
+      requireExisting: false,
+      allowRelativeData: true,
+    });
+    // Relative path is resolved against cwd for logging purposes
+    expect(result).toContain('.pgserve-data');
+  });
+
+  test('memory mode (dataDir=null) passes through without validation', () => {
+    const result = validatePgserveDataDir({
+      enabled: true,
+      port: 8432,
+      dataDir: null,
+      requireExisting: true, // even with this set, memory mode short-circuits
+      allowRelativeData: false,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('validatePgserveDataDir — require-existing guard (#412)', () => {
+  let tmpDataDir: string;
+
+  beforeEach(() => {
+    tmpDataDir = mkdtempSync(join(tmpdir(), 'pgserve-412-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  });
+
+  test('throws PgserveDataDirMissingError (missing) when dir does not exist', () => {
+    const missingDir = join(tmpdir(), `pgserve-does-not-exist-${Date.now()}`);
+
+    let caught: PgserveDataDirMissingError | undefined;
+    try {
+      validatePgserveDataDir({
+        enabled: true,
+        port: 8432,
+        dataDir: missingDir,
+        requireExisting: true,
+        allowRelativeData: false,
+      });
+    } catch (err) {
+      caught = err as PgserveDataDirMissingError;
+    }
+
+    expect(caught).toBeInstanceOf(PgserveDataDirMissingError);
+    expect(caught?.reason).toBe('missing');
+    expect(caught?.message).toContain('does not exist');
+  });
+
+  test('throws PgserveDataDirMissingError (not-initialized) when dir exists but has no PG_VERSION', () => {
+    // tmpDataDir exists but is empty — mirrors the #412 scenario where a
+    // fresh cwd-relative dir was created before pgserve initdb'd it.
+    let caught: PgserveDataDirMissingError | undefined;
+    try {
+      validatePgserveDataDir({
+        enabled: true,
+        port: 8432,
+        dataDir: tmpDataDir,
+        requireExisting: true,
+        allowRelativeData: false,
+      });
+    } catch (err) {
+      caught = err as PgserveDataDirMissingError;
+    }
+
+    expect(caught).toBeInstanceOf(PgserveDataDirMissingError);
+    expect(caught?.reason).toBe('not-initialized');
+    expect(caught?.message).toContain('PG_VERSION');
+  });
+
+  test('accepts populated data dir (with PG_VERSION marker)', () => {
+    writeFileSync(join(tmpDataDir, 'PG_VERSION'), '17\n');
+
+    const result = validatePgserveDataDir({
+      enabled: true,
+      port: 8432,
+      dataDir: tmpDataDir,
+      requireExisting: true,
+      allowRelativeData: false,
+    });
+    expect(result).toBe(tmpDataDir);
+  });
+
+  test('no-op when requireExisting=false even if dir is empty', () => {
+    const result = validatePgserveDataDir({
+      enabled: true,
+      port: 8432,
+      dataDir: tmpDataDir,
+      requireExisting: false,
+      allowRelativeData: false,
+    });
+    expect(result).toBe(tmpDataDir);
+  });
+});
+
+describe('isPopulatedPgserveDir', () => {
+  test('returns false for empty dir', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pgserve-empty-'));
+    try {
+      expect(isPopulatedPgserveDir(dir)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns true when PG_VERSION marker file exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pgserve-populated-'));
+    try {
+      writeFileSync(join(dir, 'PG_VERSION'), '17\n');
+      expect(isPopulatedPgserveDir(dir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns false when dir does not exist at all', () => {
+    expect(isPopulatedPgserveDir(join(tmpdir(), `pgserve-missing-${Date.now()}`))).toBe(false);
   });
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -11,7 +11,7 @@ import './instrument';
 import type { ChannelRegistry } from '@omni/channel-sdk';
 import { type EventBus, configureLogging, connectEventBus, createLogger, enableDefaultMetrics } from '@omni/core';
 import type { Database } from '@omni/db';
-import { agents, applyMigrations, closeDb, createDb } from '@omni/db';
+import { agents, applyMigrations, closeDb, createDb, instances } from '@omni/db';
 import * as Sentry from '@sentry/bun';
 import { eq, sql } from 'drizzle-orm';
 import { resolvePgserveConfig, startEmbeddedPgserve, stopEmbeddedPgserve } from './pgserve';
@@ -503,6 +503,22 @@ async function main() {
     throw error;
   }
   log.info('Database migrations complete', { durationMs: Date.now() - migrationStart });
+
+  // Content-aware boot banner — surfaces the #412 "fresh empty data dir" symptom
+  // immediately after migrations. A zero count on a deploy that used to have
+  // instances is a red flag: the API is talking to the wrong pgserve data dir.
+  try {
+    const [countRow] = await db.select({ count: sql<number>`count(*)::int` }).from(instances);
+    const rowCount = countRow?.count ?? 0;
+    log.info('Post-migration content snapshot', { DB_ROW_COUNT_INSTANCES: rowCount });
+    if (rowCount === 0 && pgserveConfig.requireExisting) {
+      log.error(
+        'PGSERVE_REQUIRE_EXISTING=true but instances table is empty after boot — verify PGSERVE_DATA points at the correct cluster (see #412).',
+      );
+    }
+  } catch (error) {
+    log.warn('Failed to read instances row count (non-fatal)', { error: String(error) });
+  }
 
   // Connect to NATS
   const eventBus = await connectToNats(db);

--- a/packages/api/src/pgserve.ts
+++ b/packages/api/src/pgserve.ts
@@ -9,6 +9,8 @@
  *   PGSERVE_EMBEDDED            — 'true' (default) to start in-process, 'false' to skip
  *   PGSERVE_PORT                — port for the embedded PostgreSQL proxy (default 8432)
  *   PGSERVE_DATA                — data directory path; defaults to ~/.omni/data/pgserve (set to empty string for memory mode)
+ *   PGSERVE_ALLOW_RELATIVE_DATA — when 'true', allows PGSERVE_DATA to be a relative path (DANGEROUS — PM2 cwd drift can swap data dirs). Default: reject.
+ *   PGSERVE_REQUIRE_EXISTING    — when 'true', refuse to start if the data dir is missing or not an initialized PostgreSQL cluster (no PG_VERSION file). Prevents silent initdb after PM2 cwd drift.
  *   OMNI_PGSERVE_FORCE_CLEANUP  — when 'true', aggressively kills any postgres holding the internal port (PGSERVE_PORT + 1000) at startup
  */
 
@@ -16,7 +18,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { createLogger } from '@omni/core';
 import { getDefaultDatabaseUrl } from '@omni/db';
 
@@ -36,6 +38,60 @@ export interface PgserveConfig {
   enabled: boolean;
   port: number;
   dataDir: string | null;
+  /**
+   * When true, abort startup if the data dir does not exist or is not a
+   * populated PostgreSQL cluster. Set via PGSERVE_REQUIRE_EXISTING=true.
+   */
+  requireExisting: boolean;
+  /**
+   * When true, allow a relative PGSERVE_DATA path. By default relative paths
+   * are rejected because PM2's persisted cwd can drift (see #412), causing
+   * pgserve to silently initdb a fresh data dir under the new cwd.
+   */
+  allowRelativeData: boolean;
+}
+
+/**
+ * Thrown when PGSERVE_DATA is a relative path and the explicit opt-in flag
+ * PGSERVE_ALLOW_RELATIVE_DATA=true is not set. Prevents the PM2 cwd-drift
+ * failure mode from #412 (silent switch to a fresh, empty data dir).
+ */
+export class PgserveRelativeDataPathError extends Error {
+  public readonly rawPath: string;
+  public readonly resolvedPath: string;
+
+  constructor(rawPath: string, resolvedPath: string) {
+    super(
+      `PGSERVE_DATA is a relative path ("${rawPath}" → resolved to "${resolvedPath}" against cwd "${process.cwd()}"). Relative data paths are rejected because PM2's persisted cwd can drift across restarts, causing the embedded PostgreSQL to silently initdb a fresh, empty data dir in the wrong location (see #412). To remediate:\n  1. Set PGSERVE_DATA to an absolute path (e.g. /home/<user>/.omni/data/pgserve).\n  2. Or, if you truly want a cwd-relative dev path, set PGSERVE_ALLOW_RELATIVE_DATA=true.`,
+    );
+    this.name = 'PgserveRelativeDataPathError';
+    this.rawPath = rawPath;
+    this.resolvedPath = resolvedPath;
+  }
+}
+
+/**
+ * Thrown when PGSERVE_REQUIRE_EXISTING=true is set and the configured data
+ * dir is missing or has no `PG_VERSION` marker (i.e. pgserve would initdb).
+ * Fails closed so an accidental cwd/path swap does not bring the API up on
+ * an empty database.
+ */
+export class PgserveDataDirMissingError extends Error {
+  public readonly dataDir: string;
+  public readonly reason: 'missing' | 'not-initialized';
+
+  constructor(dataDir: string, reason: 'missing' | 'not-initialized') {
+    const detail =
+      reason === 'missing'
+        ? 'directory does not exist'
+        : 'directory exists but has no PG_VERSION file — this is NOT an initialized PostgreSQL cluster';
+    super(
+      `PGSERVE_REQUIRE_EXISTING=true is set but PGSERVE_DATA="${dataDir}" ${detail}. Refusing to initdb a fresh data dir (see #412). To remediate:\n  1. Verify PGSERVE_DATA points to the canonical data dir (absolute path).\n  2. Check PM2's persisted cwd — \`pm2 describe omni-v2-api\` → \`exec cwd\`.\n  3. If this IS a first-run install, unset PGSERVE_REQUIRE_EXISTING.`,
+    );
+    this.name = 'PgserveDataDirMissingError';
+    this.dataDir = dataDir;
+    this.reason = reason;
+  }
 }
 
 /** Minimal shape of the pgserve server instance (pgserve ships no type declarations). */
@@ -68,6 +124,11 @@ let serverInstance: PgserveInstance | null = null;
 
 /**
  * Read pgserve-related env vars and return a typed config object.
+ *
+ * Does NOT validate the path here — call `validatePgserveDataDir` after
+ * resolving so tests can exercise parsing independently from filesystem
+ * checks. Falls back to the canonical `~/.omni/data/pgserve` when
+ * `PGSERVE_DATA` is unset (the default is always absolute).
  */
 export function resolvePgserveConfig(): PgserveConfig {
   const enabled = (process.env.PGSERVE_EMBEDDED ?? 'true') === 'true';
@@ -75,9 +136,79 @@ export function resolvePgserveConfig(): PgserveConfig {
   const raw = process.env.PGSERVE_DATA;
   // Default to persistent storage inside ~/.omni/data/pgserve — never memory mode unless explicitly empty
   const defaultDataDir = join(homedir(), '.omni', 'data', 'pgserve');
-  const dataDir = raw !== undefined && raw.trim().length === 0 ? null : raw?.trim() || defaultDataDir;
+  const dataDir = raw?.trim() === '' ? null : raw?.trim() || defaultDataDir;
+  const requireExisting = process.env.PGSERVE_REQUIRE_EXISTING === 'true';
+  const allowRelativeData = process.env.PGSERVE_ALLOW_RELATIVE_DATA === 'true';
 
-  return { enabled, port, dataDir };
+  return { enabled, port, dataDir, requireExisting, allowRelativeData };
+}
+
+/**
+ * Return true when `dataDir` contains a PostgreSQL `PG_VERSION` marker.
+ * That file is written by `initdb` and is the canonical signal that a
+ * directory is a populated cluster (not just an empty dir a fresh initdb
+ * is about to fill).
+ *
+ * Exported so tests can exercise the guard without touching real directories.
+ */
+export function isPopulatedPgserveDir(dataDir: string): boolean {
+  return existsSync(join(dataDir, 'PG_VERSION'));
+}
+
+/**
+ * Validate the resolved PGSERVE_DATA path against operator intent:
+ *
+ *   1. Relative paths are rejected unless PGSERVE_ALLOW_RELATIVE_DATA=true.
+ *      Rationale: PM2 persists its cwd across restarts; if the operator ran
+ *      `pm2 save` from a different directory, a relative path resolves to a
+ *      different filesystem location and pgserve silently initdb's a fresh
+ *      cluster there — the 2026-04-14 incident (#412).
+ *
+ *   2. If PGSERVE_REQUIRE_EXISTING=true, the dir must exist AND contain a
+ *      `PG_VERSION` file (i.e. it is an initialized cluster, not an empty
+ *      placeholder). Fails closed so a wrong-cwd restart never brings the
+ *      API up against an empty migrations-applied database.
+ *
+ * Both checks write a structured fatal log before throwing so the condition
+ * is obvious in PM2's log feed.
+ */
+export function validatePgserveDataDir(config: PgserveConfig): string | null {
+  if (config.dataDir === null) return null; // memory mode — nothing to validate
+
+  const raw = config.dataDir;
+  const resolved = resolve(raw);
+
+  if (!isAbsolute(raw) && !config.allowRelativeData) {
+    log.error('Refusing to start: PGSERVE_DATA is a relative path', {
+      rawPath: raw,
+      resolvedPath: resolved,
+      cwd: process.cwd(),
+      hint: 'Set PGSERVE_DATA to an absolute path, or set PGSERVE_ALLOW_RELATIVE_DATA=true for dev.',
+    });
+    throw new PgserveRelativeDataPathError(raw, resolved);
+  }
+
+  if (config.requireExisting) {
+    if (!existsSync(resolved)) {
+      log.error('Refusing to start: PGSERVE_REQUIRE_EXISTING=true but data dir is missing', {
+        dataDir: resolved,
+        cwd: process.cwd(),
+      });
+      throw new PgserveDataDirMissingError(resolved, 'missing');
+    }
+    if (!isPopulatedPgserveDir(resolved)) {
+      log.error(
+        'Refusing to start: PGSERVE_REQUIRE_EXISTING=true but data dir is not an initialized PostgreSQL cluster (no PG_VERSION)',
+        {
+          dataDir: resolved,
+          cwd: process.cwd(),
+        },
+      );
+      throw new PgserveDataDirMissingError(resolved, 'not-initialized');
+    }
+  }
+
+  return resolved;
 }
 
 function isAddressInUse(error: unknown): boolean {
@@ -564,11 +695,32 @@ export async function startEmbeddedPgserve(config: PgserveConfig): Promise<strin
     return url;
   }
 
+  // Validate PGSERVE_DATA before doing anything else. Throws PgserveRelativeDataPathError
+  // or PgserveDataDirMissingError when invariants are violated (#412).
+  const resolvedDataDir = validatePgserveDataDir(config);
+
   log.info('Starting embedded pgserve', {
     port: config.port,
     mode: config.dataDir ? 'persistent' : 'memory',
     dataDir: config.dataDir ?? '(in-memory)',
+    // Always log the fully resolved absolute path so operators can spot cwd drift in logs.
+    PGSERVE_DATA_RESOLVED: resolvedDataDir ?? '(in-memory)',
+    cwd: process.cwd(),
+    requireExisting: config.requireExisting,
   });
+
+  // Loud fresh-initdb warning — catches the cwd-drift scenario even when
+  // PGSERVE_REQUIRE_EXISTING is not set. Normal first install will still see
+  // this warning once, which is acceptable.
+  if (resolvedDataDir && !isPopulatedPgserveDir(resolvedDataDir)) {
+    log.warn(
+      'Creating new pgserve data dir — previous data will NOT be present. If this is not a first install, STOP and verify PGSERVE_DATA + PM2 cwd (see #412).',
+      {
+        dataDir: resolvedDataDir,
+        cwd: process.cwd(),
+      },
+    );
+  }
 
   // Terminate any orphaned postgres left by a previous unclean shutdown before
   // pgserve tries to start (avoids the socket-dir mismatch crash loop).


### PR DESCRIPTION
Closes #412.

## Summary

P0 ops bug: PM2 silently switched omni-api to a new empty pgserve data dir after a restart from a drifted cwd. The API came up on a fresh migrations-applied database with zero instances/chats. Data was preserved on disk but the live API was blind to it.

This PR adds three guards so the failure mode is impossible silently, and one absolute-path default so it does not recur through the standard install path.

## Mitigations (from issue #412 must-do list)

1. **Reject relative `PGSERVE_DATA`** — `validatePgserveDataDir()` throws `PgserveRelativeDataPathError` if the path is relative. Opt-in via `PGSERVE_ALLOW_RELATIVE_DATA=true` for dev.
2. **`PGSERVE_REQUIRE_EXISTING=true` guard** — refuses to start unless the data dir exists AND has a `PG_VERSION` marker (an initialized PostgreSQL cluster, not an empty dir pgserve would `initdb`).
3. **Absolute `PGSERVE_DATA` default in `ecosystem.config.cjs`** — `${HOME}/.omni/data/pgserve`, so `pm2 start` from any cwd resolves to the same dir.
4. **Loud startup logs** — `PGSERVE_DATA_RESOLVED=<abs path>` and `DB_ROW_COUNT_INSTANCES=N` are logged every boot. A fresh-initdb boot emits a visible `log.warn` with a reminder to check PM2 cwd.

## Approach picked

Mitigation (a) + (c) from the dispatcher brief — least invasive, fails closed. No health-endpoint changes beyond the row-count startup log (scoped to "must-do" list; content-aware `/health` can follow as a separate PR if needed).

## Acceptance criteria (#412)

- [x] `ecosystem.config.cjs` uses an absolute `PGSERVE_DATA`.
- [x] API refuses to boot if `PGSERVE_REQUIRE_EXISTING=true` and the target dir is missing or empty.
- [x] Startup log includes `PGSERVE_DATA_RESOLVED` (absolute) and a row-count hint.
- [ ] Health endpoint content check — intentionally deferred; row-count is logged at boot instead.
- [ ] Runbook updated — out of scope for this PR.

## Tests

14 new cases in `packages/api/src/__tests__/pgserve.test.ts`:
- `resolvePgserveConfig` env-var parsing
- Relative path rejection + opt-in escape hatch
- `PGSERVE_REQUIRE_EXISTING` guard (missing / not-initialized / populated)
- `PG_VERSION` marker detection
- Memory mode short-circuit

Full api suite: 217 pass / 0 fail. Repo-wide: 3019 pass / 0 fail.

## Test plan

- [x] `bun test packages/api/src/__tests__/pgserve.test.ts` — 31 pass
- [x] `bun run typecheck` — all 19 packages green
- [x] `bunx biome check` on changed files — clean
- [x] `bun test` repo-wide — 3019 pass / 0 fail
- [ ] Deploy to dev and verify `PGSERVE_DATA_RESOLVED` appears in logs
- [ ] Manual smoke: set `PGSERVE_DATA=./.pgserve-data` + `PGSERVE_REQUIRE_EXISTING=true` and confirm API refuses to start

🤖 Generated with [Claude Code](https://claude.com/claude-code)