### PR TITLE
Fix media transcription persistence and WhatsApp document captions

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
 import type { EventBus } from '@omni/core';
 import type { Database } from '@omni/db';
 import { omniEvents } from '@omni/db';
@@ -116,6 +117,80 @@ describeWithDb('Event Persistence Handler', () => {
       expect(persisted?.chatId).toBe('chat-123');
       expect(persisted?.status).toBe('received');
       expect(persisted?.rawPayload).toEqual({ foo: 'bar' });
+    });
+
+    test('uses UUID event id as persisted omni_events primary key', async () => {
+      await setupEventPersistence(mockEventBus, db);
+
+      const eventId = randomUUID();
+      const testEvent = {
+        id: eventId,
+        type: 'message.received',
+        timestamp: Date.now(),
+        payload: {
+          externalId: 'ext-recv-uuid-id',
+          chatId: 'chat-123',
+          from: 'user-456',
+          content: {
+            type: 'audio',
+            mediaUrl: 'file:///tmp/test.ogg',
+            mimeType: 'audio/ogg',
+          },
+          rawPayload: { id: 'raw-audio' },
+        },
+        metadata: {
+          correlationId: 'corr-uuid-id',
+          instanceId: null,
+          channelType: 'whatsapp-baileys',
+        },
+      };
+
+      await emitEvent('message.received', testEvent);
+
+      const [persisted] = await db
+        .select()
+        .from(omniEvents)
+        .where(eq(omniEvents.externalId, 'ext-recv-uuid-id'))
+        .limit(1);
+
+      expect(persisted).toBeDefined();
+      expect(persisted?.id).toBe(eventId);
+      expect(persisted?.contentType).toBe('audio');
+      expect(persisted?.mediaMimeType).toBe('audio/ogg');
+    });
+
+    test('is idempotent when the same UUID event is redelivered', async () => {
+      await setupEventPersistence(mockEventBus, db);
+
+      const eventId = randomUUID();
+      const testEvent = {
+        id: eventId,
+        type: 'message.received',
+        timestamp: Date.now(),
+        payload: {
+          externalId: 'ext-recv-redelivery',
+          chatId: 'chat-123',
+          from: 'user-456',
+          content: {
+            type: 'audio',
+            mediaUrl: 'file:///tmp/test-redelivery.ogg',
+            mimeType: 'audio/ogg',
+          },
+        },
+        metadata: {
+          correlationId: 'corr-redelivery',
+          instanceId: null,
+          channelType: 'whatsapp-baileys',
+        },
+      };
+
+      await emitEvent('message.received', testEvent);
+      await emitEvent('message.received', testEvent);
+
+      const persisted = await db.select().from(omniEvents).where(eq(omniEvents.id, eventId));
+
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0]?.externalId).toBe('ext-recv-redelivery');
     });
 
     test('handles image content type', async () => {

--- a/packages/api/src/plugins/__tests__/media-processor-persistence.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-persistence.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeAll, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import type { Database } from '@omni/db';
+import { chats, instances, mediaContent, messages, omniEvents } from '@omni/db';
+import type { MediaProcessingService } from '@omni/media-processing';
+import { eq, inArray } from 'drizzle-orm';
+import { describeWithDb, getTestDb } from '../../__tests__/db-helper';
+import { __test__ } from '../media-processor';
+
+type ProcessingResult = Awaited<ReturnType<MediaProcessingService['process']>>;
+type MediaProcessorTestContext = Parameters<typeof __test__.persistProcessingResult>[0];
+
+describeWithDb('media processor persistence', () => {
+  let db: Database;
+  const cleanup = {
+    instanceIds: [] as string[],
+    chatIds: [] as string[],
+    messageIds: [] as string[],
+    eventIds: [] as string[],
+  };
+
+  beforeAll(() => {
+    db = getTestDb();
+  });
+
+  afterEach(async () => {
+    if (cleanup.messageIds.length > 0) {
+      await db.delete(mediaContent).where(inArray(mediaContent.mediaId, cleanup.messageIds));
+      await db.delete(messages).where(inArray(messages.id, cleanup.messageIds));
+    }
+    if (cleanup.eventIds.length > 0) {
+      await db.delete(omniEvents).where(inArray(omniEvents.id, cleanup.eventIds));
+    }
+    if (cleanup.chatIds.length > 0) {
+      await db.delete(chats).where(inArray(chats.id, cleanup.chatIds));
+    }
+    if (cleanup.instanceIds.length > 0) {
+      await db.delete(instances).where(inArray(instances.id, cleanup.instanceIds));
+    }
+
+    cleanup.instanceIds = [];
+    cleanup.chatIds = [];
+    cleanup.messageIds = [];
+    cleanup.eventIds = [];
+  });
+
+  function testContext(): MediaProcessorTestContext {
+    return { db } as MediaProcessorTestContext;
+  }
+
+  function transcriptionResult(content = 'audio transcrito no teste'): ProcessingResult {
+    return {
+      success: true,
+      processingType: 'transcription',
+      content,
+      model: 'test-model',
+      provider: 'test-provider',
+      language: 'pt',
+      duration: 4,
+      inputTokens: 2,
+      outputTokens: 3,
+      processingTimeMs: 42,
+    } as ProcessingResult;
+  }
+
+  async function createAudioMessage(): Promise<{
+    instanceId: string;
+    chatId: string;
+    messageId: string;
+    externalChatId: string;
+  }> {
+    const instanceId = randomUUID();
+    const chatId = randomUUID();
+    const messageId = randomUUID();
+    const externalChatId = `120363${Math.floor(Math.random() * 1_000_000_000)}@g.us`;
+    const externalMessageId = `ext-audio-${randomUUID()}`;
+
+    cleanup.instanceIds.push(instanceId);
+    cleanup.chatIds.push(chatId);
+    cleanup.messageIds.push(messageId);
+
+    await db.insert(instances).values({
+      id: instanceId,
+      name: `media-fk-test-${instanceId}`,
+      channel: 'whatsapp-baileys',
+      isActive: false,
+    });
+
+    await db.insert(chats).values({
+      id: chatId,
+      instanceId,
+      externalId: externalChatId,
+      chatType: 'group',
+      channel: 'whatsapp-baileys',
+    });
+
+    await db.insert(messages).values({
+      id: messageId,
+      chatId,
+      externalId: externalMessageId,
+      source: 'realtime',
+      senderPlatformUserId: '5511999999999@s.whatsapp.net',
+      isFromMe: false,
+      messageType: 'audio',
+      hasMedia: true,
+      mediaMimeType: 'audio/ogg',
+      mediaLocalPath: 'whatsapp/test-audio.ogg',
+      platformTimestamp: new Date(),
+    });
+
+    return { instanceId, chatId, messageId, externalChatId };
+  }
+
+  test('stores transcription and media_content with null event id when event FK is not safe', async () => {
+    const { messageId } = await createAudioMessage();
+    const missingEventId = randomUUID();
+    const result = transcriptionResult('transcricao persistida sem FK segura');
+
+    await __test__.persistProcessingResult(testContext(), messageId, missingEventId, result, 'audio');
+
+    const [storedMessage] = await db
+      .select({ transcription: messages.transcription })
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .limit(1);
+    const [storedMedia] = await db.select().from(mediaContent).where(eq(mediaContent.mediaId, messageId)).limit(1);
+
+    expect(storedMessage?.transcription).toBe(result.content);
+    expect(storedMedia).toBeDefined();
+    expect(storedMedia?.eventId).toBeNull();
+    expect(storedMedia?.content).toBe(result.content);
+    expect(storedMedia?.processingType).toBe('transcription');
+  });
+
+  test('stores transcription and media_content linked to existing omni_event', async () => {
+    const { instanceId, messageId, externalChatId } = await createAudioMessage();
+    const eventId = randomUUID();
+    cleanup.eventIds.push(eventId);
+
+    await db.insert(omniEvents).values({
+      id: eventId,
+      externalId: `ext-event-${eventId}`,
+      channel: 'whatsapp-baileys',
+      instanceId,
+      eventType: 'message.received',
+      direction: 'inbound',
+      contentType: 'audio',
+      chatId: externalChatId,
+      status: 'received',
+      receivedAt: new Date(),
+    });
+
+    const result = transcriptionResult('transcricao persistida com FK valida');
+
+    await __test__.persistProcessingResult(testContext(), messageId, eventId, result, 'audio');
+
+    const [storedMessage] = await db
+      .select({ transcription: messages.transcription })
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .limit(1);
+    const [storedMedia] = await db.select().from(mediaContent).where(eq(mediaContent.mediaId, messageId)).limit(1);
+
+    expect(storedMessage?.transcription).toBe(result.content);
+    expect(storedMedia).toBeDefined();
+    expect(storedMedia?.eventId).toBe(eventId);
+    expect(storedMedia?.content).toBe(result.content);
+    expect(storedMedia?.processingType).toBe('transcription');
+  });
+});

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -6,14 +6,13 @@
  */
 
 import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
-import { JOURNEY_STAGES, createLogger, getJourneyTracker } from '@omni/core';
+import { JOURNEY_STAGES, createLogger, getJourneyTracker, isValidUuid } from '@omni/core';
 import type { Database, NewOmniEvent } from '@omni/db';
 import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
 import { deepSanitize, sanitizeText } from '../utils/utf8';
 
 const log = createLogger('event-persistence');
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Safely map channel type - defaults to 'discord' if unknown
@@ -39,7 +38,7 @@ function mapContentType(contentType: string | undefined): ContentType | null {
 }
 
 function eventIdInsert(eventId: string | undefined): Partial<Pick<NewOmniEvent, 'id'>> {
-  return eventId && UUID_RE.test(eventId) ? { id: eventId } : {};
+  return eventId && isValidUuid(eventId) ? { id: eventId } : {};
 }
 
 /**

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -13,6 +13,7 @@ import { and, eq } from 'drizzle-orm';
 import { deepSanitize, sanitizeText } from '../utils/utf8';
 
 const log = createLogger('event-persistence');
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Safely map channel type - defaults to 'discord' if unknown
@@ -35,6 +36,10 @@ function mapContentType(contentType: string | undefined): ContentType | null {
   }
   // Return null for unsupported types (poll, poll_update, etc.)
   return null;
+}
+
+function eventIdInsert(eventId: string | undefined): Partial<Pick<NewOmniEvent, 'id'>> {
+  return eventId && UUID_RE.test(eventId) ? { id: eventId } : {};
 }
 
 /**
@@ -92,6 +97,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
           const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
 
           const newEvent: NewOmniEvent = {
+            ...eventIdInsert(event.id),
             externalId: payload.externalId,
             channel: mapChannelType(metadata.channelType),
             instanceId: metadata.instanceId,
@@ -117,7 +123,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             chatUuid,
           };
 
-          await db.insert(omniEvents).values(newEvent);
+          await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
 
           // T4: Message stored in database — record journey checkpoint
           if (metadata.timings && metadata.correlationId) {
@@ -150,6 +156,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
           const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
 
           const newEvent: NewOmniEvent = {
+            ...eventIdInsert(event.id),
             externalId: payload.externalId,
             channel: mapChannelType(metadata.channelType),
             instanceId: metadata.instanceId,
@@ -174,7 +181,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             chatUuid,
           };
 
-          await db.insert(omniEvents).values(newEvent);
+          await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
           log.debug('Persisted message.sent', {
             externalId: payload.externalId,
             instanceId: metadata.instanceId,
@@ -211,6 +218,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             // No existing event found, create a new record
             const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
             const newEvent: NewOmniEvent = {
+              ...eventIdInsert(event.id),
               externalId: payload.externalId,
               channel: mapChannelType(metadata.channelType),
               instanceId: metadata.instanceId,
@@ -224,7 +232,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               conversationId: null,
               chatUuid,
             };
-            await db.insert(omniEvents).values(newEvent);
+            await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
           }
 
           log.debug('Persisted message.delivered', {
@@ -260,6 +268,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             // No existing event found, create a new record
             const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
             const newEvent: NewOmniEvent = {
+              ...eventIdInsert(event.id),
               externalId: payload.externalId,
               channel: mapChannelType(metadata.channelType),
               instanceId: metadata.instanceId,
@@ -273,7 +282,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               conversationId: null,
               chatUuid,
             };
-            await db.insert(omniEvents).values(newEvent);
+            await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
           }
 
           log.debug('Persisted message.read', {
@@ -306,6 +315,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
           const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
 
           const newEvent: NewOmniEvent = {
+            ...eventIdInsert(event.id),
             externalId: payload.externalId,
             channel: mapChannelType(metadata.channelType),
             instanceId: metadata.instanceId,
@@ -326,7 +336,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             chatUuid,
           };
 
-          await db.insert(omniEvents).values(newEvent);
+          await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
           log.debug('Persisted message.failed', {
             chatId: payload.chatId,
             error: payload.error,

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -20,7 +20,7 @@ import { join } from 'node:path';
 import type { ChannelType, EventBus, MessageReceivedPayload } from '@omni/core';
 import { createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
-import { mediaContent, messages } from '@omni/db';
+import { mediaContent, messages, omniEvents } from '@omni/db';
 import {
   type MediaProcessingService,
   createMediaProcessingService,
@@ -32,6 +32,7 @@ import type { Services } from '../services';
 import { MediaStorageService } from '../services/media-storage';
 
 const log = createLogger('media-processor');
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Media types that should be processed
@@ -80,6 +81,10 @@ function inferProcessingType(contentType?: string): 'transcription' | 'descripti
 function shouldProcess(contentType: string | undefined): boolean {
   if (!contentType) return false;
   return PROCESSABLE_MEDIA_TYPES.has(contentType);
+}
+
+function isUuid(value: string | undefined): value is string {
+  return typeof value === 'string' && UUID_RE.test(value);
 }
 
 /**
@@ -250,6 +255,41 @@ async function resolveMediaPath(
   };
 }
 
+async function resolveSafeMediaContentEventId(
+  ctx: MediaProcessorContext,
+  eventId: string | undefined,
+): Promise<string | null> {
+  if (!isUuid(eventId)) return null;
+
+  // media_content is audit/replay metadata, so do not block media.processed for long.
+  // Event persistence runs concurrently with this processor and should normally win within milliseconds.
+  const maxWaitMs = 250;
+  const pollMs = 50;
+  const deadline = Date.now() + maxWaitMs;
+
+  while (true) {
+    try {
+      const [event] = await ctx.db
+        .select({ id: omniEvents.id })
+        .from(omniEvents)
+        .where(eq(omniEvents.id, eventId))
+        .limit(1);
+
+      if (event) return event.id;
+    } catch (error) {
+      log.debug('Failed to validate media_content event FK', { eventId, error: String(error) });
+      return null;
+    }
+
+    if (Date.now() >= deadline) {
+      log.debug('Skipping media_content event FK; omni_event not found', { eventId });
+      return null;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+}
+
 /**
  * Store processing result in database and update message
  */
@@ -273,8 +313,10 @@ async function persistProcessingResult(
 
   // Store result in media_content table (non-critical analytics/audit record)
   try {
+    const safeEventId = await resolveSafeMediaContentEventId(ctx, eventId);
+
     await ctx.db.insert(mediaContent).values({
-      eventId: eventId ?? undefined,
+      eventId: safeEventId,
       mediaId: messageId,
       processingType: result.processingType,
       content: result.content ?? '',
@@ -585,3 +627,8 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
 
   log.info('Media processor initialized');
 }
+
+export const __test__ = {
+  persistProcessingResult,
+  resolveSafeMediaContentEventId,
+};

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -18,7 +18,7 @@
 
 import { join } from 'node:path';
 import type { ChannelType, EventBus, MessageReceivedPayload } from '@omni/core';
-import { createLogger } from '@omni/core';
+import { createLogger, isValidUuid } from '@omni/core';
 import type { Database } from '@omni/db';
 import { mediaContent, messages, omniEvents } from '@omni/db';
 import {
@@ -32,7 +32,6 @@ import type { Services } from '../services';
 import { MediaStorageService } from '../services/media-storage';
 
 const log = createLogger('media-processor');
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Media types that should be processed
@@ -84,7 +83,7 @@ function shouldProcess(contentType: string | undefined): boolean {
 }
 
 function isUuid(value: string | undefined): value is string {
-  return typeof value === 'string' && UUID_RE.test(value);
+  return typeof value === 'string' && isValidUuid(value);
 }
 
 /**

--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -74,6 +74,28 @@ describe('extractContent — mediaUrl hoist (omni#500)', () => {
     expect(content?.filename).toBe('contract.pdf');
   });
 
+  it('unwraps documentWithCaptionMessage into document content', () => {
+    const content = extractContent(
+      wrap({
+        documentWithCaptionMessage: {
+          message: {
+            documentMessage: {
+              url: 'https://mmg.whatsapp.net/v/t62.7119-24/doc-caption.enc?oe=6',
+              mimetype: 'application/pdf',
+              fileName: 'proposal.pdf',
+              caption: 'segue proposta',
+            },
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('document');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7119-24/doc-caption.enc?oe=6');
+    expect(content?.filename).toBe('proposal.pdf');
+    expect(content?.caption).toBe('segue proposta');
+    expect(content?.mimeType).toBe('application/pdf');
+  });
+
   it('hoists stickerMessage.url into mediaUrl', () => {
     const content = extractContent(
       wrap({

--- a/packages/channel-whatsapp/src/handlers/media.ts
+++ b/packages/channel-whatsapp/src/handlers/media.ts
@@ -7,10 +7,7 @@
  */
 
 import type { WAMessage } from 'baileys';
-
-function getDocumentMessage(message: NonNullable<WAMessage['message']>) {
-  return message.documentMessage ?? message.documentWithCaptionMessage?.message?.documentMessage;
-}
+import { getDocumentMessage } from '../utils/message';
 
 /**
  * Get media size from message if available

--- a/packages/channel-whatsapp/src/handlers/media.ts
+++ b/packages/channel-whatsapp/src/handlers/media.ts
@@ -8,6 +8,10 @@
 
 import type { WAMessage } from 'baileys';
 
+function getDocumentMessage(message: NonNullable<WAMessage['message']>) {
+  return message.documentMessage ?? message.documentWithCaptionMessage?.message?.documentMessage;
+}
+
 /**
  * Get media size from message if available
  */
@@ -27,8 +31,9 @@ export function getMediaSize(msg: WAMessage): number | undefined {
     return Number(message.videoMessage.fileLength);
   }
 
-  if (message.documentMessage?.fileLength) {
-    return Number(message.documentMessage.fileLength);
+  const documentMessage = getDocumentMessage(message);
+  if (documentMessage?.fileLength) {
+    return Number(documentMessage.fileLength);
   }
 
   if (message.stickerMessage?.fileLength) {

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -20,6 +20,7 @@ import { fromJid, isLidJid, isUserJid, resolveCanonicalJid, resolveToPhoneJidLeg
 import type { WhatsAppPlugin } from '../plugin';
 import type { DecryptFailureTracker } from '../utils/decrypt-failure-tracker';
 import { detectMediaType, downloadMediaToBuffer, getExtension } from '../utils/download';
+import { getDocumentMessage, getMessageContextInfo } from '../utils/message';
 import { getMediaSize } from './media';
 
 const log = createLogger('whatsapp:messages');
@@ -84,12 +85,6 @@ interface ExtractedContent {
 
 type MessageContent = proto.IMessage;
 type ContentExtractor = (message: MessageContent) => ExtractedContent | null;
-
-function getDocumentMessage(
-  message: MessageContent | undefined | null,
-): proto.Message.IDocumentMessage | null | undefined {
-  return message?.documentMessage ?? message?.documentWithCaptionMessage?.message?.documentMessage;
-}
 
 /**
  * Content extractors for each message type
@@ -459,19 +454,6 @@ function extractPhoneFromVcard(vcard: string): string | undefined {
     return telMatch[1].replace(/[\s-]/g, '');
   }
   return undefined;
-}
-
-/**
- * Extract contextInfo from text and caption-bearing message types.
- */
-function getMessageContextInfo(msg: WAMessage): proto.IContextInfo | null | undefined {
-  const message = msg.message;
-  return (
-    message?.extendedTextMessage?.contextInfo ??
-    message?.imageMessage?.contextInfo ??
-    message?.videoMessage?.contextInfo ??
-    getDocumentMessage(message)?.contextInfo
-  );
 }
 
 /**

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -85,6 +85,12 @@ interface ExtractedContent {
 type MessageContent = proto.IMessage;
 type ContentExtractor = (message: MessageContent) => ExtractedContent | null;
 
+function getDocumentMessage(
+  message: MessageContent | undefined | null,
+): proto.Message.IDocumentMessage | null | undefined {
+  return message?.documentMessage ?? message?.documentWithCaptionMessage?.message?.documentMessage;
+}
+
 /**
  * Content extractors for each message type
  * Each extractor handles one specific message type
@@ -125,14 +131,17 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
     }),
   },
   {
-    check: (m) => !!m.documentMessage,
-    extract: (m) => ({
-      type: 'document',
-      filename: m.documentMessage?.fileName ?? undefined,
-      mimeType: m.documentMessage?.mimetype ?? 'application/octet-stream',
-      caption: m.documentMessage?.caption ?? undefined,
-      mediaUrl: m.documentMessage?.url ?? undefined,
-    }),
+    check: (m) => !!getDocumentMessage(m),
+    extract: (m) => {
+      const document = getDocumentMessage(m);
+      return {
+        type: 'document',
+        filename: document?.fileName ?? undefined,
+        mimeType: document?.mimetype ?? 'application/octet-stream',
+        caption: document?.caption ?? undefined,
+        mediaUrl: document?.url ?? undefined,
+      };
+    },
   },
   {
     check: (m) => !!m.stickerMessage,
@@ -461,7 +470,7 @@ function getMessageContextInfo(msg: WAMessage): proto.IContextInfo | null | unde
     message?.extendedTextMessage?.contextInfo ??
     message?.imageMessage?.contextInfo ??
     message?.videoMessage?.contextInfo ??
-    message?.documentMessage?.contextInfo
+    getDocumentMessage(message)?.contextInfo
   );
 }
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -2660,11 +2660,12 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    */
   private getMessageContextInfo(rawMessage: WAMessage): proto.IContextInfo | null | undefined {
     const message = rawMessage.message;
+    const documentMessage = message?.documentMessage ?? message?.documentWithCaptionMessage?.message?.documentMessage;
     return (
       message?.extendedTextMessage?.contextInfo ??
       message?.imageMessage?.contextInfo ??
       message?.videoMessage?.contextInfo ??
-      message?.documentMessage?.contextInfo
+      documentMessage?.contextInfo
     );
   }
 
@@ -3727,6 +3728,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   private extractMediaContent(
     message: NonNullable<WAMessage['message']>,
   ): { type: string; mimeType?: string; caption?: string } | null {
+    const documentMessage = message.documentMessage ?? message.documentWithCaptionMessage?.message?.documentMessage;
     if (message.imageMessage) {
       return {
         type: 'image',
@@ -3744,11 +3746,11 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         caption: message.videoMessage.caption ?? undefined,
       };
     }
-    if (message.documentMessage) {
+    if (documentMessage) {
       return {
         type: 'document',
-        mimeType: message.documentMessage.mimetype ?? 'application/octet-stream',
-        caption: message.documentMessage.caption ?? undefined,
+        mimeType: documentMessage.mimetype ?? 'application/octet-stream',
+        caption: documentMessage.caption ?? undefined,
       };
     }
     if (message.stickerMessage) {

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -41,6 +41,7 @@ import { DEFAULT_SOCKET_CONFIG, type SocketConfig, closeSocket, createSocket } f
 import { DecryptFailureTracker } from './utils/decrypt-failure-tracker';
 import { ErrorCode, WhatsAppError, mapBaileysError } from './utils/errors';
 import { type MentionResolution, resolveMentions } from './utils/mention-resolver';
+import { getDocumentMessage, getMessageContextInfo } from './utils/message';
 import { type RateLimitManager, createRateLimitManager, isRateLimitError } from './utils/rate-limit';
 
 // Re-export for external consumers that previously imported from this module
@@ -2656,20 +2657,6 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   }
 
   /**
-   * Resolve contextInfo from text and caption-bearing message types.
-   */
-  private getMessageContextInfo(rawMessage: WAMessage): proto.IContextInfo | null | undefined {
-    const message = rawMessage.message;
-    const documentMessage = message?.documentMessage ?? message?.documentWithCaptionMessage?.message?.documentMessage;
-    return (
-      message?.extendedTextMessage?.contextInfo ??
-      message?.imageMessage?.contextInfo ??
-      message?.videoMessage?.contextInfo ??
-      documentMessage?.contextInfo
-    );
-  }
-
-  /**
    * Handle incoming message
    * @internal
    */
@@ -2747,7 +2734,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     };
 
     // Extract mentionedJids from contextInfo (WhatsApp mentions)
-    const contextInfo = this.getMessageContextInfo(rawMessage);
+    const contextInfo = getMessageContextInfo(rawMessage);
     if (contextInfo?.mentionedJid && contextInfo.mentionedJid.length > 0) {
       extendedPayload.mentionedJids = contextInfo.mentionedJid;
 
@@ -3728,7 +3715,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   private extractMediaContent(
     message: NonNullable<WAMessage['message']>,
   ): { type: string; mimeType?: string; caption?: string } | null {
-    const documentMessage = message.documentMessage ?? message.documentWithCaptionMessage?.message?.documentMessage;
+    const documentMessage = getDocumentMessage(message);
     if (message.imageMessage) {
       return {
         type: 'image',

--- a/packages/channel-whatsapp/src/utils/download.ts
+++ b/packages/channel-whatsapp/src/utils/download.ts
@@ -40,6 +40,10 @@ export interface DetectedMedia {
   isVoiceNote?: boolean;
 }
 
+function getDocumentMessage(message: NonNullable<WAMessage['message']>) {
+  return message.documentMessage ?? message.documentWithCaptionMessage?.message?.documentMessage;
+}
+
 /**
  * Detect media type from a Baileys message
  */
@@ -71,11 +75,12 @@ export function detectMediaType(msg: WAMessage): DetectedMedia | null {
     };
   }
 
-  if (message.documentMessage) {
+  const documentMessage = getDocumentMessage(message);
+  if (documentMessage) {
     return {
       type: 'document',
-      mimeType: message.documentMessage.mimetype || 'application/octet-stream',
-      filename: message.documentMessage.fileName || undefined,
+      mimeType: documentMessage.mimetype || 'application/octet-stream',
+      filename: documentMessage.fileName || undefined,
     };
   }
 

--- a/packages/channel-whatsapp/src/utils/download.ts
+++ b/packages/channel-whatsapp/src/utils/download.ts
@@ -9,6 +9,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { WAMessage } from 'baileys';
 import { downloadMediaMessage } from 'baileys';
+import { getDocumentMessage } from './message';
 
 /**
  * Result of downloading media
@@ -38,10 +39,6 @@ export interface DetectedMedia {
   duration?: number;
   /** Is this a voice note (ptt) */
   isVoiceNote?: boolean;
-}
-
-function getDocumentMessage(message: NonNullable<WAMessage['message']>) {
-  return message.documentMessage ?? message.documentWithCaptionMessage?.message?.documentMessage;
 }
 
 /**

--- a/packages/channel-whatsapp/src/utils/message.ts
+++ b/packages/channel-whatsapp/src/utils/message.ts
@@ -1,0 +1,20 @@
+import type { WAMessage, proto } from 'baileys';
+
+export function getDocumentMessage(
+  message: WAMessage['message'] | null | undefined,
+): proto.Message.IDocumentMessage | null | undefined {
+  return message?.documentMessage ?? message?.documentWithCaptionMessage?.message?.documentMessage;
+}
+
+/**
+ * Resolve contextInfo from text and caption-bearing message types.
+ */
+export function getMessageContextInfo(msg: WAMessage): proto.IContextInfo | null | undefined {
+  const message = msg.message;
+  return (
+    message?.extendedTextMessage?.contextInfo ??
+    message?.imageMessage?.contextInfo ??
+    message?.videoMessage?.contextInfo ??
+    getDocumentMessage(message)?.contextInfo
+  );
+}


### PR DESCRIPTION
## Summary

Fixes two runtime issues found while testing Omni locally:

- Persist media processing results safely when the original Omni event row is missing or not yet available, avoiding `media_content.event_id` foreign key failures while preserving transcription data.
- Normalize WhatsApp `documentWithCaptionMessage` payloads so document messages with captions are handled as regular document media.

## Validation

- `bun --filter @omni/api typecheck`
- `bun --filter @omni/channel-whatsapp typecheck`
- `ENABLE_DB_TESTS=true bun test packages/api/src/plugins/__tests__/media-processor-persistence.test.ts packages/api/src/__tests__/event-persistence.test.ts`
- `bun test packages/channel-whatsapp/src/__tests__/extract-content.test.ts`
- `bun run build`
- Full pre-push hook passed: `bun run typecheck` and `bun test` (`3502 pass`, `270 skip`, `0 fail`).
- Tested locally through WhatsApp with a real document and the flow worked.