### PR TITLE
fix(cli): externalize native-module deps instead of bundling them

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,15 +20,18 @@
     "test": "bun test",
     "test:integration": "RUN_INTEGRATION_TESTS=1 bun test",
     "clean": "rm -rf dist db",
-    "build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --asset-naming '[name].[ext]' --target bun --external @anthropic-ai/claude-agent-sdk",
+    "build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --asset-naming '[name].[ext]' --target bun --external @anthropic-ai/claude-agent-sdk --external @snazzah/davey --external libsodium-wrappers --external opusscript",
     "build:migrations": "rm -rf db/drizzle && mkdir -p db && cp -r ../db/drizzle db/drizzle",
     "prepack": "bun run build && bun run build:server && bun run build:migrations"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
     "@sentry/bun": "^10.43.0",
+    "@snazzah/davey": "^0.1.11",
     "chalk": "^5.4.0",
     "commander": "^13.1.0",
+    "libsodium-wrappers": "^0.7.15",
+    "opusscript": "^0.1.1",
     "ora": "^8.1.1",
     "qrcode-terminal": "^0.12.0"
   },


### PR DESCRIPTION
## Context
`@automagik/omni@next` 2.260421.3 and 2.260421.4 both crashloop at startup:

```
error: Cannot find native binding. npm has a bug related to optional dependencies
       (https://github.com/npm/cli/issues/4828). Please try `npm i` again after
       removing both package-lock.json and node_modules directory.
  at /node_modules/@automagik/omni/dist/server/index.js:119792
```

Reproduced locally: `bun add -g @automagik/omni@next` → `pm2 restart omni-api` → crashloop (120+ restarts).

## Root Cause
`@snazzah/davey` (voice-client's native binding) ships its own @napi-rs-style loader that does `require('@snazzah/davey-<platform>-<libc>')` to resolve the optional-dependency subpackage for the current runtime. When bundled, the loader's `require` calls hit inlined modules that no longer point at real `.node` files.

Previous attempts:
- **#474**: switched `--outfile` → `--outdir` to allow multi-file output. Enabled the build but the emitted hashed names didn't match the loader's expectations.
- **#475**: added `--asset-naming '[name].[ext]'` to strip the hash. Filenames became canonical (`davey.linux-x64-gnu.node`) but the loader never looks there — it only checks the optional-dep package namespaces.

## Fix
Mark the three voice-client native deps as `--external` so the bundle keeps their `require()` calls literal. At runtime the consumer's `node_modules/@snazzah/davey/` has the proper per-platform optional-dep install tree, and the @napi-rs loader resolves normally:

```diff
-"build:server": "... --external @anthropic-ai/claude-agent-sdk"
+"build:server": "... --external @anthropic-ai/claude-agent-sdk --external @snazzah/davey --external libsodium-wrappers --external opusscript"
```

For that to work at install time, those three deps need to be runtime dependencies of `@automagik/omni` (not just transitive through `packages/voice-client`, which isn't published standalone). Added to `dependencies`:

```diff
 "dependencies": {
   "@anthropic-ai/claude-agent-sdk": "^0.2.62",
   "@sentry/bun": "^10.43.0",
+  "@snazzah/davey": "^0.1.11",
   "chalk": "^5.4.0",
   "commander": "^13.1.0",
+  "libsodium-wrappers": "^0.7.15",
+  "opusscript": "^0.1.1",
   "ora": "^8.1.1",
   "qrcode-terminal": "^0.12.0"
 }
```

Versions match `packages/voice-client/package.json`.

## Verification
```
$ cd packages/cli && rm -rf dist && bun run build:server
Bundled 3678 modules in 627ms
  index.js  19.79 MB  (entry point)
# No more .node assets — externalized
```

Bundle size drops 23.97MB → 19.79MB (native assets no longer inlined).

## After this merges
- Version workflow publishes the new `@next` (via the PR-to-dev trigger).
- `bun add -g @automagik/omni@next` installs the CLI + the three external deps.
- `pm2 restart omni-api` boots cleanly — migration 0027 applies, API exposes `bridge_tmux_session`.

Final blocker to the end-to-end tmux-session flow actually working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)