### PR TITLE
fix: address gemini review comments across release PRs

### DIFF
--- a/packages/api/src/services/chats.ts
+++ b/packages/api/src/services/chats.ts
@@ -49,7 +49,7 @@ export function withIsGroup<T extends Pick<Chat, 'chatType' | 'externalId'>>(cha
   return { ...chat, isGroup: isChatGroup(chat) };
 }
 
-export interface ChatWithParticipants extends Chat {
+export interface ChatWithParticipants extends ChatWithIsGroup<Chat> {
   participants: ChatParticipant[];
 }
 

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -337,7 +337,11 @@ function processStreamBatch(items: Event[], filters: StreamFilterOptions, state:
   }
   // Bound the dedupe set — once the cursor moves past events we cannot
   // re-observe them, so a periodic flush keeps memory O(poll window).
-  if (state.seen.size > 5000) state.seen.clear();
+  // Keep the most recent batch's IDs to avoid re-emitting events returned
+  // again by an inclusive `since: state.sinceIso` query on the next poll.
+  if (state.seen.size > 5000 && items.length > 0) {
+    state.seen = new Set(items.map((ev) => ev.id));
+  }
 }
 
 async function streamEvents(client: OmniClient, options: StreamOptions): Promise<void> {

--- a/plugins/omni/skills/omni-setup/SKILL.md
+++ b/plugins/omni/skills/omni-setup/SKILL.md
@@ -87,7 +87,7 @@ This command does four things automatically:
 | Flag | Default | Behavior |
 |------|---------|----------|
 | `--mode <mode>` | `turn-based` | `turn-based` (round-trip; agent ends each turn with `omni done`) or `fire-and-forget` (Omni publishes and does not wait) |
-| `--reply-filter <filter>` | `all` | `all` reply to every inbound message; `filtered` apply `agentReplyFilter.conditions` (DM, mention, reply, name-match) |
+| `--reply-filter <filter>` | `all` | `all` reply to every inbound message; `filtered` apply `agentReplyFilter.conditions` (DM, mention, reply enabled by default; name-match disabled) |
 | `--nats-url <url>` | `localhost:4222` | NATS server URL used by the provider for publish/subscribe |
 
 > **⚠️ Reply filter default — `all` means "reply to everything."** On WhatsApp this includes every group and broadcast the account is in. If the instance will join groups, pass `--reply-filter filtered` at connect time, or tighten later with:


### PR DESCRIPTION
## Summary

Triaged every unresolved `gemini-code-assist` inline comment across the PRs merged into `dev` since the last release (PRs #420, #421, #422, #423, #424, #425, #427, #429, #430, #431, #432, #441, #442, #446) and applied the ones that flagged real issues on current code.

## Fixes applied (3)

| PR | File | Fix | Severity |
|----|------|-----|----------|
| #432 | `packages/cli/src/commands/events.ts` | On dedupe flush, rebuild `seen` from the most recent batch rather than `clear()`-ing. Prevents duplicate emissions when the inclusive `since: state.sinceIso` query returns the same trailing events. | high |
| #423 | `packages/api/src/services/chats.ts` | `ChatWithParticipants` now extends `ChatWithIsGroup<Chat>` so the interface reflects the `isGroup` flag that `getById` (and therefore `getWithParticipants`) attaches at runtime. | medium |
| #441 | `plugins/omni/skills/omni-setup/SKILL.md` | Clarify that `--reply-filter filtered` enables DM/mention/reply by default — `name-match` is off (`onNameMatch: false` in the API schema). | medium |

## Triage disposition

**ALREADY-FIXED by later commits**
- PR #420 × 4 — `chats.md` cheatsheet already uses `platformTimestamp`, `userId/name`, `chatType` on current file.
- PR #427 — `omni agents update` already exposes `--provider-agent-id`, `--config-path`, `--metadata`.
- PR #429 (high, `flushStdout`) — the `process.stdout.write('', cb)` best-effort drain is still present (output.ts:297–299); the only path that skipped it was the pre-merge snapshot gemini saw.
- PR #429 (medium, Windows test path) — outdated, test file restructured.
- PR #446 × 2 — commit `aafbe0ab` already tightened the durable regex to `/[^a-zA-Z0-9_-]/g` and dropped `ephemeralInactiveThresholdMs` to 1 hour, exactly as suggested.

**WONTFIX (documented)**
- PR #421 × 2 — suggested parallelizing `readExistingRow` with `resolveConfig` and merging `touchInboundTimestamp`+`disarm`. The current ordering is a deliberate part of the terminal-disarm guard added in #419; combining/reordering the ops would erase the safety semantics. Not a release blocker (perf nit, single extra round-trip).
- PR #422 × 2 — switch inline `z.enum(['disabled','fixed','randomized'])` to the shared `SplitDelayModeSchema` and add a `.refine()` for `max >= min`. Refactor-for-consistency + defensive validation; neither is a bug and the refactor interacts with the "strip default on PATCH" override pattern. Out of scope for a release sweep.
- PR #423 × 3 (remaining) — expanding `GROUP_CHAT_TYPES` to include `channel/thread/forum/voice/announcement/stage` would change public API semantics beyond what #403 intended (the tests explicitly codify `channel → false`). `isChatGroup` simplification is stylistic. Test update depends on the rejected expansion.
- PR #424 — `nullFilterWarnedInstances` module-level set. Bounded by instance count; worst case is a missed warn-once log after dispatcher restart-within-process. Not a real leak.
- PR #432 (medium) — immediate re-poll on a full 100-item batch. Throughput optimization, not a correctness issue. Deferred.
- PR #442 — `runOrStream` refactor to capture provider `runId`/metrics from stream events. Genuine improvement but requires changes to the streaming interface; out of scope for a release sweep.

## Validation

- `bun install` — clean
- `bun run typecheck` — **20/20 packages pass**
- `bun test` — **3150 pass / 264 skip / 0 fail** (3414 tests, 225 files)
- `bunx biome check` — no new warnings introduced by these edits

## Test plan

- [ ] CI green on this PR
- [ ] Reviewer confirms WONTFIX rationales before merging into `dev`
- [ ] After merge into `dev`, fast-forward `homolog` and proceed with the release via PR #444