### PR TITLE
feat(cli): add omni events stream for real-time event tailing (#415)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -470,6 +470,52 @@ describe('CLI Integration Tests', () => {
       const output = `${result.stdout}${result.stderr}`;
       expect(output.toLowerCase()).toContain('not found');
     });
+
+    test('events stream emits NDJSON for seeded events then shuts down on SIGTERM', async () => {
+      const { seedStreamEvent, clearStreamedEvents } = await import('./mock-api');
+      clearStreamedEvents();
+
+      const ev1 = seedStreamEvent({ eventType: 'message.received', textContent: 'stream one' });
+      const ev2 = seedStreamEvent({
+        eventType: 'message.sent',
+        direction: 'outbound',
+        textContent: 'stream two',
+      });
+
+      // --since 1h ensures the cursor starts before the seed rows; --poll-ms 200
+      // keeps the loop tight so the test completes quickly.
+      const proc = spawn({
+        cmd: ['bun', CLI_PATH, 'events', 'stream', '--since', '1h', '--poll-ms', '200', '--ndjson'],
+        env: { ...process.env, HOME: TEST_CONFIG_DIR },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      // Collect up to two NDJSON lines, then terminate.
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      const lines: string[] = [];
+      const start = Date.now();
+      while (lines.length < 2 && Date.now() - start < 5000) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split('\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          if (part.trim()) lines.push(part.trim());
+        }
+      }
+      proc.kill('SIGTERM');
+      await proc.exited;
+
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      const parsed = lines.slice(0, 2).map((l) => JSON.parse(l) as { id: string; eventType: string });
+      const ids = parsed.map((p) => p.id);
+      expect(ids).toContain(ev1.id);
+      expect(ids).toContain(ev2.id);
+    });
   });
 
   describe('chats', () => {

--- a/packages/cli/src/__tests__/events-stream.test.ts
+++ b/packages/cli/src/__tests__/events-stream.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for `omni events stream` filter predicates and formatter.
+ *
+ * Integration-level spawn coverage lives in cli.test.ts (stream smoke test).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Event } from '@omni/sdk';
+import { formatEventLine, isErrorEvent, isNoisyEvent, passesStreamFilters } from '../commands/events';
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    eventType: 'message.received',
+    contentType: 'text',
+    instanceId: '00000000-0000-0000-0000-0000000000aa',
+    personId: null,
+    direction: 'inbound',
+    textContent: 'hello world',
+    transcription: null,
+    imageDescription: null,
+    chatUuid: '00000000-0000-0000-0000-0000000000cc',
+    agentId: null,
+    conversationId: null,
+    receivedAt: '2026-04-16T10:00:00.000Z',
+    processedAt: null,
+    ...overrides,
+  };
+}
+
+describe('events stream filters', () => {
+  test('passes with no filters (non-noisy)', () => {
+    expect(passesStreamFilters(makeEvent(), {})).toBe(true);
+  });
+
+  test('hides noisy events by default, surfaces them with --all', () => {
+    const ev = makeEvent({ eventType: 'presence.typing' });
+    expect(passesStreamFilters(ev, {})).toBe(false);
+    expect(passesStreamFilters(ev, { all: true })).toBe(true);
+  });
+
+  test('instance filter matches on UUID', () => {
+    const ev = makeEvent({ instanceId: '00000000-0000-0000-0000-000000000111' });
+    expect(passesStreamFilters(ev, { instanceId: '00000000-0000-0000-0000-000000000111' })).toBe(true);
+    expect(passesStreamFilters(ev, { instanceId: '00000000-0000-0000-0000-000000000222' })).toBe(false);
+  });
+
+  test('type filter is exact match', () => {
+    const ev = makeEvent({ eventType: 'message.sent' });
+    expect(passesStreamFilters(ev, { type: 'message.sent' })).toBe(true);
+    expect(passesStreamFilters(ev, { type: 'message.received' })).toBe(false);
+  });
+
+  test('chat-id filter matches chatUuid', () => {
+    const ev = makeEvent({ chatUuid: 'chat-xyz' });
+    expect(passesStreamFilters(ev, { chatId: 'chat-xyz' })).toBe(true);
+    expect(passesStreamFilters(ev, { chatId: 'chat-abc' })).toBe(false);
+  });
+
+  test('person-id filter matches personId', () => {
+    const ev = makeEvent({ personId: 'person-42' });
+    expect(passesStreamFilters(ev, { personId: 'person-42' })).toBe(true);
+    expect(passesStreamFilters(ev, { personId: 'person-99' })).toBe(false);
+  });
+
+  test('errors-only keeps failure events and drops success', () => {
+    expect(passesStreamFilters(makeEvent({ eventType: 'message.failed' }), { errorsOnly: true })).toBe(true);
+    expect(passesStreamFilters(makeEvent({ eventType: 'access.denied' }), { errorsOnly: true })).toBe(true);
+    expect(passesStreamFilters(makeEvent({ eventType: 'message.received' }), { errorsOnly: true })).toBe(false);
+  });
+
+  test('combined filters require all to pass', () => {
+    const ev = makeEvent({ eventType: 'message.sent', chatUuid: 'chat-1' });
+    expect(passesStreamFilters(ev, { type: 'message.sent', chatId: 'chat-1' })).toBe(true);
+    expect(passesStreamFilters(ev, { type: 'message.sent', chatId: 'chat-OTHER' })).toBe(false);
+  });
+});
+
+describe('events stream classifiers', () => {
+  test('isErrorEvent tags failure/denial types', () => {
+    expect(isErrorEvent('message.failed')).toBe(true);
+    expect(isErrorEvent('sync.failed')).toBe(true);
+    expect(isErrorEvent('access.denied')).toBe(true);
+    expect(isErrorEvent('media.processing.failed')).toBe(true);
+    expect(isErrorEvent('message.received')).toBe(false);
+  });
+
+  test('isNoisyEvent tags presence/progress/delivered/read', () => {
+    expect(isNoisyEvent('presence.typing')).toBe(true);
+    expect(isNoisyEvent('message.delivered')).toBe(true);
+    expect(isNoisyEvent('message.read')).toBe(true);
+    expect(isNoisyEvent('sync.progress')).toBe(true);
+    expect(isNoisyEvent('batch-job.progress')).toBe(true);
+    expect(isNoisyEvent('message.received')).toBe(false);
+  });
+});
+
+describe('events stream formatter', () => {
+  test('formatEventLine emits HH:MM:SS + type + instance/chat + direction + summary', () => {
+    const line = formatEventLine(makeEvent());
+    expect(line).toContain('10:00:00');
+    expect(line).toContain('message.received');
+    expect(line).toContain('00000000/00000000');
+    expect(line).toContain('inbound');
+    expect(line).toContain('hello world');
+  });
+
+  test('formatEventLine truncates long text content', () => {
+    const long = 'x'.repeat(200);
+    const line = formatEventLine(makeEvent({ textContent: long }));
+    expect(line).toContain('...');
+    expect(line.length).toBeLessThan(200);
+  });
+
+  test('formatEventLine falls back to transcription/imageDescription/empty', () => {
+    const audio = formatEventLine(makeEvent({ textContent: null, transcription: 'said hi' }));
+    expect(audio).toContain('said hi');
+    const image = formatEventLine(
+      makeEvent({ textContent: null, transcription: null, imageDescription: 'a cat photo' }),
+    );
+    expect(image).toContain('a cat photo');
+    const blank = formatEventLine(makeEvent({ textContent: null, transcription: null, imageDescription: null }));
+    expect(blank).toContain('message.received');
+  });
+});

