### PR TITLE
feat(cli): expose @omni/sdk as @automagik/omni/sdk subpath + drop dispatcher-retry mock + instructive pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,45 @@
 set -e
 
+# ============================================================================
+# pre-push gate: typecheck + tests must be GREEN before any push leaves here.
+#
+# Why so strict? Code freeze + dog-food season. Every coding agent that pushes
+# from this repo inherits the contract: zero typecheck errors, zero failing
+# tests. If you (human or agent) hit a failure here, FIX IT — even if the
+# failure was already on dev. "It was already broken" is not an exception;
+# the hook stays strict so the repo state monotonically improves.
+#
+# Common causes + how to fix them:
+#
+#   • Typecheck error in packages/cli referencing SDK types
+#       → SDK dist/ is stale. Run `cd packages/sdk && bun run build`,
+#         then re-push. The hook auto-builds SDK if dist/ is missing
+#         entirely, but a stale dist (older than source) is harder to
+#         detect — always rebuild after touching packages/sdk/src.
+#
+#   • Logger / Buffer / formatter tests failing in full suite but
+#     passing in isolation
+#       → Some other test file is calling `mock.module('@omni/core', ...)`
+#         with a truncated surface. Bun's mock.module is process-wide,
+#         not file-scoped — the truncated mock contaminates every other
+#         test that resolves @omni/core. Drop the mock.module call from
+#         the dispatcher / api test (the tests usually do not assert on
+#         logger output anyway), or spread `require('@omni/core')` over
+#         the overrides so unrelated modules keep their real exports.
+#
+#   • Unrelated test failures
+#       → Bisect: `bun test <suspect_file> packages/core/src/logger`.
+#         If failing only in pairs, the suspect is poisoning shared state.
+#         Reach for spyOn/local fixtures over mock.module.
+#
+#   • Force push to main/master
+#       → Refused by design. Main is production; merge through the
+#         rolling PR process.
+#
+# DO NOT bypass with --no-verify unless explicitly authorized for the
+# specific push by the human owner. The hook is the contract.
+# ============================================================================
+
 # Block force pushes to main/master (pre-push receives: remote url on $1 $2, refs on stdin)
 remote="$1"
 while read local_ref local_oid remote_ref remote_oid; do
@@ -12,10 +52,29 @@ done
 
 # Build SDK dist if missing (CLI typecheck depends on SDK type declarations)
 if [ ! -d packages/sdk/dist ]; then
-  echo "Building SDK (dist/ missing)..."
+  echo "Building SDK (dist/ missing) — re-running typecheck against fresh dist..."
   cd packages/sdk && bun run build && cd ../..
 fi
 
-make typecheck
+echo "▶ pre-push: typecheck"
+if ! make typecheck; then
+  echo ""
+  echo "✗ typecheck failed."
+  echo "  → If errors reference SDK types, run: cd packages/sdk && bun run build"
+  echo "  → Then re-push. See hook header for full guidance."
+  exit 1
+fi
 
-bun test
+echo "▶ pre-push: full test suite"
+if ! bun test; then
+  echo ""
+  echo "✗ tests failed."
+  echo "  → If Logger / Buffer tests fail in the full suite but pass in"
+  echo "    isolation, hunt for a mock.module('@omni/core', ...) call in"
+  echo "    api/cli test files — that's the usual culprit. See hook"
+  echo "    header for full guidance."
+  echo "  → Bisect with: bun test <suspect_file> packages/core/src/logger"
+  exit 1
+fi
+
+echo "✓ pre-push gates passed."

--- a/knip.json
+++ b/knip.json
@@ -77,5 +77,6 @@
   },
   "ignoreWorkspaces": ["packages/sdk", "packages/sdk-go", "packages/sdk-python", "packages/audio-decode-shim"],
   "exclude": ["classMembers", "unresolved", "duplicates", "enumMembers"],
+  "ignoreBinaries": ["make"],
   "ignoreExportsUsedInFile": { "interface": true, "type": true }
 }

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-retry.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-retry.test.ts
@@ -18,19 +18,22 @@ mock.module('../loader', () => ({
   getPlugin: mock(() => Promise.resolve(undefined)),
 }));
 
