### PR TITLE
fix(api): invalidate provider cache on schemaConfig change

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3036,6 +3036,45 @@ export function resolveProvider(
 }
 
 /**
+ * Invalidate cached IAgentProvider instances for a specific provider.
+ *
+ * Call after provider schemaConfig / baseUrl / apiKey updates so the next
+ * dispatch rebuilds from fresh DB state instead of returning the stale
+ * cached instance. Also stops and removes the shared OpenClaw WS client
+ * for this provider since connection-level config may have changed.
+ */
+export function invalidateProviderCache(providerId: string): void {
+  const prefix = `${providerId}:`;
+  let removed = 0;
+
+  for (const [key, provider] of providerCache.entries()) {
+    if (!key.startsWith(prefix)) continue;
+    providerCache.delete(key);
+    removed++;
+    if (provider.dispose) {
+      provider.dispose().catch((err) => {
+        log.warn('Error disposing provider on cache invalidation', { key, error: String(err) });
+      });
+    }
+  }
+
+  const openclawClient = openclawClientPool.get(providerId);
+  if (openclawClient) {
+    try {
+      openclawClient.stop();
+    } catch (err) {
+      log.warn('Error stopping OpenClaw client on cache invalidation', {
+        providerId,
+        error: String(err),
+      });
+    }
+    openclawClientPool.delete(providerId);
+  }
+
+  log.debug('Provider cache invalidated', { providerId, removed });
+}
+
+/**
  * Look up provider from DB and resolve to IAgentProvider.
  * Accepts DispatchInstance which carries the transient agentProviderId stamped by applyAgentFkOverrides.
  */

--- a/packages/api/src/routes/v2/providers.ts
+++ b/packages/api/src/routes/v2/providers.ts
@@ -6,6 +6,7 @@ import { zValidator } from '@hono/zod-validator';
 import { ProviderSchemaEnum, createAgnoClient } from '@omni/core';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { invalidateProviderCache } from '../../plugins/agent-dispatcher';
 import type { AppVariables } from '../../types';
 
 const providersRoutes = new Hono<{ Variables: AppVariables }>();
@@ -149,6 +150,8 @@ providersRoutes.patch('/:id', zValidator('json', updateProviderSchema), async (c
 
   const provider = await services.providers.update(id, data);
 
+  invalidateProviderCache(id);
+
   return c.json({
     data: {
       ...provider,
@@ -166,6 +169,8 @@ providersRoutes.delete('/:id', async (c) => {
   const services = c.get('services');
 
   await services.providers.delete(id);
+
+  invalidateProviderCache(id);
 
   return c.json({ success: true });
 });

--- a/packages/api/src/services/providers.ts
+++ b/packages/api/src/services/providers.ts
@@ -6,6 +6,7 @@ import { NotFoundError } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type AgentProvider, type NewAgentProvider, agentProviders } from '@omni/db';
 import { eq } from 'drizzle-orm';
+import { invalidateProviderCache } from '../plugins/agent-dispatcher';
 
 export interface ProviderHealthResult {
   healthy: boolean;
@@ -82,6 +83,8 @@ export class ProviderService {
       throw new NotFoundError('AgentProvider', id);
     }
 
+    invalidateProviderCache(id);
+
     return updated;
   }
 
@@ -94,6 +97,8 @@ export class ProviderService {
     if (!result.length) {
       throw new NotFoundError('AgentProvider', id);
     }
+
+    invalidateProviderCache(id);
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #450.

- Add `invalidateProviderCache(providerId)` in `packages/api/src/plugins/agent-dispatcher.ts`. Removes every `providerCache` entry keyed by that providerId (the cache key is `${providerId}:${instanceId}`), disposes each instance, and stops plus drops the shared OpenClaw WS client from `openclawClientPool`.
- Wire invalidation into `ProviderService.update` / `delete` (`packages/api/src/services/providers.ts`) and the v2 `PATCH /providers/:id` / `DELETE /providers/:id` handlers (`packages/api/src/routes/v2/providers.ts`) so any successful mutation drops the stale cached provider.
- Mirrors the `RouteResolver.invalidateInstance` pattern.

Previously a provider update changed the DB row but the dispatcher kept serving the cached `IAgentProvider` — requiring an API restart for `schemaConfig` / `baseUrl` / `apiKey` edits to take effect.

## Test plan

- [x] `bun run typecheck` (packages/api) passes
- [x] pre-push test hook: 3150 pass / 0 fail across 3414 tests
- [ ] Smoke in dev: PATCH a provider's `schemaConfig`, send a new message, confirm dispatcher picks up the new config without restart