### PR TITLE
feat(gupshup): observability + real payload fixtures (#504 #505)

### DIFF
--- a/packages/channel-gupshup/RUNBOOK.md
+++ b/packages/channel-gupshup/RUNBOOK.md
@@ -1,0 +1,60 @@
+# Gupshup channel plugin — operator runbook
+
+Alerts and diagnostics for the `@omni/channel-gupshup` webhook ingestion path.
+
+## Alerts
+
+### `gupshup.webhook.received{handled=dropped_unknown_fail_open} > 0/min`
+
+**What it means.** Gupshup is sending us an `event_type` value that is not in
+`KNOWN_MESSAGE_EVENT_TYPES` (currently `user_input`, `async_response`,
+`click_to_chat_advertise`) and not in `KNOWN_NON_MESSAGE_EVENT_TYPES` either.
+The handler fails open and still processes the payload, so no messages are lost
+— but the allowlist is drifting from what Gupshup actually sends.
+
+**Why it matters.** This is the exact drift signal that would have fired at
+webhook #1 on 2026-04-22 when Gupshup flipped `user_input` → `async_response`
+(see incident #503). We want this to be a loud, early alert rather than a
+silent production outage four hours later.
+
+**What to do.**
+
+1. Filter logs for the first-seen WARN: `grep "first time seeing this event_type"`
+   in `~/.omni/logs/omni-api-out.log`. The WARN payload includes the new
+   `event_type` value.
+2. Pull a sample webhook body from a raw `"[gupshup] raw webhook received"`
+   INFO log for the same instance in the same window.
+3. Confirm the new `event_type` represents a user message (has `messageobj.id`,
+   `messageobj.type`, `messageobj.from`, `messageobj.timestamp`).
+4. Add the new value to `KNOWN_MESSAGE_EVENT_TYPES` in
+   `packages/channel-gupshup/src/handlers/webhooks.ts` and add a fixture under
+   `packages/channel-gupshup/src/__tests__/fixtures/` derived from the captured
+   body (PII scrubbed). Ship a PR with the test.
+
+### `gupshup.webhook.received{handled=dropped_unrecognized_shape} > 0/min`
+
+**What it means.** Schema validation failed on the parsed body, or the body
+could not be parsed at all.
+
+**What to do.** Log search `"webhook payload unrecognized shape"` and inspect
+the `errors` field — tells you which Zod assertion failed. Usually Gupshup
+changed a field shape (number ↔ string) or introduced a required nested
+structure.
+
+## Dashboards
+
+Counter dimensions: `{ instanceId, event_type, handled }`.
+
+Handled enum:
+
+| `handled` | Meaning |
+|-----------|---------|
+| `processed` | Known message event_type, dispatched to `processInboundMessage` successfully. |
+| `dropped_known_non_message` | Explicit denylist hit (status/billing receipts). Healthy. |
+| `dropped_unknown_fail_open` | Unknown `event_type` — processed anyway, format drift alert. |
+| `dropped_unrecognized_shape` | Schema validation failure (body malformed). |
+| `dropped_empty_content` | `extractContent()` returned null or dedupe suppressed a retry. |
+
+A healthy instance shows almost all traffic under `processed` +
+`dropped_known_non_message`. Any sustained volume under `dropped_unknown_fail_open`
+or `dropped_unrecognized_shape` is an incident.

--- a/packages/channel-gupshup/src/__tests__/fixtures/async_response-audio.json
+++ b/packages/channel-gupshup/src/__tests__/fixtures/async_response-audio.json
@@ -1,0 +1,48 @@
+{
+  "source": "channel",
+  "sender": "5521900000002",
+  "channel": "whatsapp",
+  "isGroup": false,
+  "destination": 558007779070,
+  "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+  "event_type": "async_response",
+  "request_id": "5521900000002_00000000-0000-0000-0000-000000000000_1777400100000",
+  "stack_id": 1777400100000,
+  "postbackText": null,
+  "senderobj": {
+    "channelid": "5521900000002",
+    "display": "Test Lead",
+    "channeltype": "whatsapp"
+  },
+  "contextobj": {
+    "senderName": "Test Lead",
+    "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+    "channeltype": "whatsapp",
+    "contexttype": "p2p",
+    "contextid": "5521900000002"
+  },
+  "messageobj": {
+    "id": "wamid.TEST_ASYNC_RESPONSE_AUDIO_001",
+    "type": "audio",
+    "from": "5521900000002",
+    "timestamp": 1777400100,
+    "text": "https://filemanager.gupshup.io/wa/media/0000000000000001?download=false",
+    "url": "https://filemanager.gupshup.io/wa/media/0000000000000001?download=false",
+    "mediaId": "0000000000000001",
+    "contentType": "audio/ogg; codecs=opus",
+    "raw": {
+      "payload": { "url": "https://filemanager.gupshup.io/wa/media/0000000000000001?download=false" },
+      "sender": { "phone": "5521900000002", "name": "Test Lead" },
+      "id": "wamid.TEST_ASYNC_RESPONSE_AUDIO_001",
+      "source": "5521900000002",
+      "type": "audio"
+    }
+  },
+  "messageHeader": {
+    "event_type": "async_response",
+    "nsTraceId": "6CF432CE21239AF-0000000000001235",
+    "project_id": "31569577",
+    "x-gs-priority": 4
+  },
+  "metadata": {}
+}

--- a/packages/channel-gupshup/src/__tests__/fixtures/async_response-text.json
+++ b/packages/channel-gupshup/src/__tests__/fixtures/async_response-text.json
@@ -1,0 +1,48 @@
+{
+  "source": "channel",
+  "sender": "5521900000002",
+  "channel": "whatsapp",
+  "isGroup": false,
+  "destination": 558007779070,
+  "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+  "event_type": "async_response",
+  "request_id": "5521900000002_00000000-0000-0000-0000-000000000000_1777400000000",
+  "stack_id": 1777400000000,
+  "message": "Boa noite, gostaria de contratar um plano",
+  "postbackText": null,
+  "senderobj": {
+    "channelid": "5521900000002",
+    "display": "Test Lead",
+    "channeltype": "whatsapp"
+  },
+  "contextobj": {
+    "senderName": "Test Lead",
+    "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+    "channeltype": "whatsapp",
+    "contexttype": "p2p",
+    "contextid": "5521900000002",
+    "cc": "55",
+    "dc": "21900000002"
+  },
+  "messageobj": {
+    "id": "wamid.TEST_ASYNC_RESPONSE_TEXT_001",
+    "type": "text",
+    "from": "5521900000002",
+    "timestamp": 1777400000,
+    "text": "Boa noite, gostaria de contratar um plano",
+    "raw": {
+      "payload": { "text": "Boa noite, gostaria de contratar um plano" },
+      "sender": { "phone": "5521900000002", "name": "Test Lead" },
+      "id": "wamid.TEST_ASYNC_RESPONSE_TEXT_001",
+      "source": "5521900000002",
+      "type": "text"
+    }
+  },
+  "messageHeader": {
+    "event_type": "async_response",
+    "nsTraceId": "6CF432CE21239AE-0000000000001234",
+    "project_id": "31569577",
+    "x-gs-priority": 4
+  },
+  "metadata": {}
+}

--- a/packages/channel-gupshup/src/__tests__/fixtures/billing_event.json
+++ b/packages/channel-gupshup/src/__tests__/fixtures/billing_event.json
@@ -1,0 +1,35 @@
+{
+  "source": "channel",
+  "sender": "5511900000001",
+  "channel": "whatsapp",
+  "isGroup": false,
+  "destination": 558007779070,
+  "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+  "event_type": "billing_event",
+  "postbackText": null,
+  "senderobj": {
+    "channelid": "5511900000001",
+    "channeltype": "whatsapp"
+  },
+  "contextobj": {
+    "channeltype": "whatsapp",
+    "contexttype": "p2p",
+    "contextid": "5511900000001"
+  },
+  "messageobj": {
+    "id": "wamid.TEST_BILLING_001",
+    "type": "text",
+    "from": "5511900000001",
+    "timestamp": 1776300200,
+    "text": "billing-notification"
+  },
+  "messageHeader": {
+    "event_type": "billing_event",
+    "nsTraceId": "BILLING00000001-0000000000000002",
+    "project_id": "31569577"
+  },
+  "metadata": {
+    "billing_category": "conversation",
+    "pricing_model": "CBP"
+  }
+}

--- a/packages/channel-gupshup/src/__tests__/fixtures/click_to_chat_advertise.json
+++ b/packages/channel-gupshup/src/__tests__/fixtures/click_to_chat_advertise.json
@@ -1,0 +1,61 @@
+{
+  "source": "channel",
+  "sender": "5511900000003",
+  "channel": "whatsapp",
+  "isGroup": false,
+  "destination": 558007779070,
+  "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+  "event_type": "click_to_chat_advertise",
+  "message": "Oi, vi o anúncio",
+  "postbackText": null,
+  "senderobj": {
+    "channelid": "5511900000003",
+    "display": "Test Ad Click",
+    "channeltype": "whatsapp"
+  },
+  "contextobj": {
+    "senderName": "Test Ad Click",
+    "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+    "channeltype": "whatsapp",
+    "contexttype": "p2p",
+    "contextid": "5511900000003",
+    "cc": "55",
+    "dc": "11900000003"
+  },
+  "messageobj": {
+    "id": "wamid.TEST_CTCA_001",
+    "type": "text",
+    "from": "5511900000003",
+    "timestamp": 1776300000,
+    "text": "Oi, vi o anúncio",
+    "raw": {
+      "payload": {
+        "text": "Oi, vi o anúncio",
+        "referral": {
+          "source_url": "https://fb.me/TEST_AD",
+          "source_id": "1234567890",
+          "source_type": "ad",
+          "headline": "Planos de Saúde",
+          "body": "Conheça nossos planos",
+          "media_type": "image"
+        }
+      },
+      "sender": { "phone": "5511900000003", "name": "Test Ad Click" },
+      "id": "wamid.TEST_CTCA_001",
+      "source": "5511900000003",
+      "type": "text",
+      "referral": {
+        "source_url": "https://fb.me/TEST_AD",
+        "source_id": "1234567890",
+        "source_type": "ad"
+      }
+    }
+  },
+  "messageHeader": {
+    "event_type": "click_to_chat_advertise",
+    "nsTraceId": "AD001CAFEBABE-00000000000000AD",
+    "project_id": "31569577",
+    "x-gs-priority": 4
+  },
+  "metadata": {}
+}

--- a/packages/channel-gupshup/src/__tests__/fixtures/message_event-delivery.json
+++ b/packages/channel-gupshup/src/__tests__/fixtures/message_event-delivery.json
@@ -1,0 +1,36 @@
+{
+  "source": "channel",
+  "sender": "5511900000001",
+  "channel": "whatsapp",
+  "isGroup": false,
+  "destination": 558007779070,
+  "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+  "event_type": "message_event",
+  "postbackText": null,
+  "senderobj": {
+    "channelid": "5511900000001",
+    "display": "Test User",
+    "channeltype": "whatsapp"
+  },
+  "contextobj": {
+    "senderName": "Test User",
+    "channeltype": "whatsapp",
+    "contexttype": "p2p",
+    "contextid": "5511900000001"
+  },
+  "messageobj": {
+    "id": "wamid.TEST_DELIVERY_001",
+    "type": "text",
+    "from": "5511900000001",
+    "timestamp": 1776300100,
+    "text": "delivered"
+  },
+  "messageHeader": {
+    "event_type": "message_event",
+    "nsTraceId": "DELIVERY000001-0000000000000001",
+    "project_id": "31569577"
+  },
+  "metadata": {
+    "status": "delivered"
+  }
+}

--- a/packages/channel-gupshup/src/__tests__/fixtures/user_input-text.json
+++ b/packages/channel-gupshup/src/__tests__/fixtures/user_input-text.json
@@ -1,0 +1,46 @@
+{
+  "source": "channel",
+  "sender": "5511900000001",
+  "channel": "whatsapp",
+  "isGroup": false,
+  "destination": 558007779070,
+  "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+  "event_type": "user_input",
+  "message": "Oi",
+  "postbackText": null,
+  "senderobj": {
+    "channelid": "5511900000001",
+    "display": "Test User",
+    "channeltype": "whatsapp"
+  },
+  "contextobj": {
+    "senderName": "Test User",
+    "botname": "wFXLdg7dVyO1H9eKL9l9fSL5",
+    "channeltype": "whatsapp",
+    "contexttype": "p2p",
+    "contextid": "5511900000001",
+    "cc": "55",
+    "dc": "11900000001"
+  },
+  "messageobj": {
+    "id": "wamid.TEST_USER_INPUT_TEXT_001",
+    "type": "text",
+    "from": "5511900000001",
+    "timestamp": 1776273477,
+    "text": "Oi",
+    "raw": {
+      "payload": { "text": "Oi" },
+      "sender": { "phone": "5511900000001", "name": "Test User" },
+      "id": "wamid.TEST_USER_INPUT_TEXT_001",
+      "source": "5511900000001",
+      "type": "text"
+    }
+  },
+  "messageHeader": {
+    "event_type": "user_input",
+    "nsTraceId": "1715A9A85A3EECC-000000000000157A",
+    "project_id": "31569577",
+    "x-gs-priority": 4
+  },
+  "metadata": {}
+}

--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -12,8 +12,25 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { handleGupshupWebhook } from '../handlers/webhooks';
+import { GUPSHUP_WEBHOOK_METRIC } from '../observability';
 import type { GupshupPlugin } from '../plugin';
+
+// ─────────────────────────────────────────────────────────────
+// Real-payload fixture loader (#505)
+// ─────────────────────────────────────────────────────────────
+//
+// Fixtures live in ./fixtures/*.json and mirror the shape of raw Gupshup
+// webhook bodies observed in production, with PII (phones, wamids, names)
+// scrubbed to deterministic placeholders.
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+function loadFixtureText(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf8');
+}
 
 // ─────────────────────────────────────────────────────────────
 // Native payload fixtures (from real Gupshup webhooks)
@@ -381,45 +398,26 @@ function makeHandlerHarness() {
   return { plugin, logs, received };
 }
 
-function makeWebhookRequest(payload: Record<string, unknown>): Request {
+function makeWebhookRequest(payload: Record<string, unknown> | string): Request {
+  const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
   return new Request('https://example.com/api/v2/channels/gupshup/inst-gs-handler/webhook', {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: JSON.stringify(payload),
+    body,
   });
 }
 
-const TEXT_MESSAGEOBJ = {
-  type: 'text',
-  text: 'Oi',
-  from: '5511960008976',
-  timestamp: 1776273477,
-  id: 'wamid.HANDLER_TEST_001',
-  raw: {
-    payload: { text: 'Oi' },
-    sender: { phone: '5511960008976', name: 'Gustavo Batista' },
-    id: 'wamid.HANDLER_TEST_001',
-    source: '5511960008976',
-    type: 'text',
-  },
-};
+function findMetricLogs(logs: HandlerLogCall[]) {
+  return logs.filter((l) => l.data?.metric === GUPSHUP_WEBHOOK_METRIC);
+}
 
-describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
-  it('async_response text message is processed end-to-end (post-cutover)', async () => {
+describe('handleGupshupWebhook — event_type routing against real fixtures (#503, #505)', () => {
+  it('processes async_response text message end-to-end (post-2026-04-22 cutover)', async () => {
     const { plugin, logs, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
-    const epoch = Date.now();
-    const payload = {
-      ...BASE,
-      event_type: 'async_response',
-      request_id: `5521975469499_d4296fbd-42ad-4a44-b5fb-6178182b23ef_${epoch}`,
-      stack_id: epoch,
-      messageHeader: { ...BASE.messageHeader, event_type: 'async_response' },
-      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.ASYNC_RESPONSE_001' },
-    };
 
     const response = await handleGupshupWebhook(
-      makeWebhookRequest(payload),
+      makeWebhookRequest(loadFixtureText('async_response-text.json')),
       plugin,
       'inst-gs-handler',
       undefined,
@@ -428,23 +426,36 @@ describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
 
     expect(response.status).toBe(200);
     expect(received).toHaveLength(1);
-    expect(received[0]?.externalId).toBe('wamid.ASYNC_RESPONSE_001');
+    expect(received[0]?.externalId).toBe('wamid.TEST_ASYNC_RESPONSE_TEXT_001');
+    expect(received[0]?.content.text).toBe('Boa noite, gostaria de contratar um plano');
+    expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
+  });
+
+  it('processes user_input text message (legacy format regression guard)', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(loadFixtureText('user_input-text.json')),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.TEST_USER_INPUT_TEXT_001');
     expect(received[0]?.content.text).toBe('Oi');
-    // No WARN for known message event_type
     expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
   });
 
-  it('user_input text message is still processed (regression guard)', async () => {
-    const { plugin, received, logs } = makeHandlerHarness();
+  it('processes click_to_chat_advertise text message from paid ads', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
-    const payload = {
-      ...BASE,
-      event_type: 'user_input',
-      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.USER_INPUT_001' },
-    };
 
     const response = await handleGupshupWebhook(
-      makeWebhookRequest(payload),
+      makeWebhookRequest(loadFixtureText('click_to_chat_advertise.json')),
       plugin,
       'inst-gs-handler',
       undefined,
@@ -453,21 +464,16 @@ describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
 
     expect(response.status).toBe(200);
     expect(received).toHaveLength(1);
-    expect(received[0]?.externalId).toBe('wamid.USER_INPUT_001');
+    expect(received[0]?.externalId).toBe('wamid.TEST_CTCA_001');
     expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
   });
 
-  it('click_to_chat_advertise text message is processed', async () => {
-    const { plugin, received, logs } = makeHandlerHarness();
+  it('processes async_response audio message (current format media)', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
-    const payload = {
-      ...BASE,
-      event_type: 'click_to_chat_advertise',
-      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.CTCA_001' },
-    };
 
     const response = await handleGupshupWebhook(
-      makeWebhookRequest(payload),
+      makeWebhookRequest(loadFixtureText('async_response-audio.json')),
       plugin,
       'inst-gs-handler',
       undefined,
@@ -476,21 +482,17 @@ describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
 
     expect(response.status).toBe(200);
     expect(received).toHaveLength(1);
-    expect(received[0]?.externalId).toBe('wamid.CTCA_001');
+    expect(received[0]?.externalId).toBe('wamid.TEST_ASYNC_RESPONSE_AUDIO_001');
+    expect(received[0]?.content.type).toBe('audio');
     expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
   });
 
-  it('message_event delivery receipt is ignored (processInboundMessage not called)', async () => {
-    const { plugin, received, logs } = makeHandlerHarness();
+  it('ignores message_event delivery receipt (no processInboundMessage call)', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
-    const payload = {
-      ...BASE,
-      event_type: 'message_event',
-      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.DELIVERY_RECEIPT_001' },
-    };
 
     const response = await handleGupshupWebhook(
-      makeWebhookRequest(payload),
+      makeWebhookRequest(loadFixtureText('message_event-delivery.json')),
       plugin,
       'inst-gs-handler',
       undefined,
@@ -504,18 +506,30 @@ describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
     expect(debugDrop?.data?.event_type).toBe('message_event');
   });
 
-  it('unknown event_type with valid messageobj is processed AND WARN is logged (fail-open)', async () => {
-    const { plugin, received, logs } = makeHandlerHarness();
+  it('ignores billing_event (no processInboundMessage call)', async () => {
+    const { plugin, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
-    const payload = {
-      ...BASE,
-      event_type: 'v3_message',
-      messageHeader: { ...BASE.messageHeader, event_type: 'v3_message' },
-      messageobj: { ...TEXT_MESSAGEOBJ, id: 'wamid.UNKNOWN_EVENT_001' },
-    };
 
     const response = await handleGupshupWebhook(
-      makeWebhookRequest(payload),
+      makeWebhookRequest(loadFixtureText('billing_event.json')),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(0);
+  });
+
+  it('processes + WARNs on unknown event_type (fail-open for format drift)', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    // Mutate async_response fixture to an unseen event_type to simulate a future Gupshup format.
+    const mutated = loadFixtureText('async_response-text.json').replace(/"async_response"/g, '"v3_future_format"');
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(mutated),
       plugin,
       'inst-gs-handler',
       undefined,
@@ -524,12 +538,126 @@ describe('handleGupshupWebhook — event_type routing (incident #503)', () => {
 
     expect(response.status).toBe(200);
     expect(received).toHaveLength(1);
-    expect(received[0]?.externalId).toBe('wamid.UNKNOWN_EVENT_001');
     const warn = logs.find((l) => l.level === 'warn' && l.message.includes('unknown event_type'));
     expect(warn).toBeDefined();
-    expect(warn?.data?.event_type).toBe('v3_message');
-    expect(warn?.data?.messageHeaderEventType).toBe('v3_message');
+    expect(warn?.data?.event_type).toBe('v3_future_format');
     expect(warn?.data?.messageType).toBe('text');
-    expect(warn?.data?.sender).toBe(BASE.sender);
+  });
+
+  it('handles Gupshup Request Builder double-encoding envelope (unescaped inner quotes)', async () => {
+    const { plugin, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    // Gupshup Request Builder produces an outer body whose "gupshupPayload" value
+    // is raw (not JSON-escaped), so the full string is not valid JSON. The handler
+    // strips the wrapper by string match instead of JSON.parse.
+    const inner = loadFixtureText('async_response-text.json').trim();
+    const wrapped = `{"gupshupPayload":"${inner}"}`;
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(wrapped),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.TEST_ASYNC_RESPONSE_TEXT_001');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Observability — metric emission + first-seen WARN (#504)
+// ─────────────────────────────────────────────────────────────
+
+describe('handleGupshupWebhook — observability signals (#504)', () => {
+  it('emits gupshup.webhook.received{handled=processed} on happy path', async () => {
+    const { plugin, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    await handleGupshupWebhook(
+      makeWebhookRequest(loadFixtureText('async_response-text.json')),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    const metrics = findMetricLogs(logs);
+    expect(metrics).toHaveLength(1);
+    const dims = metrics[0]?.data?.dimensions as Record<string, unknown>;
+    expect(dims.handled).toBe('processed');
+    expect(dims.event_type).toBe('async_response');
+    expect(dims.instanceId).toBe('inst-gs-handler');
+  });
+
+  it('emits gupshup.webhook.received{handled=dropped_known_non_message} for denylisted events', async () => {
+    const { plugin, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    await handleGupshupWebhook(
+      makeWebhookRequest(loadFixtureText('message_event-delivery.json')),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    const metrics = findMetricLogs(logs);
+    expect(metrics).toHaveLength(1);
+    const dims = metrics[0]?.data?.dimensions as Record<string, unknown>;
+    expect(dims.handled).toBe('dropped_known_non_message');
+    expect(dims.event_type).toBe('message_event');
+  });
+
+  it('emits gupshup.webhook.received{handled=dropped_unknown_fail_open} for unknown event_types', async () => {
+    const { plugin, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const mutated = loadFixtureText('async_response-text.json').replace(/"async_response"/g, '"v3_future_format"');
+
+    await handleGupshupWebhook(makeWebhookRequest(mutated), plugin, 'inst-gs-handler', undefined, dedupeCache);
+
+    const metrics = findMetricLogs(logs);
+    expect(metrics).toHaveLength(1);
+    const dims = metrics[0]?.data?.dimensions as Record<string, unknown>;
+    expect(dims.handled).toBe('dropped_unknown_fail_open');
+    expect(dims.event_type).toBe('v3_future_format');
+  });
+
+  it('emits gupshup.webhook.received{handled=dropped_unrecognized_shape} for schema failures', async () => {
+    const { plugin, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    const broken = JSON.stringify({ event_type: 'user_input', missing_everything: true });
+
+    await handleGupshupWebhook(makeWebhookRequest(broken), plugin, 'inst-gs-handler', undefined, dedupeCache);
+
+    const metrics = findMetricLogs(logs);
+    expect(metrics).toHaveLength(1);
+    const dims = metrics[0]?.data?.dimensions as Record<string, unknown>;
+    expect(dims.handled).toBe('dropped_unrecognized_shape');
+  });
+
+  it('first-seen event_type WARN fires once per process per value', async () => {
+    const { plugin, logs } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+    // Use a sentinel value unlikely to collide with other tests in the same process.
+    const sentinel = `first_seen_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const mutated = loadFixtureText('async_response-text.json').replace(/"async_response"/g, `"${sentinel}"`);
+
+    await handleGupshupWebhook(makeWebhookRequest(mutated), plugin, 'inst-gs-handler', undefined, dedupeCache);
+    // Re-run with a different wamid so dedupe doesn't fire, but same event_type.
+    const second = mutated.replace(/TEST_ASYNC_RESPONSE_TEXT_001/g, 'TEST_ASYNC_RESPONSE_TEXT_002');
+    await handleGupshupWebhook(makeWebhookRequest(second), plugin, 'inst-gs-handler', undefined, dedupeCache);
+
+    const firstSeenWarns = logs.filter(
+      (l) =>
+        l.level === 'warn' &&
+        l.message.includes('first time seeing this event_type') &&
+        l.data?.event_type === sentinel,
+    );
+    expect(firstSeenWarns).toHaveLength(1);
+    expect(firstSeenWarns[0]?.data?.knownMessage).toBe(false);
+    expect(firstSeenWarns[0]?.data?.knownNonMessage).toBe(false);
   });
 });

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -21,6 +21,7 @@ import { createInboundDedupeCache, sanitizeMessage } from '@omni/channel-sdk';
 import type { DedupeCache } from '@omni/channel-sdk';
 import { z } from 'zod';
 
+import { type GupshupWebhookHandled, recordGupshupWebhookReceived, seenEventTypes } from '../observability';
 import type { GupshupPlugin } from '../plugin';
 import type { GupshupNativeInboundWebhook, GupshupNativeMessageObj } from '../types';
 
@@ -251,6 +252,11 @@ export async function handleGupshupWebhook(
 
   if (!parsed) {
     // Can't parse at all — ack and move on, we already logged the raw body
+    recordGupshupWebhookReceived(logger, {
+      instanceId,
+      event_type: 'unparsed',
+      handled: 'dropped_unrecognized_shape',
+    });
     return new Response('OK', { status: 200 });
   }
 
@@ -262,20 +268,46 @@ export async function handleGupshupWebhook(
       parsed,
     });
     // Fail-open: always ack so Gupshup doesn't retry
+    const parsedEventType =
+      parsed !== null && typeof parsed === 'object' && 'event_type' in parsed
+        ? String((parsed as { event_type: unknown }).event_type ?? 'unparsed')
+        : 'unparsed';
+    recordGupshupWebhookReceived(logger, {
+      instanceId,
+      event_type: parsedEventType,
+      handled: 'dropped_unrecognized_shape',
+    });
     return new Response('OK', { status: 200 });
   }
 
   const webhook = result.data as unknown as GupshupNativeInboundWebhook;
+
+  // First-seen WARN — fires once per process per event_type value. Would have
+  // caught the 2026-04-22 async_response cutover at webhook #1.
+  if (seenEventTypes.markIfFirst(webhook.event_type)) {
+    logger.warn('[gupshup] first time seeing this event_type', {
+      instanceId,
+      event_type: webhook.event_type,
+      knownMessage: KNOWN_MESSAGE_EVENT_TYPES.has(webhook.event_type),
+      knownNonMessage: KNOWN_NON_MESSAGE_EVENT_TYPES.has(webhook.event_type),
+    });
+  }
 
   if (KNOWN_NON_MESSAGE_EVENT_TYPES.has(webhook.event_type)) {
     logger.debug('[gupshup] known non-message event ignored', {
       instanceId,
       event_type: webhook.event_type,
     });
+    recordGupshupWebhookReceived(logger, {
+      instanceId,
+      event_type: webhook.event_type,
+      handled: 'dropped_known_non_message',
+    });
     return new Response('OK', { status: 200 });
   }
 
-  if (!KNOWN_MESSAGE_EVENT_TYPES.has(webhook.event_type)) {
+  const knownMessageEvent = KNOWN_MESSAGE_EVENT_TYPES.has(webhook.event_type);
+  if (!knownMessageEvent) {
     // Unknown event_type that passed schema validation (has valid messageobj).
     // Fail-open: process it + WARN so operators notice format drift early.
     logger.warn('[gupshup] unknown event_type with valid messageobj — processing anyway', {
@@ -287,7 +319,24 @@ export async function handleGupshupWebhook(
     });
   }
 
-  await processInboundMessage(plugin, instanceId, webhook, dedupeCache);
+  const processed = await processInboundMessage(plugin, instanceId, webhook, dedupeCache);
+
+  // Unknown event_type wins the label — the alerting signal is format drift
+  // detection, independent of whether the downstream extraction succeeded.
+  let handled: GupshupWebhookHandled;
+  if (!knownMessageEvent) {
+    handled = 'dropped_unknown_fail_open';
+  } else if (!processed) {
+    handled = 'dropped_empty_content';
+  } else {
+    handled = 'processed';
+  }
+
+  recordGupshupWebhookReceived(logger, {
+    instanceId,
+    event_type: webhook.event_type,
+    handled,
+  });
 
   return new Response('OK', { status: 200 });
 }
@@ -301,18 +350,18 @@ async function processInboundMessage(
   instanceId: string,
   webhook: GupshupNativeInboundWebhook,
   dedupeCache: DedupeCache,
-): Promise<void> {
+): Promise<boolean> {
   const msg = webhook.messageobj;
   const from = webhook.sender;
 
   // Dedupe by sender phone + message ID
   const dedupeKey = `${from.trim()}:${msg.id}`;
   if (dedupeCache.isDuplicate(instanceId, dedupeKey, 'gupshup', plugin.getLogger() as import('@omni/core').Logger)) {
-    return;
+    return false;
   }
 
   const content = extractContent(msg);
-  if (!content) return;
+  if (!content) return false;
 
   // Sanitize text
   if (content.text) {
@@ -320,7 +369,7 @@ async function processInboundMessage(
       instanceId,
       messageId: msg.id,
     });
-    if (!sanitized.ok) return;
+    if (!sanitized.ok) return false;
     content.text = sanitized.text;
   }
 
@@ -344,6 +393,7 @@ async function processInboundMessage(
     platformTimestamp,
     replyTo,
   });
+  return true;
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/channel-gupshup/src/observability.ts
+++ b/packages/channel-gupshup/src/observability.ts
@@ -1,0 +1,73 @@
+/**
+ * Gupshup observability helpers
+ *
+ * Emits structured log payloads for webhook outcomes so any log-scraping
+ * metric pipeline can derive counters without requiring a dedicated
+ * metrics dependency in the channel plugin.
+ *
+ * Every webhook processing outcome increments `gupshup.webhook.received`
+ * with dimensions `{ instanceId, event_type, handled }` where `handled` is
+ * one of:
+ *   - 'processed'                     — dispatched to processInboundMessage
+ *   - 'dropped_known_non_message'     — denylist hit (message_event, billing…)
+ *   - 'dropped_unknown_fail_open'     — unknown event_type, still processed + WARN
+ *   - 'dropped_unrecognized_shape'    — schema validation failure
+ *   - 'dropped_empty_content'         — content extraction returned null
+ *
+ * A module-level set (`seenEventTypes`) tracks the first-seen event_type per
+ * process so format drift surfaces once at WARN level (would have caught the
+ * 2026-04-22 async_response cutover at webhook #1).
+ */
+
+import type { Logger } from '@omni/core';
+
+export type GupshupWebhookHandled =
+  | 'processed'
+  | 'dropped_known_non_message'
+  | 'dropped_unknown_fail_open'
+  | 'dropped_unrecognized_shape'
+  | 'dropped_empty_content';
+
+export interface GupshupWebhookMetricDimensions {
+  instanceId: string;
+  event_type: string;
+  handled: GupshupWebhookHandled;
+}
+
+export const GUPSHUP_WEBHOOK_METRIC = 'gupshup.webhook.received';
+
+/**
+ * Record a webhook outcome as a structured log emission.
+ *
+ * Shape is stable so downstream pipelines (Loki/Datadog/CloudWatch) can
+ * derive counters via log-based metric extractors.
+ */
+export function recordGupshupWebhookReceived(logger: Logger, dimensions: GupshupWebhookMetricDimensions): void {
+  logger.info('[gupshup] webhook received', {
+    metric: GUPSHUP_WEBHOOK_METRIC,
+    value: 1,
+    dimensions,
+  });
+}
+
+/**
+ * Creates a first-seen event_type tracker. Separate from the module state so
+ * tests can get an isolated set instead of bleeding across test runs.
+ */
+export function createSeenEventTypesTracker() {
+  const seen = new Set<string>();
+  return {
+    /** Returns true the first time each value is seen; false thereafter. */
+    markIfFirst(value: string): boolean {
+      if (seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    },
+    size(): number {
+      return seen.size;
+    },
+  };
+}
+
+/** Shared per-process tracker used by the webhook handler. */
+export const seenEventTypes = createSeenEventTypesTracker();

--- a/packages/channel-gupshup/src/observability.ts
+++ b/packages/channel-gupshup/src/observability.ts
@@ -51,23 +51,18 @@ export function recordGupshupWebhookReceived(logger: Logger, dimensions: Gupshup
 }
 
 /**
- * Creates a first-seen event_type tracker. Separate from the module state so
- * tests can get an isolated set instead of bleeding across test runs.
+ * Shared per-process first-seen event_type tracker used by the webhook handler.
+ * Returns true the first time each value is seen; false thereafter.
  */
-export function createSeenEventTypesTracker() {
+function createSeenEventTypesTracker() {
   const seen = new Set<string>();
   return {
-    /** Returns true the first time each value is seen; false thereafter. */
     markIfFirst(value: string): boolean {
       if (seen.has(value)) return false;
       seen.add(value);
       return true;
     },
-    size(): number {
-      return seen.size;
-    },
   };
 }
 
-/** Shared per-process tracker used by the webhook handler. */
 export const seenEventTypes = createSeenEventTypesTracker();


### PR DESCRIPTION
## Summary

Stacked on top of **#510** (incident #503 fix). Adds the follow-ups that turn the 2026-04-22 silent outage into an early, audible alert.

- **#504 — Observability**: every webhook emits a structured `gupshup.webhook.received` log-metric with `{ instanceId, event_type, handled }`. A first-seen WARN fires once per process per `event_type` value — would have caught the `async_response` cutover at webhook #1 instead of four hours later.
- **#505 — Real payload fixtures**: PII-scrubbed JSON fixtures under `packages/channel-gupshup/src/__tests__/fixtures/` for `user_input`, `async_response` (text + audio), `click_to_chat_advertise`, `message_event`, `billing_event`. Handler routing tests now load from fixtures and exercise `handleGupshupWebhook` end-to-end.
- **Runbook**: `packages/channel-gupshup/RUNBOOK.md` with the alert entry: `gupshup.webhook.received{handled=dropped_unknown_fail_open} > 0/min → format drift, investigate first-seen WARN`.

## Depends on #510

Please merge #510 first — this branch is stacked on `fix/gupshup-async-response-503`. Rebasing after #510 lands will drop its commits from the diff and leave only the two commits on this branch.

## Acceptance criteria

### #504
- [x] Fail-open drop path (unknown event_type with valid messageobj) logs at WARN including `event_type`, `messageHeader.event_type`, `messageobj.type`, `sender`.
- [x] Metric `gupshup.webhook.received{handled}` emitted on every webhook (processed + all dropped paths).
- [x] First-seen `event_type` WARN log fires once per process per value.
- [x] Runbook entry added for the `dropped_unknown_fail_open` alert.

### #505
- [x] Fixtures committed for `user_input` and `async_response` (text + audio) and `click_to_chat_advertise`.
- [x] Fixtures for two non-message event types (`message_event`, `billing_event`).
- [x] Tests exercise `handleGupshupWebhook` end-to-end against fixtures (not just schema parsing).
- [x] Double-encoding (Gupshup Request Builder unescaped-quotes envelope) is covered.
- [x] Fixtures have PII scrubbed — phones → `5511900000001`/`5521900000002`/etc., wamids → `wamid.TEST_<scenario>_NNN`, names → `Test User`/`Test Lead`/`Test Ad Click`, UUIDs → all-zero placeholders.

## Scope boundaries

- Only `packages/channel-gupshup/` touched — no `packages/core/` changes and no new metrics framework.
- Metrics ride on structured logs (`{ metric, value, dimensions }`) so any log-scraping pipeline (Loki/Datadog/CloudWatch) can derive counters without a dedicated dependency.
- The pre-existing unreachable escaped-inner path in `extractPayload` is left alone (separate refactor, not in scope for this PR).

## Test plan

- [x] `bun run --filter @omni/channel-gupshup typecheck` — green
- [x] `bunx biome check packages/channel-gupshup` — zero errors/warnings
- [x] `bun test` inside the gupshup package — **86 pass / 0 fail / 159 expect() calls**
- [x] Full repo `git push` hook pipeline — **3450 pass / 0 fail / 8433 expect() calls across 253 files**
- [ ] Post-deploy: confirm `gupshup.webhook.received{handled=processed}` shows non-zero traffic and `dropped_unknown_fail_open` stays at zero on production instances