### PR TITLE
fix(reactions): WhatsApp group reactions

### DIFF
--- a/packages/api/src/__tests__/messages-send-reaction.test.ts
+++ b/packages/api/src/__tests__/messages-send-reaction.test.ts
@@ -59,8 +59,11 @@ describeWithDb('POST /messages/send/reaction — fromMe resolution (#386)', () =
   let db: Database;
   let testInstance: Instance;
   let testChat: { id: string; externalId: string };
+  let groupChat: { id: string; externalId: string };
   let inboundMessage: { id: string; externalId: string };
   let outboundMessage: { id: string; externalId: string };
+  let groupInboundMessage: { id: string; externalId: string };
+  const groupParticipant = '178035101794451@lid';
   const insertedInstanceIds: string[] = [];
   const insertedChatIds: string[] = [];
   const insertedMessageIds: string[] = [];
@@ -93,6 +96,20 @@ describeWithDb('POST /messages/send/reaction — fromMe resolution (#386)', () =
     testChat = { id: chat.id, externalId: chat.externalId };
     insertedChatIds.push(chat.id);
 
+    const [group] = await db
+      .insert(chats)
+      .values({
+        instanceId: testInstance.id,
+        externalId: '120363424772797713@g.us',
+        chatType: 'group',
+        channel: 'whatsapp-baileys',
+        name: 'React Test Group',
+      })
+      .returning();
+    if (!group) throw new Error('Failed to create test group chat');
+    groupChat = { id: group.id, externalId: group.externalId };
+    insertedChatIds.push(group.id);
+
     const [inbound] = await db
       .insert(messages)
       .values({
@@ -109,21 +126,56 @@ describeWithDb('POST /messages/send/reaction — fromMe resolution (#386)', () =
     inboundMessage = { id: inbound.id, externalId: inbound.externalId };
     insertedMessageIds.push(inbound.id);
 
+    const outboundExternalId = `OUTBOUND-${Date.now()}`;
     const [outbound] = await db
       .insert(messages)
       .values({
         chatId: testChat.id,
-        externalId: `OUTBOUND-${Date.now()}`,
+        externalId: outboundExternalId,
         source: 'realtime',
         messageType: 'text',
         textContent: 'Outbound message',
         platformTimestamp: new Date(),
         isFromMe: true,
+        rawPayload: {
+          key: {
+            id: outboundExternalId,
+            fromMe: true,
+            remoteJid: testChat.externalId,
+            participant: '5511999999999@s.whatsapp.net',
+          },
+        },
       })
       .returning();
     if (!outbound) throw new Error('Failed to create outbound message');
     outboundMessage = { id: outbound.id, externalId: outbound.externalId };
     insertedMessageIds.push(outbound.id);
+
+    const [groupInbound] = await db
+      .insert(messages)
+      .values({
+        chatId: groupChat.id,
+        externalId: '3AAFEE9E6DB2E7864DE2',
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Inbound group message',
+        platformTimestamp: new Date(),
+        isFromMe: false,
+        rawPayload: {
+          key: {
+            id: '3AAFEE9E6DB2E7864DE2',
+            fromMe: false,
+            remoteJid: groupChat.externalId,
+            participant: groupParticipant,
+            participantAlt: '5511947879044@s.whatsapp.net',
+            addressingMode: 'lid',
+          },
+        },
+      })
+      .returning();
+    if (!groupInbound) throw new Error('Failed to create group inbound message');
+    groupInboundMessage = { id: groupInbound.id, externalId: groupInbound.externalId };
+    insertedMessageIds.push(groupInbound.id);
   });
 
   afterAll(async () => {
@@ -186,6 +238,30 @@ describeWithDb('POST /messages/send/reaction — fromMe resolution (#386)', () =
     expect(outgoing.metadata?.fromMe).toBe(false);
   });
 
+  test('target group message from another participant includes participant key metadata', async () => {
+    const sendMessageMock = mock(async () => ({ success: true, messageId: 'REACT-GROUP-1', timestamp: Date.now() }));
+    const { app } = createTestApp(sendMessageMock);
+
+    const res = await app.request('/messages/send/reaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testInstance.id,
+        to: groupChat.externalId,
+        messageId: groupInboundMessage.externalId,
+        emoji: '👍',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const outgoing = (sendMessageMock.mock.calls[0] as unknown[])[1] as {
+      metadata?: { fromMe?: boolean; targetParticipant?: string };
+    };
+    expect(outgoing.metadata?.fromMe).toBe(false);
+    expect(outgoing.metadata?.targetParticipant).toBe(groupParticipant);
+  });
+
   test('target message found and outbound → fromMe=true (sourced from DB)', async () => {
     const sendMessageMock = mock(async () => ({ success: true, messageId: 'REACT-2', timestamp: Date.now() }));
     const { app } = createTestApp(sendMessageMock);
@@ -203,9 +279,10 @@ describeWithDb('POST /messages/send/reaction — fromMe resolution (#386)', () =
 
     expect(res.status).toBe(200);
     const outgoing = (sendMessageMock.mock.calls[0] as unknown[])[1] as {
-      metadata?: { fromMe?: boolean };
+      metadata?: { fromMe?: boolean; targetParticipant?: string };
     };
     expect(outgoing.metadata?.fromMe).toBe(true);
+    expect(outgoing.metadata?.targetParticipant).toBeUndefined();
   });
 
   test('target message NOT in DB → fromMe is undefined so plugin heuristic decides (#386)', async () => {

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -73,6 +73,12 @@ function isUUID(value: string): boolean {
   return UUID_REGEX.test(value);
 }
 
+function extractReactionTargetParticipant(rawPayload: Record<string, unknown> | null | undefined): string | undefined {
+  const key = rawPayload?.key as Record<string, unknown> | undefined;
+  const participant = key?.participant;
+  return typeof participant === 'string' && participant.length > 0 ? participant : undefined;
+}
+
 /**
  * Resolve recipient - handles Omni person IDs, Omni chat IDs, and platform IDs (WA JID etc.)
  *
@@ -1123,12 +1129,18 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
   // is silently dropped by WhatsApp. When the target isn't in our DB (history gap
   // or unsynced chat), we leave fromMe undefined and let the channel plugin's
   // heuristic decide — forcing false here breaks bot-to-own-message reactions (#386).
-  let fromMe: boolean | undefined;
+  const reactionMetadata: Record<string, unknown> = {};
   const chat = await services.chats.findByExternalIdSmart(instanceId, resolvedTo);
   if (chat) {
     const target = await services.messages.getByExternalId(chat.id, messageId);
     if (target) {
-      fromMe = target.isFromMe === true;
+      reactionMetadata.fromMe = target.isFromMe === true;
+      if (target.isFromMe !== true) {
+        const participant = extractReactionTargetParticipant(
+          target.rawPayload as Record<string, unknown> | null | undefined,
+        );
+        if (participant) reactionMetadata.targetParticipant = participant;
+      }
     } else {
       log.warn('Reaction target message not found in DB; deferring fromMe to channel plugin fallback (#386)', {
         instanceId,
@@ -1146,7 +1158,7 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
     });
   }
 
-  // Build outgoing message for reaction. When fromMe is undefined, omit it from
+  // Build outgoing message for reaction. When the target is unknown, omit
   // metadata so the plugin applies its own fallback (defaults to true for Baileys).
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -1155,7 +1167,7 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
       emoji,
       targetMessageId: messageId,
     } as OutgoingContent,
-    metadata: fromMe === undefined ? {} : { fromMe },
+    metadata: reactionMetadata,
   };
 
   // Send via channel plugin

--- a/packages/channel-whatsapp/src/__tests__/plugin.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/plugin.test.ts
@@ -230,4 +230,59 @@ describe('WhatsAppPlugin', () => {
       expect(logArgs[1].error).toBe('rate limit exceeded');
     });
   });
+
+  describe('reactions', () => {
+    const INSTANCE_ID = 'test-instance';
+    const GROUP_JID = '120363424772797713@g.us';
+    const MESSAGE_ID = '3AAFEE9E6DB2E7864DE2';
+    const PARTICIPANT = '178035101794451@lid';
+
+    async function withHumanDelayDisabled(run: () => Promise<void>) {
+      const previous = process.env.WHATSAPP_HUMAN_DELAY_ENABLED;
+      process.env.WHATSAPP_HUMAN_DELAY_ENABLED = 'false';
+      try {
+        await run();
+      } finally {
+        if (previous === undefined) Reflect.deleteProperty(process.env, 'WHATSAPP_HUMAN_DELAY_ENABLED');
+        else process.env.WHATSAPP_HUMAN_DELAY_ENABLED = previous;
+      }
+    }
+
+    it('passes target participant into Baileys reaction key for group messages', async () => {
+      await withHumanDelayDisabled(async () => {
+        const plugin = new WhatsAppPlugin();
+        const sendMessage = mock(() => Promise.resolve({ key: { id: 'REACTION-MSG-ID' } }));
+        const mockSocket = { sendMessage, user: { id: '5511999999999@s.whatsapp.net' } };
+        (plugin as any).sockets = new Map([[INSTANCE_ID, mockSocket]]);
+        (plugin as any).logger = { info: mock(), debug: mock(), warn: mock(), error: mock() };
+
+        const result = await plugin.sendMessage(INSTANCE_ID, {
+          to: GROUP_JID,
+          content: {
+            type: 'reaction',
+            targetMessageId: MESSAGE_ID,
+            emoji: '👍',
+          },
+          metadata: {
+            fromMe: false,
+            targetParticipant: PARTICIPANT,
+          },
+        } as any);
+
+        expect(result.success).toBe(true);
+        expect(sendMessage).toHaveBeenCalledTimes(1);
+        const [jid, content] = sendMessage.mock.calls[0]! as unknown as [
+          string,
+          { react: { key: { id: string; remoteJid: string; fromMe: boolean; participant?: string } } },
+        ];
+        expect(jid).toBe(GROUP_JID);
+        expect(content.react.key).toEqual({
+          remoteJid: GROUP_JID,
+          id: MESSAGE_ID,
+          fromMe: false,
+          participant: PARTICIPANT,
+        });
+      });
+    });
+  });
 });

--- a/packages/channel-whatsapp/src/__tests__/reaction.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/reaction.test.ts
@@ -26,6 +26,20 @@ describe('Reaction Sender', () => {
       expect(react.key.fromMe).toBe(false);
     });
 
+    it('includes participant for group messages from other users', () => {
+      const content = buildReactionContent(
+        '120363424772797713@g.us',
+        '3AAFEE9E6DB2E7864DE2',
+        '👍',
+        false,
+        '178035101794451@lid',
+      );
+
+      const react = (content as { react: { key: { fromMe: boolean; participant?: string } } }).react;
+      expect(react.key.fromMe).toBe(false);
+      expect(react.key.participant).toBe('178035101794451@lid');
+    });
+
     it('builds removal reaction with empty string', () => {
       const content = buildReactionContent('1234567890@s.whatsapp.net', 'msg_123', '', true);
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -1371,8 +1371,10 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       };
     }
 
-    // Determine fromMe: metadata can override, default true
+    // Determine target key fields: metadata comes from the persisted target message.
     const fromMe = (message.metadata?.fromMe as boolean) ?? true;
+    const targetParticipant =
+      typeof message.metadata?.targetParticipant === 'string' ? message.metadata.targetParticipant : undefined;
 
     // Minimal delay for reactions (shorter than full humanDelay)
     await this.humanDelay(instanceId);
@@ -1382,12 +1384,13 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       targetMessageId,
       emoji: reactionEmoji || '(remove)',
       fromMe,
+      targetParticipant,
     });
 
     const correlationId = message.metadata?.correlationId as string | undefined;
     correlationId && this.captureT10(correlationId);
 
-    const reactionMsgId = await sendReaction(sock, jid, targetMessageId, reactionEmoji, fromMe);
+    const reactionMsgId = await sendReaction(sock, jid, targetMessageId, reactionEmoji, fromMe, targetParticipant);
 
     // Track sent reaction ID so shouldProcessMessage can filter the echo (#336)
     if (reactionMsgId) {

--- a/packages/channel-whatsapp/src/senders/reaction.ts
+++ b/packages/channel-whatsapp/src/senders/reaction.ts
@@ -11,21 +11,26 @@ import type { AnyMessageContent, WASocket } from 'baileys';
  * @param targetMessageId - ID of the message to react to
  * @param emoji - Reaction emoji (empty string to remove reaction)
  * @param fromMe - Whether the target message was sent by us
+ * @param participant - Group participant JID that authored the target message
  */
 export function buildReactionContent(
   targetJid: string,
   targetMessageId: string,
   emoji: string,
   fromMe = true,
+  participant?: string,
 ): AnyMessageContent {
+  const key = {
+    remoteJid: targetJid,
+    id: targetMessageId,
+    fromMe,
+    ...(participant ? { participant } : {}),
+  };
+
   return {
     react: {
       text: emoji,
-      key: {
-        remoteJid: targetJid,
-        id: targetMessageId,
-        fromMe,
-      },
+      key,
     },
   };
 }
@@ -38,6 +43,7 @@ export function buildReactionContent(
  * @param targetMessageId - Message ID to react to
  * @param emoji - Reaction emoji (use empty string to remove)
  * @param fromMe - Whether reacting to our own message
+ * @param participant - Group participant JID that authored the target message
  */
 export async function sendReaction(
   sock: WASocket,
@@ -45,8 +51,9 @@ export async function sendReaction(
   targetMessageId: string,
   emoji: string,
   fromMe = true,
+  participant?: string,
 ): Promise<string | undefined> {
-  const content = buildReactionContent(jid, targetMessageId, emoji, fromMe);
+  const content = buildReactionContent(jid, targetMessageId, emoji, fromMe, participant);
 
   const result = await sock.sendMessage(jid, content);
 
@@ -61,6 +68,7 @@ export async function removeReaction(
   jid: string,
   targetMessageId: string,
   fromMe = true,
+  participant?: string,
 ): Promise<string | undefined> {
-  return sendReaction(sock, jid, targetMessageId, '', fromMe);
+  return sendReaction(sock, jid, targetMessageId, '', fromMe, participant);
 }

--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -365,6 +365,7 @@ interface StreamEventRow {
 }
 
 let streamedEvents: StreamEventRow[] = [];
+let lastSendReactionBody: unknown = null;
 
 export function seedStreamEvent(overrides: Partial<StreamEventRow> = {}): StreamEventRow {
   const now = new Date().toISOString();
@@ -391,6 +392,19 @@ export function seedStreamEvent(overrides: Partial<StreamEventRow> = {}): Stream
 
 export function clearStreamedEvents(): void {
   streamedEvents = [];
+}
+
+export function getLastSendReactionBody<T = unknown>(): T | null {
+  return lastSendReactionBody as T | null;
+}
+
+export function clearLastSendReactionBody(): void {
+  lastSendReactionBody = null;
+}
+
+async function handleSendReaction(req: Request): Promise<Response> {
+  lastSendReactionBody = await req.json();
+  return json({ data: { messageId: 'mock-reaction-msg', success: true } });
 }
 
 function handleListEvents(req: Request): Response {
@@ -487,7 +501,7 @@ const staticRoutes: Record<RouteKey, (req: Request) => Response | Promise<Respon
   'GET /api/v2/access/rules': () => json(EMPTY_ITEMS),
   'GET /api/v2/context': () => json({ instanceId: null, chatId: null, messageId: null }),
   'POST /api/v2/messages/send': () => json({ data: { messageId: 'mock-msg-id' } }),
-  'POST /api/v2/messages/send/reaction': () => json({ data: { messageId: 'mock-reaction-msg', success: true } }),
+  'POST /api/v2/messages/send/reaction': handleSendReaction,
   'GET /api/v2/agents': () => json({ items: dynamicAgents }),
   'POST /api/v2/agents': handleCreateAgent,
   'GET /api/v2/logs/recent': handleRecentLogs,

--- a/packages/cli/src/__tests__/react-context.test.ts
+++ b/packages/cli/src/__tests__/react-context.test.ts
@@ -11,7 +11,13 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'bun';
-import { MOCK_API_KEY, startMockApi, stopMockApi } from './mock-api';
+import {
+  MOCK_API_KEY,
+  clearLastSendReactionBody,
+  getLastSendReactionBody,
+  startMockApi,
+  stopMockApi,
+} from './mock-api';
 
 // ── Unit-test mocks ──
 
@@ -220,6 +226,28 @@ describe('react command — integration with env vars', () => {
       expect(result.stderr).not.toContain('No instance');
       expect(result.stderr).not.toContain('No chat');
     }
+  });
+
+  test('react resolves --instance name to UUID before calling sendReaction', async () => {
+    clearLastSendReactionBody();
+    const result = await runCli([
+      'react',
+      '👍',
+      '--instance',
+      'test-instance',
+      '--chat',
+      '5511999999999@s.whatsapp.net',
+      '--message',
+      'test-msg-id',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(getLastSendReactionBody()).toMatchObject({
+      instanceId: '00000000-0000-0000-0000-000000000001',
+      to: '5511999999999@s.whatsapp.net',
+      messageId: 'test-msg-id',
+      emoji: '👍',
+    });
   });
 
   test('react works with ONLY env vars (no CLI flags, no stored context)', async () => {

--- a/packages/cli/src/commands/react.ts
+++ b/packages/cli/src/commands/react.ts
@@ -42,18 +42,19 @@ export function createReactCommand(): Command {
       if (!ctx.chatId) {
         return output.error('No chat in context. Set OMNI_CHAT, use --chat, or run: omni open <contact>');
       }
-      const instanceId = await resolveInstanceId(ctx.instanceId);
-      const chatId = await resolveRecipient(ctx.chatId);
-
-      // Resolve message to react to
-      const messageId = await resolveReplyTo(options.message);
-      if (!messageId) {
-        return output.error(
-          'No message to react to. Set OMNI_MESSAGE, use --message <id>, or ensure context has a trigger message.',
-        );
-      }
 
       try {
+        const instanceId = await resolveInstanceId(ctx.instanceId);
+        const chatId = await resolveRecipient(ctx.chatId);
+
+        // Resolve message to react to
+        const messageId = await resolveReplyTo(options.message);
+        if (!messageId) {
+          return output.error(
+            'No message to react to. Set OMNI_MESSAGE, use --message <id>, or ensure context has a trigger message.',
+          );
+        }
+
         const result = await client.messages.sendReaction({
           instanceId,
           to: chatId,

--- a/packages/cli/src/commands/react.ts
+++ b/packages/cli/src/commands/react.ts
@@ -11,6 +11,7 @@ import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { resolveContext, resolveReplyTo } from '../context.js';
 import * as output from '../output.js';
+import { resolveInstanceId, resolveRecipient } from '../resolve.js';
 
 interface ReactOptions {
   message?: string;
@@ -41,6 +42,8 @@ export function createReactCommand(): Command {
       if (!ctx.chatId) {
         return output.error('No chat in context. Set OMNI_CHAT, use --chat, or run: omni open <contact>');
       }
+      const instanceId = await resolveInstanceId(ctx.instanceId);
+      const chatId = await resolveRecipient(ctx.chatId);
 
       // Resolve message to react to
       const messageId = await resolveReplyTo(options.message);
@@ -52,8 +55,8 @@ export function createReactCommand(): Command {
 
       try {
         const result = await client.messages.sendReaction({
-          instanceId: ctx.instanceId,
-          to: ctx.chatId,
+          instanceId,
+          to: chatId,
           messageId,
           emoji,
         });


### PR DESCRIPTION
## Summary
- Propagate the target WhatsApp group participant from stored inbound message payloads into reaction metadata.
- Include `participant` in the Baileys reaction key for group messages sent by other participants.
- Align `omni react --instance <name>` with `omni send` by resolving instance names/prefixes to UUIDs before calling the API.

## Root cause
WhatsApp/Baileys needs `react.key.participant` when reacting to another participant's message in a group. The API already resolved `fromMe`, but did not forward the target message participant to the WhatsApp plugin, so the API returned success while WhatsApp dropped the reaction.

## Validation
- `bunx biome check --write packages/api/src/routes/v2/messages.ts packages/api/src/__tests__/messages-send-reaction.test.ts packages/channel-whatsapp/src/senders/reaction.ts packages/channel-whatsapp/src/__tests__/reaction.test.ts packages/channel-whatsapp/src/plugin.ts packages/channel-whatsapp/src/__tests__/plugin.test.ts packages/cli/src/commands/react.ts packages/cli/src/__tests__/react-context.test.ts packages/cli/src/__tests__/mock-api.ts`
- `bun test packages/channel-whatsapp/src/__tests__/reaction.test.ts packages/channel-whatsapp/src/__tests__/plugin.test.ts packages/cli/src/__tests__/react-context.test.ts`
- `ENABLE_DB_TESTS=true bun test packages/api/src/__tests__/messages-send-reaction.test.ts`
- `bun run typecheck`
- pre-push `bun test`: 3283 pass, 265 skip, 0 fail