--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -341,6 +341,72 @@ function handleGetEvent(path: string): Response {
   return json({ data: makeSeedEvent() });
 }
 
+/**
+ * In-memory event queue used by `omni events stream` integration tests.
+ * Pushed via {@link seedStreamEvent} and drained by `GET /api/v2/events`
+ * filtered by `since`. Kept separate from {@link makeSeedEvent} so the
+ * `events get` happy path stays deterministic.
+ */
+interface StreamEventRow {
+  id: string;
+  eventType: string;
+  contentType: string | null;
+  instanceId: string;
+  personId: string | null;
+  direction: 'inbound' | 'outbound';
+  textContent: string | null;
+  transcription: string | null;
+  imageDescription: string | null;
+  chatUuid: string | null;
+  agentId: string | null;
+  conversationId: string | null;
+  receivedAt: string;
+  processedAt: string | null;
+}
+
+let streamedEvents: StreamEventRow[] = [];
+
+export function seedStreamEvent(overrides: Partial<StreamEventRow> = {}): StreamEventRow {
+  const now = new Date().toISOString();
+  const ev: StreamEventRow = {
+    id: crypto.randomUUID(),
+    eventType: 'message.received',
+    contentType: 'text',
+    instanceId: SEED_INSTANCE_ID,
+    personId: null,
+    direction: 'inbound',
+    textContent: 'streamed hello',
+    transcription: null,
+    imageDescription: null,
+    chatUuid: null,
+    agentId: null,
+    conversationId: null,
+    receivedAt: now,
+    processedAt: null,
+    ...overrides,
+  };
+  streamedEvents.push(ev);
+  return ev;
+}
+
+export function clearStreamedEvents(): void {
+  streamedEvents = [];
+}
+
+function handleListEvents(req: Request): Response {
+  const url = new URL(req.url);
+  const sinceRaw = url.searchParams.get('since');
+  const since = sinceRaw ? new Date(sinceRaw).getTime() : 0;
+  const instanceId = url.searchParams.get('instanceId');
+  const eventType = url.searchParams.get('eventType');
+  const matches = streamedEvents
+    .filter((e) => new Date(e.receivedAt).getTime() >= since)
+    .filter((e) => !instanceId || e.instanceId === instanceId)
+    .filter((e) => !eventType || e.eventType === eventType)
+    .sort((a, b) => b.receivedAt.localeCompare(a.receivedAt));
+  return json({ items: matches, meta: { hasMore: false } });
+}
+
 // ── Log fixtures ──
 
 /**
@@ -410,7 +476,7 @@ const staticRoutes: Record<RouteKey, (req: Request) => Response | Promise<Respon
   'POST /api/v2/auth/validate': handleAuthValidate,
   'GET /api/v2/instances': handleListInstances,
   'POST /api/v2/instances': handleCreateInstance,
-  'GET /api/v2/events': () => json(EMPTY_LIST),
+  'GET /api/v2/events': handleListEvents,
   'POST /api/v2/events/search': () => json(EMPTY_LIST),
   'GET /api/v2/chats': () => json({ items: [], meta: { hasMore: false, cursor: null } }),
   'GET /api/v2/persons': () => json(EMPTY_ITEMS),
@@ -515,6 +581,7 @@ export async function startMockApi(): Promise<MockApiHandle> {
   dynamicInstances = [];
   dynamicProviders = [];
   dynamicAgents = [];
+  streamedEvents = [];
 
   const server = Bun.serve({
     port: 0, // OS-assigned random port
@@ -532,6 +599,7 @@ export async function startMockApi(): Promise<MockApiHandle> {
       dynamicInstances = [];
       dynamicProviders = [];
       dynamicAgents = [];
+      streamedEvents = [];
     },
   };
 

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -2,11 +2,12 @@
  * Event Commands
  *
  * omni events list --instance <id>
+ * omni events stream [flags]
  * omni events search <query>
  * omni events timeline <person-id>
  */
 
