### PR TITLE
feat(cli): nudge operators toward 'omni connect' when creating nats-genie providers manually

### DIFF
--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -35,6 +35,7 @@ describe('Output Module Exports', () => {
     expect(typeof output.header).toBe('function');
     expect(typeof output.dim).toBe('function');
     expect(typeof output.raw).toBe('function');
+    expect(typeof output.tip).toBe('function');
   });
 
   test('exports flushStdout', () => {
@@ -76,6 +77,61 @@ describe('flushStdout', () => {
 
   test('resolves after pending writes', async () => {
     await expect(output.flushStdout()).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * `tip` is the deprecation-nudge channel for the canonical-genie-omni-wiring
+ * wish (Group 5). Unlike `info` / `warn`, it MUST go to stderr in every
+ * format so CI scripts that grep stdout for command output remain stable.
+ * These tests pin the contract: stderr-only, both human and JSON formats.
+ */
+describe('tip — always writes to stderr', () => {
+  function spawnEmitter(format: 'human' | 'json'): Promise<{ stdout: string; stderr: string }> {
+    const tempDir = mkdtempSync(join(tmpdir(), 'omni-tip-'));
+    const scriptPath = join(tempDir, 'emit.ts');
+    const outputModulePath = join(import.meta.dir, '..', 'output.ts');
+    const importPath = outputModulePath.replace(/\\/g, '/').replace(/'/g, "\\'");
+    const script = `
+import { tip, flushStdout } from '${importPath}';
+tip('canonical command is omni connect');
+await flushStdout();
+`;
+    writeFileSync(scriptPath, script);
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('bun', [scriptPath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, OMNI_FORMAT: format },
+      });
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+      child.on('close', () => {
+        rmSync(tempDir, { recursive: true, force: true });
+        resolve({
+          stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        });
+      });
+      child.on('error', reject);
+    });
+  }
+
+  test('human format: tip lands on stderr, stdout stays empty', async () => {
+    const { stdout, stderr } = await spawnEmitter('human');
+    expect(stdout).toBe('');
+    expect(stderr).toContain('canonical command is omni connect');
+  });
+
+  test('json format: tip lands on stderr as JSON, stdout stays empty', async () => {
+    const { stdout, stderr } = await spawnEmitter('json');
+    expect(stdout).toBe('');
+    // stderr must be valid JSON with a `tip` field — CI scripts that pipe
+    // stdout into jq must remain unaffected by the nudge.
+    const parsed = JSON.parse(stderr.trim());
+    expect(parsed).toHaveProperty('tip', 'canonical command is omni connect');
   });
 });
 

--- a/packages/cli/src/commands/providers.ts
+++ b/packages/cli/src/commands/providers.ts
@@ -325,6 +325,18 @@ async function handleCreate(options: {
     output.info(
       `  2. Assign to instance: omni instances update <instance-id> --agent-provider ${provider.id}${options.defaultAgentId ? ` --agent ${options.defaultAgentId}` : ''}`,
     );
+
+    // Deprecation nudge — for genie-backed providers, the operator usually
+    // wants the full wire (provider + agent + instance binding) which
+    // `omni connect <instance> <agent>` does in one step (or the
+    // `/genie:omni` skill from a Claude session). Power users keep using
+    // `providers create` directly; everyone else gets steered toward the
+    // canonical command. Stderr-only so CI grep on stdout stays stable.
+    if (options.schema === 'nats-genie' && options.agentName) {
+      output.tip(
+        `For genie-backed agents, prefer 'omni connect <instance-id> ${options.agentName}' (or '/genie:omni' from a Claude session) — it creates the provider, the agent record, and binds the instance in one step. This command stays for power users.`,
+      );
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     output.error(`Failed to create provider: ${message}`);

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -106,6 +106,27 @@ export function warn(message: string): void {
   }
 }
 
+/**
+ * Output a deprecation tip / nudge — ALWAYS to stderr regardless of format.
+ *
+ * Unlike `info` / `warn`, this never goes to stdout so CI scripts that grep
+ * stdout for command output remain unaffected. Use for "prefer X over Y"
+ * hints on legacy command paths that still work but are being deprioritized
+ * (e.g., the manual nats-genie wiring chain — operators should use
+ * `omni connect` or `/genie:omni` instead).
+ */
+export function tip(message: string): void {
+  const format = getCurrentFormat();
+
+  if (format === 'json') {
+    // biome-ignore lint/suspicious/noConsole: CLI output
+    console.error(JSON.stringify({ tip: message }));
+  } else {
+    // biome-ignore lint/suspicious/noConsole: CLI output (stderr by design)
+    console.error(`${c().cyan('💡')} ${message}`);
+  }
+}
+
 /** Output info message. In JSON mode, writes to stderr to keep stdout as valid JSON. */
 export function info(message: string): void {
   const format = getCurrentFormat();


### PR DESCRIPTION
## Summary

When operators run the legacy multi-command chain to wire a genie agent into omni:

```
omni providers create --schema nats-genie --agent-name <X> --target-agent <Y> ...
omni agents create --agent-provider <provider-id> ...
omni instances update <inst> --agent <id> --agent-provider <id>
omni agent-routes create --instance <id> --agent <id> ...
```

…they're recreating what `omni connect <instance-id> <agent-name>` does in one step (and what the upcoming `/genie:omni` skill will wrap in a wizard). This PR adds a **stderr-only** nudge on the most-visible legacy entry point — `omni providers create --schema nats-genie` — pointing operators at the canonical command without breaking anything that already works.

## Why nudge, not deprecate

- Power users / CI scripts that already drive the manual chain keep working.
- Stderr-only means `omni providers create --json | jq` stays clean.
- New operators see the steering hint immediately.

## What changed

**`packages/cli/src/output.ts`** — new `tip(message)` helper:
- Always writes to stderr (both `human` and `json` modes).
- `human` mode emits `💡 <message>` (cyan).
- `json` mode emits `{"tip": "..."}` line on stderr.
- Distinct from `info` / `warn` which can land on stdout in human mode.

**`packages/cli/src/commands/providers.ts`** — wiring in `handleCreate`:
- After successful provider creation, if `options.schema === 'nats-genie'` AND `options.agentName` is set, emit:
  ```
  💡 For genie-backed agents, prefer 'omni connect <instance-id> <agent-name>'
     (or '/genie:omni' from a Claude session) — it creates the provider, the
     agent record, and binds the instance in one step. This command stays
     for power users.
  ```

**`packages/cli/src/__tests__/output.test.ts`** — pins the contract:
- `tip` is in the exports list.
- Behavioral test: spawn child process, run `tip()` in `human` mode → stdout MUST be empty, stderr MUST contain the message.
- Same in `json` mode → stderr MUST be valid JSON `{"tip": "..."}`, stdout empty.

## Test plan

- [x] `bun test packages/cli/src/__tests__/output.test.ts` → **14/14 pass** (+2 new tests pinning stderr-only contract for both formats)
- [x] `make typecheck` → green
- [x] `bunx biome check` on the three touched files → clean
- [x] Full pre-push suite → **3807 tests, 0 fail, 9014 expect() calls**

## Scope (intentionally narrow)

This PR covers **only** the schema-detected case (`providers create --schema nats-genie`). Three more legacy entry points need the same nudge but require a provider fetch to detect the nats-genie context indirectly:

- `omni agents create --agent-provider <id>` — must fetch provider, check schema
- `omni instances update <id> --agent <id>` — must fetch new agent's provider
- `omni agent-routes create ... --agent <id>` — same

Those land in a follow-up PR to keep this one focused on the foundation (the new `tip()` helper) plus the simplest wiring.

## Context

Tracked under the **canonical-genie-omni-wiring** wish (Wave 3 / Group 5, first half). The wish itself sits at `repos/genie/.genie/wishes/canonical-genie-omni-wiring/WISH.md` in the genie-configure repo. Companion brain entries + ADR: namastexlabs/genie-configure#10. Stale-hint fix in `omni connect` output: PR #552.

Triggered by a recent KHAL-V1-LAUNCH bridge incident where the operator misregistered a genie agent because there was no canonical command being suggested anywhere on the omni side. The nudge plus the subsequent `/genie:omni` skill (genie-side, separate PR) close that gap.