### PR TITLE
fix(handoff): relax Gupshup-only gate — pause + disarm on any channel (#537)

### DIFF
--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1484,6 +1484,12 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
     });
   }
 
+  // Resolve the recipient for every channel — even when we won't push a
+  // native payload we still want the audit row to record a real platform
+  // identifier (phone/JID) rather than the caller's input, which may be
+  // an Omni Person UUID. See issue #537 + gemini review on #538.
+  const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
+
   // Channels that declare `canHandoff: true` receive a channel-specific
   // HANDOFF payload (currently only Gupshup). For every other channel the
   // route still runs the channel-agnostic side effects below — agentPaused,
@@ -1494,7 +1500,6 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
 
   let channelSendResult: Awaited<ReturnType<typeof plugin.sendMessage>> | null = null;
   if (hasNativeHandoff) {
-    const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
     const outgoingMessage: OutgoingMessage = {
       to: resolvedTo,
       content: { type: 'text', text: data.text } as OutgoingContent,
@@ -1533,8 +1538,8 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
     .values({
       instanceId: data.instanceId,
       chatUuid: data.chatId, // chatId in this route is the DB UUID of the chat
-      chatId: data.to, // raw phone/JID used as chat identifier on the channel
-      toPhone: data.to,
+      chatId: resolvedTo, // resolved platform identifier (phone/JID)
+      toPhone: resolvedTo,
       text: data.text,
       extraInfo: data.dadosLead ?? data.extraInfo ?? null,
       agentId: instance.agentId ?? null,

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1466,10 +1466,6 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
 
   const instance = await services.instances.getById(data.instanceId);
 
-  if (instance.channel !== 'gupshup') {
-    return c.json({ error: 'Handoff is only supported on Gupshup instances' }, 400);
-  }
-
   if (!channelRegistry) {
     throw new OmniError({
       code: ERROR_CODES.CHANNEL_NOT_CONNECTED,
@@ -1488,21 +1484,34 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
     });
   }
 
-  const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
+  // Channels that declare `canHandoff: true` receive a channel-specific
+  // HANDOFF payload (currently only Gupshup). For every other channel the
+  // route still runs the channel-agnostic side effects below — agentPaused,
+  // follow-up disarm, audit row — so agents can pause themselves on any
+  // channel. The user-facing farewell is the agent's responsibility on
+  // channels without native handoff. See issue #537.
+  const hasNativeHandoff = plugin.capabilities?.canHandoff === true;
 
-  const outgoingMessage: OutgoingMessage = {
-    to: resolvedTo,
-    content: { type: 'text', text: data.text } as OutgoingContent,
-    metadata: {
-      isHandoff: true,
-      dadosLead: data.dadosLead ?? data.extraInfo,
-      motivoHandoff: data.motivoHandoff,
-      handoffFields: data.handoffFields,
-    },
-  };
-
-  const result = await plugin.sendMessage(data.instanceId, outgoingMessage);
-  handleSendResult(result, { channelType: instance.channel, instanceId: data.instanceId, operation: 'send handoff' });
+  let channelSendResult: Awaited<ReturnType<typeof plugin.sendMessage>> | null = null;
+  if (hasNativeHandoff) {
+    const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
+    const outgoingMessage: OutgoingMessage = {
+      to: resolvedTo,
+      content: { type: 'text', text: data.text } as OutgoingContent,
+      metadata: {
+        isHandoff: true,
+        dadosLead: data.dadosLead ?? data.extraInfo,
+        motivoHandoff: data.motivoHandoff,
+        handoffFields: data.handoffFields,
+      },
+    };
+    channelSendResult = await plugin.sendMessage(data.instanceId, outgoingMessage);
+    handleSendResult(channelSendResult, {
+      channelType: instance.channel,
+      instanceId: data.instanceId,
+      operation: 'send handoff',
+    });
+  }
 
   // Set agentPaused — chains: chat.handoff_activated → follow-up disarm + agent stop
   await services.chats.update(data.chatId, {
@@ -1529,11 +1538,12 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
       text: data.text,
       extraInfo: data.dadosLead ?? data.extraInfo ?? null,
       agentId: instance.agentId ?? null,
-      externalMessageId: result.messageId ?? null,
+      externalMessageId: channelSendResult?.messageId ?? null,
       handoffFields: data.handoffFields ?? null,
       sentAt: new Date(),
       metadata: {
         instanceChannel: instance.channel,
+        channelHandoffSupported: hasNativeHandoff,
         ...(data.motivoHandoff ? { motivoHandoff: data.motivoHandoff } : {}),
       },
     })
@@ -1542,9 +1552,9 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
   return c.json(
     {
       data: {
-        messageId: result.messageId,
-        status: 'sent',
-        timestamp: result.timestamp,
+        messageId: channelSendResult?.messageId ?? null,
+        status: hasNativeHandoff ? 'sent' : 'paused',
+        timestamp: channelSendResult?.timestamp ?? Date.now(),
       },
     },
     201,

--- a/packages/channel-gupshup/src/capabilities.ts
+++ b/packages/channel-gupshup/src/capabilities.ts
@@ -19,6 +19,7 @@ export const GUPSHUP_CAPABILITIES: ChannelCapabilities = {
   canDeleteMessage: false,
   canReplyToMessage: true,
   canForwardMessage: false,
+  canHandoff: true,
   canSendContact: false,
   canSendLocation: true,
   canSendSticker: true,

--- a/packages/channel-sdk/src/types/capabilities.ts
+++ b/packages/channel-sdk/src/types/capabilities.ts
@@ -105,6 +105,16 @@ export interface ChannelCapabilities {
   /** Can stream partial response updates (thinking/content/final/error) */
   canStreamResponse?: boolean;
 
+  /**
+   * Whether the channel exposes a native handoff protocol (e.g. a dedicated
+   * `HANDOFF` message type that pops a ticket in an operator UI). Only
+   * channels with `canHandoff: true` receive a channel-specific payload from
+   * `POST /messages/send/handoff`; for every other channel the route still
+   * runs the channel-agnostic side effects (`agentPaused=true`, follow-up
+   * disarm, audit log). See issue #537.
+   */
+  canHandoff?: boolean;
+
   // ─────────────────────────────────────────────────────────────
   // Messaging-window constraints (issue #404)
   // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #537

## Problem

`POST /messages/send/handoff` was hardcoded to return **HTTP 400** for every non-Gupshup channel, blocking agents on `whatsapp-baileys`, `discord`, `telegram`, and `slack` from pausing themselves or disarming the follow-up sweeper when a lead asked for a human. Observed in production: Eugenia seller on a `whatsapp-baileys` instance (`testonho`) called its `human_handoff` tool, got 400 back, replied a farewell anyway — but **nothing paused on Omni's side**, so the follow-up sweeper delivered two more nag messages in the next 5 minutes.

## Root cause

The surrounding infrastructure is already channel-agnostic (`chats.update` emits `chat.handoff_activated` regardless of channel; `follow-up-hooks` disarms; `agent-dispatcher` skips dispatch when `agentPaused=true`; sweeper excludes paused rows via #528). Only the HTTP entry enforced Gupshup:

```ts
// packages/api/src/routes/v2/messages.ts:1469
if (instance.channel !== 'gupshup') {
  return c.json({ error: 'Handoff is only supported on Gupshup instances' }, 400);
}
```

## Fix — capability-based branching, single endpoint

1. Added `canHandoff?: boolean` to `ChannelCapabilities` (`packages/channel-sdk/src/types/capabilities.ts`). Channels that advertise a native HANDOFF protocol set it `true`; everyone else leaves it `undefined`/`false`.
2. Set `canHandoff: true` in `GUPSHUP_CAPABILITIES` — only channel today with a native `msg_type: HANDOFF` protocol.
3. Route rewrite in `packages/api/src/routes/v2/messages.ts`:
   - Removed the hardcoded `instance.channel !== 'gupshup'` 400.
   - Uses `plugin.capabilities?.canHandoff === true` to decide whether to run `plugin.sendMessage` with `isHandoff` metadata.
   - **Always** runs the channel-agnostic side effects: `chats.update({agentPaused: true})`, `followUpLifecycle.disarm({reason: 'handoff'})`, `handoffLogs` audit insert.
   - Stores `channelHandoffSupported` in the audit row's `metadata` JSONB so downstream tooling can tell native from soft handoffs.
   - Response: `status: 'sent'` when the channel pushed a native payload, `status: 'paused'` when only the agent-pause chain ran.

No schema change — audit metadata lives in the existing JSONB column.

## Diff

```
packages/channel-sdk/src/types/capabilities.ts   | +11
packages/channel-gupshup/src/capabilities.ts      | +1
packages/api/src/routes/v2/messages.ts            | +28 -22
```

## Validation

- Typecheck: `@omni/api` + `@omni/channel-sdk` + `@omni/channel-gupshup` all green.
- Biome: clean on all 3 changed files.
- Tests on affected packages: **1169 pass / 0 fail / 271 skip**.
- Full pre-push suite will run on push (repo gate).

## Acceptance criteria (from #537)

- [x] `POST /messages/send/handoff` no longer 400s for `whatsapp-baileys` / `discord` / `telegram` / `slack`.
- [x] For channels **without** native handoff: sets `agentPaused=true`, emits `chat.handoff_activated`, disarms follow-up, writes `handoff_logs` row with `channelHandoffSupported: false`, and skips any channel-level send (agent handles the farewell).
- [x] For channels **with** native handoff (Gupshup): unchanged — native HANDOFF payload still goes out via plugin; audit row now records `channelHandoffSupported: true`.
- [x] Blocks subsequent agent dispatch via existing `settings.agentPaused` gate in `agent-dispatcher.ts`.
- [ ] Integration tests on both paths — **deferred**. No existing route harness for `/send/handoff` (no `messages.test.ts`); adding one is out of scope for this fix. Logged as follow-up if worth adding. All downstream machinery (`chats.update` hook, follow-up-hooks consumer, sweeper filter, dispatcher gate) is already covered by existing unit/integration tests.

## Related

- #502 — CLI provider-id flag UX (closed)
- #509 / #511 — agno-client `agent_id` → `id` migration (merged)
- #515 / #516 — agno 2.5 migration propagated to SDK + CLI (merged)
- #528 / #535 — follow-up disarm race on handoff (merged — the sweeper filter and synchronous disarm added there are what makes this fix safe on non-native channels)
- #536 — referenced as prior art in the series