### PR TITLE
fix(follow-up): disarm synchronously on handoff + skip paused chats in sweeper (#528)

### DIFF
--- a/packages/api/src/__tests__/follow-up-sweeper.test.ts
+++ b/packages/api/src/__tests__/follow-up-sweeper.test.ts
@@ -182,6 +182,40 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     expect(publishedEvents).toHaveLength(0);
   });
 
+  test('paused chat (settings.agentPaused=true) is not swept even when armed and due', async () => {
+    // Issue #528 — closes the race where the sweeper fires chat.idle_timeout
+    // after `/send/handoff` has set agentPaused but before the
+    // chat.handoff_activated → follow-up-hooks disarm has committed.
+    const past = new Date(Date.now() - 60_000);
+
+    await db
+      .update(chats)
+      .set({ settings: { agentPaused: true } })
+      .where(eq(chats.id, testChatId));
+
+    await db.insert(chatFollowUpState).values({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      sequenceConfig: config(),
+      sequenceIndex: 0,
+      lastAgentMessageAt: new Date(Date.now() - MS_PER_MINUTE),
+      nextFireAt: past,
+    });
+
+    const stats = await service.sweep();
+    expect(stats.scanned).toBe(0);
+    expect(publishedEvents).toHaveLength(0);
+
+    // Row remains armed — the sweeper skipped it, it didn't disarm it.
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBeNull();
+    expect(row.sequenceIndex).toBe(0);
+
+    // Reset chat settings for subsequent tests.
+    await db.update(chats).set({ settings: {} }).where(eq(chats.id, testChatId));
+  });
+
   test('future-due rows are not swept', async () => {
     const future = new Date(Date.now() + 5 * MS_PER_MINUTE);
 

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1509,6 +1509,16 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
     settings: { agentPaused: true },
   });
 
+  // Close the race between chat.handoff_activated (two NATS hops away) and the
+  // next sweeper tick (every 15s). Idempotent with the event-driven disarm in
+  // follow-up-hooks.ts — disarmActive is a no-op on already-disarmed rows.
+  // See issue #528.
+  await services.followUpLifecycle.disarm({
+    chatId: data.chatId,
+    instanceId: data.instanceId,
+    reason: 'handoff',
+  });
+
   // Persist full handoff payload for auditing and traceability
   db.insert(handoffLogs)
     .values({

--- a/packages/api/src/services/follow-up-sweeper.ts
+++ b/packages/api/src/services/follow-up-sweeper.ts
@@ -27,7 +27,7 @@ import {
 } from '@omni/core';
 import type { Database } from '@omni/db';
 import { chatFollowUpState, chats, instances } from '@omni/db';
-import { and, eq, isNull, lte } from 'drizzle-orm';
+import { and, eq, isNull, lte, sql } from 'drizzle-orm';
 
 const log = createLogger('follow-up-sweeper');
 
@@ -114,7 +114,17 @@ export class FollowUpSweeperService {
         .from(chatFollowUpState)
         .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
         .leftJoin(instances, eq(chatFollowUpState.instanceId, instances.id))
-        .where(and(isNull(chatFollowUpState.disarmReason), lte(chatFollowUpState.nextFireAt, now)))
+        .where(
+          and(
+            isNull(chatFollowUpState.disarmReason),
+            lte(chatFollowUpState.nextFireAt, now),
+            // Skip chats with agentPaused=true — closes the race where the
+            // sweeper fires idle_timeout after `/send/handoff` has set
+            // agentPaused but before the `chat.handoff_activated` disarm
+            // has committed. See issue #528.
+            sql`(${chats.settings}->>'agentPaused')::boolean IS DISTINCT FROM true`,
+          ),
+        )
         .orderBy(chatFollowUpState.nextFireAt)
         .limit(limit)
         // Lock only the state row, not the joined chat row — FOR UPDATE can't


### PR DESCRIPTION
Closes #528

## Context

A race between `chat.handoff_activated` disarm and `chat.idle_timeout` sweeper emission causes ~3.3% of handoffs in production (6/184 in a 48h window on Hapvida/Eugenia-seller Gupshup) to receive post-handoff follow-ups. One lead (`5567992565295`) got **6 follow-ups over 12h** after being handed off.

See issue #528 for the full architecture writeup, race analysis (Race #1: event already in NATS queue, Race #2: async disarm via event bus), and Definition of Done.

## Fix (two idempotent layers)

### Layer 1 — sweeper filter (belt)
`packages/api/src/services/follow-up-sweeper.ts` — `findAndLockDue()` now excludes rows whose chat has `settings.agentPaused = true`, using a parameterized drizzle `sql` predicate:

```ts
sql\`(\${chats.settings}->>'agentPaused')::boolean IS DISTINCT FROM true\`
```

Even when the `follow-up-hooks` disarm hasn't committed yet, `agentPaused` has, so the sweeper skips the row.

### Layer 2 — synchronous disarm in `POST /messages/send/handoff` (braces)
`packages/api/src/routes/v2/messages.ts` — after `services.chats.update({ settings: { agentPaused: true } })` resolves and **before** returning the HTTP response, the route now calls `services.followUpLifecycle.disarm({ chatId, instanceId, reason: 'handoff' })` inline. Idempotent with the existing event-driven disarm in `follow-up-hooks.ts` (`disarmActive` is a no-op on already-disarmed rows).

### What was NOT touched
Per the issue's guidance, the automation engine stays generic — no chat-state checks added there. The fix lives at the emission side (sweeper) and the source of truth (handoff route).

## Tests

- New integration test in `packages/api/src/__tests__/follow-up-sweeper.test.ts`: "**paused chat (settings.agentPaused=true) is not swept even when armed and due**" — parallel to the existing "already disarmed rows are not swept" coverage. Asserts `stats.scanned === 0`, zero published events, and the row stays armed (sweeper skipped, did not disarm).
- Full `@omni/api` suite: **833 pass / 0 fail / 271 skip** (including the 8 DB-integration follow-up-sweeper tests gated by `ENABLE_DB_TESTS`).
- Full repo pre-push: **3483 pass / 0 fail / 271 skip** (after killing unrelated pre-existing stale PM2 god daemons that triggered the #413 leak guard in `cli.test.ts` — not touched by this PR).

## Diff

```
packages/api/src/__tests__/follow-up-sweeper.test.ts    | +34
packages/api/src/routes/v2/messages.ts                   | +10
packages/api/src/services/follow-up-sweeper.ts           | +12 -2
```

## Definition of Done (from #528)

- [x] Adding a NOT-NULL `agentPaused` row in `chat.settings` before the sweeper tick causes the row to be skipped regardless of `disarmReason`.
- [x] A `POST /send/handoff` that completes before the next sweeper tick guarantees zero follow-ups thereafter for that chat (until operator resume).
- [x] Existing tests in `follow-up-sweeper.test.ts` still pass.
- [x] New test: sweeper with armed row but `chats.settings.agentPaused=true` does NOT emit `chat.idle_timeout`.
- [ ] New test: `/send/handoff` disarms the row synchronously — **deferred**. No existing test harness for the `/send/handoff` route (no `messages.test.ts` covering it). The synchronous call is inline and obvious from code review; adding a harness is out of scope for this fix. Logged as follow-up.