### PR TITLE
fix(cli): kill PM2 god daemon in test teardown (#413)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -34,7 +34,7 @@ function killTestPm2Daemon(): void {
   if (!existsSync(TEST_PM2_HOME)) return;
   spawnSync({
     cmd: ['pm2', 'kill'],
-    env: { ...process.env, PM2_HOME: TEST_PM2_HOME },
+    env: { ...process.env, HOME: TEST_CONFIG_DIR, PM2_HOME: TEST_PM2_HOME },
     stdout: 'ignore',
     stderr: 'ignore',
   });

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -11,7 +11,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { spawn } from 'bun';
+import { spawn, spawnSync } from 'bun';
 import { MOCK_API_KEY, startMockApi, stopMockApi } from './mock-api';
 
 // Use source entry point directly — avoids stale dist/index.js issues
@@ -19,6 +19,26 @@ const CLI_PATH = join(import.meta.dir, '../index.ts');
 
 // Temp config dir for tests
 const TEST_CONFIG_DIR = join(tmpdir(), `.omni-test-${Date.now()}`);
+// Explicit PM2_HOME under the test config dir. Without this, pm2 derives its
+// home from `HOME/.pm2`, and any CLI command that talks to pm2 (e.g. `omni
+// status` → `pm2 jlist`) will fork a god daemon there. The teardown then
+// rm-rf's TEST_CONFIG_DIR but the daemon survives, leaving an orphan attached
+// to a deleted PM2_HOME (issue #413).
+const TEST_PM2_HOME = join(TEST_CONFIG_DIR, '.pm2');
+
+/**
+ * Stop the test-mode PM2 god daemon (if any) before its home gets removed.
+ * Synchronous so it can run from non-async afterAll hooks.
+ */
+function killTestPm2Daemon(): void {
+  if (!existsSync(TEST_PM2_HOME)) return;
+  spawnSync({
+    cmd: ['pm2', 'kill'],
+    env: { ...process.env, PM2_HOME: TEST_PM2_HOME },
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+}
 
 /** Mock API URL — set in beforeAll */
 let MOCK_URL = '';
@@ -38,6 +58,7 @@ async function runCli(args: string[], env: Record<string, string> = {}): Promise
     env: {
       ...process.env,
       HOME: TEST_CONFIG_DIR, // Use test config dir
+      PM2_HOME: TEST_PM2_HOME, // Isolate pm2 daemon from the host (issue #413)
       ...env,
     },
     stdout: 'pipe',
@@ -89,6 +110,9 @@ describe('CLI Basic Tests', () => {
   });
 
   afterAll(() => {
+    // Stop the test-mode pm2 god daemon BEFORE removing its home, otherwise
+    // the daemon survives and re-parents to init with a deleted PM2_HOME.
+    killTestPm2Daemon();
     // Cleanup test config directory
     if (existsSync(TEST_CONFIG_DIR)) {
       rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
@@ -293,6 +317,8 @@ describe('CLI Integration Tests', () => {
 
   afterAll(() => {
     stopMockApi();
+    // Stop the test-mode pm2 god daemon BEFORE removing its home (issue #413).
+    killTestPm2Daemon();
     if (existsSync(TEST_CONFIG_DIR)) {
       rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
     }
@@ -486,7 +512,7 @@ describe('CLI Integration Tests', () => {
       // keeps the loop tight so the test completes quickly.
       const proc = spawn({
         cmd: ['bun', CLI_PATH, 'events', 'stream', '--since', '1h', '--poll-ms', '200', '--ndjson'],
-        env: { ...process.env, HOME: TEST_CONFIG_DIR },
+        env: { ...process.env, HOME: TEST_CONFIG_DIR, PM2_HOME: TEST_PM2_HOME },
         stdout: 'pipe',
         stderr: 'pipe',
       });


### PR DESCRIPTION
## Summary
- CLI integration tests (`packages/cli/src/__tests__/cli.test.ts`) set `HOME` to a per-run temp dir, but never set `PM2_HOME`. Any CLI command that talked to pm2 (e.g. `omni status` → `pm2 jlist`) forked a god daemon under `\$HOME/.pm2`. The `afterAll` then `rmSync`'d the temp dir without stopping the daemon, leaving an orphan reparented to init with a deleted `PM2_HOME`.
- Set `PM2_HOME` explicitly to `TEST_CONFIG_DIR/.pm2` in the `runCli` env so the daemon path is deterministic and cleanable.
- Add `killTestPm2Daemon()` helper using `spawnSync(['pm2', 'kill'], …)`, called from both `afterAll` blocks **before** the `rmSync`.
- Propagate `PM2_HOME` to the inline `events stream` spawn for consistency, and set `HOME` alongside `PM2_HOME` in the pm2-kill env for defense-in-depth.

Closes #413

## Test plan
- [x] `bun test packages/cli/src/__tests__/cli.test.ts` — 66/66 pass, 27s
- [x] `pgrep` shows no orphan `PM2 God` daemons after the run
- [x] `/tmp/.omni-test-*` dirs are fully cleaned
- [x] Full pre-push suite — 3150 pass / 0 fail / 264 skipped across 225 files