### PR TITLE
feat(cli,ci): dual-channel @next/@latest release system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         run: bunx turbo run build --filter=@automagik/omni
 
-      - name: Publish to npm
+      - name: Publish to npm (@latest, with @next promotion fallback)
         if: steps.exists.outputs.skip != 'true'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -118,7 +118,18 @@ jobs:
             echo "ERROR: NPM_TOKEN secret is not set. Cannot publish to npm." >&2
             exit 1
           fi
-          cd packages/cli && bun publish --access public
+
+          VERSION="${{ steps.pkg.outputs.version }}"
+          cd packages/cli
+
+          # Try a fresh publish as @latest. If the version already exists on npm
+          # (the Version workflow already published it as @next when this build
+          # came through dev first), promote it by retagging instead of failing.
+          if ! bun publish --access public --tag latest 2>&1; then
+            echo "Publish failed — version may already exist from @next. Retagging as latest..."
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+            npm dist-tag add "@automagik/omni@${VERSION}" latest
+          fi
 
       # Note: CHANGELOG.md is intentionally not committed back to main.
       # main is a protected branch requiring PRs. The changelog is already

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,14 +4,14 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  # This workflow always writes to `dev`, regardless of the trigger ref.
+  # Always writes to `dev` regardless of trigger ref. Keep a single group to serialize.
   group: version-dev
   cancel-in-progress: false
 
@@ -19,22 +19,37 @@ jobs:
   auto-version:
     name: Auto Version
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: >-
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'main' &&
-       startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
-       (contains(github.event.workflow_run.head_commit.message, '/dev') ||
-        contains(github.event.workflow_run.head_commit.message, '/homolog')) &&
-       !contains(github.event.workflow_run.head_commit.message, '[skip ci]'))
+       !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
+       (
+         (github.event.workflow_run.head_branch == 'main' &&
+          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
+          (contains(github.event.workflow_run.head_commit.message, '/dev') ||
+           contains(github.event.workflow_run.head_commit.message, '/homolog')))
+         ||
+         (github.event.workflow_run.head_branch == 'dev')
+       ))
 
     steps:
+      - name: Determine channel and npm tag
+        id: context
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch || 'dev' }}"
+          if [ "$BRANCH" = "main" ]; then
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_tag=next" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Triggering branch: ${BRANCH} → npm tag: (see above)"
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # This workflow always writes to `dev`. Always base version bumps on the latest `dev` to avoid
-          # non-fast-forward races when triggered via workflow_run (detached HEAD by SHA).
+          # Always bump on `dev`. main-triggered runs still push to dev — the rolling dev->main PR
+          # carries the bump back to main at release time.
           ref: dev
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -90,3 +105,22 @@ jobs:
           # When triggered via workflow_run we checkout by SHA (detached HEAD). Push the current commit to `dev`
           # explicitly so the version bump commit and its tag are both reachable from the branch.
           git push --atomic origin HEAD:refs/heads/dev "refs/tags/v${VERSION}"
+
+      - name: Build CLI
+        run: bunx turbo run build --filter=@automagik/omni
+
+      - name: Publish to npm (@${{ steps.context.outputs.npm_tag }})
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "⚠️ NPM_TOKEN not set — skipping publish"
+            exit 0
+          fi
+          cd packages/cli
+          # Publish with the resolved tag. main → @latest; dev → @next.
+          # The Release workflow on main will retag as @latest if this was
+          # first published as @next, so a promoted dev build never double-publishes.
+          bun publish --access public --tag ${{ steps.context.outputs.npm_tag }}

--- a/packages/cli/src/__tests__/update-verify.test.ts
+++ b/packages/cli/src/__tests__/update-verify.test.ts
@@ -15,8 +15,10 @@ import {
   UPDATE_ERROR_AUTH_INVALID,
   decideUpdateVerify,
   normalizeVersion,
+  resolveChannel,
   updateErrorVersionMismatch,
 } from '../commands/update.js';
