### PR TITLE
fix(media): hoist media_url on ingest + surface storeFromUrl errors (#500)

### DIFF
--- a/packages/api/src/services/__tests__/media-storage.test.ts
+++ b/packages/api/src/services/__tests__/media-storage.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for MediaStorageService.
+ *
+ * Covers the storeFromUrl error-surfacing contract that BatchJobService
+ * depends on for omni#500 diagnostic clarity: when fetch fails, the error
+ * must carry the HTTP status so callers can report the real reason instead
+ * of the legacy generic "No media file path available" message.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Database } from '@omni/db';
+import { MediaStorageService } from '../media-storage';
+
+const fakeDb = {} as unknown as Database;
+
+describe('MediaStorageService.storeFromUrl (omni#500)', () => {
+  let tmpDir: string;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'media-storage-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    globalThis.fetch = originalFetch;
+  });
+
+  it('throws with HTTP status when fetch returns non-ok', async () => {
+    globalThis.fetch = mock(async () => new Response('forbidden', { status: 403 })) as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(
+      service.storeFromUrl('inst-1', 'msg-1', 'https://mmg.whatsapp.net/v/t62.7117-24/audio.enc?oe=1', 'audio/ogg'),
+    ).rejects.toThrow('Failed to download media: 403');
+  });
+
+  it('throws when fetch itself rejects (network error)', async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(
+      service.storeFromUrl('inst-1', 'msg-1', 'https://example.com/file.bin', 'application/octet-stream'),
+    ).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('stores buffer and returns relative localPath on success', async () => {
+    globalThis.fetch = mock(
+      async () => new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    const result = await service.storeFromUrl(
+      'inst-1',
+      'msg-1',
+      'https://example.com/file.mp3',
+      'audio/mpeg',
+      new Date('2026-04-23T00:00:00Z'),
+    );
+
+    expect(result.size).toBe(4);
+    expect(result.mimeType).toBe('audio/mpeg');
+    expect(result.localPath).toBe(join('inst-1', '2026-04', 'msg-1.mp3'));
+  });
+});

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -738,12 +738,12 @@ export class BatchJobService {
       return this.failedResult(`MIME type not processable: ${mimeType}`);
     }
 
