### PR TITLE
feat(api): per-host scope enforcement for signed requests (Group 5)

### DIFF
--- a/packages/api/src/middleware/__tests__/genie-signature.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature.test.ts
@@ -36,6 +36,7 @@ interface TestHost {
   id: string;
   pubkey: string;
   revokedAt: Date | null;
+  scopes: string[];
 }
 
 /**
@@ -102,11 +103,39 @@ describe('verifySignature — happy path', () => {
       path: '/api/v2/agents',
       body: '{"name":"foo"}',
       now: NOW,
-      findHost: makeHostFinder({ id: 'host-1', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'host-1', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
 
     expect(outcome.status).toBe('verified');
     expect(outcome.hostId).toBe('host-1');
+    // Group 5: per-host scopes are surfaced on the outcome so the
+    // scope-enforcer can intersect them with the bearer's scopes.
+    expect(outcome.hostScopes).toEqual(['*']);
+  });
+
+  test('verified outcome propagates narrowed host scopes (Group 5)', async () => {
+    const { pubkeyB64Url, signCanonical } = freshKeypair();
+    const ts = new Date(NOW).toISOString();
+    const canonical = canonicalSigningInput(ts, 'POST', '/x', '');
+    const signature = signCanonical(canonical);
+
+    const outcome = await verifySignature({
+      hostIdHeader: 'narrow',
+      timestampHeader: ts,
+      signatureHeader: signature,
+      method: 'POST',
+      path: '/x',
+      body: '',
+      now: NOW,
+      findHost: makeHostFinder({
+        id: 'narrow',
+        pubkey: pubkeyB64Url,
+        revokedAt: null,
+        scopes: ['agents:read'],
+      }),
+    });
+    expect(outcome.status).toBe('verified');
+    expect(outcome.hostScopes).toEqual(['agents:read']);
   });
 
   test('GET request with empty body verifies', async () => {
@@ -123,7 +152,7 @@ describe('verifySignature — happy path', () => {
       path: '/api/v2/agents?name=foo',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'host-2', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'host-2', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
 
     expect(outcome.status).toBe('verified');
@@ -146,7 +175,7 @@ describe('verifySignature — happy path', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'host-3', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'host-3', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('verified');
   });
@@ -226,7 +255,7 @@ describe('verifySignature — replay window (±60s)', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('verified');
   });
@@ -243,7 +272,7 @@ describe('verifySignature — replay window (±60s)', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
     expect(outcome.reason).toContain('drift');
@@ -261,7 +290,7 @@ describe('verifySignature — replay window (±60s)', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
     expect(outcome.reason).toContain('drift');
@@ -299,7 +328,7 @@ describe('verifySignature — tampered inputs', () => {
       path: '/x',
       body: '{"name":"bar"}', // attacker swapped the body
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
     expect(outcome.reason).toContain('does not verify');
@@ -319,7 +348,7 @@ describe('verifySignature — tampered inputs', () => {
       path: '/admin',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
   });
@@ -338,7 +367,7 @@ describe('verifySignature — tampered inputs', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
   });
@@ -358,7 +387,7 @@ describe('verifySignature — tampered inputs', () => {
       path: '/x',
       body: 'body',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: honestHost.pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: honestHost.pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
     expect(outcome.reason).toContain('does not verify');
@@ -396,7 +425,7 @@ describe('verifySignature — host lookup', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: new Date(NOW - 1000) }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: new Date(NOW - 1000), scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
     expect(outcome.reason).toContain('revoked');
@@ -440,6 +469,7 @@ describe('verifySignature — malformed crypto material', () => {
         id: 'h',
         pubkey: Buffer.alloc(16, 1).toString('base64url'), // 16 bytes, wrong length
         revokedAt: null,
+        scopes: ['*'],
       }),
     });
     expect(outcome.status).toBe('invalid');
@@ -459,7 +489,7 @@ describe('verifySignature — malformed crypto material', () => {
       path: '/x',
       body: '',
       now: NOW,
-      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null }),
+      findHost: makeHostFinder({ id: 'h', pubkey: pubkeyB64Url, revokedAt: null, scopes: ['*'] }),
     });
     expect(outcome.status).toBe('invalid');
   });

--- a/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Per-host scope intersection tests for the scope-enforcer middleware.
+ *
+ * Wish: omni-host-fingerprint-trust, Group 5.
+ *
+ * Contract: when a request carries a verified `signedBy` host id (set by
+ * the genie-signature middleware in Group 4), the EFFECTIVE permissions
+ * are the intersection of:
+ *   - the bearer key's scopes (`apiKey.scopes`)
+ *   - the signing host's scopes (`signedByScopes`)
+ *
+ * Both must allow the route. Either side denying → 403.
+ *
+ * Backward compat: hosts default to `['*']` on first handshake, so this
+ * check is a no-op until an operator narrows via `omni trust update`.
+ *
+ * Strategy: mount only the scope-enforcer middleware on a stub Hono app,
+ * pre-set `apiKey` and `signedBy*` on the context to simulate prior
+ * middleware, hit a route mapped in SCOPE_MAP, and assert the response
+ * code. No DB, no real auth — the goal is to lock down the intersection
+ * decision in isolation.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { ApiKeyData, AppVariables } from '../../types';
+import { scopeEnforcerMiddleware } from '../scope-enforcer';
+
+interface CtxOverrides {
+  bearerScopes: string[];
+  signedBy?: string;
+  signedByScopes?: string[];
+}
+
+/**
+ * Build a tiny app with the scope-enforcer middleware in front of a
+ * pass-through `GET /agents` route (mapped to scope `agents:read` in
+ * SCOPE_MAP). All other auth is stubbed via context-setter middleware.
+ */
+function mountWithCtx(overrides: CtxOverrides): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    const apiKey: ApiKeyData = {
+      id: 'k1',
+      name: 'test',
+      scopes: overrides.bearerScopes,
+      instanceIds: null,
+      expiresAt: null,
+      profile: null,
+      chatAllowlist: [],
+      instanceAllowlist: [],
+      outboundRecipientAllowlist: [],
+    };
+    c.set('apiKey', apiKey);
+    if (overrides.signedBy) c.set('signedBy', overrides.signedBy);
+    if (overrides.signedByScopes) c.set('signedByScopes', overrides.signedByScopes);
+    await next();
+  });
+  app.use('*', scopeEnforcerMiddleware);
+  // Two routes from SCOPE_MAP we exercise below:
+  //   GET /api/v2/agents          → agents:read
+  //   POST /api/v2/agents         → agents:write
+  app.get('/api/v2/agents', (c) => c.json({ ok: true }));
+  app.post('/api/v2/agents', async (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('scope-enforcer — bearer-only path (no signature)', () => {
+  test('bearer with `*` → 200 (regression: existing behavior unchanged)', async () => {
+    const app = mountWithCtx({ bearerScopes: ['*'] });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+
+  test('bearer with namespace wildcard → 200', async () => {
+    const app = mountWithCtx({ bearerScopes: ['agents:*'] });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+
+  test('bearer missing required scope → 403', async () => {
+    const app = mountWithCtx({ bearerScopes: ['messages:read'] });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('scope-enforcer — signed request, host wildcard (back-compat default)', () => {
+  test('bearer=`*` + host=`*` → 200 (default handshake state)', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['*'],
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+
+  test('bearer=`agents:read` + host=`*` → 200', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['agents:read'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['*'],
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('scope-enforcer — signed request, host narrowed (Group 5 intersection)', () => {
+  test('bearer=`*` + host=`agents:read` allows GET /agents → 200', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['agents:read'],
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+
+  test('bearer=`*` + host=`agents:read` DENIES POST /agents → 403', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['agents:read'],
+    });
+    const res = await app.request('/api/v2/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.host).toBe('host-uuid');
+  });
+
+  test('bearer=`agents:read` + host=`agents:write` DENIES GET /agents (bearer side rejects first)', async () => {
+    // The bearer dimension fires before the host dimension. The bearer is
+    // missing `agents:read`, so we get the bearer error message — NOT the
+    // host-specific one. This locks down the order-of-evaluation.
+    const app = mountWithCtx({
+      bearerScopes: ['agents:read'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['agents:write'],
+    });
+    const res = await app.request('/api/v2/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    // Bearer-side denial: no `host` field (that's only set on host-side denials).
+    expect(body.error.host).toBeUndefined();
+  });
+
+  test('bearer=`agents:write` + host=`agents:write` → 200 on POST', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['agents:write'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['agents:write'],
+    });
+    const res = await app.request('/api/v2/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('bearer=`*` + host=[] (empty array) DENIES every scoped route', async () => {
+    // Operators who explicitly clear all scopes on a host effectively
+    // disable that host without revoking it. Useful for "freeze this host"
+    // operations during incident response.
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: [],
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(403);
+  });
+
+  test('bearer=`*` + host=`messages:read` DENIES /agents (different namespace)', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['messages:read'],
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(403);
+  });
+
+  test('host scopes apply even when bearer has wildcard (no bypass)', async () => {
+    // Critical security property: an admin bearer key MUST NOT bypass
+    // per-host restrictions. Otherwise a compromised bearer signed by a
+    // narrowed host would still get full admin.
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: ['agents:read'],
+    });
+    const res = await app.request('/api/v2/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('scope-enforcer — signed request without scopes set on context', () => {
+  test('signedBy set but signedByScopes absent → bearer-only behavior (no host gate)', async () => {
+    // Defensive: if some upstream sets `signedBy` without `signedByScopes`
+    // (shouldn't happen in production but the type allows it), we fall back
+    // to bearer-only enforcement rather than failing closed on a missing
+    // signal.
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      // signedByScopes intentionally omitted
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -104,6 +104,13 @@ function loadPubkey(pubkeyB64Url: string): KeyObject {
 interface VerificationOutcome {
   status: 'verified' | 'no-signature' | 'invalid';
   hostId?: string;
+  /**
+   * Per-host scopes from `genie_hosts.scopes`. Defaults to `['*']` on first
+   * handshake (backward compat with the bearer-only model). The scope-enforcer
+   * intersects this with the bearer key's scopes — both must allow the route.
+   * Empty array = "no permissions" → every scoped route denied.
+   */
+  hostScopes?: string[];
   reason?: string;
 }
 
@@ -116,7 +123,7 @@ export async function verifySignature(opts: {
   path: string;
   body: string;
   now: number;
-  findHost: (id: string) => Promise<{ id: string; pubkey: string; revokedAt: Date | null } | null>;
+  findHost: (id: string) => Promise<{ id: string; pubkey: string; revokedAt: Date | null; scopes: string[] } | null>;
 }): Promise<VerificationOutcome> {
   const { hostIdHeader, timestampHeader, signatureHeader, method, path, body, now, findHost } = opts;
 
@@ -142,7 +149,7 @@ export async function verifySignature(opts: {
   }
 
   // Host lookup. Unknown id → invalid (not silent fall-through).
-  let host: { id: string; pubkey: string; revokedAt: Date | null } | null;
+  let host: { id: string; pubkey: string; revokedAt: Date | null; scopes: string[] } | null;
   try {
     host = await findHost(hostIdHeader);
   } catch (err) {
@@ -179,7 +186,7 @@ export async function verifySignature(opts: {
     return { status: 'invalid', reason: 'signature does not verify under registered pubkey' };
   }
 
-  return { status: 'verified', hostId: host.id };
+  return { status: 'verified', hostId: host.id, hostScopes: host.scopes };
 }
 
 /**
@@ -231,7 +238,9 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
     now: Date.now(),
     findHost: async (id: string) => {
       const host = await services.genieHosts.findById(id);
-      return host ? { id: host.id, pubkey: host.pubkey, revokedAt: host.revokedAt } : null;
+      return host
+        ? { id: host.id, pubkey: host.pubkey, revokedAt: host.revokedAt, scopes: host.scopes ?? ['*'] }
+        : null;
     },
   });
 
@@ -255,6 +264,14 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
 
   if (outcome.status === 'verified' && outcome.hostId) {
     c.set('signedBy', outcome.hostId);
+    // Per-host scopes consumed by scope-enforcer (Group 5). Always set so the
+    // enforcer can distinguish "signed and unrestricted" (['*']) from "signed
+    // and unscoped" — the former is the back-compat default; the latter
+    // doesn't happen today but the enforcer needs the source of truth either
+    // way.
+    if (outcome.hostScopes) {
+      c.set('signedByScopes', outcome.hostScopes);
+    }
     // Best-effort last-seen update; never blocks the request.
     services.genieHosts.touchLastSeen(outcome.hostId).catch((err: unknown) => {
       log.warn('touchLastSeen failed (non-fatal)', { hostId: outcome.hostId, err: String(err) });

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -320,10 +320,19 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   const method = c.req.method.toUpperCase();
   const path = c.req.path;
 
+  const signedBy = c.get('signedBy');
+  const signedByScopes = c.get('signedByScopes');
+
   const wildcard = ApiKeyService.scopeAllows(apiKey.scopes, '*');
 
+  // Resolve the required scope ONCE so we can apply both bearer and host
+  // checks against the same policy entry. Locked behind !wildcard for the
+  // bearer dimension to preserve fast-path behavior; the host dimension
+  // (Group 5) re-uses it when needed.
+  let requiredScope: string | undefined;
+
   if (!wildcard) {
-    const requiredScope = findRequiredScope(method, path);
+    requiredScope = findRequiredScope(method, path);
 
     // Deny-by-default: no mapping means forbidden
     if (!requiredScope) {
@@ -351,6 +360,60 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
         },
         403,
       );
+    }
+  }
+
+  // Per-host scope check (Group 5: omni-host-fingerprint-trust).
+  //
+  // When a request is signed by a registered genie host, the EFFECTIVE
+  // permissions are the intersection of the bearer's scopes AND the host's
+  // scopes. This lets operators narrow a single shared bearer key on a
+  // per-machine basis without minting a new key per host.
+  //
+  // Backward compat: hosts default to `['*']` on first handshake, so this
+  // check is a no-op until an operator explicitly narrows via
+  // `omni trust update <id> --scopes <...>`.
+  //
+  // The bearer's wildcard does NOT bypass this — wildcard means "the bearer
+  // is unrestricted", but the signing host may still be locked down.
+  if (signedBy && signedByScopes) {
+    const hostWildcard = ApiKeyService.scopeAllows(signedByScopes, '*');
+    if (!hostWildcard) {
+      // Resolve the route's required scope if we haven't already (wildcard
+      // bearer skipped that step above).
+      const needed = requiredScope ?? findRequiredScope(method, path);
+
+      // Same deny-by-default semantics as the bearer path: if the route is
+      // unmapped, even a host with explicit non-wildcard scopes can't reach
+      // it. (Wildcard host scopes are already handled by the early return.)
+      if (!needed) {
+        log.warn(`DENIED: signedBy=${signedBy} route=${method} ${path} required=UNMAPPED`);
+        return c.json(
+          {
+            error: {
+              code: 'FORBIDDEN',
+              message: 'Insufficient permissions. Route not mapped in scope policy.',
+            },
+          },
+          403,
+        );
+      }
+
+      if (!ApiKeyService.scopeAllows(signedByScopes, needed)) {
+        log.warn(
+          `DENIED: signedBy=${signedBy} route=${method} ${path} required=${needed} host-scopes=${signedByScopes.join(',')}`,
+        );
+        return c.json(
+          {
+            error: {
+              code: 'FORBIDDEN',
+              message: `Insufficient permissions for signing host. Required scope: ${needed}`,
+              host: signedBy,
+            },
+          },
+          403,
+        );
+      }
     }
   }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -54,6 +54,13 @@ export interface AppVariables {
    * the request was bearer-only or unsigned.
    */
   signedBy?: string;
+  /**
+   * Per-host scopes from `genie_hosts.scopes` for the verified host
+   * (Group 5). The scope-enforcer intersects this with the bearer key's
+   * scopes — both must allow the route. Absent when the request was
+   * bearer-only or unsigned (in which case only the bearer's scopes apply).
+   */
+  signedByScopes?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Group 5 of the omni-host-fingerprint-trust wish: when a request carries a verified `X-Genie-Signature` (Group 4), the **effective permissions** are now the intersection of:

- the bearer key's scopes (`apiKey.scopes`)
- the signing host's scopes (`genie_hosts.scopes`)

Both must allow the route. Either side denying → 403.

This lets operators narrow a single shared bearer key on a per-machine basis without minting a new key per host.

## Why

Today the entire genie⇄omni link runs on one shared bearer token. If that key leaks, every host trusts the leaker. With Group 4 we know **which physical machine** signed each request; Group 5 makes that signal authoritative — operators can scope individual hosts (e.g., \"only let the laptop call /agents:read\") without disturbing the bearer.

## Backward compat

- Hosts default to `['*']` on first handshake → this check is a no-op until an operator narrows via `omni trust update <id> --scopes <...>` (Group 1.2's CLI).
- Bearer-only requests are unchanged (no `signedBy` set → host-side check is skipped).
- A bearer with `*` does **NOT** bypass per-host restrictions — critical security property: a compromised admin key signed by a narrowed host stays narrowed.

## Order-of-evaluation (locked in tests)

1. Bearer-side scope check fires first. If the bearer doesn't have the required scope, return early with a bearer-style FORBIDDEN message.
2. Host-side scope check runs only after bearer passes. Host-side denial responses include the `host` id in the error payload for operator debugging.
3. Empty host scopes (`scopes: []`) deny every scoped route — useful for incident-response \"freeze this host\" without revoking.

## Changes

- `packages/api/src/middleware/genie-signature.ts` — verifier now surfaces `host.scopes` on the verification outcome and middleware stashes it on context as `signedByScopes`
- `packages/api/src/middleware/scope-enforcer.ts` — adds an intersection pass that re-uses `ApiKeyService.scopeAllows` for consistent semantics
- `packages/api/src/types.ts` — adds `signedByScopes?: string[]` to `AppVariables`
- `packages/api/src/middleware/__tests__/genie-signature.test.ts` — verifier tests now assert `hostScopes` propagation
- `packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts` (new) — 13 contract tests covering the intersection matrix

## Test coverage

```
 100 pass / 0 fail / 173 expect() calls (full middleware suite)
  37 pass / 0 fail (genie-signature + scope-enforcer-host-scopes only)
```

Coverage matrix:

| Bearer | Host | Route | Expected |
|--------|------|-------|----------|
| `*` | _none_ (unsigned) | any | 200 (regression) |
| `agents:*` | _none_ | GET /agents | 200 |
| `messages:read` | _none_ | GET /agents | 403 (bearer fails) |
| `*` | `*` | any | 200 (default handshake) |
| `*` | `agents:read` | GET /agents | 200 |
| `*` | `agents:read` | POST /agents | 403 (host fails, error includes `host`) |
| `*` | `messages:read` | GET /agents | 403 (different namespace) |
| `*` | `[]` | any scoped route | 403 (freeze-host) |
| `agents:read` | `agents:write` | POST /agents | 403 (bearer fails first, no `host` in error) |
| `agents:write` | `agents:write` | POST /agents | 200 |
| `*` | _signedBy without signedByScopes_ | any | 200 (defensive fallback) |

## Verification

```bash
bun test packages/api/src/middleware     # 100 pass / 0 fail
bunx tsc --noEmit                         # clean
bunx biome check <changed files>          # clean
```

## Test plan
- [ ] CI green (test + lint + typecheck)
- [ ] After merge: hit a real omni instance with a narrowed-scope host (\`omni trust update <id> --scopes agents:read\`), confirm POST /agents returns 403 with `host` in the error payload
- [ ] Confirm bearer-only requests unaffected (no regression on the unsigned path)

## What's next

- Group 6: `--require-genie-signature` per-instance opt-in (flips middleware from \"verify when present\" to \"require always\")
- Group 7: brain entries + ADR

Refs: omni-host-fingerprint-trust wish, group 5