### PR TITLE
fix(cli): strip hash from native-module asset filenames

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "test": "bun test",
     "test:integration": "RUN_INTEGRATION_TESTS=1 bun test",
     "clean": "rm -rf dist db",
-    "build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --target bun --external @anthropic-ai/claude-agent-sdk",
+    "build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --asset-naming '[name].[ext]' --target bun --external @anthropic-ai/claude-agent-sdk",
     "build:migrations": "rm -rf db/drizzle && mkdir -p db && cp -r ../db/drizzle db/drizzle",
     "prepack": "bun run build && bun run build:server && bun run build:migrations"
   },


### PR DESCRIPTION
## Problem
`@automagik/omni@next = 2.260421.3` (published from #474) **crashloops at startup**:

```
error: Cannot find native binding. npm has a bug related to optional dependencies
       (https://github.com/npm/cli/issues/4828). Please try `npm i` again after
       removing both package-lock.json and node_modules directory.
  at /node_modules/@automagik/omni/dist/server/index.js:119792
```

Confirmed via `pm2 restart omni-api` against the installed 2.260421.3 bundle — 6 consecutive restarts, never reaches `listen`.

## Root Cause
PR #474 switched `build:server` from `--outfile` to `--outdir` so bun could emit multiple files (entry + native .node assets). But bun's default asset-naming adds a content hash:

```
dist/server/davey.linux-x64-gnu-vevevdy2.node   ← emitted
dist/server/davey.linux-x64-musl-3vkb94zg.node
```

The @napi-rs runtime loader embedded in the bundle constructs canonical `process.platform + process.arch` filenames (no hash) to resolve the native binding:

```
davey.linux-x64-gnu.node                        ← expected
davey.linux-x64-musl.node
```

Mismatch → loader throws → server never boots.

## Fix
Pass `--asset-naming '[name].[ext]'` so bun preserves the upstream module's native-file names:

```diff
-"build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --target bun --external @anthropic-ai/claude-agent-sdk"
+"build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --asset-naming '[name].[ext]' --target bun --external @anthropic-ai/claude-agent-sdk"
```

## Verification
```
$ cd packages/cli && rm -rf dist/server && bun run build:server
Bundled 3688 modules in 660ms
  index.js                   23.97 MB  (entry point)
  davey.linux-x64-musl.node  1.88 MB   (asset)
  davey.linux-x64-gnu.node   1.87 MB   (asset)
```

Filenames now match what the bundled loader expects.

## Merge → Ship
Merging this PR triggers Version on the merge itself (via the dev PR trigger from #472). The Version run executes `prepack` (which now uses the correct asset-naming) and publishes to `@next`. The resulting tarball will:
- Contain `davey.linux-x64-{gnu,musl}.node` at expected paths
- Boot without the "Cannot find native binding" error
- Apply migration 0027 on startup
- Expose `bridge_tmux_session` in the API

Paired with #471/#472/#473/#474/#1278 — this is the last blocker to the tmux-session feature actually working end-to-end when installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)