### PR TITLE
fix(cli): bun build:server requires --outdir for multi-file output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "test": "bun test",
     "test:integration": "RUN_INTEGRATION_TESTS=1 bun test",
     "clean": "rm -rf dist db",
-    "build:server": "bun build src/bundled-server-entry.ts --outfile dist/server/index.js --target bun --external @anthropic-ai/claude-agent-sdk",
+    "build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --target bun --external @anthropic-ai/claude-agent-sdk",
     "build:migrations": "rm -rf db/drizzle && mkdir -p db && cp -r ../db/drizzle db/drizzle",
     "prepack": "bun run build && bun run build:server && bun run build:migrations"
   },


### PR DESCRIPTION
## Problem
The `prepack` → `build:server` script has been failing on every Version workflow run since the trigger fix (#472) landed:

```
$ bun build src/bundled-server-entry.ts --outfile dist/server/index.js --target bun --external @anthropic-ai/claude-agent-sdk
error: cannot write multiple output files without an output directory
error: script \"build:server\" exited with code 1
error: script \"prepack\" exited with code 1
```

bun 1.3.x rejects `--outfile` when the bundled entry emits multiple artifacts. `bundled-server-entry.ts` transitively pulls in the `davey` native module which compiles to `.node` assets for multiple libc targets (musl + glibc), so bun needs a directory to place them alongside the JS bundle.

This has blocked every `@next` publish attempt for the tmux-session work (#471, #472, #473 all merged to dev, never published).

## Fix

```diff
-"build:server": "bun build src/bundled-server-entry.ts --outfile dist/server/index.js --target bun --external @anthropic-ai/claude-agent-sdk"
+"build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --target bun --external @anthropic-ai/claude-agent-sdk"
```

- `--outdir dist/server` — lets bun emit multiple files (entry + assets) as needed.
- `--entry-naming 'index.[ext]'` — preserves the historical output path `dist/server/index.js` so every downstream consumer that does `require('./dist/server/index.js')` continues to work.

## Test Evidence

```
$ cd packages/cli && bun run prepack
...
Bundled 3688 modules in 657ms
  index.js                            23.97 MB  (entry point)
  davey.linux-x64-musl-*.node          1.88 MB   (asset)
  davey.linux-x64-gnu-*.node           1.87 MB   (asset)

$ ls dist/server/index.js
dist/server/index.js
```

No behavior change for consumers — only the build command that produces the file is different.

## Pre-Existing
This failure predates my tmux-session work. Nothing about the publishes landed a file referenced by this path since 2.260410.1 (April 10) — the last successful publish was via a different code path. The Version trigger fix in #472 is what finally gets the workflow far enough to surface this bug.

## Merge → Publish Chain
After this merges:
- Any subsequent PR merge to dev fires Version on `pull_request: closed+merged` (trigger fix from #472).
- Version runs `prepack` → now green.
- `bun publish --tag next` uploads the bundle.
- `bun add -g @automagik/omni@next` finally resolves.

Alternatively, merging this PR itself will trigger Version via the same path, which should be the first successful `@next` publish in 11 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)