### PR TITLE
feat(api,cli): omni trust namespace — list/get/update/revoke (D5 Group 1.2)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/trust-handshake.test.ts
+++ b/packages/api/src/routes/v2/__tests__/trust-handshake.test.ts
@@ -54,16 +54,22 @@ interface RegisterInput {
 
 function mountTrust(opts: {
   findByPubkey?: (pubkey: string) => Promise<FakeHost | null>;
+  findById?: (id: string) => Promise<FakeHost | null>;
   register?: (input: RegisterInput) => Promise<FakeHost>;
   listActive?: () => Promise<FakeHost[]>;
+  updateScopes?: (id: string, scopes: string[]) => Promise<FakeHost | null>;
+  revoke?: (id: string) => Promise<FakeHost | null>;
 }): Hono<{ Variables: AppVariables }> {
   const app = new Hono<{ Variables: AppVariables }>();
   app.use('*', async (c, next) => {
     c.set('services', {
       genieHosts: {
         findByPubkey: opts.findByPubkey ?? (async () => null),
+        findById: opts.findById ?? (async () => null),
         register: opts.register ?? (async (input: RegisterInput) => makeHost(input)),
         listActive: opts.listActive ?? (async () => []),
+        updateScopes: opts.updateScopes ?? (async () => null),
+        revoke: opts.revoke ?? (async () => null),
       },
     } as never);
     await next();
@@ -167,5 +173,109 @@ describe('GET /trust/hosts', () => {
     expect(json.items).toHaveLength(2);
     expect(json.items[0]?.hostname).toBe('one');
     expect(json.items[1]?.hostname).toBe('two');
+  });
+});
+
+const VALID_UUID = '11111111-2222-3333-4444-555555555555';
+
+describe('GET /trust/hosts/:id', () => {
+  test('returns 404 when host id does not exist', async () => {
+    const app = mountTrust({ findById: async () => null });
+    const res = await app.request(`/trust/hosts/${VALID_UUID}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 400 on malformed uuid', async () => {
+    const app = mountTrust({});
+    const res = await app.request('/trust/hosts/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns the host when found (active or revoked)', async () => {
+    const app = mountTrust({
+      findById: async (id) => (id === VALID_UUID ? makeHost({ id: VALID_UUID, hostname: 'gettable' }) : null),
+    });
+    const res = await app.request(`/trust/hosts/${VALID_UUID}`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { id: string; hostname: string } };
+    expect(json.data.id).toBe(VALID_UUID);
+    expect(json.data.hostname).toBe('gettable');
+  });
+});
+
+async function patchJson(app: Hono<{ Variables: AppVariables }>, path: string, body: unknown) {
+  const res = await app.request(path, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+describe('PATCH /trust/hosts/:id (update scopes)', () => {
+  test('replaces scopes wholesale and returns updated host', async () => {
+    let receivedScopes: string[] | undefined;
+    const app = mountTrust({
+      updateScopes: async (id, scopes) => {
+        receivedScopes = scopes;
+        return makeHost({ id, scopes });
+      },
+    });
+    const { status, json } = await patchJson(app, `/trust/hosts/${VALID_UUID}`, {
+      scopes: ['agents:write', 'providers:write'],
+    });
+    expect(status).toBe(200);
+    expect(receivedScopes).toEqual(['agents:write', 'providers:write']);
+    expect((json as { data: { scopes: string[] } }).data.scopes).toEqual(['agents:write', 'providers:write']);
+  });
+
+  test('returns 404 when host is revoked or missing', async () => {
+    const app = mountTrust({ updateScopes: async () => null });
+    const { status } = await patchJson(app, `/trust/hosts/${VALID_UUID}`, { scopes: ['x:write'] });
+    expect(status).toBe(404);
+  });
+
+  test('returns 400 on missing scopes field', async () => {
+    const app = mountTrust({});
+    const { status } = await patchJson(app, `/trust/hosts/${VALID_UUID}`, {});
+    expect(status).toBe(400);
+  });
+
+  test('accepts empty scopes array (means "nothing allowed")', async () => {
+    let receivedScopes: string[] | undefined;
+    const app = mountTrust({
+      updateScopes: async (id, scopes) => {
+        receivedScopes = scopes;
+        return makeHost({ id, scopes });
+      },
+    });
+    const { status } = await patchJson(app, `/trust/hosts/${VALID_UUID}`, { scopes: [] });
+    expect(status).toBe(200);
+    expect(receivedScopes).toEqual([]);
+  });
+});
+
+describe('DELETE /trust/hosts/:id (revoke)', () => {
+  test('returns 200 + the revoked host record', async () => {
+    let receivedId: string | undefined;
+    const app = mountTrust({
+      revoke: async (id) => {
+        receivedId = id;
+        return makeHost({ id, revokedAt: new Date() });
+      },
+    });
+    const res = await app.request(`/trust/hosts/${VALID_UUID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(receivedId).toBe(VALID_UUID);
+    const json = (await res.json()) as { data: { id: string; revokedAt: string | null } };
+    expect(json.data.id).toBe(VALID_UUID);
+    expect(json.data.revokedAt).not.toBeNull();
+  });
+
+  test('returns 404 when host already revoked or missing', async () => {
+    const app = mountTrust({ revoke: async () => null });
+    const res = await app.request(`/trust/hosts/${VALID_UUID}`, { method: 'DELETE' });
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/api/src/routes/v2/trust.ts
+++ b/packages/api/src/routes/v2/trust.ts
@@ -70,4 +70,69 @@ trustRoutes.get('/hosts', async (c) => {
   return c.json({ items });
 });
 
+const idParamSchema = z.object({ id: z.string().uuid() });
+
+/**
+ * GET /trust/hosts/:id — fetch one host by id (active or revoked).
+ *
+ * Returns 404 when the id doesn't resolve. `omni trust get` consumes this.
+ */
+trustRoutes.get('/hosts/:id', zValidator('param', idParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const services = c.get('services');
+  const host = await services.genieHosts.findById(id);
+  if (!host) {
+    return c.json({ error: { code: 'NOT_FOUND', message: `genie host ${id} not found` } }, 404);
+  }
+  return c.json({ data: host });
+});
+
+const updateScopesSchema = z.object({
+  scopes: z.array(z.string().min(1)).max(64),
+});
+
+/**
+ * PATCH /trust/hosts/:id — wholesale replace a host's scopes.
+ *
+ * Wholesale replace (not merge) is intentional: scopes are the authoritative
+ * permission grant for a host; operators specify the full new set explicitly.
+ * To narrow, pass fewer scopes; to widen, pass more; empty array = nothing
+ * allowed (effectively a soft-revoke without the audit tombstone).
+ *
+ * Returns 404 if the host is revoked or doesn't exist.
+ */
+trustRoutes.patch(
+  '/hosts/:id',
+  zValidator('param', idParamSchema),
+  zValidator('json', updateScopesSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const { scopes } = c.req.valid('json');
+    const services = c.get('services');
+    const host = await services.genieHosts.updateScopes(id, scopes);
+    if (!host) {
+      return c.json({ error: { code: 'NOT_FOUND', message: `genie host ${id} not found or revoked` } }, 404);
+    }
+    return c.json({ data: host });
+  },
+);
+
+/**
+ * DELETE /trust/hosts/:id — soft-delete (stamp revokedAt).
+ *
+ * Irreversible by design — to "un-revoke" a host, register a fresh keypair.
+ * The revoked record stays in the table as the audit tombstone. Idempotent
+ * on already-revoked rows (returns 404 to indicate the operation didn't
+ * change anything; the record itself still exists).
+ */
+trustRoutes.delete('/hosts/:id', zValidator('param', idParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const services = c.get('services');
+  const host = await services.genieHosts.revoke(id);
+  if (!host) {
+    return c.json({ error: { code: 'NOT_FOUND', message: `genie host ${id} not found or already revoked` } }, 404);
+  }
+  return c.json({ data: host });
+});
+
 export { trustRoutes };

--- a/packages/api/src/services/genie-hosts.ts
+++ b/packages/api/src/services/genie-hosts.ts
@@ -103,4 +103,46 @@ export class GenieHostsService {
       .set({ lastSeenAt: new Date(), updatedAt: new Date() })
       .where(and(eq(genieHosts.id, id), isNull(genieHosts.revokedAt)));
   }
+
+  /**
+   * Replace a host's scopes wholesale (operator-driven). Returns the
+   * updated host or null if the host doesn't exist / is revoked.
+   *
+   * Wholesale replace (not merge) is intentional: scopes are the
+   * authoritative permission grant for a host; operators specify the
+   * full new set explicitly. To narrow a host's permissions, pass
+   * fewer scopes; to widen, pass more. Empty array = nothing allowed.
+   */
+  async updateScopes(id: string, scopes: string[]): Promise<GenieHost | null> {
+    const [updated] = await this.db
+      .update(genieHosts)
+      .set({ scopes, updatedAt: new Date() })
+      .where(and(eq(genieHosts.id, id), isNull(genieHosts.revokedAt)))
+      .returning();
+    if (updated) {
+      log.info('genie host scopes updated', { hostId: updated.id, scopes });
+    }
+    return updated ?? null;
+  }
+
+  /**
+   * Soft-delete: stamp `revoked_at`. Irreversible by design — to
+   * "un-revoke" a host, register a fresh keypair (the previous record
+   * stays around for the audit trail).
+   *
+   * Returns the revoked host or null if it didn't exist / was already
+   * revoked. Idempotent on already-revoked records.
+   */
+  async revoke(id: string): Promise<GenieHost | null> {
+    const now = new Date();
+    const [revoked] = await this.db
+      .update(genieHosts)
+      .set({ revokedAt: now, updatedAt: now })
+      .where(and(eq(genieHosts.id, id), isNull(genieHosts.revokedAt)))
+      .returning();
+    if (revoked) {
+      log.info('genie host revoked', { hostId: revoked.id, hostname: revoked.hostname });
+    }
+    return revoked ?? null;
+  }
 }

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -1,0 +1,157 @@
+/**
+ * Trust Commands — manage genie host fingerprint registrations.
+ *
+ *   omni trust list                            List active genie hosts
+ *   omni trust get <id>                        Show one host (active or revoked)
+ *   omni trust update <id> --scope <a,b,c>     Replace host scopes wholesale
+ *   omni trust revoke <id>                     Soft-delete (stamps revoked_at)
+ *
+ * Wish: omni-host-fingerprint-trust, Group 1.2. Talks to the
+ * `/api/v2/trust/hosts` endpoints landed in Group 1.1 (#556).
+ *
+ * Why raw fetch instead of the OmniClient SDK: trust types aren't in the
+ * OpenAPI spec yet (the SDK is generated from there). Adding them requires
+ * a regen + version bump; out of scope for this PR. We use the same
+ * baseUrl / apiKey the SDK uses, so behavior is identical.
+ */
+
+import { Command } from 'commander';
+import { hasAuth, loadConfig } from '../config.js';
+import * as output from '../output.js';
+
+interface TrustHost {
+  id: string;
+  pubkey: string;
+  hostname: string;
+  capabilities: Record<string, unknown>;
+  scopes: string[];
+  lastSeenAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function trustEndpoint(path: string): string {
+  if (!hasAuth()) {
+    output.error('Not authenticated. Run: omni auth login --api-key <key>', undefined, 2);
+  }
+  const config = loadConfig();
+  const baseUrl = (config.apiUrl ?? 'http://localhost:8882').replace(/\/+$/, '');
+  return `${baseUrl}/api/v2/trust${path}`;
+}
+
+function authHeaders(): Record<string, string> {
+  const config = loadConfig();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+  return headers;
+}
+
+async function callApi<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const res = await fetch(trustEndpoint(path), {
+    method,
+    headers: authHeaders(),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`HTTP ${res.status} ${res.statusText}${text ? `: ${text}` : ''}`);
+  }
+  return (await res.json()) as T;
+}
+
+function formatHostRow(host: TrustHost): Record<string, string> {
+  return {
+    id: host.id.slice(0, 8),
+    hostname: host.hostname,
+    scopes: host.scopes.join(', ') || '(none)',
+    pubkeyPrefix: `${host.pubkey.slice(0, 12)}…`,
+    lastSeen: host.lastSeenAt ? new Date(host.lastSeenAt).toISOString().replace('T', ' ').slice(0, 16) : 'never',
+    status: host.revokedAt ? 'revoked' : 'active',
+  };
+}
+
+// ============================================================================
+// Subcommand actions
+// ============================================================================
+
+async function handleList(): Promise<void> {
+  try {
+    const { items } = await callApi<{ items: TrustHost[] }>('GET', '/hosts');
+    output.list(items.map(formatHostRow), {
+      emptyMessage: 'No genie hosts registered. Run `genie omni handshake` from a genie installation to register one.',
+      rawData: items,
+    });
+  } catch (err) {
+    output.error(`Failed to list genie hosts: ${err instanceof Error ? err.message : 'Unknown error'}`);
+  }
+}
+
+async function handleGet(id: string): Promise<void> {
+  try {
+    const { data } = await callApi<{ data: TrustHost }>('GET', `/hosts/${encodeURIComponent(id)}`);
+    output.data(data);
+  } catch (err) {
+    output.error(`Failed to get genie host: ${err instanceof Error ? err.message : 'Unknown error'}`);
+  }
+}
+
+async function handleUpdate(id: string, options: { scope: string }): Promise<void> {
+  // Wholesale replace: operators provide the FULL new scope set.
+  // Comma-separated string keeps the CLI ergonomic; the API takes an array.
+  const scopes = options.scope
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (scopes.length === 0) {
+    output.error('--scope must contain at least one scope (use `omni trust revoke <id>` to deny everything).');
+  }
+  try {
+    const { data } = await callApi<{ data: TrustHost }>('PATCH', `/hosts/${encodeURIComponent(id)}`, { scopes });
+    output.success(`Updated genie host ${data.id} scopes: ${data.scopes.join(', ')}`);
+    output.data(data);
+  } catch (err) {
+    output.error(`Failed to update genie host: ${err instanceof Error ? err.message : 'Unknown error'}`);
+  }
+}
+
+async function handleRevoke(id: string): Promise<void> {
+  try {
+    const { data } = await callApi<{ data: TrustHost }>('DELETE', `/hosts/${encodeURIComponent(id)}`);
+    output.success(`Revoked genie host ${data.id} (${data.hostname}). Tombstone kept for audit.`);
+    output.data(data);
+  } catch (err) {
+    output.error(`Failed to revoke genie host: ${err instanceof Error ? err.message : 'Unknown error'}`);
+  }
+}
+
+// ============================================================================
+// Command factory
+// ============================================================================
+
+export function createTrustCommand(): Command {
+  const trust = new Command('trust').description('Manage genie host fingerprint registrations');
+
+  trust.command('list').description('List active (non-revoked) genie hosts').action(handleList);
+
+  trust.command('get <id>').description('Show details for one genie host (active or revoked)').action(handleGet);
+
+  trust
+    .command('update <id>')
+    .description('Replace a genie host scopes (comma-separated)')
+    .requiredOption('--scope <list>', 'Comma-separated scope list, e.g. "agents:write,providers:write"')
+    .action(handleUpdate);
+
+  trust
+    .command('revoke <id>')
+    .description('Revoke a genie host (irreversible — re-register with a fresh keypair to restore trust)')
+    .action(handleRevoke);
+
+  return trust;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,6 +55,7 @@ import { createSpeakCommand } from './commands/speak.js';
 import { createStartCommand } from './commands/start.js';
 import { createStatusCommand } from './commands/status.js';
 import { createStopCommand } from './commands/stop.js';
+import { createTrustCommand } from './commands/trust.js';
 import { createTtsCommand } from './commands/tts.js';
 import { createTurnsCommand } from './commands/turns.js';
 import { createUpdateCommand } from './commands/update.js';
@@ -264,6 +265,12 @@ const COMMANDS: CommandDef[] = [
     category: 'core',
     helpGroup: 'Management',
     helpDescription: 'API key management',
+  },
+  {
+    create: createTrustCommand,
+    category: 'advanced',
+    helpGroup: 'Management',
+    helpDescription: 'Genie host fingerprint trust (omni-host-fingerprint-trust wish)',
   },
   {
     create: createAccessCommand,


### PR DESCRIPTION
## Summary

Group 1.2 of the **omni-host-fingerprint-trust** wish. Adds the operator surface that Group 1.1's handshake foundation enables: API endpoints to read/update/revoke registered genie hosts, plus the matching `omni trust` CLI namespace.

**This PR stacks on top of #556** (handshake endpoint). After both merge, all of Group 1 is in.

## API endpoints added

| Method | Path | Returns |
|---|---|---|
| `GET` | `/trust/hosts/:id` | 200 + `{ data }` \| 404 missing |
| `PATCH` | `/trust/hosts/:id` | 200 + `{ data }` \| 404 if revoked/missing. Body: `{ scopes: string[] }` |
| `DELETE` | `/trust/hosts/:id` | 200 + revoked record \| 404 already revoked |

**Wholesale-replace semantics for scopes** — operators specify the full new set explicitly. To narrow, pass fewer; to widen, pass more; empty array = "nothing allowed". Merge semantics would invite "I forgot a scope" bugs that are silent until rollout.

**Soft-delete via `revokedAt`** — irreversible by design. To restore trust, register a fresh keypair (the previous record stays as the audit tombstone).

## CLI namespace

```
omni trust list                              List active hosts
omni trust get <id>                          Show one (active or revoked)
omni trust update <id> --scope <a,b,c>       Replace scopes wholesale
omni trust revoke <id>                       Soft-delete (irreversible)
```

The CLI uses raw fetch with the same `baseUrl` / `apiKey` the SDK uses, because trust types aren't in the OpenAPI spec yet (the SDK is generated from there). Adding them = regen + version bump; out of scope for this PR. Tracked as a follow-up cleanup.

## What changed

| File | Change |
|---|---|
| `packages/api/src/services/genie-hosts.ts` | + `updateScopes(id, scopes)` (wholesale replace, returns null if revoked) and `revoke(id)` (soft-delete, idempotent on already-revoked) |
| `packages/api/src/routes/v2/trust.ts` | + 3 new endpoints (`GET /:id`, `PATCH /:id`, `DELETE /:id`) |
| `packages/api/src/routes/v2/__tests__/trust-handshake.test.ts` | +9 contract tests for the new endpoints |
| `packages/cli/src/commands/trust.ts` (new) | `omni trust` Commander namespace with 4 subcommands |
| `packages/cli/src/index.ts` | Register `createTrustCommand` in the command registry |

## Test plan

- [x] `bun test packages/api/src/routes/v2/__tests__/trust-handshake.test.ts` → **15/15 pass** (6 from Group 1.1 + 9 new)
- [x] `make typecheck` → green (FULL TURBO)
- [x] `bunx biome check` on touched files → clean
- [x] Pre-push gate (typecheck + lint + dead-code + 3815 tests) → all green

## Cross-PR coordination

This is the third micro-delivery of the omni-host-fingerprint-trust wish. After this lands:

| Group | Repo | PR | Status |
|---|---|---|---|
| 1.0 | omni | #555 | ✅ merged |
| 1.1 | omni | #556 | ⏳ open (this PR is based on it) |
| **1.2** | omni | **this PR** | open |
| 2 | genie | next | `genie omni handshake` command |
| 3 | genie | next | genie request signing |
| 4 | omni | next | verification middleware **(security review)** |
| 5 | omni | next | per-host scope **enforcement** (this PR only stores them) |
| 6 | omni | next | `--require-genie-signature` per-instance opt-in |
| 7 | genie-configure | next | brain entries + ADR |

Wish doc: `<genie-repo>/.genie/wishes/omni-host-fingerprint-trust/WISH.md` (filed in genie #1520).