### PR TITLE
fix(api): prevent silent reconnect failure and fix health endpoint accuracy

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,6 +29,7 @@ const pluginLog = createLogger('api:plugins');
 const shutdownLog = createLogger('api:shutdown');
 import packageJson from '../package.json';
 import { type App, createApp } from './app';
+import { markPluginsDegraded } from './plugin-state';
 import {
   InstanceMonitor,
   loadChannelPlugins,
@@ -658,7 +659,12 @@ async function main() {
     try {
       await initializeChannelPlugins(db, eventBus);
     } catch (error) {
-      pluginLog.error('Failed to load channel plugins', { error: String(error) });
+      const reason = String(error);
+      pluginLog.error('Failed to load channel plugins', { error: reason });
+      // Issue #408: a plugin init failure previously left the API running
+      // in a silently broken state where /health returned healthy. Flip the
+      // degraded flag so operators can detect it.
+      markPluginsDegraded(reason);
     }
   } else {
     pluginLog.warn('Skipping channel plugin loading (no event bus)');

--- a/packages/api/src/plugin-state.ts
+++ b/packages/api/src/plugin-state.ts
@@ -1,0 +1,23 @@
+/**
+ * Module-level plugin state flags shared across the API server.
+ *
+ * `pluginsDegraded` is set when channel plugin initialization throws at
+ * startup so the /health endpoint can report `status: 'degraded'` instead
+ * of silently returning `healthy` (issue #408).
+ */
+
+let pluginsDegraded = false;
+let pluginsDegradedReason: string | null = null;
+
+export function markPluginsDegraded(reason: string): void {
+  pluginsDegraded = true;
+  pluginsDegradedReason = reason;
+}
+
+export function arePluginsDegraded(): boolean {
+  return pluginsDegraded;
+}
+
+export function getPluginsDegradedReason(): string | null {
+  return pluginsDegradedReason;
+}

--- a/packages/api/src/plugins/instance-monitor.ts
+++ b/packages/api/src/plugins/instance-monitor.ts
@@ -75,6 +75,13 @@ const DEFAULT_CONFIG: Required<MonitorConfig> = {
 // ============================================================================
 
 /**
+ * Maximum age (ms) for an in-flight 'reconnecting' or 'connecting' state
+ * before the monitor assumes the plugin-level retry loop has silently died
+ * and takes over the reconnect itself (issue #408).
+ */
+const STALE_TRANSITION_MAX_AGE_MS = 10 * 60 * 1000;
+
+/**
  * Check if an instance needs reconnection based on its status.
  *
  * IMPORTANT: Do NOT reconnect instances in 'reconnecting' state — the
@@ -82,9 +89,24 @@ const DEFAULT_CONFIG: Required<MonitorConfig> = {
  * own exponential backoff. Having two systems reconnect the same instance
  * creates duplicate sockets and rapid connect/disconnect churn that
  * WhatsApp interprets as bot activity (leading to temp bans).
+ *
+ * EXCEPTION: If the transition state is older than
+ * STALE_TRANSITION_MAX_AGE_MS, the plugin-side loop has likely died
+ * without transitioning us out. Fall through to reconnect anyway.
  */
-function needsReconnect(state: string): boolean {
-  return state === 'disconnected' || state === 'error';
+function needsReconnect(status: { state: string; since?: Date }): boolean {
+  if (status.state === 'disconnected' || status.state === 'error') {
+    return true;
+  }
+
+  if (status.state === 'reconnecting' || status.state === 'connecting') {
+    const since = status.since instanceof Date ? status.since.getTime() : Number.NaN;
+    if (Number.isFinite(since) && Date.now() - since > STALE_TRANSITION_MAX_AGE_MS) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -350,7 +372,7 @@ export class InstanceMonitor {
     try {
       const status = await plugin.getStatus(instance.id);
 
-      if (needsReconnect(status.state)) {
+      if (needsReconnect(status)) {
         this.handleUnhealthyInstance(instance, status.state, status.message);
       }
     } catch (error) {

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -6,6 +6,7 @@ import { consumerOffsets, instances } from '@omni/db';
 import { sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import packageJson from '../../package.json';
+import { arePluginsDegraded, getPluginsDegradedReason } from '../plugin-state';
 import type { AppVariables, HealthCheck, HealthResponse } from '../types';
 
 const VERSION = packageJson.version;
@@ -19,6 +20,7 @@ export const healthRoutes = new Hono<{ Variables: AppVariables }>();
 healthRoutes.get('/health', async (c) => {
   const db = c.get('db');
   const eventBus = c.get('eventBus');
+  const channelRegistry = c.get('channelRegistry');
 
   // Check database
   let dbCheck: HealthCheck;
@@ -57,21 +59,37 @@ healthRoutes.get('/health', async (c) => {
 
     const byChannel: Record<string, number> = {};
     let total = 0;
-    let connected = 0;
+    let active = 0;
 
     for (const row of instanceCounts) {
       byChannel[row.channel] = row.total;
       total += row.total;
-      connected += row.active;
+      active += row.active;
     }
 
-    instanceStats = { total, connected, byChannel };
+    // `connected` must reflect live channel-plugin state, not the `isActive`
+    // row flag. Active rows that failed to reconnect would otherwise be
+    // counted as connected and mask the bug in issue #408.
+    let connected = 0;
+    if (channelRegistry) {
+      for (const plugin of channelRegistry.getAll()) {
+        connected += plugin.getConnectedInstances().length;
+      }
+    }
+
+    instanceStats = { total, active, connected, byChannel };
   } catch {
     // Ignore instance stats errors
   }
 
+  // Channel plugin initialization check (issue #408)
+  const pluginsFailed = arePluginsDegraded();
+  const pluginsCheck: HealthCheck = pluginsFailed
+    ? { status: 'error', error: getPluginsDegradedReason() ?? 'Plugin initialization failed' }
+    : { status: 'ok' };
+
   // Determine overall status
-  const hasErrors = dbCheck.status === 'error' || natsCheck.status === 'error';
+  const hasErrors = dbCheck.status === 'error' || natsCheck.status === 'error' || pluginsFailed;
   const status: HealthResponse['status'] = hasErrors ? 'degraded' : 'healthy';
 
   const response: HealthResponse = {
@@ -82,6 +100,7 @@ healthRoutes.get('/health', async (c) => {
     checks: {
       database: dbCheck,
       nats: natsCheck,
+      plugins: pluginsCheck,
     },
     instances: instanceStats,
   };
@@ -94,10 +113,11 @@ healthRoutes.get('/health', async (c) => {
  */
 healthRoutes.get('/info', async (c) => {
   const db = c.get('db');
+  const channelRegistry = c.get('channelRegistry');
 
   // Get basic stats
   let instancesTotal = 0;
-  let instancesConnected = 0;
+  let instancesActive = 0;
   const eventsToday = 0;
   const eventsTotal = 0;
 
@@ -105,14 +125,22 @@ healthRoutes.get('/info', async (c) => {
     const [instanceStats] = await db
       .select({
         total: sql<number>`count(*)::int`,
-        connected: sql<number>`count(*) filter (where ${instances.isActive})::int`,
+        active: sql<number>`count(*) filter (where ${instances.isActive})::int`,
       })
       .from(instances);
 
     instancesTotal = instanceStats?.total ?? 0;
-    instancesConnected = instanceStats?.connected ?? 0;
+    instancesActive = instanceStats?.active ?? 0;
   } catch {
     // Ignore errors
+  }
+
+  // Real connected count from channel registry (see /health rationale).
+  let instancesConnected = 0;
+  if (channelRegistry) {
+    for (const plugin of channelRegistry.getAll()) {
+      instancesConnected += plugin.getConnectedInstances().length;
+    }
   }
 
   return c.json({
@@ -121,6 +149,7 @@ healthRoutes.get('/info', async (c) => {
     uptime: Math.floor((Date.now() - startTime) / 1000),
     instances: {
       total: instancesTotal,
+      active: instancesActive,
       connected: instancesConnected,
     },
     events: {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -51,9 +51,13 @@ export interface HealthResponse {
   checks: {
     database: HealthCheck;
     nats: HealthCheck;
+    plugins?: HealthCheck;
   };
   instances?: {
     total: number;
+    /** Rows with instances.isActive = true (DB flag, not live socket state). */
+    active: number;
+    /** Live connected instances reported by channel plugins. */
     connected: number;
     byChannel: Record<string, number>;
   };

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -2623,6 +2623,20 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    */
   handleConnectionError(instanceId: string, error: string, willRetry: boolean): void {
     this.logger.error('Connection error', { instanceId, error, willRetry });
+
+    if (!willRetry) {
+      // Baileys gave up its internal retry loop — transition to 'disconnected'
+      // so InstanceMonitor.needsReconnect() re-arms the API-level backoff.
+      // Otherwise the socket lingers in 'reconnecting' forever (issue #408).
+      const config = this.instances.get(instanceId)?.config;
+      if (config) {
+        void this.updateInstanceStatus(instanceId, config, {
+          state: 'disconnected',
+          since: new Date(),
+          message: error,
+        });
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #408.

## Summary

- **channel-whatsapp** `handleConnectionError`: when Baileys gives up its internal retry loop (`willRetry === false`), transition the instance to `disconnected` so `InstanceMonitor` re-arms the API-level backoff. Previously instances lingered in `reconnecting` forever and never recovered.
- **instance-monitor** `needsReconnect`: staleness fallback — if an instance is stuck in `reconnecting` or `connecting` for more than 10 minutes, force a reconnect anyway.
- **/health and /info**: `connected` now reflects live channel-plugin state via `getConnectedInstances()` rather than the misleading `isActive` row flag. `active` (DB-flag count) is exposed alongside so both signals are visible.
- **startup**: new module-level `pluginsDegraded` flag is set when `initializeChannelPlugins` throws. `/health` reports `status: 'degraded'` with a dedicated `plugins` check so operators can detect silent init failures.

## Test plan

- [x] `bunx turbo typecheck --filter=@omni/api --filter=@omni/channel-whatsapp` passes
- [x] `bunx turbo test --filter=@omni/api --filter=@omni/channel-whatsapp` — 625 pass, 0 fail
- [x] Full repo test suite on pre-push hook — 3150 pass, 0 fail
- [ ] Manual smoke: kill a WhatsApp socket and confirm InstanceMonitor picks it back up (issue #408 repro)
- [ ] Manual smoke: force `initializeChannelPlugins` to throw and verify `/health` returns `status: degraded` with `checks.plugins.status === 'error'`