### PR TITLE
feat(sdk): rename @omni/sdk → @automagik/omni-sdk + drop dispatcher-retry mock + instructive pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,45 @@
 set -e
 
+# ============================================================================
+# pre-push gate: typecheck + tests must be GREEN before any push leaves here.
+#
+# Why so strict? Code freeze + dog-food season. Every coding agent that pushes
+# from this repo inherits the contract: zero typecheck errors, zero failing
+# tests. If you (human or agent) hit a failure here, FIX IT — even if the
+# failure was already on dev. "It was already broken" is not an exception;
+# the hook stays strict so the repo state monotonically improves.
+#
+# Common causes + how to fix them:
+#
+#   • Typecheck error in packages/cli referencing SDK types
+#       → SDK dist/ is stale. Run `cd packages/sdk && bun run build`,
+#         then re-push. The hook auto-builds SDK if dist/ is missing
+#         entirely, but a stale dist (older than source) is harder to
+#         detect — always rebuild after touching packages/sdk/src.
+#
+#   • Logger / Buffer / formatter tests failing in full suite but
+#     passing in isolation
+#       → Some other test file is calling `mock.module('@omni/core', ...)`
+#         with a truncated surface. Bun's mock.module is process-wide,
+#         not file-scoped — the truncated mock contaminates every other
+#         test that resolves @omni/core. Drop the mock.module call from
+#         the dispatcher / api test (the tests usually do not assert on
+#         logger output anyway), or spread `require('@omni/core')` over
+#         the overrides so unrelated modules keep their real exports.
+#
+#   • Unrelated test failures
+#       → Bisect: `bun test <suspect_file> packages/core/src/logger`.
+#         If failing only in pairs, the suspect is poisoning shared state.
+#         Reach for spyOn/local fixtures over mock.module.
+#
+#   • Force push to main/master
+#       → Refused by design. Main is production; merge through the
+#         rolling PR process.
+#
+# DO NOT bypass with --no-verify unless explicitly authorized for the
+# specific push by the human owner. The hook is the contract.
+# ============================================================================
+
 # Block force pushes to main/master (pre-push receives: remote url on $1 $2, refs on stdin)
 remote="$1"
 while read local_ref local_oid remote_ref remote_oid; do
@@ -12,10 +52,29 @@ done
 
 # Build SDK dist if missing (CLI typecheck depends on SDK type declarations)
 if [ ! -d packages/sdk/dist ]; then
-  echo "Building SDK (dist/ missing)..."
+  echo "Building SDK (dist/ missing) — re-running typecheck against fresh dist..."
   cd packages/sdk && bun run build && cd ../..
 fi
 
-make typecheck
+echo "▶ pre-push: typecheck"
+if ! make typecheck; then
+  echo ""
+  echo "✗ typecheck failed."
+  echo "  → If errors reference SDK types, run: cd packages/sdk && bun run build"
+  echo "  → Then re-push. See hook header for full guidance."
+  exit 1
+fi
 
