### PR TITLE
fix(gupshup): accept async_response event_type (#503)

### DIFF
--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -3,13 +3,17 @@
  *
  * Verifies:
  * - Gupshup native payload shapes (all 8 message types)
- * - event_type filtering (non-user_input ignored)
+ * - event_type routing (user_input / async_response / click_to_chat_advertise
+ *   → processInboundMessage; known non-message events dropped; unknown
+ *   event_types fail-open with WARN — incident #503)
  * - Deduplication (second identical webhook is dropped)
  * - Location lat/lng string-to-float conversion
  * - Reply context extraction
  */
 
 import { describe, expect, it } from 'bun:test';
+import { handleGupshupWebhook } from '../handlers/webhooks';
+import type { GupshupPlugin } from '../plugin';
 
 // ─────────────────────────────────────────────────────────────
 // Native payload fixtures (from real Gupshup webhooks)
@@ -242,12 +246,14 @@ describe('Gupshup native inbound payload shapes', () => {
     expect(rc.id).toBe('03309zQxh2vOdjjUI6ly3y');
   });
 
-  it('non-user_input event_type is not a message', () => {
+  it('known non-message event_type (message_event) is not processed as a message', () => {
     const payload = makePayload(
       { type: 'text', text: 'x', from: '551196', timestamp: 1, id: 'wamid.x' },
       { event_type: 'message_event' },
     );
-    expect(payload.event_type).not.toBe('user_input');
+    // Semantic shift post-2026-04-22: async_response is now a message event,
+    // so the denylist-based check uses a known non-message type instead.
+    expect(payload.event_type).toBe('message_event');
   });
 
   it('sender name resolved from senderobj.display', () => {
@@ -317,5 +323,213 @@ describe('Gupshup inbound dedup — cache behavior', () => {
 
     cache.dispose();
     expect(cache.size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// handleGupshupWebhook — event_type routing (incident #503)
+// ─────────────────────────────────────────────────────────────
+
+interface HandlerLogCall {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function makeHandlerHarness() {
+  const logs: HandlerLogCall[] = [];
+  const received: Array<{
+    instanceId: string;
+    externalId: string;
+    from: string;
+    content: { type: string; text?: string };
+  }> = [];
+
+  const logger = {
+    debug: (message: string, data?: Record<string, unknown>) => {
+      logs.push({ level: 'debug', message, data });
+    },
+    info: (message: string, data?: Record<string, unknown>) => {
+      logs.push({ level: 'info', message, data });
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      logs.push({ level: 'warn', message, data });
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      logs.push({ level: 'error', message, data });
+    },
+    child: () => logger,
+  };
+
+  const plugin = {
+    getLogger: () => logger,
+    handleMessageReceived: async (params: {
+      instanceId: string;
+      externalId: string;
+      from: string;
+      content: { type: string; text?: string };
+    }) => {
+      received.push({
+        instanceId: params.instanceId,
+        externalId: params.externalId,
+        from: params.from,
+        content: params.content,
+      });
+    },
+  } as unknown as GupshupPlugin;
+
+  return { plugin, logs, received };
+}
+
+function makeWebhookRequest(payload: Record<string, unknown>): Request {
+  return new Request('https://example.com/api/v2/channels/gupshup/inst-gs-handler/webhook', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: JSON.stringify(payload),
+  });
+}
+
+const TEXT_MESSAGEOBJ = {
+  type: 'text',
+  text: 'Oi',
+  from: '5511960008976',
+  timestamp: 1776273477,
+  id: 'wamid.HANDLER_TEST_001',
+  raw: {
+    payload: { text: 'Oi' },
+    sender: { phone: '5511960008976', name: 'Gustavo Batista' },
+    id: 'wamid.HANDLER_TEST_001',
+    source: '5511960008976',
+    type: 'text',
+  },
+};
+
+describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
+  it('async_response text message is processed end-to-end (post-cutover)', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const epoch = Date.now();
+    const payload = {
+      ...BASE,
+      event_type: 'async_response',
+      request_id: `5521975469499_d4296fbd-42ad-4a44-b5fb-6178182b23ef_${epoch}`,
+      stack_id: epoch,
+      messageHeader: { ...BASE.messageHeader, event_type: 'async_response' },
+      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.ASYNC_RESPONSE_001' },
+    };
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(payload),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.ASYNC_RESPONSE_001');
+    expect(received[0]?.content.text).toBe('Oi');
+    // No WARN for known message event_type
+    expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
+  });
+
+  it('user_input text message is still processed (regression guard)', async () => {
+    const { plugin, received, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const payload = {
+      ...BASE,
+      event_type: 'user_input',
+      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.USER_INPUT_001' },
+    };
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(payload),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.USER_INPUT_001');
+    expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
+  });
+
+  it('click_to_chat_advertise text message is processed', async () => {
+    const { plugin, received, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const payload = {
+      ...BASE,
+      event_type: 'click_to_chat_advertise',
+      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.CTCA_001' },
+    };
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(payload),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.CTCA_001');
+    expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
+  });
+
+  it('message_event delivery receipt is ignored (processInboundMessage not called)', async () => {
+    const { plugin, received, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const payload = {
+      ...BASE,
+      event_type: 'message_event',
+      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.DELIVERY_RECEIPT_001' },
+    };
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(payload),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(0);
+    const debugDrop = logs.find((l) => l.level === 'debug' && l.message.includes('known non-message event'));
+    expect(debugDrop).toBeDefined();
+    expect(debugDrop?.data?.event_type).toBe('message_event');
+  });
+
+  it('unknown event_type with valid messageobj is processed AND WARN is logged (fail-open)', async () => {
+    const { plugin, received, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const payload = {
+      ...BASE,
+      event_type: 'v3_message',
+      messageHeader: { ...BASE.messageHeader, event_type: 'v3_message' },
+      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.UNKNOWN_EVENT_001' },
+    };
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(payload),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.UNKNOWN_EVENT_001');
+    const warn = logs.find((l) => l.level === 'warn' && l.message.includes('unknown event_type'));
+    expect(warn).toBeDefined();
+    expect(warn?.data?.event_type).toBe('v3_message');
+    expect(warn?.data?.messageHeaderEventType).toBe('v3_message');
+    expect(warn?.data?.messageType).toBe('text');
+    expect(warn?.data?.sender).toBe(BASE.sender);
   });
 });

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -6,8 +6,12 @@
  * Wire format: Content-Type is application/x-www-form-urlencoded but the body
  * is raw JSON — JSON.parse(await request.text()) is the correct parse strategy.
  *
- * Only event_type === 'user_input' is processed. All other event types (status
- * updates, billing, etc.) are acknowledged with 200 and discarded.
+ * Message-bearing event_types (`user_input`, `async_response`,
+ * `click_to_chat_advertise`) are dispatched to processInboundMessage. Known
+ * non-message events (status, billing, opt-in/out, etc.) are acknowledged with
+ * 200 and discarded at DEBUG. Unknown event_types that pass schema validation
+ * fail-open (processed + WARN) so Gupshup format drift surfaces in logs
+ * instead of silently dropping messages (see incident 2026-04-22 #503).
  *
  * Webhook verification: query param `?token=X` is compared against instance
  * `webhookVerifyToken`. If not set, skip token check.
@@ -99,6 +103,26 @@ const GupshupNativeWebhookSchema = z
 
 // Download guard for media (100MB limit)
 const _downloadGuard = createInboundDedupeCache;
+
+// Known event_type values that carry a user message in messageobj.
+// Unknown values still fall through to processInboundMessage (schema validation
+// is the real gate) but are logged at WARN so format drift is visible.
+const KNOWN_MESSAGE_EVENT_TYPES = new Set<string>([
+  'user_input', // legacy — pre-2026-04-22 format
+  'async_response', // current — post-2026-04-22 17:58 BRT cutover
+  'click_to_chat_advertise', // ad click → message from FB/IG ad
+]);
+
+// Known event_type values that are NOT messages (status/billing/etc.)
+const KNOWN_NON_MESSAGE_EVENT_TYPES = new Set<string>([
+  'message_event', // delivery/read receipts
+  'billing_event',
+  'opt_in',
+  'opt_out',
+  'template_event',
+  'system_event',
+  'account_event',
+]);
 
 // ─────────────────────────────────────────────────────────────
 // Payload extraction — handles multiple Gupshup envelope formats
@@ -243,10 +267,24 @@ export async function handleGupshupWebhook(
 
   const webhook = result.data as unknown as GupshupNativeInboundWebhook;
 
-  // Only process user input events — ignore status, billing, etc.
-  if (webhook.event_type !== 'user_input') {
-    logger.debug('[gupshup] non-user_input event ignored', { instanceId, event_type: webhook.event_type });
+  if (KNOWN_NON_MESSAGE_EVENT_TYPES.has(webhook.event_type)) {
+    logger.debug('[gupshup] known non-message event ignored', {
+      instanceId,
+      event_type: webhook.event_type,
+    });
     return new Response('OK', { status: 200 });
+  }
+
+  if (!KNOWN_MESSAGE_EVENT_TYPES.has(webhook.event_type)) {
+    // Unknown event_type that passed schema validation (has valid messageobj).
+    // Fail-open: process it + WARN so operators notice format drift early.
+    logger.warn('[gupshup] unknown event_type with valid messageobj — processing anyway', {
+      instanceId,
+      event_type: webhook.event_type,
+      messageHeaderEventType: webhook.messageHeader?.event_type,
+      messageType: webhook.messageobj?.type,
+      sender: webhook.sender,
+    });
   }
 
   await processInboundMessage(plugin, instanceId, webhook, dedupeCache);

--- a/packages/channel-gupshup/src/types.ts
+++ b/packages/channel-gupshup/src/types.ts
@@ -96,7 +96,7 @@ export interface GupshupNativeInboundWebhook {
   isGroup?: boolean;
   destination: string | number;
   botname: string; // instance identifier
-  event_type: string; // "user_input" for inbound messages
+  event_type: string; // "user_input" / "async_response" / "click_to_chat_advertise" for inbound messages; non-message events (message_event, billing_event, etc.) are dropped upstream
   message?: string; // redundant — prefer messageobj
   postbackText?: string | null;
   senderobj: GupshupNativeSenderObj;


### PR DESCRIPTION
## Summary

**P0 production incident fix.** On 2026-04-22 17:58 BRT, Gupshup silently changed inbound webhook root `event_type` from `"user_input"` to `"async_response"`. The strict `!==` filter in `packages/channel-gupshup/src/handlers/webhooks.ts:247` dropped every webhook since — production instance `hml-gupshup` lost 245+ lead messages (239 unique senders) at HTTP 200 with only a DEBUG log, invisible at default log level.

Resolves #503.

## Changes

- **`packages/channel-gupshup/src/handlers/webhooks.ts`** — replaced the strict `webhook.event_type !== 'user_input'` filter with:
  - `KNOWN_MESSAGE_EVENT_TYPES` allowlist: `user_input`, `async_response`, `click_to_chat_advertise` → processed.
  - `KNOWN_NON_MESSAGE_EVENT_TYPES` denylist: `message_event`, `billing_event`, `opt_in`, `opt_out`, `template_event`, `system_event`, `account_event` → acked and dropped at DEBUG (unchanged behavior).
  - Unknown `event_type` with a schema-valid `messageobj` → **fail-open**: processed AND WARN logged (with `instanceId`, `event_type`, `messageHeaderEventType`, `messageType`, `sender`). Schema is the real gate; fail-open prevents another silent-drop incident if Gupshup introduces a new label.
  - Docstring rewritten to describe the multi-value / fail-open posture and reference this incident.
- **`packages/channel-gupshup/src/types.ts`** — updated `event_type` comment on `GupshupNativeInboundWebhook` to list the three message event types.
- **`packages/channel-gupshup/src/__tests__/webhooks.test.ts`** — rescoped the existing "non-user_input" test to use `message_event` (since `async_response` is now a message event), added a new `handleGupshupWebhook` harness (mock plugin + logger + dedupe cache), and added five handler-level tests:
  1. `async_response` text message → processed end-to-end
  2. `user_input` text message → processed (regression guard)
  3. `click_to_chat_advertise` → processed
  4. `message_event` delivery receipt → dropped at DEBUG, `handleMessageReceived` NOT called
  5. Unknown `event_type: "v3_message"` with valid `messageobj` → processed + WARN emitted

## Acceptance criteria

- [x] `async_response` text messages are processed end-to-end (webhook → `processInboundMessage` invoked).
- [x] `click_to_chat_advertise` messages are processed.
- [x] Known non-message events (`message_event`, etc.) are still dropped at DEBUG level, `processInboundMessage` not invoked.
- [x] Unknown `event_type` with valid `messageobj` → processed AND WARN log emitted.
- [x] Tests cover all five cases.
- [x] `bun run --filter @omni/channel-gupshup typecheck`, `bunx biome check packages/channel-gupshup`, `bun test --filter @omni/channel-gupshup` all green.

## Test plan

- [x] `bun run --filter @omni/channel-gupshup typecheck` → exit 0
- [x] `bunx biome check packages/channel-gupshup` → zero warnings, zero errors (1039 files checked)
- [x] `bun run --filter @omni/channel-gupshup test` → 78 pass / 0 fail / 136 expect() calls
- [x] Full repo pre-push pipeline (`make typecheck && make test`) → 3442 pass / 265 skip / 0 fail / 8418 expect() calls / 91.80s
- [ ] Post-deploy: `grep -c 'module":"message","msg":"Received"' ~/.omni/logs/omni-api-out.log` should grow again on hml-gupshup.
- [ ] Post-deploy: `SELECT COUNT(*) FROM messages WHERE NOT is_from_me AND created_at > NOW() - interval '5 minutes'` > 0 on hml-gupshup.

## Incident recap

Instance: `c88f18fd-3e0a-49ed-9835-efd2c2be3988` (hml-gupshup). Cutover window: last `user_input` webhook at 2026-04-22 17:57:58.275 BRT, first `async_response` at 18:00:15.346 BRT (137s silent gap). Payload delta was root `event_type` + `messageHeader.event_type` flip plus two new fields (`request_id`, `stack_id`) — `messageobj` (wamid, sender, text, timestamp, raw) unchanged. Full evidence: #503.