### PR TITLE
fix(api): persist BATCH_PRICING_VERSION on batch records for audit trail

### DIFF
--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -34,7 +34,7 @@ import {
   createMediaProcessingService,
 } from '@omni/media-processing';
 import { and, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
-import { computeEstimatedCostCents } from './batch-pricing';
+import { BATCH_PRICING_VERSION, computeEstimatedCostCents } from './batch-pricing';
 import { MediaStorageService } from './media-storage';
 
 const log = createLogger('services:batch-jobs');
@@ -168,6 +168,14 @@ export class BatchJobService {
       force,
       delayMinMs: delayMinMs ?? BatchJobService.DEFAULT_DELAY_MIN_MS,
       delayMaxMs: delayMaxMs ?? BatchJobService.DEFAULT_DELAY_MAX_MS,
+      // Stamp the pricing table version used to derive any cost estimate
+      // at creation time. Persisted on the batch record via the
+      // `request_params` jsonb column for audit + pricing-drift
+      // provenance (see #485, follow-up to #477). No dedicated
+      // `pricing_version` column — storing alongside requestParams keeps
+      // the fix migration-free; a schema column can be added later if
+      // filtering/indexing by version becomes useful.
+      pricingVersion: BATCH_PRICING_VERSION,
     };
 
     const jobData: NewBatchJob = {
@@ -190,7 +198,12 @@ export class BatchJobService {
       throw new Error('Failed to create batch job');
     }
 
-    log.info('Batch job created', { jobId: created.id, jobType, instanceId });
+    log.info('Batch job created', {
+      jobId: created.id,
+      jobType,
+      instanceId,
+      pricingVersion: BATCH_PRICING_VERSION,
+    });
 
     // Emit created event
     if (this.eventBus) {
@@ -363,6 +376,11 @@ export class BatchJobService {
     // vision as of 2026-04). See issue #477: the previous hardcoded
     // per-item cents were off by ~150× for that provider mix.
     const estimatedCostCents = computeEstimatedCostCents(counts);
+    log.debug('Batch cost estimated', {
+      totalItems: items.length,
+      estimatedCostCents,
+      pricingVersion: BATCH_PRICING_VERSION,
+    });
 
     // Factor in average random delay between items (midpoint of default range)
     const avgDelayMs = (BatchJobService.DEFAULT_DELAY_MIN_MS + BatchJobService.DEFAULT_DELAY_MAX_MS) / 2;


### PR DESCRIPTION
## Summary
- PR #485 added `BATCH_PRICING_VERSION` to `packages/api/src/services/batch-pricing.ts` but left it unimported; knip flagged it as a regression on `dev`.
- The constant's docstring makes the intent explicit: stamp it on persisted batch records for audit + pricing-drift provenance (follow-up to #477).
- Minimal wiring: import in `batch-jobs.ts`, stamp into the existing `requestParams` jsonb column on `create()` (no schema migration), log the version at the estimate and create sites.

## Files changed
- `packages/api/src/services/batch-jobs.ts` (+20 -2)

## Persistence surface
`requestParams` is typed as `jsonb('request_params').$type<Record<string, unknown>>()` on `batch_jobs` — adding `pricingVersion` there persists it on every row at creation time without any schema change. A dedicated `pricing_version` column is a plausible follow-up if we ever need to filter/index by version, but is not required for the audit-trail use case.

## Knip delta
**Before (on `dev`):**
```
Unused exports (1)
BATCH_PRICING_VERSION  unknown  packages/api/src/services/batch-pricing.ts:79:14
Unused dependencies (3)
@snazzah/davey / libsodium-wrappers / opusscript  packages/cli/package.json
```
**After (this PR):**
```
Unused dependencies (3)
@snazzah/davey / libsodium-wrappers / opusscript  packages/cli/package.json
```
The `BATCH_PRICING_VERSION` line is gone. The remaining 3 unused deps are pre-existing and tracked under #481 — out of scope.

## Validation
- [x] `bun run build` — 5/5 tasks successful
- [x] `bunx biome check packages/api` — 243 files, 0 errors
- [x] `bun test packages/api/src/services/__tests__/batch-pricing.test.ts` — 7 pass, 0 fail
- [x] `bun test packages/api` — 757 pass, 265 skip, 0 fail (1022 tests / 79 files)
- [x] `bunx knip` — `BATCH_PRICING_VERSION` flag cleared

## Risks / Not verified
- **Not verified:** no runtime exercise against a live `POST /v2/batch-jobs` endpoint — relied on unit tests only. The change is purely additive (extra jsonb field + log fields), so the blast radius is bounded.
- **Not verified:** schema migration was **not** needed. If a future consumer wants to filter batch jobs by pricing version, a dedicated `pricing_version` column is the next logical step.

## Follow-up to
- #485 (dog-fooder flagged `BATCH_PRICING_VERSION` as an unused export on merge)
- #477 (original batch-cost accuracy issue that introduced the pricing table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)