### PR TITLE
fix(channel-telegram): detect and recover from 409 Conflict polling death

### DIFF
--- a/packages/channel-telegram/src/__tests__/caption-overflow.test.ts
+++ b/packages/channel-telegram/src/__tests__/caption-overflow.test.ts
@@ -9,7 +9,7 @@ function createMockBot() {
     catch: mock(() => {}),
     init: mock(() => Promise.resolve()),
     stop: mock(() => {}),
-    start: mock(() => {}),
+    start: mock(() => Promise.resolve()),
     api: {
       answerCallbackQuery: mock(() => Promise.resolve({})),
       sendChatAction: mock(() => Promise.resolve({})),

--- a/packages/channel-telegram/src/__tests__/download-retry.test.ts
+++ b/packages/channel-telegram/src/__tests__/download-retry.test.ts
@@ -9,7 +9,7 @@ function createMockBot(getFileMock?: ReturnType<typeof mock>) {
     catch: mock(() => {}),
     init: mock(() => Promise.resolve()),
     stop: mock(() => {}),
-    start: mock(() => {}),
+    start: mock(() => Promise.resolve()),
     api: {
       answerCallbackQuery: mock(() => Promise.resolve({})),
       sendChatAction: mock(() => Promise.resolve({})),

--- a/packages/channel-telegram/src/__tests__/reaction-levels.test.ts
+++ b/packages/channel-telegram/src/__tests__/reaction-levels.test.ts
@@ -15,7 +15,7 @@ function createMockBot() {
     catch: mock(() => {}),
     init: mock(() => Promise.resolve()),
     stop: mock(() => {}),
-    start: mock(() => {}),
+    start: mock(() => Promise.resolve()),
     api: {
       answerCallbackQuery: mock(() => Promise.resolve({})),
       sendChatAction: mock(() => Promise.resolve({})),

--- a/packages/channel-telegram/src/grammy-shim.ts
+++ b/packages/channel-telegram/src/grammy-shim.ts
@@ -85,7 +85,8 @@ export interface TelegramBotLike {
   catch: (handler: (err: unknown) => unknown | Promise<unknown>) => void;
   init: () => Promise<void>;
   stop: () => void;
-  start: (options: Record<string, unknown>) => void;
+  start: (options: Record<string, unknown>) => Promise<void>;
+  isRunning?: () => boolean;
 
   token: string;
 

--- a/packages/channel-telegram/src/plugin.ts
+++ b/packages/channel-telegram/src/plugin.ts
@@ -12,6 +12,7 @@
 import { BaseChannelPlugin, createInboundDedupeCache } from '@omni/channel-sdk';
 import type {
   ChannelCapabilities,
+  ConnectionStatus,
   DedupeCache,
   FetchHistoryOptions,
   FetchHistoryResult,
@@ -365,7 +366,7 @@ export class TelegramPlugin extends BaseChannelPlugin {
     if (telegramConfig.mode === 'webhook') {
       await this.startWebhook(bot, instanceId, telegramConfig);
     } else {
-      await this.startPolling(bot, instanceId);
+      await this.startPolling(bot, instanceId, config);
     }
 
     // Update instance state
@@ -411,6 +412,28 @@ export class TelegramPlugin extends BaseChannelPlugin {
     });
 
     await this.emitInstanceDisconnected(instanceId, 'Manual disconnect');
+  }
+
+  /**
+   * Report 'error' when the tracked status says 'connected' but the underlying
+   * grammy bot is no longer polling (e.g. a 409 Conflict killed the poller
+   * without rejecting bot.start()'s promise in time for state to update).
+   * InstanceMonitor relies on this to schedule a reconnect.
+   */
+  override async getStatus(instanceId: string): Promise<ConnectionStatus> {
+    const status = await super.getStatus(instanceId);
+    if (status.state !== 'connected') return status;
+
+    const bot = getBot(instanceId);
+    const pollingAlive = bot?.isRunning ? bot.isRunning() : Boolean(bot);
+    if (!pollingAlive) {
+      return {
+        state: 'error',
+        since: new Date(),
+        message: 'Polling stopped',
+      };
+    }
+    return status;
   }
 
   // ────────────────────────────────────────────────────────────
@@ -876,32 +899,40 @@ export class TelegramPlugin extends BaseChannelPlugin {
   // Private helpers
   // ────────────────────────────────────────────────────────────
 
-  private async startPolling(bot: TelegramBotLike, instanceId: string): Promise<void> {
+  private async startPolling(bot: TelegramBotLike, instanceId: string, config: InstanceConfig): Promise<void> {
     this.logger.info('Starting polling mode', { instanceId });
 
-    // Start polling in background (non-blocking)
-    bot.start({
-      drop_pending_updates: true,
-      allowed_updates: [
-        'message',
-        'edited_message',
-        'channel_post',
-        'edited_channel_post',
-        'message_reaction',
-        'callback_query',
-        'poll',
-        'poll_answer',
-        'my_chat_member',
-      ],
-      onStart: () => {
-        this.logger.info('Polling started', { instanceId });
-      },
-    });
-
-    // grammy emits 'error' on polling failures — the bot.catch() handler will
-    // catch these, and grammy will automatically retry polling with backoff.
-    // If polling stops entirely (e.g. bot revoked), the health check will
-    // surface the failure via getHealthChecks().
+    // Start polling in background (non-blocking). Attach a .catch() so fatal
+    // errors (e.g. 409 Conflict when another poller is active) surface through
+    // getStatus() and let InstanceMonitor schedule a reconnect.
+    bot
+      .start({
+        drop_pending_updates: true,
+        allowed_updates: [
+          'message',
+          'edited_message',
+          'channel_post',
+          'edited_channel_post',
+          'message_reaction',
+          'callback_query',
+          'poll',
+          'poll_answer',
+          'my_chat_member',
+        ],
+        onStart: () => {
+          this.logger.info('Polling started', { instanceId });
+        },
+      })
+      .catch(async (err) => {
+        const message = `Polling stopped: ${err instanceof Error ? err.message : String(err)}`;
+        this.logger.error('Polling terminated', { instanceId, error: message });
+        await this.updateInstanceStatus(instanceId, config, {
+          state: 'error',
+          since: new Date(),
+          message,
+        });
+        await this.emitInstanceDisconnected(instanceId, message);
+      });
   }
 
   private async startWebhook(_bot: TelegramBotLike, instanceId: string, _config: TelegramConfig): Promise<void> {


### PR DESCRIPTION
## Summary
Closes #395.

- `InstanceMonitor` never reconnected Telegram bots that hit a 409 Conflict (or other fatal grammy poller error) because `bot.start()`'s rejection was unhandled, the instance status stayed `connected`, and the monitor's health check therefore never flagged the instance.
- Now `startPolling` attaches `.catch()` to `bot.start()` → marks the instance `error` and emits `instance.disconnected`, which the monitor uses to schedule a reconnect with exponential backoff.
- `TelegramPlugin.getStatus()` is overridden so a tracked `connected` state but a dead underlying bot reports `error` with `"Polling stopped"` — covers the race where the poller dies before `.catch()` updates state.
- Removed the misleading comment that claimed grammy auto-retries polling.

## Test plan
- [x] `bun run typecheck` (all 20 workspace tasks)
- [x] `bun test` in `packages/channel-telegram` (158 pass / 0 fail)
- [x] Full `bun test` on push (3150 pass / 0 fail)