### PR TITLE
feat(cli): nudge operators toward 'omni connect' on indirect legacy paths

### DIFF
--- a/packages/cli/src/__tests__/genie-wiring-nudge.test.ts
+++ b/packages/cli/src/__tests__/genie-wiring-nudge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the shared deprecation-nudge helper used by:
+ *   - omni agents create        (when --agent-provider points at a nats-genie provider)
+ *   - omni instances update     (when --agent-provider points at a nats-genie provider)
+ *   - omni agent-routes create  (when --agent's provider is nats-genie, via 2-hop)
+ *
+ * Pins the contract:
+ *   - Emits the tip ONLY when the provider's schema is `nats-genie`.
+ *   - Stays silent for any other schema (`agno`, `webhook`, `claude-code`, etc.).
+ *   - Best-effort — provider lookup failures must NOT throw.
+ *   - The tip text references both `omni connect` and `/genie:omni`.
+ *
+ * Strategy: capture writes to `process.stderr` (where `output.tip` lands in
+ * both human and JSON modes — pinned by output.test.ts). ESM exports are
+ * read-only so we can't monkey-patch the module; intercepting stderr at the
+ * process level is the cleanest way to assert the behavior end-to-end.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { maybeNudgeForGenieBackedAgent } from '../utils/genie-wiring-nudge.js';
+
+let originalConsoleError: typeof console.error;
+let captured: string[];
+
+beforeEach(() => {
+  captured = [];
+  originalConsoleError = console.error;
+  console.error = ((...args: unknown[]) => {
+    captured.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+  }) as typeof console.error;
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+function makeFakeClient(provider: { schema: string } | Error | null) {
+  return {
+    providers: {
+      get: mock(async () => {
+        if (provider instanceof Error) throw provider;
+        if (provider === null) throw new Error('not found');
+        return provider;
+      }),
+    },
+  } as unknown as Parameters<typeof maybeNudgeForGenieBackedAgent>[0];
+}
+
+describe('maybeNudgeForGenieBackedAgent', () => {
+  test('emits the tip when schema is nats-genie (folds in agentName)', async () => {
+    const client = makeFakeClient({ schema: 'nats-genie' });
+    await maybeNudgeForGenieBackedAgent(client, 'provider-uuid', 'khal-os-3');
+
+    const stderr = captured.join('');
+    expect(stderr).toContain('omni connect');
+    expect(stderr).toContain('khal-os-3');
+    expect(stderr).toContain('/genie:omni');
+  });
+
+  test('uses <agent> placeholder when agentName is omitted', async () => {
+    const client = makeFakeClient({ schema: 'nats-genie' });
+    await maybeNudgeForGenieBackedAgent(client, 'provider-uuid');
+
+    const stderr = captured.join('');
+    expect(stderr).toContain('<agent>');
+  });
+
+  test('stays silent for non-nats-genie schemas', async () => {
+    for (const schema of ['agno', 'webhook', 'claude-code', 'a2a', 'ag-ui']) {
+      captured = [];
+      const client = makeFakeClient({ schema });
+      await maybeNudgeForGenieBackedAgent(client, 'provider-uuid', 'someone');
+      expect(captured.join('')).toBe('');
+    }
+  });
+
+  test('best-effort — provider lookup failures do not throw or nudge', async () => {
+    const client = makeFakeClient(new Error('ECONNREFUSED'));
+    // Must NOT throw
+    await maybeNudgeForGenieBackedAgent(client, 'provider-uuid', 'someone');
+    expect(captured.join('')).toBe('');
+  });
+});

--- a/packages/cli/src/commands/agent-routes.ts
+++ b/packages/cli/src/commands/agent-routes.ts
@@ -15,6 +15,7 @@ import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
 import { resolveInstanceId, resolveRouteId } from '../resolve.js';
+import { maybeNudgeForGenieBackedAgent } from '../utils/genie-wiring-nudge.js';
 
 type ReplyFilter =
   | { mode: string; conditions?: { onDm?: boolean; onMention?: boolean; onReply?: boolean } }
@@ -102,6 +103,25 @@ async function createAgentRouteAction(options: {
     });
 
     output.success(`Route created: ${route.id}`);
+
+    // Deprecation nudge — when the route's agent is bound to a nats-genie
+    // provider, the operator is recreating step 4 of the legacy 5-command
+    // wiring chain. The route create takes an agentId, so we have to do a
+    // 2-hop lookup (agent → provider) before checking the schema. All
+    // failures are silently swallowed: the nudge is a UX hint, not a
+    // contract.
+    if (options.agent) {
+      try {
+        const agent = await client.agents.get(options.agent);
+        const providerId = (agent as { agentProviderId?: string }).agentProviderId;
+        const agentName = (agent as { name?: string }).name;
+        if (providerId) {
+          await maybeNudgeForGenieBackedAgent(client, providerId, agentName);
+        }
+      } catch {
+        // best-effort; skip silently
+      }
+    }
     output.data(route);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -14,6 +14,7 @@ import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
 import { resolveAgentId } from '../resolve.js';
+import { maybeNudgeForGenieBackedAgent } from '../utils/genie-wiring-nudge.js';
 
 const VALID_PROVIDERS = ['claude', 'agno', 'openai', 'gemini', 'custom', 'omni-internal'] as const;
 type AgentProvider = (typeof VALID_PROVIDERS)[number];
@@ -245,9 +246,20 @@ export function createAgentsCommand(): Command {
       const body = buildCreateAgentBody(options);
 
       try {
-        const agent = await getClient().agents.create(body);
+        const client = getClient();
+        const agent = await client.agents.create(body);
         output.success(`Agent created: ${agent.id}`);
         output.data(agent);
+
+        // Deprecation nudge — when the agent is bound to a nats-genie
+        // provider, the operator is recreating step 2 of the legacy
+        // 5-command wiring chain. `omni connect <instance> <agent>` does
+        // the same thing in one step, plus binds the instance. Stderr-only
+        // so CI stdout grep stays stable. The fetch is best-effort: if the
+        // provider lookup fails, we silently skip the nudge.
+        if (options.agentProvider) {
+          await maybeNudgeForGenieBackedAgent(client, options.agentProvider, agent.name);
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to create agent: ${message}`);

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -24,6 +24,7 @@ import qrcode from 'qrcode-terminal';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
 import { resolveInstanceId } from '../resolve.js';
+import { maybeNudgeForGenieBackedAgent } from '../utils/genie-wiring-nudge.js';
 
 const VALID_CHANNELS: Channel[] = [
   'whatsapp-baileys',
@@ -921,6 +922,17 @@ export function createInstancesCommand(): Command {
         if (Object.keys(body).length > 0) {
           await client.instances.update(id, body);
           output.success(`Instance updated: ${id}`, body);
+
+          // Deprecation nudge — when an operator binds an instance to a
+          // genie-backed agent via `--agent-provider <id>`, they're
+          // recreating step 3 of the legacy 5-command wiring chain.
+          // `omni connect <instance> <agent>` does the same thing in one
+          // step (and creates the provider if it doesn't exist yet).
+          // Best-effort lookup; nudge is stderr-only.
+          const agentProviderId = options.agentProvider as string | undefined;
+          if (agentProviderId && agentProviderId !== 'null') {
+            await maybeNudgeForGenieBackedAgent(client, agentProviderId);
+          }
         } else if (!options.profileName) {
           output.error('No update options provided. Use --help to see all available options.');
         }

--- a/packages/cli/src/utils/genie-wiring-nudge.ts
+++ b/packages/cli/src/utils/genie-wiring-nudge.ts
@@ -1,0 +1,55 @@
+/**
+ * Genie Wiring Deprecation Nudge
+ *
+ * Shared helper that emits a stderr tip when an operator runs one of the
+ * legacy multi-command genie-wiring entry points (`agents create`,
+ * `instances update --agent`, `agent-routes create`) on a `nats-genie`
+ * provider. The tip steers them toward the canonical
+ * `omni connect <instance> <agent>` (or the `/genie:omni` skill from a
+ * Claude session) without breaking the legacy path.
+ *
+ * Why a shared helper: each caller needs the same provider-fetch +
+ * schema-check logic. A single helper keeps the nudge text in one place
+ * and makes the "best-effort, never throw" semantics explicit.
+ *
+ * Tracked under the canonical-genie-omni-wiring wish (Wave 3 / Group 5,
+ * second half — indirect-detection). The schema-detected case
+ * (`providers create --schema nats-genie`) was wired in PR #553.
+ */
+
+import type { OmniClient } from '@omni/sdk';
+import * as output from '../output.js';
+
+/**
+ * If `providerId` references a provider whose schema is `nats-genie`,
+ * emit the deprecation nudge to stderr. Best-effort: if the provider
+ * lookup fails (network, 404, etc.), silently skip — the nudge is a
+ * UX hint, not a contract.
+ *
+ * @param agentName Optional agent name to fold into the suggested
+ *   `omni connect <instance> <agentName>` example. When omitted (e.g.,
+ *   `agent-routes create` doesn't always know the agent's display name),
+ *   the example uses a placeholder.
+ */
+export async function maybeNudgeForGenieBackedAgent(
+  client: OmniClient,
+  providerId: string,
+  agentName?: string,
+): Promise<void> {
+  let schema: string | undefined;
+  try {
+    const provider = await client.providers.get(providerId);
+    schema = (provider as { schema?: string }).schema;
+  } catch {
+    // Provider lookup failed — silently skip. The legacy command itself
+    // will surface any real error from its own code path.
+    return;
+  }
+
+  if (schema !== 'nats-genie') return;
+
+  const agentSlot = agentName ?? '<agent>';
+  output.tip(
+    `For genie-backed agents, prefer 'omni connect <instance-id> ${agentSlot}' (or '/genie:omni' from a Claude session) — it creates the provider, the agent record, and binds the instance in one step. This command stays for power users.`,
+  );
+}


### PR DESCRIPTION
## Summary

Extends the deprecation nudge from PR #553 to the **three remaining legacy entry points** in the manual genie-wiring chain. After this PR, every command an operator can reach for to wire a genie-backed agent into omni emits a stderr nudge pointing at the canonical `omni connect <instance> <agent>` (or the `/genie:omni` skill from a Claude session).

## Coverage matrix

| Entry point | Detection | Status |
|---|---|---|
| `omni providers create --schema nats-genie` | Direct (flag value) | ✅ shipped in #553 |
| `omni agents create --agent-provider <id>` | Indirect (1-hop fetch) | **this PR** |
| `omni instances update <id> --agent-provider <id>` | Indirect (1-hop fetch) | **this PR** |
| `omni agent-routes create ... --agent <agent-uuid>` | Indirect (2-hop: agent → provider) | **this PR** |

All paths share a new helper at `packages/cli/src/utils/genie-wiring-nudge.ts`:

```ts
export async function maybeNudgeForGenieBackedAgent(
  client: OmniClient,
  providerId: string,
  agentName?: string,
): Promise<void>
```

- Fetches the provider via `client.providers.get(providerId)`.
- Checks `provider.schema === 'nats-genie'`.
- If true, emits `output.tip(...)` (stderr-only, per #553's contract).
- **Best-effort** — provider lookup failures (network, 404) are silently swallowed; the nudge is a UX hint, not a contract.
- Folds `agentName` into the suggested command when known; falls back to `<agent>` placeholder when not (e.g., routes create where the SDK doesn't surface the display name on the resolved agent UUID).

## Why best-effort

The legacy commands are still meant to work. If the provider lookup fails (CI sandbox, transient network, race), we don't want to:

1. Throw and break the legacy command's normal flow.
2. Print a misleading error.
3. Pollute stderr with a noisy "could not check schema" line.

A silent skip is the right behavior — operators who genuinely use a non-nats-genie provider (or who hit a transient lookup failure) see no extra noise.

## Test plan

- [x] `bun test packages/cli/src/__tests__/genie-wiring-nudge.test.ts` → **4/4 pass**
  - Pins: emit on `nats-genie`, silent on `agno`/`webhook`/`claude-code`/`a2a`/`ag-ui`, no-throw on lookup failure, agentName folded in
- [x] `bun test packages/cli/src/__tests__/output.test.ts packages/cli/src/__tests__/connect.test.ts` → 22/22 pass (no regression)
- [x] `make typecheck` → green
- [x] `bunx biome check` on all 5 touched files → clean
- [x] Pre-push gate (full typecheck + lint + dead-code + skills/wishes lint + emit-discipline + 3800+ tests) → all green

## What changed

| File | Change |
|---|---|
| `packages/cli/src/utils/genie-wiring-nudge.ts` (new) | Shared helper. Single source of truth for the nudge text + best-effort semantics. |
| `packages/cli/src/commands/agents.ts` | After `agents create` success, if `--agent-provider` was set, call the helper with the resolved agent's name. |
| `packages/cli/src/commands/instances.ts` | After `instances update` success, if the patch body included an `agentProviderId` (from `--agent-provider`), call the helper. |
| `packages/cli/src/commands/agent-routes.ts` | After `routes create` success, if `--agent` was set, fetch the agent to find `agentProviderId`, then call the helper. 2-hop is its own try/catch. |
| `packages/cli/src/__tests__/genie-wiring-nudge.test.ts` (new) | Unit tests pinning all four contract clauses. |

## Cross-PR coordination

This is the **seventh and final** micro-delivery of the `canonical-genie-omni-wiring` wish on the omni side:

| # | Repo | PR | Status |
|---|---|---|---|
| 1 | `namastexlabs/genie-configure` | [#10](https://github.com/namastexlabs/genie-configure/pull/10) | merged — knowledge layer + ADR |
| 2 | `automagik-dev/omni` | [#552](https://github.com/automagik-dev/omni/pull/552) | merged — drop stale `genie omni start` |
| 3 | `automagik-dev/omni` | [#553](https://github.com/automagik-dev/omni/pull/553) | merged — `tip()` helper + direct nudge |
| 4 | `automagik-dev/genie` | [#1514](https://github.com/automagik-dev/genie/pull/1514) | merged — symlink validation + `--skip-omni` warning |
| 5 | `automagik-dev/genie` | [#1516](https://github.com/automagik-dev/genie/pull/1516) | open — `/genie:omni` skill |
| 6 | `automagik-dev/genie` | [#1518](https://github.com/automagik-dev/genie/pull/1518) | open — `dir edit --dir` relocation |
| **7** | `automagik-dev/omni` | **this PR** | indirect-detection nudges (3 paths) |

After this PR lands, the wish's defect ledger is fully addressed:

- D1 (symlink loophole) → genie #1514 ✅
- D2 (`--skip-omni` silent) → genie #1514 ✅
- D3 (stale `genie omni start`) → omni #552 ✅
- D4 (`dir edit` chicken-and-egg) → genie #1518 (open)
- D5 (per-host fingerprint trust) → **deferred to a follow-up wish** (security review needed)
- D6 (brain has no record) → genie-configure #10 ✅

The deferred D5 will be filed as its own wish once this rollout settles.