### PR TITLE
fix(api): apply optionalDateParam to remaining v2 routes (#494)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/keys-audit-date-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-audit-date-validation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression test for automagik-dev/omni#494
+ *
+ * Contract:
+ *   GET /keys/:id/audit MUST return HTTP 400 (not 500) when `since` or
+ *   `until` query parameters are present but not parseable as a date.
+ *   Valid ISO 8601 input must reach the audit service as a real `Date`
+ *   instance (never `Invalid Date`).
+ *
+ * @see packages/api/src/schemas/date-query.ts — shared helper
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { keysRoutes } from '../keys';
+
+type AuditCall = { id: string; options: Record<string, unknown> };
+
+const KEY_ID = '11111111-1111-1111-1111-111111111111';
+
+function mountKeysRoutes(calls: AuditCall[]): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      apiKeys: {
+        getById: mock(async (id: string) => ({ id, name: 'test', status: 'active' })),
+      },
+      audit: {
+        listByKeyId: mock(async (id: string, options: Record<string, unknown>) => {
+          calls.push({ id, options });
+          return { items: [], total: 0, hasMore: false, cursor: null };
+        }),
+      },
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/keys', keysRoutes);
+  return app;
+}
+
+describe('GET /keys/:id/audit — date parameter validation (#494)', () => {
+  test('returns 400 when `since` is a UUID', async () => {
+    const calls: AuditCall[] = [];
+    const app = mountKeysRoutes(calls);
+
+    const res = await app.request(`/keys/${KEY_ID}/audit?since=550e8400-e29b-41d4-a716-446655440000`);
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 400 when `until` is arbitrary garbage', async () => {
+    const calls: AuditCall[] = [];
+    const app = mountKeysRoutes(calls);
+
+    const res = await app.request(`/keys/${KEY_ID}/audit?until=not-a-date-at-all`);
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 200 and passes real Date instances to audit service for valid ISO 8601', async () => {
+    const calls: AuditCall[] = [];
+    const app = mountKeysRoutes(calls);
+
+    const res = await app.request(
+      `/keys/${KEY_ID}/audit?since=2024-01-01T00:00:00.000Z&until=2024-02-01T00:00:00.000Z`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.options.since).toBeInstanceOf(Date);
+    expect(calls[0]?.options.until).toBeInstanceOf(Date);
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/messages-date-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-date-validation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for automagik-dev/omni#494
+ *
+ * Contract:
+ *   GET /messages MUST return HTTP 400 (not 500) when the `since` or
+ *   `until` query parameters are present but not parseable as a date.
+ *   Valid ISO 8601 input must reach the messages service as a real
+ *   `Date` instance (never `Invalid Date`).
+ *
+ * @see packages/api/src/schemas/date-query.ts — shared helper
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { messagesRoutes } from '../messages';
+
+type ListCall = { query: Record<string, unknown> };
+
+function mountMessagesRoutes(calls: ListCall[]): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      messages: {
+        list: mock(async (query: Record<string, unknown>) => {
+          calls.push({ query });
+          return { items: [], hasMore: false, cursor: null };
+        }),
+        count: mock(async () => 0),
+      },
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/messages', messagesRoutes);
+  return app;
+}
+
+describe('GET /messages — date parameter validation (#494)', () => {
+  test('returns 400 when `since` is a UUID', async () => {
+    const calls: ListCall[] = [];
+    const app = mountMessagesRoutes(calls);
+
+    const res = await app.request('/messages?since=550e8400-e29b-41d4-a716-446655440000');
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 400 when `until` is arbitrary garbage', async () => {
+    const calls: ListCall[] = [];
+    const app = mountMessagesRoutes(calls);
+
+    const res = await app.request('/messages?until=not-a-date-at-all');
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 200 and passes real Date instances to the service for valid ISO 8601', async () => {
+    const calls: ListCall[] = [];
+    const app = mountMessagesRoutes(calls);
+
+    const res = await app.request('/messages?since=2024-01-01T00:00:00.000Z&until=2024-02-01T00:00:00.000Z');
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.query.since).toBeInstanceOf(Date);
+    expect(calls[0]?.query.until).toBeInstanceOf(Date);
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/persons-timeline-date-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/persons-timeline-date-validation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test for automagik-dev/omni#494
+ *
+ * Contract:
+ *   GET /persons/:id/timeline MUST return HTTP 400 (not 500) when the
+ *   `since` or `until` query parameters are present but not parseable
+ *   as a date. Valid ISO 8601 input must reach the events service as
+ *   a real `Date` instance (never `Invalid Date`).
+ *
+ * @see packages/api/src/schemas/date-query.ts — shared helper
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { personsRoutes } from '../persons';
+
+type TimelineCall = { personId: string; input: Record<string, unknown> };
+
+const PERSON_ID = '11111111-1111-1111-1111-111111111111';
+
+function mountPersonsRoutes(calls: TimelineCall[]): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      events: {
+        getTimeline: mock(async (personId: string, input: Record<string, unknown>) => {
+          calls.push({ personId, input });
+          return { items: [], hasMore: false, cursor: null };
+        }),
+      },
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/persons', personsRoutes);
+  return app;
+}
+
+describe('GET /persons/:id/timeline — date parameter validation (#494)', () => {
+  test('returns 400 when `since` is a UUID', async () => {
+    const calls: TimelineCall[] = [];
+    const app = mountPersonsRoutes(calls);
+
+    const res = await app.request(`/persons/${PERSON_ID}/timeline?since=550e8400-e29b-41d4-a716-446655440000`);
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 400 when `until` is arbitrary garbage', async () => {
+    const calls: TimelineCall[] = [];
+    const app = mountPersonsRoutes(calls);
+
+    const res = await app.request(`/persons/${PERSON_ID}/timeline?until=not-a-date-at-all`);
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 200 and passes real Date instances to events.getTimeline for valid ISO 8601', async () => {
+    const calls: TimelineCall[] = [];
+    const app = mountPersonsRoutes(calls);
+
+    const res = await app.request(
+      `/persons/${PERSON_ID}/timeline?since=2024-01-01T00:00:00.000Z&until=2024-02-01T00:00:00.000Z`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input.since).toBeInstanceOf(Date);
+    expect(calls[0]?.input.until).toBeInstanceOf(Date);
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/settings-history-date-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/settings-history-date-validation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for automagik-dev/omni#494
+ *
+ * Contract:
+ *   GET /settings/:key/history MUST return HTTP 400 (not 500) when the
+ *   `since` query parameter is present but not parseable as a date.
+ *   Valid ISO 8601 input must reach the settings service as a real
+ *   `Date` instance (never `Invalid Date`).
+ *
+ * @see packages/api/src/schemas/date-query.ts — shared helper
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { settingsRoutes } from '../settings';
+
+type HistoryCall = { key: string; options: Record<string, unknown> };
+
+const SETTING_KEY = 'example.setting';
+
+function mountSettingsRoutes(calls: HistoryCall[]): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      settings: {
+        getHistory: mock(async (key: string, options: Record<string, unknown>) => {
+          calls.push({ key, options });
+          return [];
+        }),
+      },
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/settings', settingsRoutes);
+  return app;
+}
+
+describe('GET /settings/:key/history — date parameter validation (#494)', () => {
+  test('returns 400 when `since` is a UUID', async () => {
+    const calls: HistoryCall[] = [];
+    const app = mountSettingsRoutes(calls);
+
+    const res = await app.request(`/settings/${SETTING_KEY}/history?since=550e8400-e29b-41d4-a716-446655440000`);
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 400 when `since` is arbitrary garbage', async () => {
+    const calls: HistoryCall[] = [];
+    const app = mountSettingsRoutes(calls);
+
+    const res = await app.request(`/settings/${SETTING_KEY}/history?since=not-a-date-at-all`);
+
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns 200 and passes a real Date instance to settings.getHistory for valid ISO 8601', async () => {
+    const calls: HistoryCall[] = [];
+    const app = mountSettingsRoutes(calls);
+
+    const res = await app.request(`/settings/${SETTING_KEY}/history?since=2024-01-01T00:00:00.000Z`);
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.options.since).toBeInstanceOf(Date);
+  });
+});

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -9,6 +9,7 @@ import { zValidator } from '@hono/zod-validator';
 import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 import { ProfileResolutionError, type ResolveProfileInput, resolveProfile } from '../../lib/resolve-profile';
+import { optionalDateParam } from '../../schemas/date-query';
 import type { AppVariables } from '../../types';
 
 export const keysRoutes = new Hono<{ Variables: AppVariables }>();
@@ -80,18 +81,8 @@ const listQuerySchema = z.object({
 });
 
 const auditQuerySchema = z.object({
-  since: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined))
-    .describe('Filter logs from this timestamp'),
-  until: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined))
-    .describe('Filter logs until this timestamp'),
+  since: optionalDateParam('since').describe('Filter logs from this timestamp'),
+  until: optionalDateParam('until').describe('Filter logs until this timestamp'),
   path: z.string().optional().describe('Filter by request path (partial match)'),
   statusCode: z.coerce.number().int().optional().describe('Filter by HTTP status code'),
   limit: z.coerce.number().int().min(1).max(100).default(50).describe('Max results'),

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -47,6 +47,7 @@ import * as Sentry from '@sentry/bun';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { sentryEnabled } from '../../lib/sentry-scrub';
+import { optionalDateParam } from '../../schemas/date-query';
 import type { Services } from '../../services';
 import { ApiKeyService } from '../../services/api-keys';
 import { MediaStorageService } from '../../services/media-storage';
@@ -286,16 +287,8 @@ const listQuerySchema = z.object({
     .transform((v) => v?.split(',') as z.infer<typeof MessageStatusSchema>[] | undefined),
   hasMedia: z.coerce.boolean().optional(),
   senderPersonId: z.string().uuid().optional(),
-  since: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined)),
-  until: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined)),
+  since: optionalDateParam('since'),
+  until: optionalDateParam('until'),
   search: z.string().optional(),
   includeHidden: z.coerce.boolean().default(false),
   limit: z.coerce.number().int().min(1).max(100).default(50),

--- a/packages/api/src/routes/v2/persons.ts
+++ b/packages/api/src/routes/v2/persons.ts
@@ -6,6 +6,7 @@ import { zValidator } from '@hono/zod-validator';
 import type { ChannelTypeSchema } from '@omni/core';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { optionalDateParam } from '../../schemas/date-query';
 import type { AppVariables } from '../../types';
 
 const personsRoutes = new Hono<{ Variables: AppVariables }>();
@@ -23,16 +24,8 @@ const timelineQuerySchema = z.object({
     .string()
     .optional()
     .transform((v) => v?.split(',') as z.infer<typeof ChannelTypeSchema>[] | undefined),
-  since: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined)),
-  until: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined)),
+  since: optionalDateParam('since'),
+  until: optionalDateParam('until'),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   cursor: z.string().optional(),
 });

