### PR TITLE
fix(bridge): address PR #471 review feedback on per-instance tmux env

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -1357,6 +1357,14 @@ function buildMessageTrigger(
   allContextMessages: string[],
 ): AgentTrigger {
   const threadId = extractThreadId(messages);
+  // Instance-scoped env that any provider/bridge path should see, regardless
+  // of turn-based vs fire-and-forget. The turn-based helper layers
+  // OMNI_TURN_ID on top after opening the turn; that extension merges with
+  // whatever we set here, never replaces it.
+  const env: Record<string, string> = {};
+  if (instance.bridgeTmuxSession) {
+    env.GENIE_TMUX_SESSION = instance.bridgeTmuxSession;
+  }
   return {
     traceId,
     type: triggerType,
@@ -1380,6 +1388,7 @@ function buildMessageTrigger(
     },
     sessionId,
     contextMessages: allContextMessages.length > 0 ? allContextMessages : undefined,
+    env: Object.keys(env).length > 0 ? env : undefined,
   };
 }
 
@@ -1738,22 +1747,18 @@ async function dispatchViaTurnBasedProvider(
     timestamp: new Date().toISOString(),
   });
 
-  // Inject env vars into trigger for the agent bridge.
-  // OMNI_TURN_ID allows the agent to close the correct turn via POST /v2/turns/close.
-  // GENIE_TMUX_SESSION is the per-instance override for the consumer genie bridge's
-  // tmux-session resolution chain — see automagik/genie `resolveBridgeTmuxSession`.
-  // Only emit the key when the instance has the override set, so older genie
-  // consumers (or default routing) remain unaffected.
-  const envPayload: Record<string, string> = {
+  // Inject turn-based env vars. OMNI_TURN_ID lets the agent close the correct
+  // turn via POST /v2/turns/close. Instance-scoped env keys (e.g.
+  // GENIE_TMUX_SESSION for per-instance tmux routing) are populated by
+  // buildMessageTrigger already — merge instead of replace so both layers
+  // reach the bridge.
+  trigger.env = {
+    ...(trigger.env ?? {}),
     OMNI_INSTANCE: instance.id,
     OMNI_CHAT: chatId,
     OMNI_MESSAGE: messageId,
     OMNI_TURN_ID: turn.id,
   };
-  if (instance.bridgeTmuxSession) {
-    envPayload.GENIE_TMUX_SESSION = instance.bridgeTmuxSession;
-  }
-  trigger.env = envPayload;
 
   // Dispatch (fire-and-forget — agent uses verb commands + omni done)
   const dispatchStart = Date.now();

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -190,10 +190,20 @@ const createInstanceSchema = z.object({
   bridgeTmuxSession: z
     .string()
     .min(1)
+    .max(64)
+    // Allow tmux-safe chars only: alphanumerics, `_`, `-`, `.`. Tmux reserves
+    // `/` and `:` as target separators; other punctuation can break shell
+    // quoting in downstream invocations. The consumer genie bridge also
+    // normalises `/` and `:` to `-`, but we reject them at the API boundary
+    // so users see the error early instead of surprise mutation.
+    .regex(
+      /^[a-zA-Z0-9_.-]+$/,
+      'Tmux session name must be alphanumeric with `_`, `-`, or `.` (no `/`, `:`, or whitespace).',
+    )
     .optional()
     .nullable()
     .describe(
-      'Tmux session name the genie bridge will spawn into for this instance. Propagated via NATS env as GENIE_TMUX_SESSION. Null clears the override (genie falls back to its agent-level or name-based default).',
+      'Tmux session name the genie bridge will spawn into for this instance. Propagated via NATS env as GENIE_TMUX_SESSION. Null clears the override (genie falls back to its agent-level or name-based default). Max 64 chars, `[A-Za-z0-9_.-]` only.',
     ),
 });
 

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -341,6 +341,11 @@ export function createInstancesCommand(): Command {
     .option('--gupshup-auth-token <token>', 'Gupshup Custom Integration auth token')
     .option('--gupshup-event-id <id>', 'Gupshup event ID (default: nx_omni_agent_reply)')
     .option('--gupshup-webhook-verify-token <token>', 'Gupshup webhook verify token')
+    // Bridge tmux session override (parity with `update`; propagated via NATS env)
+    .option(
+      '--bridge-tmux-session <name>',
+      'Tmux session name the genie bridge spawns into for this instance (propagated as GENIE_TMUX_SESSION via NATS). Use "null" to clear.',
+    )
     // Default
     .option('--is-default', 'Set as default instance for channel')
     .action(async (options: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary
Addresses three reviewer comments on PR #471 (merged):

| # | Reviewer | Severity | Issue |
|---|---|---|---|
| 1 | Gemini | MEDIUM | `GENIE_TMUX_SESSION` injected only in turn-based dispatch; standard/fire-and-forget paths drop it |
| 2 | Gemini | MEDIUM + security | `bridgeTmuxSession` accepts arbitrary strings — tmux rejects `/` and `:`, and shell metachars are a command-injection vector |
| 3 | Gemini | MEDIUM | `--bridge-tmux-session` flag on `update` but missing from `create` |

## Changes

**`packages/api/src/plugins/agent-dispatcher.ts`**
- `buildMessageTrigger` now sets `trigger.env.GENIE_TMUX_SESSION` when the instance has the override — every caller (turn-based, fire-and-forget, streaming) inherits it.
- Turn-based helper merges (not replaces) `trigger.env` so instance-scoped keys survive the turn-scoped additions.

**`packages/api/src/routes/v2/instances.ts`**
- `bridgeTmuxSession` zod schema: `.min(1).max(64).regex(/^[A-Za-z0-9_.-]+$/, ...)` — alphanumerics + `_`, `-`, `.` only. Rejects `/`, `:`, whitespace, shell metachars at the API boundary with a descriptive error.

**`packages/cli/src/commands/instances.ts`**
- Added `--bridge-tmux-session <name>` to `omni instances create` (parity with `update`; same `"null"` sentinel semantics).

## Test Evidence
```
$ bun test packages/core/src/providers/__tests__/nats-genie-provider.test.ts
13/13 green (env pass-through contract unchanged — still covers both states)

$ bun run typecheck
clean across all 20 packages

$ bun packages/cli/src/index.ts instances create --help | grep tmux
  --bridge-tmux-session <name>   Tmux session name … Use "null" to clear.
```

## Defense In Depth
- **API layer** (this PR): regex rejects unsafe chars before storage.
- **Dispatcher layer** (this PR): injects env for every path.
- **Bridge layer** (automagik/genie#1278, sibling PR): normalises `/` → `-`, `:` → `-` on the consumer side so legacy rows or external producers can't crash tmux.

## Out of Scope
- `buildMessageTrigger` remains un-exported, so the env-injection test lives at the provider/NATS payload layer (via `nats-genie-provider.test.ts`). Refactoring that for direct unit testability is a separate concern.
- Stricter char-set (e.g. alphanumeric-only) would reject legitimate names like `whatsapp-scout-12`; the chosen `[A-Za-z0-9_.-]+` set matches the consumer's post-normalization alphabet.

## Refs
- Parent wish: `.genie/wishes/per-instance-bridge-tmux-session/WISH.md`
- Original PR: #471 (merged)
- Sibling genie PR: automagik/genie#1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)