-    const filePath = await this.resolveFilePath(instanceId, message, mimeType);
-    if (!filePath) {
-      return this.failedResult('No media file path available');
+    const resolved = await this.resolveFilePath(instanceId, message, mimeType);
+    if (!resolved.ok) {
+      return this.failedResult(resolved.reason);
     }
 
-    const fullPath = join(this.mediaStorage.getBasePath(), filePath);
+    const fullPath = join(this.mediaStorage.getBasePath(), resolved.path);
     const result = await this.mediaService.process(fullPath, mimeType, {
       language: 'pt',
       caption: message.textContent ?? undefined,
@@ -773,15 +773,24 @@ export class BatchJobService {
   }
 
   /**
-   * Resolve file path - download from URL if needed
+   * Resolve file path - download from URL if needed.
+   *
+   * Returns a tagged result so callers can surface the real reason a file
+   * could not be resolved (missing local path, missing url, download failure).
+   * Previously all three paths collapsed into a generic "No media file path
+   * available" error, which made #500 diagnosis impossible.
    */
-  private async resolveFilePath(instanceId: string, message: Message, mimeType: string): Promise<string | null> {
+  private async resolveFilePath(
+    instanceId: string,
+    message: Message,
+    mimeType: string,
+  ): Promise<{ ok: true; path: string } | { ok: false; reason: string }> {
     if (message.mediaLocalPath) {
-      return message.mediaLocalPath;
+      return { ok: true, path: message.mediaLocalPath };
     }
 
     if (!message.mediaUrl) {
-      return null;
+      return { ok: false, reason: 'No media_url and no media_local_path on message' };
     }
 
     try {
@@ -793,9 +802,15 @@ export class BatchJobService {
         message.platformTimestamp ?? undefined,
       );
       await this.mediaStorage.updateMessageLocalPath(message.id, result.localPath);
-      return result.localPath;
-    } catch {
-      return null;
+      return { ok: true, path: result.localPath };
+    } catch (error) {
+      const reason = `storeFromUrl failed: ${error instanceof Error ? error.message : String(error)}`;
+      log.warn('storeFromUrl failed during batch retrofill', {
+        messageId: message.id,
+        mediaUrl: message.mediaUrl,
+        error: reason,
+      });
+      return { ok: false, reason };
     }
   }
 

--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for extractContent — ensures proto media URLs are hoisted into
+ * ExtractedContent.mediaUrl so they reach messages.media_url at persist time
+ * even when ingest-time blob download fails.
+ *
+ * Regression guard for omni#500 Bug 1.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { WAMessage } from 'baileys';
+import { extractContent } from '../handlers/messages';
+
+function wrap(message: Record<string, unknown>): WAMessage {
+  return {
+    key: { id: 'TEST', remoteJid: '5511999998888@s.whatsapp.net', fromMe: false },
+    message,
+  } as unknown as WAMessage;
+}
+
+describe('extractContent — mediaUrl hoist (omni#500)', () => {
+  it('hoists imageMessage.url into mediaUrl', () => {
+    const content = extractContent(
+      wrap({
+        imageMessage: {
+          url: 'https://mmg.whatsapp.net/v/t62.7118-24/img.enc?oe=1',
+          mimetype: 'image/jpeg',
+          caption: 'hello',
+        },
+      }),
+    );
+    expect(content?.type).toBe('image');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7118-24/img.enc?oe=1');
+    expect(content?.mimeType).toBe('image/jpeg');
+  });
+
+  it('hoists audioMessage.url into mediaUrl', () => {
+    const content = extractContent(
+      wrap({
+        audioMessage: {
+          url: 'https://mmg.whatsapp.net/v/t62.7117-24/audio.enc?oe=2',
+          mimetype: 'audio/ogg; codecs=opus',
+        },
+      }),
+    );
+    expect(content?.type).toBe('audio');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7117-24/audio.enc?oe=2');
+  });
+
+  it('hoists videoMessage.url into mediaUrl', () => {
+    const content = extractContent(
+      wrap({
+        videoMessage: {
+          url: 'https://mmg.whatsapp.net/v/t62.7161-24/video.enc?oe=3',
+          mimetype: 'video/mp4',
+        },
+      }),
+    );
+    expect(content?.type).toBe('video');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7161-24/video.enc?oe=3');
+  });
+
+  it('hoists documentMessage.url into mediaUrl', () => {
+    const content = extractContent(
+      wrap({
+        documentMessage: {
+          url: 'https://mmg.whatsapp.net/v/t62.7119-24/doc.enc?oe=4',
+          mimetype: 'application/pdf',
+          fileName: 'contract.pdf',
+        },
+      }),
+    );
+    expect(content?.type).toBe('document');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7119-24/doc.enc?oe=4');
+    expect(content?.filename).toBe('contract.pdf');
+  });
+
+  it('hoists stickerMessage.url into mediaUrl', () => {
+    const content = extractContent(
+      wrap({
+        stickerMessage: {
+          url: 'https://mmg.whatsapp.net/v/t62.15575-24/sticker.enc?oe=5',
+          mimetype: 'image/webp',
+        },
+      }),
+    );
+    expect(content?.type).toBe('sticker');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.15575-24/sticker.enc?oe=5');
+  });
+
+  it('leaves mediaUrl undefined when proto url is missing', () => {
+    const content = extractContent(wrap({ audioMessage: { mimetype: 'audio/ogg' } }));
+    expect(content?.type).toBe('audio');
+    expect(content?.mediaUrl).toBeUndefined();
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -104,6 +104,7 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
       type: 'image',
       caption: m.imageMessage?.caption ?? undefined,
       mimeType: m.imageMessage?.mimetype ?? 'image/jpeg',
+      mediaUrl: m.imageMessage?.url ?? undefined,
     }),
   },
   {
@@ -111,6 +112,7 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
     extract: (m) => ({
       type: 'audio',
       mimeType: m.audioMessage?.mimetype ?? 'audio/ogg',
+      mediaUrl: m.audioMessage?.url ?? undefined,
     }),
   },
   {
@@ -119,6 +121,7 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
       type: 'video',
       caption: m.videoMessage?.caption ?? undefined,
       mimeType: m.videoMessage?.mimetype ?? 'video/mp4',
+      mediaUrl: m.videoMessage?.url ?? undefined,
     }),
   },
   {
@@ -128,6 +131,7 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
       filename: m.documentMessage?.fileName ?? undefined,
       mimeType: m.documentMessage?.mimetype ?? 'application/octet-stream',
       caption: m.documentMessage?.caption ?? undefined,
+      mediaUrl: m.documentMessage?.url ?? undefined,
     }),
   },
   {
@@ -135,6 +139,7 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
     extract: (m) => ({
       type: 'sticker',
       mimeType: m.stickerMessage?.mimetype ?? 'image/webp',
+      mediaUrl: m.stickerMessage?.url ?? undefined,
     }),
   },
   {
@@ -421,7 +426,7 @@ function extractUnknownContent(message: MessageContent): ExtractedContent | null
  * Extract content from a Baileys message using handler map
  * Falls back to 'unknown' type for unrecognized messages to ensure nothing is lost
  */
-function extractContent(msg: WAMessage): ExtractedContent | null {
+export function extractContent(msg: WAMessage): ExtractedContent | null {
   const message = msg.message;
   if (!message) return null;
 


### PR DESCRIPTION
## Summary

Closes #500. Addresses both compounding bugs that made WhatsApp media retrofill structurally impossible:

1. **Ingest-time URL hoist** — WhatsApp content extractors now pull `m.<type>Message.url` into `ExtractedContent.mediaUrl`, so the URL always reaches the `messages.media_url` column even when `tryDownloadMedia` fails. Previously the URL was lost whenever atomic ingest download failed (TTL, auth, transient), leaving ~96 items/day per instance unrecoverable despite the URL still existing in `raw_payload`.
2. **Real error surface in batch retrofill** — `BatchJobService.resolveFilePath` now returns a tagged `{ ok, path | reason }` and logs `storeFromUrl failed: <http status>` instead of collapsing every failure into the generic `"No media file path available"`. This is the 5-minute diagnostic patch from the issue (Fix 4); authenticated Baileys-based refetch (Fix 1–3) remains follow-up.

## Files

- `packages/channel-whatsapp/src/handlers/messages.ts` — 5 content extractors (image/audio/video/document/sticker) now set `mediaUrl: m.<type>Message.url`. `extractContent` exported to enable regression tests.
- `packages/api/src/services/batch-jobs.ts` — `resolveFilePath` returns tagged result; `processItem` surfaces the real reason; log warning now emitted on `storeFromUrl` failure with `messageId`, `mediaUrl`, and the underlying error.
- `packages/channel-whatsapp/src/__tests__/extract-content.test.ts` — new (6 tests) regression guard for the hoist.
- `packages/api/src/services/__tests__/media-storage.test.ts` — new (3 tests) verifies `storeFromUrl` propagates HTTP status and network errors.

## Evidence — before / after

**Before** (from issue #500):
```
"No media file path available"  ← 2309 of 2452 failures (94.2%)
```
This message was emitted whether (a) no `media_url` was set, (b) fetch returned 403, or (c) network failed. Operators could not tell which.

**After**:
- Missing URL: `"No media_url and no media_local_path on message"`
- HTTP failure: `"storeFromUrl failed: Failed to download media: 403"`
- Network failure: `"storeFromUrl failed: ECONNREFUSED"`

Bug 1 fix mirrors the SQL `COALESCE(raw_payload->'message'->'<type>Message'->>'url', …)` pattern proven on 2181 of 2182 (99.95%) URL-null items in Stéfani's instance.

## Test plan

- [x] `bun test` under `packages/channel-whatsapp` — 367 pass, 0 fail (new 6 tests included)
- [x] `bun test` under `packages/api` — 628 pass, 264 skip, 0 fail (new 3 tests included)
- [x] `bun run typecheck` clean on both packages
- [x] `bun run lint` clean (2 pre-existing warnings in `turn-monitor-fallback.test.ts` unrelated to this change)
- [ ] Dogfood on Stéfani's instance post-merge: re-run `rehydrate-url.ts` from khal-os/brain PR #357 to hoist historical `raw_payload` URLs into `media_url`, then rerun retrofill batch and confirm real error strings surface in the failure log.

## Out of scope (follow-up)

- Authenticated Baileys-based refetch for WhatsApp encrypted blobs (`downloadMediaMessage` with `mediaKey`) — tracked as the structural fix. This PR only preserves the URL and surfaces errors so diagnostics work.
- Backfill script to hoist URLs from historical `raw_payload` rows (rehydration script already lives in khal-os/brain `brain-lab/rehydrate-url.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages when media file processing fails, providing clearer diagnostic information

* **Tests**
  * Added test suites validating media storage error handling and media URL extraction for multiple message types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->