-import type { OmniClient } from '@omni/sdk';
+import type { Event, OmniClient } from '@omni/sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { getOutputFormat, loadConfig } from '../config.js';
@@ -201,6 +202,187 @@ function displayRecordBreakdown(title: string, record: Record<string, number>, k
   output.list(items);
 }
 
+// ============================================================================
+// STREAM
+// ============================================================================
+
+/**
+ * High-frequency event types hidden by default on `omni events stream`.
+ * `--all` surfaces them. Mirrors `genie events stream --all`.
+ */
+const NOISY_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'presence.typing',
+  'presence.online',
+  'presence.offline',
+  'message.delivered',
+  'message.read',
+  'sync.progress',
+  'batch-job.progress',
+]);
+
+/** True when event_type denotes a failure/denial — used by --errors-only. */
+export function isErrorEvent(eventType: string): boolean {
+  return eventType.endsWith('.failed') || eventType === 'access.denied' || eventType.endsWith('.processing.failed');
+}
+
+/** True when event_type is considered noisy and should be hidden unless --all is set. */
+export function isNoisyEvent(eventType: string): boolean {
+  return NOISY_EVENT_TYPES.has(eventType);
+}
+
+/** Filter predicate matrix for `omni events stream`. Exported for unit tests. */
+export interface StreamFilterOptions {
+  instanceId?: string;
+  channel?: string;
+  type?: string;
+  chatId?: string;
+  personId?: string;
+  errorsOnly?: boolean;
+  all?: boolean;
+}
+
+/**
+ * Return true when event should be emitted given the filter options.
+ * The API pre-filters by instanceId / channel / eventType / since, so this
+ * is primarily a post-fetch sieve for filters the list API does not support
+ * (chat-id, person-id, errors-only, noise suppression).
+ */
+export function passesStreamFilters(event: Event, options: StreamFilterOptions): boolean {
+  if (options.instanceId && event.instanceId !== options.instanceId) return false;
+  if (options.type && event.eventType !== options.type) return false;
+  if (options.chatId && event.chatUuid !== options.chatId) return false;
+  if (options.personId && event.personId !== options.personId) return false;
+  if (options.errorsOnly && !isErrorEvent(event.eventType)) return false;
+  if (!options.all && isNoisyEvent(event.eventType)) return false;
+  return true;
+}
+
+/** Format an event as a single human-readable line. */
+export function formatEventLine(event: Event): string {
+  const time = new Date(event.receivedAt).toISOString().slice(11, 19);
+  const instance = event.instanceId?.slice(0, 8) ?? '--------';
+  const chat = event.chatUuid?.slice(0, 8) ?? '--------';
+  const summary = event.textContent ?? event.transcription ?? event.imageDescription ?? '';
+  const trimmed = summary.length > 80 ? `${summary.slice(0, 77)}...` : summary;
+  return `${time}  ${event.eventType.padEnd(28)}  ${instance}/${chat}  ${event.direction.padEnd(8)}  ${trimmed}`.trimEnd();
+}
+
+/** Emit an event through the drain-safe stdout helper — never raw console.log. */
+function emitStreamEvent(event: Event, ndjson: boolean): void {
+  if (ndjson) {
+    output.raw(JSON.stringify(event));
+  } else {
+    output.raw(formatEventLine(event));
+  }
+}
+
+interface StreamOptions {
+  instance?: string;
+  channel?: string;
+  type?: string;
+  chatId?: string;
+  personId?: string;
+  since?: string;
+  errorsOnly?: boolean;
+  all?: boolean;
+  ndjson?: boolean;
+  pollMs?: number;
+}
+
+/**
+ * Poll `/events` and emit new rows as they arrive.
+ *
+ * Transport: polls `client.events.list({ since })` because the API does not
+ * currently expose an SSE/WS stream for events. Polling keeps the CLI thin,
+ * reuses the list query path (zero schema/regression risk), and mirrors
+ * `genie events stream`'s internal follower cadence. An SSE/WS endpoint is
+ * a follow-up (see issue #415 non-goals).
+ */
+interface StreamState {
+  sinceIso: string;
+  seen: Set<string>;
+}
+
+async function fetchStreamBatch(
+  client: OmniClient,
+  filters: StreamFilterOptions,
+  channel: string | undefined,
+  type: string | undefined,
+  sinceIso: string,
+): Promise<Event[]> {
+  try {
+    const result = await client.events.list({
+      instanceId: filters.instanceId,
+      channel,
+      eventType: type,
+      since: sinceIso,
+      limit: 100,
+    });
+    return result.items;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    output.warn(`events stream: ${message}`);
+    return [];
+  }
+}
+
+function processStreamBatch(items: Event[], filters: StreamFilterOptions, state: StreamState, ndjson: boolean): void {
+  const ascending = [...items].sort((a, b) => a.receivedAt.localeCompare(b.receivedAt));
+  for (const ev of ascending) {
+    if (state.seen.has(ev.id)) continue;
+    state.seen.add(ev.id);
+    if (!passesStreamFilters(ev, filters)) continue;
+    emitStreamEvent(ev, ndjson);
+    if (ev.receivedAt > state.sinceIso) state.sinceIso = ev.receivedAt;
+  }
+  // Bound the dedupe set — once the cursor moves past events we cannot
+  // re-observe them, so a periodic flush keeps memory O(poll window).
+  if (state.seen.size > 5000) state.seen.clear();
+}
+
+async function streamEvents(client: OmniClient, options: StreamOptions): Promise<void> {
+  const ndjson = options.ndjson === true || getOutputFormat() === 'json';
+  const pollMs = Math.max(250, options.pollMs ?? 2000);
+  const instanceId = options.instance ? await resolveInstanceId(options.instance) : undefined;
+  const chatId = options.chatId ? await resolveChatId(options.chatId) : undefined;
+
+  const state: StreamState = {
+    sinceIso: options.since ? parseSinceTime(options.since) : new Date().toISOString(),
+    seen: new Set<string>(),
+  };
+  const filters: StreamFilterOptions = {
+    instanceId,
+    channel: options.channel,
+    type: options.type,
+    chatId,
+    personId: options.personId,
+    errorsOnly: options.errorsOnly,
+    all: options.all,
+  };
+
+  let stopped = false;
+  const shutdown = (): void => {
+    stopped = true;
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  if (!ndjson) output.dim(`Streaming events (poll=${pollMs}ms). Ctrl+C to stop.`);
+
+  try {
+    while (!stopped) {
+      const items = await fetchStreamBatch(client, filters, options.channel, options.type, state.sinceIso);
+      processStreamBatch(items, filters, state, ndjson);
+      if (stopped) break;
+      await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+    }
+  } finally {
+    process.off('SIGINT', shutdown);
+    process.off('SIGTERM', shutdown);
+    await output.flushStdout();
+  }
+}
+
 export function createEventsCommand(): Command {
   const events = new Command('events').description('Query events');
 
@@ -257,6 +439,43 @@ export function createEventsCommand(): Command {
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error';
           output.error(`Failed to list events: ${message}`);
+        }
+      },
+    );
+
+  // omni events stream
+  events
+    .command('stream')
+    .description('Stream events in real-time (tail -f style). Ctrl+C to stop.')
+    .option('--instance <id>', 'Filter by instance ID')
+    .option('--channel <type>', 'Filter by channel type')
+    .option('--type <type>', 'Filter by event type')
+    .option('--chat-id <id>', 'Filter by chat ID')
+    .option('--person-id <id>', 'Filter by person ID')
+    .option('--since <time>', 'Start cursor (e.g., 5min, 24h, 7d, or ISO timestamp)')
+    .option('--errors-only', 'Show only error/failure events')
+    .option('--all', 'Include noisy event types (presence, delivered, read, progress)')
+    .option('--ndjson', 'Emit JSON Lines (one event per line) — same as global --json in stream mode')
+    .option('--poll-ms <n>', 'Polling interval in milliseconds', (v) => Number.parseInt(v, 10), 2000)
+    .action(
+      async (options: {
+        instance?: string;
+        channel?: string;
+        type?: string;
+        chatId?: string;
+        personId?: string;
+        since?: string;
+        errorsOnly?: boolean;
+        all?: boolean;
+        ndjson?: boolean;
+        pollMs?: number;
+      }) => {
+        const client = getClient();
+        try {
+          await streamEvents(client, options);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          output.error(`Failed to stream events: ${message}`);
         }
       },
     );