-bun test
+echo "▶ pre-push: full test suite"
+if ! bun test; then
+  echo ""
+  echo "✗ tests failed."
+  echo "  → If Logger / Buffer tests fail in the full suite but pass in"
+  echo "    isolation, hunt for a mock.module('@omni/core', ...) call in"
+  echo "    api/cli test files — that's the usual culprit. See hook"
+  echo "    header for full guidance."
+  echo "  → Bisect with: bun test <suspect_file> packages/core/src/logger"
+  exit 1
+fi
+
+echo "✓ pre-push gates passed."

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ omni dead-letters list --limit 20              # Failed events
 
 **TypeScript**
 ```typescript
-import { createOmniClient } from '@omni/sdk';
+import { createOmniClient } from '@automagik/omni-sdk';
 const omni = createOmniClient({
   baseUrl: 'http://localhost:8882',
   apiKey: 'your-api-key',

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -38,7 +38,7 @@ In production, the API serves the built UI:
 - **Tailwind v4** - CSS framework (CSS-first config)
 - **TypeScript** - Type safety
 - **Biome** - Linting and formatting
-- **@omni/sdk** - API client
+- **@automagik/omni-sdk** - API client
 
 ## Scripts
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "biome check --write src/"
   },
   "dependencies": {
-    "@omni/sdk": "workspace:*",
+    "@automagik/omni-sdk": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/apps/ui/src/components/chats/ChatHeader.tsx
+++ b/apps/ui/src/components/chats/ChatHeader.tsx
@@ -2,7 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { getChatDisplayName } from '@/lib/chat-utils';
 import { cn } from '@/lib/utils';
-import type { Chat, Instance } from '@omni/sdk';
+import type { Chat, Instance } from '@automagik/omni-sdk';
 import { ArrowLeft, Bot, BotOff, Hash, Megaphone, MessageCircle, Mic, Radio, Search, User, Users } from 'lucide-react';
 import { useState } from 'react';
 import { MessageSearch } from './MessageSearch';

--- a/apps/ui/src/components/chats/ChatList.tsx
+++ b/apps/ui/src/components/chats/ChatList.tsx
@@ -2,7 +2,7 @@ import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import { flattenChats, useInfiniteChats } from '@/hooks/useInfiniteChats';
 import { useInstances } from '@/hooks/useInstances';
-import type { Chat } from '@omni/sdk';
+import type { Chat } from '@automagik/omni-sdk';
 import { MessageSquare, Search } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChatListItem } from './ChatListItem';

--- a/apps/ui/src/components/chats/ChatListItem.tsx
+++ b/apps/ui/src/components/chats/ChatListItem.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { getChatDisplayName } from '@/lib/chat-utils';
 import { cn, formatRelativeTime, truncate } from '@/lib/utils';
-import type { Chat } from '@omni/sdk';
+import type { Chat } from '@automagik/omni-sdk';
 import { Hash, Megaphone, MessageCircle, Mic, Radio, User, Users } from 'lucide-react';
 
 interface ChatListItemProps {

--- a/apps/ui/src/components/chats/ChatPanel.tsx
+++ b/apps/ui/src/components/chats/ChatPanel.tsx
@@ -2,7 +2,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { useChatParticipants, useSendMedia, useSendMessage, useToggleAgent } from '@/hooks/useChats';
 import { flattenAndReverseMessages, useInfiniteMessages } from '@/hooks/useInfiniteMessages';
 import { useInstance } from '@/hooks/useInstances';
-import type { Chat } from '@omni/sdk';
+import type { Chat } from '@automagik/omni-sdk';
 import { MessageSquare } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChatHeader } from './ChatHeader';

--- a/apps/ui/src/components/chats/ContactPicker.tsx
+++ b/apps/ui/src/components/chats/ContactPicker.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import type { SendContactBody } from '@omni/sdk';
+import type { SendContactBody } from '@automagik/omni-sdk';
 import { useState } from 'react';
 
 interface ContactPickerProps {

--- a/apps/ui/src/components/chats/LocationPicker.tsx
+++ b/apps/ui/src/components/chats/LocationPicker.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import type { SendLocationBody } from '@omni/sdk';
+import type { SendLocationBody } from '@automagik/omni-sdk';
 import { MapPin, Navigation } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';

--- a/apps/ui/src/components/chats/MessageInput.tsx
+++ b/apps/ui/src/components/chats/MessageInput.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { usePresence } from '@/hooks/usePresence';
 import { useSendContact, useSendLocation, useSendPoll } from '@/hooks/useSpecialMessages';
 import { cn } from '@/lib/utils';
-import type { SendContactBody, SendLocationBody, SendPollBody } from '@omni/sdk';
+import type { SendContactBody, SendLocationBody, SendPollBody } from '@automagik/omni-sdk';
 import { BarChart3, Contact, FileText, Image, MapPin, Mic, Paperclip, Send, Smile, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';

--- a/apps/ui/src/components/chats/PollCreator.tsx
+++ b/apps/ui/src/components/chats/PollCreator.tsx
@@ -10,7 +10,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import type { SendPollBody } from '@omni/sdk';
+import type { SendPollBody } from '@automagik/omni-sdk';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';

--- a/apps/ui/src/components/contacts/ContactCard.tsx
+++ b/apps/ui/src/components/contacts/ContactCard.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import type { Contact } from '@omni/sdk';
+import type { Contact } from '@automagik/omni-sdk';
 import { Building, Phone, User, Users } from 'lucide-react';
 
 interface ContactCardProps {

--- a/apps/ui/src/components/instances/AgentConfigForm.tsx
+++ b/apps/ui/src/components/instances/AgentConfigForm.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { useUpdateInstance } from '@/hooks/useInstances';
 import { useCheckProviderHealth, useProviderAgents, useProviders } from '@/hooks/useProviders';
 import { cn } from '@/lib/utils';
-import type { Instance } from '@omni/sdk';
+import type { Instance } from '@automagik/omni-sdk';
 import { Bot, Check, RefreshCw, Zap } from 'lucide-react';
 import { useEffect, useState } from 'react';
 

--- a/apps/ui/src/components/instances/CreateInstanceModal.tsx
+++ b/apps/ui/src/components/instances/CreateInstanceModal.tsx
@@ -11,7 +11,7 @@ import {
   usePairInstance,
 } from '@/hooks/useInstances';
 import { cn } from '@/lib/utils';
-import type { Channel, Instance } from '@omni/sdk';
+import type { Channel, Instance } from '@automagik/omni-sdk';
 import { ArrowLeft, ArrowRight, Check, Phone, QrCode, X } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useEffect, useState } from 'react';

--- a/apps/ui/src/components/persons/PersonCard.tsx
+++ b/apps/ui/src/components/persons/PersonCard.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { cn, formatRelativeTime } from '@/lib/utils';
-import type { Person } from '@omni/sdk';
+import type { Person } from '@automagik/omni-sdk';
 import { User } from 'lucide-react';
 
 interface PersonCardProps {

--- a/apps/ui/src/components/settings/SettingRow.tsx
+++ b/apps/ui/src/components/settings/SettingRow.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toaster';
 import { useUpdateSetting } from '@/hooks/useSettings';
 import { cn } from '@/lib/utils';
-import type { Setting } from '@omni/sdk';
+import type { Setting } from '@automagik/omni-sdk';
 import { Check, Eye, EyeOff, Pencil, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 

--- a/apps/ui/src/hooks/useAccessRules.ts
+++ b/apps/ui/src/hooks/useAccessRules.ts
@@ -1,7 +1,7 @@
 import { toast } from '@/components/ui/toaster';
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { CreateAccessRuleBody, ListAccessRulesParams } from '@omni/sdk';
+import type { CreateAccessRuleBody, ListAccessRulesParams } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useAutomations.ts
+++ b/apps/ui/src/hooks/useAutomations.ts
@@ -1,5 +1,5 @@
 import { getClient } from '@/lib/sdk';
-import type { Automation, CreateAutomationBody } from '@omni/sdk';
+import type { Automation, CreateAutomationBody } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useBatchJobs.ts
+++ b/apps/ui/src/hooks/useBatchJobs.ts
@@ -1,5 +1,5 @@
 import { getClient } from '@/lib/sdk';
-import type { BatchJob, CreateBatchJobBody, ListBatchJobsParams } from '@omni/sdk';
+import type { BatchJob, CreateBatchJobBody, ListBatchJobsParams } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useChats.ts
+++ b/apps/ui/src/hooks/useChats.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { ChatParticipant, ListChatsParams, SendMessageBody } from '@omni/sdk';
+import type { ChatParticipant, ListChatsParams, SendMessageBody } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useContacts.ts
+++ b/apps/ui/src/hooks/useContacts.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { ListContactsParams } from '@omni/sdk';
+import type { ListContactsParams } from '@automagik/omni-sdk';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useDeadLetters.ts
+++ b/apps/ui/src/hooks/useDeadLetters.ts
@@ -1,7 +1,7 @@
 import { toast } from '@/components/ui/toaster';
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { ListDeadLettersParams, ResolveDeadLetterBody } from '@omni/sdk';
+import type { ListDeadLettersParams, ResolveDeadLetterBody } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useInfiniteChats.ts
+++ b/apps/ui/src/hooks/useInfiniteChats.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { ListChatsParams } from '@omni/sdk';
+import type { ListChatsParams } from '@automagik/omni-sdk';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 const PAGE_SIZE = 50;

--- a/apps/ui/src/hooks/useInstances.ts
+++ b/apps/ui/src/hooks/useInstances.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { CreateInstanceBody, ListInstancesParams } from '@omni/sdk';
+import type { CreateInstanceBody, ListInstancesParams } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useLogs.ts
+++ b/apps/ui/src/hooks/useLogs.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { ListLogsParams } from '@omni/sdk';
+import type { ListLogsParams } from '@automagik/omni-sdk';
 import { useQuery } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/usePersons.ts
+++ b/apps/ui/src/hooks/usePersons.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { SearchPersonsParams } from '@omni/sdk';
+import type { SearchPersonsParams } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useReactions.ts
+++ b/apps/ui/src/hooks/useReactions.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { SendReactionBody } from '@omni/sdk';
+import type { SendReactionBody } from '@automagik/omni-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/hooks/useSettings.ts
+++ b/apps/ui/src/hooks/useSettings.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { apiFetch, getClient } from '@/lib/sdk';
-import type { ListSettingsParams, Setting } from '@omni/sdk';
+import type { ListSettingsParams, Setting } from '@automagik/omni-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 

--- a/apps/ui/src/hooks/useSpecialMessages.ts
+++ b/apps/ui/src/hooks/useSpecialMessages.ts
@@ -1,6 +1,6 @@
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
-import type { SendContactBody, SendLocationBody, SendPollBody } from '@omni/sdk';
+import type { SendContactBody, SendLocationBody, SendPollBody } from '@automagik/omni-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**

--- a/apps/ui/src/lib/chat-utils.ts
+++ b/apps/ui/src/lib/chat-utils.ts
@@ -1,4 +1,4 @@
-import type { Chat } from '@omni/sdk';
+import type { Chat } from '@automagik/omni-sdk';
 
 /**
  * Format external ID for display when no name is available

--- a/apps/ui/src/lib/sdk.ts
+++ b/apps/ui/src/lib/sdk.ts
@@ -4,7 +4,7 @@
  * Creates and manages the Omni SDK client instance.
  */
 
-import { type OmniClient, createOmniClient } from '@omni/sdk';
+import { type OmniClient, createOmniClient } from '@automagik/omni-sdk';
 
 let client: OmniClient | null = null;
 

--- a/apps/ui/src/pages/AccessRules.tsx
+++ b/apps/ui/src/pages/AccessRules.tsx
@@ -15,7 +15,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { useAccessRules, useCheckAccess, useCreateAccessRule, useDeleteAccessRule } from '@/hooks/useAccessRules';
 import { useInstances } from '@/hooks/useInstances';
 import { cn, formatDateTime } from '@/lib/utils';
-import type { AccessRule, CreateAccessRuleBody } from '@omni/sdk';
+import type { AccessRule, CreateAccessRuleBody } from '@automagik/omni-sdk';
 import { AlertCircle, CheckCircle2, Plus, Search, Shield, ShieldBan, ShieldCheck, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 

--- a/apps/ui/src/pages/Automations.tsx
+++ b/apps/ui/src/pages/Automations.tsx
@@ -12,7 +12,7 @@ import {
   useEnableAutomation,
 } from '@/hooks/useAutomations';
 import { cn } from '@/lib/utils';
-import type { Automation, CreateAutomationBody } from '@omni/sdk';
+import type { Automation, CreateAutomationBody } from '@automagik/omni-sdk';
 import {
   ArrowRight,
   Check,

--- a/apps/ui/src/pages/BatchJobs.tsx
+++ b/apps/ui/src/pages/BatchJobs.tsx
@@ -13,7 +13,7 @@ import {
 import { useChats } from '@/hooks/useChats';
 import { useInstances } from '@/hooks/useInstances';
 import { cn } from '@/lib/utils';
-import type { BatchJob, BatchJobStatus, BatchJobType } from '@omni/sdk';
+import type { BatchJob, BatchJobStatus, BatchJobType } from '@automagik/omni-sdk';
 import {
   AlertTriangle,
   CheckCircle2,

--- a/apps/ui/src/pages/Chats.tsx
+++ b/apps/ui/src/pages/Chats.tsx
@@ -1,7 +1,7 @@
 import { ChatList, ChatPanel } from '@/components/chats';
 import { Spinner } from '@/components/ui/spinner';
 import { useChat } from '@/hooks/useChats';
-import type { Chat } from '@omni/sdk';
+import type { Chat } from '@automagik/omni-sdk';
 import { MessageSquare } from 'lucide-react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 

--- a/apps/ui/src/pages/Contacts.tsx
+++ b/apps/ui/src/pages/Contacts.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { useInfiniteContacts } from '@/hooks/useContacts';
 import { useInstances } from '@/hooks/useInstances';
 import { cn } from '@/lib/utils';
-import type { Contact } from '@omni/sdk';
+import type { Contact } from '@automagik/omni-sdk';
 import { BookUser, Server } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 

--- a/apps/ui/src/pages/Dashboard.tsx
+++ b/apps/ui/src/pages/Dashboard.tsx
@@ -7,7 +7,7 @@ import { useInstances } from '@/hooks/useInstances';
 import { queryKeys } from '@/lib/query';
 import { getClient } from '@/lib/sdk';
 import { formatRelativeTime } from '@/lib/utils';
-import type { EventAnalytics, EventMetrics } from '@omni/sdk';
+import type { EventAnalytics, EventMetrics } from '@automagik/omni-sdk';
 import { useQuery } from '@tanstack/react-query';
 import { Activity, AlertCircle, Database, Gauge, Radio, RefreshCw, Server, TrendingUp } from 'lucide-react';
 

--- a/apps/ui/src/pages/DeadLetters.tsx
+++ b/apps/ui/src/pages/DeadLetters.tsx
@@ -20,7 +20,7 @@ import {
   useRetryDeadLetter,
 } from '@/hooks/useDeadLetters';
 import { cn, formatDateTime } from '@/lib/utils';
-import type { DeadLetter } from '@omni/sdk';
+import type { DeadLetter } from '@automagik/omni-sdk';
 import {
   Archive,
   CheckCircle2,

--- a/apps/ui/src/pages/Logs.tsx
+++ b/apps/ui/src/pages/Logs.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import { useLogs } from '@/hooks/useLogs';
 import { cn, formatDateTime } from '@/lib/utils';
-import type { ListLogsParams } from '@omni/sdk';
+import type { ListLogsParams } from '@automagik/omni-sdk';
 import { Check, ChevronDown, ChevronRight, Copy, FileText, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 

--- a/apps/ui/src/pages/Persons.tsx
+++ b/apps/ui/src/pages/Persons.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import { useMergePersons, usePersons } from '@/hooks/usePersons';
 import { cn } from '@/lib/utils';
-import type { Person } from '@omni/sdk';
+import type { Person } from '@automagik/omni-sdk';
 import { GitMerge, Search, Users, X } from 'lucide-react';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';

--- a/bun.lock
+++ b/bun.lock
@@ -18,9 +18,9 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
-        "@omni/sdk": "workspace:*",
+        "@automagik/omni-sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -86,7 +86,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -161,7 +161,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -195,7 +195,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -210,7 +210,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -230,7 +230,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -249,6 +249,7 @@
         "qrcode-terminal": "^0.12.0",
       },
       "devDependencies": {
+        "@automagik/omni-sdk": "workspace:*",
         "@omni/api": "workspace:*",
         "@omni/channel-discord": "workspace:*",
         "@omni/channel-gupshup": "workspace:*",
@@ -257,7 +258,6 @@
         "@omni/channel-telegram": "workspace:*",
         "@omni/channel-whatsapp": "workspace:*",
         "@omni/core": "workspace:*",
-        "@omni/sdk": "workspace:*",
         "@types/node": "^22.10.3",
         "@types/qrcode-terminal": "^0.12.2",
         "typescript": "^5.7.3",
@@ -265,7 +265,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -280,7 +280,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -294,7 +294,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -312,15 +312,15 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
       },
     },
     "packages/sdk": {
-      "name": "@omni/sdk",
-      "version": "2.260423.8",
+      "name": "@automagik/omni-sdk",
+      "version": "2.260424.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -334,7 +334,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260423.8",
+      "version": "2.260424.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",
@@ -353,6 +353,8 @@
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@7.3.4", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^3.20.2" } }, "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA=="],
 
     "@automagik/omni": ["@automagik/omni@workspace:packages/cli"],
+
+    "@automagik/omni-sdk": ["@automagik/omni-sdk@workspace:packages/sdk"],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -677,8 +679,6 @@
     "@omni/media-processing": ["@omni/media-processing@workspace:packages/media-processing"],
 
     "@omni/plugin-openclaw": ["@omni/plugin-openclaw@workspace:packages/plugin-openclaw"],
-
-    "@omni/sdk": ["@omni/sdk@workspace:packages/sdk"],
 
     "@omni/ui": ["@omni/ui@workspace:apps/ui"],
 

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-retry.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-retry.test.ts
@@ -18,19 +18,21 @@ mock.module('../loader', () => ({
   getPlugin: mock(() => Promise.resolve(undefined)),
 }));
 
-mock.module('@omni/core', () => {
-  return {
-    createLogger: () => ({
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-      debug: () => {},
-    }),
-    generateCorrelationId: (prefix: string) => `${prefix}-test`,
-    OmniError: class OmniError extends Error {},
-    ERROR_CODES: {},
-  };
-});
+// REMOVED: previous version mocked '@omni/core' via mock.module to swap
+// out createLogger / generateCorrelationId / OmniError / ERROR_CODES.
+// Even with `child()` and a full surface restored, the mock was
+// poisoning packages/core/src/logger/__tests__/logger.test.ts in the
+// full suite — 13 Logger tests failed whenever this file ran in the
+// same bun process. The dispatcher tests do not assert on logger
+// output, so the simplest sound fix is to drop the @omni/core mock
+// entirely and let the real implementations pass through. Real
+// createLogger writes to stdout/stderr during these tests, which is
+// noise but harmless; tests assert on the dispatcher's behavior, not
+// on log lines.
+//
+// If a future test in this file needs deterministic log capture, use
+// spyOn(process.stdout, 'write') in beforeEach scoped to that
+// describe — local mocks don't leak across files.
 
 import {
   TRANSIENT_DISPATCH_ERROR_PATTERNS,

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -33,11 +33,20 @@ mock.module('../loader', () => ({
   getPlugin: mock(() => Promise.resolve(undefined)),
 }));
 
-// Mock @omni/core selectively — only mock classes/functions the dispatcher needs.
-// IMPORTANT: Do NOT mock createLogger here — bun's mock.module merges with the
-// real module, and mocking createLogger contaminates concurrent test files
-// (logger.test.ts) because bun applies the mock process-wide.
+// Mock @omni/core selectively. Bun's mock.module is a TOTAL replacement,
+// not a merge — the previous comment that claimed "merge behavior"
+// was incorrect, which is why logger.test.ts (and 12 sibling Logger
+// tests) failed in the full suite: their `createLogger` and friends
+// vanished into our truncated factory return. The fix is to require()
+// the real module before the mock takes effect and spread its exports
+// over our overrides, so unrelated tests that import @omni/core still
+// see the real surface.
 mock.module('@omni/core', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: spread the real surface
+  // without typing it — the mock's job is to override, not to assert
+  // module shape.
+  const real: any = require('@omni/core');
+
   // We need to provide the class constructors for agent providers
   class MockAgnoAgentProvider {
     readonly schema = 'agno' as const;
@@ -86,9 +95,12 @@ mock.module('@omni/core', () => {
   // paths but shares the module graph via Bun's deduplication).
   // No dispatcher test exercises the OpenClaw code path (all use schema: 'agno').
 
-  // createLogger is NOT mocked — the real implementation passes through via
-  // bun's merge behavior, keeping logger.test.ts and other test files working.
   return {
+    // Spread real exports first so createLogger / configureLogging /
+    // LogBuffer / OmniError / ERROR_CODES / etc. all keep their real
+    // implementations when other test files import @omni/core.
+    ...real,
+    // Override only what the dispatcher tests need to be deterministic.
     AgnoAgentProvider: MockAgnoAgentProvider,
     WebhookAgentProvider: MockWebhookAgentProvider,
     createProviderClient: mock(() => ({})),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "@omni/channel-telegram": "workspace:*",
     "@omni/channel-whatsapp": "workspace:*",
     "@omni/core": "workspace:*",
-    "@omni/sdk": "workspace:*",
+    "@automagik/omni-sdk": "workspace:*",
     "@types/node": "^22.10.3",
     "@types/qrcode-terminal": "^0.12.2",
     "typescript": "^5.7.3"

--- a/packages/cli/src/__tests__/events-stream.test.ts
+++ b/packages/cli/src/__tests__/events-stream.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { Event } from '@omni/sdk';
+import type { Event } from '@automagik/omni-sdk';
 import { formatEventLine, isErrorEvent, isNoisyEvent, passesStreamFilters } from '../commands/events';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {

--- a/packages/cli/src/__tests__/sdk-coverage.test.ts
+++ b/packages/cli/src/__tests__/sdk-coverage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createOmniClient } from '@omni/sdk';
+import { createOmniClient } from '@automagik/omni-sdk';
 
 /**
  * SDK methods that are INTERNAL and should NOT be exposed in CLI.

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -4,7 +4,7 @@
  * Creates SDK client from config and handles auth errors.
  */
 
-import { type OmniClient, createOmniClient } from '@omni/sdk';
+import { type OmniClient, createOmniClient } from '@automagik/omni-sdk';
 import { hasAuth, loadConfig } from './config.js';
 import * as output from './output.js';
 import { VERSION } from './version.js';

--- a/packages/cli/src/commands/__tests__/keys.test.ts
+++ b/packages/cli/src/commands/__tests__/keys.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import type { OmniClient } from '@omni/sdk';
+import type { OmniClient } from '@automagik/omni-sdk';
 import { __testables } from '../keys';
 
 const { ADMIN_CONFIRMATION_PHRASE, handleCreate, promptAdminConfirmation } = __testables;

--- a/packages/cli/src/commands/__tests__/providers.test.ts
+++ b/packages/cli/src/commands/__tests__/providers.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@omni/sdk';
+import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@automagik/omni-sdk';
 import { __testables } from '../providers';
 
 const { mapAgnoAgentRow, mapAgnoTeamRow, mapAgnoWorkflowRow } = __testables;

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -7,7 +7,7 @@
  * omni auth recover
  */
 
-import { createOmniClient } from '@omni/sdk';
+import { createOmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { deleteConfigValue, getConfigDir, getConfigPath, loadConfig, loadServerConfig, saveConfig } from '../config.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -10,7 +10,7 @@
  * @see media-processing-batch wish
  */
 
-import type { BatchJobType, CostEstimate, OmniClient, ProcessableContentType } from '@omni/sdk';
+import type { BatchJobType, CostEstimate, OmniClient, ProcessableContentType } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/channels.ts
+++ b/packages/cli/src/commands/channels.ts
@@ -9,7 +9,7 @@
  */
 
 import * as readline from 'node:readline';
-import type { Channel } from '@omni/sdk';
+import type { Channel } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { loadConfig } from '../config.js';

--- a/packages/cli/src/commands/chats.ts
+++ b/packages/cli/src/commands/chats.ts
@@ -12,7 +12,7 @@
  * omni chats participants <id>
  */
 
-import type { Channel, Chat, Message, OmniClient } from '@omni/sdk';
+import type { Channel, Chat, Message, OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import type { OmniClient } from '@omni/sdk';
+import type { OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -40,7 +40,7 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { createOmniClient } from '@omni/sdk';
+import { createOmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { type Config, type ServerConfig, loadConfig, loadServerConfig, saveConfig } from '../config.js';
 import { getHealthCheckUrl } from '../health.js';

--- a/packages/cli/src/commands/done.ts
+++ b/packages/cli/src/commands/done.ts
@@ -12,7 +12,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { basename, extname } from 'node:path';
-import type { OmniClient } from '@omni/sdk';
+import type { OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { type ResolvedContext, resolveContext, resolveReplyTo } from '../context.js';

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -7,7 +7,7 @@
  * omni events timeline <person-id>
  */
 
-import type { Event, OmniClient } from '@omni/sdk';
+import type { Event, OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { getOutputFormat, loadConfig } from '../config.js';

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -18,7 +18,7 @@
  * omni instances syncs <id> [job-id]
  */
 
-import type { Channel } from '@omni/sdk';
+import type { Channel } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import qrcode from 'qrcode-terminal';
 import { getClient } from '../client.js';

--- a/packages/cli/src/commands/keys.ts
+++ b/packages/cli/src/commands/keys.ts
@@ -11,7 +11,7 @@
  * interactive TTY. Any non-TTY invocation (pipe, redirect, CI) is refused.
  */
 
-import type { ApiKeyRecord, ApiKeyStatus, OmniClient } from '@omni/sdk';
+import type { ApiKeyRecord, ApiKeyStatus, OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/messages.ts
+++ b/packages/cli/src/commands/messages.ts
@@ -6,7 +6,7 @@
  * omni messages read --batch --instance <id> --chat <id> --ids <id1,id2,...>
  */
 
-import type { Chat, Message, OmniClient } from '@omni/sdk';
+import type { Chat, Message, OmniClient } from '@automagik/omni-sdk';
 import { Command, Option } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/payloads.ts
+++ b/packages/cli/src/commands/payloads.ts
@@ -9,7 +9,7 @@
  * omni payloads stats
  */
 
-import type { OmniClient } from '@omni/sdk';
+import type { OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -17,7 +17,7 @@
  */
 
 import { PROVIDER_SCHEMAS, type ProviderSchema } from '@omni/core';
-import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@omni/sdk';
+import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -16,8 +16,8 @@
  * omni providers delete <id>
  */
 
-import { PROVIDER_SCHEMAS, type ProviderSchema } from '@omni/core';
 import type { AgnoAgent, AgnoTeam, AgnoWorkflow } from '@automagik/omni-sdk';
+import { PROVIDER_SCHEMAS, type ProviderSchema } from '@omni/core';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';

--- a/packages/cli/src/commands/see.ts
+++ b/packages/cli/src/commands/see.ts
@@ -13,7 +13,7 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { extname } from 'node:path';
-import type { OmniClient } from '@omni/sdk';
+import type { OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { resolveContext, resolveReplyTo } from '../context.js';

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { basename, extname } from 'node:path';
-import { OmniApiError, type OmniClient } from '@omni/sdk';
+import { OmniApiError, type OmniClient } from '@automagik/omni-sdk';
 import chalk, { Chalk, type ChalkInstance } from 'chalk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -4,7 +4,7 @@
  * omni status - Show API health and connection info
  */
 
-import type { OmniClient } from '@omni/sdk';
+import type { OmniClient } from '@automagik/omni-sdk';
 import { Command } from 'commander';
 import { getOptionalClient } from '../client.js';
 import { getConfigDir, hasAuth, loadConfig } from '../config.js';

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -22,7 +22,7 @@
  */
 
 import { createInterface } from 'node:readline';
-import { createOmniClient } from '@omni/sdk';
+import { createOmniClient } from '@automagik/omni-sdk';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-# @omni/sdk
+# @automagik/omni-sdk
 
 > TypeScript SDK for the Omni v2 API
 
@@ -7,13 +7,13 @@ Auto-generated from OpenAPI spec with type-safe wrapper and full IDE autocomplet
 ## Installation
 
 ```bash
