### PR TITLE
Configure WhatsApp outbound timing env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,24 @@ API_MANAGED=true
 # -----------------------------------------------------------------------------
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
+
+# -----------------------------------------------------------------------------
+# WhatsApp outbound timing
+# -----------------------------------------------------------------------------
+# Humanized delay before outgoing WhatsApp actions. Set ENABLED=false to disable.
+# WHATSAPP_HUMAN_DELAY_ENABLED=true
+# WHATSAPP_HUMAN_DELAY_MIN_MS=1500
+# WHATSAPP_HUMAN_DELAY_MAX_MS=3500
+
+# Typing simulation before text/caption sends. Set ENABLED=false to disable.
+# Delay is min(BASE_MS + text.length * PER_CHAR_MS, MAX_MS).
+# WHATSAPP_TYPING_SIMULATION_ENABLED=true
+# WHATSAPP_TYPING_DELAY_BASE_MS=800
+# WHATSAPP_TYPING_DELAY_PER_CHAR_MS=30
+# WHATSAPP_TYPING_DELAY_MAX_MS=4000
+# WHATSAPP_TYPING_DEFAULT_MS=3000
+
+# Exponential backoff used after WhatsApp/Baileys rate-limit errors.
+# WHATSAPP_RATE_LIMIT_INITIAL_BACKOFF_MS=1000
+# WHATSAPP_RATE_LIMIT_MAX_BACKOFF_MS=30000
+# WHATSAPP_RATE_LIMIT_JITTER_FACTOR=0.2

--- a/docs/channel-parity/telegram-whatsapp.md
+++ b/docs/channel-parity/telegram-whatsapp.md
@@ -62,7 +62,7 @@ each plugin's `capabilities.ts` and the real implementation status from the audi
 | Typing indicator (inbound) | ❌ library-blocked | 📥 handler exists, not emitted | **blocked** (TG) | TG Bot API does not expose typing events to bots. WA fires `presence.update` but handler is a TODO stub. |
 | Markdown → native format | ✅ `markdownToTelegramHtml()` (HTML) | ✅ `markdownToWhatsApp()` | **match** | Both respect `messageFormatMode: 'convert' | 'passthrough'`. |
 | Smart message splitting | ✅ `splitHtmlMessage()` | ✅ `splitWhatsAppMessage()` | **match** | Both split at `maxMessageLength`, respecting code blocks. |
-| Human delay / anti-bot | ❌ not needed | ✅ `humanDelay()` 1.5–3.5 s | **out-of-scope** | Telegram bots are expected to be bots; no delay needed. |
+| Human delay / anti-bot | ❌ not needed | ✅ `humanDelay()` default 1.5–3.5 s | **out-of-scope** | Telegram bots are expected to be bots; WA timing is configurable via `WHATSAPP_HUMAN_DELAY_*` env vars. |
 
 ---
 
@@ -196,7 +196,7 @@ These are **permanent platform constraints** — Telegram's Bot API does not exp
 | No slash commands | WhatsApp has no command registration mechanism |
 | Broadcast list support is partial | Baileys exposes broadcast JIDs but sending is unreliable; newsletters are a separate API |
 | Custom emoji reactions not supported | WhatsApp restricts reactions to standard Unicode emoji |
-| Rate limits ≈ human hand speed | Baileys mimics the WhatsApp Web client; sending too fast triggers rate limits and temporary bans. Use `humanDelay()` (1.5–3.5 s) and `simulateTyping()` (text-length-scaled) to stay safe. This is **not** API throughput — it's anti-automation detection. |
+| Rate limits ≈ human hand speed | Baileys mimics the WhatsApp Web client; sending too fast triggers rate limits and temporary bans. Use `humanDelay()` (default 1.5–3.5 s) and `simulateTyping()` (text-length-scaled) to stay safe. Both are configurable via `WHATSAPP_*` env vars. This is **not** API throughput — it's anti-automation detection. |
 | Session stability | Baileys uses a reverse-engineered protocol; connection can drop. Exponential backoff + `seedAuthenticated()` required. |
 
 ---
@@ -206,7 +206,7 @@ These are **permanent platform constraints** — Telegram's Bot API does not exp
 | Channel | Model | Details |
 |---------|-------|---------|
 | **Telegram** | API throughput | Bot API allows ~30 msg/s globally, ~1 msg/s per chat in groups. grammy handles 429 retries automatically. |
