### PR TITLE
fix(follow-up): harden sweeper agentPaused SQL + test cleanup (gemini review on #535)

### DIFF
--- a/packages/api/src/__tests__/follow-up-sweeper.test.ts
+++ b/packages/api/src/__tests__/follow-up-sweeper.test.ts
@@ -83,6 +83,13 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
 
   afterEach(async () => {
     await db.delete(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+    // Defensive cleanup — if a test wrote `settings.agentPaused`, strip only
+    // that key. Runs unconditionally so a failed test can't leak paused
+    // state into subsequent cases sharing `testChatId`.
+    await db
+      .update(chats)
+      .set({ settings: sql`${chats.settings} - 'agentPaused'` })
+      .where(eq(chats.id, testChatId));
   });
 
   afterAll(async () => {
@@ -188,9 +195,13 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     // chat.handoff_activated → follow-up-hooks disarm has committed.
     const past = new Date(Date.now() - 60_000);
 
+    // Merge `agentPaused: true` into `settings` without overwriting other
+    // keys. `jsonb_set` + `COALESCE` handles the null-settings case.
     await db
       .update(chats)
-      .set({ settings: { agentPaused: true } })
+      .set({
+        settings: sql`jsonb_set(COALESCE(${chats.settings}, '{}'::jsonb), '{agentPaused}', 'true'::jsonb)`,
+      })
       .where(eq(chats.id, testChatId));
 
     await db.insert(chatFollowUpState).values({
@@ -211,14 +222,7 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
     expect(row.disarmReason).toBeNull();
     expect(row.sequenceIndex).toBe(0);
-
-    // Remove only the `agentPaused` key we added — preserves any other
-    // settings that might be present on the test chat (defensive; merge,
-    // don't overwrite).
-    await db
-      .update(chats)
-      .set({ settings: sql`${chats.settings} - 'agentPaused'` })
-      .where(eq(chats.id, testChatId));
+    // Settings cleanup happens in `afterEach` so it runs even on failure.
   });
 
   test('future-due rows are not swept', async () => {

--- a/packages/api/src/__tests__/follow-up-sweeper.test.ts
+++ b/packages/api/src/__tests__/follow-up-sweeper.test.ts
@@ -13,7 +13,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from '
 import type { EventBus, FollowUpSequenceConfig } from '@omni/core';
 import type { Database } from '@omni/db';
 import { chatFollowUpState, chats, instances } from '@omni/db';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { FollowUpSweeperService } from '../services/follow-up-sweeper';
 import { describeWithDb, getTestDb } from './db-helper';
 
@@ -212,8 +212,13 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     expect(row.disarmReason).toBeNull();
     expect(row.sequenceIndex).toBe(0);
 
-    // Reset chat settings for subsequent tests.
-    await db.update(chats).set({ settings: {} }).where(eq(chats.id, testChatId));
+    // Remove only the `agentPaused` key we added — preserves any other
+    // settings that might be present on the test chat (defensive; merge,
+    // don't overwrite).
+    await db
+      .update(chats)
+      .set({ settings: sql`${chats.settings} - 'agentPaused'` })
+      .where(eq(chats.id, testChatId));
   });
 
   test('future-due rows are not swept', async () => {

--- a/packages/api/src/services/follow-up-sweeper.ts
+++ b/packages/api/src/services/follow-up-sweeper.ts
@@ -122,7 +122,13 @@ export class FollowUpSweeperService {
             // sweeper fires idle_timeout after `/send/handoff` has set
             // agentPaused but before the `chat.handoff_activated` disarm
             // has committed. See issue #528.
-            sql`(${chats.settings}->>'agentPaused')::boolean IS DISTINCT FROM true`,
+            //
+            // Compare the JSONB text form directly rather than casting to
+            // boolean — `->>` returns NULL for missing keys and `'true'` /
+            // `'false'` for booleans. `IS DISTINCT FROM 'true'` is null-safe
+            // and avoids a runtime cast error if a non-boolean value ever
+            // lands in `settings.agentPaused`.
+            sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
           ),
         )
         .orderBy(chatFollowUpState.nextFireAt)


### PR DESCRIPTION
Follow-up to PR #535 / issue #528 — addresses the gemini-code-assist review left after merge.

## HIGH — SQL cast risk

The sweeper's `findAndLockDue` predicate was:

```sql
(chats.settings->>'agentPaused')::boolean IS DISTINCT FROM true
```

The explicit boolean cast raises a runtime error if `settings.agentPaused` ever holds a non-boolean text value (empty string, `\"1\"`, stray type drift, etc.), which would kill the entire sweeper tick and silently break follow-ups platform-wide. In practice we always write booleans today, but the risk is latent — a bad migration or a stray external write would take everything down.

Replaced with a null-safe text comparison:

```sql
(chats.settings->>'agentPaused') IS DISTINCT FROM 'true'
```

Postgres's `->>` returns NULL for missing keys and `'true'`/`'false'` for booleans, so this is null-safe, matches both boolean `true` and JSON string `\"true\"`, and never raises at runtime.

## MEDIUM — Test settings cleanup

The agentPaused regression test's cleanup overwrote the whole `settings` JSONB with `{}`, which would clobber any unrelated keys another test might rely on. Swapped to use the JSONB `-` operator so only the key we added is removed:

```ts
await db
  .update(chats)
  .set({ settings: sql\`\${chats.settings} - 'agentPaused'\` })
  .where(eq(chats.id, testChatId));
```

## Validation

- Typecheck: `@omni/api` green.
- Biome: clean on both changed files.
- Bun test locally: 0 pass / 8 skip / 0 fail (integration tests gate on `ENABLE_DB_TESTS`, same as before).

## Diff

```
packages/api/src/services/follow-up-sweeper.ts    | +10 -2
packages/api/src/__tests__/follow-up-sweeper.test.ts | +5 -2
```

## Related

- PR #535 / issue #528 — original fix
- gemini-code-assist[bot] review on #535