### PR TITLE
feat(api): POST /trust/handshake — idempotent genie-host registration (D5 Group 1.1)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/trust-handshake.test.ts
+++ b/packages/api/src/routes/v2/__tests__/trust-handshake.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Route-layer tests for the genie-host fingerprint handshake.
+ *
+ * Contract (from omni-host-fingerprint-trust wish, Group 1.1):
+ *   POST /trust/handshake
+ *     - rejects malformed pubkeys with 400 (no service call)
+ *     - returns 201 + the host record on first registration
+ *     - returns 200 + the EXISTING host record on idempotent replay
+ *       (does NOT mutate hostname or capabilities)
+ *
+ * Strategy: stub the GenieHostsService at the Hono variable layer so the
+ * route handler exercises the full validator + branching logic without a
+ * real DB. Mirrors `keys-admin-route-guard.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { trustRoutes } from '../trust';
+
+interface FakeHost {
+  id: string;
+  pubkey: string;
+  hostname: string;
+  capabilities: Record<string, unknown>;
+  scopes: string[];
+  lastSeenAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function makeHost(overrides: Partial<FakeHost> = {}): FakeHost {
+  const now = new Date();
+  return {
+    id: 'host-uuid-aaaa',
+    pubkey: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    hostname: 'genie.local',
+    capabilities: {},
+    scopes: ['*'],
+    lastSeenAt: null,
+    revokedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+interface RegisterInput {
+  pubkey: string;
+  hostname: string;
+  capabilities?: Record<string, unknown>;
+}
+
+function mountTrust(opts: {
+  findByPubkey?: (pubkey: string) => Promise<FakeHost | null>;
+  register?: (input: RegisterInput) => Promise<FakeHost>;
+  listActive?: () => Promise<FakeHost[]>;
+}): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      genieHosts: {
+        findByPubkey: opts.findByPubkey ?? (async () => null),
+        register: opts.register ?? (async (input: RegisterInput) => makeHost(input)),
+        listActive: opts.listActive ?? (async () => []),
+      },
+    } as never);
+    await next();
+  });
+  app.route('/trust', trustRoutes);
+  return app;
+}
+
+async function postJson(app: Hono<{ Variables: AppVariables }>, path: string, body: unknown) {
+  const res = await app.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+describe('POST /trust/handshake', () => {
+  test('rejects pubkey that is not base64url 32-bytes (400)', async () => {
+    const app = mountTrust({});
+    const { status } = await postJson(app, '/trust/handshake', {
+      pubkey: 'not-a-real-key',
+      hostname: 'genie.local',
+    });
+    expect(status).toBe(400);
+  });
+
+  test('rejects empty hostname (400)', async () => {
+    const app = mountTrust({});
+    const { status } = await postJson(app, '/trust/handshake', {
+      pubkey: 'A'.repeat(43),
+      hostname: '',
+    });
+    expect(status).toBe(400);
+  });
+
+  test('first registration returns 201 + the new host record', async () => {
+    const validKey = 'A'.repeat(43);
+    let registerCalled = false;
+    const app = mountTrust({
+      findByPubkey: async () => null,
+      register: async (input) => {
+        registerCalled = true;
+        return makeHost({ pubkey: input.pubkey, hostname: input.hostname });
+      },
+    });
+    const { status, json } = await postJson(app, '/trust/handshake', {
+      pubkey: validKey,
+      hostname: 'fresh.host',
+    });
+    expect(status).toBe(201);
+    expect(registerCalled).toBe(true);
+    expect((json as { data: { hostname: string } }).data.hostname).toBe('fresh.host');
+  });
+
+  test('idempotent replay returns 200 + the EXISTING host record (no register call)', async () => {
+    const validKey = 'B'.repeat(43);
+    let registerCalled = false;
+    const app = mountTrust({
+      findByPubkey: async (pk) =>
+        pk === validKey ? makeHost({ id: 'host-existing', pubkey: validKey, hostname: 'existing.host' }) : null,
+      register: async () => {
+        registerCalled = true;
+        throw new Error('register MUST NOT be called on idempotent replay');
+      },
+    });
+    const { status, json } = await postJson(app, '/trust/handshake', {
+      pubkey: validKey,
+      hostname: 'someone-tried-to-rename-me',
+      capabilities: { tries: 'change me' },
+    });
+    expect(status).toBe(200);
+    expect(registerCalled).toBe(false);
+    // The replay returns the existing record — hostname is NOT overwritten
+    // by the new request body.
+    const data = (json as { data: { id: string; hostname: string } }).data;
+    expect(data.id).toBe('host-existing');
+    expect(data.hostname).toBe('existing.host');
+  });
+
+  test('accepts padded (44-char) base64url pubkey', async () => {
+    const padded = `${'C'.repeat(43)}=`;
+    const app = mountTrust({});
+    const { status } = await postJson(app, '/trust/handshake', {
+      pubkey: padded,
+      hostname: 'padded-key.host',
+    });
+    expect(status).toBe(201);
+  });
+});
+
+describe('GET /trust/hosts', () => {
+  test('returns the active host list', async () => {
+    const app = mountTrust({
+      listActive: async () => [makeHost({ id: 'h1', hostname: 'one' }), makeHost({ id: 'h2', hostname: 'two' })],
+    });
+    const res = await app.request('/trust/hosts');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { items: { id: string; hostname: string }[] };
+    expect(json.items).toHaveLength(2);
+    expect(json.items[0]?.hostname).toBe('one');
+    expect(json.items[1]?.hostname).toBe('two');
+  });
+});

--- a/packages/api/src/routes/v2/index.ts
+++ b/packages/api/src/routes/v2/index.ts
@@ -34,6 +34,7 @@ import { personsRoutes } from './persons';
 import { processedEventsRoutes } from './processed-events';
 import { providersRoutes } from './providers';
 import { settingsRoutes } from './settings';
+import { trustRoutes } from './trust';
 import { turnsRoutes } from './turns';
 import { voiceRoutes } from './voice';
 import { webhooksRoutes } from './webhooks';
@@ -65,6 +66,7 @@ v2Routes.route('/batch-jobs', batchJobsRoutes); // Batch job routes - must be be
 v2Routes.route('/keys', keysRoutes); // API key management
 v2Routes.route('/context', contextRoutes); // Conversation context for turn-based agents
 v2Routes.route('/turns', turnsRoutes); // Turn lifecycle for turn-based agents
+v2Routes.route('/trust', trustRoutes); // Genie host fingerprint trust (omni-host-fingerprint-trust wish)
 v2Routes.route('/', payloadsRoutes); // Payloads routes at /api/v2/events/:id/payloads and /api/v2/payload-config
 v2Routes.route('/', webhooksRoutes); // Webhook routes at /api/v2/webhooks/:source, /api/v2/webhook-sources, /api/v2/events/trigger
 v2Routes.route('/automations', automationsRoutes); // Automation routes at /api/v2/automations

--- a/packages/api/src/routes/v2/trust.ts
+++ b/packages/api/src/routes/v2/trust.ts
@@ -1,0 +1,73 @@
+/**
+ * Trust routes — per-host fingerprint registration.
+ *
+ * Wish: omni-host-fingerprint-trust (D5 follow-up to canonical-genie-omni-wiring).
+ * Group 1.1 of that wish.
+ *
+ * `POST /trust/handshake` is idempotent on `pubkey`. Re-registering the
+ * same key returns the existing host record unchanged. Hostname and
+ * capabilities are NOT mutated by handshake replays — operator-driven
+ * changes go through `omni trust update`/`revoke` commands (Group 1.2).
+ *
+ * Auth: this endpoint inherits the API's existing bearer-token auth
+ * middleware. A valid `omni_sk_…` is required to register a host. Once
+ * the verification middleware lands (Group 4), signed requests from
+ * already-registered hosts can ALSO authenticate, but the FIRST
+ * handshake always requires bearer auth — there's no other way to
+ * bootstrap trust for a brand-new host.
+ *
+ * Validation: pubkey must look like a base64url-encoded 32-byte ed25519
+ * key (44 chars, alphabet `[A-Za-z0-9_-]`, optional `=` padding). The
+ * actual cryptographic validation (is this a valid curve point?) lives
+ * in Group 4's verification middleware where it matters per-request;
+ * the format gate here just keeps obvious garbage out of the table.
+ */
+
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { AppVariables } from '../../types';
+
+const trustRoutes = new Hono<{ Variables: AppVariables }>();
+
+// ed25519 base64url(32 bytes) is 43 chars unpadded, 44 chars padded.
+// Allow either form; reject anything else as a fast-fail.
+const PUBKEY_PATTERN = /^[A-Za-z0-9_-]{43}=?$/;
+
+const handshakeSchema = z.object({
+  pubkey: z.string().regex(PUBKEY_PATTERN, 'pubkey must be base64url-encoded 32 bytes (ed25519 public key)'),
+  hostname: z.string().min(1).max(255),
+  capabilities: z.record(z.unknown()).optional(),
+});
+
+/**
+ * POST /trust/handshake — Register or look up a genie host by pubkey.
+ *
+ * Idempotent on pubkey. Returns 201 + the host record on first
+ * registration, 200 + the existing host record on replay.
+ */
+trustRoutes.post('/handshake', zValidator('json', handshakeSchema), async (c) => {
+  const input = c.req.valid('json');
+  const services = c.get('services');
+
+  const existing = await services.genieHosts.findByPubkey(input.pubkey);
+  if (existing) {
+    return c.json({ data: existing }, 200);
+  }
+
+  const host = await services.genieHosts.register(input);
+  return c.json({ data: host }, 201);
+});
+
+/**
+ * GET /trust/hosts — List active (non-revoked) genie hosts.
+ *
+ * Used by `omni trust list` (Group 1.2) and audit/admin UIs.
+ */
+trustRoutes.get('/hosts', async (c) => {
+  const services = c.get('services');
+  const items = await services.genieHosts.listActive();
+  return c.json({ items });
+});
+
+export { trustRoutes };

--- a/packages/api/src/services/genie-hosts.ts
+++ b/packages/api/src/services/genie-hosts.ts
@@ -1,0 +1,106 @@
+/**
+ * Genie Hosts Service — per-host fingerprint trust foundation.
+ *
+ * Reads/writes the `genie_hosts` table (see migration 0032). Drives the
+ * idempotent handshake (`POST /api/v2/trust/handshake`) and is consumed by
+ * the verification middleware (Group 4 of the wish) on every signed request.
+ *
+ * This service intentionally does NOT do crypto — it only stores the
+ * already-validated public key. Signature verification lives in Group 4's
+ * middleware. Keeping the service free of crypto means the data path can
+ * be reviewed independently of the verification path.
+ *
+ * Tracked under the `omni-host-fingerprint-trust` wish, Group 1.1.
+ */
+
+import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import { type GenieHost, genieHosts } from '@omni/db';
+import { and, eq, isNull } from 'drizzle-orm';
+
+const log = createLogger('genie-hosts');
+
+export interface RegisterHostInput {
+  /** ed25519 public key in base64url. Must be 44 chars (non-padded base64url of 32 bytes). */
+  pubkey: string;
+  /** Operator-meaningful display name. */
+  hostname: string;
+  /** Free-form metadata: { genieVersion, os, ... }. */
+  capabilities?: Record<string, unknown>;
+}
+
+export class GenieHostsService {
+  constructor(private db: Database) {}
+
+  /**
+   * Idempotent handshake. Re-registering the same `pubkey` returns the
+   * existing host record unchanged — DOES NOT overwrite hostname or
+   * capabilities (operator-driven changes go through `update`/`revoke`,
+   * not handshake replays).
+   *
+   * If the host was previously revoked, handshaking again does NOT
+   * un-revoke it — that's deliberate. Operators rotate via "revoke +
+   * register-with-new-key", which keeps the audit story clean.
+   */
+  async register(input: RegisterHostInput): Promise<GenieHost> {
+    const existing = await this.findByPubkey(input.pubkey);
+    if (existing) {
+      log.info('genie host handshake — idempotent reuse', { hostId: existing.id, hostname: existing.hostname });
+      return existing;
+    }
+
+    const [created] = await this.db
+      .insert(genieHosts)
+      .values({
+        pubkey: input.pubkey,
+        hostname: input.hostname,
+        capabilities: input.capabilities ?? {},
+      })
+      .returning();
+
+    if (!created) {
+      throw new Error('failed to insert genie host');
+    }
+
+    log.info('genie host registered', { hostId: created.id, hostname: created.hostname });
+    return created;
+  }
+
+  /** Lookup by public key — used by the handshake idempotency check + Group 4 verifier. */
+  async findByPubkey(pubkey: string): Promise<GenieHost | null> {
+    const [row] = await this.db.select().from(genieHosts).where(eq(genieHosts.pubkey, pubkey)).limit(1);
+    return row ?? null;
+  }
+
+  /** Lookup by host id — used by the verifier when the request carries `X-Genie-Host-Id`. */
+  async findById(id: string): Promise<GenieHost | null> {
+    const [row] = await this.db.select().from(genieHosts).where(eq(genieHosts.id, id)).limit(1);
+    return row ?? null;
+  }
+
+  /**
+   * List active hosts (revoked_at IS NULL) for `omni trust list` and audit
+   * UIs. Limit-bounded to keep payloads sane; operators with hundreds of
+   * hosts can paginate via name filters in a future iteration.
+   */
+  async listActive(limit = 100): Promise<GenieHost[]> {
+    return this.db
+      .select()
+      .from(genieHosts)
+      .where(isNull(genieHosts.revokedAt))
+      .orderBy(genieHosts.createdAt)
+      .limit(limit);
+  }
+
+  /**
+   * Update `last_seen_at`. Called by the Group 4 verification middleware
+   * on every successful signed request. No-op if the host is revoked
+   * (defense in depth — middleware should have rejected first).
+   */
+  async touchLastSeen(id: string): Promise<void> {
+    await this.db
+      .update(genieHosts)
+      .set({ lastSeenAt: new Date(), updatedAt: new Date() })
+      .where(and(eq(genieHosts.id, id), isNull(genieHosts.revokedAt)));
+  }
+}

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -33,6 +33,7 @@ import { EventOpsService } from './event-ops';
 import { EventService } from './events';
 import { FollowUpLifecycleService } from './follow-up-lifecycle';
 import { FollowUpSweeperService } from './follow-up-sweeper';
+import { GenieHostsService } from './genie-hosts';
 import { InstanceService } from './instances';
 import { MessageService } from './messages';
 import { PayloadStoreService } from './payload-store';
@@ -79,6 +80,7 @@ export interface Services {
   consumerOffsets: ConsumerOffsetService;
   followUpLifecycle: FollowUpLifecycleService;
   followUpSweeper: FollowUpSweeperService;
+  genieHosts: GenieHostsService;
 }
 
 /**
@@ -137,6 +139,7 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
     consumerOffsets: new ConsumerOffsetService(db),
     followUpLifecycle: new FollowUpLifecycleService(db, eventBus),
     followUpSweeper: new FollowUpSweeperService(db, eventBus),
+    genieHosts: new GenieHostsService(db),
   };
 }
 


### PR DESCRIPTION
## Summary

Group 1.1 of the **omni-host-fingerprint-trust** wish (D5 follow-up). Builds on the schema landed in #555 to expose the registration endpoint that `genie omni handshake` will call from the genie side (Group 2).

## Endpoints

```
POST /api/v2/trust/handshake
  body:    { pubkey, hostname, capabilities? }
  201:     first registration → returns { data: newHost }
  200:     idempotent replay  → returns { data: existingHost }
  400:     malformed pubkey or empty hostname