### PR DESCRIPTION
Closes #415.

## Summary

Adds `omni events stream` — a `tail -f`-style real-time feed that mirrors `genie events stream` ergonomics. Users no longer need the `while true; omni events list --since 10s` shell loop when debugging live traffic.

- Filters mirror `events list`: `--instance`, `--channel`, `--type`, `--chat-id`, `--person-id`, `--since`.
- `--errors-only` surfaces failure/denial events; `--all` opts in to noisy high-frequency types (presence, delivered, read, progress).
- Default output is one human-readable line per event. `--ndjson` (or the global `--json`) emits JSON Lines for `jq`/fluent-bit pipelines.
- `--poll-ms <n>` tunes the follower cadence (default 2000 ms, clamped to >=250 ms).
- `SIGINT`/`SIGTERM` flip a stopped flag, break the poll loop, and `flushStdout()` drains the pipe before exit — reusing the 64 KB drain pattern from #429. No `console.log` paths.

## Transport choice

**Polling `/events` with an advancing `since` cursor**, deduping by id. The API has no SSE/WS endpoint today and the issue's non-goals section explicitly defers a server-side stream. Polling keeps the CLI thin, reuses the existing list query path (zero schema/regression risk), and matches the `--poll-ms` hint in the issue. An SSE/WS endpoint remains an easy follow-up.

## Acceptance criteria

- [x] `omni events stream` runs until interrupted.
- [x] All `list` filters (`--instance`, `--channel`, `--type`, `--chat-id`, `--since`) work on `stream`.
- [x] `--json` emits JSONL (one object per line), stable schema.
- [x] `Ctrl+C` shuts down cleanly, no dangling promises.
- [x] Unit test: filter matrix. Integration test: spawn → seed → observe → SIGTERM.
- [x] No regression on `omni events list` (shared query path).

## Test plan

- [x] `bun test src/__tests__/events-stream.test.ts` — 13 unit tests pass (filters, classifiers, formatter).
- [x] `bun test src/__tests__/cli.test.ts` — 66 tests pass, including the new stream integration test that seeds two events and asserts two NDJSON lines.
- [x] `make typecheck` green.
- [x] `bunx biome check packages/cli/src/commands/events.ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)