### PR TITLE
fix(agno-client): discover() reads id not agent_id (#509)

### DIFF
--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -272,8 +272,28 @@ describe('AgnoClient', () => {
   // --- IAgentClient interface: discover() ---
 
   describe('discover', () => {
-    it('returns combined agents, teams, and workflows', async () => {
-      // Three sequential fetches: agents, teams, workflows
+    it('returns combined agents, teams, and workflows (agno 2.5 shape)', async () => {
+      // agno 2.5+ exposes `id` at the top level of each entity — regression for #509.
+      mockImpl
+        .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 'a1', name: 'Agent 1' }]), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 't1', name: 'Team 1' }]), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 'w1', name: 'Workflow 1' }]), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      const entries = await client.discover();
+
+      expect(entries).toHaveLength(3);
+      expect(entries[0]).toMatchObject({ id: 'a1', name: 'Agent 1', type: 'agent' });
+      expect(entries[1]).toMatchObject({ id: 't1', name: 'Team 1', type: 'team' });
+      expect(entries[2]).toMatchObject({ id: 'w1', name: 'Workflow 1', type: 'workflow' });
+      // Every entry must have a defined id — guards against the #509 regression.
+      for (const entry of entries) {
+        expect(entry.id).toBeDefined();
+        expect(entry.id).not.toBe(undefined);
+      }
+    });
+
+    it('falls back to legacy agent_id/team_id/workflow_id fields (pre-agno-2.5)', async () => {
       mockImpl
         .mockResolvedValueOnce(new Response(JSON.stringify([{ agent_id: 'a1', name: 'Agent 1' }]), { status: 200 }))
         .mockResolvedValueOnce(new Response(JSON.stringify([{ team_id: 't1', name: 'Team 1' }]), { status: 200 }))
@@ -285,14 +305,14 @@ describe('AgnoClient', () => {
       const entries = await client.discover();
 
       expect(entries).toHaveLength(3);
-      expect(entries[0]).toMatchObject({ id: 'a1', name: 'Agent 1', type: 'agent' });
-      expect(entries[1]).toMatchObject({ id: 't1', name: 'Team 1', type: 'team' });
-      expect(entries[2]).toMatchObject({ id: 'w1', name: 'Workflow 1', type: 'workflow' });
+      expect(entries[0]).toMatchObject({ id: 'a1', type: 'agent' });
+      expect(entries[1]).toMatchObject({ id: 't1', type: 'team' });
+      expect(entries[2]).toMatchObject({ id: 'w1', type: 'workflow' });
     });
 
     it('returns partial results when some endpoints fail', async () => {
       mockImpl
-        .mockResolvedValueOnce(new Response(JSON.stringify([{ agent_id: 'a1', name: 'Agent 1' }]), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 'a1', name: 'Agent 1' }]), { status: 200 }))
         .mockRejectedValueOnce(new Error('Teams endpoint down'))
         .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
 
@@ -309,8 +329,8 @@ describe('AgnoClient', () => {
   describe('listAgents', () => {
     it('returns list of agents on success', async () => {
       const agents = [
-        { agent_id: 'agent-1', name: 'Test Agent' },
-        { agent_id: 'agent-2', name: 'Another Agent' },
+        { id: 'agent-1', name: 'Test Agent' },
+        { id: 'agent-2', name: 'Another Agent' },
       ];
 
       mockImpl.mockResolvedValueOnce(
@@ -363,7 +383,7 @@ describe('AgnoClient', () => {
 
   describe('listTeams', () => {
     it('returns list of teams on success', async () => {
-      const teams = [{ team_id: 'team-1', name: 'Test Team' }];
+      const teams = [{ id: 'team-1', name: 'Test Team' }];
 
       mockImpl.mockResolvedValueOnce(
         new Response(JSON.stringify(teams), {
@@ -381,7 +401,7 @@ describe('AgnoClient', () => {
 
   describe('listWorkflows', () => {
     it('returns list of workflows on success', async () => {
-      const workflows = [{ workflow_id: 'wf-1', name: 'Test Workflow' }];
+      const workflows = [{ id: 'wf-1', name: 'Test Workflow' }];
 
       mockImpl.mockResolvedValueOnce(
         new Response(JSON.stringify(workflows), {

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -99,21 +99,21 @@ export class AgnoClient implements IAgentClient {
 
     const entries: AgentDiscoveryEntry[] = [
       ...agents.map((a) => ({
-        id: a.agent_id,
+        id: a.id ?? a.agent_id,
         name: a.name,
         type: 'agent' as const,
         description: a.description,
         metadata: a.model ? { model: a.model } : undefined,
       })),
       ...teams.map((t) => ({
-        id: t.team_id,
+        id: t.id ?? t.team_id,
         name: t.name,
         type: 'team' as const,
         description: t.description,
         metadata: t.mode ? { mode: t.mode, memberCount: t.members?.length } : undefined,
       })),
       ...workflows.map((w) => ({
-        id: w.workflow_id,
+        id: w.id ?? w.workflow_id,
         name: w.name,
         type: 'workflow' as const,
         description: w.description,

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -145,9 +145,14 @@ export type StreamDelta =
 
 /**
  * Agent entity from Agno
+ *
+ * agno 2.5+ returns `id` at the top level. `agent_id` is kept optional for
+ * backward compatibility with pre-2.5 deployments.
  */
 export interface AgnoAgent {
-  agent_id: string;
+  id: string;
+  /** @deprecated pre-agno-2.5 field; use `id` */
+  agent_id?: string;
   name: string;
   model?: {
     provider?: string;
@@ -159,23 +164,34 @@ export interface AgnoAgent {
 
 /**
  * Team entity from Agno
+ *
+ * agno 2.5+ returns `id` at the top level. `team_id` is kept optional for
+ * backward compatibility with pre-2.5 deployments.
  */
 export interface AgnoTeam {
-  team_id: string;
+  id: string;
+  /** @deprecated pre-agno-2.5 field; use `id` */
+  team_id?: string;
   name: string;
   description?: string;
   mode?: string;
   members?: Array<{
     agent_id: string;
+    id?: string;
     role?: string;
   }>;
 }
 
 /**
  * Workflow entity from Agno
+ *
+ * agno 2.5+ returns `id` at the top level. `workflow_id` is kept optional for
+ * backward compatibility with pre-2.5 deployments.
  */
 export interface AgnoWorkflow {
-  workflow_id: string;
+  id: string;
+  /** @deprecated pre-agno-2.5 field; use `id` */
+  workflow_id?: string;
   name: string;
   description?: string;
 }


### PR DESCRIPTION
## Summary

Resolves #509 — agno 2.5+ returns `id` at the top level of the agent / team / workflow list response (the legacy `agent_id` / `team_id` / `workflow_id` fields are gone). As a result, every entry returned by `AgnoClient.discover()` had `id: undefined`, breaking any Omni flow that relies on discovery-driven registration.

## Change

Three-line fix in `packages/core/src/providers/agno-client.ts`:

```diff
- id: a.agent_id,
+ id: a.id ?? a.agent_id,
- id: t.team_id,
+ id: t.id ?? t.team_id,
- id: w.workflow_id,
+ id: w.id ?? w.workflow_id,
```

`AgnoAgent` / `AgnoTeam` / `AgnoWorkflow` in `packages/core/src/providers/types.ts` now declare `id: string` as the authoritative field and keep the legacy IDs as optional (deprecated) for backward-compat with pre-2.5 deployments.

One regression test added — plus an existing test repurposed — in `packages/core/src/providers/__tests__/agno-client.test.ts`:
- `returns combined agents, teams, and workflows (agno 2.5 shape)` — asserts `entry.id` is defined for every discovered entity.
- `falls back to legacy agent_id/team_id/workflow_id fields (pre-agno-2.5)` — exercises the `??` fallback.

## Acceptance criteria

- [x] Field rename — `AgnoAgent.agent_id` / `AgnoTeam.team_id` / `AgnoWorkflow.workflow_id` aligned to agno 2.5 `id` schema.
- [x] Backward compat preserved via optional legacy fields + `??` runtime fallback.
- [x] Regression test added that exercises the agno 2.5 shape and asserts non-undefined `id`.
- [x] Similar check applied for `AgnoTeam` and `AgnoWorkflow` — not just `AgnoAgent`.

## Follow-up (out of scope for this PR)

Two other surfaces still index the legacy fields and will print `id: undefined` on agno 2.5 — both live outside `packages/core/src/providers/` and use the Omni SDK's own `AgnoAgent` / `AgnoTeam` / `AgnoWorkflow` type copies:

- `packages/sdk/src/client.ts:421,432,443` — SDK type declarations still use `agent_id` / `team_id` / `workflow_id`.
- `packages/cli/src/commands/providers.ts:400,425,451` — `omni providers agents/teams/workflows` list commands read the legacy fields.

Scope of #509 is the core provider; I've left the SDK + CLI call sites for a follow-up so this fix stays focused.

## Test plan

- [x] `bun run --filter @omni/core typecheck` — green
- [x] `bunx biome check packages/core` — no warnings
- [x] `bun test src/providers/__tests__/agno-client.test.ts` — 24 pass, 0 fail
- [x] Pre-push hook full suite — 3438 pass, 0 fail (2 pre-existing flaky NATS `RetentionPolicy` failures when running from `packages/core` only are independent of this change)