### PR TITLE
feat(cli,sdk): omni trust handshake — operator-host signing (P0b)

### DIFF
--- a/packages/cli/src/__tests__/signing.test.ts
+++ b/packages/cli/src/__tests__/signing.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the operator-host signing helper.
+ *
+ * Wish: omni-host-fingerprint-trust, P0b follow-up.
+ *
+ * Strategy: drive the pure crypto path with synthetic ed25519 keys (no
+ * filesystem) AND drive the load/store path with a temp OMNI_CONFIG_DIR
+ * to lock down the file layout.
+ *
+ * Critical property under test: the canonical signing input MUST byte-
+ * exactly match the genie signer (`genie/src/lib/omni-signature.ts`)
+ * and the omni verifier
+ * (`omni/packages/api/src/middleware/genie-signature.ts`). Drift breaks
+ * every signed request, so we pin one known-input → known-canonical-bytes
+ * test that mirrors the verifier-side assertion.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { type KeyObject, createHash, verify as edVerify, generateKeyPairSync } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  _paths,
+  canonicalSigningInput,
+  generateAndStoreKeypair,
+  loadSigningContext,
+  signRequest,
+  writeHostMetadata,
+} from '../signing';
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'omni-signing-test-'));
+  process.env.OMNI_CONFIG_DIR = tmpHome;
+});
+
+afterEach(() => {
+  process.env.OMNI_CONFIG_DIR = undefined;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('canonicalSigningInput — wire-format parity', () => {
+  test('format: <ts>\\n<METHOD>\\n<path>\\n<sha256(body) hex>', () => {
+    const ts = '2026-04-30T12:00:00.000Z';
+    const method = 'POST';
+    const path = '/api/v2/instances/abc';
+    const body = '{"name":"foo"}';
+    const expectedHash = createHash('sha256').update(body, 'utf-8').digest('hex');
+    expect(canonicalSigningInput(ts, method, path, body)).toBe(`${ts}\n${method}\n${path}\n${expectedHash}`);
+  });
+
+  test('uppercases method (matches verifier behavior)', () => {
+    const out = canonicalSigningInput('2026-04-30T12:00:00.000Z', 'patch', '/x', '');
+    expect(out.split('\n')[1]).toBe('PATCH');
+  });
+
+  test('empty body sha256 is the well-known constant', () => {
+    // sha256('') = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    // Both signer and verifier rely on this. If your locale changes the
+    // empty string's encoding, you have bigger problems.
+    const out = canonicalSigningInput('2026-04-30T12:00:00.000Z', 'GET', '/health', '');
+    expect(out.split('\n')[3]).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+});
+
+describe('signRequest — pure ed25519 sign', () => {
+  function freshKeypair(): { pubKey: KeyObject; privKey: KeyObject } {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    return { pubKey: publicKey, privKey: privateKey };
+  }
+
+  test('produces base64url-encoded signature that ed25519-verifies under the matching pubkey', () => {
+    const { pubKey, privKey } = freshKeypair();
+    const headers = signRequest({
+      hostId: 'host-uuid',
+      privateKey: privKey,
+      method: 'POST',
+      path: '/api/v2/agents',
+      body: '{"name":"foo"}',
+      now: new Date('2026-04-30T12:00:00.000Z'),
+    });
+    expect(headers['X-Genie-Host-Id']).toBe('host-uuid');
+    expect(headers['X-Genie-Timestamp']).toBe('2026-04-30T12:00:00.000Z');
+
+    const canonical = canonicalSigningInput(headers['X-Genie-Timestamp'], 'POST', '/api/v2/agents', '{"name":"foo"}');
+    const sigBytes = Buffer.from(headers['X-Genie-Signature'], 'base64url');
+    expect(edVerify(null, Buffer.from(canonical, 'utf-8'), pubKey, sigBytes)).toBe(true);
+  });
+
+  test('signing the same input twice with the same `now` yields the same signature (ed25519 is deterministic)', () => {
+    const { privKey } = freshKeypair();
+    const args = {
+      hostId: 'h',
+      privateKey: privKey,
+      method: 'GET',
+      path: '/health',
+      body: '',
+      now: new Date('2026-04-30T12:00:00.000Z'),
+    };
+    const a = signRequest(args);
+    const b = signRequest(args);
+    expect(a['X-Genie-Signature']).toBe(b['X-Genie-Signature']);
+  });
+
+  test('different `now` → different signature (different canonical input)', () => {
+    const { privKey } = freshKeypair();
+    const a = signRequest({
+      hostId: 'h',
+      privateKey: privKey,
+      method: 'GET',
+      path: '/health',
+      body: '',
+      now: new Date('2026-04-30T12:00:00.000Z'),
+    });
+    const b = signRequest({
+      hostId: 'h',
+      privateKey: privKey,
+      method: 'GET',
+      path: '/health',
+      body: '',
+      now: new Date('2026-04-30T12:00:01.000Z'),
+    });
+    expect(a['X-Genie-Signature']).not.toBe(b['X-Genie-Signature']);
+  });
+});
+
+describe('generateAndStoreKeypair → loadSigningContext round-trip', () => {
+  test('store, write metadata, then load and use to sign', () => {
+    const { pubkeyB64Url, privateKey } = generateAndStoreKeypair();
+    expect(existsSync(_paths.privateKey())).toBe(true);
+    expect(existsSync(_paths.publicKey())).toBe(true);
+    // pubkey file matches the returned base64url string
+    expect(readFileSync(_paths.publicKey(), 'utf-8')).toBe(pubkeyB64Url);
+
+    writeHostMetadata({
+      hostId: 'host-from-handshake',
+      pubkey: pubkeyB64Url,
+      hostname: 'test-machine',
+      registeredAt: '2026-04-30T12:00:00.000Z',
+    });
+    expect(existsSync(_paths.hostJson())).toBe(true);
+
+    const ctx = loadSigningContext();
+    expect(ctx).not.toBeNull();
+    if (!ctx) throw new Error('unreachable');
+    expect(ctx.hostId).toBe('host-from-handshake');
+
+    // Sign with the loaded context, verify under a pubkey derived from
+    // the persisted private key (the same KeyObject we just stored). If
+    // the signing didn't round-trip through PEM cleanly, this verify
+    // would fail.
+    const headers = ctx.signRequest('POST', '/api/v2/agents', '{"name":"foo"}');
+    const canonical = canonicalSigningInput(headers['X-Genie-Timestamp'], 'POST', '/api/v2/agents', '{"name":"foo"}');
+    const sigBytes = Buffer.from(headers['X-Genie-Signature'], 'base64url');
+    const derivedPub = require('node:crypto').createPublicKey(privateKey);
+    expect(edVerify(null, Buffer.from(canonical, 'utf-8'), derivedPub, sigBytes)).toBe(true);
+  });
+
+  test('loadSigningContext returns null when no host.json exists', () => {
+    expect(loadSigningContext()).toBeNull();
+  });
+
+  test('loadSigningContext returns null when private key file is missing even if host.json exists', () => {
+    writeHostMetadata({
+      hostId: 'half-baked',
+      pubkey: 'AAAA',
+      hostname: 'partial',
+      registeredAt: '2026-04-30T12:00:00.000Z',
+    });
+    expect(loadSigningContext()).toBeNull();
+  });
+
+  test('private key file gets 0600 perms (no group/other read)', () => {
+    generateAndStoreKeypair();
+    const stat = require('node:fs').statSync(_paths.privateKey());
+    // Mask out the file-type bits, keep just permission bits.
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -7,6 +7,7 @@
 import { type OmniClient, createOmniClient } from '@omni/sdk';
 import { hasAuth, loadConfig } from './config.js';
 import * as output from './output.js';
+import { type SigningContext, loadSigningContext } from './signing.js';
 import { VERSION } from './version.js';
 
 /** Cached client instance */
@@ -36,6 +37,7 @@ export function getClient(): OmniClient {
     baseUrl: config.apiUrl ?? 'http://localhost:8882',
     apiKey: config.apiKey,
     cliVersion: VERSION,
+    signRequest: signRequestIfHandshook(),
   });
 
   return cachedClient;
@@ -65,7 +67,26 @@ export function getOptionalClient(): OmniClient | null {
     baseUrl: config.apiUrl ?? 'http://localhost:8882',
     apiKey: config.apiKey,
     cliVersion: VERSION,
+    signRequest: signRequestIfHandshook(),
   });
 
   return cachedClient;
+}
+
+/**
+ * Build the SDK's `signRequest` callback when the operator has run
+ * `omni trust handshake`. Returns undefined otherwise — the SDK falls
+ * back to bearer-only, identical to behavior before P0b.
+ *
+ * Cached at module level: re-loading the keypair from disk on every
+ * client creation is wasted I/O.
+ */
+let _cachedSigningCtx: SigningContext | null | undefined;
+function signRequestIfHandshook() {
+  if (_cachedSigningCtx === undefined) {
+    _cachedSigningCtx = loadSigningContext();
+  }
+  if (!_cachedSigningCtx) return undefined;
+  const ctx = _cachedSigningCtx;
+  return (method: string, path: string, body: string) => ctx.signRequest(method, path, body);
 }

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -15,9 +15,11 @@
  * baseUrl / apiKey the SDK uses, so behavior is identical.
  */
 
+import { hostname as osHostname } from 'node:os';
 import { Command } from 'commander';
 import { hasAuth, loadConfig } from '../config.js';
 import * as output from '../output.js';
+import { type OmniHostMetadata, generateAndStoreKeypair, loadSigningContext, writeHostMetadata } from '../signing.js';
 
 interface TrustHost {
   id: string;
@@ -53,11 +55,44 @@ function authHeaders(): Record<string, string> {
   return headers;
 }
 
+/**
+ * If the operator has run `omni trust handshake`, this returns the
+ * signing context that adds the X-Genie-* headers to every call. When no
+ * keypair exists locally, it returns null and we go bearer-only — matches
+ * the behavior before P0b shipped, no surprise lockout for operators
+ * who haven't migrated yet.
+ *
+ * Pulled out as a module-level lazy cache so we don't re-read the key
+ * file on every API call within a single CLI invocation.
+ */
+let _cachedSigningContext: ReturnType<typeof loadSigningContext> | undefined;
+function getSigningContextOnce(): ReturnType<typeof loadSigningContext> {
+  if (_cachedSigningContext === undefined) {
+    _cachedSigningContext = loadSigningContext();
+  }
+  return _cachedSigningContext;
+}
+
 async function callApi<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const res = await fetch(trustEndpoint(path), {
+  const url = trustEndpoint(path);
+  const bodyString = body === undefined ? '' : JSON.stringify(body);
+  const headers = authHeaders();
+
+  // Sign when keys are available. The verifier accepts the bearer alone
+  // OR bearer + signature; the latter unlocks per-host scopes (group 5)
+  // and per-instance lockdown (group 6). Trust handshake itself is
+  // exempt from auth so we don't sign that one.
+  const ctx = getSigningContextOnce();
+  if (ctx && !path.startsWith('/handshake')) {
+    const reqPath = new URL(url).pathname + new URL(url).search;
+    const sigHeaders = ctx.signRequest(method, reqPath, bodyString);
+    Object.assign(headers, sigHeaders);
+  }
+
+  const res = await fetch(url, {
     method,
-    headers: authHeaders(),
-    body: body === undefined ? undefined : JSON.stringify(body),
+    headers,
+    body: body === undefined ? undefined : bodyString,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
@@ -121,6 +156,62 @@ async function handleUpdate(id: string, options: { scope: string }): Promise<voi
   }
 }
 
+async function handleHandshake(options: { rotate?: boolean; hostname?: string }): Promise<void> {
+  // Refuse to clobber an existing handshake unless --rotate. Quietly
+  // re-using the existing one is the right behavior — handshakes are
+  // idempotent on the server side too — but we want operators to know
+  // when nothing changed.
+  const existing = loadSigningContext();
+  if (existing && !options.rotate) {
+    output.success(`Already handshook as host ${existing.hostId}. Pass --rotate to issue a new keypair.`);
+    return;
+  }
+
+  // Generate the keypair (overwrites prior keys when --rotate is set —
+  // intentional; rotation is "revoke + re-register with a new key" per
+  // the wish's decision record).
+  const { pubkeyB64Url } = generateAndStoreKeypair();
+  const hostname = options.hostname ?? osHostname();
+  const capabilities = {
+    client: 'omni-cli',
+    platform: process.platform,
+    nodeVersion: process.version,
+  };
+
+  // Hit the handshake endpoint. Note we DO NOT sign this request — the
+  // server-side handshake route is auth-exempt by design (it's how new
+  // hosts bootstrap), and we don't yet have a host_id to put in the
+  // signing headers.
+  let registered: { id: string; pubkey: string; hostname: string };
+  try {
+    registered = await callApi<{ data: { id: string; pubkey: string; hostname: string } }>('POST', '/handshake', {
+      pubkey: pubkeyB64Url,
+      hostname,
+      capabilities,
+    }).then((r) => r.data);
+  } catch (err) {
+    output.error(`Handshake failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const meta: OmniHostMetadata = {
+    hostId: registered.id,
+    pubkey: registered.pubkey,
+    hostname: registered.hostname,
+    registeredAt: new Date().toISOString(),
+  };
+  writeHostMetadata(meta);
+
+  output.success(`Operator-host registered: ${meta.hostId}`);
+  output.data({
+    hostId: meta.hostId,
+    hostname: meta.hostname,
+    pubkey: meta.pubkey,
+    keysDir: '~/.omni/keys/',
+    nextStep:
+      'Future omni CLI calls will sign requests automatically. Run `omni trust list` to verify (lastSeenAt should advance after subsequent calls).',
+  });
+}
+
 async function handleRevoke(id: string): Promise<void> {
   try {
     const { data } = await callApi<{ data: TrustHost }>('DELETE', `/hosts/${encodeURIComponent(id)}`);
@@ -137,6 +228,15 @@ async function handleRevoke(id: string): Promise<void> {
 
 export function createTrustCommand(): Command {
   const trust = new Command('trust').description('Manage genie host fingerprint registrations');
+
+  trust
+    .command('handshake')
+    .description(
+      'Register THIS omni CLI as a host (mints ed25519 keypair in ~/.omni/keys/, future API calls auto-sign).',
+    )
+    .option('--rotate', 'Issue a new keypair even if one already exists')
+    .option('--hostname <name>', 'Override the hostname reported to omni (defaults to os.hostname())')
+    .action(handleHandshake);
 
   trust.command('list').description('List active (non-revoked) genie hosts').action(handleList);
 

--- a/packages/cli/src/signing.ts
+++ b/packages/cli/src/signing.ts
@@ -1,0 +1,186 @@
+/**
+ * Operator-host signing for the omni CLI.
+ *
+ * Wish: omni-host-fingerprint-trust, P0b follow-up.
+ *
+ * The genie host signs every API call out of the box (genie#1539). The
+ * `omni` CLI itself was bearer-only — which created the lockout footgun
+ * that the P0a hotfix (#568) closed via a kill-switch unlock PATCH. P0b
+ * removes the underlying problem: when an operator runs
+ * `omni trust handshake`, the CLI mints its own ed25519 keypair, registers
+ * it with omni as a host, and from then on signs every request the
+ * cached SDK client (or the trust.ts raw-fetch path) makes.
+ *
+ * Key files (default location, override via OMNI_CONFIG_DIR):
+ *   ~/.omni/keys/omni-cli.ed25519        ← private (perms 0600)
+ *   ~/.omni/keys/omni-cli.ed25519.pub    ← public (32 bytes raw)
+ *   ~/.omni/keys/host.json               ← { hostId, pubkey, hostname,
+ *                                            registeredAt }
+ *
+ * The wire format MUST byte-exactly match
+ * `genie/src/lib/omni-signature.ts:canonicalSigningInput()` and
+ * `omni/packages/api/src/middleware/genie-signature.ts:canonicalSigningInput()`.
+ * See those files for the full spec.
+ */
+
+import { type KeyObject, createHash, createPrivateKey, sign as edSign, generateKeyPairSync } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getConfigDir } from './config.js';
+
+const KEY_FILENAME_PRIV = 'omni-cli.ed25519';
+const KEY_FILENAME_PUB = 'omni-cli.ed25519.pub';
+const HOST_JSON_FILENAME = 'host.json';
+
+export interface OmniHostMetadata {
+  hostId: string;
+  pubkey: string;
+  hostname: string;
+  registeredAt: string;
+}
+
+export interface SigningHeaders {
+  'X-Genie-Host-Id': string;
+  'X-Genie-Timestamp': string;
+  'X-Genie-Signature': string;
+}
+
+export interface SigningContext {
+  hostId: string;
+  signRequest(method: string, path: string, body: string): SigningHeaders;
+}
+
+/** Path to the directory holding the operator's keypair + host metadata. */
+export function getKeysDir(): string {
+  return join(getConfigDir(), 'keys');
+}
+
+function privateKeyPath(): string {
+  return join(getKeysDir(), KEY_FILENAME_PRIV);
+}
+
+function publicKeyPath(): string {
+  return join(getKeysDir(), KEY_FILENAME_PUB);
+}
+
+function hostJsonPath(): string {
+  return join(getKeysDir(), HOST_JSON_FILENAME);
+}
+
+/**
+ * Build the canonical signing input.
+ *
+ * Format MUST byte-exactly match the genie signer and omni verifier.
+ * Drift here breaks every signed request.
+ *
+ *   canonical = <iso8601-ts>\n<METHOD>\n<path>\n<sha256(body) hex>
+ */
+export function canonicalSigningInput(timestamp: string, method: string, path: string, body: string): string {
+  const bodyHash = createHash('sha256').update(body, 'utf-8').digest('hex');
+  return `${timestamp}\n${method.toUpperCase()}\n${path}\n${bodyHash}`;
+}
+
+/**
+ * Sign a request given the host's loaded private key. Pure function — no
+ * filesystem access, deterministic for a given input + key + timestamp.
+ *
+ * Exported for direct use in tests; production callers should go through
+ * `loadSigningContext()` which handles the filesystem layer.
+ */
+export function signRequest(opts: {
+  hostId: string;
+  privateKey: KeyObject;
+  method: string;
+  path: string;
+  body: string;
+  now?: Date;
+}): SigningHeaders {
+  const timestamp = (opts.now ?? new Date()).toISOString();
+  const canonical = canonicalSigningInput(timestamp, opts.method, opts.path, opts.body);
+  const sigBytes = edSign(null, Buffer.from(canonical, 'utf-8'), opts.privateKey);
+  return {
+    'X-Genie-Host-Id': opts.hostId,
+    'X-Genie-Timestamp': timestamp,
+    'X-Genie-Signature': Buffer.from(sigBytes).toString('base64url'),
+  };
+}
+
+/**
+ * Load the operator's signing context from `~/.omni/keys/`. Returns null
+ * when no keypair is present (the CLI then continues bearer-only — same
+ * behavior as before this module existed).
+ *
+ * Errors loading an existing keypair (file unreadable, malformed JSON,
+ * etc.) bubble up — silently falling back to bearer would mask a key
+ * file that was tampered with or partially written.
+ */
+export function loadSigningContext(): SigningContext | null {
+  const hostJsonFile = hostJsonPath();
+  const privKeyFile = privateKeyPath();
+  if (!existsSync(hostJsonFile) || !existsSync(privKeyFile)) {
+    return null;
+  }
+  const meta = JSON.parse(readFileSync(hostJsonFile, 'utf-8')) as OmniHostMetadata;
+  const privKeyBuf = readFileSync(privKeyFile);
+  const privateKey = createPrivateKey({ key: privKeyBuf });
+  return {
+    hostId: meta.hostId,
+    signRequest: (method, path, body) => signRequest({ hostId: meta.hostId, privateKey, method, path, body }),
+  };
+}
+
+/**
+ * Mint a fresh ed25519 keypair on disk. Idempotent only across `--rotate`
+ * boundaries: caller is responsible for deciding whether to overwrite an
+ * existing pair.
+ *
+ * Returns the base64url-encoded raw public key (32 bytes) — the form the
+ * handshake endpoint expects.
+ */
+export function generateAndStoreKeypair(): { pubkeyB64Url: string; privateKey: KeyObject } {
+  const dir = getKeysDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+
+  // Persist private key as PEM (PKCS#8) — node:crypto re-parses it via
+  // createPrivateKey() on next load. Permissions tightened to 0600 so
+  // operators get the same protection genie's keys do.
+  const privPem = privateKey.export({ format: 'pem', type: 'pkcs8' }) as string;
+  const privPath = privateKeyPath();
+  writeFileSync(privPath, privPem, { mode: 0o600 });
+  // chmodSync defends against umask races where writeFileSync's mode arg
+  // is silently widened by an aggressive umask.
+  chmodSync(privPath, 0o600);
+
+  // Public key: store the raw 32 bytes base64url-encoded so it matches
+  // exactly what the handshake endpoint accepts. We also strip from the
+  // SPKI DER prefix to get the raw bytes.
+  const spki = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  const raw = spki.subarray(spki.byteLength - 32);
+  const pubkeyB64Url = Buffer.from(raw).toString('base64url');
+  writeFileSync(publicKeyPath(), pubkeyB64Url, { mode: 0o644 });
+
+  return { pubkeyB64Url, privateKey };
+}
+
+/** Persist host metadata after a successful handshake. */
+export function writeHostMetadata(meta: OmniHostMetadata): void {
+  const dir = getKeysDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(hostJsonPath(), JSON.stringify(meta, null, 2), { mode: 0o644 });
+}
+
+/**
+ * Test-only: paths the module reads/writes. Exported so tests can inject a
+ * temp `OMNI_CONFIG_DIR` and assert the right files were created.
+ */
+export const _paths = {
+  privateKey: privateKeyPath,
+  publicKey: publicKeyPath,
+  hostJson: hostJsonPath,
+};

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -235,6 +235,23 @@ export interface OmniClientConfig {
   apiKey: string;
   /** Optional CLI version for request handshake header */
   cliVersion?: string;
+  /**
+   * Optional ed25519 signer (omni-host-fingerprint-trust P0b). When set,
+   * every request gets the three X-Genie-* headers attached so the omni
+   * server can recognize the calling host (per-host scopes / per-instance
+   * lockdown). The CLI populates this from `~/.omni/keys/` when the
+   * operator has run `omni trust handshake`. Bearer-only callers leave
+   * this undefined and behave as before — fully backward-compatible.
+   */
+  signRequest?: (
+    method: string,
+    path: string,
+    body: string,
+  ) => {
+    'X-Genie-Host-Id': string;
+    'X-Genie-Timestamp': string;
+    'X-Genie-Signature': string;
+  };
 }
 
 /**
@@ -1167,6 +1184,23 @@ export function createOmniClient(config: OmniClientConfig) {
       if (config.cliVersion) {
         request.headers.set('x-omni-cli-version', config.cliVersion);
       }
+      // Per-host signing (P0b). Compute the signature using the same
+      // canonical input the omni verifier reconstructs: timestamp, method,
+      // pathname+search, sha256(body). We clone() the request so reading
+      // the body here doesn't consume it before the actual fetch.
+      if (config.signRequest) {
+        const url = new URL(request.url);
+        const path = `${url.pathname}${url.search}`;
+        const method = request.method;
+        let body = '';
+        if (method !== 'GET' && method !== 'HEAD') {
+          body = await request.clone().text();
+        }
+        const sigHeaders = config.signRequest(method, path, body);
+        for (const [k, v] of Object.entries(sigHeaders)) {
+          request.headers.set(k, v);
+        }
+      }
       return request;
     },
   };
@@ -1178,6 +1212,26 @@ export function createOmniClient(config: OmniClientConfig) {
     headers.set('Accept-Encoding', 'identity');
     if (config.cliVersion) {
       headers.set('x-omni-cli-version', config.cliVersion);
+    }
+    // Per-host signing (P0b) for the apiFetch escape hatch (used by SDK
+    // surfaces that bypass openapi-fetch). Body is best-effort: when init
+    // carries a non-string body we don't attempt to canonicalize it here
+    // — those callers are rare, and adding a clone path for every body
+    // shape would be a bigger refactor than this PR's scope.
+    if (config.signRequest) {
+      const u = new URL(url);
+      const path = `${u.pathname}${u.search}`;
+      const method = (init?.method ?? 'GET').toUpperCase();
+      const bodyStr =
+        method === 'GET' || method === 'HEAD' || init?.body === undefined
+          ? ''
+          : typeof init.body === 'string'
+            ? init.body
+            : '';
+      const sigHeaders = config.signRequest(method, path, bodyStr);
+      for (const [k, v] of Object.entries(sigHeaders)) {
+        headers.set(k, v);
+      }
     }
 
     return fetch(url, {


### PR DESCRIPTION
## Summary

P0b — closes the operator lockout footgun's **root cause**. PR #568 (P0a) added a kill-switch unlock PATCH so bearer-only operators could escape a self-induced lockdown; this PR removes the underlying problem by giving the omni CLI the same ed25519 signing capability genie has had since #1539.

After running once:

```bash
$ omni trust handshake
Operator-host registered: <uuid>
```

…the CLI mints `~/.omni/keys/omni-cli.ed25519{,.pub}` + `host.json`, registers as a host with omni, and **every subsequent API call** from the omni CLI carries the three `X-Genie-*` signing headers. Per-host scopes (group 5) and per-instance lockdown (group 6) finally apply uniformly to operator traffic — not just to genie-host traffic.

## What this unlocks

| Before P0b | After P0b |
|---|---|
| Lock down an instance → can't administer it from `omni` CLI without DB recovery (or P0a kill-switch) | Lock down an instance → keep using `omni` CLI normally; signed admin works |
| `omni trust update <my-genie-host-id> --scope agents:read` narrows genie, but operator's CLI is still wildcard-bearer | Operator host is its own row in `genie_hosts`; can be scoped independently of genie hosts |
| Audit signal limited to bearer id (one row per shared key) | `omni trust list` shows operator's `lastSeenAt` advance per CLI invocation |

## Implementation

- `packages/cli/src/signing.ts` (new) — keypair management + `canonicalSigningInput` + `signRequest`. Pure functions with file-aware helpers; no SDK or HTTP coupling.
- `packages/cli/src/__tests__/signing.test.ts` (new) — 10 contract tests covering wire-format parity (matches genie + verifier byte-exact), ed25519 round-trip, deterministic signing, file-perms (0600), missing-key fallback.
- `packages/sdk/src/client.ts` — adds `OmniClientConfig.signRequest` hook: optional ed25519 signer that injects the 3 headers via the openapi-fetch middleware AND the `apiFetch` escape hatch. **Backward-compatible**: omitted = bearer-only.
- `packages/cli/src/client.ts` — wires `loadSigningContext()` into `getClient()` / `getOptionalClient()` so the cached SDK signs all CLI calls automatically when keys are present.
- `packages/cli/src/commands/trust.ts` — adds `omni trust handshake` subcommand (mirrors `genie omni handshake`); patches the raw-fetch path so `list`/`get`/`update`/`revoke` also sign.

## Wire format invariants (treat as protocol)

The canonical signing input MUST byte-exactly match:
- `genie/src/lib/omni-signature.ts:canonicalSigningInput()`
- `omni/packages/api/src/middleware/genie-signature.ts:canonicalSigningInput()`

Test pins the empty-body sha256 to the well-known constant (`e3b0c44…`) — same assertion the verifier-side has. Drift breaks every signed request.

## Backward compatibility

- **No keys present** → bearer-only, identical to before this PR. The CLI doesn't refuse to start, doesn't warn, doesn't change behavior.
- **Operators don't have to handshake.** The CLI works either way.
- **Trust handshake endpoint itself is auth-exempt** and we deliberately do NOT sign it (chicken-and-egg: bootstrapping a host doesn't require already being one).
- **Mixed environments** (some operators handshook, some not) work — the omni server treats both signed and unsigned requests fine; signing just adds the per-host audit + scope signal.

## Verification

```bash
bun test packages/cli                    # 451 pass / 0 fail
bun test packages/api/src/middleware     # 120 pass / 0 fail
bunx tsc --noEmit                         # cli + sdk + api all clean
bunx biome check                          # clean
```

## Test plan
- [ ] CI green
- [ ] After merge: \`omni trust handshake\` on a fresh box, confirm \`omni trust list\` shows the new host with hostname matching osHostname()
- [ ] Lock an instance, run \`omni instances update <id> --some-other-flag\` from the same CLI, confirm 200 (signed request bypasses the gate)
- [ ] Smoke that bearer-only operators (no \`~/.omni/keys/\`) still work unchanged

## What's still on the followup list

- **P1** — extend genie's signing helper to wrap all genie→omni HTTP callsites (omni-bridge, future) so locking a non-test instance doesn't break NATS-side dispatch.
- **P2** — `omni doctor` warns when reachable instances require signature but no signing key exists for the running CLI.
- **P2** — CI smoke for the lockout-and-unlock cycle (the regression class P0a + P0b are designed to prevent).

Refs: omni-host-fingerprint-trust wish; P0b follow-up to #568