### PR TITLE
fix(channel-sdk): add explicit senderName/chatName to event params (#426)

### DIFF
--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -188,7 +188,7 @@ function buildChatPreview(payload: MessageReceivedPayload, rawPayload: Record<st
 
   // Prefix with sender name for groups (not from self)
   if (isGroup && !isFromMe) {
-    const sender = (rawPayload?.pushName as string) || (rawPayload?.displayName as string) || '';
+    const sender = payload.senderName || (rawPayload?.pushName as string) || (rawPayload?.displayName as string) || '';
     if (sender) preview = `${sender}: ${preview}`;
   }
 
@@ -258,7 +258,7 @@ async function processSenderIdentity(
     return { personId: metadata.personId, platformIdentityId: undefined };
   }
 
-  const displayName = truncate(payload.rawPayload?.pushName as string | undefined, 255);
+  const displayName = truncate(payload.senderName ?? (payload.rawPayload?.pushName as string | undefined), 255);
   const platformUserId = truncate(payload.from, 255) ?? payload.from;
   // LID-addressed senders have numeric IDs that look like phones but are NOT E.164 numbers.
   // Skip phone extraction to prevent misidentifying LID IDs as phone numbers and linking to wrong people.
@@ -408,6 +408,7 @@ async function postProcessChat(
   instanceId: string,
   rawPayload: Record<string, unknown> | undefined,
   isFromMe: boolean,
+  chatName: string | undefined,
 ): Promise<void> {
   // Populate canonicalId ONLY if not already set
   // (Usually set during creation, but handle legacy chats or edge cases)
@@ -423,7 +424,7 @@ async function postProcessChat(
   // Note: we process both new and existing chats — new chats may have been created
   // without a name if effectiveName was not available at findOrCreate time.
   {
-    const chatNameLocal = rawPayload?.chatName as string | undefined;
+    const chatNameLocal = chatName ?? (rawPayload?.chatName as string | undefined);
     const effectiveNameLocal = resolveEffectiveChatName({
       chatType,
       isFromMe,
@@ -440,14 +441,17 @@ async function postProcessChat(
 
 /**
  * Resolve sender display name with fallback chain
- * Priority: pushName > participant displayName > undefined
+ * Priority: senderName > rawPayload.pushName > participant displayName > undefined
  */
 function resolveSenderDisplayName(
+  senderName: string | undefined,
   rawPayload: Record<string, unknown> | undefined,
   participantResult: { participant: { displayName: string | null } } | undefined,
 ): string | undefined {
   return (
-    truncate(rawPayload?.pushName as string | undefined, 255) || participantResult?.participant.displayName || undefined
+    truncate(senderName ?? (rawPayload?.pushName as string | undefined), 255) ||
+    participantResult?.participant.displayName ||
+    undefined
   );
 }
 
@@ -458,12 +462,13 @@ async function maybeFindOrCreateParticipant(
   rawPayload: Record<string, unknown> | undefined,
   personId: string | undefined,
   platformIdentityId: string | undefined,
+  senderName: string | undefined,
 ): Promise<Awaited<ReturnType<typeof services.chats.findOrCreateParticipant>> | undefined> {
   if (!from) return undefined;
 
   const participantUserId = truncate(from, 255) ?? from;
   return services.chats.findOrCreateParticipant(chatId, participantUserId, {
-    displayName: truncate(rawPayload?.pushName as string | undefined, 255),
+    displayName: truncate(senderName ?? (rawPayload?.pushName as string | undefined), 255),
     personId,
     platformIdentityId,
   });
@@ -588,8 +593,8 @@ async function handleMessageReceived(
   // Resolve the chat name based on direction and chat type.
   // For outbound DMs, we look at rawPayload fields (recipientName, verifiedBizName)
   // since pushName is our own name, not the contact's.
-  const pushName = truncate(rawPayload?.pushName as string | undefined, 255);
-  const chatName = truncate(rawPayload?.chatName as string | undefined, 255);
+  const pushName = truncate(payload.senderName ?? (rawPayload?.pushName as string | undefined), 255);
+  const chatName = truncate(payload.chatName ?? (rawPayload?.chatName as string | undefined), 255);
   const effectiveName = resolveEffectiveChatName({ chatType, isFromMe, chatName, pushName, rawPayload });
 
   // Determine canonicalId upfront for phone-based chats
@@ -617,6 +622,7 @@ async function handleMessageReceived(
     metadata.instanceId,
     rawPayload,
     isFromMe,
+    chatName,
   );
 
   // Step 2: Process sender identity (before participant, so we have IDs)
@@ -630,10 +636,11 @@ async function handleMessageReceived(
     rawPayload,
     personId,
     platformIdentityId,
+    payload.senderName,
   );
 
-  // Step 4: Resolve sender display name (fallback chain: pushName > participant > undefined)
-  const senderDisplayName = resolveSenderDisplayName(rawPayload, participantResult);
+  // Step 4: Resolve sender display name (fallback chain: senderName > pushName > participant > undefined)
+  const senderDisplayName = resolveSenderDisplayName(payload.senderName, rawPayload, participantResult);
 
   // Step 5: Build and create message
   const quotedMessage = rawPayload?.quotedMessage as Record<string, unknown> | undefined;

--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -1541,11 +1541,16 @@ export class DiscordPlugin extends BaseChannelPlugin {
     // Discord timestamps are already in milliseconds
     const timings = platformTimestamp ? this.captureInboundTimings(platformTimestamp) : undefined;
 
+    const senderName = typeof rawPayload.displayName === 'string' ? rawPayload.displayName : undefined;
+    const chatName = typeof rawPayload.chatName === 'string' ? rawPayload.chatName : undefined;
+
     const correlationId = await this.emitMessageReceived({
       instanceId,
       externalId,
       chatId,
       from,
+      senderName,
+      chatName,
       content,
       replyToId,
       rawPayload,

--- a/packages/channel-sdk/src/helpers/events.ts
+++ b/packages/channel-sdk/src/helpers/events.ts
@@ -27,6 +27,12 @@ export interface EmitMessageReceivedParams {
   /** Sender identifier on the platform */
   from: string;
 
+  /** Display name of the sender (normalized across channels) */
+  senderName?: string;
+
+  /** Group/chat display name (for group chats) */
+  chatName?: string;
+
   /** Message content */
   content: {
     type: ContentType;

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -960,11 +960,13 @@ export class SlackPlugin extends BaseChannelPlugin {
   ): Promise<Record<string, unknown>> {
     const displayName = await this.resolveUserDisplayName(instanceId, from);
     const isDm = rawPayload.isDm as boolean;
+    const chatName = isDm ? displayName : undefined;
     return {
       ...rawPayload,
       displayName,
+      senderName: displayName,
       pushName: displayName,
-      chatName: isDm ? displayName : undefined,
+      chatName,
       isGroup: !isDm,
     };
   }
@@ -1322,11 +1324,21 @@ export class SlackPlugin extends BaseChannelPlugin {
   ): Promise<void> {
     const timings = platformTimestamp ? this.captureInboundTimings(platformTimestamp) : undefined;
 
+    const senderName =
+      typeof rawPayload.senderName === 'string'
+        ? rawPayload.senderName
+        : typeof rawPayload.displayName === 'string'
+          ? rawPayload.displayName
+          : undefined;
+    const chatName = typeof rawPayload.chatName === 'string' ? rawPayload.chatName : undefined;
+
     const correlationId = await this.emitMessageReceived({
       instanceId,
       externalId,
       chatId,
       from,
+      senderName,
+      chatName,
       content,
       replyToId,
       rawPayload,

--- a/packages/channel-telegram/src/plugin.ts
+++ b/packages/channel-telegram/src/plugin.ts
@@ -726,11 +726,16 @@ export class TelegramPlugin extends BaseChannelPlugin {
     // Telegram timestamps arrive pre-normalized to ms from the handler
     const timings = platformTimestamp ? this.captureInboundTimings(platformTimestamp) : undefined;
 
+    const senderName = typeof rawPayload.displayName === 'string' ? rawPayload.displayName : undefined;
+    const chatName = typeof rawPayload.chatName === 'string' ? rawPayload.chatName : undefined;
+
     const correlationId = await this.emitMessageReceived({
       instanceId,
       externalId,
       chatId,
       from,
+      senderName,
+      chatName,
       content: {
         type: content.type as import('@omni/core/types').ContentType,
         text: content.text,

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -2783,6 +2783,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       externalId,
       chatId,
       from,
+      senderName: senderPushName,
+      chatName: typeof extendedPayload.chatName === 'string' ? extendedPayload.chatName : undefined,
       content: {
         type: content.type,
         text: content.text || content.caption,
@@ -3544,11 +3546,15 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       };
       this.enrichPayloadWithChatName(rawPayload, instanceId, chatId);
 
+      const historySenderName = (msg as { pushName?: string | null }).pushName ?? undefined;
+
       await this.emitMessageReceived({
         instanceId,
         externalId: msg.key.id,
         chatId,
         from: senderId,
+        senderName: historySenderName,
+        chatName: typeof rawPayload.chatName === 'string' ? rawPayload.chatName : undefined,
         content: {
           type: content.type as ContentType,
           text: content.text || content.caption,

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -204,6 +204,10 @@ export interface MessageReceivedPayload {
   /** Optional thread/topic identifier (e.g. Telegram forum topic) */
   threadId?: string;
   from: string;
+  /** Display name of the sender (normalized across channels) */
+  senderName?: string;
+  /** Group/chat display name (for group chats) */
+  chatName?: string;
   content: {
     type: ContentType;
     text?: string;


### PR DESCRIPTION
## Summary

- Adds first-class `senderName?` and `chatName?` fields to `EmitMessageReceivedParams` (channel-sdk) and `MessageReceivedPayload` (core) so channel plugins publish identity data explicitly.
- Wires each plugin (WhatsApp, Telegram, Slack, Discord) to set these fields from the channel-native source (Baileys `pushName`, Telegram `displayName`/`buildChatName`, Slack resolved profile, Discord member `displayName`).
- Updates `api/message-persistence.ts` to prefer `payload.senderName` / `payload.chatName` over the legacy `rawPayload.pushName` / `rawPayload.chatName` fallback at all 7 sites.

Ends the implicit `rawPayload.pushName` contract that made Gupshup (and any new channel integration) silently lose display names unless the implementer read Baileys source to discover the convention.

Closes #426.

## Test plan

- [x] `bun run typecheck` — all 18 packages pass
- [x] pre-commit lint + tests — 3150 pass / 264 skip / 0 fail (3414 total)
- [ ] Manual smoke: inbound WhatsApp DM → chat + contact get populated `displayName`
- [ ] Manual smoke: inbound Telegram group message → chat name from `buildChatName`, sender from `displayName`
- [ ] Manual smoke: inbound Slack DM → chat + contact get Slack profile `display_name`
- [ ] Manual smoke: inbound Discord guild message → chat name from `resolveChatName`, sender from `member.displayName`