### PR TITLE
fix(batch): compute estimatedCostCents from provider pricing table (#477)

### DIFF
--- a/packages/api/src/services/__tests__/batch-pricing.test.ts
+++ b/packages/api/src/services/__tests__/batch-pricing.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the batch-job cost pricing table (#477).
+ *
+ * These tests pin two behaviors:
+ *   1. `computeEstimatedCostCents` does the arithmetic correctly against a
+ *      synthetic pricing table with known round numbers — so arithmetic
+ *      bugs are caught without coupling the test to real provider prices.
+ *   2. The real `BATCH_PRICING_V1` table produces a total within ~2× of
+ *      the billing order-of-magnitude the original bug report observed
+ *      ($1–2 for 1662 audio + 1256 image + 381 document items). This
+ *      keeps #477's acceptance criteria enforceable in CI without
+ *      freezing exact cents against drifting provider prices.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { BATCH_PRICING_V1, type BatchPricingRates, computeEstimatedCostCents } from '../batch-pricing';
+
+describe('computeEstimatedCostCents', () => {
+  test('returns 0 for all-zero counts regardless of pricing', () => {
+    expect(
+      computeEstimatedCostCents({
+        audioCount: 0,
+        imageCount: 0,
+        videoCount: 0,
+        documentCount: 0,
+      }),
+    ).toBe(0);
+  });
+
+  test('computes a known total from a synthetic pricing table', () => {
+    // Synthetic table chosen for clean arithmetic:
+    //   audio: $0.001/min × 1 min/item × 1000 items = $1.00
+    //   image: $0.15 / 1k × 1000 items              = $0.15
+    //   video: $9.00 / 1k × 1000 items              = $9.00
+    //   document: $0.50 / 1k × 1000 items           = $0.50
+    //   total                                        = $10.65 → 1065¢
+    const pricing: BatchPricingRates = {
+      audioPerMinuteUsd: 0.001,
+      audioAvgMinutes: 1,
+      imagePer1kUsd: 0.15,
+      videoPer1kUsd: 9.0,
+      documentPer1kUsd: 0.5,
+    };
+
+    const cents = computeEstimatedCostCents(
+      {
+        audioCount: 1000,
+        imageCount: 1000,
+        videoCount: 1000,
+        documentCount: 1000,
+      },
+      pricing,
+    );
+
+    expect(cents).toBe(1065);
+  });
+
+  test('rounds fractional cents up so totals never under-report', () => {
+    // One image @ $0.00015 → 0.015¢ → ceil(0.015) = 1¢
+    const pricing: BatchPricingRates = {
+      audioPerMinuteUsd: 0,
+      audioAvgMinutes: 0,
+      imagePer1kUsd: 0.15,
+      videoPer1kUsd: 0,
+      documentPer1kUsd: 0,
+    };
+    expect(computeEstimatedCostCents({ audioCount: 0, imageCount: 1, videoCount: 0, documentCount: 0 }, pricing)).toBe(
+      1,
+    );
+  });
+
+  test('scales linearly per content type (additivity)', () => {
+    const counts = {
+      audioCount: 100,
+      imageCount: 200,
+      videoCount: 50,
+      documentCount: 25,
+    };
+    const single = computeEstimatedCostCents(counts);
+    const doubled = computeEstimatedCostCents({
+      audioCount: counts.audioCount * 2,
+      imageCount: counts.imageCount * 2,
+      videoCount: counts.videoCount * 2,
+      documentCount: counts.documentCount * 2,
+    });
+    // Doubling counts should (roughly) double the total. Allow a 2¢
+    // tolerance for the per-segment ceil() rounding.
+    expect(doubled).toBeGreaterThanOrEqual(single * 2 - 2);
+    expect(doubled).toBeLessThanOrEqual(single * 2 + 2);
+  });
+});
+
+describe('BATCH_PRICING_V1 sanity check (#477)', () => {
+  test('issue #477 repro counts estimate in the $0.50–$5.00 range (not $178)', () => {
+    // Exact counts from the #477 bug report:
+    //   1662 audio, 1256 image, 0 video, 381 document
+    // Old hardcoded estimator returned $178.76. Real provider bill was
+    // $1–2. New estimator must land in the same order of magnitude as
+    // the real bill (within ~2× is the acceptance target).
+    const cents = computeEstimatedCostCents({
+      audioCount: 1662,
+      imageCount: 1256,
+      videoCount: 0,
+      documentCount: 381,
+    });
+
+    expect(cents).toBeGreaterThanOrEqual(50); // $0.50 lower bound
+    expect(cents).toBeLessThanOrEqual(500); // $5.00 upper bound
+  });
+
+  test('documents never estimate at $0.00 (regression: old table had *0)', () => {
+    const cents = computeEstimatedCostCents({
+      audioCount: 0,
+      imageCount: 0,
+      videoCount: 0,
+      documentCount: 10_000,
+    });
+    expect(cents).toBeGreaterThan(0);
+  });
+
+  test('all rates in BATCH_PRICING_V1 are non-negative finite numbers', () => {
+    for (const value of Object.values(BATCH_PRICING_V1)) {
+      expect(Number.isFinite(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -34,6 +34,7 @@ import {
   createMediaProcessingService,
 } from '@omni/media-processing';
 import { and, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
+import { computeEstimatedCostCents } from './batch-pricing';
 import { MediaStorageService } from './media-storage';
 
 const log = createLogger('services:batch-jobs');
@@ -357,13 +358,11 @@ export class BatchJobService {
       else if (type === 'document') counts.documentCount++;
     }
 
-    // Rough cost estimates (in cents)
-    // Audio: ~$0.04/hour = ~0.1 cents per 10-second clip
-    // Image: ~$0.01 per image (Gemini vision tokens)
-    // Video: ~$0.02 per video (Gemini)
-    // Document: ~$0.00 (local processing)
-    const estimatedCostCents =
-      counts.audioCount * 10 + counts.imageCount * 1 + counts.videoCount * 2 + counts.documentCount * 0;
+    // Cost estimate derived from the declarative provider pricing table
+    // (`batch-pricing.ts`, pinned to default Groq STT + Gemini Flash-Lite
+    // vision as of 2026-04). See issue #477: the previous hardcoded
+    // per-item cents were off by ~150× for that provider mix.
+    const estimatedCostCents = computeEstimatedCostCents(counts);
 
     // Factor in average random delay between items (midpoint of default range)
     const avgDelayMs = (BatchJobService.DEFAULT_DELAY_MIN_MS + BatchJobService.DEFAULT_DELAY_MAX_MS) / 2;

--- a/packages/api/src/services/batch-pricing.ts
+++ b/packages/api/src/services/batch-pricing.ts
@@ -1,0 +1,107 @@
+/**
+ * Batch cost pricing — declarative provider rate table.
+ *
+ * The batch-job cost estimator used to be hardcoded per-item cents
+ * (`audio*10 + image*1 + video*2 + document*0`), which was off by ~150×
+ * vs. real provider billing for the default Groq+Gemini-Flash-Lite mix
+ * (issue #477). This module replaces that with a declarative rate table
+ * pinned to the configured default providers, so the number in
+ * `omni batch estimate` reflects order-of-magnitude real spend and
+ * drifts only when provider prices actually change.
+ *
+ * **Source of truth (2026-04):**
+ *
+ * - Groq Whisper Large v3 Turbo (STT): $0.04 per audio-hour.
+ *   https://groq.com/pricing
+ * - Gemini 2.5 Flash-Lite vision input: ~$0.00015 per image.
+ * - Gemini 2.5 Flash-Lite vision: ~$0.0003 per video-second
+ *   (WhatsApp-style ~30s video → ~$0.009 per video).
+ * - Gemini 2.5 Flash-Lite OCR/vision per document page: ~$0.0005.
+ *   https://ai.google.dev/pricing
+ *
+ * Audio cost scales with duration (per-minute rate × average minutes per
+ * item). Image/video/document scale as flat per-1k prices so the table
+ * stays easy to eyeball-verify against published provider pricing pages.
+ *
+ * To update rates: edit `BATCH_PRICING_V1` below and bump the version
+ * constant. The test in `batch-pricing.test.ts` pins a known-answer
+ * computation against a synthetic pricing table — it does **not** pin
+ * these real rates, so you can update them without editing tests.
+ */
+
+/**
+ * Per-content-type provider pricing used by the batch-job cost estimator.
+ *
+ * All fields are USD. `audioPerMinuteUsd` × `audioAvgMinutes` gives the
+ * per-item audio cost; image/video/document are expressed per 1k items
+ * for readability when comparing against provider pricing pages.
+ */
+export interface BatchPricingRates {
+  /** USD per minute of audio processed by the STT provider. */
+  audioPerMinuteUsd: number;
+  /**
+   * Average audio duration per item (in minutes), used together with
+   * `audioPerMinuteUsd` to estimate per-item audio cost. Defaults to a
+   * WhatsApp-voice-note-ish ~40 seconds (0.667 min).
+   */
+  audioAvgMinutes: number;
+  /** USD per 1,000 images processed by the vision provider. */
+  imagePer1kUsd: number;
+  /**
+   * USD per 1,000 videos processed by the vision provider. Bakes in an
+   * assumed average video duration (~30s) because per-video duration is
+   * not known at estimate time.
+   */
+  videoPer1kUsd: number;
+  /** USD per 1,000 documents processed by OCR/vision. */
+  documentPer1kUsd: number;
+}
+
+/**
+ * Rate table pinned against the default omni provider mix (Groq STT +
+ * Gemini Flash-Lite vision/OCR) as of 2026-04. Update these numbers —
+ * *not* the tests — when provider pricing changes.
+ */
+export const BATCH_PRICING_V1: BatchPricingRates = {
+  // Groq Whisper Large v3 Turbo: $0.04 / audio-hour = $0.04/60 per minute.
+  audioPerMinuteUsd: 0.04 / 60,
+  // WhatsApp voice note average duration (~40 seconds).
+  audioAvgMinutes: 40 / 60,
+  // Gemini 2.5 Flash-Lite vision input ≈ $0.00015/image → $0.15 / 1k.
+  imagePer1kUsd: 0.15,
+  // Gemini vision @ $0.0003/sec × ~30s avg ≈ $0.009/video → $9.00 / 1k.
+  videoPer1kUsd: 9.0,
+  // Gemini OCR/vision per document page ≈ $0.0005/doc → $0.50 / 1k.
+  documentPer1kUsd: 0.5,
+};
+
+/** Semver-ish tag for the current pricing table; bump on real rate changes. */
+export const BATCH_PRICING_VERSION = '2026-04-v1';
+
+/**
+ * Per-content-type item counts fed into the estimator.
+ */
+export interface BatchContentCounts {
+  audioCount: number;
+  imageCount: number;
+  videoCount: number;
+  documentCount: number;
+}
+
+/**
+ * Compute the estimated batch cost in whole cents for the given counts
+ * against the given pricing table. Pure function — safe to unit test in
+ * isolation. Rounds up (`Math.ceil`) so the displayed cents never
+ * under-report fractional provider spend.
+ */
+export function computeEstimatedCostCents(
+  counts: BatchContentCounts,
+  pricing: BatchPricingRates = BATCH_PRICING_V1,
+): number {
+  const audioUsd = counts.audioCount * pricing.audioAvgMinutes * pricing.audioPerMinuteUsd;
+  const imageUsd = (counts.imageCount / 1000) * pricing.imagePer1kUsd;
+  const videoUsd = (counts.videoCount / 1000) * pricing.videoPer1kUsd;
+  const documentUsd = (counts.documentCount / 1000) * pricing.documentPer1kUsd;
+  const totalUsd = audioUsd + imageUsd + videoUsd + documentUsd;
+  return Math.ceil(totalUsd * 100);
+}


### PR DESCRIPTION
## Summary

- Replace the hardcoded per-item cost arithmetic in `BatchJobService.estimate()` (`audio*10 + image*1 + video*2 + document*0`) with a declarative provider pricing table (`packages/api/src/services/batch-pricing.ts`) pinned to Groq Whisper Large v3 Turbo + Gemini 2.5 Flash-Lite rates as of 2026-04.
- Audio is now duration-scaled (rate/min × avg minutes/item); image/video/document are expressed per-1k-items so the table can be eyeballed directly against published provider pricing pages.
- Documents no longer estimate at $0.00 (old table had `*0`); PDF-heavy batches now report non-zero cost.

Fixes automagik-dev/omni#477 — the old estimator reported $178.76 for a batch whose real provider bill was $1–2 (~150× overcost), scaring users out of runs that were effectively free.

## Pricing table (reviewers: sanity-check these rates)

| Key | Value | Source (2026-04) |
|---|---|---|
| `audioPerMinuteUsd` | `0.04 / 60` | Groq Whisper Large v3 Turbo @ $0.04/audio-hour |
| `audioAvgMinutes` | `40 / 60` | WhatsApp voice note average ~40s |
| `imagePer1kUsd` | `0.15` | Gemini 2.5 Flash-Lite vision ~$0.00015/image |
| `videoPer1kUsd` | `9.00` | Gemini vision @ $0.0003/s × ~30s avg ≈ $0.009/video |
| `documentPer1kUsd` | `0.50` | Gemini OCR/vision ~$0.0005/document |

Updating drift = edit the table only; tests don't pin real rates.

## Test plan

- [x] `bun test packages/api/src/services/__tests__/batch-pricing.test.ts` — 7/7 pass (known-answer on synthetic table + #477 repro counts in $0.50–$5.00 sanity band + non-zero documents + linear scaling + non-negative finite rates)
- [x] `bun run build` — all 5 packages green
- [x] `bunx biome check` on touched files — clean
- [x] `tsc --noEmit` on `@omni/api` — clean
- [ ] **Not verified:** real provider-billing reconciliation against a live `omni batch estimate` + actual Groq/Gemini invoice — requires credentials and real media the reviewer can run against.

## Risks

- Provider pricing drifts; table is a snapshot, not a feed. Mitigated by being a single declarative block with citation comments; mis-estimate will be within ~2× for typical mixes until rates change. Versioned via `BATCH_PRICING_VERSION`.
- Audio estimate assumes ~40s avg duration (WhatsApp voice-note ballpark). Chat populations with very long audio will under-estimate; we'd need real per-item duration (out of scope for estimate-only path).
- Video rate (`videoPer1kUsd: 9.0`) is the highest per-item cost in the table — a video-heavy batch still looks pricey, matching reality rather than masking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)