+import type { Config } from '../config.js';
 
 describe('normalizeVersion', () => {
   test('strips a git-hash suffix', () => {
@@ -94,6 +96,33 @@ describe('decideUpdateVerify', () => {
       keyValid: false,
     });
     expect(result).toEqual({ kind: 'auth-invalid' });
+  });
+});
+
+describe('resolveChannel', () => {
+  test('--next overrides everything else', () => {
+    const config: Config = { updateChannel: 'latest' };
+    expect(resolveChannel({ next: true }, config)).toBe('next');
+  });
+
+  test('--stable overrides everything else', () => {
+    const config: Config = { updateChannel: 'next' };
+    expect(resolveChannel({ stable: true }, config)).toBe('latest');
+  });
+
+  test('uses saved updateChannel when no flag is provided', () => {
+    expect(resolveChannel({}, { updateChannel: 'next' })).toBe('next');
+    expect(resolveChannel({}, { updateChannel: 'latest' })).toBe('latest');
+  });
+
+  test('defaults to latest when no flag and no saved channel', () => {
+    expect(resolveChannel({}, {})).toBe('latest');
+  });
+
+  test('defaults to latest when saved channel is invalid', () => {
+    // Simulate a legacy 'main' value left over from before the rename.
+    const config = { updateChannel: 'main' } as unknown as Config;
+    expect(resolveChannel({}, config)).toBe('latest');
   });
 });
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -26,7 +26,7 @@ import { createOmniClient } from '@omni/sdk';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
-import { loadConfig, loadServerConfig } from '../config.js';
+import { type Config, loadConfig, loadServerConfig, saveConfig } from '../config.js';
 import { getHealthCheckUrl } from '../health.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES } from '../pm2.js';
@@ -45,15 +45,54 @@ interface UpdateOptions {
   yes?: boolean;
   restart?: boolean;
   sidecarCleanup?: boolean;
+  next?: boolean;
+  stable?: boolean;
+}
+
+export type UpdateChannel = 'latest' | 'next';
+
+/**
+ * Resolve the npm dist-tag to install. Priority:
+ *   1. --next / --stable flag (explicit override)
+ *   2. Saved `updateChannel` in ~/.omni/config.json
+ *   3. Default to 'latest'
+ */
+export function resolveChannel(options: { next?: boolean; stable?: boolean }, config?: Config): UpdateChannel {
+  if (options.next) return 'next';
+  if (options.stable) return 'latest';
+
+  const saved = (config ?? loadConfig()).updateChannel;
+  if (saved === 'latest' || saved === 'next') return saved;
+
+  return 'latest';
+}
+
+/**
+ * Persist the chosen channel to ~/.omni/config.json. Only called when the user
+ * passed --next or --stable explicitly — so subsequent `omni update` calls stay
+ * on the chosen track until switched again.
+ */
+function persistChannel(channel: UpdateChannel): void {
+  try {
+    const config = loadConfig();
+    config.updateChannel = channel;
+    saveConfig(config);
+  } catch {
+    // Non-fatal — channel preference lost but update still works
+  }
 }
 
 type Pm2ProcessName = (typeof PM2_PROCESSES)[keyof typeof PM2_PROCESSES];
 
