### PR TITLE
feat(cli): doctor warns when locked instances exist + no signing key (P2a)

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -60,6 +60,10 @@ interface HarnessState {
   maxRestartsAfterFix: number | undefined;
   /** Whether pm2 conf becomes healthy after a fix attempt. */
   pm2ConfAfterFix: string | null;
+  /** Instances reported by listLockedInstances() (P2a check input). */
+  lockedInstances: Array<{ id: string; name: string }>;
+  /** Whether cliHasSigningKey() returns true. */
+  cliHasSigningKey: boolean;
 }
 
 /** Canonical healthy `pm2 conf` output — matches PM2_LOGROTATE_SETTINGS. */
@@ -99,6 +103,10 @@ function mkHarness(overrides?: Partial<HarnessState>): HarnessState {
     pm2DriftAfterFix: false,
     maxRestartsAfterFix: undefined,
     pm2ConfAfterFix: null,
+    // P2a defaults: no locked instances + no signing key → check is OK
+    // ("nothing to assert"). Tests opt into the WARN path explicitly.
+    lockedInstances: [],
+    cliHasSigningKey: false,
     ...overrides,
   };
 }
@@ -179,6 +187,8 @@ function mkDeps(state: HarnessState): DoctorDeps {
       // No real sleep in tests — we're deterministic.
     },
     capturePm2Conf: async () => state.pm2ConfOutput,
+    listLockedInstances: async () => [...state.lockedInstances],
+    cliHasSigningKey: () => state.cliHasSigningKey,
   };
 }
 
