### PR TITLE
fix(cli): bundle @omni/channel-gupshup in npm package (#513)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -86,7 +86,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -161,7 +161,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -195,7 +195,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -210,7 +210,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -230,7 +230,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -251,6 +251,7 @@
       "devDependencies": {
         "@omni/api": "workspace:*",
         "@omni/channel-discord": "workspace:*",
+        "@omni/channel-gupshup": "workspace:*",
         "@omni/channel-sdk": "workspace:*",
         "@omni/channel-slack": "workspace:*",
         "@omni/channel-telegram": "workspace:*",
@@ -264,7 +265,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -279,7 +280,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -293,7 +294,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -311,7 +312,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -319,7 +320,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -333,7 +334,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260422.13",
+      "version": "2.260423.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",
@@ -2199,8 +2200,6 @@
 
     "@omni/api/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@omni/channel-gupshup/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
     "@omni/channel-internal/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@omni/channel-sdk/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
@@ -2427,8 +2426,6 @@
 
     "@omni/api/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@omni/channel-gupshup/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
     "@omni/channel-sdk/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@omni/core/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
@@ -2597,8 +2594,6 @@
 
     "@omni/api/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "@omni/channel-gupshup/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
-
     "@omni/channel-sdk/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@omni/core/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -2626,8 +2621,6 @@
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
-
-    "@omni/channel-gupshup/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@omni/api": "workspace:*",
     "@omni/channel-discord": "workspace:*",
+    "@omni/channel-gupshup": "workspace:*",
     "@omni/channel-sdk": "workspace:*",
     "@omni/channel-slack": "workspace:*",
     "@omni/channel-telegram": "workspace:*",

--- a/packages/cli/src/bundled-server-entry.ts
+++ b/packages/cli/src/bundled-server-entry.ts
@@ -9,6 +9,7 @@
 import { type ChannelPlugin, channelRegistry } from '@omni/channel-sdk';
 
 import discordPlugin from '@omni/channel-discord';
+import gupshupPlugin from '@omni/channel-gupshup';
 import slackPlugin from '@omni/channel-slack';
 import telegramPlugin from '@omni/channel-telegram';
 import whatsappPlugin from '@omni/channel-whatsapp';
@@ -16,7 +17,7 @@ import whatsappPlugin from '@omni/channel-whatsapp';
 // Pre-register all bundled channel plugins
 // Type assertion needed: channel plugins implement ChannelPlugin but
 // some have narrower parameter types (e.g. Discord's fetchContacts)
-for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin] as ChannelPlugin[]) {
+for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin, gupshupPlugin] as ChannelPlugin[]) {
   channelRegistry.register(plugin);
 }
 


### PR DESCRIPTION
## Summary

Two-line fix so the published `@automagik/omni` npm bundle includes the gupshup channel plugin. Today it does not — operators running `bun install -g @automagik/omni` get a bundle that silently lacks gupshup, so any production install has to cherry-pick these changes by hand.

The cherry-pick has been carried locally in at least two production deploys (2026-04-21 bug #445 remediation + 2026-04-23 #510 deploy). This promotes it upstream.

Resolves #513.

## Changes

- **`packages/cli/package.json`** — added `@omni/channel-gupshup: workspace:*` to `devDependencies`, alphabetically next to the other `@omni/channel-*` workspace deps.
- **`packages/cli/src/bundled-server-entry.ts`** — added `import gupshupPlugin from '@omni/channel-gupshup'` and included it in the pre-registration array alongside telegram/discord/whatsapp/slack.
- **`bun.lock`** — regenerated.

Diff is +22 / -27 across 3 files (lockfile shuffling dominates). Code change is literally two lines across two files:

```diff
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@omni/api": "workspace:*",
     "@omni/channel-discord": "workspace:*",
+    "@omni/channel-gupshup": "workspace:*",
     "@omni/channel-sdk": "workspace:*",
```

```diff
--- a/packages/cli/src/bundled-server-entry.ts
+++ b/packages/cli/src/bundled-server-entry.ts
@@ -9,6 +9,7 @@
 import { type ChannelPlugin, channelRegistry } from '@omni/channel-sdk';
 
 import discordPlugin from '@omni/channel-discord';
+import gupshupPlugin from '@omni/channel-gupshup';
 import slackPlugin from '@omni/channel-slack';
 import telegramPlugin from '@omni/channel-telegram';
 import whatsappPlugin from '@omni/channel-whatsapp';
@@ -16,7 +17,7 @@ import whatsappPlugin from '@omni/channel-whatsapp';
 // Pre-register all bundled channel plugins
 // Type assertion needed: channel plugins implement ChannelPlugin but
 // some have narrower parameter types (e.g. Discord's fetchContacts)
-for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin] as ChannelPlugin[]) {
+for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin, gupshupPlugin] as ChannelPlugin[]) {
   channelRegistry.register(plugin);
 }
```

## Verification

Locally built `packages/cli/dist/server/index.js` with this PR applied, then grep for the strings that PR #510 introduced to confirm gupshup really bundles:

```
$ bun run build:server
Bundled 3170 modules in 583ms
  index.js  17.48 MB  (entry point)

$ grep -c "raw webhook received"          dist/server/index.js  →  1
$ grep -c "KNOWN_MESSAGE_EVENT_TYPES"     dist/server/index.js  →  2
$ grep -c "async_response"                dist/server/index.js  →  1
```

Without this PR (on clean origin/dev) the same greps all return 0.

No changes to the `build:server` script are needed — the script already handles the native externals (`@snazzah/davey`, `libsodium-wrappers`, `opusscript`, `pdf-parse`, `mammoth`, `exceljs`) generically for all channels.

## Test plan

- [x] `bun install` → lockfile regenerated cleanly, no conflicts
- [x] `cd packages/cli && bun run build:server` → success, 17.48 MB bundle
- [x] `bunx biome check .` → 1047 files, zero warnings/errors
- [x] Full repo test suite: `make test` → 3442 pass / 265 skip / 0 fail / 8420 expect() calls / 91.43s
- [ ] Pre-existing typecheck errors in `packages/cli` about `twilio-whatsapp` (`chats.ts:27`, `instances.ts:35`, `instances.ts:633`) are **not** related to this change — confirmed by reverting the cli/* files to origin/dev and reproducing identical errors. Tracked separately.
- [ ] Post-merge + next publish: operators upgrading via `omni update` or fresh install should find gupshup bundled without manual intervention.

## Context

Gupshup was likely the most recent channel plugin added and slipped through the bundling step. All other bundled channels (telegram, discord, whatsapp, slack) are pre-registered. Filesystem discovery used in monorepo dev mode masks the gap locally — the bug only surfaces when installing the published npm package onto production hosts.

Incident that triggered the investigation: 2026-04-22 Gupshup webhook format cutover → PR #510 → while deploying #510 noticed the published bundle still wouldn't include gupshup without another cherry-pick. #513 captures the full discussion.