### PR TITLE
ci(version): trigger on PR-merged-to-dev instead of push-to-dev

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,10 +1,20 @@
 name: Version
 
 on:
+  # Fire when a PR merges to dev — the canonical "new thing shipped" event.
+  # Prior trigger (workflow_run CI on branch=dev) never fired because CI's
+  # `on.push` only lists `[main, homolog]`, never `dev`; merges to dev thus
+  # produced no push-event CI run for workflow_run to observe.
+  pull_request:
+    types: [closed]
+    branches: [dev]
+  # main-side promotion still arrives via CI-on-push (main IS in CI's push
+  # branches). Keep this path so release-to-@latest continues to trigger
+  # automatically when the rolling PR dev→main merges.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main, dev]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -22,29 +32,33 @@ jobs:
     timeout-minutes: 10
     if: >-
       (github.event_name == 'workflow_dispatch') ||
-      (github.event.workflow_run.conclusion == 'success' &&
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true) ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
        !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
-       (
-         (github.event.workflow_run.head_branch == 'main' &&
-          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
-          (contains(github.event.workflow_run.head_commit.message, '/dev') ||
-           contains(github.event.workflow_run.head_commit.message, '/homolog')))
-         ||
-         (github.event.workflow_run.head_branch == 'dev')
-       ))
+       startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
+       (contains(github.event.workflow_run.head_commit.message, '/dev') ||
+        contains(github.event.workflow_run.head_commit.message, '/homolog')))
 
     steps:
       - name: Determine channel and npm tag
         id: context
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch || 'dev' }}"
-          if [ "$BRANCH" = "main" ]; then
+          # Branch semantics:
+          #   - workflow_run on main → promoted release → @latest
+          #   - pull_request merged on dev → new dev build → @next
+          #   - workflow_dispatch → defaults to @next (manual dev trigger)
+          if [ "${{ github.event_name }}" = "workflow_run" ] && \
+             [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "Triggering branch: main → npm tag: latest"
           else
             echo "npm_tag=next" >> "$GITHUB_OUTPUT"
+            echo "Triggering event: ${{ github.event_name }} → npm tag: next"
           fi
-          echo "Triggering branch: ${BRANCH} → npm tag: (see above)"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -33,7 +33,8 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true) ||
+       github.event.pull_request.merged == true &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&


### PR DESCRIPTION
## Problem
The Version workflow's trigger `workflow_run: CI completed on branches=[main, dev]` never fires on dev merges because CI's own `on.push` only lists `[main, homolog]` — there's no push-event CI run for `workflow_run` to observe when code lands on dev. Every dev merge silently skips version-bump + @next publish.

Evidence: PR #471 (per-instance bridge tmux session) merged to dev at 10:41Z today. No Version run. No version-bump commit. `@automagik/omni@next` dist-tag doesn't even exist on npm (latest is `2.260410.1` from April 10, `next` = unset). `bun add -g @automagik/omni@next` fails.

Secondary: the Rolling-PR workflow that normally carries dev→main has been failing on `HTTP 401: Bad credentials` since at least 05:32 today — separate secret-rotation issue, but it means @latest publishes are also stalled until the rolling PR works again.

## Fix
Flip the dev side to the canonical ship event (PR merged to dev). Main stays on `workflow_run` since main IS in CI's `push.branches`, so that path continues to work unchanged.

```yaml
on:
  pull_request:
    types: [closed]
    branches: [dev]
  workflow_run:
    workflows: ["CI"]
    types: [completed]
    branches: [main]
  workflow_dispatch:
```

Job guard updated:
- `workflow_dispatch` → run (manual trigger, defaults to @next)
- `pull_request` with `merged == true` → run, publish @next
- `workflow_run` on main with push event + merge-PR commit + `/dev` or `/homolog` in subject → run, publish @latest

`npm_tag` resolution clarified inline so the log makes the mapping explicit.

## Backward Compatibility
- **main path unchanged.** The `workflow_run` condition has been narrowed to `head_branch == 'main'` only (previously accepted `main` OR `dev`, but the `dev` case was unreachable). Every main-promotion scenario that worked before still works.
- **workflow_dispatch unchanged.** Manual trigger still runs, still defaults to @next.
- **dev path starts working.** First PR merge to dev after this lands bumps to `2.260421.N` and publishes `@next`.

## Follow-up (not in this PR)
- Rotate/refresh `GH_TOKEN` secret on the Rolling PR Maintenance workflow so dev→main promotion resumes.
- Once this PR merges, a subsequent PR merge to dev will retroactively publish the already-merged tmux-session feature (#471) as `@next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)