### PR TITLE
chore(cli): drop unused export getKeysDir to satisfy knip

### DIFF
--- a/packages/cli/src/signing.ts
+++ b/packages/cli/src/signing.ts
@@ -51,7 +51,7 @@ export interface SigningContext {
 }
 
 /** Path to the directory holding the operator's keypair + host metadata. */
-export function getKeysDir(): string {
+function getKeysDir(): string {
   return join(getConfigDir(), 'keys');
 }
 


### PR DESCRIPTION
Quality Gate (knip dead-code check) flagged `getKeysDir` as an unused export after #569 merged. Drop the export keyword — only internal callers use it. The `_paths` test fixture (still exported) is what the test suite actually needs.

Restores green dev CI.

Refs: #569 follow-up