### PR TITLE
feat: per-instance signature requirement opt-in (Group 6)

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -45,6 +45,7 @@ import { authMiddleware, requireInstanceAccess } from './middleware/auth';
 import { defaultBodyLimitMiddleware } from './middleware/body-limit';
 import { genieSignatureMiddleware } from './middleware/genie-signature';
 import { outputRedactorMiddleware } from './middleware/output-redactor';
+import { requireSignedInstanceMiddleware } from './middleware/require-signed-instance';
 import { scopeEnforcerMiddleware } from './middleware/scope-enforcer';
 
 import { createContextMiddleware } from './middleware/context';
@@ -251,15 +252,17 @@ export function createApp(
   // Protected routes
   const protectedApp = new Hono<{ Variables: AppVariables }>();
   protectedApp.use('*', authMiddleware);
-  protectedApp.use('*', scopeEnforcerMiddleware);
-  // Genie host signature verification — additive in this rollout. When the
-  // request carries the `X-Genie-Signature` header set, the middleware
-  // verifies it (replay-window + ed25519) and sets `signedBy` on context
-  // for downstream audit. Missing headers fall through unchanged. The
-  // per-instance enforcement opt-in (`--require-genie-signature`, Group 6
-  // of the omni-host-fingerprint-trust wish) flips this from "verify when
-  // present" to "require always".
+  // Genie host signature verification (omni-host-fingerprint-trust group 4).
+  // Runs BEFORE scope-enforcer so `signedBy`/`signedByScopes` are populated
+  // on the context when scope-enforcer reads them for the per-host scope
+  // intersection added in group 5. Bearer-only requests fall through unchanged.
   protectedApp.use('*', genieSignatureMiddleware);
+  // Per-instance signature requirement (omni-host-fingerprint-trust group 6).
+  // When `instance.requireGenieSignature = true` is set on the targeted
+  // instance, requests without a verified `signedBy` are rejected with 401.
+  // Default: false (additive rollout).
+  protectedApp.use('*', requireSignedInstanceMiddleware);
+  protectedApp.use('*', scopeEnforcerMiddleware);
   protectedApp.use('*', outputRedactorMiddleware);
   protectedApp.use('*', rateLimitMiddleware);
 

--- a/packages/api/src/middleware/__tests__/require-signed-instance.test.ts
+++ b/packages/api/src/middleware/__tests__/require-signed-instance.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Contract tests for the per-instance signature requirement gate.
+ *
+ * Wish: omni-host-fingerprint-trust, Group 6.
+ *
+ * Strategy: mount only the require-signed-instance middleware in front of
+ * a pass-through route, stub `services.instances.getById`, and assert the
+ * status code + error envelope across the matrix:
+ *
+ *   instance.requireGenieSignature × signedBy × routeHasInstanceTarget
+ *
+ * Default state (requireGenieSignature=false everywhere) must be a no-op
+ * for the rollout to stay additive. Opt-in instances reject bearer-only
+ * requests with 401 + GENIE_SIGNATURE_REQUIRED.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../types';
+import { requireSignedInstanceMiddleware } from '../require-signed-instance';
+
+interface FakeInstance {
+  id: string;
+  requireGenieSignature: boolean;
+}
+
+function mountWithStub(opts: {
+  instance?: FakeInstance | null;
+  signedBy?: string;
+  /** Throw on getById to simulate "instance not found". */
+  notFound?: boolean;
+}): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: async (id: string) => {
+          if (opts.notFound) throw new Error('not found');
+          if (opts.instance && opts.instance.id === id) return opts.instance;
+          throw new Error('not found');
+        },
+      },
+    } as never);
+    if (opts.signedBy) c.set('signedBy', opts.signedBy);
+    c.set('apiKey', {
+      id: 'k1',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.use('*', requireSignedInstanceMiddleware);
+  app.get('/api/v2/instances/:id', (c) => c.json({ ok: true }));
+  app.post('/api/v2/messages/send', async (c) => c.json({ ok: true }));
+  app.get('/api/v2/agents', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('require-signed-instance — default behavior (rollout additive)', () => {
+  test('instance.requireGenieSignature=false → bearer-only request passes', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: false },
+    });
+    const res = await app.request('/api/v2/instances/i1');
+    expect(res.status).toBe(200);
+  });
+
+  test('route without instance target (no path param, no body) → bypassed', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(200);
+  });
+
+  test('unknown instance id → 404 deferred to route handler (no 401 leak)', async () => {
+    // The middleware MUST NOT 401 on unknown ids — that would let attackers
+    // probe the instance namespace. Instead it falls through to the route,
+    // which handles the 404.
+    const app = mountWithStub({ notFound: true });
+    const res = await app.request('/api/v2/instances/probe-attempt');
+    // Our test app's GET /instances/:id returns 200; in production it would
+    // 404. The point is the middleware doesn't shortcut — it lets the
+    // request through.
+    expect(res.status).toBe(200);
+  });
+
+  test('signed request → always passes regardless of instance setting', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+      signedBy: 'host-uuid',
+    });
+    const res = await app.request('/api/v2/instances/i1');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('require-signed-instance — opt-in enforcement', () => {
+  test('require=true + bearer-only path-param request → 401 GENIE_SIGNATURE_REQUIRED', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await app.request('/api/v2/instances/i1');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string; instance: string; message: string } };
+    expect(body.error.code).toBe('GENIE_SIGNATURE_REQUIRED');
+    expect(body.error.instance).toBe('i1');
+    expect(body.error.message).toContain('omni instances update');
+  });
+
+  test('require=true + bearer-only body-instance request → 401', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await app.request('/api/v2/messages/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instanceId: 'i1', to: 'x', text: 'y' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('require=true + signedBy set → 200', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+      signedBy: 'host-uuid',
+    });
+    const res = await app.request('/api/v2/messages/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instanceId: 'i1', to: 'x', text: 'y' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('require-signed-instance — defensive fallbacks', () => {
+  test('services registry missing → middleware falls through (no false 401)', async () => {
+    // If the service registry isn't wired (boot order glitch or healthcheck
+    // path), don't fail closed — that would brick the API for an internal
+    // config issue. Bearer auth or downstream still gates.
+    const app = new Hono<{ Variables: AppVariables }>();
+    app.use('*', async (c, next) => {
+      c.set('services', undefined as never);
+      await next();
+    });
+    app.use('*', requireSignedInstanceMiddleware);
+    app.get('/api/v2/instances/i1', (c) => c.json({ ok: true }));
+    const res = await app.request('/api/v2/instances/i1');
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/api/src/middleware/require-signed-instance.ts
+++ b/packages/api/src/middleware/require-signed-instance.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-instance signature requirement enforcement.
+ *
+ * Wish: omni-host-fingerprint-trust, Group 6.
+ *
+ * When an instance has `instances.require_genie_signature = true` set
+ * (via `omni instances update <id> --require-genie-signature`), every
+ * request that targets that instance MUST carry a verified
+ * `X-Genie-Signature`. Bearer-only requests get 401 with code
+ * `GENIE_SIGNATURE_REQUIRED`.
+ *
+ * Pipeline placement:
+ *
+ *   authMiddleware            ← bearer auth, sets `apiKey`
+ *   genieSignatureMiddleware  ← verifies signature, sets `signedBy`/`signedByScopes`
+ *   requireSignedInstanceMiddleware  ← THIS — 401s when signature is required and missing
+ *   scopeEnforcerMiddleware   ← bearer + per-host scope intersection
+ *
+ * Default behavior is additive: `require_genie_signature` defaults to
+ * false on every instance, so this middleware is a no-op until an
+ * operator opts in.
+ *
+ * Target extraction re-uses the same `extractLockTargets` helper as the
+ * scope-enforcer to avoid drift between AUTHN (this middleware: 401) and
+ * AUTHZ (scope-enforcer: 403). The instance id is read from path params
+ * (/instances/:id...) and JSON body (`instanceId`) — same source set.
+ *
+ * Routes that don't carry an instance target (auth-system routes, trust
+ * handshake, etc.) bypass this check entirely.
+ */
+
+import { createLogger } from '@omni/core';
+import type { Context } from 'hono';
+import { createMiddleware } from 'hono/factory';
+import type { AppVariables } from '../types';
+import { extractLockTargets } from './scope-enforcer';
+
+const log = createLogger('api:require-signed-instance');
+
+/**
+ * Safely parse a JSON request body. Returns null when there's no body
+ * or it isn't JSON — matches scope-enforcer's behavior.
+ */
+async function safeReadJsonBody(c: Context<{ Variables: AppVariables }>): Promise<unknown | null> {
+  const method = c.req.method.toUpperCase();
+  if (method === 'GET' || method === 'DELETE' || method === 'HEAD' || method === 'OPTIONS') return null;
+  const contentType = c.req.header('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) return null;
+  try {
+    return await c.req.json();
+  } catch {
+    return null;
+  }
+}
+
+export const requireSignedInstanceMiddleware = createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
+  const services = c.get('services');
+  if (!services?.instances) {
+    // Service registry not initialized — fall through. Bearer auth or
+    // downstream middleware will handle it. Failing closed here would
+    // mask real causes during boot/healthcheck.
+    return next();
+  }
+
+  const method = c.req.method.toUpperCase();
+  const path = c.req.path;
+  const body = await safeReadJsonBody(c);
+
+  const targets = extractLockTargets(method, path, body);
+  if (!targets.instance) {
+    // No instance target → nothing to enforce.
+    return next();
+  }
+
+  let instance: { id: string; requireGenieSignature: boolean } | null = null;
+  try {
+    const row = await services.instances.getById(targets.instance);
+    instance = { id: row.id, requireGenieSignature: row.requireGenieSignature };
+  } catch {
+    // Unknown instance → defer to the route handler (it will 404). Don't
+    // 401 on an unknown id — that would leak information about whether
+    // an instance exists.
+    return next();
+  }
+
+  if (!instance.requireGenieSignature) {
+    // Instance hasn't opted into signature requirement → fall through.
+    return next();
+  }
+
+  const signedBy = c.get('signedBy');
+  if (signedBy) {
+    // Already verified by genie-signature middleware → allow.
+    return next();
+  }
+
+  const apiKey = c.get('apiKey');
+  log.warn('rejecting unsigned request to require_genie_signature instance', {
+    instanceId: instance.id,
+    apiKeyId: apiKey?.id,
+    method,
+    path,
+  });
+  return c.json(
+    {
+      error: {
+        code: 'GENIE_SIGNATURE_REQUIRED',
+        message: `Instance ${instance.id} requires a verified X-Genie-Signature; bearer-only requests are rejected. Sign with \`genie omni handshake\` + per-request signing, or remove the requirement via \`omni instances update ${instance.id} --no-require-genie-signature\`.`,
+        instance: instance.id,
+      },
+    },
+    401,
+  );
+});

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -214,6 +214,15 @@ const createInstanceSchema = z.object({
     .describe(
       'Tmux session name the genie bridge will spawn into for this instance. Propagated via NATS env as GENIE_TMUX_SESSION. Null clears the override (genie falls back to its agent-level or name-based default). Max 64 chars, `[A-Za-z0-9_.-]` only.',
     ),
+  // Per-instance signature enforcement (omni-host-fingerprint-trust group 6).
+  // Optional + default(false) — additive rollout: existing bearer flows keep
+  // working until an operator explicitly opts in.
+  requireGenieSignature: z
+    .boolean()
+    .default(false)
+    .describe(
+      'When true, requests targeting this instance MUST carry a verified X-Genie-Signature. Bearer-only requests get 401. Default: false (additive rollout).',
+    ),
 });
 
 // Update instance schema - allow null to clear values (only for nullable DB fields)
@@ -259,6 +268,9 @@ const updateInstanceSchema = createInstanceSchema.partial().extend({
   messageSplitDelayMinMs: z.number().int().min(0).optional(),
   messageSplitDelayMaxMs: z.number().int().min(0).optional(),
   twilioValidateSignature: z.boolean().optional(),
+  // Strip the .default(false) from the create-time schema so a PATCH that
+  // omits this key doesn't silently flip the stored value back to false.
+  requireGenieSignature: z.boolean().optional(),
 });
 
 /**

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -135,6 +135,11 @@ function applyMiscFields(body: Record<string, unknown>, opts: Record<string, unk
   setVal(body, 'twilioWebhookUrl', opts.twilioWebhookUrl);
   setBool(body, 'twilioValidateSignature', opts.twilioValidateSignature);
   setVal(body, 'bridgeTmuxSession', opts.bridgeTmuxSession);
+  // Per-instance signature requirement (omni-host-fingerprint-trust group 6).
+  // Commander pairs `--require-genie-signature` (true) and
+  // `--no-require-genie-signature` (false) automatically when the option is
+  // declared with `--require-genie-signature` syntax.
+  setBool(body, 'requireGenieSignature', opts.requireGenieSignature);
   if (opts.triggerEvents !== undefined) {
     const raw = opts.triggerEvents as string;
     body.triggerEvents = raw === 'null' ? null : raw.split(',').map((s) => s.trim());
@@ -376,6 +381,12 @@ export function createInstancesCommand(): Command {
       '--bridge-tmux-session <name>',
       'Tmux session name the genie bridge spawns into for this instance (propagated as GENIE_TMUX_SESSION via NATS). Use "null" to clear.',
     )
+    // Per-instance signature requirement (omni-host-fingerprint-trust group 6)
+    .option(
+      '--require-genie-signature',
+      'Require a verified X-Genie-Signature on requests targeting this instance. Bearer-only requests will be rejected with 401.',
+    )
+    .option('--no-require-genie-signature', 'Allow bearer-only requests targeting this instance (default).')
     // Default
     .option('--is-default', 'Set as default instance for channel')
     .action(async (options: Record<string, unknown>) => {
@@ -901,6 +912,12 @@ export function createInstancesCommand(): Command {
       '--bridge-tmux-session <name>',
       'Tmux session name the genie bridge spawns into for this instance (propagated as GENIE_TMUX_SESSION via NATS). Use "null" to clear.',
     )
+    // Per-instance signature requirement (omni-host-fingerprint-trust group 6)
+    .option(
+      '--require-genie-signature',
+      'Require a verified X-Genie-Signature on requests targeting this instance. Bearer-only requests will be rejected with 401.',
+    )
+    .option('--no-require-genie-signature', 'Allow bearer-only requests targeting this instance (default).')
     .action(async (rawId: string, options: Record<string, unknown>) => {
       const client = getClient();
 

--- a/packages/db/drizzle/0034_instances_require_genie_signature.sql
+++ b/packages/db/drizzle/0034_instances_require_genie_signature.sql
@@ -1,0 +1,18 @@
+-- Per-instance signature enforcement opt-in (omni-host-fingerprint-trust wish, Group 6).
+--
+-- Adds `instances.require_genie_signature` (default false). When true, any
+-- request that targets the instance MUST carry a verified `X-Genie-Signature`
+-- (see middleware/genie-signature.ts). Bearer-only requests get 401.
+--
+-- This flips the verification middleware from "verify when present" to
+-- "require always" on a per-instance basis. Default is false so the rollout
+-- stays additive — existing bearer flows keep working until an operator
+-- explicitly opts the instance in via:
+--
+--   omni instances update <id> --require-genie-signature
+--
+-- Hand-written (not `drizzle-kit generate`) to avoid the gupshup column
+-- rename prompts that block non-interactive runs in this repo.
+
+ALTER TABLE "instances"
+  ADD COLUMN IF NOT EXISTS "require_genie_signature" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1777590000000,
       "tag": "0033_close_contact_logs",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0034_instances_require_genie_signature",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -866,6 +866,22 @@ export const instances = pgTable(
      */
     bridgeTmuxSession: text('bridge_tmux_session'),
 
+    // ---- Per-instance signature enforcement (omni-host-fingerprint-trust, group 6) ----
+    /**
+     * When true, any request that targets this instance MUST carry a verified
+     * `X-Genie-Signature` (see middleware/genie-signature.ts). Bearer-only
+     * requests get 401 with code `GENIE_SIGNATURE_REQUIRED`.
+     *
+     * Default: false (additive rollout — existing bearer flows keep working
+     * until an operator explicitly opts the instance in via
+     * `omni instances update <id> --require-genie-signature`).
+     *
+     * Pairs with `genie_hosts.scopes` (group 5) to give operators a complete
+     * per-host trust story: which hosts can talk to this instance, and what
+     * each host is allowed to do.
+     */
+    requireGenieSignature: boolean('require_genie_signature').notNull().default(false),
+
     // ---- Timestamps ----
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),