-bun add @omni/sdk
+bun add @automagik/omni-sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { createOmniClient } from '@omni/sdk';
+import { createOmniClient } from '@automagik/omni-sdk';
 
 const omni = createOmniClient({
   baseUrl: 'http://localhost:8882',
@@ -468,7 +468,7 @@ console.log(health.status); // 'healthy' | 'degraded' | 'unhealthy'
 All errors are thrown as `OmniApiError`:
 
 ```typescript
-import { createOmniClient, OmniApiError } from '@omni/sdk';
+import { createOmniClient, OmniApiError } from '@automagik/omni-sdk';
 
 try {
   await omni.instances.get('non-existent-id');
@@ -524,7 +524,7 @@ import type {
   SyncJobCreated,
   SyncJobSummary,
   SyncJobStatus,
-} from '@omni/sdk';
+} from '@automagik/omni-sdk';
 ```
 
 ### Low-level Types
@@ -532,7 +532,7 @@ import type {
 For advanced type manipulation, you can import the generated OpenAPI types:
 
 ```typescript
-import type { paths, components, operations } from '@omni/sdk';
+import type { paths, components, operations } from '@automagik/omni-sdk';
 ```
 
 ## Development

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,9 +10,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target node && bun run build:types",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@omni/sdk",
+  "name": "@automagik/omni-sdk",
   "version": "2.260424.3",
   "type": "module",
   "main": "dist/index.js",
@@ -10,7 +10,9 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target node && bun run build:types",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
@@ -27,5 +29,8 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * @omni/sdk - TypeScript SDK for Omni v2 API
+ * @automagik/omni-sdk - TypeScript SDK for Omni v2 API
  *
  * Auto-generated types from OpenAPI spec with type-safe wrapper.
  *
  * @example
  * ```typescript
- * import { createOmniClient } from '@omni/sdk';
+ * import { createOmniClient } from '@automagik/omni-sdk';
  *
  * const omni = createOmniClient({
  *   baseUrl: 'http://localhost:8882',


### PR DESCRIPTION
## Summary

Two related shifts that landed together because the pre-push gate
surfaced the second one when I tried to push the first:

1. **Rename `@omni/sdk` → `@automagik/omni-sdk`** so the SDK can be
   published to the public npm registry under the @automagik scope.
   The SDK at packages/sdk has always been the public-facing client
   that other apps (notably @khal-os/brain) consume — but its
   workspace-local @omni/* namespace blocked publish, so external
   installs of brain hit a 404 and fell back to a "@omni/sdk
   unavailable" wizard error.

2. **Drop `mock.module('@omni/core', ...)` from
   agent-dispatcher-retry.test.ts** + spread the real surface in
   agent-dispatcher.test.ts + rewrite the pre-push hook to be
   instructive. Pre-push surfaced 13 Logger test failures and 3
   typecheck errors when I tried to push (1); per repo policy ("we
   always fix things WHEN we find") I fixed both rather than bypass.

## Changes — Rename

- `packages/sdk/package.json`: name → `@automagik/omni-sdk`,
  `publishConfig.access = public`.
- 62 src files across `packages/cli` + `apps/ui` updated to import
  `@automagik/omni-sdk`. Workspace `:*` pin preserves internal
  resolution, no version drift.
- READMEs updated for consistency.
- biome import-order auto-fix on `packages/cli/src/commands/providers.ts`.

**No breaking changes outside this monorepo.** The only external
consumer of `@omni/sdk` was `@khal-os/brain` via a local `file:` link,
which will swap to a real npm dep once this lands and `npm publish`
lifts `@automagik/omni-sdk@2.260423.2` to the registry.

## Changes — Test infra & pre-push hook

- **`agent-dispatcher-retry.test.ts`**: removed the
  `mock.module('@omni/core', ...)` call. Bun's mock.module is
  process-wide; the truncated factory return value was poisoning
  Logger tests in the full suite. Even with a full-surface spread
  (`require('@omni/core')` + ...real) the contamination persisted —
  the dispatcher tests do not assert on logger output, so the
  surgical fix is to drop the mock entirely. 28 dispatcher-retry
  tests still pass.
- **`agent-dispatcher.test.ts`**: the @omni/core mock factory now
  spreads `require('@omni/core')` over overrides so real classes
  (LogBuffer, configureLogging, OmniError) keep their shape. The
  comment that claimed Bun's mock.module had "merge behavior" was
  wrong; corrected inline.
- **`.husky/pre-push`**: rewritten to be instructive. Previous version
  exited silently with `set -e`, leaving agents guessing. New version
  has a 38-line header explaining the contract, step labels with
  remediation hints printed inline ("If errors reference SDK types,
  run `cd packages/sdk && bun run build`"), and a final ✓
  acknowledgment when all gates pass.

## Validation

- `make typecheck` ✅ clean (was 3 pre-existing errors in providers.ts,
  fixed by SDK rebuild during the rename).
- `make lint` ✅ clean.
- `bun test` ✅ **3801 pass / 271 skip / 0 fail** (was 13 fail on dev
  before this branch).
- `bun install` ✅ workspaces relinked cleanly.

## Follow-up

Brain repo PR will swap its file:-link dependency for the published
@automagik/omni-sdk once a tagged release lifts it to the registry.

## Context

Code-freeze + dog-food season. Felipe's directive when pre-push
flagged pre-existing failures: "we are not in favor of 'this was
already here', we always fix things WHEN we find. update the hook
output to be more instructive." Both done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)