### PR TITLE
chore(knip): ignore externalized media deps in packages/cli (#481)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -50,7 +50,7 @@
     "packages/cli": {
       "entry": ["src/commands/*.ts", "src/bundled-server-entry.ts"],
       "project": ["src/**/*.ts"],
-      "ignoreDependencies": ["@anthropic-ai/claude-agent-sdk"]
+      "ignoreDependencies": ["@anthropic-ai/claude-agent-sdk", "exceljs", "mammoth", "pdf-parse"]
     },
     "packages/db": {
       "project": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary
- Fixes CI **Quality Gate → Dead code check (knip)** which was failing `exit 1` on `dev` with 3 "unused" dependencies in `packages/cli/package.json`: `exceljs`, `mammoth`, `pdf-parse`.
- Adds those three names to `packages/cli.ignoreDependencies` in `knip.json` — matches the existing pattern for `@anthropic-ai/claude-agent-sdk`.

## Scope shift (audit trail)
Issue #481 was originally filed for `@snazzah/davey`, `libsodium-wrappers`, `opusscript`. Those were removed from `packages/cli/package.json` as a side effect of **PR #483** (media externalization). Post-merge, knip still exits 1 on `dev` — but the findings are now the 3 media-processing deps introduced by #483. This PR addresses the current knip failure under the same issue.

## Why `ignoreDependencies` instead of deleting them
These three packages are declared as runtime deps of `@automagik/omni` because they are **externalized** (not bundled) by `build:server`:

```
bun build src/bundled-server-entry.ts ... --external pdf-parse --external mammoth --external exceljs ...
```

After `bun build`, `dist/server/index.js` still contains literal `require("pdf-parse")` / `require("mammoth")` / `require("exceljs")` calls. For runtime resolution to succeed when end users `npm install -g @automagik/omni`, the modules MUST remain in the published `dependencies`. Knip inspects source imports only, can't see the externalized bundler requirement, and reports them as unused — same class of false-positive as `@anthropic-ai/claude-agent-sdk`, which is already handled via `ignoreDependencies`.

## Evidence

Before:
```
$ bunx knip
Unused dependencies (3)
exceljs    packages/cli/package.json:32:6
mammoth    packages/cli/package.json:33:6
pdf-parse  packages/cli/package.json:35:6
$ echo \$?
1
```

After this PR:
```
$ bunx knip
$ echo \$?
0
```

## Validation
- `bunx knip` — exit 0 ✓
- `bunx knip --workspace packages/cli` — exit 0 ✓
- `bunx biome check knip.json` — clean ✓
- `bun run build` (sdk + cli) — 1145 modules / 4.83 MB bundle, no errors ✓
- `bun dist/index.js --help` — runs, no missing-module errors ✓

## Files changed
- `knip.json` — 1 line (added 3 entries to `packages/cli.ignoreDependencies` array)

## Risks
None. Zero code changes, zero runtime behaviour change — knip config only. If a future refactor actually moves these media deps out of the CLI bundle, this ignore entry can be removed in the same PR.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)