### PR TITLE
fix(cli): restore @snazzah/davey + libsodium + opusscript deps (#476 regression)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -86,7 +86,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -161,7 +161,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -195,7 +195,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -210,7 +210,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -230,17 +230,20 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "bin": {
         "omni": "./bin/omni",
       },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@sentry/bun": "^10.43.0",
+        "@snazzah/davey": "^0.1.11",
         "chalk": "^5.4.0",
         "commander": "^13.1.0",
         "exceljs": "^4.4.0",
+        "libsodium-wrappers": "^0.7.15",
         "mammoth": "^1.8.0",
+        "opusscript": "^0.1.1",
         "ora": "^8.1.1",
         "pdf-parse": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
@@ -261,7 +264,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -276,7 +279,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -290,7 +293,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -308,7 +311,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -316,7 +319,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -330,7 +333,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260422.12",
+      "version": "2.260422.13",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",
@@ -2196,19 +2199,11 @@
 
     "@omni/api/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@omni/channel-discord/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
     "@omni/channel-gupshup/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@omni/channel-internal/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@omni/channel-sdk/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "@omni/channel-slack/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
-    "@omni/channel-telegram/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
-    "@omni/channel-whatsapp/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@omni/core/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -2432,17 +2427,9 @@
 
     "@omni/api/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@omni/channel-discord/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
     "@omni/channel-gupshup/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@omni/channel-sdk/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
-
-    "@omni/channel-slack/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@omni/channel-telegram/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@omni/channel-whatsapp/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@omni/core/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
@@ -2610,17 +2597,9 @@
 
     "@omni/api/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "@omni/channel-discord/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
-
     "@omni/channel-gupshup/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@omni/channel-sdk/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@omni/channel-slack/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
-
-    "@omni/channel-telegram/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
-
-    "@omni/channel-whatsapp/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@omni/core/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2648,15 +2627,7 @@
 
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
 
-    "@omni/channel-discord/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "@omni/channel-gupshup/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@omni/channel-slack/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@omni/channel-telegram/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@omni/channel-whatsapp/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/knip.json
+++ b/knip.json
@@ -50,7 +50,15 @@
     "packages/cli": {
       "entry": ["src/commands/*.ts", "src/bundled-server-entry.ts"],
       "project": ["src/**/*.ts"],
-      "ignoreDependencies": ["@anthropic-ai/claude-agent-sdk", "exceljs", "mammoth", "pdf-parse"]
+      "ignoreDependencies": [
+        "@anthropic-ai/claude-agent-sdk",
+        "@snazzah/davey",
+        "exceljs",
+        "libsodium-wrappers",
+        "mammoth",
+        "opusscript",
+        "pdf-parse"
+      ]
     },
     "packages/db": {
       "project": ["src/**/*.ts"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,10 +27,13 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
     "@sentry/bun": "^10.43.0",
+    "@snazzah/davey": "^0.1.11",
     "chalk": "^5.4.0",
     "commander": "^13.1.0",
     "exceljs": "^4.4.0",
+    "libsodium-wrappers": "^0.7.15",
     "mammoth": "^1.8.0",
+    "opusscript": "^0.1.1",
     "ora": "^8.1.1",
     "pdf-parse": "^1.1.1",
     "qrcode-terminal": "^0.12.0"


### PR DESCRIPTION
## Context

`@automagik/omni@next` from `2.260422.4` onward crashes immediately on boot:

```
error: Cannot find module '@snazzah/davey' from
  /home/genie/.bun/install/global/node_modules/@automagik/omni/dist/server/index.js
```

Reproduced on a clean server:

```
bun add -g @automagik/omni@next
pm2 restart omni-api
# omni-api crashloops (200+ restarts, never reaches HTTP listener)
# omni doctor:  ✗ pgserve-reachable, ✗ omni-db-exists, ✗ cli-key-valid  (cascade from dead API)
```

## Root Cause

#483 ("fix(media): Gemini Vision 30s timeout + extended retry + externalize pdf-parse") accidentally reverted the dependency half of #476 ("fix(cli): externalize native-module deps instead of bundling them").

`git show db63bdb8 -- packages/cli/package.json` shows a single hunk:

```diff
 "dependencies": {
   "@anthropic-ai/claude-agent-sdk": "^0.2.62",
   "@sentry/bun": "^10.43.0",
-  "@snazzah/davey": "^0.1.11",
   "chalk": "^5.4.0",
   "commander": "^13.1.0",
-  "libsodium-wrappers": "^0.7.15",
-  "opusscript": "^0.1.1",
+  "exceljs": "^4.4.0",
+  "mammoth": "^1.8.0",
   "ora": "^8.1.1",
+  "pdf-parse": "^1.1.1",
   "qrcode-terminal": "^0.12.0"
 }
```

#483's PR body explicitly says it **adds** `pdf-parse/mammoth/exceljs` — no mention of removing the three voice deps. Almost certainly a bad conflict resolution during rebase onto a base that predated #476.

The `build:server` script still marks all seven packages `--external`, so on dev today:

```
externals declared in build:server: @anthropic-ai/claude-agent-sdk, @snazzah/davey,
                                    libsodium-wrappers, opusscript, pdf-parse, mammoth, exceljs
EXTERNAL BUT NOT IN DEPENDENCIES:   @snazzah/davey, libsodium-wrappers, opusscript
```

Which means published tarballs never ship these deps, and the bundle's preserved `require('@snazzah/davey')` call fails at first Discord channel plugin load.

`@latest` on npm is still pinned at `2.260410.1` (pre-#476), so stable users haven't hit this — only `@next`.

## Fix

Restore the three deps at the same versions pinned in `packages/voice-client/package.json` (and matching what #476 originally landed). No build changes — `build:server` already externalizes them correctly.

## Verification

1. **Lockfile:** `bun install` cleanly resolves the three packages + 6 `@napi-rs`-style platform subpackages for davey's native loader.
2. **Local deployment on broken install:** copied the resolved `node_modules/{@snazzah/davey,davey-linux-*,libsodium,libsodium-wrappers,opusscript}` trees into `/home/genie/.bun/install/global/node_modules/`, ran `pm2 restart omni-api`:
   ```
   $ omni doctor
     ✓ cli-key-valid        stored CLI key validates against server
     ✓ pgserve-reachable    pgserve listening on :8432
     ✓ omni-db-exists       omni database is reachable
     ✓ version-match        cli=v2.260422.12 server=v2.260422.12
     ✓ pm2-status           omni-api and omni-nats online
     summary: 9 OK, 0 WARN, 0 FAIL
   ```
3. **Pre-push hook:** typecheck + biome + full test suite (`3437 pass, 265 skip, 0 fail`) green.

## References

- Original fix: #476 (fix(cli): externalize native-module deps)
- Regression:  #483 (fix(media): Gemini Vision timeout + externalize pdf-parse)
- Voice deps originally pulled in by: #396 (feat: Voice Gateway with DAVE E2EE)

## Test plan

- [ ] CI green (typecheck / lint / tests / knip)
- [ ] After merge + version bump, `bun add -g @automagik/omni@next` followed by `pm2 restart omni-api` boots to healthy state
- [ ] `omni doctor` returns all green on a fresh install