### PR TITLE
fix(api): unlock-only PATCH bypasses require_genie_signature gate (operator lockout)

### DIFF
--- a/packages/api/src/middleware/__tests__/require-signed-instance.test.ts
+++ b/packages/api/src/middleware/__tests__/require-signed-instance.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Hono } from 'hono';
 import type { AppVariables } from '../../types';
-import { requireSignedInstanceMiddleware } from '../require-signed-instance';
+import { isUnlockOnlyBody, requireSignedInstanceMiddleware } from '../require-signed-instance';
 
 interface FakeInstance {
   id: string;
@@ -53,9 +53,18 @@ function mountWithStub(opts: {
   });
   app.use('*', requireSignedInstanceMiddleware);
   app.get('/api/v2/instances/:id', (c) => c.json({ ok: true }));
+  app.patch('/api/v2/instances/:id', async (c) => c.json({ ok: true, patched: await c.req.json() }));
   app.post('/api/v2/messages/send', async (c) => c.json({ ok: true }));
   app.get('/api/v2/agents', (c) => c.json({ ok: true }));
   return app;
+}
+
+async function patchJson(app: Hono<{ Variables: AppVariables }>, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 }
 
 describe('require-signed-instance — default behavior (rollout additive)', () => {
@@ -107,7 +116,10 @@ describe('require-signed-instance — opt-in enforcement', () => {
     const body = (await res.json()) as { error: { code: string; instance: string; message: string } };
     expect(body.error.code).toBe('GENIE_SIGNATURE_REQUIRED');
     expect(body.error.instance).toBe('i1');
-    expect(body.error.message).toContain('omni instances update');
+    // Error message points operators at both recovery paths: signing
+    // (via genie omni handshake) and the bearer-only kill-switch unlock.
+    expect(body.error.message).toContain('genie omni handshake');
+    expect(body.error.message).toContain('"requireGenieSignature": false');
   });
 
   test('require=true + bearer-only body-instance request → 401', async () => {
@@ -149,6 +161,106 @@ describe('require-signed-instance — defensive fallbacks', () => {
     app.use('*', requireSignedInstanceMiddleware);
     app.get('/api/v2/instances/i1', (c) => c.json({ ok: true }));
     const res = await app.request('/api/v2/instances/i1');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('isUnlockOnlyBody — body shape predicate', () => {
+  test('exact unlock body → true', () => {
+    expect(isUnlockOnlyBody({ requireGenieSignature: false })).toBe(true);
+  });
+
+  test('mixed body (unlock + other field) → false (no smuggling)', () => {
+    expect(isUnlockOnlyBody({ requireGenieSignature: false, name: 'sneaky' })).toBe(false);
+  });
+
+  test('lock body (true) → false (no recovery scenario for the inverse)', () => {
+    expect(isUnlockOnlyBody({ requireGenieSignature: true })).toBe(false);
+  });
+
+  test('wrong type for the unlock value → false', () => {
+    expect(isUnlockOnlyBody({ requireGenieSignature: 'false' })).toBe(false);
+    expect(isUnlockOnlyBody({ requireGenieSignature: 0 })).toBe(false);
+    expect(isUnlockOnlyBody({ requireGenieSignature: null })).toBe(false);
+  });
+
+  test('no requireGenieSignature key → false', () => {
+    expect(isUnlockOnlyBody({ name: 'foo' })).toBe(false);
+    expect(isUnlockOnlyBody({})).toBe(false);
+  });
+
+  test('non-objects → false', () => {
+    expect(isUnlockOnlyBody(null)).toBe(false);
+    expect(isUnlockOnlyBody(undefined)).toBe(false);
+    expect(isUnlockOnlyBody('string')).toBe(false);
+    expect(isUnlockOnlyBody(42)).toBe(false);
+    expect(isUnlockOnlyBody([{ requireGenieSignature: false }])).toBe(false);
+  });
+});
+
+describe('require-signed-instance — kill-switch exemption (operator lockout prevention)', () => {
+  test('PATCH unlock body on locked instance → 200 (bearer-only allowed)', async () => {
+    // The whole point: an operator with a bearer-only client (the omni
+    // CLI itself today) MUST be able to flip require_genie_signature back
+    // off. Without this exemption, lockdown is a one-way door.
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await patchJson(app, '/api/v2/instances/i1', { requireGenieSignature: false });
+    expect(res.status).toBe(200);
+  });
+
+  test('PATCH mixed body (unlock + other field) on locked instance → 401', async () => {
+    // Smuggling check: an attacker who flipped the gate ON shouldn't be
+    // able to combine unlock with other writes from a bearer-only path.
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await patchJson(app, '/api/v2/instances/i1', {
+      requireGenieSignature: false,
+      name: 'rename-attempt',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('PATCH lock body (true) on already-locked instance → 401', async () => {
+    // Locking a locked instance is a no-op-equivalent admin action and
+    // there's no operator-recovery scenario for it. Stay locked down.
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await patchJson(app, '/api/v2/instances/i1', { requireGenieSignature: true });
+    expect(res.status).toBe(401);
+  });
+
+  test('PATCH unrelated field on locked instance → 401 (only the unlock body is exempt)', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+    });
+    const res = await patchJson(app, '/api/v2/instances/i1', { name: 'rename' });
+    expect(res.status).toBe(401);
+  });
+
+  test('PATCH unlock body on UNLOCKED instance → 200 (no-op-equivalent, never gated)', async () => {
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: false },
+    });
+    const res = await patchJson(app, '/api/v2/instances/i1', { requireGenieSignature: false });
+    expect(res.status).toBe(200);
+  });
+
+  test('signed PATCH with mixed body on locked instance → 200 (signature path bypasses the gate)', async () => {
+    // The exemption is for bearer-only callers. Signed callers have the
+    // full surface available, so a signed PATCH with whatever body shape
+    // still goes through the regular allow path.
+    const app = mountWithStub({
+      instance: { id: 'i1', requireGenieSignature: true },
+      signedBy: 'host-uuid',
+    });
+    const res = await patchJson(app, '/api/v2/instances/i1', {
+      requireGenieSignature: false,
+      name: 'rename',
+    });
     expect(res.status).toBe(200);
   });
 });

--- a/packages/api/src/middleware/require-signed-instance.ts
+++ b/packages/api/src/middleware/require-signed-instance.ts
@@ -38,6 +38,32 @@ import { extractLockTargets } from './scope-enforcer';
 const log = createLogger('api:require-signed-instance');
 
 /**
+ * Decide whether a PATCH body is an "unlock-only" request — i.e. the only
+ * change is flipping `requireGenieSignature` to false. Used by the
+ * kill-switch exemption: we let unlocks through even when the lockdown is
+ * active, but we DON'T let bearer-only callers smuggle other field
+ * changes alongside the unlock.
+ *
+ * Cases:
+ *   { requireGenieSignature: false }                → true  (unlock)
+ *   { requireGenieSignature: false, name: 'x' }    → false (mixed write)
+ *   { requireGenieSignature: true }                → false (no recovery scenario)
+ *   { requireGenieSignature: 'false' }             → false (wrong type)
+ *   { name: 'x' }                                  → false (no unlock at all)
+ *   undefined / non-object / array                 → false
+ *
+ * Exported so tests can lock down the matrix without HTTP.
+ */
+export function isUnlockOnlyBody(body: unknown): boolean {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
+  const obj = body as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length !== 1) return false;
+  if (keys[0] !== 'requireGenieSignature') return false;
+  return obj.requireGenieSignature === false;
+}
+
+/**
  * Safely parse a JSON request body. Returns null when there's no body
  * or it isn't JSON — matches scope-enforcer's behavior.
  */
@@ -94,6 +120,31 @@ export const requireSignedInstanceMiddleware = createMiddleware<{ Variables: App
     return next();
   }
 
+  // KILL-SWITCH EXEMPTION (omni-host-fingerprint-trust hotfix).
+  //
+  // Without this, the lockdown is a one-way door: an operator with a
+  // bearer-only client (the `omni` CLI itself today, or any non-genie
+  // caller) flips `requireGenieSignature: true` and then can't flip it
+  // back — the unlock PATCH gets gated by the gate it just enabled. The
+  // only recovery is a direct DB write or scripting raw signed HTTP from
+  // a genie host.
+  //
+  // We exempt PATCH /instances/:id when the body's ONLY effective change
+  // is `requireGenieSignature: false`. Other fields in the same body
+  // (name, agentId, etc.) make the request ineligible for the exemption
+  // so an attacker can't smuggle changes alongside the unlock.
+  //
+  // We deliberately do NOT exempt the inverse (`requireGenieSignature:
+  // true`) — there's no recovery scenario for "I need to enable this but
+  // can't sign," and exempting it would let bearer-only callers escalate.
+  if (method === 'PATCH' && isUnlockOnlyBody(body)) {
+    log.info('allowing unlock-only PATCH on require_genie_signature instance', {
+      instanceId: instance.id,
+      apiKeyId: c.get('apiKey')?.id,
+    });
+    return next();
+  }
+
   const apiKey = c.get('apiKey');
   log.warn('rejecting unsigned request to require_genie_signature instance', {
     instanceId: instance.id,
@@ -105,7 +156,7 @@ export const requireSignedInstanceMiddleware = createMiddleware<{ Variables: App
     {
       error: {
         code: 'GENIE_SIGNATURE_REQUIRED',
-        message: `Instance ${instance.id} requires a verified X-Genie-Signature; bearer-only requests are rejected. Sign with \`genie omni handshake\` + per-request signing, or remove the requirement via \`omni instances update ${instance.id} --no-require-genie-signature\`.`,
+        message: `Instance ${instance.id} requires a verified X-Genie-Signature; bearer-only requests are rejected. Sign with \`genie omni handshake\` + per-request signing, or unlock with PATCH /api/v2/instances/${instance.id} body {"requireGenieSignature": false} (always allowed via bearer to prevent operator lockout).`,
         instance: instance.id,
       },
     },


### PR DESCRIPTION
## Summary

Hotfix for a foot-gun caught in production dogfood today (2026-04-30): an operator with a bearer-only client (the \`omni\` CLI itself, or any non-genie caller) flips \`--require-genie-signature\` ON, then **can't flip it back** — the unlock PATCH is gated by the same gate it just enabled. Recovery requires direct DB write or scripting raw signed HTTP from a host that has genie's keys.

I hit this on this server during smoke testing of group 6. The instance ended up locked, the omni CLI couldn't unlock it, and recovery required a manual \`UPDATE instances SET require_genie_signature = false\` against postgres.

## Fix

\`PATCH /instances/:id\` is exempted from the gate when the body is **unlock-only** — i.e., the only effective change is \`requireGenieSignature: false\`. The exemption is precise:

| Body | Behavior on locked instance |
|---|---|
| \`{ requireGenieSignature: false }\` | ✅ allowed (kill switch) |
| \`{ requireGenieSignature: false, name: 'x' }\` | ❌ 401 (smuggling rejected) |
| \`{ requireGenieSignature: true }\` | ❌ 401 (no recovery scenario) |
| \`{ requireGenieSignature: 'false' }\` | ❌ 401 (wrong type) |
| \`{ name: 'x' }\` | ❌ 401 (no unlock at all) |

The inverse direction (\`requireGenieSignature: true\`) is **not** exempted — there's no operator-recovery scenario for \"enable lockdown but I can't sign,\" and exempting it would let bearer-only callers escalate.

## Error message also fixed

Before: pointed operators at \`omni instances update <id> --no-require-genie-signature\` — which loops them back to the same wall they just hit.

After: tells operators exactly how to escape, including the unlock-only PATCH recipe:

> \"Instance \\<id\\> requires a verified X-Genie-Signature; bearer-only requests are rejected. Sign with \`genie omni handshake\` + per-request signing, **or unlock with PATCH /api/v2/instances/\\<id\\> body {\\\"requireGenieSignature\\\": false} (always allowed via bearer to prevent operator lockout).**\"

## Why this was missed in #565

The 8 original tests covered the matrix of \`requireGenieSignature × signedBy × routeHasInstanceTarget\`, but they tested it as a static state. The lockout-and-unlock loop wasn't exercised — the very mode that actually breaks operators.

## Coverage added

- \`isUnlockOnlyBody\` predicate exported and tested in isolation (6 tests covering the unlock matrix above)
- 6 new contract tests on the middleware itself for the kill-switch behavior
- Tests cover both the \"smuggling rejected\" property and the \"signed callers can do anything\" path (signed callers bypass the gate entirely, so the exemption is moot for them)

```
20 pass / 0 fail / 31 expect() calls — require-signed-instance suite
120 pass / 0 fail / 204 expect() calls — full middleware suite
```

## Verification

```bash
bun test packages/api/src/middleware     # 120 pass / 0 fail
bunx tsc --noEmit                         # clean
bunx biome check                          # clean
```

## Test plan
- [ ] CI green (test + lint + typecheck)
- [ ] After merge: lock an instance, confirm unlock-only PATCH succeeds via bearer; confirm mixed-body PATCH still 401s
- [ ] Update brain runbook (PR #12 in genie-configure) with the kill-switch unlock recipe + DB recovery escape hatch

## What's still missing (P0b — separate PR)

The omni CLI itself still has no signing capability. The kill-switch makes lockdown safe to flip on, but operators still can't issue OTHER admin writes (rename, agent reassignment, etc.) against a locked instance from a bearer-only CLI. The proper fix is \`omni handshake\` mirroring \`genie omni handshake\`, after which the CLI signs every call. Tracked separately.

Refs: omni-host-fingerprint-trust wish; dogfood findings 2026-04-30