### PR TITLE
fix(sdk,cli): propagate agno 2.5 id migration (#515)

### DIFF
--- a/apps/ui/src/components/instances/AgentConfigForm.tsx
+++ b/apps/ui/src/components/instances/AgentConfigForm.tsx
@@ -186,27 +186,30 @@ export function AgentConfigForm({ instance }: AgentConfigFormProps) {
               </div>
             ) : (
               <div className="space-y-2">
-                {agents.map((agent) => (
-                  <button
-                    key={agent.agent_id}
-                    type="button"
-                    onClick={() => setSelectedAgentId(agent.agent_id)}
-                    className={cn(
-                      'flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors',
-                      selectedAgentId === agent.agent_id
-                        ? 'border-primary bg-primary/5'
-                        : 'hover:border-muted-foreground/50 hover:bg-accent',
-                    )}
-                  >
-                    <div className="flex-1">
-                      <p className="font-medium">{agent.name}</p>
-                      {agent.description && (
-                        <p className="text-sm text-muted-foreground line-clamp-1">{agent.description}</p>
+                {agents.map((agent) => {
+                  const agentId = agent.id ?? agent.agent_id;
+                  return (
+                    <button
+                      key={agentId}
+                      type="button"
+                      onClick={() => agentId && setSelectedAgentId(agentId)}
+                      className={cn(
+                        'flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors',
+                        selectedAgentId === agentId
+                          ? 'border-primary bg-primary/5'
+                          : 'hover:border-muted-foreground/50 hover:bg-accent',
                       )}
-                    </div>
-                    {selectedAgentId === agent.agent_id && <Check className="h-5 w-5 text-primary" />}
-                  </button>
-                ))}
+                    >
+                      <div className="flex-1">
+                        <p className="font-medium">{agent.name}</p>
+                        {agent.description && (
+                          <p className="text-sm text-muted-foreground line-clamp-1">{agent.description}</p>
+                        )}
+                      </div>
+                      {selectedAgentId === agentId && <Check className="h-5 w-5 text-primary" />}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </CardContent>

--- a/packages/cli/src/commands/__tests__/providers.test.ts
+++ b/packages/cli/src/commands/__tests__/providers.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `omni providers {agents,teams,workflows} list` row mapping.
+ *
+ * Regression for #515 — the CLI previously read legacy `agent_id` /
+ * `team_id` / `workflow_id` fields, which are undefined on agno 2.5+
+ * (where the API returns `id` instead). Mapping must accept both shapes.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@omni/sdk';
+import { __testables } from '../providers';
+
+const { mapAgnoAgentRow, mapAgnoTeamRow, mapAgnoWorkflowRow } = __testables;
+
+describe('mapAgnoAgentRow', () => {
+  test('reads agno 2.5+ id', () => {
+    const agent: AgnoAgent = { id: 'a1', name: 'Agent 1', model: { name: 'gpt-4' } };
+    expect(mapAgnoAgentRow(agent).id).toBe('a1');
+  });
+
+  test('falls back to legacy agent_id when id is missing', () => {
+    const agent = { agent_id: 'legacy-a1', name: 'Agent Legacy' } as unknown as AgnoAgent;
+    expect(mapAgnoAgentRow(agent).id).toBe('legacy-a1');
+  });
+
+  test('prefers id over legacy agent_id when both present', () => {
+    const agent = { id: 'new', agent_id: 'old', name: 'Agent' } as AgnoAgent;
+    expect(mapAgnoAgentRow(agent).id).toBe('new');
+  });
+});
+
+describe('mapAgnoTeamRow', () => {
+  test('reads agno 2.5+ id', () => {
+    const team: AgnoTeam = { id: 't1', name: 'Team 1', mode: 'coordinate' };
+    expect(mapAgnoTeamRow(team).id).toBe('t1');
+  });
+
+  test('falls back to legacy team_id when id is missing', () => {
+    const team = { team_id: 'legacy-t1', name: 'Team Legacy' } as unknown as AgnoTeam;
+    expect(mapAgnoTeamRow(team).id).toBe('legacy-t1');
+  });
+});
+
+describe('mapAgnoWorkflowRow', () => {
+  test('reads agno 2.5+ id', () => {
+    const wf: AgnoWorkflow = { id: 'w1', name: 'Workflow 1' };
+    expect(mapAgnoWorkflowRow(wf).id).toBe('w1');
+  });
+
+  test('falls back to legacy workflow_id when id is missing', () => {
+    const wf = { workflow_id: 'legacy-w1', name: 'Workflow Legacy' } as unknown as AgnoWorkflow;
+    expect(mapAgnoWorkflowRow(wf).id).toBe('legacy-w1');
+  });
+});

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -17,11 +17,69 @@
  */
 
 import { PROVIDER_SCHEMAS, type ProviderSchema } from '@omni/core';
+import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@omni/sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
 import { resolveProviderId } from '../resolve.js';
 import { createSetupCommand } from './providers-setup.js';
+
+/**
+ * Map agno 2.5+ (`id`) and pre-2.5 (`agent_id`) agent shapes to the list row.
+ */
+function mapAgnoAgentRow(a: AgnoAgent): {
+  id: string | undefined;
+  name: string;
+  model: string;
+  description: string;
+} {
+  return {
+    id: a.id ?? a.agent_id,
+    name: a.name,
+    model: a.model?.name ?? '-',
+    description: a.description?.slice(0, 50) ?? '-',
+  };
+}
+
+/**
+ * Map agno 2.5+ (`id`) and pre-2.5 (`team_id`) team shapes to the list row.
+ */
+function mapAgnoTeamRow(t: AgnoTeam): {
+  id: string | undefined;
+  name: string;
+  mode: string;
+  members: number;
+  description: string;
+} {
+  return {
+    id: t.id ?? t.team_id,
+    name: t.name,
+    mode: t.mode ?? '-',
+    members: t.members?.length ?? 0,
+    description: t.description?.slice(0, 50) ?? '-',
+  };
+}
+
+/**
+ * Map agno 2.5+ (`id`) and pre-2.5 (`workflow_id`) workflow shapes to the list row.
+ */
+function mapAgnoWorkflowRow(w: AgnoWorkflow): {
+  id: string | undefined;
+  name: string;
+  description: string;
+} {
+  return {
+    id: w.id ?? w.workflow_id,
+    name: w.name,
+    description: w.description?.slice(0, 50) ?? '-',
+  };
+}
+
+export const __testables = {
+  mapAgnoAgentRow,
+  mapAgnoTeamRow,
+  mapAgnoWorkflowRow,
+};
 
 // Single source of truth: derive VALID_SCHEMAS from @omni/core (DEC-12)
 const VALID_SCHEMAS: readonly string[] = PROVIDER_SCHEMAS;
@@ -396,12 +454,7 @@ export function createProvidersCommand(): Command {
       try {
         const agents = await client.providers.listAgents(resolvedId);
 
-        const items = agents.map((a) => ({
-          id: a.agent_id,
-          name: a.name,
-          model: a.model?.name ?? '-',
-          description: a.description?.slice(0, 50) ?? '-',
-        }));
+        const items = agents.map(mapAgnoAgentRow);
 
         output.list(items, { emptyMessage: 'No agents found.' });
       } catch (err) {
@@ -421,13 +474,7 @@ export function createProvidersCommand(): Command {
       try {
         const teams = await client.providers.listTeams(resolvedId);
 
-        const items = teams.map((t) => ({
-          id: t.team_id,
-          name: t.name,
-          mode: t.mode ?? '-',
-          members: t.members?.length ?? 0,
-          description: t.description?.slice(0, 50) ?? '-',
-        }));
+        const items = teams.map(mapAgnoTeamRow);
 
         output.list(items, { emptyMessage: 'No teams found.' });
       } catch (err) {
@@ -447,11 +494,7 @@ export function createProvidersCommand(): Command {
       try {
         const workflows = await client.providers.listWorkflows(resolvedId);
 
-        const items = workflows.map((w) => ({
-          id: w.workflow_id,
-          name: w.name,
-          description: w.description?.slice(0, 50) ?? '-',
-        }));
+        const items = workflows.map(mapAgnoWorkflowRow);
 
         output.list(items, { emptyMessage: 'No workflows found.' });
       } catch (err) {

--- a/packages/sdk/src/__tests__/providers-agno.test.ts
+++ b/packages/sdk/src/__tests__/providers-agno.test.ts
@@ -1,0 +1,118 @@
+/**
+ * SDK providers.listAgents/listTeams/listWorkflows agno 2.5+ id migration.
+ *
+ * Regression for #515 — the SDK's `AgnoAgent` / `AgnoTeam` / `AgnoWorkflow`
+ * interfaces previously declared only legacy `agent_id` / `team_id` /
+ * `workflow_id`, which are undefined on agno 2.5+ (where the API returns
+ * `id` instead). The interfaces now declare `id` as authoritative and keep
+ * the legacy fields as deprecated optionals for pre-2.5 deployments.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createOmniClient } from '../index';
+
+function createMockFetch() {
+  const mockImpl = mock((_input: string | URL | Request, _init?: RequestInit) => Promise.resolve(new Response()));
+  const mockFetch = Object.assign((input: string | URL | Request, init?: RequestInit) => mockImpl(input, init), {
+    preconnect: () => {},
+  }) as typeof fetch;
+  return { mockFetch, mockImpl };
+}
+
+describe('SDK providers — agno 2.5+ id migration (#515)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let mockImpl: ReturnType<typeof createMockFetch>['mockImpl'];
+
+  const client = createOmniClient({
+    baseUrl: 'http://localhost:8882',
+    apiKey: 'test-key',
+  });
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    const mocks = createMockFetch();
+    mockImpl = mocks.mockImpl;
+    globalThis.fetch = mocks.mockFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('listAgents exposes agno 2.5+ id on returned entries', async () => {
+    mockImpl.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [{ id: 'a1', name: 'Agent One' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const agents = await client.providers.listAgents('prov-1');
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.id).toBe('a1');
+  });
+
+  test('listAgents still carries pre-2.5 agent_id for backward compat', async () => {
+    mockImpl.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [{ agent_id: 'legacy-a1', name: 'Legacy Agent' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const agents = await client.providers.listAgents('prov-1');
+    expect(agents).toHaveLength(1);
+    // id is authoritative; consumers should read it via `?? agent_id` fallback
+    expect(agents[0]?.id ?? agents[0]?.agent_id).toBe('legacy-a1');
+  });
+
+  test('listTeams exposes agno 2.5+ id on returned entries', async () => {
+    mockImpl.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [{ id: 't1', name: 'Team One', mode: 'coordinate' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const teams = await client.providers.listTeams('prov-1');
+    expect(teams).toHaveLength(1);
+    expect(teams[0]?.id).toBe('t1');
+  });
+
+  test('listTeams still carries pre-2.5 team_id for backward compat', async () => {
+    mockImpl.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [{ team_id: 'legacy-t1', name: 'Legacy Team' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const teams = await client.providers.listTeams('prov-1');
+    expect(teams[0]?.id ?? teams[0]?.team_id).toBe('legacy-t1');
+  });
+
+  test('listWorkflows exposes agno 2.5+ id on returned entries', async () => {
+    mockImpl.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [{ id: 'w1', name: 'Workflow One' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const workflows = await client.providers.listWorkflows('prov-1');
+    expect(workflows).toHaveLength(1);
+    expect(workflows[0]?.id).toBe('w1');
+  });
+
+  test('listWorkflows still carries pre-2.5 workflow_id for backward compat', async () => {
+    mockImpl.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [{ workflow_id: 'legacy-w1', name: 'Legacy Workflow' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const workflows = await client.providers.listWorkflows('prov-1');
+    expect(workflows[0]?.id ?? workflows[0]?.workflow_id).toBe('legacy-w1');
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -416,9 +416,14 @@ export interface ProviderHealthResult {
 
 /**
  * Agno agent entity
+ *
+ * agno 2.5+ returns `id` at the top level. `agent_id` is kept optional for
+ * backward compatibility with pre-2.5 deployments.
  */
 export interface AgnoAgent {
-  agent_id: string;
+  id: string;
+  /** @deprecated pre-agno-2.5 field; use `id` */
+  agent_id?: string;
   name: string;
   model?: { provider?: string; name?: string };
   description?: string;
@@ -427,20 +432,30 @@ export interface AgnoAgent {
 
 /**
  * Agno team entity
+ *
+ * agno 2.5+ returns `id` at the top level. `team_id` is kept optional for
+ * backward compatibility with pre-2.5 deployments.
  */
 export interface AgnoTeam {
-  team_id: string;
+  id: string;
+  /** @deprecated pre-agno-2.5 field; use `id` */
+  team_id?: string;
   name: string;
   description?: string;
   mode?: string;
-  members?: Array<{ agent_id: string; role?: string }>;
+  members?: Array<{ agent_id: string; id?: string; role?: string }>;
 }
 
 /**
  * Agno workflow entity
+ *
+ * agno 2.5+ returns `id` at the top level. `workflow_id` is kept optional for
+ * backward compatibility with pre-2.5 deployments.
  */
 export interface AgnoWorkflow {
-  workflow_id: string;
+  id: string;
+  /** @deprecated pre-agno-2.5 field; use `id` */
+  workflow_id?: string;
   name: string;
   description?: string;
 }


### PR DESCRIPTION
## Summary

Follow-up to #509 / #511. That fix landed on the core `AgnoClient.discover()` path; this PR propagates the same migration to the two surfaces #511 explicitly left out, plus one UI call site that broke once the SDK types were updated.

**Problem.** agno 2.5+ returns `id` at the top level of agent / team / workflow entities. The pre-2.5 names (`agent_id` / `team_id` / `workflow_id`) are gone. The SDK's `AgnoAgent` / `AgnoTeam` / `AgnoWorkflow` interfaces, the CLI's `omni providers agents|teams|workflows <id>` list mappers, and the instance settings UI all still read the legacy fields — so the ID column / selection is blank on any agno 2.5 deployment.

**Fix.** Mirror #511:

- `packages/sdk/src/client.ts` — `id: string` becomes the authoritative field; legacy `{agent,team,workflow}_id` kept as optional `@deprecated` for pre-2.5 back-compat. Applied to `AgnoAgent`, `AgnoTeam`, `AgnoTeam.members[]`, `AgnoWorkflow`.
- `packages/cli/src/commands/providers.ts` — three list rows now read `x.id ?? x.legacy_id`. Extracted to `mapAgnoAgentRow` / `mapAgnoTeamRow` / `mapAgnoWorkflowRow` and exported via `__testables` for unit coverage.
- `apps/ui/src/components/instances/AgentConfigForm.tsx` — same `agent.id ?? agent.agent_id` fallback in the agent picker (required after making `agent_id` optional on the SDK interface).

**Tests.**

- `packages/sdk/src/__tests__/providers-agno.test.ts` (new) — 6 tests. Mocks `globalThis.fetch`, asserts `listAgents` / `listTeams` / `listWorkflows` expose `id` on agno 2.5 shapes and still surface legacy `*_id` via the documented fallback.
- `packages/cli/src/commands/__tests__/providers.test.ts` (new) — 7 tests. Unit-level coverage of the three row mappers on both shapes (prefers `id`, falls back to legacy).

## Acceptance criteria (from #515)

- [x] `packages/sdk/src/client.ts` — agent/team/workflow ID readers handle both `id` and legacy `{agent|team|workflow}_id`.
- [x] `packages/cli/src/commands/providers.ts` — list commands show the correct ID on agno 2.5 and remain compatible with pre-2.5 deployments.
- [x] Regression tests added in SDK + CLI mirroring `agno-client.test.ts` style.
- [ ] Optional: factor the three type declarations into one shared module — deferred as scope creep; left for a dedicated refactor.

## Test plan

- [x] `bun run --filter @omni/sdk typecheck` — clean
- [x] `bun run --filter '@automagik/omni' typecheck` — clean
- [x] `bun run --filter @omni/ui typecheck` — clean
- [x] `bunx biome check packages/sdk packages/cli apps/ui` — zero warnings
- [x] `bun test packages/sdk` — 28/28 pass
- [x] `bun test packages/cli` — 308/308 pass
- [x] Full `make typecheck` (pre-push hook) — green across the monorepo
- [x] Full test suite (pre-push hook) — 3456 pass, 0 fail
- [x] `bunx knip` — no new findings