### PR TITLE
fix(cli): persist --target-agent and --team-name in nats-genie schemaConfig

### DIFF
--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -61,7 +61,7 @@ async function handleCreateProvider(req: Request): Promise<Response> {
   const provider = makeProvider(
     id,
     body.name ?? 'unnamed',
-    body.schema ?? 'genie',
+    body.schema ?? 'nats-genie',
     body.baseUrl ?? '',
     body.schemaConfig,
     body.apiKey,

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -61,8 +61,8 @@ function validateCreateOptions(options: {
   if (options.schema === 'claude-code' && !options.projectPath) {
     return 'Claude Code providers require --project-path.\nExample: omni providers create --name "My Project" --schema claude-code --base-url http://localhost:8882 --project-path /home/user/myproject';
   }
-  if (options.schema === 'genie' && (!options.agentName || !options.targetAgent)) {
-    return 'Genie providers require --agent-name and --target-agent.\nExample: omni providers create --name "My Genie" --schema genie --base-url "file:///home/user/.claude/teams" --agent-name omni --target-agent team-lead --team-name "workspace-{chat_id}"';
+  if (options.schema === 'nats-genie' && (!options.agentName || !options.targetAgent)) {
+    return 'Genie providers require --agent-name and --target-agent.\nExample: omni providers create --name "My Genie" --schema nats-genie --base-url "file:///home/user/.claude/teams" --agent-name omni --target-agent team-lead --team-name "workspace-{chat_id}"';
   }
   return null;
 }
@@ -98,6 +98,8 @@ function buildClaudeCodeConfig(options: SchemaConfigOptions): Record<string, unk
 function buildNatsGenieConfig(options: SchemaConfigOptions): Record<string, unknown> {
   const config: Record<string, unknown> = {};
   if (options.agentName) config.agentName = options.agentName;
+  if (options.targetAgent) config.targetAgent = options.targetAgent;
+  if (options.teamName) config.teamName = options.teamName;
   return config;
 }
 

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -51,6 +51,10 @@ export interface OpenClawConfig {
 export interface NatsGenieConfig {
   /** Genie agent name (from genie directory) */
   agentName: string;
+  /** Target agent inbox to deliver to (e.g. 'team-lead') */
+  targetAgent?: string;
+  /** Team name template, supports {chat_id}, {thread_id}, {sender_id} */
+  teamName?: string;
   /** Agent directory path */
   agentDir?: string;
   /** NATS server URL (default: localhost:4222) */

--- a/plugins/omni/skills/omni-ops/SKILL.md
+++ b/plugins/omni/skills/omni-ops/SKILL.md
@@ -136,7 +136,7 @@ omni routes list --instance <id> --active --json | jq '.[] | {id, label, scope, 
 
 ## Providers
 
-Manage AI/agent providers that define how Omni connects to backend services. Supported schemas: `genie`, `claude-code`, `a2a`, `ag-ui`, `agno`, `openclaw`, `webhook`.
+Manage AI/agent providers that define how Omni connects to backend services. Supported schemas: `nats-genie`, `claude-code`, `a2a`, `ag-ui`, `agno`, `openclaw`, `webhook`.
 
 ### Key commands
 
@@ -147,7 +147,7 @@ omni providers list --active --json
 omni providers get <id> --json
 
 # Create by schema
-omni providers create --name "genie-prod" --schema genie --agent-name "omni-agent" --target-agent "team-lead" --team-name "omni-{chat_id}" --json
+omni providers create --name "genie-prod" --schema nats-genie --agent-name "omni-agent" --target-agent "team-lead" --team-name "omni-{chat_id}" --json
 omni providers create --name "claude-local" --schema claude-code --project-path /home/user/project --max-turns 10 --permission-mode bypassPermissions --json
 omni providers create --name "a2a-svc" --schema a2a --base-url https://a2a.example.com --api-key <key> --json
 omni providers create --name "agui-svc" --schema ag-ui --base-url https://agui.example.com --api-key <key> --stream --json


### PR DESCRIPTION
## Summary

- `buildNatsGenieConfig` was silently dropping `--target-agent` and `--team-name` because it only copied `agentName` into the schemaConfig payload. Both fields are now persisted when present.
- `validateCreateOptions` guarded on `schema === 'genie'`, but the real schema identifier is `nats-genie` (see `PROVIDER_SCHEMAS` in `packages/core/src/types/agent.ts`). The required-field check never fired, so `omni providers create --schema nats-genie` would accept incomplete input and write a schemaConfig missing its routing target.
- `NatsGenieConfig` now exposes optional `targetAgent` and `teamName` so the type matches what the CLI actually writes and what the runtime already uses.

Closes #449.

## Test plan

- [x] `bun turbo typecheck --filter=@automagik/omni --filter=@omni/core` — all 16 typecheck tasks pass
- [x] `bun test` in `packages/cli` — 288 pass, 0 fail
- [x] Pre-push hook full suite — 3150 pass, 264 skip, 0 fail
- [ ] Manual smoke: `omni providers create --schema nats-genie --agent-name omni --target-agent team-lead --team-name "workspace-{chat_id}" ...` and confirm all three fields land in schemaConfig