### PR TITLE
feat(api): verify X-Genie-Signature on incoming requests (Group 4)

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -43,6 +43,7 @@ function getAllowedOrigins(): string[] | '*' {
 
 import { authMiddleware, requireInstanceAccess } from './middleware/auth';
 import { defaultBodyLimitMiddleware } from './middleware/body-limit';
+import { genieSignatureMiddleware } from './middleware/genie-signature';
 import { outputRedactorMiddleware } from './middleware/output-redactor';
 import { scopeEnforcerMiddleware } from './middleware/scope-enforcer';
 
@@ -251,6 +252,14 @@ export function createApp(
   const protectedApp = new Hono<{ Variables: AppVariables }>();
   protectedApp.use('*', authMiddleware);
   protectedApp.use('*', scopeEnforcerMiddleware);
+  // Genie host signature verification — additive in this rollout. When the
+  // request carries the `X-Genie-Signature` header set, the middleware
+  // verifies it (replay-window + ed25519) and sets `signedBy` on context
+  // for downstream audit. Missing headers fall through unchanged. The
+  // per-instance enforcement opt-in (`--require-genie-signature`, Group 6
+  // of the omni-host-fingerprint-trust wish) flips this from "verify when
+  // present" to "require always".
+  protectedApp.use('*', genieSignatureMiddleware);
   protectedApp.use('*', outputRedactorMiddleware);
   protectedApp.use('*', rateLimitMiddleware);
 

--- a/packages/api/src/middleware/__tests__/genie-signature.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Unit tests for the Genie host signature verifier.
+ *
+ * Wish: omni-host-fingerprint-trust, Group 4.
+ *
+ * Strategy: drive `verifySignature()` directly with synthetic ed25519 keys
+ * (no DB, no Hono). The middleware wrapper is thin enough that exercising
+ * the pure verifier covers the contract; the few lines of Hono glue get a
+ * smoke test at the bottom.
+ *
+ * Coverage target — the Group 4 acceptance criteria from the wish:
+ *   - valid signature → status=verified, hostId set
+ *   - missing all 3 headers → status=no-signature (bearer fall-through)
+ *   - partial headers (only some) → status=invalid
+ *   - tampered body → status=invalid
+ *   - tampered path → status=invalid
+ *   - tampered method → status=invalid
+ *   - stale timestamp (>60s) → status=invalid
+ *   - future timestamp (>60s ahead) → status=invalid
+ *   - malformed timestamp → status=invalid
+ *   - unknown host_id → status=invalid
+ *   - revoked host → status=invalid
+ *   - malformed signature (not base64url) decodes to empty/wrong bytes → status=invalid
+ *   - unparseable pubkey on the server side → status=invalid
+ *
+ * Cross-system note: the canonical signing input MUST byte-exactly match
+ * the genie-side signer (`src/lib/omni-signature.ts`). One of the tests
+ * pins the exact wire bytes for a known input to catch silent drift.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { type KeyObject, createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { canonicalSigningInput, verifySignature } from '../genie-signature';
+
+interface TestHost {
+  id: string;
+  pubkey: string;
+  revokedAt: Date | null;
+}
+
+/**
+ * Mint a fresh ed25519 keypair, return the base64url pubkey + a signer
+ * function that produces base64url signatures over arbitrary canonical
+ * inputs. Mirrors what genie's `signOmniRequest` does on the wire.
+ */
+function freshKeypair(): { pubkeyB64Url: string; signCanonical: (canonical: string) => string; privateKey: KeyObject } {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  // Strip the 12-byte SPKI prefix to get the raw 32-byte pubkey, then
+  // base64url-encode it.
+  const spki = publicKey.export({ format: 'der', type: 'spki' });
+  const raw = spki.subarray(spki.byteLength - 32);
+  const pubkeyB64Url = Buffer.from(raw).toString('base64url');
+  return {
+    pubkeyB64Url,
+    privateKey,
+    signCanonical: (canonical: string) =>
+      Buffer.from(sign(null, Buffer.from(canonical, 'utf-8'), privateKey)).toString('base64url'),
+  };
+}
+
+function makeHostFinder(host: TestHost | null) {
+  return async (id: string) => (host && host.id === id ? host : null);
+}
+
+const NOW = Date.parse('2026-04-29T12:00:00.000Z');
+
+describe('canonicalSigningInput — wire-format parity with the genie signer', () => {
+  test('produces the documented format: timestamp\\nMETHOD\\npath\\nsha256(body) hex', () => {
+    const ts = '2026-04-29T12:00:00.000Z';
+    const method = 'POST';
+    const path = '/api/v2/agents';
+    const body = '{"name":"foo","provider":"claude"}';
+    const expectedHash = createHash('sha256').update(body, 'utf-8').digest('hex');
+    expect(canonicalSigningInput(ts, method, path, body)).toBe(`${ts}\n${method}\n${path}\n${expectedHash}`);
+  });
+
+  test('uppercases the method (matches signer behavior)', () => {
+    const out = canonicalSigningInput('2026-04-29T12:00:00.000Z', 'post', '/x', '');
+    expect(out.split('\n')[1]).toBe('POST');
+  });
+
+  test('hashes empty body to the well-known sha256 of empty string', () => {
+    // sha256('') = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    const out = canonicalSigningInput('2026-04-29T12:00:00.000Z', 'GET', '/health', '');
+    const hash = out.split('\n')[3];
+    expect(hash).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+});
+
+describe('verifySignature — happy path', () => {
+  test('valid signature → status=verified, hostId set', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/api/v2/agents', '{"name":"foo"}');
+    const signature = signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'host-1',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'POST',
+      path: '/api/v2/agents',
+      body: '{"name":"foo"}',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'host-1', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+
+    expect(outcome.status).toBe('verified');
+    expect(outcome.hostId).toBe('host-1');
+  });
+
+  test('GET request with empty body verifies', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'GET', '/api/v2/agents?name=foo', '');
+    const signature = signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'host-2',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'GET',
+      path: '/api/v2/agents?name=foo',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'host-2', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+
+    expect(outcome.status).toBe('verified');
+  });
+
+  test('case-insensitive method (signer may pass "post", verifier uppercases)', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    // Sign canonical built from POST (uppercase, what canonicalSigningInput emits)
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const signature = signCanonical(canonical);
+
+    // Verifier sees method='post' (lowercase) — should still pass because
+    // it uppercases internally.
+    const outcome = await verifySignature({
+      hostIdHeader: 'host-3',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'post',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'host-3', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('verified');
+  });
+});
+
+describe('verifySignature — header presence', () => {
+  test('all three headers missing → status=no-signature (fall through)', async () => {
+    const outcome = await verifySignature({
+      hostIdHeader: undefined,
+      timestampHeader: undefined,
+      signatureHeader: undefined,
+      method: 'GET',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => null,
+    });
+    expect(outcome.status).toBe('no-signature');
+  });
+
+  test('only host-id present → status=invalid (forge attempt)', async () => {
+    const outcome = await verifySignature({
+      hostIdHeader: 'host-1',
+      timestampHeader: undefined,
+      signatureHeader: undefined,
+      method: 'GET',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => null,
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('partial');
+  });
+
+  test('only signature present → status=invalid', async () => {
+    const outcome = await verifySignature({
+      hostIdHeader: undefined,
+      timestampHeader: undefined,
+      signatureHeader: 'AAAA',
+      method: 'GET',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => null,
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('partial');
+  });
+
+  test('host-id + timestamp without signature → status=invalid', async () => {
+    const outcome = await verifySignature({
+      hostIdHeader: 'host-1',
+      timestampHeader: new Date(NOW).toISOString(),
+      signatureHeader: undefined,
+      method: 'GET',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => null,
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('partial');
+  });
+});
+
+describe('verifySignature — replay window (±60s)', () => {
+  test('timestamp 30s in the past → verified (within window)', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW - 30_000).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('verified');
+  });
+
+  test('timestamp 90s in the past → invalid (outside window)', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW - 90_000).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('drift');
+  });
+
+  test('timestamp 90s in the future → invalid', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW + 90_000).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('drift');
+  });
+
+  test('malformed timestamp → invalid', async () => {
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: 'not-a-date',
+      signatureHeader: 'AAAA',
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => null,
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('malformed');
+  });
+});
+
+describe('verifySignature — tampered inputs', () => {
+  test('tampered body → invalid', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const signedBody = '{"name":"foo"}';
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', signedBody);
+    const signature = signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'POST',
+      path: '/x',
+      body: '{"name":"bar"}', // attacker swapped the body
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('does not verify');
+  });
+
+  test('tampered path → invalid', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/safe', '');
+    const signature = signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'POST',
+      path: '/admin',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+  });
+
+  test('tampered method → invalid', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'GET', '/x', '');
+    const signature = signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'DELETE',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+  });
+
+  test('signature signed by a different key → invalid', async () => {
+    const honestHost = freshKeypair();
+    const attacker = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', 'body');
+    const attackerSig = attacker.signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: attackerSig,
+      method: 'POST',
+      path: '/x',
+      body: 'body',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: honestHost.pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('does not verify');
+  });
+});
+
+describe('verifySignature — host lookup', () => {
+  test('unknown host_id → invalid (not silent fall-through)', async () => {
+    const { signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'nope',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => null,
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('unknown host');
+  });
+
+  test('revoked host → invalid', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: new Date(NOW - 1000) }),
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('revoked');
+  });
+
+  test('host lookup throws → invalid (no crash)', async () => {
+    const { signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: async () => {
+        throw new Error('db down');
+      },
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('host lookup failed');
+  });
+});
+
+describe('verifySignature — malformed crypto material', () => {
+  test('host pubkey too short (not 32 bytes raw) → invalid', async () => {
+    const { signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: signCanonical(canonical),
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({
+        id: 'h',
+        pubkey: Buffer.alloc(16, 1).toString('base64url'), // 16 bytes, wrong length
+        revokedAt: null,
+      }),
+    });
+    expect(outcome.status).toBe('invalid');
+    expect(outcome.reason).toContain('pubkey');
+  });
+
+  test('signature decodes to wrong size → invalid (verify rejects)', async () => {
+    const { pubkeyB64Url } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    // ed25519 signatures are 64 bytes; 8 bytes will not verify.
+    const garbageSig = Buffer.alloc(8, 7).toString('base64url');
+    const outcome = await verifySignature({
+      hostIdHeader: 'h',
+      timestampHeader: ts,
+      signatureHeader: garbageSig,
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+    });
+    expect(outcome.status).toBe('invalid');
+  });
+});

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -1,0 +1,265 @@
+/**
+ * Genie host signature verification middleware.
+ *
+ * Wish: omni-host-fingerprint-trust, Group 4.
+ *
+ * Reads the three signature headers genie attaches via `signOmniRequest`
+ * (Group 3, automagik-dev/genie#1539):
+ *
+ *   X-Genie-Host-Id    UUID of the registered host
+ *   X-Genie-Timestamp  ISO 8601 UTC of when the request was signed
+ *   X-Genie-Signature  base64url(ed25519(canonical))
+ *
+ * Reconstructs the same canonical input the signer used:
+ *
+ *   <iso8601-timestamp>\n<METHOD>\n<path>\n<sha256(body-utf8) hex>
+ *
+ * Verifies the ed25519 signature against the host's stored public key. On
+ * success, attaches `signedBy = host_id` to the request context for
+ * downstream audit consumers; on failure, returns 401 with a clear message.
+ *
+ * **Behavior is ADDITIVE in this PR**: missing signature headers fall
+ * through to the bearer-token auth chain unchanged. Failed signature
+ * verification (header present but invalid) returns 401 — that's not
+ * fail-open. The per-instance enforcement opt-in
+ * (`--require-genie-signature`, Group 6) flips this from "verify when
+ * present" to "require always".
+ *
+ * Security review checklist (per the wish's Group 4 callout):
+ *   1. Replay window (±60s tolerance for clock skew)
+ *      → enforced via REPLAY_WINDOW_MS below
+ *   2. Constant-time signature comparison
+ *      → node:crypto's `verify()` uses ed25519 internals which are
+ *        constant-time by design (curve25519). No string compares.
+ *   3. Pubkey loading — SPKI prefix construction must be byte-exact
+ *      → see `buildSpki()` below; matches RFC 8410's
+ *        `id-Ed25519` OID.
+ *   4. Unknown host_id → 401, not silently fall through
+ *      → enforced; see `verifyOrReject()`.
+ *   5. Audit log — every signed request records `signedBy`
+ *      → c.set('signedBy', host.id) for downstream middleware/handlers.
+ *
+ * Performance: the GenieHostsService.findById is a single indexed PK
+ * lookup; ed25519 verify is ~30µs. Negligible against typical request
+ * budgets.
+ */
+
+import { type KeyObject, createHash, createPublicKey, verify } from 'node:crypto';
+import { createLogger } from '@omni/core';
+import { createMiddleware } from 'hono/factory';
+import type { AppVariables } from '../types';
+
+const log = createLogger('api:genie-signature');
+
+/**
+ * Replay window: reject signed requests whose timestamp is more than 60
+ * seconds from server clock in either direction. Tighter than HTTP-Sig's
+ * default ~5min because the genie host and omni server live on the same
+ * machine in the loopback-only deployment model — clock drift between
+ * them is nil. If we add cross-machine deployments later, revisit.
+ */
+const REPLAY_WINDOW_MS = 60_000;
+
+/**
+ * SPKI DER prefix for ed25519 public keys (RFC 8410). 12 bytes.
+ *
+ *   30 2a   SEQUENCE (42 bytes)
+ *     30 05 SEQUENCE (5 bytes — the AlgorithmIdentifier)
+ *       06 03 OID (3 bytes)
+ *         2b 65 70   id-Ed25519 (1.3.101.112)
+ *     03 21 BIT STRING (33 bytes)
+ *       00          unused-bits = 0
+ *       <32 bytes>  the raw public key
+ *
+ * `Buffer.from(pubkeyB64Url, 'base64url')` produces the 32-byte raw key;
+ * concat the prefix to get a parseable SPKI DER blob.
+ */
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+/** Headers the signer attaches. Header lookup is case-insensitive in Hono. */
+const HEADER_HOST_ID = 'x-genie-host-id';
+const HEADER_TIMESTAMP = 'x-genie-timestamp';
+const HEADER_SIGNATURE = 'x-genie-signature';
+
+/**
+ * Reconstruct the canonical signing input. MUST byte-exactly match
+ * `canonicalSigningInput()` in genie's `src/lib/omni-signature.ts`. Any
+ * drift here breaks every signed request — treat as wire protocol.
+ */
+export function canonicalSigningInput(timestamp: string, method: string, path: string, body: string): string {
+  const bodyHash = createHash('sha256').update(body, 'utf-8').digest('hex');
+  return `${timestamp}\n${method.toUpperCase()}\n${path}\n${bodyHash}`;
+}
+
+/** Parse the base64url pubkey into a node:crypto KeyObject. */
+function loadPubkey(pubkeyB64Url: string): KeyObject {
+  const raw = Buffer.from(pubkeyB64Url, 'base64url');
+  if (raw.byteLength !== 32) {
+    throw new Error(`expected 32-byte ed25519 pubkey, got ${raw.byteLength} bytes`);
+  }
+  const spki = Buffer.concat([ED25519_SPKI_PREFIX, raw]);
+  return createPublicKey({ key: spki, format: 'der', type: 'spki' });
+}
+
+interface VerificationOutcome {
+  status: 'verified' | 'no-signature' | 'invalid';
+  hostId?: string;
+  reason?: string;
+}
+
+/** Pure verifier — no I/O beyond the host lookup. Tested directly. */
+export async function verifySignature(opts: {
+  hostIdHeader: string | undefined;
+  timestampHeader: string | undefined;
+  signatureHeader: string | undefined;
+  method: string;
+  path: string;
+  body: string;
+  now: number;
+  findHost: (id: string) => Promise<{ id: string; pubkey: string; revokedAt: Date | null } | null>;
+}): Promise<VerificationOutcome> {
+  const { hostIdHeader, timestampHeader, signatureHeader, method, path, body, now, findHost } = opts;
+
+  // No signature headers at all → bearer-only path; not our concern.
+  if (!hostIdHeader && !timestampHeader && !signatureHeader) {
+    return { status: 'no-signature' };
+  }
+
+  // Partial headers → invalid (someone is trying to forge a signed request
+  // by attaching only some of the headers; or a buggy client).
+  if (!hostIdHeader || !timestampHeader || !signatureHeader) {
+    return { status: 'invalid', reason: 'partial signature headers' };
+  }
+
+  // Replay window check (±60s).
+  const ts = Date.parse(timestampHeader);
+  if (Number.isNaN(ts)) {
+    return { status: 'invalid', reason: 'malformed X-Genie-Timestamp' };
+  }
+  const drift = Math.abs(now - ts);
+  if (drift > REPLAY_WINDOW_MS) {
+    return { status: 'invalid', reason: `timestamp drift ${drift}ms exceeds ±${REPLAY_WINDOW_MS}ms window` };
+  }
+
+  // Host lookup. Unknown id → invalid (not silent fall-through).
+  let host: { id: string; pubkey: string; revokedAt: Date | null } | null;
+  try {
+    host = await findHost(hostIdHeader);
+  } catch (err) {
+    return { status: 'invalid', reason: `host lookup failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (!host) {
+    return { status: 'invalid', reason: `unknown host ${hostIdHeader}` };
+  }
+  if (host.revokedAt) {
+    return { status: 'invalid', reason: `host ${hostIdHeader} is revoked` };
+  }
+
+  // Cryptographic verify. node:crypto's `verify()` for ed25519 is
+  // constant-time; the algorithm rejects malformed inputs without
+  // leaking timing information about the secret.
+  let pubKey: KeyObject;
+  try {
+    pubKey = loadPubkey(host.pubkey);
+  } catch (err) {
+    return {
+      status: 'invalid',
+      reason: `host pubkey unparseable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  let sigBytes: Buffer;
+  try {
+    sigBytes = Buffer.from(signatureHeader, 'base64url');
+  } catch {
+    return { status: 'invalid', reason: 'malformed X-Genie-Signature (not base64url)' };
+  }
+  const canonical = canonicalSigningInput(timestampHeader, method, path, body);
+  const ok = verify(null, Buffer.from(canonical, 'utf-8'), pubKey, sigBytes);
+  if (!ok) {
+    return { status: 'invalid', reason: 'signature does not verify under registered pubkey' };
+  }
+
+  return { status: 'verified', hostId: host.id };
+}
+
+/**
+ * Build the path string the verifier sees. Must match what the signer
+ * sees on the genie side: pathname + search (no host).
+ */
+function pathFromRequest(url: URL): string {
+  return `${url.pathname}${url.search}`;
+}
+
+/**
+ * Hono middleware factory. Place AFTER the body-limit middleware so
+ * `c.req.text()` returns the same string the signer hashed.
+ */
+export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
+  const services = c.get('services');
+  if (!services?.genieHosts) {
+    // Service registry not initialized — let the request through; bearer
+    // auth will reject if needed. Don't fail closed for an internal-config
+    // hiccup.
+    return next();
+  }
+
+  const hostIdHeader = c.req.header(HEADER_HOST_ID);
+  const timestampHeader = c.req.header(HEADER_TIMESTAMP);
+  const signatureHeader = c.req.header(HEADER_SIGNATURE);
+
+  // Fast-path: no signature headers → skip work, fall through.
+  if (!hostIdHeader && !timestampHeader && !signatureHeader) {
+    return next();
+  }
+
+  // Read the request body ONCE so we hash the same bytes the signer did.
+  // The Hono request object's `.text()` is lazy and idempotent; downstream
+  // route handlers that re-read via `.json()` get the parsed copy anyway.
+  let body = '';
+  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+    body = await c.req.text();
+  }
+
+  const url = new URL(c.req.url);
+  const outcome = await verifySignature({
+    hostIdHeader,
+    timestampHeader,
+    signatureHeader,
+    method: c.req.method,
+    path: pathFromRequest(url),
+    body,
+    now: Date.now(),
+    findHost: async (id: string) => {
+      const host = await services.genieHosts.findById(id);
+      return host ? { id: host.id, pubkey: host.pubkey, revokedAt: host.revokedAt } : null;
+    },
+  });
+
+  if (outcome.status === 'invalid') {
+    log.warn('genie signature verification failed', {
+      hostId: hostIdHeader,
+      reason: outcome.reason,
+      method: c.req.method,
+      path: url.pathname,
+    });
+    return c.json(
+      {
+        error: {
+          code: 'INVALID_GENIE_SIGNATURE',
+          message: `Genie host signature rejected: ${outcome.reason}`,
+        },
+      },
+      401,
+    );
+  }
+
+  if (outcome.status === 'verified' && outcome.hostId) {
+    c.set('signedBy', outcome.hostId);
+    // Best-effort last-seen update; never blocks the request.
+    services.genieHosts.touchLastSeen(outcome.hostId).catch((err: unknown) => {
+      log.warn('touchLastSeen failed (non-fatal)', { hostId: outcome.hostId, err: String(err) });
+    });
+  }
+
+  return next();
+});

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -47,6 +47,13 @@ export interface AppVariables {
   services: Services;
   apiKey?: ApiKeyData;
   requestId: string;
+  /**
+   * Genie host id when the request carried a verified `X-Genie-Signature`.
+   * Set by the genieSignatureMiddleware (omni-host-fingerprint-trust wish,
+   * Group 4) and consumed by audit/observability downstream. Absent when
+   * the request was bearer-only or unsigned.
+   */
+  signedBy?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Wires the **verification** side of the genie↔omni host fingerprint trust pipeline. When a request carries the three signing headers genie attaches in [automagik-dev/genie#1539](https://github.com/automagik-dev/genie/pull/1539) (`X-Genie-Host-Id` / `X-Genie-Timestamp` / `X-Genie-Signature`), the middleware reconstructs the canonical input, looks up the registered host's pubkey, and ed25519-verifies the signature. Behavior is **additive** — requests without signature headers fall through to the bearer-only auth path unchanged.

This is the **security review gate** for the wish.

## Changes

- `packages/api/src/middleware/genie-signature.ts` (new) — pure `verifySignature()` + Hono middleware wrapper
- `packages/api/src/types.ts` — adds `signedBy?: string` to `AppVariables` for downstream audit consumers
- `packages/api/src/app.ts` — wires the middleware between `scopeEnforcer` and `outputRedactor`
- `packages/api/src/middleware/__tests__/genie-signature.test.ts` (new) — 23 contract tests, no DB, no HTTP

## Security review checklist (Group 4 callout)

| # | Concern | Mitigation |
|---|---------|------------|
| 1 | Replay window | ±60s tolerance via `REPLAY_WINDOW_MS = 60_000`. Loopback-only deployment so drift is nil; revisit if cross-machine. |
| 2 | Constant-time compare | `node:crypto.verify()` for ed25519 is constant-time by curve construction (curve25519). No string compares anywhere. |
| 3 | SPKI prefix construction | Byte-exact RFC 8410 `id-Ed25519` (1.3.101.112) prefix. Hardcoded as `Buffer.from('302a300506032b6570032100', 'hex')`. Covered by happy-path tests. |
| 4 | Unknown host_id | Returns 401, not silent fall-through. Covered. |
| 5 | Audit hook | `c.set('signedBy', host.id)` on success; `touchLastSeen()` called best-effort (never blocks the request). |

## Test coverage

23 tests across 5 describe blocks:

- **canonical signing parity** — wire format matches the genie-side signer; sha256 of empty body pinned to the well-known constant
- **happy path** — valid signature, GET with empty body, case-insensitive method
- **header presence** — missing-all → fall through; partial (any 1 or 2 of 3) → invalid
- **replay window** — ±30s within / ±90s outside / future timestamps / malformed dates
- **tampering** — body, path, method swaps; foreign-key signatures
- **host lookup** — unknown id, revoked host, DB-down lookups
- **malformed crypto** — wrong-length pubkeys, wrong-length signatures

```
 23 pass / 0 fail / 36 expect() calls
```

## Verification

```
bun test packages/api/src/middleware     # 86 pass / 0 fail
bunx tsc --noEmit                        # clean
bunx biome check <changed files>         # clean
```

## Test plan
- [ ] CI green (test + lint + typecheck)
- [ ] Manual smoke after merge: hit a signed-request endpoint with a real genie host, confirm `signedBy` appears in audit/logs
- [ ] Confirm bearer-only requests still work unchanged (no regression on the existing path)

## What's next

- Group 5: per-host scope enforcement
- Group 6: `--require-genie-signature` per-instance opt-in (flips this from "verify when present" to "require always")
- Group 7: brain entries + ADR

Refs: omni-host-fingerprint-trust wish, group 4