-| **WhatsApp** | Human hand speed | Baileys ≈ web client; rate is limited by anti-bot detection, not an API quota. `humanDelay()` randomizes 1.5–3.5 s between actions. `simulateTyping()` scales delay to message length. Sending too fast → temp ban (24 h in severe cases). |
+| **WhatsApp** | Human hand speed | Baileys ≈ web client; rate is limited by anti-bot detection, not an API quota. `humanDelay()` defaults to 1.5–3.5 s between actions. `simulateTyping()` scales delay to message length. Outbound timing and rate-limit backoff are configurable via `WHATSAPP_*` env vars. Sending too fast → temp ban (24 h in severe cases). |
 
 ---
 

--- a/packages/channel-whatsapp/src/__tests__/env.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/env.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_WHATSAPP_OUTBOUND_TIMING,
+  DEFAULT_WHATSAPP_RATE_LIMIT,
+  getWhatsAppOutboundTimingConfig,
+  getWhatsAppRateLimitConfig,
+} from '../env';
+
+describe('WhatsApp env config', () => {
+  test('uses production-safe outbound timing defaults', () => {
+    expect(getWhatsAppOutboundTimingConfig({})).toEqual(DEFAULT_WHATSAPP_OUTBOUND_TIMING);
+  });
+
+  test('parses outbound timing overrides and disable flags', () => {
+    const config = getWhatsAppOutboundTimingConfig({
+      WHATSAPP_HUMAN_DELAY_ENABLED: 'false',
+      WHATSAPP_HUMAN_DELAY_MIN_MS: '0',
+      WHATSAPP_HUMAN_DELAY_MAX_MS: '0',
+      WHATSAPP_TYPING_SIMULATION_ENABLED: 'off',
+      WHATSAPP_TYPING_DELAY_BASE_MS: '100',
+      WHATSAPP_TYPING_DELAY_PER_CHAR_MS: '2',
+      WHATSAPP_TYPING_DELAY_MAX_MS: '500',
+      WHATSAPP_TYPING_DEFAULT_MS: '750',
+    });
+
+    expect(config).toEqual({
+      humanDelayEnabled: false,
+      humanDelayMinMs: 0,
+      humanDelayMaxMs: 0,
+      typingSimulationEnabled: false,
+      typingDelayBaseMs: 100,
+      typingDelayPerCharMs: 2,
+      typingDelayMaxMs: 500,
+      typingDefaultMs: 750,
+    });
+  });
+
+  test('normalizes invalid values and inverted ranges', () => {
+    const config = getWhatsAppOutboundTimingConfig({
+      WHATSAPP_HUMAN_DELAY_ENABLED: 'maybe',
+      WHATSAPP_HUMAN_DELAY_MIN_MS: '3000',
+      WHATSAPP_HUMAN_DELAY_MAX_MS: '1000',
+      WHATSAPP_TYPING_DELAY_BASE_MS: '-1',
+      WHATSAPP_TYPING_DELAY_PER_CHAR_MS: 'nope',
+    });
+
+    expect(config.humanDelayEnabled).toBe(true);
+    expect(config.humanDelayMinMs).toBe(3000);
+    expect(config.humanDelayMaxMs).toBe(3000);
+    expect(config.typingDelayBaseMs).toBe(DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingDelayBaseMs);
+    expect(config.typingDelayPerCharMs).toBe(DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingDelayPerCharMs);
+  });
+
+  test('uses rate-limit defaults', () => {
+    expect(getWhatsAppRateLimitConfig({})).toEqual(DEFAULT_WHATSAPP_RATE_LIMIT);
+  });
+
+  test('parses rate-limit overrides and normalizes max backoff', () => {
+    expect(
+      getWhatsAppRateLimitConfig({
+        WHATSAPP_RATE_LIMIT_INITIAL_BACKOFF_MS: '5000',
+        WHATSAPP_RATE_LIMIT_MAX_BACKOFF_MS: '1000',
+        WHATSAPP_RATE_LIMIT_JITTER_FACTOR: '0',
+      }),
+    ).toEqual({
+      initialBackoffMs: 5000,
+      maxBackoffMs: 5000,
+      jitterFactor: 0,
+    });
+  });
+});

