### PR TITLE
docs(wish): omni-scope-profiles — verb-bucket profile system

### DIFF
--- a/.genie/brainstorms/omni-scope-profiles/DESIGN.md
+++ b/.genie/brainstorms/omni-scope-profiles/DESIGN.md
@@ -40,17 +40,36 @@ A new resolver `verbsToScopes(buckets)` derives the concrete scope list. No cons
 
 ### 2. Five profile templates
 
-Each profile is a verb-bucket composition plus a set of enforcement locks. Every profile is expressible as a plain TypeScript object in `constants/profiles.ts`.
+Each profile is a verb-bucket composition plus optional per-verb overrides plus a set of enforcement locks. Every profile is expressible as a plain TypeScript object in `constants/profiles.ts` of shape:
+
+```ts
+type ProfileTemplate = {
+  name: 'cs' | 'personal' | 'scout' | 'coworker' | 'admin';
+  buckets: BucketName[];                 // whole-bucket inclusion
+  verbs?: { add?: Verb[]; remove?: Verb[] };  // per-verb delta on top of buckets
+  requiresLocks: LockField[];            // which lock arrays must be non-empty at create time
+  defaultLocks?: Partial<LockFields>;    // baked-in lock values (e.g. scout's ownerJid)
+};
+```
+
+Matrix (✓ = full bucket, ⊕ = bucket + extra verbs, ⊖ = bucket minus verbs, — = excluded):
 
 | Profile | `outgoing` | `read` | `context` | `turn` | `mm_in` | `mm_out` | Default locks |
 |---|---|---|---|---|---|---|---|
-| `cs` | ✓ | ✓ | open/close | ✓ | enterprise-override | enterprise-override | **chatAllowlist + instanceAllowlist required at create time** |
+| `cs` | ✓ | ✓ | ⊖ (no `use`) | ✓ | enterprise-override | enterprise-override | **chatAllowlist + instanceAllowlist required at create time** |
 | `personal` | per-instance | ✓ | ✓ | ✓ | ✓ | ✓ | `instanceAllowlist` + per-instance `outboundRecipientAllowlist` |
-| `scout` | **owner-only** | ✓ | `where` only | — | ✓ | — | `outboundRecipientAllowlist = [ownerJid]` (absolute — cannot be widened) |
+| `scout` | **owner-only** | ⊖ (no `history`) | — | — | ✓ | — | `outboundRecipientAllowlist = [ownerJid]` (absolute — cannot be widened) |
 | `coworker` | ✓ (multi-chat) | ✓ | ✓ | ✓ | ✓ | ✓ | `instanceAllowlist` + **output denylist** (redaction middleware) |
 | `admin` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | none |
 
+Concrete per-verb overrides:
+
+- `cs`: `buckets: ['outgoing', 'read', 'context', 'turn']`, `verbs: { remove: ['use'] }` — `use` lets a key switch active instance at the CLI level, which breaks the single-customer-per-key guarantee. A CS key is pinned to one instance by lock anyway, so `use` is pointless and revoking it prevents operator error.
+- `scout`: `buckets: ['outgoing', 'multimodal_in']`, `verbs: { add: ['where'], remove: ['history'] }` — scout needs to know which chat it's looking at (`where` reads state) but must never see prior-message history (`history`), because ingesting arbitrary customer chat context into a scout's alerting logic is a data-exfil vector.
+
 The `cs` multimodal buckets default to **off** and enterprises flip them on per-tenant via `profile_overrides`. The platform does not bake multimodal in because it is a commercial / regulatory choice downstream.
+
+**Resolver semantics.** `verbsToScopes(profile)` first expands `buckets` to a verb set, then applies `verbs.add` and `verbs.remove` in order, then maps the final verb set through the verb→scope table. `remove` of a verb not present is a no-op (safe). `add` of a verb already present is a no-op. The add/remove sets must be disjoint (validated at template load time — overlap throws).
 
 ### 3. Three new enforcement primitives in the scope-enforcer
 
@@ -60,7 +79,7 @@ The `cs` multimodal buckets default to **off** and enterprises flip them on per-
 - `instanceAllowlist: string[]` — any request whose target instance is not in the allowlist is denied. Enforces per-VM / per-tenant isolation.
 - `outboundRecipientAllowlist: string[]` — any `messages:send` whose target recipient JID is not in the allowlist is denied. Enforces scout's owner-only alerting and personal's bot-number allowlist.
 
-These locks live on the `agent_keys` row alongside `scopes`, so the middleware can enforce them with a single fetch that is already happening on every request.
+These locks live on the `api_keys` row alongside `scopes`, so the middleware can enforce them with a single fetch that is already happening on every request.
 
 ### 4. Output filter middleware for coworker secret redaction
 
@@ -90,7 +109,7 @@ This ensures no AI agent running non-interactively can ever mint a god-key, even
 
 ### 6. Data model
 
-Extend the `agent_keys` table:
+Extend the `api_keys` table:
 
 | Column | Type | Purpose |
 |---|---|---|
@@ -126,7 +145,7 @@ Non-admin profile creation remains non-interactive (scriptable by automations). 
 
 | Risk | Severity | Mitigation |
 |---|---|---|
-| Redactor middleware introduces send-path latency | Medium | Benchmark on CI. Denylist compiled once at startup. If latency > 10ms p99, move to async fire-and-forget with best-effort scrub |
+| Redactor middleware introduces send-path latency | Medium | Redaction stays **synchronous** — an async fire-and-forget path would leak the unredacted message into the channel's send buffer before the scrub completed, defeating the whole point. Mitigate via Aho-Corasick automaton (all literal denylist entries compiled into a single DFA, O(n) scan regardless of denylist size) + pre-compiled regex array for pattern entries. Benchmark on CI with a 1k-entry denylist over a 10KB message body; target p99 < 5ms. Cap denylist size per tenant at 10k entries with a CLI warning past that threshold. |
 | Enterprises want per-chat multimodal overrides inside a single CS tenant | Medium | `profile_overrides` is per-key already. A tenant can mint multiple CS keys with different multimodal configs per customer tier |
 | Admin TTY check breaks CI smoke tests | Low | Tests use the factory function directly with explicit "accept" flag that is not a CLI flag |
 | Scope-enforcer regression on existing keys | High | Every existing key gets a backfill migration that sets `profile = NULL`, `scopes` preserved verbatim. Enforcer reads `scopes` column regardless of profile — profile is metadata for audit |

