### PR TITLE
fix(channel-whatsapp): canonicalize LID/JID before debounce and session (#374)

### DIFF
--- a/.genie/wishes/fix-lid-jid-fragmentation/WISH.md
+++ b/.genie/wishes/fix-lid-jid-fragmentation/WISH.md
@@ -2,10 +2,33 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | IN-PROGRESS |
 | **Slug** | `fix-lid-jid-fragmentation` |
 | **Date** | 2026-04-09 |
 | **Design** | Canonicalize in channel-whatsapp plugin (Option 2 from issue) |
+| **Branch** | `fix/374-lid-jid-canonicalize` |
+
+## Implementation notes (2026-04-16)
+
+- `storeLidMapping` now populates both `lid→phone` and `phone→lid` in the
+  same `Map` (the `@lid` / `@s.whatsapp.net` key namespaces don't collide).
+  `publishLidMappings` filters to `@lid`-keyed entries so DB persistence only
+  sees the canonical forward direction.
+- `resolveCanonicalJid` was a no-op; it now upgrades phone JIDs to LID via
+  `remoteJidAlt` first, then the bidirectional cache. Group / broadcast /
+  newsletter JIDs short-circuit unchanged; missing mappings fall back to
+  the phone JID.
+- `resolveChatId` and `resolveSenderJid` call `resolveCanonicalJid` in
+  LID-first mode so the chatId and sender the event publishes are already
+  stable per human — debounce, session computation, and typing debounce
+  all key to a single identity.
+- Raw `remoteJid` is preserved on the raw payload as `rawChatId` (via
+  `annotateLidResolution`) so audit trails still show what Baileys sent.
+- DEC-8 legacy path (`lidFirstEnabled=false`) is untouched.
+- Coverage: new `__tests__/canonicalize-jid.test.ts` asserts same-human
+  collapse across `@lid`/`@s.whatsapp.net`, group passthrough, and legacy
+  mode. Existing `jid.test.ts` cases were updated to reflect the real
+  canonicalization behavior.
 
 ## Summary
 

--- a/packages/channel-whatsapp/src/__tests__/canonicalize-jid.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/canonicalize-jid.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression tests for #374 — LID/JID canonicalization in WhatsApp message
+ * handlers. Baileys can route messages from the same human under both
+ * `<lid>@lid` and `<phone>@s.whatsapp.net`, which fragments the debounce
+ * buffer and per-chat / per-user sessions. The handlers must collapse both
+ * forms onto the LID canonical form before the event is published.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { WAMessage } from 'baileys';
+import { resolveChatId, resolveSenderJid } from '../handlers/messages';
+import { WhatsAppPlugin } from '../plugin';
+
+const LID_JID = '217046273028329@lid';
+const PHONE_JID = '555197285829@s.whatsapp.net';
+const GROUP_JID = '120363000000000000@g.us';
+const PARTICIPANT_LID = '217046273028329@lid';
+const PARTICIPANT_PHONE = '555197285829@s.whatsapp.net';
+
+function buildPlugin(opts?: { lidFirstEnabled?: boolean }): WhatsAppPlugin {
+  const plugin = new WhatsAppPlugin();
+  // Plugin defers logger creation until init(); stub it for unit tests.
+  (plugin as unknown as { logger: Record<string, (...args: unknown[]) => void> }).logger = {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+  if (opts?.lidFirstEnabled === false) {
+    (plugin as unknown as { lidFirstEnabledMap: Map<string, boolean> }).lidFirstEnabledMap.set('inst', false);
+  }
+  return plugin;
+}
+
+function buildMessage(opts: {
+  remoteJid: string;
+  remoteJidAlt?: string;
+  participant?: string;
+  participantAlt?: string;
+  fromMe?: boolean;
+}): WAMessage {
+  const key: Record<string, unknown> = {
+    remoteJid: opts.remoteJid,
+    fromMe: opts.fromMe ?? false,
+    id: '3EB0AAAA',
+  };
+  if (opts.remoteJidAlt) key.remoteJidAlt = opts.remoteJidAlt;
+  if (opts.participant) key.participant = opts.participant;
+  if (opts.participantAlt) key.participantAlt = opts.participantAlt;
+  return { key, message: { conversation: 'hi' } } as unknown as WAMessage;
+}
+
+describe('LID/JID canonicalization (#374)', () => {
+  describe('storeLidMapping', () => {
+    it('stores both lid→phone and phone→lid in the same cache', () => {
+      const plugin = buildPlugin();
+      plugin.storeLidMapping('inst', LID_JID, PHONE_JID);
+
+      const cache = plugin.getLidMappingCache('inst');
+      expect(cache.get(LID_JID)).toBe(PHONE_JID);
+      expect(cache.get(PHONE_JID)).toBe(LID_JID);
+    });
+  });
+
+  describe('resolveChatId — LID-first mode', () => {
+    it('keeps a LID chatId unchanged and stamps the raw chatId', () => {
+      const plugin = buildPlugin();
+      const msg = buildMessage({ remoteJid: LID_JID, remoteJidAlt: PHONE_JID });
+
+      const { chatId, rawChatId } = resolveChatId(plugin, 'inst', msg);
+
+      expect(chatId).toBe(LID_JID);
+      expect(rawChatId).toBe(LID_JID);
+    });
+
+    it('upgrades a phone chatId to LID via remoteJidAlt', () => {
+      const plugin = buildPlugin();
+      const msg = buildMessage({ remoteJid: PHONE_JID, remoteJidAlt: LID_JID });
+
+      const { chatId, rawChatId } = resolveChatId(plugin, 'inst', msg);
+
+      expect(chatId).toBe(LID_JID);
+      expect(rawChatId).toBe(PHONE_JID);
+    });
+
+    it('collapses two messages from the same human onto a single chatId', () => {
+      const plugin = buildPlugin();
+      // First message arrives via @lid with the phone JID as alt — populates
+      // the bidirectional cache.
+      const first = buildMessage({ remoteJid: LID_JID, remoteJidAlt: PHONE_JID });
+      const second = buildMessage({ remoteJid: PHONE_JID });
+
+      const a = resolveChatId(plugin, 'inst', first);
+      const b = resolveChatId(plugin, 'inst', second);
+
+      expect(a.chatId).toBe(LID_JID);
+      expect(b.chatId).toBe(LID_JID);
+      // Same canonical chatId means a single debounce buffer for this human.
+      expect(a.chatId).toBe(b.chatId);
+    });
+
+    it('falls back to the phone JID when no mapping is known yet', () => {
+      const plugin = buildPlugin();
+      const msg = buildMessage({ remoteJid: PHONE_JID });
+
+      const { chatId } = resolveChatId(plugin, 'inst', msg);
+
+      expect(chatId).toBe(PHONE_JID);
+    });
+
+    it('leaves group chat IDs unchanged', () => {
+      const plugin = buildPlugin();
+      // Pre-seed cache to prove canonicalization does not touch group JIDs.
+      plugin.storeLidMapping('inst', LID_JID, PHONE_JID);
+      const msg = buildMessage({ remoteJid: GROUP_JID, participant: PARTICIPANT_PHONE });
+
+      const { chatId, rawChatId } = resolveChatId(plugin, 'inst', msg);
+
+      expect(chatId).toBe(GROUP_JID);
+      expect(rawChatId).toBe(GROUP_JID);
+    });
+  });
+
+  describe('resolveChatId — legacy (lidFirstEnabled=false)', () => {
+    it('still downconverts LID to phone (no regression)', () => {
+      const plugin = buildPlugin({ lidFirstEnabled: false });
+      const msg = buildMessage({ remoteJid: LID_JID, remoteJidAlt: PHONE_JID });
+
+      const { chatId, rawChatId } = resolveChatId(plugin, 'inst', msg);
+
+      expect(chatId).toBe(PHONE_JID);
+      expect(rawChatId).toBe(LID_JID);
+    });
+  });
+
+  describe('resolveSenderJid — LID-first mode', () => {
+    it('canonicalizes a phone-form sender to LID for stable per_user sessions', () => {
+      const plugin = buildPlugin();
+      // Group chat where the same human has been seen as a LID before.
+      plugin.storeLidMapping('inst', PARTICIPANT_LID, PARTICIPANT_PHONE);
+      const msg = buildMessage({
+        remoteJid: GROUP_JID,
+        participant: PARTICIPANT_PHONE,
+      });
+
+      const sender = resolveSenderJid(plugin, 'inst', msg, GROUP_JID);
+
+      expect(sender).toBe(PARTICIPANT_LID);
+    });
+
+    it('collapses LID and phone sender forms onto one identity', () => {
+      const plugin = buildPlugin();
+      // Sender first arrives as a LID with participantAlt pointing to the
+      // phone JID — populates the bidirectional cache.
+      const lidMsg = buildMessage({
+        remoteJid: GROUP_JID,
+        participant: PARTICIPANT_LID,
+        participantAlt: PARTICIPANT_PHONE,
+      });
+      const phoneMsg = buildMessage({
+        remoteJid: GROUP_JID,
+        participant: PARTICIPANT_PHONE,
+      });
+
+      const a = resolveSenderJid(plugin, 'inst', lidMsg, GROUP_JID);
+      const b = resolveSenderJid(plugin, 'inst', phoneMsg, GROUP_JID);
+
+      expect(a).toBe(PARTICIPANT_LID);
+      expect(b).toBe(PARTICIPANT_LID);
+      expect(a).toBe(b);
+    });
+  });
+});

--- a/packages/channel-whatsapp/src/__tests__/jid.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/jid.test.ts
@@ -221,16 +221,33 @@ describe('JID Utilities', () => {
   });
 
   describe('resolveCanonicalJid', () => {
-    it('returns LID JID unchanged (no phone downconversion)', () => {
+    it('returns LID JID unchanged (already canonical)', () => {
       expect(resolveCanonicalJid('100000001@lid', null, undefined)).toBe('100000001@lid');
     });
 
-    it('returns phone JID unchanged', () => {
+    it('returns phone JID unchanged when no mapping is available', () => {
       expect(resolveCanonicalJid('5511999@s.whatsapp.net', null, undefined)).toBe('5511999@s.whatsapp.net');
     });
 
-    it('returns LID JID unchanged even with remoteJidAlt', () => {
+    it('returns LID JID unchanged even when remoteJidAlt is a phone JID', () => {
       expect(resolveCanonicalJid('100000001@lid', '5511999@s.whatsapp.net', undefined)).toBe('100000001@lid');
+    });
+
+    it('upgrades phone JID to LID via remoteJidAlt when alt is a LID', () => {
+      expect(resolveCanonicalJid('5511999@s.whatsapp.net', '100000001@lid', undefined)).toBe('100000001@lid');
+    });
+
+    it('upgrades phone JID to LID via the bidirectional cache', () => {
+      const cache = new Map([
+        ['100000001@lid', '5511999@s.whatsapp.net'],
+        ['5511999@s.whatsapp.net', '100000001@lid'],
+      ]);
+      expect(resolveCanonicalJid('5511999@s.whatsapp.net', null, cache)).toBe('100000001@lid');
+    });
+
+    it('prefers remoteJidAlt over the cache when both are present', () => {
+      const cache = new Map([['5511999@s.whatsapp.net', '999999999@lid']]);
+      expect(resolveCanonicalJid('5511999@s.whatsapp.net', '100000001@lid', cache)).toBe('100000001@lid');
     });
 
     it('returns empty string for null/undefined jid', () => {
@@ -239,7 +256,22 @@ describe('JID Utilities', () => {
     });
 
     it('returns group JID unchanged', () => {
-      expect(resolveCanonicalJid('123-456@g.us', null, undefined)).toBe('123-456@g.us');
+      const cache = new Map([['100000001@lid', '5511999@s.whatsapp.net']]);
+      expect(resolveCanonicalJid('123-456@g.us', '100000001@lid', cache)).toBe('123-456@g.us');
+    });
+
+    it('returns broadcast JID unchanged', () => {
+      expect(resolveCanonicalJid('status@broadcast', null, undefined)).toBe('status@broadcast');
+    });
+
+    it('returns newsletter JID unchanged', () => {
+      expect(resolveCanonicalJid('abc123@newsletter', null, undefined)).toBe('abc123@newsletter');
+    });
+
+    it('ignores cache entries that point to non-LID JIDs', () => {
+      // Defensive: if the cache lookup yields something that isn't a LID, fall back to phone JID
+      const cache = new Map([['5511999@s.whatsapp.net', '5599888@s.whatsapp.net']]);
+      expect(resolveCanonicalJid('5511999@s.whatsapp.net', null, cache)).toBe('5511999@s.whatsapp.net');
     });
   });
 

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -16,7 +16,7 @@ import type { DedupeCache } from '@omni/channel-sdk';
 import { createLogger } from '@omni/core';
 import type { ContentType } from '@omni/core/types';
 import type { MessageUpsertType, WAMessage, WAMessageKey, WASocket, proto } from 'baileys';
-import { fromJid, isLidJid, isUserJid, resolveToPhoneJidLegacy } from '../jid';
+import { fromJid, isLidJid, isUserJid, resolveCanonicalJid, resolveToPhoneJidLegacy } from '../jid';
 import type { WhatsAppPlugin } from '../plugin';
 import type { DecryptFailureTracker } from '../utils/decrypt-failure-tracker';
 import { detectMediaType, downloadMediaToBuffer, getExtension } from '../utils/download';
@@ -487,7 +487,7 @@ function isFromMe(msg: WAMessage): boolean {
  * Fixes:
  * - isFromMe in groups: uses the bot's own JID instead of group JID
  */
-function resolveSenderJid(plugin: WhatsAppPlugin, instanceId: string, msg: WAMessage, chatId: string): string {
+export function resolveSenderJid(plugin: WhatsAppPlugin, instanceId: string, msg: WAMessage, chatId: string): string {
   if (isFromMe(msg)) {
     // Use the bot's own JID for own messages (not chatId, which could be a group)
     return plugin.getMeJid(instanceId) || chatId;
@@ -500,6 +500,8 @@ function resolveSenderJid(plugin: WhatsAppPlugin, instanceId: string, msg: WAMes
   // Always store bidirectional mapping when participantAlt provides the alternate form
   if (isLidJid(senderJid) && participantAlt && isUserJid(participantAlt)) {
     plugin.storeLidMapping(instanceId, senderJid, participantAlt);
+  } else if (isUserJid(senderJid) && participantAlt && isLidJid(participantAlt)) {
+    plugin.storeLidMapping(instanceId, participantAlt, senderJid);
   }
 
   // DEC-8: when lidFirstEnabled is disabled, resolve LID sender → phone (legacy behavior)
@@ -508,8 +510,10 @@ function resolveSenderJid(plugin: WhatsAppPlugin, instanceId: string, msg: WAMes
     return resolveToPhoneJidLegacy(senderJid, participantAlt, lidCache);
   }
 
-  // LID-first: keep sender JID as-is (LID stays LID, phone stays phone)
-  return senderJid;
+  // LID-first: canonicalize to LID so per_user sessions stay stable across
+  // the two JID forms Baileys emits for the same human (#374).
+  const lidCache = plugin.getLidMappingCache(instanceId);
+  return resolveCanonicalJid(senderJid, participantAlt, lidCache);
 }
 
 /**
@@ -660,17 +664,22 @@ async function handleSpecialMessage(
  */
 function annotateLidResolution(msg: WAMessage, rawChatId: string): void {
   const remoteJidAlt = (msg.key as Record<string, unknown>).remoteJidAlt as string | undefined;
+  const annotated = msg as unknown as Record<string, unknown>;
+
+  // Always preserve the raw remoteJid so audit trails and debugging see what
+  // Baileys actually delivered, independent of any canonicalization.
+  annotated.rawChatId = rawChatId;
 
   if (isLidJid(rawChatId)) {
-    (msg as unknown as Record<string, unknown>).originalLidJid = rawChatId;
-    (msg as unknown as Record<string, unknown>).addressingMode = 'lid';
+    annotated.originalLidJid = rawChatId;
+    annotated.addressingMode = 'lid';
     if (remoteJidAlt && isUserJid(remoteJidAlt)) {
-      (msg as unknown as Record<string, unknown>).resolvedPhoneJid = remoteJidAlt;
+      annotated.resolvedPhoneJid = remoteJidAlt;
     }
   } else if (isUserJid(rawChatId) && remoteJidAlt && isLidJid(remoteJidAlt)) {
-    (msg as unknown as Record<string, unknown>).originalLidJid = remoteJidAlt;
-    (msg as unknown as Record<string, unknown>).resolvedPhoneJid = rawChatId;
-    (msg as unknown as Record<string, unknown>).addressingMode = 'phone';
+    annotated.originalLidJid = remoteJidAlt;
+    annotated.resolvedPhoneJid = rawChatId;
+    annotated.addressingMode = 'phone';
   }
 }
 
@@ -680,7 +689,7 @@ function annotateLidResolution(msg: WAMessage, rawChatId: string): void {
  * LID-first: keeps @lid JIDs as canonical chatId (no phone downconversion).
  * Stores bidirectional LID↔phone mapping when remoteJidAlt provides it.
  */
-function resolveChatId(
+export function resolveChatId(
   plugin: WhatsAppPlugin,
   instanceId: string,
   msg: WAMessage,
@@ -705,8 +714,12 @@ function resolveChatId(
     return { chatId, rawChatId };
   }
 
-  // LID-first: use rawChatId as canonical (no resolution to phone)
-  return { chatId: rawChatId, rawChatId };
+  // LID-first: canonicalize to a single stable chatId per human so debounce
+  // and session keys don't fragment across the two JID forms Baileys emits
+  // for the same contact (#374).
+  const lidCache = plugin.getLidMappingCache(instanceId);
+  const chatId = resolveCanonicalJid(rawChatId, remoteJidAlt, lidCache);
+  return { chatId, rawChatId };
 }
 
 /**

--- a/packages/channel-whatsapp/src/jid.ts
+++ b/packages/channel-whatsapp/src/jid.ts
@@ -175,17 +175,27 @@ export function isLidJid(jid: string): boolean {
 }
 
 /**
- * Resolve a JID to its canonical form (LID-first).
+ * Resolve a JID to its canonical form under the LID-first model.
  *
- * In the LID-first model, LID JIDs are kept as-is (they ARE canonical).
- * Phone JIDs are also kept as-is (they're canonical when no LID is known).
- * The only resolution that happens is storing the bidirectional mapping
- * when `remoteJidAlt` provides the alternate form.
+ * The same human can be addressed by Baileys under two JIDs — `<lid>@lid`
+ * and `<phone>@s.whatsapp.net`. To stop debounce/session keys from
+ * fragmenting we collapse both forms onto the LID whenever a mapping is
+ * known. The LID is preferred because it is the default modern addressing
+ * mode, so most messages already arrive in canonical form and only the
+ * occasional phone-addressed message gets remapped.
  *
- * @param jid - The JID to resolve (may be @lid or @s.whatsapp.net)
- * @param remoteJidAlt - Alternative JID from msg.key.remoteJidAlt (if available)
- * @param lidCache - Map of LID JID → phone JID for this instance (used for mapping storage, not resolution)
- * @returns The canonical JID (unchanged — LID stays LID, phone stays phone)
+ * Resolution rules:
+ * - Empty / nullish JID         → ''
+ * - Group / broadcast / newsletter → unchanged (no canonicalization needed)
+ * - `@lid` JID                  → unchanged (already canonical)
+ * - `@s.whatsapp.net` JID       → upgrade to LID via `remoteJidAlt` first,
+ *                                 then via the bidirectional cache; fall
+ *                                 back to the original phone JID when no
+ *                                 mapping exists yet (best effort).
+ *
+ * @param jid - The JID to canonicalize (may be `@lid` or `@s.whatsapp.net`)
+ * @param remoteJidAlt - Alt JID from `msg.key.remoteJidAlt` / `participantAlt`
+ * @param lidCache - Bidirectional LID↔phone cache for this instance
  */
 export function resolveCanonicalJid(
   jid: string | undefined | null,
@@ -194,12 +204,26 @@ export function resolveCanonicalJid(
 ): string {
   if (!jid) return '';
 
-  // In LID-first model, every JID is already canonical — return as-is
-  // The remoteJidAlt and lidCache params are kept for caller convenience
-  // (callers may use them for mapping storage at the call site)
-  void remoteJidAlt;
-  void lidCache;
+  // Non-user JIDs (group / broadcast / newsletter) — already canonical.
+  if (!isCanonicalJid(jid)) return jid;
 
+  // Already a LID — canonical under LID-first.
+  if (isLidJid(jid)) return jid;
+
+  // Phone-addressed: try to upgrade to LID. Prefer the alt JID from the
+  // message key (most authoritative — it came directly from Baileys).
+  if (remoteJidAlt && isLidJid(remoteJidAlt)) {
+    return remoteJidAlt;
+  }
+
+  // Fall back to the bidirectional cache (phone→LID direction).
+  if (lidCache) {
+    const lidJid = lidCache.get(jid);
+    if (lidJid && isLidJid(lidJid)) return lidJid;
+  }
+
+  // No mapping yet — keep the phone JID. A later message from the same
+  // human will populate the cache and subsequent ones will canonicalize.
   return jid;
 }
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -388,7 +388,13 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   private static readonly MESSAGE_KEY_CACHE_TTL_MS = 60_000; // 1 minute
 
   /**
-   * Store a LID → phone JID mapping for an instance
+   * Store a bidirectional LID ↔ phone JID mapping for an instance.
+   *
+   * Both directions are stored in the same Map (key namespaces don't collide:
+   * `@lid` vs `@s.whatsapp.net`). The forward direction (lid→phone) is what
+   * `publishLidMappings` persists to the DB. The reverse (phone→lid) is what
+   * `resolveCanonicalJid` uses to upgrade a phone-addressed message to its
+   * LID canonical form so debounce/session keying stays stable per human.
    */
   storeLidMapping(instanceId: string, lidJid: string, phoneJid: string): void {
     let cache = this.lidMappingCache.get(instanceId);
@@ -397,7 +403,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       this.lidMappingCache.set(instanceId, cache);
     }
     cache.set(lidJid, phoneJid);
-    this.logger.debug('Stored LID mapping', { instanceId, lidJid, phoneJid });
+    cache.set(phoneJid, lidJid);
+    this.logger.debug('Stored LID↔phone mapping', { instanceId, lidJid, phoneJid });
   }
 
   /**
@@ -3202,7 +3209,11 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     const lidCache = this.lidMappingCache.get(instanceId);
     if (!lidCache || lidCache.size === 0) return;
 
-    const mappings = Array.from(lidCache.entries()).map(([lidJid, phoneJid]) => ({ lidJid, phoneJid }));
+    // Cache stores both directions (lid→phone and phone→lid). Only the
+    // lid-keyed direction belongs in DB persistence as the canonical mapping.
+    const mappings = Array.from(lidCache.entries())
+      .filter(([key]) => key.endsWith('@lid'))
+      .map(([lidJid, phoneJid]) => ({ lidJid, phoneJid }));
     this.eventBus
       .publishGeneric(
         'custom.lid-mapping.batch',

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3212,7 +3212,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     // Cache stores both directions (lid→phone and phone→lid). Only the
     // lid-keyed direction belongs in DB persistence as the canonical mapping.
     const mappings = Array.from(lidCache.entries())
-      .filter(([key]) => key.endsWith('@lid'))
+      .filter(([key]) => isLidJid(key))
       .map(([lidJid, phoneJid]) => ({ lidJid, phoneJid }));
     this.eventBus
       .publishGeneric(


### PR DESCRIPTION
## Summary

Closes #374. Baileys can address the same human under both `<lid>@lid` and `<phone>@s.whatsapp.net`, fragmenting the debounce buffer and per-chat / per-user sessions: messages that should batch together arrive on different keys, and the agent loses conversation history across the two identities.

This change canonicalizes the chatId and sender in the WhatsApp channel plugin **before** the `message.received` event is published, so all downstream consumers (debounce, session computation, typing debounce, rate limiting) see a single stable identity per human.

Wish: `.genie/wishes/fix-lid-jid-fragmentation/WISH.md`.

## What changed

- **`resolveCanonicalJid()` is no longer a no-op.** It now upgrades phone JIDs to LID using `remoteJidAlt` first and the in-memory cache as a fallback. Group / broadcast / newsletter JIDs short-circuit. Missing mappings fall back to the phone JID so first-touch traffic still flows.
- **`storeLidMapping()` is bidirectional.** Both `lid→phone` and `phone→lid` are written to the same per-instance Map (the suffixes don't collide). `publishLidMappings()` filters to the `@lid`-keyed direction so the DB persistence still sees only the canonical forward mapping.
- **`resolveChatId()` and `resolveSenderJid()` invoke the canonicalizer** in LID-first mode. Debounce keying (`agent-dispatcher`), session computation (`agent-runner`), and typing debounce all key on the canonical identity now.
- **Raw `remoteJid` is preserved** on the raw payload as `rawChatId` (via `annotateLidResolution`) for debugging / audit trails.
- **DEC-8 legacy mode** (`lidFirstEnabled=false`) is unchanged.

## Test plan

- [x] `bun test packages/channel-whatsapp/` — 361 pass, 0 fail
- [x] `bun test packages/api/` — 588 pass, 0 fail
- [x] `make typecheck` — clean across all packages
- [x] `bunx biome check .` — no new warnings (2 pre-existing in `turn-monitor-fallback.test.ts`)
- [x] Pre-push hook full repo suite — 3284 pass, 0 fail
- [x] New `__tests__/canonicalize-jid.test.ts` covers:
  - Same human via `@lid` + `@s.whatsapp.net` collapses to a single canonical chatId (single debounce buffer)
  - Group JIDs pass through unchanged
  - Bidirectional cache resolves both directions
  - Sender canonicalization stabilizes `per_user` sessions
  - Legacy `lidFirstEnabled=false` mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)