--- a/packages/api/src/routes/v2/settings.ts
+++ b/packages/api/src/routes/v2/settings.ts
@@ -5,6 +5,7 @@
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { optionalDateParam } from '../../schemas/date-query';
 import type { AppVariables } from '../../types';
 
 const settingsRoutes = new Hono<{ Variables: AppVariables }>();
@@ -29,11 +30,7 @@ const bulkUpdateSchema = z.object({
 // History query schema
 const historyQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
-  since: z
-    .string()
-    .datetime()
-    .optional()
-    .transform((v) => (v ? new Date(v) : undefined)),
+  since: optionalDateParam('since'),
 });
 
 /**


### PR DESCRIPTION
## Summary

Completes the #494 sweep: applies the shared `optionalDateParam` helper
(from `packages/api/src/schemas/date-query.ts`, shipped in #491) to every
remaining v2 route that still hand-rolled
`z.string().datetime().optional().transform((v) => (v ? new Date(v) : undefined))`
for `since` / `until` query parameters.

Before: malformed input (UUID, garbage string, etc.) silently produced
`Invalid Date`, flowed into Drizzle `gte`/`lte`, and surfaced as HTTP 500.
After: `zValidator('query', ...)` rejects it with HTTP 400 at the edge,
and the handler receives a real `Date` instance.

## Routes migrated

| File | Schema | Fields |
|---|---|---|
| `packages/api/src/routes/v2/keys.ts` | `auditQuerySchema` (GET /keys/:id/audit) | `since`, `until` |
| `packages/api/src/routes/v2/messages.ts` | `listQuerySchema` (GET /messages) | `since`, `until` |
| `packages/api/src/routes/v2/persons.ts` | `timelineQuerySchema` (GET /persons/:id/timeline) | `since`, `until` |
| `packages/api/src/routes/v2/settings.ts` | `historyQuerySchema` (GET /settings/:key/history) | `since` |

## Tests added

Four new regression files under `packages/api/src/routes/v2/__tests__/`
(12 new test cases, 31 assertions) mirroring the pattern established by
`events-date-validation.test.ts`:

- `keys-audit-date-validation.test.ts`
- `messages-date-validation.test.ts`
- `persons-timeline-date-validation.test.ts`
- `settings-history-date-validation.test.ts`

Each file covers: UUID → 400, garbage → 400, valid ISO 8601 → 200 with
`Date` instance reaching the service.

## Not applicable

**`packages/api/src/routes/v2/journeys.ts:34`** — the `since` param on
`GET /journeys/summary` returns `number` (epoch ms), supports relative
durations (`"1h"` / `"30m"` / `"24h"`), and already has an explicit
`Number.isNaN` guard that converts unparseable input to `undefined`
rather than `Invalid Date`. Migrating would change the return type and
drop relative-duration support. Same rationale as `instances.ts:2697`
which was also excluded from #491.

## Validation

- `bun run build` — 5/5 packages green
- `bunx biome check packages/api` — 0 errors
- `bun test packages/api` — 810 pass / 265 skip / **0 fail** (12 new tests)
- `bunx knip` — still 0 issues
- Pre-push hook full suite — **3358 pass / 0 fail**
- Final grep: no `transform((v) => (v ? new Date(v) : undefined))` in
  any of the 5 target files; remaining `new Date(v)` is the intentional
  NaN-guarded timestamp path in `journeys.ts` (see above).

Closes #494

## Test plan

- [x] Regression tests pass locally (12/12)
- [x] Full api package test suite green (810 pass, 0 fail)
- [x] Full monorepo test suite green via pre-push hook (3358 pass, 0 fail)
- [x] Biome + knip clean
- [x] Build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)