### PR TITLE
chore(deps): bump pgserve 1.1.8 → 1.1.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "hono": "^4.6.17",
         "lru-cache": "^11.2.6",
         "nats": "^2.29.3",
-        "pgserve": "^1.1.8",
+        "pgserve": "^1.1.10",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -1830,7 +1830,7 @@
 
     "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
-    "pgserve": ["pgserve@1.1.8", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-CZJK6uWqua50Bz/l4T9hubGWdWfycJfWN0UptnhMhvGVmdKBOC9qQTleBr4HaF6ESTaHBBfq/WuWpKfscGhxNA=="],
+    "pgserve": ["pgserve@1.1.10", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-HPP5qoEY+SvJlbH/mQFgBoc5KQYZVDB8osGvaSRXTX7Ri2sMLzYCQgYCcHQ4ZEP6A8zE9x4/HKr3iMft/V453g=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,7 +43,7 @@
     "hono": "^4.6.17",
     "lru-cache": "^11.2.6",
     "nats": "^2.29.3",
-    "pgserve": "^1.1.8",
+    "pgserve": "^1.1.10",
     "zod": "^3.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `packages/api`'s \`pgserve\` dependency from \`^1.1.8\` to \`^1.1.10\`.

Upstream changes between the two versions:
- [pgserve PR #21](https://github.com/namastexlabs/pgserve/pull/21) (v1.1.9): pgvector auto-heal via sidecar metadata
- [pgserve PR #22](https://github.com/namastexlabs/pgserve/pull/22) (v1.1.10): bun postinstall self-heal when skipped

## Context

Today (2026-04-20) the Eugênia prod \`omni-v2-api\` went into an infinite internal retry loop:

- postgres backend on \`127.0.0.1:9432\` was healthy (direct psql worked, returned 4 instances)
- pgserve proxy router on \`127.0.0.1:8432\` errored on every connection attempt with \`\"Failed to connect\"\` from \`router.js:366\`
- 2,130 errors/sec in the PM2 error log (~15 MB in minutes); 100%+ CPU sustained
- 1,457 stale \`/tmp/pgserve-sock-*\` directories leaked during the storm

Root cause diagnosed: **pgserve 1.1.8's router caches a stale \`socketPath\` reference**. \`pgManager.getSocketPath()\` resolves once and never recomputes, so when the postgres subprocess restarts (which happened continuously under a concurrent PM2 crash-loop of a separate obsolete \`omni-api\` entry), the NEW postgres gets a NEW socket dir but the router keeps connecting to the OLD path.

Neither 1.1.9 nor 1.1.10 directly addresses the socketPath caching bug — I'll file a separate issue upstream against \`namastexlabs/pgserve\` for that.

## Why bump anyway

1. **Hygiene** — two patch versions of fixes compound
2. **Prerequisite for future issue report** — upstream maintainers prefer repros on latest
3. **Low risk** — patch versions, no breaking changes, automated tests pass

## Changes

- \`packages/api/package.json\`: \`pgserve ^1.1.8\` → \`^1.1.10\`
- \`bun.lock\`: regenerated

Zero source code changes.

## Test plan

- [x] \`bun install\` completes cleanly
- [x] Pre-push hook ran full test suite (3,544 tests across 233 files, passed)
- [x] No source code changed — runtime behavior only differs in the pgserve library internals
- [ ] Reviewer spot-checks the pgserve changelog diff (linked above)

## Related follow-ups (not in this PR)

1. Issue against \`namastexlabs/pgserve\`: **router caches stale \`socketPath\` on postgres respawn**. Will file with minimal repro.
2. Issue against this repo: \`packages/api/src/pgserve.ts:217\` \`isAddressInUse()\` checks \`\"Failed to listen on\"\` but \`Bun.listen\` throws \`\"Failed to listen at\"\`. The wording mismatch masks the port-retry fallback when EADDRINUSE occurs.