### PR TITLE
fix(cli): accept name or UUID in provider, agent, and webhook commands

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -13,6 +13,7 @@
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
+import { resolveAgentId } from '../resolve.js';
 
 const VALID_PROVIDERS = ['claude', 'agno', 'openai', 'gemini', 'custom', 'omni-internal'] as const;
 type AgentProvider = (typeof VALID_PROVIDERS)[number];
@@ -210,10 +211,11 @@ export function createAgentsCommand(): Command {
     .command('get <id>')
     .description('Get agent details')
     .action(async (id: string) => {
+      const resolvedId = await resolveAgentId(id);
       const client = getClient();
 
       try {
-        const agent = await client.agents.get(id);
+        const agent = await client.agents.get(resolvedId);
         output.data(agent);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
@@ -279,6 +281,7 @@ export function createAgentsCommand(): Command {
 
       // Validate --metadata JSON up front (fails fast before any network call).
       const parsedMetadata = parseMetadataJson(options.metadata);
+      const resolvedId = await resolveAgentId(id);
       const client = getClient();
 
       try {
@@ -286,7 +289,7 @@ export function createAgentsCommand(): Command {
         // clobbering keys the user didn't pass, fetch-then-merge whenever
         // --metadata or --provider-agent-id is supplied.
         if (parsedMetadata !== undefined || options.providerAgentId !== undefined) {
-          const existing = await client.agents.get(id);
+          const existing = await client.agents.get(resolvedId);
           const existingMetadata = (existing.metadata ?? {}) as Record<string, unknown>;
           const merged: Record<string, unknown> = { ...existingMetadata, ...(parsedMetadata ?? {}) };
           if (options.providerAgentId !== undefined) merged.providerAgentId = options.providerAgentId;
@@ -299,7 +302,7 @@ export function createAgentsCommand(): Command {
           );
         }
 
-        const agent = await client.agents.update(id, body);
+        const agent = await client.agents.update(resolvedId, body);
         output.data(agent);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
@@ -312,11 +315,12 @@ export function createAgentsCommand(): Command {
     .command('delete <id>')
     .description('Delete an agent (soft-delete, sets inactive)')
     .action(async (id: string) => {
+      const resolvedId = await resolveAgentId(id);
       const client = getClient();
 
       try {
-        await client.agents.delete(id);
-        output.success(`Agent ${id} deleted.`);
+        await client.agents.delete(resolvedId);
+        output.success(`Agent ${resolvedId} deleted.`);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to delete agent: ${message}`, undefined, 3);

--- a/packages/cli/src/commands/follow-up.ts
+++ b/packages/cli/src/commands/follow-up.ts
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
+import { resolveAgentId, resolveChatId, resolveInstanceId } from '../resolve.js';
 
 type Scope = 'agents' | 'instances' | 'chats';
 
@@ -22,6 +23,12 @@ function assertScope(scope: string): asserts scope is Scope {
   if (!VALID_SCOPES.includes(scope as Scope)) {
     output.error(`Invalid scope: ${scope}. Expected one of: ${VALID_SCOPES.join(', ')}`);
   }
+}
+
+async function resolveScopedId(scope: Scope, id: string): Promise<string> {
+  if (scope === 'agents') return resolveAgentId(id);
+  if (scope === 'instances') return resolveInstanceId(id);
+  return resolveChatId(id);
 }
 
 function readJsonArg(raw: string): unknown {
@@ -49,14 +56,15 @@ export function createFollowUpCommand(): Command {
     .description('Read follow-up config at a scope (agents|instances|chats).')
     .action(async (scope: string, id: string) => {
       assertScope(scope);
+      const resolvedId = await resolveScopedId(scope, id);
       const client = getClient();
       try {
         const data =
           scope === 'agents'
-            ? await client.followUp.getAgent(id)
+            ? await client.followUp.getAgent(resolvedId)
             : scope === 'instances'
-              ? await client.followUp.getInstance(id)
-              : await client.followUp.getChat(id);
+              ? await client.followUp.getInstance(resolvedId)
+              : await client.followUp.getChat(resolvedId);
         output.data(data);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
@@ -70,15 +78,16 @@ export function createFollowUpCommand(): Command {
     .action(async (scope: string, id: string, json: string) => {
       assertScope(scope);
       const config = readJsonArg(json);
+      const resolvedId = await resolveScopedId(scope, id);
       const client = getClient();
       try {
         const data =
           scope === 'agents'
-            ? await client.followUp.setAgent(id, config as never)
+            ? await client.followUp.setAgent(resolvedId, config as never)
             : scope === 'instances'
-              ? await client.followUp.setInstance(id, config as never)
-              : await client.followUp.setChat(id, config as never);
-        output.success(`Follow-up config set on ${scope.slice(0, -1)} ${id}.`, data);
+              ? await client.followUp.setInstance(resolvedId, config as never)
+              : await client.followUp.setChat(resolvedId, config as never);
+        output.success(`Follow-up config set on ${scope.slice(0, -1)} ${resolvedId}.`, data);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to set ${scope} follow-up: ${message}`, undefined, 3);
@@ -90,12 +99,13 @@ export function createFollowUpCommand(): Command {
     .description('Clear the override at a scope so broader scopes apply.')
     .action(async (scope: string, id: string) => {
       assertScope(scope);
+      const resolvedId = await resolveScopedId(scope, id);
       const client = getClient();
       try {
-        if (scope === 'agents') await client.followUp.unsetAgent(id);
-        else if (scope === 'instances') await client.followUp.unsetInstance(id);
-        else await client.followUp.unsetChat(id);
-        output.success(`Follow-up config cleared on ${scope.slice(0, -1)} ${id}.`);
+        if (scope === 'agents') await client.followUp.unsetAgent(resolvedId);
+        else if (scope === 'instances') await client.followUp.unsetInstance(resolvedId);
+        else await client.followUp.unsetChat(resolvedId);
+        output.success(`Follow-up config cleared on ${scope.slice(0, -1)} ${resolvedId}.`);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to unset ${scope} follow-up: ${message}`, undefined, 3);

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -20,6 +20,7 @@ import { PROVIDER_SCHEMAS, type ProviderSchema } from '@omni/core';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
+import { resolveProviderId } from '../resolve.js';
 import { createSetupCommand } from './providers-setup.js';
 
 // Single source of truth: derive VALID_SCHEMAS from @omni/core (DEC-12)
@@ -209,9 +210,10 @@ async function handleList(options: { active?: boolean }): Promise<void> {
 }
 
 async function handleGet(id: string): Promise<void> {
+  const resolvedId = await resolveProviderId(id);
   const client = getClient();
   try {
-    const provider = await client.providers.get(id);
+    const provider = await client.providers.get(resolvedId);
     output.data(provider);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
@@ -270,9 +272,10 @@ async function handleCreate(options: {
 }
 
 async function handleTest(id: string): Promise<void> {
+  const resolvedId = await resolveProviderId(id);
   const client = getClient();
   try {
-    const result = await client.providers.checkHealth(id);
+    const result = await client.providers.checkHealth(resolvedId);
     if (result.healthy) {
       output.success(`Provider is healthy (latency: ${result.latency}ms)`);
     } else {
@@ -297,17 +300,18 @@ async function handleUpdate(id: string, options: Record<string, unknown>): Promi
     return;
   }
 
+  const resolvedId = await resolveProviderId(id);
   const client = getClient();
   try {
     // If updating individual schemaConfig fields (not raw --schema-config JSON),
     // merge with the existing config to avoid dropping required fields.
     if (body.schemaConfig && !options.schemaConfig) {
-      const existing = await client.providers.get(id);
+      const existing = await client.providers.get(resolvedId);
       const existingConfig = (existing.schemaConfig as Record<string, unknown>) ?? {};
       body.schemaConfig = { ...existingConfig, ...(body.schemaConfig as Record<string, unknown>) };
     }
 
-    const provider = await client.providers.update(id, body);
+    const provider = await client.providers.update(resolvedId, body);
     output.success(`Updated provider: ${provider.id}`);
     output.data(provider);
   } catch (err) {
@@ -321,10 +325,11 @@ async function handleDelete(id: string, options: { force?: boolean }): Promise<v
     output.warn(`This will delete provider ${id}. Use --force to confirm.`);
     return;
   }
+  const resolvedId = await resolveProviderId(id);
   const client = getClient();
   try {
-    await client.providers.delete(id);
-    output.success(`Deleted provider: ${id}`);
+    await client.providers.delete(resolvedId);
+    output.success(`Deleted provider: ${resolvedId}`);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     output.error(`Failed to delete provider: ${message}`);
@@ -383,10 +388,11 @@ export function createProvidersCommand(): Command {
     .command('agents <id>')
     .description('List agents from provider (Agno)')
     .action(async (id: string) => {
+      const resolvedId = await resolveProviderId(id);
       const client = getClient();
 
       try {
-        const agents = await client.providers.listAgents(id);
+        const agents = await client.providers.listAgents(resolvedId);
 
         const items = agents.map((a) => ({
           id: a.agent_id,
@@ -407,10 +413,11 @@ export function createProvidersCommand(): Command {
     .command('teams <id>')
     .description('List teams from provider (Agno)')
     .action(async (id: string) => {
+      const resolvedId = await resolveProviderId(id);
       const client = getClient();
 
       try {
-        const teams = await client.providers.listTeams(id);
+        const teams = await client.providers.listTeams(resolvedId);
 
         const items = teams.map((t) => ({
           id: t.team_id,
@@ -432,10 +439,11 @@ export function createProvidersCommand(): Command {
     .command('workflows <id>')
     .description('List workflows from provider (Agno)')
     .action(async (id: string) => {
+      const resolvedId = await resolveProviderId(id);
       const client = getClient();
 
       try {
-        const workflows = await client.providers.listWorkflows(id);
+        const workflows = await client.providers.listWorkflows(resolvedId);
 
         const items = workflows.map((w) => ({
           id: w.workflow_id,

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -12,6 +12,7 @@
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
+import { resolveWebhookId } from '../resolve.js';
 
 export function createWebhooksCommand(): Command {
   const webhooks = new Command('webhooks').description('Manage webhook sources');
@@ -53,10 +54,11 @@ export function createWebhooksCommand(): Command {
     .command('get <id>')
     .description('Get webhook source details')
     .action(async (id: string) => {
+      const resolvedId = await resolveWebhookId(id);
       const client = getClient();
 
       try {
-        const source = await client.webhooks.getSource(id);
+        const source = await client.webhooks.getSource(resolvedId);
         output.data(source);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
@@ -113,6 +115,7 @@ export function createWebhooksCommand(): Command {
     .option('--disable', 'Disable the webhook')
     .action(
       async (id: string, options: { name?: string; description?: string; enable?: boolean; disable?: boolean }) => {
+        const resolvedId = await resolveWebhookId(id);
         const client = getClient();
 
         try {
@@ -122,7 +125,7 @@ export function createWebhooksCommand(): Command {
           if (options.enable) updates.enabled = true;
           if (options.disable) updates.enabled = false;
 
-          const source = await client.webhooks.updateSource(id, updates);
+          const source = await client.webhooks.updateSource(resolvedId, updates);
           output.success(`Webhook source updated: ${source.id}`, {
             id: source.id,
             name: source.name,
@@ -140,11 +143,12 @@ export function createWebhooksCommand(): Command {
     .command('delete <id>')
     .description('Delete a webhook source')
     .action(async (id: string) => {
+      const resolvedId = await resolveWebhookId(id);
       const client = getClient();
 
       try {
-        await client.webhooks.deleteSource(id);
-        output.success(`Webhook source deleted: ${id}`);
+        await client.webhooks.deleteSource(resolvedId);
+        output.success(`Webhook source deleted: ${resolvedId}`);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to delete webhook source: ${message}`);

--- a/packages/cli/src/resolve.ts
+++ b/packages/cli/src/resolve.ts
@@ -325,6 +325,135 @@ export async function resolveBatchJobId(input: string): Promise<string> {
 }
 
 /**
+ * Resolve a provider identifier to a UUID.
+ *
+ * Matches in order:
+ *   1. Exact UUID match (skip API call)
+ *   2. UUID prefix match (minimum 2 hex chars)
+ *   3. Exact name match (case-insensitive)
+ *   4. Name substring match (case-insensitive)
+ *
+ * Exits with error if no match or ambiguous.
+ */
+export async function resolveProviderId(input: string): Promise<string> {
+  if (UUID_RE.test(input)) return input;
+
+  const client = getClient();
+  const providers = await client.providers.list({});
+
+  // Partial UUID prefix (at least 2 chars, looks hex-ish)
+  if (/^[0-9a-f]{2,}$/i.test(input)) {
+    const matches = providers.filter((p) => p.id.toLowerCase().startsWith(input.toLowerCase()));
+    if (matches.length === 1) return matches[0].id;
+    if (matches.length > 1) {
+      const names = matches.map((p) => `  ${p.id.slice(0, 8)}  ${p.name}`).join('\n');
+      output.error(`Ambiguous ID prefix "${input}" matches ${matches.length} providers:\n${names}`);
+    }
+  }
+
+  // Exact name match (case-insensitive)
+  const lower = input.toLowerCase();
+  const exactName = providers.find((p) => p.name.toLowerCase() === lower);
+  if (exactName) return exactName.id;
+
+  // Name substring match
+  const nameMatches = providers.filter((p) => p.name.toLowerCase().includes(lower));
+  if (nameMatches.length === 1) return nameMatches[0].id;
+  if (nameMatches.length > 1) {
+    const names = nameMatches.map((p) => `  ${p.id.slice(0, 8)}  ${p.name}`).join('\n');
+    output.error(`Ambiguous name "${input}" matches ${nameMatches.length} providers:\n${names}`);
+  }
+
+  output.error(`No provider found matching "${input}"`);
+}
+
+/**
+ * Resolve an agent identifier to a UUID.
+ *
+ * Matches in order:
+ *   1. Exact UUID match (skip API call)
+ *   2. UUID prefix match (minimum 2 hex chars)
+ *   3. Exact name match (case-insensitive)
+ *   4. Name substring match (case-insensitive)
+ *
+ * Exits with error if no match or ambiguous.
+ */
+export async function resolveAgentId(input: string): Promise<string> {
+  if (UUID_RE.test(input)) return input;
+
+  const client = getClient();
+  const { items: agents } = await client.agents.list({ limit: 100 });
+
+  // Partial UUID prefix (at least 2 chars, looks hex-ish)
+  if (/^[0-9a-f]{2,}$/i.test(input)) {
+    const matches = agents.filter((a) => a.id.toLowerCase().startsWith(input.toLowerCase()));
+    if (matches.length === 1) return matches[0].id;
+    if (matches.length > 1) {
+      const names = matches.map((a) => `  ${a.id.slice(0, 8)}  ${a.name}`).join('\n');
+      output.error(`Ambiguous ID prefix "${input}" matches ${matches.length} agents:\n${names}`);
+    }
+  }
+
+  // Exact name match (case-insensitive)
+  const lower = input.toLowerCase();
+  const exactName = agents.find((a) => a.name.toLowerCase() === lower);
+  if (exactName) return exactName.id;
+
+  // Name substring match
+  const nameMatches = agents.filter((a) => a.name.toLowerCase().includes(lower));
+  if (nameMatches.length === 1) return nameMatches[0].id;
+  if (nameMatches.length > 1) {
+    const names = nameMatches.map((a) => `  ${a.id.slice(0, 8)}  ${a.name}`).join('\n');
+    output.error(`Ambiguous name "${input}" matches ${nameMatches.length} agents:\n${names}`);
+  }
+
+  output.error(`No agent found matching "${input}"`);
+}
+
+/**
+ * Resolve a webhook source identifier to a UUID.
+ *
+ * Matches in order:
+ *   1. Exact UUID match (skip API call)
+ *   2. UUID prefix match (minimum 2 hex chars)
+ *   3. Exact name match (case-insensitive)
+ *   4. Name substring match (case-insensitive)
+ *
+ * Exits with error if no match or ambiguous.
+ */
+export async function resolveWebhookId(input: string): Promise<string> {
+  if (UUID_RE.test(input)) return input;
+
+  const client = getClient();
+  const sources = await client.webhooks.listSources({});
+
+  // Partial UUID prefix (at least 2 chars, looks hex-ish)
+  if (/^[0-9a-f]{2,}$/i.test(input)) {
+    const matches = sources.filter((w) => w.id.toLowerCase().startsWith(input.toLowerCase()));
+    if (matches.length === 1) return matches[0].id;
+    if (matches.length > 1) {
+      const names = matches.map((w) => `  ${w.id.slice(0, 8)}  ${w.name}`).join('\n');
+      output.error(`Ambiguous ID prefix "${input}" matches ${matches.length} webhook sources:\n${names}`);
+    }
+  }
+
+  // Exact name match (case-insensitive)
+  const lower = input.toLowerCase();
+  const exactName = sources.find((w) => w.name.toLowerCase() === lower);
+  if (exactName) return exactName.id;
+
+  // Name substring match
+  const nameMatches = sources.filter((w) => w.name.toLowerCase().includes(lower));
+  if (nameMatches.length === 1) return nameMatches[0].id;
+  if (nameMatches.length > 1) {
+    const names = nameMatches.map((w) => `  ${w.id.slice(0, 8)}  ${w.name}`).join('\n');
+    output.error(`Ambiguous name "${input}" matches ${nameMatches.length} webhook sources:\n${names}`);
+  }
+
+  output.error(`No webhook source found matching "${input}"`);
+}
+
+/**
  * Resolve an agent route identifier to a UUID.
  *
  * Routes are scoped to an instance, so instanceId must already be resolved.

--- a/packages/cli/src/resolve.ts
+++ b/packages/cli/src/resolve.ts
@@ -382,7 +382,7 @@ export async function resolveAgentId(input: string): Promise<string> {
   if (UUID_RE.test(input)) return input;
 
   const client = getClient();
-  const { items: agents } = await client.agents.list({ limit: 100 });
+  const { items: agents } = await client.agents.list({});
 
   // Partial UUID prefix (at least 2 chars, looks hex-ish)
   if (/^[0-9a-f]{2,}$/i.test(input)) {


### PR DESCRIPTION
## Summary
- Add `resolveProviderId`, `resolveAgentId`, and `resolveWebhookId` to `packages/cli/src/resolve.ts`, mirroring the existing `resolveKeyId` pattern (UUID → UUID prefix → exact name → name substring, ambiguity errors included).
- Wire the new resolvers into every command that accepts an `<id>` argument:
  - `providers`: `get`, `test`, `agents`, `teams`, `workflows`, `update`, `delete`
  - `agents`: `get`, `update`, `delete`
  - `webhooks`: `get`, `update`, `delete`
  - `follow-up`: dispatch by scope — `agents` → `resolveAgentId`, `instances` → `resolveInstanceId`, `chats` → `resolveChatId`
- Fixes #437: before, these commands required raw UUIDs; now they accept name, UUID prefix, or full UUID just like instances/chats/keys/automations.

## Test plan
- [x] `turbo typecheck` clean across all 20 packages (including `@automagik/omni`).
- [x] Full test suite run by pre-push hook: **3150 pass / 0 fail / 264 skip / 7695 expectations** across 225 files.
- [ ] Manual smoke: `omni providers get <name>`, `omni agents delete <name>`, `omni webhooks update <name> --disable`, `omni follow-up get agents <name>`.

Closes #437.