### PR TITLE
fix(api): auto-set reply filter when agent assigned to instance

### DIFF
--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -531,6 +531,14 @@ instancesRoutes.post('/', zValidator('json', createInstanceSchema), async (c) =>
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
+  if (data.agentId && data.agentReplyFilter === undefined) {
+    data.agentReplyFilter = {
+      mode: 'all',
+      conditions: { onDm: true, onMention: true, onReply: true, onNameMatch: false },
+    };
+    log.info('Auto-set agentReplyFilter for new instance', { agentId: data.agentId });
+  }
+
   // Map generic `token` → channel-specific DB column + resolve connect token
   const connectToken = resolveChannelToken(data);
 
@@ -572,15 +580,26 @@ instancesRoutes.patch('/:id', instanceAccess, zValidator('json', updateInstanceS
   const data = c.req.valid('json');
   const services = c.get('services');
 
-  // Detect agent assignment changes for auto-key provisioning
+  // Detect agent assignment changes for auto-key provisioning and auto-reply-filter
   let oldAgentId: string | null | undefined;
-  if (data.agentId !== undefined) {
+  let current: Awaited<ReturnType<typeof services.instances.getById>> | undefined;
+  if (data.agentId !== undefined || data.agentReplyFilter === undefined) {
     try {
-      const current = await services.instances.getById(id);
+      current = await services.instances.getById(id);
       oldAgentId = current.agentId;
     } catch {
       // Instance not found — update will throw
     }
+  }
+
+  // Auto-set agentReplyFilter when agent is assigned (new or existing) and no filter configured
+  const finalAgentId = data.agentId !== undefined ? data.agentId : (current?.agentId ?? null);
+  if (finalAgentId && data.agentReplyFilter === undefined && !current?.agentReplyFilter) {
+    data.agentReplyFilter = {
+      mode: 'all',
+      conditions: { onDm: true, onMention: true, onReply: true, onNameMatch: false },
+    };
+    log.info('Auto-set agentReplyFilter on agent assignment', { instanceId: id, agentId: finalAgentId });
   }
 
   const instance = await services.instances.update(id, data);


### PR DESCRIPTION
## Summary

- POST /instances: when `agentId` is set and `agentReplyFilter` is `undefined`, auto-assign the default filter `{ mode: 'all', conditions: { onDm: true, onMention: true, onReply: true, onNameMatch: false } }`.
- PATCH /instances/:id: reuse the existing `current` fetch, compute `finalAgentId` from payload or persisted record, and apply the same default only when neither payload nor persisted record already has a filter.
- Explicit `null` from the caller is preserved (opt-out stays respected).

Closes #443

## Why

Assigning an agent without a reply filter silently dropped all inbound messages — a `null` filter was interpreted downstream as "reply to nothing." This caused ~30 minutes of invisible failures during Telegram setup.

## Test plan

- [x] `bun run typecheck` in `packages/api` — passes
- [x] `bun test` in `packages/api` — 625 pass / 0 fail
- [x] Pre-push full workspace suite — 3150 pass / 0 fail
- [ ] Manual: create instance with `--agent-fk-id <uuid>` → verify `agentReplyFilter` is auto-populated with default object and messages dispatch
- [ ] Manual: patch instance to add agent (no filter payload) → verify default filter is stored
- [ ] Manual: patch instance with `agentReplyFilter: null` → verify explicit null is preserved