--- a/.genie/brainstorms/omni-scope-profiles/DESIGN.md
+++ b/.genie/brainstorms/omni-scope-profiles/DESIGN.md
@@ -1,0 +1,133 @@
+# Design: Omni Scope Profiles
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `omni-scope-profiles` |
+| **Date** | 2026-04-19 |
+| **WRS** | 100/100 |
+| **Source** | Conversation in `agents/genie-configure` — Felipe clarified use cases and enforcement requirements |
+
+## Problem
+
+Omni's scope system today is a flat list of strings on each API key. Everyone who creates a key has to hand-author the scope array. There are no composable profiles, no instance/chat locks, and no output-side filtering. This makes it unsafe to issue a key to a customer-service agent, a coworker-facing PM agent, or an autonomous observer — every role would need a bespoke set of scopes and additional guardrails that don't exist yet.
+
+Four concrete use cases surfaced:
+
+1. **Customer Service (CS)** — a turn agent that speaks on behalf of a tenant to **one specific customer** at a time. Data is sensitive; the key must not be able to read a sibling customer's chat even by accident. Multimodal (image gen, TTS, vision) is an **enterprise preference**, not a platform default — some enterprises want it, others refuse.
+2. **Personal assistant (owner-only)** — the operator's own agent, permissive on their instances. On this operator's setup there are two numbers: a "bot number" that can send to an allowlist, and a "personal number" that is read-only so the agent can consume the stream without ever posting.
+3. **Scout (public observer)** — autonomous observer that reads conversations and can **only** send to the operator as alerts. Never replies to conversation participants. Has access to a personal brain for context enrichment.
+4. **Coworker PM** (the use case on the KHAL-OS VM) — a project manager agent with its own WhatsApp number that acts as a peer to employees. Answers tech/business/roadmap questions from multiple coworkers, eats meeting transcripts. **Must never reveal core code, secret sauce, or internal product knowledge** beyond what an employee is cleared to see.
+5. **Admin** — god key, everything on. Equivalent to `--dangerously-skip-permissions`. Only a human operator at a TTY should be able to mint one.
+
+## Decisions
+
+### 1. Profile is the primary abstraction, verbs are the building block
+
+Agents today invoke omni through **verb commands** (`say`, `react`, `listen`, `imagine`, `film`, `speak`, `see`, `history`, `open`, `close`, `use`, `where`, `done`, `send`). These verbs are the natural unit of capability. A profile is a composition of verb buckets + enforcement locks, not a hand-written scope array.
+
+**Verb buckets**
+
+| Bucket | Verbs | Underlying scopes |
+|---|---|---|
+| `outgoing` | `send`, `say`, `react` | `messages:send` |
+| `read` | `history`, `where` | `chats:read` |
+| `context` | `open`, `close`, `use` | `context:write`, `instances:read` |
+| `turn` | `done` | `turns:close` |
+| `multimodal_in` | `listen`, `see` | `media:read`, `messages:send` |
+| `multimodal_out` | `speak`, `imagine`, `film` | `tts:synthesize`, `media:write`, `messages:send` |
+
+A new resolver `verbsToScopes(buckets)` derives the concrete scope list. No consumer writes scope strings directly anymore.
+
+### 2. Five profile templates
+
+Each profile is a verb-bucket composition plus a set of enforcement locks. Every profile is expressible as a plain TypeScript object in `constants/profiles.ts`.
+
+| Profile | `outgoing` | `read` | `context` | `turn` | `mm_in` | `mm_out` | Default locks |
+|---|---|---|---|---|---|---|---|
+| `cs` | ✓ | ✓ | open/close | ✓ | enterprise-override | enterprise-override | **chatAllowlist + instanceAllowlist required at create time** |
+| `personal` | per-instance | ✓ | ✓ | ✓ | ✓ | ✓ | `instanceAllowlist` + per-instance `outboundRecipientAllowlist` |
+| `scout` | **owner-only** | ✓ | `where` only | — | ✓ | — | `outboundRecipientAllowlist = [ownerJid]` (absolute — cannot be widened) |
+| `coworker` | ✓ (multi-chat) | ✓ | ✓ | ✓ | ✓ | ✓ | `instanceAllowlist` + **output denylist** (redaction middleware) |
+| `admin` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | none |
+
+The `cs` multimodal buckets default to **off** and enterprises flip them on per-tenant via `profile_overrides`. The platform does not bake multimodal in because it is a commercial / regulatory choice downstream.
+
+### 3. Three new enforcement primitives in the scope-enforcer
+
+`packages/api/src/middleware/scope-enforcer.ts` is extended with:
+
+- `chatAllowlist: string[]` — any request whose target chat is not in the allowlist is denied. Enforces CS single-customer isolation.
+- `instanceAllowlist: string[]` — any request whose target instance is not in the allowlist is denied. Enforces per-VM / per-tenant isolation.
+- `outboundRecipientAllowlist: string[]` — any `messages:send` whose target recipient JID is not in the allowlist is denied. Enforces scout's owner-only alerting and personal's bot-number allowlist.
+
+These locks live on the `agent_keys` row alongside `scopes`, so the middleware can enforce them with a single fetch that is already happening on every request.
+
+### 4. Output filter middleware for coworker secret redaction
+
+Secret redaction is **not** a scope — a scope is about "can I make this call." Redaction is about "what can the response contain." It's a separate layer. New module:
+
+```
+packages/api/src/middleware/output-redactor.ts
+```
+
+At message-send time, the middleware runs the message body through a denylist of patterns and filenames. Matches are replaced with `[redacted]` and logged as a `secret.redacted` event. The denylist is per-profile and per-tenant:
+
+- **coworker** profile denylist: file paths under `repos/core/**`, specific keywords like `SECRET_SAUCE_TOKEN` or whatever the tenant configures, regex patterns for API keys / secrets.
+- Redaction logs are fed into Sentry so the operator sees when the agent *tried* to leak.
+
+Redaction applies to **outbound** messages only — the agent can still hold the context in memory; it just can't say it.
+
+This is an independent layer intentionally: an `admin` profile would skip redaction, a `cs` profile would use tenant-customized denylists, etc.
+
+### 5. Admin profile requires interactive TTY confirmation
+
+`omni keys create --profile admin` must:
+- Detect the process is attached to a TTY. Refuse to create without one.
+- Prompt the operator: `You are about to create an ADMIN key with all scopes and no locks. This bypasses every profile enforcement. Type "I UNDERSTAND" to continue:` — case-sensitive exact match required.
+- Log a `key.admin_created` audit event with operator identity + timestamp.
+
+This ensures no AI agent running non-interactively can ever mint a god-key, even if it somehow acquires enough scope to call `keys:write`.
+
+### 6. Data model
+
+Extend the `agent_keys` table:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `profile` | `text` (nullable) | Profile name (`cs`, `personal`, `scout`, `coworker`, `admin`) |
+| `profile_overrides` | `jsonb` (nullable) | Per-key overrides merged on top of template. Holds tenant multimodal prefs, denylist additions, allowlist extensions |
+| `chat_allowlist` | `text[]` (default empty) | Chat JIDs this key may touch |
+| `instance_allowlist` | `text[]` (default empty) | Instance IDs this key may touch |
+| `outbound_recipient_allowlist` | `text[]` (default empty) | Recipient JIDs this key may `messages:send` to |
+
+`scopes` column stays — it's still the canonical enforcement surface. The resolver populates it from `profile + profile_overrides` at key create time, so no existing enforcer code has to change its shape.
+
+### 7. CLI surface
+
+```bash
+omni keys create --profile cs --lock-chat <jid> --lock-instance <id> --name "acme-corp-support"
+omni keys create --profile personal --lock-instance <jid1> --lock-instance <jid2>
+omni keys create --profile scout --owner <ownerJid>
+omni keys create --profile coworker --lock-instance <id> --denylist-preset khal-os-core
+omni keys create --profile admin       # interactive confirmation
+```
+
+Non-admin profile creation remains non-interactive (scriptable by automations). Admin is the sole gated path.
+
+## Non-goals
+
+- **Profile editing of existing keys.** Keys are immutable — rotation means revoke + recreate. This avoids the "silently widened key" footgun.
+- **Dynamic verb additions.** The verb set is frozen at each omni release. New verbs land in a new release, and profiles reference them by name.
+- **Custom profile authoring via the API.** Profiles are code-defined. Tenants can override via `profile_overrides` but cannot create a fully custom `cs-for-acme` profile in the DB. (If that ever becomes necessary, it's a follow-up wish — the override layer is the forward compat.)
+- **Secret-redaction denylist management UI.** Denylists are code/config for this wish. A management UI is a separate wish.
+- **Brain integration.** The `coworker` profile references a brain for context but the omni side is agnostic about where the brain lives. Brain wiring is a consumer-side concern (separate wish in khal-os repo for the khal-os PM consumer).
+
+## Open risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Redactor middleware introduces send-path latency | Medium | Benchmark on CI. Denylist compiled once at startup. If latency > 10ms p99, move to async fire-and-forget with best-effort scrub |
+| Enterprises want per-chat multimodal overrides inside a single CS tenant | Medium | `profile_overrides` is per-key already. A tenant can mint multiple CS keys with different multimodal configs per customer tier |
+| Admin TTY check breaks CI smoke tests | Low | Tests use the factory function directly with explicit "accept" flag that is not a CLI flag |
+| Scope-enforcer regression on existing keys | High | Every existing key gets a backfill migration that sets `profile = NULL`, `scopes` preserved verbatim. Enforcer reads `scopes` column regardless of profile — profile is metadata for audit |
+| Output redactor corrupts a legitimate business message | Medium | Redaction emits a `secret.redacted` event with the matched pattern — operator can audit false positives and tune denylist |

--- a/.genie/wishes/omni-scope-profiles/WISH.md
+++ b/.genie/wishes/omni-scope-profiles/WISH.md
@@ -19,7 +19,7 @@ Introduce **profiles** as the primary abstraction for issuing omni API keys. A p
 - New `packages/api/src/lib/verbs-to-scopes.ts` resolver (buckets + overrides → flat scope list)
 - Extend `scope-enforcer.ts` middleware with `chatAllowlist`, `instanceAllowlist`, `outboundRecipientAllowlist` checks
 - New `packages/api/src/middleware/output-redactor.ts` for per-profile/per-tenant secret redaction on outbound messages, with `secret.redacted` event emission
-- Drizzle migration: add `profile`, `profile_overrides`, `chat_allowlist`, `instance_allowlist`, `outbound_recipient_allowlist` columns to `agent_keys`
+- Drizzle migration: add `profile`, `profile_overrides`, `chat_allowlist`, `instance_allowlist`, `outbound_recipient_allowlist` columns to `api_keys`
 - Extend `omni keys create` CLI with `--profile`, `--lock-chat`, `--lock-instance`, `--owner`, `--denylist-preset` flags
 - Interactive TTY confirmation for `--profile admin` (case-sensitive "I UNDERSTAND" prompt) + `key.admin_created` audit event
 - Unit tests for: resolver, every profile template, every new enforcement primitive, redactor middleware, admin TTY gate
@@ -59,7 +59,7 @@ Introduce **profiles** as the primary abstraction for issuing omni API keys. A p
 - [ ] All 5 profile templates resolve to a scope list via `verbsToScopes()` — scope set matches the documented expectation in each profile's unit test
 - [ ] Existing keys continue to work unmodified (backfill migration sets `profile = NULL`, preserves `scopes` verbatim)
 - [ ] `secret.redacted` event fires when the coworker redactor catches a pattern match on an outgoing message
-- [ ] OpenAPI docs include the new `agent_keys` fields; CLI help text documents `--profile`, `--lock-chat`, `--lock-instance`, `--owner`, `--denylist-preset`
+- [ ] OpenAPI docs include the new `api_keys` fields; CLI help text documents `--profile`, `--lock-chat`, `--lock-instance`, `--owner`, `--denylist-preset`
 - [ ] `docs/profiles.md` exists and documents every profile's verb buckets, default locks, override shape, and an example `omni keys create` invocation
 
 ## Execution Strategy
@@ -69,7 +69,7 @@ Introduce **profiles** as the primary abstraction for issuing omni API keys. A p
 | Group | Agent | Description |
 |-------|-------|-------------|
 | 1 | engineer | Verbs enum + verb-bucket groupings (`constants/verbs.ts`) |
-| 3 | engineer | Drizzle migration for `agent_keys` columns |
+| 3 | engineer | Drizzle migration for `api_keys` columns |
 
 ### Wave 2 (parallel — after Wave 1)
 
@@ -128,15 +128,20 @@ cd packages/api && bun test src/constants/__tests__/verbs.test.ts
 ---
 
 ### Group 2: verbsToScopes resolver
-**Goal:** Pure function that takes a profile shape + overrides and returns a flat deduplicated scope array.
+**Goal:** Pure function that takes a profile shape (buckets + per-verb add/remove + extra scopes) and returns a flat deduplicated scope array.
 **Deliverables:**
-1. `packages/api/src/lib/verbs-to-scopes.ts` exporting `verbsToScopes(input: { buckets: VerbBucket[]; extraScopes?: string[] }): string[]`
-2. Dedup + sort for deterministic output
+1. `packages/api/src/lib/verbs-to-scopes.ts` exporting `verbsToScopes(input: { buckets: VerbBucket[]; verbs?: { add?: Verb[]; remove?: Verb[] }; extraScopes?: string[] }): string[]`
+2. Resolver expands `buckets` → verb set, applies `verbs.add` then `verbs.remove`, maps final verb set through verb→scope table, merges `extraScopes`, dedups, sorts
+3. Throws on `verbs.add` and `verbs.remove` overlap (disjointness invariant)
 
 **Acceptance Criteria:**
 - [ ] Given `{ buckets: ['outgoing'] }` returns `['messages:send']`
 - [ ] Given `{ buckets: ['outgoing', 'multimodal_out'] }` returns the union, deduped
 - [ ] Given `{ buckets: ['outgoing'], extraScopes: ['chats:read'] }` adds the extra
+- [ ] Given `{ buckets: ['read'], verbs: { remove: ['history'] } }` omits the `chats:read` scope contribution from `history` (scout case)
+- [ ] Given `{ buckets: ['outgoing'], verbs: { add: ['where'] } }` includes scopes for `where` even though it lives in a different bucket (scout case)
+- [ ] Given `{ buckets: ['context'], verbs: { remove: ['use'] } }` omits `use`'s scope contribution (cs case)
+- [ ] `verbs.add` and `verbs.remove` sharing any verb throws at resolver call time
 - [ ] Output is sorted (deterministic snapshots)
 
 **Validation:**
@@ -148,7 +153,7 @@ cd packages/api && bun test src/lib/__tests__/verbs-to-scopes.test.ts
 
 ---
 
-### Group 3: Drizzle migration for agent_keys
+### Group 3: Drizzle migration for api_keys
 **Goal:** Add profile metadata + allowlist columns without breaking existing keys.
 **Deliverables:**
 1. Schema edit in `packages/db/src/schema.ts` adding 5 columns (`profile`, `profile_overrides`, `chat_allowlist`, `instance_allowlist`, `outbound_recipient_allowlist`)
@@ -174,7 +179,9 @@ make test-api
 **Goal:** 5 code-defined profiles consumable by the CLI and the key-creation route.
 **Deliverables:**
 1. `packages/api/src/constants/profiles.ts` exporting `PROFILES: Record<ProfileName, ProfileTemplate>`
-2. `ProfileTemplate` type: `{ buckets: VerbBucket[]; requiresLocks: LockRequirement[]; defaultOverrides?: Partial<ProfileOverrides>; adminOnlyFlag?: true }`
+2. `ProfileTemplate` type: `{ buckets: VerbBucket[]; verbs?: { add?: Verb[]; remove?: Verb[] }; requiresLocks: LockRequirement[]; defaultOverrides?: Partial<ProfileOverrides>; adminOnlyFlag?: true }`
+3. `cs` template: `buckets: ['outgoing','read','context','turn']`, `verbs: { remove: ['use'] }` (CS key is locked to one instance; `use` would defeat the lock)
+4. `scout` template: `buckets: ['outgoing','multimodal_in']`, `verbs: { add: ['where'], remove: ['history'] }` (scout can locate current chat but never ingest prior history — data-exfil prevention)
 3. Unit tests asserting each template's resolved scope list
 
 **Acceptance Criteria:**
@@ -182,6 +189,8 @@ make test-api
 - [ ] `scout` template has `outboundRecipientAllowlist` as a locked override (not tenant-editable)
 - [ ] `coworker` template defaults `outputDenylist` to a documented preset
 - [ ] `admin` template has `adminOnlyFlag: true` — rejected by non-TTY callers
+- [ ] `cs` resolved scope list does NOT include `use`'s scope contribution (bucket minus verb)
+- [ ] `scout` resolved scope list includes scopes needed for `where`, does NOT include `history`'s contribution
 - [ ] Unit test snapshot confirms resolved scope list per template
 
 **Validation:**
@@ -349,7 +358,7 @@ packages/api/src/middleware/__tests__/output-redactor.test.ts (new)
 packages/api/bench/output-redactor.bench.ts              (new)
 packages/api/src/routes/v2/keys.ts                       (edit)
 packages/db/src/schema.ts                                (edit)
-packages/db/drizzle/NNNN_agent_keys_profiles.sql         (new, generated)
+packages/db/drizzle/NNNN_api_keys_profiles.sql           (new, generated)
 packages/cli/src/commands/keys.ts                        (edit)
 packages/cli/src/commands/__tests__/keys.test.ts         (edit)
 docs/profiles.md                                         (new)

--- a/.genie/wishes/omni-scope-profiles/WISH.md
+++ b/.genie/wishes/omni-scope-profiles/WISH.md
@@ -45,6 +45,8 @@ Introduce **profiles** as the primary abstraction for issuing omni API keys. A p
 | Output redactor is middleware, not a scope | Scopes gate "can I make this API call" — redaction gates "what can the response contain." Different layer |
 | Admin key creation requires TTY + exact-match prompt | Prevents any non-interactive caller (AI agents, scripts, CI) from ever minting a god-key — even one that has `keys:write`. Human-gated by construction |
 | `chat_allowlist` / `instance_allowlist` / `outbound_recipient_allowlist` are `text[]` columns, not a separate join table | Small cardinality (tens, not thousands), read on every authed request, denormalized for latency |
+| Denylist presets (e.g. `khal-os-core`) are loaded from tenant config/env at key-creation time, **not bundled** in omni source | Keeps platform/consumer boundary clean. `profiles.ts` ships only a `coworker.defaultDenylistPresetKey: string` pointer; the actual pattern list is resolved from `OMNI_DENYLIST_PRESETS` env (or equivalent tenant config) at runtime. Consumer-specific secret-sauce taxonomy (khal-os core paths, specific token names) never enters the omni platform repo |
+| Empty allowlist is profile-aware: legacy NULL-profile keys treat `[]` as "no lock" (backward compat); profile keys where the template declares `requiresLocks` treat `[]` as "deny all" | Prevents a cleared allowlist (via direct DB edit, bug, or misuse) from silently granting unrestricted access on a profile that was explicitly designed to be scoped |
 
 ## Success Criteria
 
@@ -62,34 +64,44 @@ Introduce **profiles** as the primary abstraction for issuing omni API keys. A p
 
 ## Execution Strategy
 
-### Wave 1 (parallel — foundational, no dependencies)
+### Wave 1 (parallel — truly no dependencies)
 
 | Group | Agent | Description |
 |-------|-------|-------------|
 | 1 | engineer | Verbs enum + verb-bucket groupings (`constants/verbs.ts`) |
-| 2 | engineer | `verbsToScopes()` resolver (`lib/verbs-to-scopes.ts`) |
 | 3 | engineer | Drizzle migration for `agent_keys` columns |
 
-### Wave 2 (after Wave 1)
+### Wave 2 (parallel — after Wave 1)
 
 | Group | Agent | Description |
 |-------|-------|-------------|
-| 4 | engineer | 5 profile templates (`constants/profiles.ts`) — consumes Groups 1 + 2 |
+| 2 | engineer | `verbsToScopes()` resolver — consumes Group 1 |
 | 5 | engineer | Scope-enforcer extensions (chat/instance/outbound allowlists) — consumes Group 3 |
 
 ### Wave 3 (after Wave 2)
 
 | Group | Agent | Description |
 |-------|-------|-------------|
-| 6 | engineer | Output-redactor middleware + `secret.redacted` events |
-| 7 | engineer | CLI extensions (`omni keys create --profile …`) + admin TTY gate |
+| 4 | engineer | 5 profile templates (`constants/profiles.ts`) — consumes Groups 1 + 2 |
 
-### Wave 4 (after all above)
+### Wave 4 (after Wave 3)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 6 | engineer | Output-redactor middleware + `secret.redacted` events — consumes Group 4 |
+
+### Wave 5 (after Wave 4)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 7 | engineer | CLI extensions (`omni keys create --profile …`) + admin TTY gate + API-route guard — consumes Groups 4 + 5 + 6 |
+
+### Wave 6 (after Wave 5)
 
 | Group | Agent | Description |
 |-------|-------|-------------|
 | 8 | engineer | Docs (`docs/profiles.md`) + OpenAPI regen + CLI help polish |
-| review | reviewer | Full-wish review — security focus on admin gate + enforcer primitives |
+| review | reviewer | Full-wish review — security focus on admin gate + enforcer primitives + API-route guard |
 | qa | qa | Integration tests on dev — every profile + every lock primitive |
 
 ## Execution Groups
@@ -192,7 +204,10 @@ cd packages/api && bun test src/constants/__tests__/profiles.test.ts
 - [ ] Request to `POST /chats/:otherJid/messages` from a cs-locked key returns 403 with `lock: chatAllowlist`
 - [ ] `messages:send` to a non-allowlisted recipient from a scout key returns 403 with `lock: outboundRecipientAllowlist`
 - [ ] Request against an instance not in `instance_allowlist` returns 403 with `lock: instanceAllowlist`
-- [ ] Empty allowlist (`[]`) is treated as "no lock" (not "deny all") — backward compat for pre-profile keys
+- [ ] Empty allowlist semantics are **profile-aware**:
+  - For keys with `profile IS NULL` (pre-profile legacy keys), empty `[]` = "no lock" (backward compat)
+  - For keys with `profile != NULL` where the profile template declares the lock in `requiresLocks` (e.g. `cs` requires `chatAllowlist` + `instanceAllowlist`, `scout` requires `outboundRecipientAllowlist`), empty `[]` = **deny all** — never "no lock". This closes the hole where a cleared allowlist silently grants unrestricted access.
+  - Unit test covers both cases: legacy key with `[]` allowed; profile key with `requiresLocks` lock cleared to `[]` denied with `lock: <name> (deny-all: profile requires lock)`.
 - [ ] Unit tests cover allow + deny per primitive
 
 **Validation:**
@@ -242,10 +257,12 @@ bun run bench/output-redactor.bench.ts
 - [ ] `omni keys create --profile admin` on a TTY prompts exactly the DESIGN-documented text
 - [ ] Wrong confirmation text aborts with exit code 1 and no key created
 - [ ] `omni events --type key.admin_created` shows the event after success
+- [ ] API route `POST /keys` rejects `{ profile: 'admin' }` unconditionally with 403 — admin key minting is CLI-only and never reachable via HTTP. `operator_confirmed` is never a valid request body field; the API route does not read it. Enforced at the route layer (not just the CLI flag parser) so `keys:write` scope alone cannot mint a god-key. Integration test proves it: POST with `{profile:'admin',operator_confirmed:true}` returns 403.
 
 **Validation:**
 ```bash
 cd packages/cli && bun test src/commands/__tests__/keys.test.ts
+cd packages/api && bun test src/routes/v2/__tests__/keys-admin-route-guard.test.ts
 # manual TTY verification step (documented in QA criteria)
 ```
 

--- a/.genie/wishes/omni-scope-profiles/WISH.md
+++ b/.genie/wishes/omni-scope-profiles/WISH.md
@@ -1,0 +1,340 @@
+# Wish: Omni Scope Profiles
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `omni-scope-profiles` |
+| **Date** | 2026-04-19 |
+| **Design** | [DESIGN.md](../../brainstorms/omni-scope-profiles/DESIGN.md) |
+
+## Summary
+
+Introduce **profiles** as the primary abstraction for issuing omni API keys. A profile is a composition of verb buckets plus enforcement locks (chat, instance, outbound recipient). Replace hand-authored scope arrays with code-defined templates — `cs`, `personal`, `scout`, `coworker`, `admin` — that map onto concrete scopes via a new `verbsToScopes` resolver. Extend the scope-enforcer with three new primitives (`chatAllowlist`, `instanceAllowlist`, `outboundRecipientAllowlist`) and add an output-redactor middleware so the `coworker` profile can run as a peer-to-employees agent without leaking secret sauce. Gate `admin` key creation behind interactive TTY confirmation so no AI can mint a god-key.
+
+## Scope
+
+### IN
+- New `packages/api/src/constants/verbs.ts` with verb enum + verb-bucket groupings
+- New `packages/api/src/constants/profiles.ts` with 5 profile templates (`cs`, `personal`, `scout`, `coworker`, `admin`)
+- New `packages/api/src/lib/verbs-to-scopes.ts` resolver (buckets + overrides → flat scope list)
+- Extend `scope-enforcer.ts` middleware with `chatAllowlist`, `instanceAllowlist`, `outboundRecipientAllowlist` checks
+- New `packages/api/src/middleware/output-redactor.ts` for per-profile/per-tenant secret redaction on outbound messages, with `secret.redacted` event emission
+- Drizzle migration: add `profile`, `profile_overrides`, `chat_allowlist`, `instance_allowlist`, `outbound_recipient_allowlist` columns to `agent_keys`
+- Extend `omni keys create` CLI with `--profile`, `--lock-chat`, `--lock-instance`, `--owner`, `--denylist-preset` flags
+- Interactive TTY confirmation for `--profile admin` (case-sensitive "I UNDERSTAND" prompt) + `key.admin_created` audit event
+- Unit tests for: resolver, every profile template, every new enforcement primitive, redactor middleware, admin TTY gate
+- OpenAPI docs regenerated with new fields + CLI help text updated
+- Docs in `docs/profiles.md` documenting each template, its locks, and override shape
+
+### OUT
+- Profile editing on existing keys (keys are immutable — rotate via revoke + recreate)
+- Dynamic verb additions at runtime (verbs frozen per omni release)
+- Custom profile authoring via API (only `profile_overrides` is tenant-editable)
+- Secret-redaction denylist management UI (config/env only for this wish)
+- Brain wiring for the `coworker` profile (consumer-side concern — separate wish in khal-os repo)
+- Meeting-data ingest pipeline for coworker (consumer-side)
+- UI/dashboard changes for profile visualization
+
+## Decisions
+
+| Decision | Rationale |
+|---|---|
+| Profiles are code-defined, not DB-defined | Type-safe, no round-trip per auth request, reviewable in PR. Overrides at tenant level land in a jsonb column — forward-compat without losing profile integrity |
+| Verb buckets are the authoring unit, not raw scopes | Consumers shouldn't need to know scope names. Buckets map 1:1 to capabilities the agent actually uses |
+| `scopes` column stays as the enforcement surface | Enforcer does not need to know about profiles. Profile resolver populates `scopes` at key create time. Backward compatible with every existing key — they get `profile = NULL` |
+| Output redactor is middleware, not a scope | Scopes gate "can I make this API call" — redaction gates "what can the response contain." Different layer |
+| Admin key creation requires TTY + exact-match prompt | Prevents any non-interactive caller (AI agents, scripts, CI) from ever minting a god-key — even one that has `keys:write`. Human-gated by construction |
+| `chat_allowlist` / `instance_allowlist` / `outbound_recipient_allowlist` are `text[]` columns, not a separate join table | Small cardinality (tens, not thousands), read on every authed request, denormalized for latency |
+
+## Success Criteria
+
+- [ ] `omni keys create --profile cs --lock-chat <jid> --lock-instance <id>` creates a key whose enforcer denies any request targeting a different chat or instance
+- [ ] `omni keys create --profile scout --owner <jid>` creates a key that can only `messages:send` to `<jid>` — any other recipient returns 403
+- [ ] `omni keys create --profile coworker --lock-instance <id>` creates a key whose outbound messages are scrubbed against the coworker denylist before delivery
+- [ ] `omni keys create --profile admin` refuses to proceed when stdin is not a TTY
+- [ ] `omni keys create --profile admin` on a TTY requires the operator to type `I UNDERSTAND` exactly — any other input aborts
+- [ ] `key.admin_created` event is emitted for every admin key creation with operator identity + timestamp
+- [ ] All 5 profile templates resolve to a scope list via `verbsToScopes()` — scope set matches the documented expectation in each profile's unit test
+- [ ] Existing keys continue to work unmodified (backfill migration sets `profile = NULL`, preserves `scopes` verbatim)
+- [ ] `secret.redacted` event fires when the coworker redactor catches a pattern match on an outgoing message
+- [ ] OpenAPI docs include the new `agent_keys` fields; CLI help text documents `--profile`, `--lock-chat`, `--lock-instance`, `--owner`, `--denylist-preset`
+- [ ] `docs/profiles.md` exists and documents every profile's verb buckets, default locks, override shape, and an example `omni keys create` invocation
+
+## Execution Strategy
+
+### Wave 1 (parallel — foundational, no dependencies)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Verbs enum + verb-bucket groupings (`constants/verbs.ts`) |
+| 2 | engineer | `verbsToScopes()` resolver (`lib/verbs-to-scopes.ts`) |
+| 3 | engineer | Drizzle migration for `agent_keys` columns |
+
+### Wave 2 (after Wave 1)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 4 | engineer | 5 profile templates (`constants/profiles.ts`) — consumes Groups 1 + 2 |
+| 5 | engineer | Scope-enforcer extensions (chat/instance/outbound allowlists) — consumes Group 3 |
+
+### Wave 3 (after Wave 2)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 6 | engineer | Output-redactor middleware + `secret.redacted` events |
+| 7 | engineer | CLI extensions (`omni keys create --profile …`) + admin TTY gate |
+
+### Wave 4 (after all above)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 8 | engineer | Docs (`docs/profiles.md`) + OpenAPI regen + CLI help polish |
+| review | reviewer | Full-wish review — security focus on admin gate + enforcer primitives |
+| qa | qa | Integration tests on dev — every profile + every lock primitive |
+
+## Execution Groups
+
+### Group 1: Verbs enum + bucket groupings
+**Goal:** Canonical verb vocabulary and capability buckets usable by profiles and resolver.
+**Deliverables:**
+1. `packages/api/src/constants/verbs.ts` with `VERBS` enum (all 14 current verbs) and `VERB_BUCKETS` mapping
+2. Exported type `VerbBucket = 'outgoing' | 'read' | 'context' | 'turn' | 'multimodal_in' | 'multimodal_out'`
+3. Exported `bucketToScopes: Record<VerbBucket, string[]>` table
+
+**Acceptance Criteria:**
+- [ ] All 14 verbs present with correct bucket assignment per DESIGN.md
+- [ ] Unit test proves every bucket resolves to the documented scope list
+- [ ] No duplicate scopes in a single bucket's list
+
+**Validation:**
+```bash
+cd packages/api && bun test src/constants/__tests__/verbs.test.ts
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: verbsToScopes resolver
+**Goal:** Pure function that takes a profile shape + overrides and returns a flat deduplicated scope array.
+**Deliverables:**
+1. `packages/api/src/lib/verbs-to-scopes.ts` exporting `verbsToScopes(input: { buckets: VerbBucket[]; extraScopes?: string[] }): string[]`
+2. Dedup + sort for deterministic output
+
+**Acceptance Criteria:**
+- [ ] Given `{ buckets: ['outgoing'] }` returns `['messages:send']`
+- [ ] Given `{ buckets: ['outgoing', 'multimodal_out'] }` returns the union, deduped
+- [ ] Given `{ buckets: ['outgoing'], extraScopes: ['chats:read'] }` adds the extra
+- [ ] Output is sorted (deterministic snapshots)
+
+**Validation:**
+```bash
+cd packages/api && bun test src/lib/__tests__/verbs-to-scopes.test.ts
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Drizzle migration for agent_keys
+**Goal:** Add profile metadata + allowlist columns without breaking existing keys.
+**Deliverables:**
+1. Schema edit in `packages/db/src/schema.ts` adding 5 columns (`profile`, `profile_overrides`, `chat_allowlist`, `instance_allowlist`, `outbound_recipient_allowlist`)
+2. `bunx drizzle-kit generate` produces migration file
+3. Existing keys backfill: migration sets `profile = NULL`, other columns default to `[]` or `{}`
+
+**Acceptance Criteria:**
+- [ ] `make test-api` green after migration applies
+- [ ] Existing key rows are unmodified for `scopes` column
+- [ ] Drizzle journal entry committed alongside SQL
+
+**Validation:**
+```bash
+cd packages/db && bunx drizzle-kit check
+make test-api
+```
+
+**depends-on:** none
+
+---
+
+### Group 4: Profile templates
+**Goal:** 5 code-defined profiles consumable by the CLI and the key-creation route.
+**Deliverables:**
+1. `packages/api/src/constants/profiles.ts` exporting `PROFILES: Record<ProfileName, ProfileTemplate>`
+2. `ProfileTemplate` type: `{ buckets: VerbBucket[]; requiresLocks: LockRequirement[]; defaultOverrides?: Partial<ProfileOverrides>; adminOnlyFlag?: true }`
+3. Unit tests asserting each template's resolved scope list
+
+**Acceptance Criteria:**
+- [ ] `cs` template requires `chatAllowlist` + `instanceAllowlist` at create time
+- [ ] `scout` template has `outboundRecipientAllowlist` as a locked override (not tenant-editable)
+- [ ] `coworker` template defaults `outputDenylist` to a documented preset
+- [ ] `admin` template has `adminOnlyFlag: true` — rejected by non-TTY callers
+- [ ] Unit test snapshot confirms resolved scope list per template
+
+**Validation:**
+```bash
+cd packages/api && bun test src/constants/__tests__/profiles.test.ts
+```
+
+**depends-on:** Group 1, Group 2
+
+---
+
+### Group 5: Scope-enforcer extensions
+**Goal:** Middleware denies requests that violate chat/instance/outbound-recipient locks.
+**Deliverables:**
+1. Extend `packages/api/src/middleware/scope-enforcer.ts` with three new check functions
+2. Extract target chat/instance/recipient from the request body via a small helper per route category
+3. 403 responses include the lock that matched + the attempted value (for operator debugging)
+
+**Acceptance Criteria:**
+- [ ] Request to `POST /chats/:otherJid/messages` from a cs-locked key returns 403 with `lock: chatAllowlist`
+- [ ] `messages:send` to a non-allowlisted recipient from a scout key returns 403 with `lock: outboundRecipientAllowlist`
+- [ ] Request against an instance not in `instance_allowlist` returns 403 with `lock: instanceAllowlist`
+- [ ] Empty allowlist (`[]`) is treated as "no lock" (not "deny all") — backward compat for pre-profile keys
+- [ ] Unit tests cover allow + deny per primitive
+
+**Validation:**
+```bash
+cd packages/api && bun test src/middleware/__tests__/scope-enforcer.test.ts
+```
+
+**depends-on:** Group 3
+
+---
+
+### Group 6: Output-redactor middleware
+**Goal:** Scrub outbound message bodies against per-profile denylists before delivery.
+**Deliverables:**
+1. `packages/api/src/middleware/output-redactor.ts` that runs on the send-message pipeline
+2. Denylist compiled once at startup from `profiles.ts` preset + per-key `profile_overrides.denylistExtras`
+3. `secret.redacted` event emitted with matched pattern + message ID
+4. Benchmark: send-path p99 latency overhead < 10ms for a 2KB body against a 200-entry denylist
+
+**Acceptance Criteria:**
+- [ ] Coworker profile with denylist preset `khal-os-core` scrubs a message containing a denied keyword to `[redacted]`
+- [ ] Admin profile bypasses redaction entirely
+- [ ] `secret.redacted` event fires on every redaction with full metadata
+- [ ] Benchmark in `packages/api/bench/output-redactor.bench.ts` passes latency budget
+
+**Validation:**
+```bash
+cd packages/api && bun test src/middleware/__tests__/output-redactor.test.ts
+bun run bench/output-redactor.bench.ts
+```
+
+**depends-on:** Group 4
+
+---
+
+### Group 7: CLI key-creation surface
+**Goal:** `omni keys create --profile …` resolves profile to columns and persists via API.
+**Deliverables:**
+1. Extend `packages/cli/src/commands/keys.ts` with new flags: `--profile`, `--lock-chat` (repeatable), `--lock-instance` (repeatable), `--owner`, `--denylist-preset`
+2. For `--profile admin`: detect TTY via `process.stdin.isTTY`, prompt for `I UNDERSTAND`, abort on mismatch or pipe
+3. API route `POST /keys` accepts `{ profile, overrides }` and resolves via `verbsToScopes` + profile template
+4. `key.admin_created` audit event on admin creation
+
+**Acceptance Criteria:**
+- [ ] `omni keys create --profile scout --owner <jid>` persists a key with the expected scopes + outbound lock
+- [ ] `echo "" | omni keys create --profile admin` refuses with "admin keys require a TTY"
+- [ ] `omni keys create --profile admin` on a TTY prompts exactly the DESIGN-documented text
+- [ ] Wrong confirmation text aborts with exit code 1 and no key created
+- [ ] `omni events --type key.admin_created` shows the event after success
+
+**Validation:**
+```bash
+cd packages/cli && bun test src/commands/__tests__/keys.test.ts
+# manual TTY verification step (documented in QA criteria)
+```
+
+**depends-on:** Group 4, Group 5, Group 6
+
+---
+
+### Group 8: Docs + OpenAPI regen
+**Goal:** Every new surface is documented and the SDK knows the new fields exist.
+**Deliverables:**
+1. `docs/profiles.md` with one section per profile: verb buckets, default locks, overrides, CLI invocation example
+2. `make sdk-generate` produces updated SDK with new key fields
+3. CLI `--help` text for `keys create` lists every new flag with a one-line description
+4. Changelog entry in keepachangelog format
+
+**Acceptance Criteria:**
+- [ ] `docs/profiles.md` covers all 5 profiles with at least one example each
+- [ ] SDK has new typed `profile` field on key-create input + response
+- [ ] CLI `omni keys create --help` includes `--profile`, `--lock-chat`, `--lock-instance`, `--owner`, `--denylist-preset`
+- [ ] Changelog entry under `Unreleased`
+
+**Validation:**
+```bash
+make sdk-generate && git diff --exit-code packages/sdk/src/generated  # should either be clean or include only expected additions
+omni keys create --help | grep -E '\-\-profile|\-\-lock-chat|\-\-lock-instance|\-\-owner|\-\-denylist-preset' | wc -l  # expects 5
+```
+
+**depends-on:** Group 7
+
+---
+
+## QA Criteria
+
+_What must be verified on dev after merge. The QA agent tests each criterion._
+
+- [ ] Create one key per profile on a dev omni and exercise a representative call per profile — expected allows succeed, expected denies return 403 with the correct `lock:` field
+- [ ] Admin creation via non-TTY (pipe) is refused; via TTY with the correct phrase succeeds
+- [ ] Secret redaction fires on a coworker key sending a message containing a denied keyword; `secret.redacted` event visible via `omni events`
+- [ ] Existing (pre-migration) keys continue working without change — sample five from dev and exercise their current scopes
+- [ ] Benchmark run on dev: redactor adds < 10ms p99 on a representative payload
+- [ ] OpenAPI surface at `/api/v2/docs` renders new fields; SDK type-checks
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Output redactor introduces meaningful send-path latency | Medium | Benchmark in Group 6 with a hard budget. Compile denylist once; use a single-pass Aho-Corasick over a regex union |
+| Admin TTY check breaks smoke tests in CI | Low | Tests bypass the CLI and call the factory with an explicit `operator_confirmed: true` flag that is NOT a CLI flag |
+| A consumer has a legitimate business message that matches the denylist | Medium | Redactor emits `secret.redacted` events so operators can audit false positives; denylist is tunable per-tenant |
+| Backward compat for pre-profile keys regresses | High | Group 3 backfill sets `profile = NULL` and preserves `scopes`. Enforcer reads `scopes` regardless — profile is metadata. Added integration test: five fixture pre-profile keys still pass their existing allow/deny matrix |
+| A tenant requests a fully custom profile | Low | Override surface (`profile_overrides`) handles most cases. Fully custom templates are deferred to a follow-up wish — documented in OUT scope |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Follow-up wishes (not this scope)
+
+- **`omni-coworker-consumer`** (lives in `agents/khal-os` repo) — wire the khal-os PM agent to a WhatsApp instance using the `coworker` profile, connect to its own brain, ingest meeting transcripts
+- **`omni-scout-consumer`** (lives in operator's personal VM) — scout agent using the `scout` profile + personal brain
+- **`omni-profile-management-ui`** — dashboard view to inspect profiles, override denylists, rotate keys
+
+---
+
+## Files to Create/Modify
+
+```
+packages/api/src/constants/verbs.ts                      (new)
+packages/api/src/constants/profiles.ts                   (new)
+packages/api/src/constants/__tests__/verbs.test.ts       (new)
+packages/api/src/constants/__tests__/profiles.test.ts    (new)
+packages/api/src/lib/verbs-to-scopes.ts                  (new)
+packages/api/src/lib/__tests__/verbs-to-scopes.test.ts   (new)
+packages/api/src/middleware/scope-enforcer.ts            (edit)
+packages/api/src/middleware/__tests__/scope-enforcer.test.ts (edit)
+packages/api/src/middleware/output-redactor.ts           (new)
+packages/api/src/middleware/__tests__/output-redactor.test.ts (new)
+packages/api/bench/output-redactor.bench.ts              (new)
+packages/api/src/routes/v2/keys.ts                       (edit)
+packages/db/src/schema.ts                                (edit)
+packages/db/drizzle/NNNN_agent_keys_profiles.sql         (new, generated)
+packages/cli/src/commands/keys.ts                        (edit)
+packages/cli/src/commands/__tests__/keys.test.ts         (edit)
+docs/profiles.md                                         (new)
+CHANGELOG.md                                             (edit)
+```


### PR DESCRIPTION
## Summary

Planning artifacts only — introduces **profiles** as the primary abstraction for API keys:

- 5 templates: `cs`, `personal`, `scout`, `coworker`, `admin`
- Composed from **verb buckets** (`outgoing`, `read`, `context`, `turn`, `multimodal_in`, `multimodal_out`), not hand-authored scope lists
- New enforcement primitives: `chatAllowlist`, `instanceAllowlist`, `outboundRecipientAllowlist`
- New output-redactor middleware (coworker can't leak core code even if prompted)
- `admin` creation gated behind interactive TTY \"I UNDERSTAND\" prompt — no AI can mint a god-key

## Why

Today every consumer hand-authors a \`scopes: string[]\` on each key. There is no way to ship a customer-service agent (single-customer locked), a peer-to-employees agent (multi-chat with secret redaction), or an observer (owner-only alerts) without bespoke enforcement per role. Profiles make these roles first-class and composable.

## What changed here

- \`.genie/brainstorms/omni-scope-profiles/DESIGN.md\` — problem, 5 use cases, verb-bucket taxonomy, enforcement primitives, redactor layer, admin TTY gate, non-goals, risks
- \`.genie/wishes/omni-scope-profiles/WISH.md\` — 8 execution groups across 4 waves, per-group acceptance + validation commands, QA criteria, files-to-touch list

## Related / follow-ups (separate wishes)

- \`omni-coworker-consumer\` (in \`agents/khal-os\`) — wire the khal-os PM agent to the \`coworker\` profile on its own WhatsApp number with brain + meeting ingest
- \`omni-scout-consumer\` (in the operator's personal VM) — scout using the \`scout\` profile

## Test plan

- [ ] \`/review\` pass on the wish before any code lands
- [ ] Each group's validation command runs and is green before that group closes
- [ ] QA criteria exercised on dev after merge