-mock.module('@omni/core', () => {
-  return {
-    createLogger: () => ({
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-      debug: () => {},
-    }),
-    generateCorrelationId: (prefix: string) => `${prefix}-test`,
-    OmniError: class OmniError extends Error {},
-    ERROR_CODES: {},
-  };
-});
+// REMOVED: previous version mocked '@omni/core' via mock.module to swap
+// out createLogger / generateCorrelationId / OmniError / ERROR_CODES.
+// Bun's mock.module is process-wide — the truncated factory return
+// poisoned packages/core/src/logger/__tests__/logger.test.ts in the
+// full suite (13 Logger tests failed whenever this file ran). Even
+// with a full-surface spread the contamination persisted.
+//
+// The dispatcher tests do not assert on logger output, so the
+// surgical fix is to drop the @omni/core mock entirely and let the
+// real implementations pass through. createLogger writes to
+// stdout/stderr during these tests — harmless test noise; the tests
+// assert on dispatcher behavior, not log lines.
+//
+// If a future test in this file needs deterministic log capture, use
+// spyOn(process.stdout, 'write') in beforeEach scoped to that
+// describe — local mocks don't leak across files.
 
 import {
   TRANSIENT_DISPATCH_ERROR_PATTERNS,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,12 +8,23 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./sdk": {
+      "types": "./dist/sdk/index.d.ts",
+      "import": "./dist/sdk/index.js"
+    }
+  },
   "files": ["dist", "bin", "db"],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun && bun run build:types",
+    "build": "bun run build:sdk-subpath && bun build ./src/index.ts --outdir ./dist --target bun && bun run build:types",
+    "build:sdk-subpath": "cd ../sdk && bun run build && cd ../cli && mkdir -p ./dist/sdk && cp -r ../sdk/dist/. ./dist/sdk/",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
     "dev": "echo 'CLI package - no dev server (use: bun run ./src/index.ts <command>)'",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Exposes the workspace-internal `@omni/sdk` as a **subpath export of the published `@automagik/omni`** package, so external consumers can `import { ... } from "@automagik/omni/sdk"` without a separate npm publish.

Replaces #544 (which proposed renaming the SDK to `@automagik/omni-sdk` as a separate package). Per Felipe's call: single package, lockstep versioning, simpler consumer install.

## Three things in one PR

### 1. SDK subpath export

- `packages/cli/package.json` adds `exports`:
  ```json
  ".":     { "import": "./dist/index.js",     "types": "./dist/index.d.ts" }
  "./sdk": { "import": "./dist/sdk/index.js", "types": "./dist/sdk/index.d.ts" }
  ```
- New `build:sdk-subpath` script rebuilds `packages/sdk` and copies its `dist/*` (incl. `.d.ts`) into `packages/cli/dist/sdk/`. The main `build` calls it first so subsequent `bun build` of the CLI bundle leaves `dist/sdk/` intact.
- **No source changes needed** in `packages/cli` or `apps/ui` — they continue importing `@omni/sdk` via workspace resolution.
- **No breaking changes** for any existing consumer.
- Validation: `node -e "import('@automagik/omni/sdk').then(m => console.log(Object.keys(m).slice(0,5)))"` → `['OmniApiError', 'OmniConfigError', 'VERSION', 'createOmniClient']` ✓

### 2. Drop `mock.module('@omni/core', ...)` from `agent-dispatcher-retry.test.ts`

Pre-push surfaced 13 Logger test failures on dev. Root cause: Bun's `mock.module` is process-wide; the truncated factory in `agent-dispatcher-retry.test.ts` was contaminating `packages/core/src/logger/__tests__/logger.test.ts` whenever both ran in the same `bun test` process.

The dispatcher tests don't assert on logger output, so the surgical fix is to drop the mock entirely and let the real `createLogger` pass through. 28 dispatcher-retry tests still pass.

### 3. Instructive pre-push hook

Previous version exited silently with `set -e`, leaving agents guessing why a push was rejected. New version:
- 38-line header documenting the contract and how to fix each common failure (stale SDK dist, mock.module poisoning, force-push to main)
- Per-gate remediation hints printed inline ("If errors reference SDK types, run `cd packages/sdk && bun run build`")
- Final ✓ acknowledgment when gates pass

Per Felipe's directive: "we always fix things WHEN we find. update the hook output to be more instructive."

## Validation

| Check | Result |
|-------|--------|
| `cd packages/cli && bun run build` | ✅ CLI 4.84 MB + SDK subpath 79 KB |
| Subpath import smoke | ✅ exports resolve correctly |
| `make typecheck` | ✅ clean |
| `make lint` | ✅ clean |
| `bun test` | ✅ **3801 pass / 271 skip / 0 fail** (was 13 fail on dev) |

## Follow-up

Brain repo PR will swap its `file:` link for `@automagik/omni` semver, importing via `@automagik/omni/sdk`. Blocked on this landing + a new `@automagik/omni` version shipping `dist/sdk/` in the published tarball.

## Context

Code-freeze + dog-food season. Brain's `omni init` wizard was failing for any consumer not in the omni monorepo (no published SDK to npm install). This unblocks frictionless brain onboarding while keeping the public API surface minimal — single package install, single version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)