### PR TITLE
chore(cli-tests): kill PM2 god daemon on teardown + add stale sweeper (#413)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
         db-push db-migrate db-studio db-reset \
         ensure-nats ensure-ffmpeg check-ffmpeg check-deps start stop restart logs status \
         restart-api restart-nats restart-pgserve logs-api \
-        kill-ghosts reset sdk-generate \
+        kill-ghosts kill-stale-test-daemons reset sdk-generate \
         cli cli-build cli-build-full cli-link \
         migrate-messages migrate-messages-dry \
         _init-db-wait _sync-db
@@ -39,6 +39,7 @@ help:
 	@echo "  make test-api      Run API package tests only"
 	@echo "  make test-db       Run DB package tests only"
 	@echo "  make test-file F=<path>  Run a specific test file"
+	@echo "  make kill-stale-test-daemons  Sweep leaked PM2 god daemons from CLI tests (#413)"
 	@echo ""
 	@echo "Database:"
 	@echo "  make db-push       Push schema changes (dev-only; requires I_KNOW_WHAT_IM_DOING=1)"
@@ -365,6 +366,11 @@ kill-ghosts:
 	-lsof -ti :4222 | xargs kill -9 2>/dev/null || true
 	-lsof -ti :8432 | xargs kill -9 2>/dev/null || true
 	@echo "Ghost cleanup complete"
+
+# Sweep up leaked PM2 god daemons spawned by CLI tests (issue #413).
+# Stale daemons have a PM2_HOME under /tmp/.omni-test-* that no longer exists.
+kill-stale-test-daemons:
+	@bun scripts/kill-stale-test-daemons.ts
 
 # ============================================================================
 # Utilities

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@5.85.0/schema.json",
   "workspaces": {
     ".": {
-      "entry": ["scripts/test-messaging.ts"],
+      "entry": ["scripts/test-messaging.ts", "scripts/kill-stale-test-daemons.ts"],
       "project": ["scripts/**/*.ts"],
       "ignore": [
         "scripts/backfill-*.ts",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -14,6 +14,40 @@ import { join } from 'node:path';
 import { spawn, spawnSync } from 'bun';
 import { MOCK_API_KEY, startMockApi, stopMockApi } from './mock-api';
 
+/**
+ * Pre-suite guard (#413): fail fast if a prior test run leaked a PM2 god
+ * daemon attached to a `.omni-test` PM2_HOME. Leaving these around pollutes
+ * the host and can confuse a subsequent suite that rebinds the same PM2
+ * socket path.
+ */
+function assertNoLeakedTestDaemons(): void {
+  const ps = spawnSync({ cmd: ['ps', '-eo', 'pid,args'], stdout: 'pipe', stderr: 'pipe' });
+  if (ps.exitCode !== 0) return; // non-fatal — if ps is unavailable, skip the guard
+  const output = new TextDecoder().decode(ps.stdout);
+  // Anchored to args start to avoid matching processes that merely mention
+  // the string (e.g. this source file itself, grep commands, transcripts).
+  const pattern = /^PM2\s+[^:]*:\s*God Daemon\s+\([^)]*\.omni-test[^)]*\)/;
+  const leaked: string[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const pidMatch = trimmed.match(/^\d+\s+(.*)$/);
+    const args = pidMatch?.[1] ?? '';
+    if (!pattern.test(args)) continue;
+    leaked.push(trimmed);
+  }
+  if (leaked.length > 0) {
+    const pids = leaked
+      .map((l) => l.match(/^(\d+)\s/)?.[1])
+      .filter((p): p is string => p !== undefined)
+      .join(' ');
+    const hint = pids ? `  # or: kill ${pids}\n` : '';
+    throw new Error(
+      `Pre-suite leak guard (#413): ${leaked.length} stale PM2 god daemon(s) detected:\n${leaked.join('\n')}\n\nKill them before re-running this suite:\n  make kill-stale-test-daemons\n${hint}`,
+    );
+  }
+}
+
 // Use source entry point directly — avoids stale dist/index.js issues
 const CLI_PATH = join(import.meta.dir, '../index.ts');
 
@@ -98,6 +132,9 @@ function assertSuccess(result: CliResult, context: string): void {
 
 describe('CLI Basic Tests', () => {
   beforeAll(() => {
+    // Fail fast if a prior run left a god daemon around (#413). Runs before
+    // any other setup so the error surfaces cleanly at suite startup.
+    assertNoLeakedTestDaemons();
     // Create test config directory
     if (!existsSync(TEST_CONFIG_DIR)) {
       mkdirSync(TEST_CONFIG_DIR, { recursive: true });

--- a/scripts/kill-stale-test-daemons.ts
+++ b/scripts/kill-stale-test-daemons.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+/**
+ * kill-stale-test-daemons — sweep up leaked PM2 god daemons spawned by CLI tests.
+ *
+ * The CLI test suite runs the real `omni` binary under an isolated PM2_HOME
+ * (e.g. `/tmp/.omni-test-<timestamp>/.pm2`). If teardown is skipped or the
+ * suite crashes before its afterAll hook, pm2 forks a god daemon that
+ * re-parents to init once the test runner exits. The PM2_HOME directory is
+ * then rm-rf'd, leaving an orphan process attached to a path that no longer
+ * exists. See issue #413.
+ *
+ * This script:
+ *   1. Scans `ps -eo pid,args` for processes matching
+ *      `PM2 ... God Daemon (<path>)` where <path> contains `.omni-test`.
+ *   2. For each match, checks whether <path> still exists on disk.
+ *   3. If the path is gone → SIGTERM the process, wait 2s, SIGKILL if still alive.
+ *      (If the path still exists, the daemon may be in-use by a running test
+ *      and is left alone — use `--force` to kill those too.)
+ *
+ * Flags:
+ *   --dry-run   List stale daemons without killing them.
+ *   --force     Kill matching daemons even if their PM2_HOME still exists.
+ *
+ * Exit codes:
+ *   0  Clean — no stale daemons, or all stale daemons killed successfully.
+ *   1  At least one daemon could not be killed.
+ */
+
+import { existsSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { spawnSync } from 'bun';
+
+interface StaleDaemon {
+  pid: number;
+  pm2Home: string;
+  homeExists: boolean;
+  command: string;
+}
+
+// Matches a pm2 god daemon title whose PM2_HOME path contains `.omni-test`.
+// Anchored so it must be at the START of the process args, not embedded
+// somewhere mid-string — otherwise any process whose cmdline happens to
+// contain the literal text (e.g. this script's source, a grep command, a
+// transcript buffer) would match and could be killed by mistake.
+const DAEMON_PATTERN = /^PM2\s+[^:]*:\s*God Daemon\s+\((?<home>[^)]*\.omni-test[^)]*)\)/;
+
+function parseDaemonLine(line: string): StaleDaemon | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const pidMatch = trimmed.match(/^(\d+)\s+(.*)$/);
+  if (!pidMatch) return null;
+  const pid = Number(pidMatch[1]);
+  if (!Number.isFinite(pid)) return null;
+  const args = pidMatch[2] ?? '';
+  const match = args.match(DAEMON_PATTERN);
+  if (!match?.groups?.home) return null;
+  const pm2Home = match.groups.home;
+  return {
+    pid,
+    pm2Home,
+    homeExists: existsSync(pm2Home),
+    command: args,
+  };
+}
+
+function listStaleDaemons(): StaleDaemon[] {
+  const result = spawnSync({
+    cmd: ['ps', '-eo', 'pid,args'],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`ps failed with exit code ${result.exitCode}`);
+  }
+  const output = new TextDecoder().decode(result.stdout);
+  const daemons: StaleDaemon[] = [];
+  for (const line of output.split('\n')) {
+    const parsed = parseDaemonLine(line);
+    if (parsed) daemons.push(parsed);
+  }
+  return daemons;
+}
+
+/**
+ * Re-reads /proc/<pid>/cmdline (or falls back to `ps -p <pid> -o args=`) at
+ * kill time and verifies the daemon signature still matches. A pid can be
+ * recycled between listing and killing; this recheck prevents us from
+ * killing an unrelated process that happened to inherit the same pid.
+ */
+function verifyDaemonByPid(pid: number): boolean {
+  const res = spawnSync({
+    cmd: ['ps', '-p', String(pid), '-o', 'args='],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (res.exitCode !== 0) return false;
+  const args = new TextDecoder().decode(res.stdout).trim();
+  return DAEMON_PATTERN.test(args);
+}
+
+async function killProcess(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    // ESRCH — already gone. That's a success.
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return true;
+    return false;
+  }
+  // Wait up to 2s for graceful exit.
+  for (let i = 0; i < 20; i++) {
+    await Bun.sleep(100);
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') return true;
+    }
+  }
+  // Still alive — escalate.
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return true;
+    return false;
+  }
+  // Brief settle after SIGKILL.
+  await Bun.sleep(100);
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+}
+
+async function main(): Promise<number> {
+  const { values } = parseArgs({
+    args: Bun.argv.slice(2),
+    options: {
+      'dry-run': { type: 'boolean', default: false },
+      force: { type: 'boolean', default: false },
+    },
+    allowPositionals: false,
+  });
+
+  const daemons = listStaleDaemons();
+  if (daemons.length === 0) {
+    console.log('No stale omni-test PM2 god daemons found.');
+    return 0;
+  }
+
+  // Split by staleness. "Stale" = PM2_HOME gone from disk.
+  const stale = daemons.filter((d) => !d.homeExists);
+  const live = daemons.filter((d) => d.homeExists);
+
+  for (const d of stale) {
+    console.log(`stale   pid=${d.pid} pm2_home=${d.pm2Home} (home missing)`);
+  }
+  for (const d of live) {
+    console.log(`live    pid=${d.pid} pm2_home=${d.pm2Home} (home exists — use --force to kill)`);
+  }
+
+  const targets = values.force ? daemons : stale;
+  if (targets.length === 0) {
+    return 0;
+  }
+
+  if (values['dry-run']) {
+    console.log(`\n--dry-run: would kill ${targets.length} daemon(s).`);
+    return 0;
+  }
+
+  let failures = 0;
+  for (const d of targets) {
+    // Re-verify the pid still belongs to a stale pm2 god daemon right
+    // before killing it. Guards against pid recycling between list and kill.
+    if (!verifyDaemonByPid(d.pid)) {
+      console.log(`skip    pid=${d.pid} (no longer a pm2 god daemon)`);
+      continue;
+    }
+    process.stdout.write(`killing pid=${d.pid} ... `);
+    const ok = await killProcess(d.pid);
+    console.log(ok ? 'ok' : 'FAILED');
+    if (!ok) failures += 1;
+  }
+
+  return failures === 0 ? 0 : 1;
+}
+
+const code = await main();
+process.exit(code);


### PR DESCRIPTION
## Summary

Closes #413. The CLI test suite (`packages/cli/src/__tests__/cli.test.ts`) spawns the real `omni` binary under an isolated `PM2_HOME` at `/tmp/.omni-test-<ts>/.pm2`. If the suite crashed or skipped teardown, pm2 would fork a god daemon that re-parented to init once the test runner exited; the `afterAll` hook then `rm -rf`'d the PM2_HOME, leaving an orphan process attached to a deleted path (~25 MB RSS each).

The teardown contract itself — `pm2 kill` before `rm -rf` — already landed on dev in commits `b9443ed` / `ccfc148`. This PR finishes the remaining scope from the issue:

- **Pre-suite leak guard** in `cli.test.ts` — `beforeAll` scans `ps -eo pid,args` for processes whose title starts with `PM2 ... God Daemon (.../.omni-test...)` and fails fast with the offending pids + `make kill-stale-test-daemons` hint. Anchored to the start of args so it cannot match processes that merely mention the string (transcripts, greps, this file itself).
- **Stale-zombie sweeper** at `scripts/kill-stale-test-daemons.ts` — lists every omni-test god daemon, kills the ones whose PM2_HOME is gone from disk (SIGTERM → 2 s grace → SIGKILL). `--dry-run` lists without killing; `--force` also kills daemons whose home still exists. Re-verifies each pid's args right before killing to guard against pid recycling.
- **Makefile target** `make kill-stale-test-daemons` — wires the sweeper in; help entry added under the Quality section.
- **knip** — registers the new script as an entry so dead-code check stays green.

No CI workflow edits; a manual `make` target is the minimum bar the issue called for.

## Test plan

- [x] `bunx biome check .` → 0 findings on 1038 files
- [x] `bunx knip` → 0 findings (new script registered as entry)
- [x] `bun run build` → 5/5 turbo tasks green
- [x] `bun test` → **3471 pass / 265 skip / 0 fail** (matches post-#407 baseline exactly)
- [x] `bun test packages/cli/src/__tests__/cli.test.ts` → 66 pass / 0 fail
- [x] Pre/post CLI-test daemon count: `ps -eo pid,command | grep -cE '^\s*[0-9]+\s+PM2.*God Daemon.*omni-test'` → **0 → 0** (no leak)
- [x] Sweeper exercised on 7 real stale daemons (5 from prior runs, 2 from a disabled-teardown sanity check) → all killed cleanly; subsequent guard pass went 2 → 0.
- [x] False-positive protection verified: sweeper correctly skips a Claude agent process whose args literally contain the string `God Daemon (/tmp/.omni-test-*/...)` because the pattern is anchored to the start of the args.

Refs: #413