### PR TITLE
fix(api): align isAddressInUse() with Bun.listen error shape (#469)

### DIFF
--- a/packages/api/src/__tests__/pgserve.test.ts
+++ b/packages/api/src/__tests__/pgserve.test.ts
@@ -23,6 +23,7 @@ import {
   type SystemCalls,
   ensureInternalPortFree,
   findProcessOnPort,
+  isAddressInUse,
   isPopulatedPgserveDir,
   killOrphanedPostgres,
   killPostgresByPid,
@@ -609,5 +610,47 @@ describe('isPopulatedPgserveDir', () => {
 
   test('returns false when dir does not exist at all', () => {
     expect(isPopulatedPgserveDir(join(tmpdir(), `pgserve-missing-${Date.now()}`))).toBe(false);
+  });
+});
+
+/**
+ * Regression guard for automagik-dev/omni#469.
+ *
+ * `tryStartOnPort` relies on `isAddressInUse` to convert a port-conflict throw
+ * into a `null` return, so the `MAX_PORT_RETRIES` loop can advance to port+1.
+ * If this check drifts behind Bun's error wording, the fallback silently
+ * disengages and a simple port collision surfaces as a fatal main() crash.
+ *
+ * Both wordings below are observed in production:
+ *   - Bun.listen (bun ≥ 1.3.11): "Failed to listen at 127.0.0.1"
+ *   - pgserve wrapper:           "Failed to listen on 0.0.0.0:54321"
+ */
+describe('isAddressInUse', () => {
+  test('matches Bun.listen wording ("Failed to listen at <hostname>", no port)', () => {
+    expect(isAddressInUse(new Error('Failed to listen at 127.0.0.1'))).toBe(true);
+  });
+
+  test('matches pgserve wrapper wording ("Failed to listen on <hostname>:<port>")', () => {
+    expect(isAddressInUse(new Error('Failed to listen on 0.0.0.0:54321'))).toBe(true);
+  });
+
+  test('matches canonical Node/libuv EADDRINUSE errno string', () => {
+    expect(isAddressInUse(new Error('listen EADDRINUSE: address already in use 0.0.0.0:54321'))).toBe(true);
+  });
+
+  test('matches lowercase "address already in use" fragment alone', () => {
+    expect(isAddressInUse(new Error('bind failed: address already in use'))).toBe(true);
+  });
+
+  test('accepts non-Error throwables by stringifying them', () => {
+    expect(isAddressInUse('Failed to listen at ::1')).toBe(true);
+    expect(isAddressInUse({ toString: () => 'EADDRINUSE' })).toBe(true);
+  });
+
+  test('returns false for unrelated errors so they propagate as fatal', () => {
+    expect(isAddressInUse(new Error('ENOENT: no such file or directory'))).toBe(false);
+    expect(isAddressInUse(new Error('permission denied'))).toBe(false);
+    expect(isAddressInUse(undefined)).toBe(false);
+    expect(isAddressInUse(null)).toBe(false);
   });
 });

--- a/packages/api/src/pgserve.ts
+++ b/packages/api/src/pgserve.ts
@@ -211,10 +211,30 @@ export function validatePgserveDataDir(config: PgserveConfig): string | null {
   return resolved;
 }
 
-function isAddressInUse(error: unknown): boolean {
+/**
+ * Decide whether a caught error indicates the listener port is already bound,
+ * so `tryStartOnPort` can return `null` and let the retry loop advance to the
+ * next port instead of surfacing a fatal crash.
+ *
+ * Wording is deliberately broad because the error originates in two layers:
+ *   - `Bun.listen` (bun ≥ 1.3.11, Linux x64) throws `"Failed to listen at <hostname>"`
+ *     (preposition **at**, no port) when `reusePort` is not set and the port is taken.
+ *   - pgserve's own wrapper has historically thrown
+ *     `"Failed to listen on <hostname>:<port>"` (preposition **on**, with port).
+ *   - `Node` / `libuv` surfaces `EADDRINUSE` / "address already in use".
+ *
+ * Bun's internal string is an implementation detail that can drift between versions;
+ * matching both prepositions keeps the port-retry fallback resilient without
+ * coupling to a specific runtime build. See automagik-dev/omni#469.
+ */
+export function isAddressInUse(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
-  // pgserve throws "Failed to listen on 0.0.0.0:<port>" when the proxy port is taken
-  return msg.includes('EADDRINUSE') || msg.includes('address already in use') || msg.includes('Failed to listen on');
+  return (
+    msg.includes('EADDRINUSE') ||
+    msg.includes('address already in use') ||
+    msg.includes('Failed to listen on') ||
+    msg.includes('Failed to listen at')
+  );
 }
 
 function buildDatabaseUrl(port: number): string {


### PR DESCRIPTION
## Summary

- Fix `isAddressInUse()` in `packages/api/src/pgserve.ts` so port-in-use errors actually drive the `MAX_PORT_RETRIES` fallback in `tryStartOnPort` / `startEmbeddedPgserve`.
- Broaden the check to match **both** wordings — `Bun.listen` throws `"Failed to listen at <hostname>"` (preposition **at**, no port), while pgserve's own wrapper throws `"Failed to listen on <hostname>:<port>"`. The old check only matched the latter.
- Export the helper and add regression tests for every observed wording + the canonical `EADDRINUSE` / `"address already in use"` strings, plus negative cases.

## Why this matters

Closes #469. During the recent Eugênia prod outage, a direct `Bun.listen` conflict slipped past the old check, so `tryStartOnPort` re-threw instead of returning `null`. The port-fallback loop never ran, `main()` crashed, PM2 restarted, the port was still held — infinite loop.

Matching both prepositions plus `EADDRINUSE` keeps the fallback resilient against future Bun wording drift without coupling us to a specific runtime build.

## Changes

- `packages/api/src/pgserve.ts` — widen `isAddressInUse`, export it, add rationale comment citing Bun 1.3.11 message format and #469.
- `packages/api/src/__tests__/pgserve.test.ts` — new `describe('isAddressInUse', …)` block covering:
  - Bun.listen wording (`"Failed to listen at 127.0.0.1"`)
  - pgserve wrapper wording (`"Failed to listen on 0.0.0.0:54321"`)
  - Node/libuv `EADDRINUSE`
  - lowercase `"address already in use"`
  - non-`Error` throwables (string + object with `toString`)
  - negative cases (ENOENT, permission-denied, `null`, `undefined`)

## Validation

- `bun run build` — 5/5 tasks succeeded (root turbo)
- `bunx biome check packages/api` — 240 files, 0 issues
- `bun test` in `packages/api` — **744 pass / 0 fail / 265 skip** across 77 files (1955 expect calls)

## Test plan

- [x] Unit: both wordings round-trip to `true`, negative wordings to `false`
- [ ] Integration: pre-bind `127.0.0.1:8432` and boot pgserve to assert retry to `8433` (left for follow-up — requires live pgserve, out of scope for this surgical fix)
- [x] Regression guard: rationale comment in source cites Bun version + #469 so future wording drift has a breadcrumb

## Not verified

- The **real** port-retry path in a live port conflict — I did not boot pgserve against a held port. The unit tests prove `isAddressInUse` now returns `true` for the Bun wording; `tryStartOnPort`'s call site is unchanged and already covered by a `return null` on that predicate.

Closes #469