### PR TITLE
fix(claude-code): expose pathToClaudeCodeExecutable + auto-detect glibc/musl (#501)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -86,7 +86,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -161,7 +161,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -195,7 +195,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -210,7 +210,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -230,7 +230,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -265,7 +265,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -280,7 +280,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -294,7 +294,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -312,7 +312,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -320,7 +320,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -334,7 +334,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260423.3",
+      "version": "2.260423.5",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/packages/api/src/routes/v2/providers.ts
+++ b/packages/api/src/routes/v2/providers.ts
@@ -43,7 +43,7 @@ const providerBaseSchema = z.object({
     .describe(
       'Schema-specific config. Required fields by schema: ' +
         'agno: { agentId }, openclaw: { defaultAgentId }, ' +
-        'claude-code: { projectPath, apiKey?, model?, systemPrompt?, maxTurns?, permissionMode?, allowedTools?, mcpServers? }, ' +
+        'claude-code: { projectPath, apiKey?, model?, systemPrompt?, maxTurns?, permissionMode?, allowedTools?, mcpServers?, pathToClaudeCodeExecutable? }, ' +
         'webhook: { mode?, retries? }. ' +
         'Note: apiKey in schemaConfig overrides the provider-level apiKey.',
     ),

--- a/packages/core/src/providers/__tests__/claude-code-client.test.ts
+++ b/packages/core/src/providers/__tests__/claude-code-client.test.ts
@@ -268,6 +268,16 @@ describe('ClaudeCodeClient', () => {
       expect(mcpServers.gateway.url).toBe('https://mcp.example.com/v1');
     });
 
+    it('forwards explicit pathToClaudeCodeExecutable to SDK options', () => {
+      const client = new ClaudeCodeClient({
+        ...baseConfig,
+        pathToClaudeCodeExecutable: '/opt/claude/claude',
+      });
+      const options = getBuildOptions(client)(baseRequest);
+
+      expect(options.pathToClaudeCodeExecutable).toBe('/opt/claude/claude');
+    });
+
     it('URL-encodes param values safely', () => {
       const mcpServers = {
         gateway: { type: 'http' as const, url: 'https://mcp.example.com/v1' },

--- a/packages/core/src/providers/__tests__/claude-code-executable.test.ts
+++ b/packages/core/src/providers/__tests__/claude-code-executable.test.ts
@@ -1,0 +1,186 @@
+/**
+ * claude-code-executable — libc probe + subpackage resolver tests.
+ *
+ * The probe is pure: it dispatches on `platform`, `arch`, and a filesystem
+ * presence check, all injectable. The resolver wraps `require.resolve`, also
+ * injectable. These tests lock in the glibc / musl / unknown branches and the
+ * error-message wrapper's behavior.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  describeClaudeCodeStartupError,
+  detectLinuxLibc,
+  resolveClaudeCodeExecutable,
+} from '../claude-code-executable';
+
+function fsWith(paths: Set<string>) {
+  return (path: string) => paths.has(path);
+}
+
+describe('detectLinuxLibc', () => {
+  it('returns glibc when the glibc dynamic linker is present (x86_64 uses hyphen)', () => {
+    // Note: glibc spells x86_64 with a hyphen in the loader filename,
+    // while musl spells it with an underscore. These MUST stay in sync with
+    // archLinkerNames() in claude-code-executable.ts.
+    const existsSync = fsWith(new Set(['/lib64/ld-linux-x86-64.so.2']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'x64', existsSync })).toBe('glibc');
+  });
+
+  it('returns glibc from the Debian multi-arch path', () => {
+    const existsSync = fsWith(new Set(['/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'x64', existsSync })).toBe('glibc');
+  });
+
+  it('returns musl when the musl dynamic linker is present', () => {
+    const existsSync = fsWith(new Set(['/lib/ld-musl-x86_64.so.1']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'x64', existsSync })).toBe('musl');
+  });
+
+  it('prefers musl when both linkers somehow coexist', () => {
+    // musl is tried first because that matches the SDK's own resolution order;
+    // this keeps us consistent with what the SDK would pick if we did nothing.
+    const existsSync = fsWith(new Set(['/lib/ld-musl-x86_64.so.1', '/lib64/ld-linux-x86-64.so.2']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'x64', existsSync })).toBe('musl');
+  });
+
+  it('returns unknown when neither linker is found', () => {
+    const existsSync = fsWith(new Set());
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'x64', existsSync })).toBe('unknown');
+  });
+
+  it('returns unknown on non-linux platforms', () => {
+    const existsSync = fsWith(new Set(['/lib/ld-musl-x86_64.so.1']));
+    expect(detectLinuxLibc({ platform: 'darwin', arch: 'x64', existsSync })).toBe('unknown');
+    expect(detectLinuxLibc({ platform: 'win32', arch: 'x64', existsSync })).toBe('unknown');
+  });
+
+  it('returns unknown for unsupported arches', () => {
+    const existsSync = fsWith(new Set(['/lib/ld-musl-x86_64.so.1']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'mips', existsSync })).toBe('unknown');
+  });
+
+  it('detects glibc on arm64 via the aarch64 linker name', () => {
+    const existsSync = fsWith(new Set(['/lib/ld-linux-aarch64.so.1']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'arm64', existsSync })).toBe('glibc');
+  });
+
+  it('detects musl on arm64', () => {
+    const existsSync = fsWith(new Set(['/lib/ld-musl-aarch64.so.1']));
+    expect(detectLinuxLibc({ platform: 'linux', arch: 'arm64', existsSync })).toBe('musl');
+  });
+});
+
+describe('resolveClaudeCodeExecutable', () => {
+  it('returns the glibc subpackage binary when libc=glibc on x64', () => {
+    const resolve = (specifier: string) => {
+      expect(specifier).toBe('@anthropic-ai/claude-agent-sdk-linux-x64/claude');
+      return '/opt/sdk/linux-x64/claude';
+    };
+    const result = resolveClaudeCodeExecutable({
+      libc: 'glibc',
+      platform: 'linux',
+      arch: 'x64',
+      resolve,
+    });
+    expect(result).toBe('/opt/sdk/linux-x64/claude');
+  });
+
+  it('returns the musl subpackage binary when libc=musl on x64', () => {
+    const resolve = (specifier: string) => {
+      expect(specifier).toBe('@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude');
+      return '/opt/sdk/linux-x64-musl/claude';
+    };
+    const result = resolveClaudeCodeExecutable({
+      libc: 'musl',
+      platform: 'linux',
+      arch: 'x64',
+      resolve,
+    });
+    expect(result).toBe('/opt/sdk/linux-x64-musl/claude');
+  });
+
+  it('returns undefined when require.resolve throws (subpackage missing)', () => {
+    const resolve = () => {
+      throw new Error("Cannot find module '@anthropic-ai/claude-agent-sdk-linux-x64/claude'");
+    };
+    const result = resolveClaudeCodeExecutable({
+      libc: 'glibc',
+      platform: 'linux',
+      arch: 'x64',
+      resolve,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined on non-linux platforms', () => {
+    const resolve = () => {
+      throw new Error('should not be called');
+    };
+    expect(resolveClaudeCodeExecutable({ libc: 'glibc', platform: 'darwin', arch: 'x64', resolve })).toBeUndefined();
+  });
+
+  it('returns undefined when libc is unknown', () => {
+    const resolve = () => {
+      throw new Error('should not be called');
+    };
+    expect(resolveClaudeCodeExecutable({ libc: 'unknown', platform: 'linux', arch: 'x64', resolve })).toBeUndefined();
+  });
+
+  it('returns undefined for unsupported arches', () => {
+    const resolve = () => {
+      throw new Error('should not be called');
+    };
+    expect(resolveClaudeCodeExecutable({ libc: 'glibc', platform: 'linux', arch: 'mips', resolve })).toBeUndefined();
+  });
+
+  it('uses arm64 suffix for arm64 hosts', () => {
+    const resolve = (specifier: string) => {
+      expect(specifier).toBe('@anthropic-ai/claude-agent-sdk-linux-arm64-musl/claude');
+      return '/opt/sdk/linux-arm64-musl/claude';
+    };
+    const result = resolveClaudeCodeExecutable({
+      libc: 'musl',
+      platform: 'linux',
+      arch: 'arm64',
+      resolve,
+    });
+    expect(result).toBe('/opt/sdk/linux-arm64-musl/claude');
+  });
+});
+
+describe('describeClaudeCodeStartupError', () => {
+  it('annotates the opaque startup crash on Linux without an explicit path', () => {
+    const msg = describeClaudeCodeStartupError(new Error('Claude Code process exited with code 1'), {
+      platform: 'linux',
+    });
+    expect(msg).toContain('glibc/musl ABI mismatch');
+    expect(msg).toContain('pathToClaudeCodeExecutable');
+    expect(msg).toContain('bun remove @anthropic-ai/claude-agent-sdk-linux-x64-musl');
+  });
+
+  it('mentions the configured path when one was explicitly set', () => {
+    const msg = describeClaudeCodeStartupError(new Error('Claude Code process exited with code 1'), {
+      platform: 'linux',
+      explicitExecutablePath: '/opt/bad/claude',
+    });
+    expect(msg).toContain('/opt/bad/claude');
+    expect(msg).toContain('did not launch');
+    // When explicitly configured the remove-subpackage suggestion is not useful
+    expect(msg).not.toContain('bun remove');
+  });
+
+  it('returns the raw message unchanged when the error is not a startup crash', () => {
+    const msg = describeClaudeCodeStartupError(new Error('Timed out after 30s'), {
+      platform: 'linux',
+    });
+    expect(msg).toBe('Error: Timed out after 30s');
+  });
+
+  it('returns the raw message unchanged on non-linux platforms', () => {
+    const msg = describeClaudeCodeStartupError(new Error('Claude Code process exited with code 1'), {
+      platform: 'darwin',
+    });
+    expect(msg).toBe('Error: Claude Code process exited with code 1');
+  });
+});

--- a/packages/core/src/providers/claude-code-client.ts
+++ b/packages/core/src/providers/claude-code-client.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger } from '../logger';
+import { describeClaudeCodeStartupError, resolveClaudeCodeExecutable } from './claude-code-executable';
 import type {
   AgentHealthResult,
   IAgentClient,
@@ -53,6 +54,18 @@ export interface ClaudeCodeConfig {
 
   /** Max turns per query (safety limit, default: 10) */
   maxTurns?: number;
+
+  /**
+   * Explicit path to the Claude Code native binary.
+   *
+   * Forwarded to the SDK's `pathToClaudeCodeExecutable` option. Use this to
+   * override the SDK's built-in binary resolver when auto-detection picks
+   * the wrong libc ABI (see automagik-dev/omni#501). When omitted, the
+   * provider auto-detects glibc vs musl on Linux and resolves the matching
+   * optional subpackage; if detection is inconclusive, the SDK's default
+   * resolver is used.
+   */
+  pathToClaudeCodeExecutable?: string;
 }
 
 /**
@@ -606,6 +619,15 @@ function buildQueryOptions(
   if (config.model) options.model = config.model;
   if (config.systemPrompt) options.systemPrompt = config.systemPrompt;
 
+  // Pin the native binary path when available.
+  // Explicit config wins; otherwise auto-detect on Linux to avoid the SDK's
+  // musl-first resolver crashing on glibc hosts (#501). When detection is
+  // inconclusive we leave the option unset and let the SDK resolve.
+  const executablePath = config.pathToClaudeCodeExecutable ?? resolveClaudeCodeExecutable();
+  if (executablePath) {
+    options.pathToClaudeCodeExecutable = executablePath;
+  }
+
   if (config.mcpServers) {
     options.mcpServers = resolveMcpServers(config.mcpServers, request.mcpUrlParams);
   }
@@ -724,8 +746,11 @@ async function* generateStream(
       yield { phase: 'error', error: 'Aborted' };
       return;
     }
-    log.error('streamRun: threw', { error: String(error), sessionId: state.sessionId });
-    yield { phase: 'error', error: `Agent error: ${String(error)}` };
+    const annotated = describeClaudeCodeStartupError(error, {
+      explicitExecutablePath: config.pathToClaudeCodeExecutable,
+    });
+    log.error('streamRun: threw', { error: annotated, sessionId: state.sessionId });
+    yield { phase: 'error', error: `Agent error: ${annotated}` };
   }
 }
 
@@ -763,9 +788,12 @@ export class ClaudeCodeClient implements IAgentClient {
         if (earlyReturn) return earlyReturn;
       }
     } catch (error) {
-      log.error('Claude Code agent threw', { error: String(error), sessionId: acc.sessionId });
+      const annotated = describeClaudeCodeStartupError(error, {
+        explicitExecutablePath: this.config.pathToClaudeCodeExecutable,
+      });
+      log.error('Claude Code agent threw', { error: annotated, sessionId: acc.sessionId });
       return {
-        content: `Agent error: ${String(error)}`,
+        content: `Agent error: ${annotated}`,
         runId: crypto.randomUUID(),
         sessionId: acc.sessionId,
         status: 'failed',

--- a/packages/core/src/providers/claude-code-executable.ts
+++ b/packages/core/src/providers/claude-code-executable.ts
@@ -1,0 +1,164 @@
+/**
+ * Claude Code executable resolution — libc ABI safety net.
+ *
+ * The @anthropic-ai/claude-agent-sdk (>= 0.2.117) ships native binaries as
+ * optional subpackages. Its internal resolver tries the musl binary FIRST on
+ * Linux via `require.resolve()`. If the musl optional package is installed but
+ * the host is glibc (no /lib/ld-musl-*), the musl binary is returned and then
+ * crashes on exec with code 1 — see automagik-dev/omni#501.
+ *
+ * This module provides:
+ *   1. `detectLinuxLibc()` — probes well-known dynamic-linker paths to decide
+ *      whether the host uses glibc or musl.
+ *   2. `resolveClaudeCodeExecutable()` — given a libc flavor, tries to resolve
+ *      the matching SDK subpackage binary so the caller can pass it via
+ *      `pathToClaudeCodeExecutable` before the SDK's own resolver runs.
+ *   3. `describeClaudeCodeStartupError()` — wraps the opaque "exited with
+ *      code 1" message with an actionable hint when auto-detection may have
+ *      mismatched the host's ABI.
+ *
+ * All helpers accept injectable FS/require to keep them unit-testable.
+ */
+
+import { existsSync as nodeExistsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import { createLogger } from '../logger';
+
+const log = createLogger('provider:claude-code:libc');
+
+export type LinuxLibcFlavor = 'glibc' | 'musl' | 'unknown';
+
+export interface DetectLinuxLibcOptions {
+  platform?: NodeJS.Platform;
+  arch?: string;
+  existsSync?: (path: string) => boolean;
+}
+
+/**
+ * Map Node arch → (muslName, glibcName) — the arch token in linker paths.
+ *
+ * Note the asymmetry on x64: musl uses `x86_64` (underscore) while the glibc
+ * loader is `ld-linux-x86-64.so.2` (hyphen). aarch64 uses the same spelling
+ * in both, but glibc on aarch64 suffixes `.so.1` instead of `.so.2`.
+ */
+function archLinkerNames(arch: string): { musl: string; glibc: string } | null {
+  if (arch === 'x64') return { musl: 'x86_64', glibc: 'x86-64' };
+  if (arch === 'arm64') return { musl: 'aarch64', glibc: 'aarch64' };
+  return null;
+}
+
+function muslLinkerPath(muslName: string): string {
+  return `/lib/ld-musl-${muslName}.so.1`;
+}
+
+/** Candidate glibc dynamic-linker paths across common Linux distros. */
+function glibcLinkerCandidates(glibcName: string, muslName: string, nodeArch: string): string[] {
+  // Canonical glibc loader suffix: x86_64 → .so.2, aarch64 → .so.1
+  const suffix = nodeArch === 'arm64' ? '1' : '2';
+  const fileName = `ld-linux-${glibcName}.so.${suffix}`;
+  return [`/lib64/${fileName}`, `/lib/${muslName}-linux-gnu/${fileName}`, `/lib/${fileName}`];
+}
+
+/**
+ * Detect whether the current Linux host uses glibc or musl.
+ *
+ * Probes the canonical dynamic-linker paths. musl always installs at
+ * `/lib/ld-musl-<arch>.so.1`; glibc lives at one of a handful of distro-
+ * dependent paths. Returns `'unknown'` on non-Linux platforms, unsupported
+ * arches, or when neither linker is found.
+ */
+export function detectLinuxLibc(options: DetectLinuxLibcOptions = {}): LinuxLibcFlavor {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'linux') return 'unknown';
+
+  const arch = options.arch ?? process.arch;
+  const names = archLinkerNames(arch);
+  if (!names) return 'unknown';
+
+  const exists = options.existsSync ?? nodeExistsSync;
+
+  if (exists(muslLinkerPath(names.musl))) return 'musl';
+  if (glibcLinkerCandidates(names.glibc, names.musl, arch).some(exists)) return 'glibc';
+
+  return 'unknown';
+}
+
+export interface ResolveClaudeCodeExecutableOptions {
+  libc?: LinuxLibcFlavor;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  /** Override require function (tests). Defaults to `createRequire(import.meta.url)`. */
+  resolve?: (specifier: string) => string;
+}
+
+/**
+ * Resolve the SDK subpackage binary that matches the host's libc ABI.
+ *
+ * Returns the absolute path to the `claude` binary when the correct subpackage
+ * is installed, or `undefined` when detection is not confident (non-Linux,
+ * unknown libc, unsupported arch, subpackage missing). Callers should fall
+ * back to the SDK's built-in resolver when this returns `undefined`.
+ */
+export function resolveClaudeCodeExecutable(options: ResolveClaudeCodeExecutableOptions = {}): string | undefined {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'linux') return undefined;
+
+  const libc = options.libc ?? detectLinuxLibc({ platform, arch: options.arch });
+  if (libc === 'unknown') return undefined;
+
+  const arch = options.arch ?? process.arch;
+  if (arch !== 'x64' && arch !== 'arm64') return undefined;
+
+  const suffix = libc === 'musl' ? `-${arch}-musl` : `-${arch}`;
+  const specifier = `@anthropic-ai/claude-agent-sdk-linux${suffix}/claude`;
+
+  const resolve = options.resolve ?? createRequire(import.meta.url).resolve;
+  try {
+    const resolved = resolve(specifier);
+    log.debug('Resolved Claude Code executable for host libc', { libc, arch, resolved });
+    return resolved;
+  } catch (error) {
+    log.debug('Claude Code subpackage not installed; falling back to SDK default', {
+      libc,
+      arch,
+      specifier,
+      error: String(error),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Wrap an opaque Claude Code startup crash with an actionable libc-mismatch hint.
+ *
+ * When the SDK's resolver picks a binary that cannot execute (the canonical
+ * case: musl binary on glibc host, issue #501), the SDK throws an error whose
+ * message is the bare `Claude Code process exited with code 1`. This helper
+ * adds context pointing at `pathToClaudeCodeExecutable` and the glibc/musl
+ * optional-subpackage workaround so operators have something to act on.
+ *
+ * Returns the original error message unchanged when it does not match the
+ * known startup-crash signature or when an explicit executable was configured.
+ */
+export function describeClaudeCodeStartupError(
+  error: unknown,
+  options: {
+    explicitExecutablePath?: string;
+    platform?: NodeJS.Platform;
+  } = {},
+): string {
+  const raw = String(error);
+  const platform = options.platform ?? process.platform;
+
+  const isStartupCrash = /process exited with code 1/i.test(raw);
+  if (!isStartupCrash || platform !== 'linux') return raw;
+
+  const configuredHint = options.explicitExecutablePath
+    ? `Configured pathToClaudeCodeExecutable=${options.explicitExecutablePath} did not launch — verify the binary is executable on this host.`
+    : 'Set `pathToClaudeCodeExecutable` on the provider to the correct SDK binary for this host, ' +
+      'or remove the mismatched optional subpackage ' +
+      '(e.g. `bun remove @anthropic-ai/claude-agent-sdk-linux-x64-musl` on glibc).';
+
+  return `${raw} — Claude Code binary failed to start. This is typically a glibc/musl ABI mismatch: the SDK resolved an optional subpackage whose native binary cannot execute on this host's dynamic linker. ${configuredHint}`;
+}


### PR DESCRIPTION
## Summary

Fixes #501. SDK `@anthropic-ai/claude-agent-sdk >= 0.2.117` replaced pure-JS `cli.js` with native binaries split across optional subpackages. Its internal resolver tries the musl binary first on Linux; `require.resolve()` succeeds when the musl optional package is installed, but the binary then fails to exec on glibc hosts — producing `Claude Code process exited with code 1` with no actionable context. 100% agent failure on Debian.

Three layers, smallest-first:
1. `ClaudeCodeConfig.pathToClaudeCodeExecutable?: string` — operator escape hatch, forwarded to the SDK.
2. `detectLinuxLibc()` + `resolveClaudeCodeExecutable()` — probe `/lib/ld-musl-<arch>.so.1` vs the handful of glibc loader paths (note x86_64 glibc spells the loader with a hyphen: `ld-linux-x86-64.so.2`, while musl uses underscore) and pre-resolve the matching `@anthropic-ai/claude-agent-sdk-linux-<arch>[-musl]/claude` subpackage before the SDK's resolver runs. Falls back to undefined (SDK default) when detection is inconclusive or the matching subpackage isn't installed — silent no-op on older SDKs and on hosts we can't classify.
3. `describeClaudeCodeStartupError()` wraps the opaque exit-code-1 crash with the ABI-mismatch hypothesis and points operators at either `pathToClaudeCodeExecutable` or the `bun remove` workaround.

## Repro

Before the fix: omni on glibc Linux + SDK ≥ 0.2.117 with the musl optional subpackage installed globally → every WhatsApp agent returns `Agent error: Error: Claude Code process exited with code 1` within ~26ms; no LLM call is made (issue #501).

After the fix: `buildQueryOptions` sets `pathToClaudeCodeExecutable` to the resolved glibc subpackage binary, sidestepping the SDK's musl-first resolver. If detection cannot classify the host, the SDK's default resolver is used (unchanged behavior). If the SDK then still crashes at startup, the error message now names the likely cause and the workaround.

The installed SDK in this repo is 0.2.63 (pre-subpackages), so on this glibc host `detectLinuxLibc()` returns `"glibc"` and `resolveClaudeCodeExecutable()` returns `undefined` — the fix is a silent no-op until the SDK upgrade that introduced the bug lands. Behavior is still verified by 19 new unit tests pinning the glibc/musl/unknown branches plus the error-wrapper path.

## Test plan

- [x] `bunx biome check .` — clean
- [x] `bunx knip` — exit 0
- [x] `bun run build` — 5/5 turbo tasks green
- [x] `bun test` — 3501 pass / 265 skip / 0 fail (no regressions vs baseline)
- [x] 19 new unit tests in `claude-code-executable.test.ts` covering libc probe + subpackage resolver + error wrapper
- [x] 1 new client test verifying `pathToClaudeCodeExecutable` flows into SDK options
- [x] Live smoke on this Debian 13 (glibc 2.41) host: `detectLinuxLibc()` returns `"glibc"`
- [ ] End-to-end verification with SDK ≥ 0.2.117 — out of scope for this PR (SDK upgrade is a separate change), but the error-wrapper path is unit-tested to produce the actionable message.

References #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)