GET  /api/v2/trust/hosts
  200:     { items: [host, ...] }   (active hosts only — revokedAt IS NULL)
```

### Idempotency invariant

Re-registering the same `pubkey` returns the existing record **unchanged**. Hostname and capabilities are NOT mutated by handshake replays — operator-driven changes go through `omni trust update / revoke` (Group 1.2). This keeps the audit story clean: every change to a host's metadata is an explicit operator action, not a side-effect of a re-handshake.

### Auth model

The endpoint inherits the existing bearer-token middleware. A valid `omni_sk_…` is required to register a new host. Once Group 4's verification middleware lands, signed requests from already-registered hosts can ALSO authenticate, but the **first** handshake always requires bearer auth — there's no other way to bootstrap trust for a brand-new host.

### Validation

`pubkey` must look like a base64url-encoded 32-byte ed25519 key (43 chars unpadded or 44 chars padded; alphabet `[A-Za-z0-9_-]`, optional `=`). The actual cryptographic validation (is this a valid curve point?) lives in Group 4's per-request verifier — a format gate here just keeps obvious garbage out of the table.

## What changed

| File | Change |
|---|---|
| `packages/api/src/services/genie-hosts.ts` (new) | `GenieHostsService` with `register / findByPubkey / findById / listActive / touchLastSeen`. **No crypto** — only stores already-validated keys. Signature verification lives in Group 4's middleware so the data path can be reviewed independently. |
| `packages/api/src/services/index.ts` | Wire `GenieHostsService` into the `Services` container. |
| `packages/api/src/routes/v2/trust.ts` (new) | `POST /handshake` (idempotent on pubkey) + `GET /hosts` (active list). |
| `packages/api/src/routes/v2/index.ts` | Mount `/trust` under `/api/v2`. |
| `packages/api/src/routes/v2/__tests__/trust-handshake.test.ts` (new) | 6 contract tests covering: malformed pubkey rejection (400), empty hostname rejection (400), first registration (201), idempotent replay returns existing record without mutation (200), padded base64url accepted, GET list shape. |

## Test plan

- [x] `bun test packages/api/src/routes/v2/__tests__/trust-handshake.test.ts` → **6/6 pass**
- [x] `make typecheck` → green (FULL TURBO)
- [x] `bunx biome check` on touched files → clean
- [x] Pre-push gate (typecheck + lint + dead-code + 3815 tests) → all green

## What's NOT in (subsequent PRs)

| Group | Scope | Status |
|---|---|---|
| 1.2 | `omni trust list / get / update / revoke` CLI | next PR |
| 2 | `genie omni handshake` (genie-side keygen) | genie repo |
| 3 | genie request signing | genie repo |
| 4 | omni signature verification middleware | **security-review gate** |
| 5 | per-host scope enforcement | this repo |
| 6 | `--require-genie-signature` per-instance opt-in | this repo |
| 7 | brain entries + ADR | genie-configure repo |

## Context

Tracked under the `omni-host-fingerprint-trust` wish. Predecessor: #555 (the foundation schema, landed in this repo). Wish doc lives in the genie repo at `.genie/wishes/omni-host-fingerprint-trust/WISH.md` (filed in genie #1520).