### PR TITLE
fix(api): resolve chat UUID → external_id in call_agent action

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -380,6 +380,46 @@ function setupShutdownHandlers(server: ReturnType<typeof Bun.serve>, earlyShutdo
   process.on('SIGTERM', shutdown);
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve chat UUID → channel-native external_id for a call_agent invocation.
+ *
+ * Symmetric with the send_message action (above) which already auto-resolves
+ * UUIDs for the same reason: system-initiated events (chat.idle_timeout) emit
+ * payload.chatId as the internal chats.id UUID, but the seller dispatch path
+ * carries the external_id (e.g. WA phone). Without resolution, the agent
+ * runner's computeSessionId produces session_ids that diverge from sessions
+ * created by the seller path.
+ *
+ * Also resolves senderId — extractAgentCallContext falls back senderId=chatId
+ * when payload.from/senderId are absent (follow-up events).
+ *
+ * On missing chat row, logs a warning and falls through with the raw UUID so
+ * the call still runs (avoids hard-failing the automation action).
+ */
+async function resolveCallAgentChatIds(
+  services: ReturnType<typeof createApp>['services'],
+  ctx: { chatId: string; senderId: string; instanceId: string },
+): Promise<{ chatId: string; senderId: string }> {
+  if (!UUID_RE.test(ctx.chatId)) {
+    return { chatId: ctx.chatId, senderId: ctx.senderId };
+  }
+  try {
+    const chat = await services.chats.getById(ctx.chatId, { includeHidden: true });
+    return {
+      chatId: chat.externalId,
+      senderId: ctx.senderId === ctx.chatId ? chat.externalId : ctx.senderId,
+    };
+  } catch {
+    log.warn('call_agent: chat UUID not resolvable, using raw value (session may diverge)', {
+      chatId: ctx.chatId,
+      instanceId: ctx.instanceId,
+    });
+    return { chatId: ctx.chatId, senderId: ctx.senderId };
+  }
+}
+
 /**
  * Setup event bus related services (plugins, persistence, workers)
  * Extracted to reduce main() complexity
@@ -440,6 +480,12 @@ async function setupEventBusServices(
         const instance = await services.instances.getById(ctx.instanceId);
         if (!instance) throw new Error(`Instance not found: ${ctx.instanceId}`);
 
+        // System-initiated events (chat.idle_timeout) emit payload.chatId as
+        // the internal chats.id UUID; the seller dispatch path carries the
+        // channel-native external_id. Resolve UUID → external_id so the
+        // computed session_id matches sessions created by the seller path.
+        const { chatId: resolvedChatId, senderId: resolvedSenderId } = await resolveCallAgentChatIds(services, ctx);
+
         const agentFkId = ctx.agentId ?? instance.agentId;
         if (!agentFkId) throw new Error(`No agent configured for instance ${instance.id}`);
 
@@ -482,8 +528,8 @@ async function setupEventBusServices(
         // progressively. See issue #410.
         const result = await services.agentRunner.runOrStream({
           instance: runInstance,
-          chatId: ctx.chatId,
-          senderId: ctx.senderId,
+          chatId: resolvedChatId,
+          senderId: resolvedSenderId,
           senderName: ctx.senderName,
           chatType: 'dm',
           messages: ctx.messages,


### PR DESCRIPTION
## Summary

The automation `call_agent` action invokes the agent runner with `ctx.chatId` verbatim. For `chat.idle_timeout` events (from the follow-up sweeper), that chatId is the **internal `chats.id` UUID**. For regular inbound dispatch, the chatId is the **channel-native `external_id`** (e.g. WhatsApp phone). The agent runner's `computeSessionId` sees the value as opaque — so the two paths end up computing **different session_ids for the same chat**.

Mirrors the existing UUID-resolution pattern in the `send_message` action above (which already auto-resolves UUID → externalId for the same reason). Deployed to production on 2026-04-23 ~03:05 BRT to unblock an ongoing production incident.

## Prod symptom that motivated the fix

After deploying a Haiku-backed follow-up agent on a downstream project (namastexlabs/genie-hv-eugenia — separate repo), real `chat.idle_timeout` automations started failing agno's precheck:

```
2026-04-23T02:08:00,054 WARNING agno_api.main:
  followup_runs_omni precheck failed:
  session '4d77b471-5fab-46af-a74a-dc9440094011' is None
  or has no session_data — nothing to contextualize follow-up from
```

Investigation showed:

| chat.id (UUID)                          | external_id       | name     |
|-----------------------------------------|-------------------|----------|
| 40648294-9268-4a2e-85e0-6e352a2e35e5   | 5522988240159     | Luiz     |
| 4d77b471-5fab-46af-a74a-dc9440094011   | 5599999999999     | …        |
| ad8cae2d-57df-4646-99ed-5ddae6a97219   | 5571992989696     | Lar 7 Maravilhas |
| e97338fe-b2e5-442d-9fb4-5ce2b535c7f7   | 5511956757846     | fabio    |

- The seller (regular inbound) had created agno sessions keyed by `5522988240159`, `5511956757846`, etc. (external_id)
- The follow-up automation sent the UUID; agno had no such session → 409 / RunFailed.

Failure rate on real follow-ups was **50% (4 of 8) over a 60-minute observation window** — growing as chat idle-timeouts advanced through the day.

## Why this is the right fix

`send_message` in the same file (lines 427-436) already does exactly the same resolution, with an identical rationale:
> "Resolve internal chat UUID → channel-native external_id (e.g. WA JID). Automation payloads carry chat UUIDs; plugins expect channel JIDs."

`call_agent` was missing the symmetric treatment. The runtime already accepts the external_id shape because that's what the regular dispatch path produces, so sessions line up transparently after this patch.

## Diff outline

```diff
+ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+ async function resolveCallAgentChatIds(services, ctx) {
+   if (!UUID_RE.test(ctx.chatId)) {
+     return { chatId: ctx.chatId, senderId: ctx.senderId };
+   }
+   try {
+     const chat = await services.chats.getById(ctx.chatId, { includeHidden: true });
+     return {
+       chatId: chat.externalId,
+       senderId: ctx.senderId === ctx.chatId ? chat.externalId : ctx.senderId,
+     };
+   } catch {
+     log.warn('call_agent: chat UUID not resolvable, using raw value (session may diverge)', {
+       chatId: ctx.chatId, instanceId: ctx.instanceId,
+     });
+     return { chatId: ctx.chatId, senderId: ctx.senderId };
+   }
+ }

// In callAgent closure:
- chatId: ctx.chatId,
- senderId: ctx.senderId,
+ const { chatId: resolvedChatId, senderId: resolvedSenderId } = await resolveCallAgentChatIds(services, ctx);
...
+ chatId: resolvedChatId,
+ senderId: resolvedSenderId,
```

Extracted into a helper because inline resolution pushed `callAgent`'s cognitive complexity to 22 (limit 20). Also covers senderId because `extractAgentCallContext` in core falls back to `senderId = chatId` for events without `payload.from`/`senderId` (chat.idle_timeout shape).

## Failure-mode handling

If the chat row doesn't exist in the DB (deleted, replication lag), the resolver logs a WARN and returns the raw UUID. The call still runs. Previous behavior preserved on the error path — no regression risk for the existing per_user strategy users.

## Test plan

- [x] `bun run --filter @omni/api typecheck` → exit 0
- [x] `bunx biome check packages/api/src/index.ts` → clean
- [x] `make test` — full repo suite: **3729 tests pass, 0 fail, 8476 expect() calls, ~101s**
- [x] Build: `bun run --filter @automagik/omni build:server` → 17.48 MB bundle, clean
- [x] Deployed to prod 2026-04-23 ~03:05 BRT via standard swap pattern; pre-deploy snapshot at `brain/snapshots/omni-deploy-2026-04-23/dist_before_callagent_fix.js`
- [ ] **Monitor next 60 min of real follow-ups — expect precheck-failure rate drop from ~50% toward <5%** (remaining failures would be genuinely-missing chats)

## Related

- `namastexlabs/genie-hv-eugenia#60` — downstream agno-api fix for the same incident (followup write-back wasn't firing because agno 2.5 Haiku doesn't emit `RunCompleted` — separate root cause same feature path)
- `automagik-dev/omni#502` — CLI `--provider-id` flag confusion (surfaced during the same investigation; independent issue)

## Rollback

Swap `brain/snapshots/omni-deploy-2026-04-23/dist_before_callagent_fix.js` back in place + `pm2 restart omni-api --update-env`. No schema migrations in this PR; safe.