@@ -187,7 +197,7 @@ function mkDeps(state: HarnessState): DoctorDeps {
 // ---------------------------------------------------------------------------
 
 describe('runDoctor — read-only mode', () => {
-  test('reports all 9 checks with OK when state is healthy', async () => {
+  test('reports all 10 checks with OK when state is healthy', async () => {
     // Match the harness version to whatever the CLI currently reports so
     // `version-match` is OK without hard-coding the CLI version here.
     const { VERSION } = await import('../version.js');
@@ -196,7 +206,7 @@ describe('runDoctor — read-only mode', () => {
 
     const report = await runDoctor({ fix: false }, deps);
 
-    expect(report.checks).toHaveLength(9);
+    expect(report.checks).toHaveLength(10);
     const ids = report.checks.map((c) => c.id);
     expect(ids).toEqual([
       'pm2-env-drift',
@@ -208,11 +218,12 @@ describe('runDoctor — read-only mode', () => {
       'pm2-status',
       'pm2-max-restarts',
       'pm2-logrotate-installed',
+      'cli-signing-key-for-locked-instances',
     ]);
     for (const check of report.checks) {
       expect(check.level).toBe('OK');
     }
-    expect(report.summary).toEqual({ ok: 9, warn: 0, fail: 0 });
+    expect(report.summary).toEqual({ ok: 10, warn: 0, fail: 0 });
     expect(report.fixesApplied).toEqual([]);
   });
 
@@ -384,6 +395,83 @@ Module: pm2-logrotate
 
     const check = report.checks.find((c) => c.id === 'pm2-logrotate-installed');
     expect(check?.level).toBe('WARN');
+  });
+
+  test('cli-signing-key-for-locked-instances OK when no instances are locked', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION, lockedInstances: [], cliHasSigningKey: false });
+    const deps = mkDeps(state);
+
+    const report = await runDoctor({ fix: false }, deps);
+
+    const check = report.checks.find((c) => c.id === 'cli-signing-key-for-locked-instances');
+    expect(check?.level).toBe('OK');
+    expect(check?.detail).toContain('no instances require signed requests');
+  });
+
+  test('cli-signing-key-for-locked-instances OK when locked instances + key present', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({
+      serverVersion: VERSION,
+      lockedInstances: [{ id: 'inst-1', name: 'whatsapp-prod' }],
+      cliHasSigningKey: true,
+    });
+    const deps = mkDeps(state);
+
+    const report = await runDoctor({ fix: false }, deps);
+
+    const check = report.checks.find((c) => c.id === 'cli-signing-key-for-locked-instances');
+    expect(check?.level).toBe('OK');
+    expect(check?.detail).toContain('CLI has a signing key');
+  });
+
+  test('cli-signing-key-for-locked-instances WARN when locked instances + no key', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({
+      serverVersion: VERSION,
+      lockedInstances: [
+        { id: 'inst-1', name: 'whatsapp-prod' },
+        { id: 'inst-2', name: 'telegram-prod' },
+      ],
+      cliHasSigningKey: false,
+    });
+    const deps = mkDeps(state);
+
+    const report = await runDoctor({ fix: false }, deps);
+
+    const check = report.checks.find((c) => c.id === 'cli-signing-key-for-locked-instances');
+    expect(check?.level).toBe('WARN');
+    expect(check?.detail).toContain('whatsapp-prod');
+    expect(check?.detail).toContain('telegram-prod');
+    expect(check?.detail).toContain('omni trust handshake');
+    // Operator's escape hatch is mentioned so they know they're not stuck.
+    expect(check?.detail).toContain('unlock-only PATCH');
+  });
+
+  test('cli-signing-key-for-locked-instances WARN truncates list at 3 with "+N more" suffix', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({
+      serverVersion: VERSION,
+      lockedInstances: [
+        { id: 'i1', name: 'a' },
+        { id: 'i2', name: 'b' },
+        { id: 'i3', name: 'c' },
+        { id: 'i4', name: 'd' },
+        { id: 'i5', name: 'e' },
+      ],
+      cliHasSigningKey: false,
+    });
+    const deps = mkDeps(state);
+
+    const report = await runDoctor({ fix: false }, deps);
+
+    const check = report.checks.find((c) => c.id === 'cli-signing-key-for-locked-instances');
+    expect(check?.level).toBe('WARN');
+    expect(check?.detail).toContain('a, b, c');
+    expect(check?.detail).toContain('+2 more');
+    // Names beyond the first 3 are NOT in the message — keeps the warning
+    // readable when an operator has many instances locked.
+    expect(check?.detail).not.toContain(', d');
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -49,6 +49,7 @@ import * as output from '../output.js';
 import { PM2_HARDENED_DEFAULTS, PM2_PROCESSES, buildPm2StartArgs, capturePm2, isPm2Available, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv, resolvePgservePort } from '../runtime-env.js';
 import { getServerLauncherPath } from '../server-bundle.js';
+import { loadSigningContext } from '../signing.js';
 import { generateApiKey } from '../utils/keys.js';
 import { VERSION } from '../version.js';
 
@@ -69,7 +70,8 @@ export type CheckId =
   | 'version-match'
   | 'pm2-status'
   | 'pm2-max-restarts'
-  | 'pm2-logrotate-installed';
+  | 'pm2-logrotate-installed'
+  | 'cli-signing-key-for-locked-instances';
 
 export interface CheckResult {
   id: CheckId;
@@ -177,6 +179,21 @@ export interface DoctorDeps {
   sleepMs: (ms: number) => Promise<void>;
   /** Capture `pm2 conf` stdout (or null on error). Used by pm2-logrotate check. */
   capturePm2Conf: () => Promise<string | null>;
+  /**
+   * List instances that have `requireGenieSignature: true` set. Used by the
+   * signature-key-for-locked-instances check (omni-host-fingerprint-trust
+   * P2). Returns an empty array when the API is unreachable — the check
+   * then becomes a no-op rather than false-positive WARN.
+   */
+  listLockedInstances: () => Promise<{ id: string; name: string }[]>;
+  /**
+   * Return true when the running CLI has a usable ed25519 keypair (i.e.
+   * `omni trust handshake` has been run). Locked instances refuse
+   * bearer-only requests, so an operator without a key can only do the
+   * unlock-only PATCH escape — anything else fails with 401. We surface
+   * that as a WARN so it's caught before the operator hits the wall.
+   */
+  cliHasSigningKey: () => boolean;
 }
 
 /** Default production deps — each is a thin shim around the real call. */
@@ -265,6 +282,28 @@ function productionDeps(): DoctorDeps {
       if (code !== 0) return null;
       return stdout;
     },
+    listLockedInstances: async () => {
+      const cliConfig = loadConfig();
+      // Without a stored CLI key we can't even reach /instances. Fall
+      // back to "no locked instances visible" rather than crash; the
+      // cli-key-valid check already FAILs and surfaces the real problem.
+      if (!cliConfig.apiKey) return [];
+      try {
+        const apiPort = loadServerConfig().port;
+        const baseUrl = cliConfig.apiUrl ?? `http://localhost:${apiPort}`;
+        const client = createOmniClient({ baseUrl, apiKey: cliConfig.apiKey, cliVersion: VERSION });
+        const { items } = await client.instances.list({ limit: 200 });
+        return items
+          .filter((i) => (i as unknown as { requireGenieSignature?: boolean }).requireGenieSignature === true)
+          .map((i) => ({ id: i.id, name: i.name }));
+      } catch {
+        // API unreachable / network blip → no-op the check rather than
+        // false-positive WARN. Other doctor checks already cover the
+        // "API unreachable" failure mode (pgserve-reachable, omni-db-exists).
+        return [];
+      }
+    },
+    cliHasSigningKey: () => loadSigningContext() !== null,
   };
 }
 
@@ -618,11 +657,55 @@ function fixOrphanedDataDirs(deps: DoctorDeps): string {
   return `printed ${found.length} rm-rf suggestion(s)`;
 }
 
+/**
+ * Check 10: when one or more instances are locked
+ * (require_genie_signature = true) but this CLI doesn't have a signing
+ * keypair, warn that bearer-only admin will fail and tell the operator
+ * how to fix it.
+ *
+ * Three cases:
+ *   - No locked instances → OK (signature pipeline may or may not be
+ *     in use; nothing for this check to assert).
+ *   - Locked instances + key present → OK (signed admin works).
+ *   - Locked instances + no key → WARN with the exact recovery command.
+ *
+ * The kill-switch unlock PATCH (omni#568) still works without a key,
+ * so this is genuinely a WARN (operator can recover) rather than FAIL.
+ */
+async function checkSigningKeyForLockedInstances(deps: DoctorDeps): Promise<CheckResult> {
+  const locked = await deps.listLockedInstances();
+  if (locked.length === 0) {
+    return {
+      id: 'cli-signing-key-for-locked-instances',
+      level: 'OK',
+      detail: 'no instances require signed requests (or API unreachable — check pgserve-reachable / omni-db-exists)',
+    };
+  }
+  const hasKey = deps.cliHasSigningKey();
+  if (hasKey) {
+    return {
+      id: 'cli-signing-key-for-locked-instances',
+      level: 'OK',
+      detail: `${locked.length} instance(s) require signing; CLI has a signing key — admin will sign automatically`,
+    };
+  }
+  const names = locked
+    .slice(0, 3)
+    .map((i) => i.name || i.id.slice(0, 8))
+    .join(', ');
+  const more = locked.length > 3 ? ` (+${locked.length - 3} more)` : '';
+  return {
+    id: 'cli-signing-key-for-locked-instances',
+    level: 'WARN',
+    detail: `${locked.length} instance(s) require signing (${names}${more}) but this CLI has no key in ~/.omni/keys/. Bearer-only admin against these instances will fail with 401 GENIE_SIGNATURE_REQUIRED. Run \`omni trust handshake\` to enable signed requests. (The unlock-only PATCH escape from omni#568 still works without a key.)`,
+  };
+}
+
 // ============================================================================
 // MAIN
 // ============================================================================
 
-/** Run the full 9-check battery sequentially. */
+/** Run the full check battery sequentially. */
 async function runAllChecks(deps: DoctorDeps): Promise<CheckResult[]> {
   return [
     await checkPm2EnvDrift(deps),
@@ -634,6 +717,7 @@ async function runAllChecks(deps: DoctorDeps): Promise<CheckResult[]> {
     await checkPm2Status(deps),
     await checkPm2MaxRestarts(deps),
     await checkPm2LogrotateInstalled(deps),
+    await checkSigningKeyForLockedInstances(deps),
   ];
 }
 


### PR DESCRIPTION
## Summary

Adds a tenth doctor check to surface the host-fingerprint-trust footgun **before** operators hit it. If one or more instances have \`require_genie_signature: true\` and the running CLI doesn't have a keypair in \`~/.omni/keys/\`, doctor now WARNs with the exact recovery command.

Today operators only learn about this by trying \`omni instances update <locked-id> --some-field\` and getting 401 GENIE_SIGNATURE_REQUIRED. With this check, \`omni doctor\` catches it pre-flight.

## Three states

| Locked instances | CLI has key | Result |
|---|---|---|
| 0 | n/a | ✅ OK ("no instances require signed requests") |
| ≥1 | yes | ✅ OK ("signed admin works automatically") |
| ≥1 | no | ⚠ WARN with names, \`omni trust handshake\` recipe, and the kill-switch unlock reminder |

## Why WARN not FAIL

- The kill-switch unlock-only PATCH (omni#568) still works regardless of key state. Operator is never truly stuck.
- Many setups won't lock any instances at all — locking is opt-in.
- FAIL would inflate the summary count and bury other doctor failures.

## Implementation

Two new \`DoctorDeps\` functions (DI seam preserved):
- \`listLockedInstances()\` — API call → array of \`{id, name}\` (returns empty array on API error rather than crash)
- \`cliHasSigningKey()\` — boolean from \`loadSigningContext()\` (zero filesystem if no keys present)

The check function \`checkSigningKeyForLockedInstances\` wires them together with the truncated-list message format.

## Coverage

- 27/27 doctor tests pass (23 existing + **4 new** covering all three states + the \"truncate to 3 + +N more\" path)
- Healthy state regression test now expects 10 checks (was 9)

## Verification

```bash
bun test packages/cli                # 335 pass / 0 fail
bunx tsc --noEmit                     # clean
bunx biome check                      # clean
bunx knip                             # clean
```

## Test plan
- [ ] CI green
- [ ] Manual: lock an instance, run \`omni doctor\` from a CLI with no \`~/.omni/keys/\` → expect WARN
- [ ] Run \`omni trust handshake\`, re-run doctor → expect OK
- [ ] Unlock the instance, re-run doctor → expect OK with "no instances require signed requests"

Refs: omni-host-fingerprint-trust wish; P2a follow-up to omni#569