### PR TITLE
fix(api): reject invalid after parameter on GET /v2/chats/:id/messages (#462)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/chats-messages-after-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/chats-messages-after-validation.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for automagik-dev/omni#462
+ *
+ * Contract:
+ *   GET /chats/:id/messages MUST return HTTP 400 (not 500) when
+ *   `before` or `after` query parameters are not parseable date
+ *   strings. Previously, invalid values (e.g. a UUID) flowed into
+ *   `new Date(...)` producing an `Invalid Date` that surfaced as a
+ *   500 INTERNAL_ERROR via a downstream Drizzle comparison.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { chatsRoutes } from '../chats';
+
+type CallArgs = { chatId: string; options: Record<string, unknown> };
+
+function mountChatsRoutes(calls: CallArgs[]): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      messages: {
+        getChatMessages: mock(async (chatId: string, options: Record<string, unknown>) => {
+          calls.push({ chatId, options });
+          return [];
+        }),
+      },
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/chats', chatsRoutes);
+  return app;
+}
+
+describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
+  test('returns 400 when `after` is a UUID (unparseable as date)', async () => {
+    const calls: CallArgs[] = [];
+    const app = mountChatsRoutes(calls);
+
+    const res = await app.request('/chats/chat-123/messages?after=550e8400-e29b-41d4-a716-446655440000');
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0); // service must not be called with Invalid Date
+  });
+
+  test('returns 400 when `after` is arbitrary garbage', async () => {
+    const calls: CallArgs[] = [];
+    const app = mountChatsRoutes(calls);
+
+    const res = await app.request('/chats/chat-123/messages?after=not-a-date-at-all');
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 400 when `before` is a UUID (same class of bug)', async () => {
+    const calls: CallArgs[] = [];
+    const app = mountChatsRoutes(calls);
+
+    const res = await app.request('/chats/chat-123/messages?before=550e8400-e29b-41d4-a716-446655440000');
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 200 and passes a Date to the service when `after` is valid ISO 8601', async () => {
+    const calls: CallArgs[] = [];
+    const app = mountChatsRoutes(calls);
+
+    const res = await app.request('/chats/chat-123/messages?after=2024-01-01T00:00:00.000Z');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.chatId).toBe('chat-123');
+    const after = calls[0]?.options.after;
+    expect(after).toBeInstanceOf(Date);
+    expect((after as Date).toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  test('returns 200 and omits `after`/`before` when no parameters are provided', async () => {
+    const calls: CallArgs[] = [];
+    const app = mountChatsRoutes(calls);
+
+    const res = await app.request('/chats/chat-123/messages');
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.options.after).toBeUndefined();
+    expect(calls[0]?.options.before).toBeUndefined();
+  });
+
+  test('honours `mediaOnly=true`', async () => {
+    const calls: CallArgs[] = [];
+    const app = mountChatsRoutes(calls);
+
+    const res = await app.request('/chats/chat-123/messages?mediaOnly=true');
+
+    expect(res.status).toBe(200);
+    expect(calls[0]?.options.mediaOnly).toBe(true);
+  });
+});

--- a/packages/api/src/routes/v2/chats.ts
+++ b/packages/api/src/routes/v2/chats.ts
@@ -553,20 +553,55 @@ chatsRoutes.patch(
 );
 
 /**
+ * Parse an optional date query parameter, emitting a Zod issue
+ * (→ HTTP 400 via zValidator) if the value is present but not a
+ * parseable date string. Accepts any input `new Date()` resolves
+ * to a valid instant (ISO 8601 is the recommended form).
+ *
+ * Fixes: https://github.com/automagik-dev/omni/issues/462 —
+ * previously, invalid values (e.g. a UUID) flowed into `new Date(...)`
+ * producing an `Invalid Date` that surfaced as a 500 INTERNAL_ERROR
+ * from the downstream Drizzle `gte`/`lte` comparison.
+ */
+const optionalDateParam = (paramName: string) =>
+  z
+    .string()
+    .optional()
+    .transform((v, ctx) => {
+      if (v === undefined || v === '') return undefined;
+      const parsed = new Date(v);
+      if (Number.isNaN(parsed.getTime())) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `invalid ${paramName} parameter: expected ISO 8601 date string, got "${v}"`,
+        });
+        return z.NEVER;
+      }
+      return parsed;
+    });
+
+const listMessagesQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(1000).default(100),
+  before: optionalDateParam('before'),
+  after: optionalDateParam('after'),
+  mediaOnly: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
+});
+
+/**
  * GET /chats/:id/messages - Get messages for a chat
  */
-chatsRoutes.get('/:id/messages', async (c) => {
+chatsRoutes.get('/:id/messages', zValidator('query', listMessagesQuerySchema), async (c) => {
   const chatId = c.req.param('id');
-  const limit = Number.parseInt(c.req.query('limit') ?? '100', 10);
-  const before = c.req.query('before');
-  const after = c.req.query('after');
-  const mediaOnly = c.req.query('mediaOnly') === 'true';
+  const { limit, before, after, mediaOnly } = c.req.valid('query');
   const services = c.get('services');
 
   const messages = await services.messages.getChatMessages(chatId, {
     limit,
-    before: before ? new Date(before) : undefined,
-    after: after ? new Date(after) : undefined,
+    before,
+    after,
     mediaOnly,
   });
 


### PR DESCRIPTION
## Summary

- GET `/v2/chats/:id/messages` previously fed `before`/`after` query params straight into `new Date(v)`, then into Drizzle's `gte`/`lte`. Unparseable inputs (e.g. a UUID) produced an `Invalid Date` that surfaced as HTTP 500 `INTERNAL_ERROR`.
- Wrap the route in `zValidator('query', ...)` with a date-parsing schema that emits a Zod issue (→ HTTP 400) with an actionable message when the value is not a parseable date string. Success path returns a real `Date` to the service.
- Adds regression tests: 400 for UUID and garbage inputs on both `after` and `before`, 200 for valid ISO 8601, and 200 when the params are absent.

Fixes #462.

## Test plan

- [x] `bun test packages/api/src/routes/v2/__tests__/chats-messages-after-validation.test.ts` — 6/6 pass
- [x] `bun test packages/api` — 750 pass / 265 skip / 0 fail (no regressions)
- [x] `bunx biome check packages/api` — clean
- [x] `bun run build` — all tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)