--- a/packages/channel-whatsapp/src/env.ts
+++ b/packages/channel-whatsapp/src/env.ts
@@ -1,0 +1,133 @@
+type EnvMap = Record<string, string | undefined>;
+
+export interface WhatsAppOutboundTimingConfig {
+  humanDelayEnabled: boolean;
+  humanDelayMinMs: number;
+  humanDelayMaxMs: number;
+  typingSimulationEnabled: boolean;
+  typingDelayBaseMs: number;
+  typingDelayPerCharMs: number;
+  typingDelayMaxMs: number;
+  typingDefaultMs: number;
+}
+
+export interface WhatsAppRateLimitEnvConfig {
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  jitterFactor: number;
+}
+
+export const DEFAULT_WHATSAPP_OUTBOUND_TIMING: WhatsAppOutboundTimingConfig = {
+  humanDelayEnabled: true,
+  humanDelayMinMs: 1500,
+  humanDelayMaxMs: 3500,
+  typingSimulationEnabled: true,
+  typingDelayBaseMs: 800,
+  typingDelayPerCharMs: 30,
+  typingDelayMaxMs: 4000,
+  typingDefaultMs: 3000,
+};
+
+export const DEFAULT_WHATSAPP_RATE_LIMIT: WhatsAppRateLimitEnvConfig = {
+  initialBackoffMs: 1000,
+  maxBackoffMs: 30_000,
+  jitterFactor: 0.2,
+};
+
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off', 'disabled']);
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on', 'enabled']);
+
+function readBooleanEnv(env: EnvMap, name: string, fallback: boolean): boolean {
+  const raw = env[name]?.trim().toLowerCase();
+  if (!raw) return fallback;
+  if (FALSE_VALUES.has(raw)) return false;
+  if (TRUE_VALUES.has(raw)) return true;
+  return fallback;
+}
+
+function readNonNegativeIntEnv(env: EnvMap, name: string, fallback: number): number {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function readNonNegativeNumberEnv(env: EnvMap, name: string, fallback: number): number {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function getWhatsAppOutboundTimingConfig(env: EnvMap = process.env): WhatsAppOutboundTimingConfig {
+  const humanDelayMinMs = readNonNegativeIntEnv(
+    env,
+    'WHATSAPP_HUMAN_DELAY_MIN_MS',
+    DEFAULT_WHATSAPP_OUTBOUND_TIMING.humanDelayMinMs,
+  );
+  const rawHumanDelayMaxMs = readNonNegativeIntEnv(
+    env,
+    'WHATSAPP_HUMAN_DELAY_MAX_MS',
+    DEFAULT_WHATSAPP_OUTBOUND_TIMING.humanDelayMaxMs,
+  );
+
+  return {
+    humanDelayEnabled: readBooleanEnv(
+      env,
+      'WHATSAPP_HUMAN_DELAY_ENABLED',
+      DEFAULT_WHATSAPP_OUTBOUND_TIMING.humanDelayEnabled,
+    ),
+    humanDelayMinMs,
+    humanDelayMaxMs: Math.max(humanDelayMinMs, rawHumanDelayMaxMs),
+    typingSimulationEnabled: readBooleanEnv(
+      env,
+      'WHATSAPP_TYPING_SIMULATION_ENABLED',
+      DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingSimulationEnabled,
+    ),
+    typingDelayBaseMs: readNonNegativeIntEnv(
+      env,
+      'WHATSAPP_TYPING_DELAY_BASE_MS',
+      DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingDelayBaseMs,
+    ),
+    typingDelayPerCharMs: readNonNegativeIntEnv(
+      env,
+      'WHATSAPP_TYPING_DELAY_PER_CHAR_MS',
+      DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingDelayPerCharMs,
+    ),
+    typingDelayMaxMs: readNonNegativeIntEnv(
+      env,
+      'WHATSAPP_TYPING_DELAY_MAX_MS',
+      DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingDelayMaxMs,
+    ),
+    typingDefaultMs: readNonNegativeIntEnv(
+      env,
+      'WHATSAPP_TYPING_DEFAULT_MS',
+      DEFAULT_WHATSAPP_OUTBOUND_TIMING.typingDefaultMs,
+    ),
+  };
+}
+
+export function getWhatsAppRateLimitConfig(env: EnvMap = process.env): WhatsAppRateLimitEnvConfig {
+  const initialBackoffMs = readNonNegativeIntEnv(
+    env,
+    'WHATSAPP_RATE_LIMIT_INITIAL_BACKOFF_MS',
+    DEFAULT_WHATSAPP_RATE_LIMIT.initialBackoffMs,
+  );
+  const rawMaxBackoffMs = readNonNegativeIntEnv(
+    env,
+    'WHATSAPP_RATE_LIMIT_MAX_BACKOFF_MS',
+    DEFAULT_WHATSAPP_RATE_LIMIT.maxBackoffMs,
+  );
+
+  return {
+    initialBackoffMs,
+    maxBackoffMs: Math.max(initialBackoffMs, rawMaxBackoffMs),
+    jitterFactor: readNonNegativeNumberEnv(
+      env,
+      'WHATSAPP_RATE_LIMIT_JITTER_FACTOR',
+      DEFAULT_WHATSAPP_RATE_LIMIT.jitterFactor,
+    ),
+  };
+}

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -23,6 +23,7 @@ import type { GroupMetadata, WAMessage, WASocket, proto } from 'baileys';
 
 import { clearAuthState, createStorageAuthState } from './auth';
 import { WHATSAPP_CAPABILITIES } from './capabilities';
+import { getWhatsAppOutboundTimingConfig, getWhatsAppRateLimitConfig } from './env';
 import { setupAllEventHandlers } from './handlers/all-events';
 import {
   cancelPendingReconnect,
@@ -269,7 +270,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   private getRateLimitManager(instanceId: string): RateLimitManager {
     let manager = this.rateLimitManagers.get(instanceId);
     if (!manager) {
-      manager = createRateLimitManager(instanceId, this.logger);
+      manager = createRateLimitManager(instanceId, this.logger, getWhatsAppRateLimitConfig());
       this.rateLimitManagers.set(instanceId, manager);
     }
     return manager;
@@ -283,10 +284,13 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    * enough time has passed since the previous action.
    */
   private async humanDelay(instanceId: string): Promise<void> {
+    const timing = getWhatsAppOutboundTimingConfig();
+    if (!timing.humanDelayEnabled) return;
+
     const now = Date.now();
     const last = this.lastActionTime.get(instanceId) || 0;
-    const minDelay = 1500;
-    const maxDelay = 3500;
+    const minDelay = timing.humanDelayMinMs;
+    const maxDelay = timing.humanDelayMaxMs;
     const randomDelay = minDelay + Math.random() * (maxDelay - minDelay);
     const elapsed = now - last;
 
@@ -302,9 +306,17 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    * Duration scales with text length to look natural.
    */
   private async simulateTyping(instanceId: string, jid: string, text: string): Promise<void> {
+    const timing = getWhatsAppOutboundTimingConfig();
+    if (!timing.typingSimulationEnabled) return;
+
     try {
       const sock = this.getSocket(instanceId);
-      const typingMs = Math.min(800 + text.length * 30, 4000);
+      const typingMs = Math.min(
+        timing.typingDelayBaseMs + text.length * timing.typingDelayPerCharMs,
+        timing.typingDelayMaxMs,
+      );
+      if (typingMs <= 0) return;
+
       await sock.sendPresenceUpdate('composing', jid);
       await new Promise<void>((r) => setTimeout(r, typingMs));
       await sock.sendPresenceUpdate('paused', jid);
@@ -1515,7 +1527,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   /**
    * Send typing indicator
    */
-  async sendTyping(instanceId: string, chatId: string, duration = 3000): Promise<void> {
+  async sendTyping(instanceId: string, chatId: string, duration?: number): Promise<void> {
+    const resolvedDuration = duration ?? getWhatsAppOutboundTimingConfig().typingDefaultMs;
     const sock = this.getSocket(instanceId);
     const jid = toJid(chatId);
 
@@ -1529,7 +1542,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       } catch {
         // Ignore errors when pausing typing
       }
-    }, duration);
+    }, resolvedDuration);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add typed WhatsApp env parsing for outbound timing and rate-limit knobs.
- Wire human delay, typing simulation, sendTyping default duration, and rate-limit fallback to env config.
- Document defaults in `.env.example` and channel parity docs.

## Validation
- `bun test packages/channel-whatsapp/src/__tests__/env.test.ts packages/channel-whatsapp/src/__tests__/rate-limit.test.ts`
- `bun run --cwd packages/channel-whatsapp typecheck`
- `bunx biome check packages/channel-whatsapp/src/env.ts packages/channel-whatsapp/src/plugin.ts packages/channel-whatsapp/src/__tests__/env.test.ts docs/channel-parity/telegram-whatsapp.md .env.example`
- pre-push: `bun run typecheck`
- pre-push: `bun test`