### PR DESCRIPTION
## Summary

Group 6 of the omni-host-fingerprint-trust wish: opt-in per-instance enforcement of the genie host signature.

When an operator runs `omni instances update <id> --require-genie-signature`, the API rejects any bearer-only request targeting that instance with **401 / GENIE_SIGNATURE_REQUIRED**. Signed requests (verified by Group 4's middleware) pass through; bearer-only requests get a clear error pointing at the toggle and the handshake command.

This also fixes a critical wiring bug introduced in Group 4 — see \"Bug fix\" below.

## Why

Groups 1–5 give us:
- Per-host identity (handshake, ed25519 keys)
- Per-request signing
- Per-host scopes (intersection with bearer)

But until now, **operators couldn't tell omni \"this instance is genie-only\"**. Bearer-only callers could still reach a host-scoped instance. Group 6 adds the explicit opt-in.

## Bug fix: Group 4 middleware order

Group 4's wiring was wrong:

```
BEFORE (broken):
  authMiddleware → scopeEnforcerMiddleware → genieSignatureMiddleware → outputRedactor

AFTER (correct):
  authMiddleware
  → genieSignatureMiddleware           ← sets signedBy/signedByScopes
  → requireSignedInstanceMiddleware    ← NEW (Group 6)
  → scopeEnforcerMiddleware            ← Group 5's intersection now actually fires
  → outputRedactorMiddleware
  → rateLimitMiddleware
```

Without this reorder, Group 5's per-host scope intersection was dead code in production — the unit tests passed because they manually pre-set context. **Group 6 is what makes Group 5 effective.**

## Changes

- `packages/db/src/schema.ts` — adds `instances.require_genie_signature: boolean default false`
- `packages/db/drizzle/0034_instances_require_genie_signature.sql` — hand-written migration (gupshup column drift prevents non-interactive drizzle-kit; same convention as 0032)
- `packages/db/drizzle/meta/_journal.json` — journal entry for migration 34
- `packages/api/src/middleware/require-signed-instance.ts` (new) — the gate; re-uses `extractLockTargets` from scope-enforcer to avoid drift
- `packages/api/src/middleware/__tests__/require-signed-instance.test.ts` (new) — 8 contract tests
- `packages/api/src/app.ts` — fixed middleware order; mounted new gate
- `packages/api/src/routes/v2/instances.ts` — Zod schema accepts `requireGenieSignature` on create + update
- `packages/cli/src/commands/instances.ts` — `--require-genie-signature` / `--no-require-genie-signature` flags on both \`omni instances create\` and \`omni instances update\`

## Defensive behavior

- **Unknown instance id** → fall through (don't 401 — that would leak whether an instance exists)
- **Missing services registry** → fall through (don't brick the API on a boot/healthcheck glitch)
- **Routes without an instance target** (auth, trust handshake, etc.) → bypass entirely
- **Default false everywhere** → existing bearer flows keep working

## Test coverage

```
108 pass / 0 fail / 184 expect() calls (full middleware suite)
  8 pass / 0 fail (require-signed-instance only)
```

Matrix tested:
- requireGenieSignature=false × bearer-only → 200 (regression)
- requireGenieSignature=true × bearer-only × instance route (path) → 401 + GENIE_SIGNATURE_REQUIRED
- requireGenieSignature=true × bearer-only × instance route (body) → 401
- requireGenieSignature=true × signed → 200
- requireGenieSignature=true × no instance target → bypass
- unknown instance id → fall through (no 401 leak)
- services registry missing → fall through

## Verification

```bash
bun test packages/api/src/middleware     # 108 pass / 0 fail
bunx tsc --noEmit                         # api + cli + db all clean
bunx biome check <changed files>          # clean
```

## Test plan
- [ ] CI green (test + lint + typecheck)
- [ ] After merge: \`omni instances update <id> --require-genie-signature\`, hit the API with a bearer-only key → expect 401 + GENIE_SIGNATURE_REQUIRED
- [ ] Same instance, hit with a real signed request → expect 200
- [ ] Default-state instance → bearer-only still works (no regression)

## What's next

- Group 7: brain entries + ADR (genie-configure repo)

Refs: omni-host-fingerprint-trust wish, group 6