### PR TITLE
fix(automations): honor agentStreamMode in call_agent adapter

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -476,7 +476,10 @@ async function setupEventBusServices(
           agentTimeout: cfg.timeoutMs ? Math.ceil(cfg.timeoutMs / 1000) : instance.agentTimeout,
         };
 
-        const result = await services.agentRunner.run({
+        // Honor instance.agentStreamMode — sync mode waits for the full agent run
+        // before sending anything (11-14s on some providers); stream mode returns
+        // progressively. See issue #410.
+        const result = await services.agentRunner.runOrStream({
           instance: runInstance,
           chatId: ctx.chatId,
           senderId: ctx.senderId,

--- a/packages/api/src/services/__tests__/agent-runner.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner.test.ts
@@ -1,9 +1,11 @@
 /**
  * Tests for computeSessionId — per_thread strategy and backwards compatibility
+ * Tests for runOrStream — branches on instance.agentStreamMode (issue #410)
  */
 
-import { describe, expect, it } from 'bun:test';
-import { computeSessionId } from '../agent-runner';
+import { describe, expect, it, mock } from 'bun:test';
+import type { Database, Instance } from '@omni/db';
+import { type AgentRunContext, type AgentRunResult, AgentRunnerService, computeSessionId } from '../agent-runner';
 
 describe('computeSessionId', () => {
   describe('per_thread strategy', () => {
@@ -63,5 +65,66 @@ describe('computeSessionId', () => {
       expect(computeSessionId('per_user', 'user-1', 'chat-A')).toBe('user-1');
       expect(computeSessionId('per_chat', 'user-1', 'chat-A')).toBe('chat-A');
     });
+  });
+});
+
+describe('AgentRunnerService.runOrStream', () => {
+  const fakeDb = {} as Database;
+
+  function baseContext(agentStreamMode: boolean): AgentRunContext {
+    const instance = {
+      id: 'inst-1',
+      agentStreamMode,
+      agentSessionStrategy: 'per_chat' as const,
+    } as unknown as Instance;
+    return {
+      instance,
+      chatId: 'chat-1',
+      senderId: 'sender-1',
+      chatType: 'dm',
+      messages: ['hi'],
+    };
+  }
+
+  it('calls run() (sync) when agentStreamMode is false', async () => {
+    const runner = new AgentRunnerService(fakeDb);
+    const runResult: AgentRunResult = {
+      parts: ['sync-response'],
+      metadata: { runId: 'run-sync', sessionId: 'chat-1', status: 'completed' },
+    };
+    const runMock = mock(async () => runResult);
+    const streamMock = mock(async function* () {
+      yield 'should-not-run';
+    });
+    runner.run = runMock as unknown as typeof runner.run;
+    runner.stream = streamMock as unknown as typeof runner.stream;
+
+    const result = await runner.runOrStream(baseContext(false));
+
+    expect(runMock).toHaveBeenCalledTimes(1);
+    expect(streamMock).not.toHaveBeenCalled();
+    expect(result).toBe(runResult);
+  });
+
+  it('consumes stream() and collects parts when agentStreamMode is true', async () => {
+    const runner = new AgentRunnerService(fakeDb);
+    const runMock = mock(async () => {
+      throw new Error('run() must not be invoked in stream mode');
+    });
+    const streamMock = mock(async function* () {
+      yield 'part-1';
+      yield 'part-2';
+    });
+    runner.run = runMock as unknown as typeof runner.run;
+    runner.stream = streamMock as unknown as typeof runner.stream;
+
+    const result = await runner.runOrStream(baseContext(true));
+
+    expect(streamMock).toHaveBeenCalledTimes(1);
+    expect(runMock).not.toHaveBeenCalled();
+    expect(result.parts).toEqual(['part-1', 'part-2']);
+    expect(result.metadata.status).toBe('completed');
+    expect(result.metadata.sessionId).toBe('chat-1');
+    expect(result.metadata.runId).toBeString();
   });
 });

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -493,6 +493,39 @@ export class AgentRunnerService {
   }
 
   /**
+   * Run or stream an agent call based on `instance.agentStreamMode`.
+   *
+   * When `agentStreamMode` is true, consumes `stream()` and collects parts
+   * into an AgentRunResult. Otherwise, delegates to `run()` (sync mode).
+   *
+   * Used by callers that must honor the per-instance stream flag without
+   * owning the branching logic themselves (e.g. the automation `call_agent`
+   * adapter — see issue #410).
+   */
+  async runOrStream(context: AgentRunContext): Promise<AgentRunResult> {
+    if (!context.instance.agentStreamMode) {
+      return this.run(context);
+    }
+
+    const parts: string[] = [];
+    for await (const part of this.stream(context)) {
+      parts.push(part);
+    }
+
+    const sessionStrategy = context.instance.agentSessionStrategy ?? 'per_chat';
+    const sessionId = computeSessionId(sessionStrategy, context.senderId, context.chatId);
+
+    return {
+      parts,
+      metadata: {
+        runId: crypto.randomUUID(),
+        sessionId,
+        status: 'completed',
+      },
+    };
+  }
+
+  /**
    * Stream an agent call
    * Yields split parts as they become available
    */


### PR DESCRIPTION
## Summary
- `call_agent` automation adapter hardcoded `agentRunner.run()` regardless of `instance.agentStreamMode`. Follow-up fires on `agentStreamMode: true` instances waited ~11–14s for the full generation before sending anything.
- Adds `AgentRunnerService.runOrStream(context)` that branches on `instance.agentStreamMode`: `false` → existing `run()`; `true` → consume `stream()`, collect parts, return an `AgentRunResult` with `status: 'completed'`.
- Adapter in `packages/api/src/index.ts` now calls `runOrStream` — inbound dispatch already honored the flag via the dispatcher guard; this brings the automation path in line.

## Test plan
- [x] `bun test packages/api/src/services/__tests__/agent-runner.test.ts` — 12 pass, covers both branches of `runOrStream`
- [x] `bun run --filter=@omni/api test` — 625 pass / 0 fail
- [x] `bun run typecheck` — green
- [x] `bun run lint` — no new errors (2 pre-existing warnings in `turn-monitor-fallback.test.ts` unrelated)
- [ ] Live validation on `testonho` / `eugenia-seller` — follow-up fires should stream parts instead of landing as a single blob

Closes #410