-/** Fetch the latest published version from the npm registry via bunx. */
-async function fetchLatestVersion(): Promise<string | null> {
+/**
+ * Fetch the latest published version for the given channel from the npm registry.
+ * `channel='latest'` returns the stable release; `channel='next'` returns the
+ * most recent dev build.
+ */
+async function fetchLatestVersion(channel: UpdateChannel): Promise<string | null> {
   try {
     const proc = Bun.spawn({
-      cmd: ['bunx', 'npm', 'view', PACKAGE_NAME, 'version'],
+      cmd: ['bunx', 'npm', 'view', `${PACKAGE_NAME}@${channel}`, 'version'],
       stdout: 'pipe',
       stderr: 'pipe',
     });
@@ -103,10 +142,16 @@ function getRunningPm2Services(): Pm2ProcessName[] {
   }
 }
 
-/** Run `bun add -g @automagik/omni@latest`. Returns true on success. */
-async function installLatest(): Promise<boolean> {
+/**
+ * Install the given channel globally via bun. Returns true on success.
+ *
+ * Uses `--force --no-cache` to work around bun's global lockfile pinning —
+ * without these flags, switching channels (e.g. next → latest) may silently
+ * reuse a cached version. Mirrors the genie CLI update behavior.
+ */
+async function installLatest(channel: UpdateChannel): Promise<boolean> {
   const proc = Bun.spawn({
-    cmd: ['bun', 'add', '-g', `${PACKAGE_NAME}@latest`],
+    cmd: ['bun', 'add', '-g', '--force', '--no-cache', `${PACKAGE_NAME}@${channel}`],
     stdin: 'inherit',
     stdout: 'inherit',
     stderr: 'inherit',
@@ -380,9 +425,19 @@ async function promptConfirm(question: string): Promise<boolean> {
 }
 
 async function runUpdate(options: UpdateOptions): Promise<void> {
-  // Check latest version from npm
-  const versionSpinner = ora(`Checking latest version of ${PACKAGE_NAME}...`).start();
-  const latest = await fetchLatestVersion();
+  const channel = resolveChannel(options);
+
+  // Persist explicit channel switch so subsequent `omni update` stays on the
+  // chosen track until switched again.
+  if (options.next || options.stable) {
+    persistChannel(channel);
+  }
+
+  output.info(`Channel: ${channel}${channel === 'next' ? ' (dev builds)' : ' (stable)'}`);
+
+  // Check latest version on the resolved channel
+  const versionSpinner = ora(`Checking ${channel} version of ${PACKAGE_NAME}...`).start();
+  const latest = await fetchLatestVersion(channel);
   versionSpinner.stop();
 
   if (latest === null) {
@@ -394,11 +449,11 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
   const currentClean = VERSION.split('+')[0];
 
   if (currentClean === latest) {
-    output.success(`Already up to date (v${latest})`);
+    output.success(`Already up to date (v${latest}, channel: ${channel})`);
     process.exit(0);
   }
 
-  output.info(`Update available: v${currentClean} → v${latest}`);
+  output.info(`Update available: v${currentClean} → v${latest} (${channel})`);
 
   if (!options.yes) {
     const confirmed = await promptConfirm(`Update from v${currentClean} to v${latest}? [Y/n] `);
@@ -410,8 +465,8 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
 
   const servicesToRestart = options.restart !== false ? getRunningPm2Services() : [];
 
-  const installSpinner = ora(`Updating ${PACKAGE_NAME}...`).start();
-  const installed = await installLatest();
+  const installSpinner = ora(`Updating ${PACKAGE_NAME}@${channel}...`).start();
+  const installed = await installLatest(channel);
   installSpinner.stop();
 
   if (!installed) {
@@ -442,9 +497,22 @@ export function createUpdateCommand(): Command {
     .option('-y, --yes', 'Skip confirmation prompts (non-interactive)')
     .option('--no-restart', 'Update CLI only; skip service restarts and verification')
     .option('--no-sidecar-cleanup', 'Skip the legacy nats-reply-sidecar.mjs cleanup step')
+    .option('--next', 'Switch to dev builds (npm @next tag) and persist as default')
+    .option('--stable', 'Switch to stable releases (npm @latest tag) and persist as default')
     .addHelpText(
       'after',
       `
+Channels:
+  - stable (default) — tracks the npm @latest tag, bumped from main branch releases.
+  - next (dev builds) — tracks the npm @next tag, bumped on every CI-green dev merge.
+
+  Use --next to switch to dev builds; --stable to switch back. The choice is
+  persisted to ~/.omni/config.json under 'updateChannel' so subsequent
+  'omni update' calls stay on the selected track. Check or change manually:
+    omni config get updateChannel
+    omni config set updateChannel next
+    omni config set updateChannel latest
+
 Behavior:
   - Installs the latest CLI package first.
   - Restarts tracked Omni services only when they were online before the update.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -43,7 +43,7 @@ export interface Config {
   format?: 'human' | 'json';
   showCommands?: string; // 'all' or comma-separated categories
   telemetry?: string; // 'true' or 'false' — error telemetry via Sentry
-  updateChannel?: 'main' | 'dev';
+  updateChannel?: 'latest' | 'next';
   server?: Partial<ServerConfig>;
 }
 
@@ -77,8 +77,8 @@ export const CONFIG_KEYS: Record<ConfigKey, { description: string; values?: stri
     values: ['true', 'false'],
   },
   updateChannel: {
-    description: 'Update track for omni update',
-    values: ['main', 'dev'],
+    description: 'Update track for omni update (latest=stable, next=dev builds)',
+    values: ['latest', 'next'],
   },
   'server.port': { description: 'Server port (default: 8882)' },
   'server.databaseUrl': { description: 'PostgreSQL connection URL' },


### PR DESCRIPTION
## Summary
Port genie's release topology to omni so:
- Dev merges auto-publish to npm as `@automagik/omni@next`
- Main merges publish as `@automagik/omni@latest` (retagging any prior `@next` for the same version)
- `omni update --next` / `--stable` switch channels and persist the choice to `~/.omni/config.json`

This mirrors `genie update --next/--stable` exactly — same flag semantics, same dist-tag naming, same persisted-channel behavior.

## Changes

### CI / Release flow
- **`.github/workflows/version.yml`** — trigger extended to `branches: [main, dev]`. Adds `npm_tag` context step (main→`latest`, dev→`next`) and a final `bun publish --tag <npm_tag>` step. Still always bumps the version on dev.
- **`.github/workflows/release.yml`** — publish step now falls back to `npm dist-tag add @automagik/omni@<version> latest` if `bun publish` fails because the version was already published from a preceding dev run. Prevents duplicate-publish failures during promotion.

### CLI (`omni update`)
- **`packages/cli/src/commands/update.ts`**
  - `UpdateChannel = 'latest' | 'next'` type
  - `resolveChannel(options, config?)` — explicit flag → saved config → default `latest`
  - `persistChannel(channel)` — writes to `~/.omni/config.json` on explicit `--next` / `--stable`
  - `installLatest(channel)` now runs `bun add -g --force --no-cache @automagik/omni@<channel>` (mirrors genie's global-lockfile workaround)
  - `fetchLatestVersion(channel)` queries the resolved dist-tag so the displayed version always matches what will be installed
  - New CLI flags: `--next`, `--stable`

### Config
- **`packages/cli/src/config.ts`** — `updateChannel` values renamed from `'main' | 'dev'` → `'latest' | 'next'` to match npm dist-tag naming and the CLI flags. Legacy `'main'` value degrades gracefully to `'latest'` via `resolveChannel`'s whitelist check.

## Tests
5 new `resolveChannel` tests covering flag override, saved config, defaults, and invalid legacy values. **16/16 update-verify tests pass. 293/293 CLI suite pass. 3160/3160 full repo pass.**

## Test plan
- [x] `bunx turbo typecheck --filter=@automagik/omni` — clean
- [x] `bun test packages/cli/src/__tests__` — 293 pass
- [x] `bun test` full repo — 3160 pass, 0 fail, 264 skip (unchanged from baseline)
- [x] `bunx biome check` on changed files — clean
- [x] `bunx knip --no-progress` — exit 0
- [ ] On merge: first dev CI run publishes `@automagik/omni@next` to npm
- [ ] On next dev→main promotion: Release workflow retags that version as `@latest`
- [ ] `omni update --next` installs the dev build and saves channel; `omni update` reuses it; `omni update --stable` switches back

## Ref
Mirrors genie's `.github/workflows/version.yml` + `release.yml` + `src/genie-commands/update.ts` (v4 release system).