### PR TITLE
fix(cli): drop stale 'genie omni start' hint from omni connect

### DIFF
--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -176,7 +176,15 @@ export function createConnectCommand(): Command {
       output.keyValue('Inbound', `omni.message.${instanceId}.*`);
       output.keyValue('Outbound', `omni.reply.${instanceId}.*`);
 
+      // The omni-bridge is hosted inside `genie serve` — there is no
+      // standalone `genie omni start` command. Operators on a fresh
+      // host should verify the bridge is running with `genie serve
+      // status`; if it isn't, start it with `genie serve start
+      // --headless`. The legacy "genie omni start" wording was a stale
+      // reference left over from before the bridge was folded into
+      // `genie serve`.
       output.header('Next Step');
-      output.info('Start the genie bridge:  genie omni start');
+      output.info('Verify the bridge is running:  genie serve status');
+      output.info('If not running, start it with: genie serve start --headless');
     });
 }


### PR DESCRIPTION
## Summary

`omni connect` printed:

```
Next Step
  Start the genie bridge:  genie omni start
```

But `genie omni` is **not a real subcommand** — running it returns `error: unknown command 'omni'`. The omni-bridge has lived inside `genie serve` for several releases (since the bridge was folded in by feat: NATS Genie provider). The hint is stale, sends operators down a dead end, and was a contributing factor in a recent KHAL-V1-LAUNCH bridge incident triage where it cost recovery time.

## What changed

`packages/cli/src/commands/connect.ts:179-180` now prints:

```
Next Step
  Verify the bridge is running:  genie serve status
  If not running, start it with: genie serve start --headless
```

Plus an inline comment so the next maintainer knows the bridge folded into `genie serve` and doesn't revert to the legacy wording.

## Test plan

- [x] `make typecheck` → green (after rebuilding stale SDK dist per hook hint)
- [x] `bun test packages/cli/src/__tests__/connect.test.ts` → 8/8 pass
- [x] Full pre-push suite: **3534 pass, 271 skip, 0 fail, 8999 expect() calls**
- [x] biome clean on `connect.ts`
- [x] No test fixtures asserted on the literal "genie omni start" string

## Context

Tracked under the `canonical-genie-omni-wiring` wish (Wave 1 / Group 2 — first omni-side fix in the canonical wiring rollout). Companion brain entries + ADR landed at namastexlabs/genie-configure#10. Subsequent micro-PRs in the same wish:

- omni: deprecation nudges on legacy multi-command path (Group 5)
- genie: symlink-aware `AGENTS.md` validation + `--skip-omni` warning + `dir edit --dir` fix (Group 1)
- genie: `/genie:omni` skill markdown (Group 4)

Each will be its own focused PR.