### PR TITLE
fix(cli): auto-set reply filter when agent assigned to instance (#443)

### DIFF
--- a/packages/api/src/__tests__/auto-reply-filter.test.ts
+++ b/packages/api/src/__tests__/auto-reply-filter.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for omni#443 auto-set reply filter logic.
+ *
+ * When an agent is assigned to an instance and no reply filter is configured,
+ * the API auto-populates `agentReplyFilter = { mode: 'all', conditions: { onDm: true } }`
+ * to prevent silent message drops.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_AGENT_REPLY_FILTER, shouldApplyDefaultReplyFilter } from '../routes/v2/instances';
+
+describe('omni#443 auto-set agentReplyFilter', () => {
+  test('default filter shape matches issue spec (mode=all, onDm=true)', () => {
+    expect(DEFAULT_AGENT_REPLY_FILTER).toEqual({
+      mode: 'all',
+      conditions: { onDm: true },
+    });
+  });
+
+  describe('create (no prior instance state)', () => {
+    test('applies default when agent is assigned and no filter provided', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: undefined,
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(true);
+    });
+
+    test('does NOT apply when no agent is assigned', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: null,
+          currentAgentId: null,
+          explicitReplyFilter: undefined,
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+
+    test('does NOT apply when user provides explicit filter', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: { mode: 'filtered', conditions: { onMention: true } },
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+
+    test('respects explicit null filter (user clearing)', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: null,
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('update (existing instance)', () => {
+    test('applies default when agent is newly assigned and instance has no filter', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'new-agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: undefined,
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(true);
+    });
+
+    test('does NOT apply when instance already has a reply filter', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: undefined,
+          currentReplyFilter: { mode: 'filtered', conditions: { onDm: true } },
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+
+    test('does NOT apply when reassigning agent and filter already exists', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'new-agent-uuid',
+          currentAgentId: 'old-agent-uuid',
+          explicitReplyFilter: undefined,
+          currentReplyFilter: { mode: 'all', conditions: {} },
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+
+    test('does NOT apply when unsetting the agent (agentId: null)', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: null,
+          currentAgentId: 'old-agent-uuid',
+          explicitReplyFilter: undefined,
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+
+    test('does NOT apply when request does not touch agentId', () => {
+      // PATCH that only updates name / other fields — must not auto-populate
+      // even if the instance has agentId set but no filter. The trigger is
+      // "user is assigning an agent", not "instance currently has an agent".
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: undefined,
+          currentAgentId: 'existing-agent-uuid',
+          explicitReplyFilter: undefined,
+          currentReplyFilter: null,
+          agentIdTouched: false,
+        }),
+      ).toBe(false);
+    });
+
+    test('respects explicit filter even during agent reassignment', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'new-agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: { mode: 'filtered', conditions: { onMention: true } },
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+
+    test('respects explicit null filter (clear) during agent assignment', () => {
+      expect(
+        shouldApplyDefaultReplyFilter({
+          newAgentId: 'new-agent-uuid',
+          currentAgentId: null,
+          explicitReplyFilter: null,
+          currentReplyFilter: null,
+          agentIdTouched: true,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -246,6 +246,52 @@ const updateInstanceSchema = createInstanceSchema.partial().extend({
 });
 
 /**
+ * Default reply filter applied when an agent is assigned without an explicit filter.
+ *
+ * Matches omni#443 acceptance criteria: assigning an agent implies the user wants
+ * responses, so an unset filter shouldn't silently drop messages. `mode: 'all'` +
+ * `onDm: true` makes the DM-first intent explicit on the stored row.
+ */
+export const DEFAULT_AGENT_REPLY_FILTER = {
+  mode: 'all' as const,
+  conditions: { onDm: true },
+};
+
+/**
+ * Decide whether to auto-set a default `agentReplyFilter` for an instance
+ * create/update request.
+ *
+ * Applies when:
+ *   - the request leaves the instance with an agent assigned
+ *     (`newAgentId` non-null, OR unchanged `currentAgentId` non-null), AND
+ *   - the caller did NOT explicitly send `agentReplyFilter` in this request
+ *     (`explicitReplyFilter === undefined`), AND
+ *   - the instance does not already have a reply filter stored
+ *     (`currentReplyFilter` is null/undefined).
+ *
+ * An explicit `null` in the request (user clearing the filter) is respected and
+ * returns `false`. Exported for unit testing.
+ *
+ * The trigger for update is "this request touches agentId" — bare field updates
+ * on an already-agent-assigned instance don't auto-populate. This matches the
+ * acceptance criteria in omni#443.
+ */
+export function shouldApplyDefaultReplyFilter(args: {
+  newAgentId: string | null | undefined;
+  currentAgentId: string | null | undefined;
+  explicitReplyFilter: unknown;
+  currentReplyFilter: unknown;
+  agentIdTouched: boolean;
+}): boolean {
+  if (!args.agentIdTouched) return false;
+  if (args.explicitReplyFilter !== undefined) return false;
+  const effectiveAgentId = args.newAgentId !== undefined ? args.newAgentId : args.currentAgentId;
+  if (!effectiveAgentId) return false;
+  if (args.currentReplyFilter != null) return false;
+  return true;
+}
+
+/**
  * Map the generic `token` field to the correct channel-specific DB column.
  * Also returns the token to use for the plugin connect call.
  */
@@ -549,6 +595,25 @@ instancesRoutes.post('/', zValidator('json', createInstanceSchema), async (c) =>
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
+  // omni#443: Auto-set reply filter when agent is assigned but no filter is set.
+  // Prevents the silent-drop bug where a newly created instance with `agentId`
+  // but `agentReplyFilter: null` receives messages but never dispatches.
+  if (
+    shouldApplyDefaultReplyFilter({
+      newAgentId: data.agentId,
+      currentAgentId: null,
+      explicitReplyFilter: data.agentReplyFilter,
+      currentReplyFilter: null,
+      agentIdTouched: data.agentId !== undefined,
+    })
+  ) {
+    (data as { agentReplyFilter?: typeof DEFAULT_AGENT_REPLY_FILTER }).agentReplyFilter = DEFAULT_AGENT_REPLY_FILTER;
+    log.info('Agent assigned without reply filter — defaulting to mode:all onDm:true (omni#443)', {
+      agentId: data.agentId,
+      defaultFilter: DEFAULT_AGENT_REPLY_FILTER,
+    });
+  }
+
   // Map generic `token` → channel-specific DB column + resolve connect token
   const connectToken = resolveChannelToken(data);
 
@@ -590,15 +655,36 @@ instancesRoutes.patch('/:id', instanceAccess, zValidator('json', updateInstanceS
   const data = c.req.valid('json');
   const services = c.get('services');
 
-  // Detect agent assignment changes for auto-key provisioning
+  // Detect agent assignment changes for auto-key provisioning + auto reply-filter (omni#443)
   let oldAgentId: string | null | undefined;
+  let currentReplyFilter: unknown = null;
   if (data.agentId !== undefined) {
     try {
       const current = await services.instances.getById(id);
       oldAgentId = current.agentId;
+      currentReplyFilter = current.agentReplyFilter;
     } catch {
       // Instance not found — update will throw
     }
+  }
+
+  // omni#443: Auto-set reply filter when an agent is being assigned to this instance
+  // and neither the request nor the existing row provides one. Prevents silent drops.
+  if (
+    shouldApplyDefaultReplyFilter({
+      newAgentId: data.agentId,
+      currentAgentId: oldAgentId,
+      explicitReplyFilter: data.agentReplyFilter,
+      currentReplyFilter,
+      agentIdTouched: data.agentId !== undefined,
+    })
+  ) {
+    (data as { agentReplyFilter?: typeof DEFAULT_AGENT_REPLY_FILTER }).agentReplyFilter = DEFAULT_AGENT_REPLY_FILTER;
+    log.info('Agent assigned without reply filter — defaulting to mode:all onDm:true (omni#443)', {
+      instanceId: id,
+      agentId: data.agentId,
+      defaultFilter: DEFAULT_AGENT_REPLY_FILTER,
+    });
   }
 
   const instance = await services.instances.update(id, data);

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -269,7 +269,10 @@ export function createInstancesCommand(): Command {
     .requiredOption('--name <name>', 'Instance name')
     .requiredOption('--channel <type>', `Channel type (${VALID_CHANNELS.join(', ')})`)
     // Agent routing
-    .option('--agent-fk-id <uuid>', 'Agent FK UUID (references agents table, use "null" to clear)')
+    .option(
+      '--agent-fk-id <uuid>',
+      'Agent FK UUID (references agents table, use "null" to clear). When set without --reply-filter-mode, reply filter defaults to {mode:"all", onDm:true} so messages are dispatched instead of silently dropped (omni#443).',
+    )
     .option('--agent-provider <id>', 'Agent provider ID')
     .option('--agent <id>', 'Agent ID')
     .option('--agent-type <type>', 'Agent type: agent, team, or workflow')
@@ -747,7 +750,10 @@ export function createInstancesCommand(): Command {
     .option('--is-default', 'Set as default instance for channel')
     .option('--no-is-default', 'Unset as default instance for channel')
     // Agent routing
-    .option('--agent-fk-id <uuid>', 'Agent FK UUID (references agents table, use "null" to clear)')
+    .option(
+      '--agent-fk-id <uuid>',
+      'Agent FK UUID (references agents table, use "null" to clear). When assigning an agent on an instance with no reply filter, the filter defaults to {mode:"all", onDm:true} so messages are dispatched instead of silently dropped (omni#443).',
+    )
     .option('--agent-provider <id>', 'Agent provider ID (use "null" to clear)')
     .option('--agent <id>', 'Agent ID (use "null" to clear)')
     .option('--agent-type <type>', 'Agent type: agent, team, or workflow')


### PR DESCRIPTION
## Summary

- Auto-populate `agentReplyFilter = { mode: "all", conditions: { onDm: true } }` on `POST /instances` and `PATCH /instances/:id` when an agent is assigned (`agentId` non-null) and no reply filter is explicitly provided and the instance has no existing filter.
- Log an explicit `info` line on auto-apply so operators see the default was injected.
- CLI `--agent-fk-id --help` now documents the default behavior (both create and update).
- Surgical: 3 files touched, 254 insertions. Pure-function helper `shouldApplyDefaultReplyFilter()` exported and unit-tested.

## Why

Assigning an agent left `agentReplyFilter: null` — the instance received messages but never dispatched them. Silent failure, no error, no warning. Real user reported 30 min of Telegram debugging before identifying the null filter.

Fix preserves explicit user intent: a body that sends `agentReplyFilter: null` (clear) or a populated filter is always respected. Auto-set only fires when the user is assigning an agent and did not send `agentReplyFilter` at all.

## Note re #453

PR #453 (sibling branch `fix/443-auto-set-reply-filter`) also targets this issue but touches dozens of unrelated files (wish docs, workflows, biome config, bench files). This PR is scoped to the behavior change + test only. Reviewers may prefer this narrower diff.

## Test plan

- [x] New unit test `packages/api/src/__tests__/auto-reply-filter.test.ts` — 12/12 pass covering create, update, explicit override, explicit null, reassignment, unassignment, and bare-field updates.
- [x] `bun run build` — green
- [x] `bunx biome check .` — green
- [x] `make typecheck` — green
- [x] Existing `instances-delete.test.ts`, `instances-profiles.test.ts`, `guild-config.test.ts`, `connect.test.ts` — 25 pass, 21 skip, 0 fail
- [ ] E2E: manually assign agent via `omni instances update --agent-fk-id <uuid>` and verify a Telegram message dispatches to the agent (requires live Telegram instance — not exercised by this agent)

Fixes: https://github.com/automagik-dev/omni/issues/443

🤖 Generated with [Claude Code](https://claude.com/claude-code)