### PR TITLE
fix(api): expose accurate progressPercent for history-push sync jobs

### DIFF
--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -11,7 +11,7 @@ import type { ChannelRegistry, FetchHistoryOptions, HistorySyncMessage } from '@
 import type { EventBus } from '@omni/core';
 import { createLogger } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
-import type { Database, SyncJobConfig, SyncJobType } from '@omni/db';
+import type { Database, SyncJobConfig, SyncJobProgress, SyncJobType } from '@omni/db';
 import { omniGroups } from '@omni/db';
 import { and, eq, sql } from 'drizzle-orm';
 import type { Services } from '../services';
@@ -889,6 +889,16 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
         const { instanceId, channelType } = event.payload;
 
         try {
+          // Reuse an already-running history-push job for this instance instead of
+          // creating a duplicate on every reconnect.
+          if (await services.syncJobs.hasActiveJob(instanceId, 'history-push')) {
+            historyPushLog.debug('Active history-push job already exists — skipping create', {
+              instanceId,
+              channel: channelType,
+            });
+            return;
+          }
+
           // Create a running history-push sync job
           const job = await services.syncJobs.create({
             instanceId,
@@ -943,16 +953,17 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
             return;
           }
 
-          await services.syncJobs.updateProgress(historyPushJob.id, {
+          // Only update counters we actually have from Baileys. Never reset
+          // stored/duplicates/mediaDownloaded to 0 — ingestion updates them
+          // separately and they must not be clobbered by a progress event.
+          const update: Partial<SyncJobProgress> = {
             fetched: payload.fetched ?? 0,
-            stored: 0,
-            duplicates: 0,
-            mediaDownloaded: 0,
-            totalEstimated:
-              payload.progress && payload.progress > 0
-                ? Math.round((payload.fetched ?? 0) / (payload.progress / 100))
-                : 0,
-          });
+          };
+          if (typeof payload.progress === 'number' && payload.progress > 0) {
+            update.totalEstimated = Math.round((payload.fetched ?? 0) / (payload.progress / 100));
+          }
+
+          await services.syncJobs.updateProgress(historyPushJob.id, update);
 
           historyPushLog.debug('Updated history-push progress', {
             jobId: historyPushJob.id,

--- a/packages/api/src/services/sync-jobs.ts
+++ b/packages/api/src/services/sync-jobs.ts
@@ -189,6 +189,7 @@ export class SyncJobService {
     const updatedProgress: SyncJobProgress = {
       ...currentProgress,
       ...progress,
+      lastProgressAt: new Date().toISOString(),
     };
 
     const [updated] = await this.db

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3620,13 +3620,18 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
 
       const meta = { instanceId, channelType: this.id };
 
-      // Publish sync.progress event
+      // Publish sync.progress event — omit `progress` when Baileys didn't report one
+      // so downstream can distinguish "unknown denominator" from "0%".
+      const payload: { instanceId: string; jobType: 'history-push'; fetched: number; progress?: number } = {
+        instanceId,
+        jobType: 'history-push',
+        fetched: totalFetched,
+      };
+      if (typeof progress === 'number') {
+        payload.progress = progress;
+      }
       this.eventBus
-        .publishGeneric(
-          'sync.progress' as const,
-          { instanceId, jobType: 'history-push', fetched: totalFetched, progress: progress ?? 0 },
-          meta,
-        )
+        .publishGeneric('sync.progress' as const, payload, meta)
         .catch((err) => this.logger.warn('Failed to publish sync.progress for history-push', { error: String(err) }));
 
       // Publish sync.completed when Baileys signals completion

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1536,6 +1536,12 @@ export interface SyncJobProgress {
   duplicates: number;
   mediaDownloaded: number;
   totalEstimated?: number;
+  /**
+   * ISO-8601 timestamp of the last `updateProgress` call. Lets clients
+   * distinguish "running slowly" from "stuck" when `progressPercent` cannot
+   * be computed (e.g. Baileys never reports a denominator). See issue #398.
+   */
+  lastProgressAt?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the four concrete gaps behind #398 — `history-push` sync jobs return no usable progress signal and the tracker spams new jobs on every reconnect.

- `packages/channel-whatsapp/src/plugin.ts` — `sync.progress` payload now omits `progress` when Baileys didn't emit a number, so downstream can tell "unknown denominator" apart from a literal 0%.
- `packages/api/src/plugins/sync-worker.ts` — `updateProgress` caller no longer resets `stored` / `duplicates` / `mediaDownloaded` to 0 on every event (they're owned by the ingest path), and only sets `totalEstimated` when we actually have a non-zero progress fraction.
- `packages/api/src/plugins/sync-worker.ts` — `setupHistoryPushTracker` now calls `services.syncJobs.hasActiveJob(instanceId, 'history-push')` before creating a new job on `instance.connected`, so reconnects reuse the running job instead of piling up duplicates.
- `packages/db/src/schema.ts` + `packages/api/src/services/sync-jobs.ts` — extend `SyncJobProgress` with `lastProgressAt?: string` and stamp it on every `updateProgress` call. Lets clients distinguish "running slowly" from "stuck" when no denominator is available.

Closes #398.

## Test plan
- [x] `bun run typecheck` — all 20 packages pass (`@omni/db`, `@omni/channel-whatsapp`, `@omni/api` rebuilt from source; rest cache-hit)
- [x] Pre-push test suite — 3150 pass / 264 skip / 0 fail
- [ ] Manual: trigger a `history-push` sync, call `omni instances syncs <id> <jobId> --json`, confirm response exposes `progressPercent` (once Baileys emits a denominator) or `lastProgressAt` otherwise, and that counters (`stored`/`duplicates`/`mediaDownloaded`) are not clobbered between events
- [ ] Manual: toggle the instance offline/online several times and confirm only one active `history-push` job exists (no duplicates)