### PR TITLE
fix(cli): postinstall self-heals @automagik/omni semver drift to legacy versions

### DIFF
--- a/packages/cli/__tests__/postinstall-pin-version.test.ts
+++ b/packages/cli/__tests__/postinstall-pin-version.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the postinstall-pin-version hook.
+ *
+ * Why CommonJS .cjs script + TypeScript test? The script must run from
+ * raw `node` (no bun, no transpiler) on bare-metal npm/bun installs
+ * before any of our build artifacts exist. Tests run via bun:test and
+ * shell out to `node` against the real script with a temp HOME so the
+ * effects are observable on disk.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const SCRIPT = resolve(__dirname, '..', 'scripts', 'postinstall-pin-version.cjs');
+
+let tmpHome: string;
+
+function runScript(env: Record<string, string> = {}): { code: number; stderr: string } {
+  const result = spawnSync('node', [SCRIPT], {
+    env: { ...process.env, HOME: tmpHome, ...env },
+    encoding: 'utf8',
+  });
+  return { code: result.status ?? -1, stderr: result.stderr };
+}
+
+function writeBunGlobalManifest(deps: Record<string, string>): string {
+  const dir = join(tmpHome, '.bun', 'install', 'global');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'package.json');
+  writeFileSync(path, JSON.stringify({ dependencies: deps }, null, 2));
+  return path;
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'omni-postinstall-'));
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('postinstall-pin-version', () => {
+  test('rewrites caret range to exact for @automagik/omni', async () => {
+    const manifest = writeBunGlobalManifest({
+      '@automagik/omni': '^2.260430.0',
+      '@automagik/genie': '^4.260430.12',
+    });
+
+    const { code } = runScript();
+    expect(code).toBe(0);
+
+    const after = JSON.parse(readFileSync(manifest, 'utf-8'));
+    // @automagik/omni: pinned to whatever this package's version is (no caret)
+    expect(after.dependencies['@automagik/omni']).not.toMatch(/^[\^~]/);
+    // package.json's own version dictates the pin
+    const ourPkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'));
+    expect(after.dependencies['@automagik/omni']).toBe(ourPkg.version);
+    // Other deps untouched (only our package gets pinned)
+    expect(after.dependencies['@automagik/genie']).toBe('^4.260430.12');
+  });
+
+  test('leaves exact-pinned omni alone (idempotent)', async () => {
+    const ourPkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'));
+    const manifest = writeBunGlobalManifest({
+      '@automagik/omni': ourPkg.version, // already exact
+    });
+
+    const before = readFileSync(manifest, 'utf-8');
+    const { code } = runScript();
+    expect(code).toBe(0);
+    const after = readFileSync(manifest, 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  test('also rewrites tilde ranges (~) — they have the same drift risk', async () => {
+    const manifest = writeBunGlobalManifest({
+      '@automagik/omni': '~2.260430.0',
+    });
+
+    runScript();
+
+    const after = JSON.parse(readFileSync(manifest, 'utf-8'));
+    expect(after.dependencies['@automagik/omni']).not.toMatch(/^[\^~]/);
+  });
+
+  test('leaves non-range specs alone (file:, git+, tarball URL)', async () => {
+    const manifest = writeBunGlobalManifest({
+      '@automagik/omni': 'file:../local-omni-tarball.tgz',
+    });
+
+    runScript();
+
+    const after = JSON.parse(readFileSync(manifest, 'utf-8'));
+    expect(after.dependencies['@automagik/omni']).toBe('file:../local-omni-tarball.tgz');
+  });
+
+  test('OMNI_SKIP_POSTINSTALL_PIN=1 short-circuits the script', async () => {
+    const manifest = writeBunGlobalManifest({
+      '@automagik/omni': '^2.260430.0',
+    });
+
+    const before = readFileSync(manifest, 'utf-8');
+    const { code } = runScript({ OMNI_SKIP_POSTINSTALL_PIN: '1' });
+    expect(code).toBe(0);
+    const after = readFileSync(manifest, 'utf-8');
+    // Nothing was written — operator opt-out respected.
+    expect(after).toBe(before);
+  });
+
+  test('missing global manifest is a no-op (no error, exit 0)', async () => {
+    // No manifest written. Script should exit cleanly.
+    const { code } = runScript();
+    expect(code).toBe(0);
+  });
+
+  test('malformed global manifest is a no-op (no crash, exit 0)', async () => {
+    const dir = join(tmpHome, '.bun', 'install', 'global');
+    mkdirSync(dir, { recursive: true });
+    const manifest = join(dir, 'package.json');
+    writeFileSync(manifest, '{ this is { not valid JSON }');
+
+    const { code } = runScript();
+    expect(code).toBe(0);
+    // The garbage file is left untouched — we never write back malformed
+    // content.
+    expect(readFileSync(manifest, 'utf-8')).toContain('not valid JSON');
+  });
+
+  test('installation never fails — even when manifest write would error', async () => {
+    // Make the manifest readonly so writeJsonAtomic's rename throws.
+    // The script must STILL exit 0 — install path is too critical to
+    // fail on a self-heal hook.
+    const manifest = writeBunGlobalManifest({
+      '@automagik/omni': '^2.260430.0',
+    });
+    const dir = join(tmpHome, '.bun', 'install', 'global');
+    // Drop write perms on the directory so atomic rename can't clobber.
+    require('node:fs').chmodSync(dir, 0o500);
+
+    try {
+      const { code } = runScript();
+      expect(code).toBe(0);
+    } finally {
+      // Restore perms so cleanup can rm the dir.
+      require('node:fs').chmodSync(dir, 0o755);
+      // Ensure manifest still exists (we restored, didn't delete).
+      expect(existsSync(manifest)).toBe(true);
+    }
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
       "import": "./dist/sdk/index.js"
     }
   },
-  "files": ["dist", "bin", "db"],
+  "files": ["dist", "bin", "db", "scripts/postinstall-pin-version.cjs"],
   "publishConfig": {
     "access": "public"
   },
@@ -29,6 +29,7 @@
     "dev": "echo 'CLI package - no dev server (use: bun run ./src/index.ts <command>)'",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "postinstall": "node scripts/postinstall-pin-version.cjs",
     "test:integration": "RUN_INTEGRATION_TESTS=1 bun test",
     "clean": "rm -rf dist db",
     "build:server": "bun build src/bundled-server-entry.ts --outdir dist/server --entry-naming 'index.[ext]' --asset-naming '[name].[ext]' --target bun --external @anthropic-ai/claude-agent-sdk --external @snazzah/davey --external libsodium-wrappers --external opusscript --external pdf-parse --external mammoth --external exceljs",

--- a/packages/cli/scripts/postinstall-pin-version.cjs
+++ b/packages/cli/scripts/postinstall-pin-version.cjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * postinstall-pin-version.cjs
+ *
+ * Self-heal the global package.json caret range that triggers the
+ * "version drift back to 2.20260221.x" footgun.
+ *
+ * Background
+ * ----------
+ * Omni's version scheme is `2.YYMMDD.X` (e.g. `2.260430.7`). The legacy
+ * scheme used 8-digit YYYYMMDD minors (e.g. `2.20260221.1`). Semver
+ * compares minors numerically:
+ *
+ *     2.260430.7    →  MINOR = 260430
+ *     2.20260221.1  →  MINOR = 20260221     ← 77× larger
+ *
+ * So `^2.260430.7` in a package.json semver-resolves to
+ * `2.20260221.1` (legacy version still on the registry). Every range-
+ * resolving install (e.g. plain `bun install -g`, or any tool that
+ * re-resolves the global manifest) flips the install backward.
+ *
+ * What this script does
+ * ---------------------
+ * On every `bun add -g @automagik/omni` / `npm install -g
+ * @automagik/omni`, this postinstall runs and rewrites the
+ * `@automagik/omni` entry in the global manifest from a caret range to
+ * an exact pin (`"2.260430.7"` no `^`). That stops the drift at the
+ * source — operators don't need to remember `--exact`, and any later
+ * range-resolve sees the exact version they last installed.
+ *
+ * Where this script writes
+ * ------------------------
+ *   - `~/.bun/install/global/package.json` (bun's global manifest)
+ *   - `<npm root -g>/package.json` (only if it exists; npm's global
+ *     install layout doesn't always include this file)
+ *
+ * Hardening
+ * ---------
+ *   - Best-effort: NEVER fails the install. Any error → log to stderr
+ *     and exit 0. The install proceeds; the operator can still pin
+ *     manually.
+ *   - Idempotent: writing the same file twice is a no-op.
+ *   - Touches ONLY `@automagik/omni` — leaves other dependencies alone.
+ *   - No-op when run inside the package's own dev tree (workspace
+ *     install): we detect via the absence of the global manifest path.
+ *   - No-op when env `OMNI_SKIP_POSTINSTALL_PIN=1` (escape hatch for
+ *     CI / testers / downstream packagers who pin via their own tooling).
+ *
+ * Removal
+ * -------
+ * When the legacy `2.20260218–2.20260221` versions are deprecated or
+ * unpublished from the registry (the proper fix), this script becomes a
+ * no-op safely. It can be removed at that point.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PACKAGE_NAME = '@automagik/omni';
+
+function log(msg) {
+  // Stderr only so JSON tooling consuming stdout stays clean.
+  process.stderr.write(`[omni postinstall] ${msg}\n`);
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (_err) {
+    return null;
+  }
+}
+
+function writeJsonAtomic(filePath, data) {
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o644 });
+  fs.renameSync(tmp, filePath);
+}
+
+/**
+ * Replace `"@automagik/omni": "^X.Y.Z"` with the exact version. Returns
+ * true when a change was applied, false otherwise.
+ */
+function pinInManifest(manifestPath, exactVersion) {
+  if (!fs.existsSync(manifestPath)) return false;
+  const manifest = readJson(manifestPath);
+  if (!manifest || typeof manifest !== 'object') return false;
+
+  let changed = false;
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    const deps = manifest[field];
+    if (!deps || typeof deps !== 'object') continue;
+    const current = deps[PACKAGE_NAME];
+    if (typeof current !== 'string') continue;
+    // Skip when already exact OR when not a caret range (e.g. a tarball
+    // URL, git ref, file: spec, or workspace marker — none of these are
+    // affected by the legacy-version-resolve-up bug).
+    if (!current.startsWith('^') && !current.startsWith('~')) continue;
+    if (current === exactVersion) continue;
+    deps[PACKAGE_NAME] = exactVersion;
+    changed = true;
+  }
+
+  if (changed) {
+    writeJsonAtomic(manifestPath, manifest);
+  }
+  return changed;
+}
+
+function getOurVersion() {
+  // package.json sits one directory up from this script (packages/cli/
+  // when running from source, or the package root when running from
+  // npm-installed tarball — same relative layout in both).
+  const pkgPath = path.resolve(__dirname, '..', 'package.json');
+  const pkg = readJson(pkgPath);
+  if (!pkg || typeof pkg.version !== 'string') return null;
+  return pkg.version;
+}
+
+function getNpmGlobalRoot() {
+  // Best-effort: shell out to npm root -g. Cap a short timeout so a
+  // hung npm doesn't block the install pipeline.
+  try {
+    const { execFileSync } = require('node:child_process');
+    const out = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', timeout: 3000 });
+    return out.trim();
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  if (process.env.OMNI_SKIP_POSTINSTALL_PIN === '1') {
+    return; // operator opt-out
+  }
+
+  const ourVersion = getOurVersion();
+  if (!ourVersion) {
+    log('skipped: could not read own package version');
+    return;
+  }
+
+  const targets = [];
+
+  // bun global manifest
+  const bunGlobalManifest = path.join(os.homedir(), '.bun', 'install', 'global', 'package.json');
+  targets.push({ label: 'bun', path: bunGlobalManifest });
+
+  // npm global manifest (only if `npm` is installed)
+  const npmRoot = getNpmGlobalRoot();
+  if (npmRoot) {
+    targets.push({ label: 'npm', path: path.join(npmRoot, '..', 'package.json') });
+  }
+
+  let pinned = 0;
+  for (const target of targets) {
+    try {
+      if (pinInManifest(target.path, ourVersion)) {
+        log(`pinned ${PACKAGE_NAME} to ${ourVersion} in ${target.label} global manifest (${target.path})`);
+        pinned += 1;
+      }
+    } catch (err) {
+      // Never fail the install. Surface the reason for diagnosis but
+      // exit 0 below.
+      log(`warning: could not pin ${target.label} manifest at ${target.path}: ${err?.message ? err.message : err}`);
+    }
+  }
+
+  if (pinned === 0) {
+    // Either no global manifest had a caret entry (already pinned, or
+    // installed via a path that doesn't write to package.json), or the
+    // package isn't in any global manifest. Either way: no-op is fine.
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  // Last-resort safety net. The install MUST NOT fail because of this
+  // script.
+  process.stderr.write(`[omni postinstall] unexpected error (non-fatal): ${err?.stack ? err.stack : err}\n`);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

Fixes the operator footgun where \`@automagik/omni\` keeps drifting back to \`2.20260221.x\` after every install. Caused by the dual version scheme on the npm registry — modern (\`2.YYMMDD.X\`) vs legacy (\`2.YYYYMMDD.X\`) — semver-resolving the legacy versions as \"higher\" because of raw integer minor-comparison.

## Root cause

```
2.260430.7    →  MINOR = 260430
2.20260221.1  →  MINOR = 20260221    ← 77× larger numerically
```

Any \`^2.260430.x\` range in a package.json resolves to \`2.20260221.1\` because semver compares minors as integers. Every \`bun install -g\` (or auto-re-resolve) flips the install backward.

## Fix

A \`postinstall\` script (\`scripts/postinstall-pin-version.cjs\`) that runs after every install and rewrites \`@automagik/omni\` from caret/tilde ranges to the **exact installed version** in both bun's global manifest (\`~/.bun/install/global/package.json\`) and npm's global manifest (\`npm root -g/../package.json\`).

```diff
- "@automagik/omni": "^2.260430.7"
+ "@automagik/omni": "2.260430.7"
```

After this lands, no operator needs to remember \`--exact\` or pin manually — install once, stays put.

## Properties

| Property | How |
|---|---|
| Install never fails | All errors caught, exit 0 always (postinstall hook contract) |
| Idempotent | Already-exact pin is a no-op |
| Targeted | Only \`@automagik/omni\` is rewritten — every other dep is left as-is |
| Atomic | Write via tmp + rename, no half-baked manifest possible |
| Opt-out | \`OMNI_SKIP_POSTINSTALL_PIN=1\` short-circuits |
| Removable | When legacy versions are deprecated/unpublished, this becomes a no-op — delete file + script entry |

## Why D (postinstall) over C (patch update.ts)

| Path | Coverage |
|---|---|
| C — Patch \`omni update\` to use \`--exact\` | Only fires when operator explicitly runs \`omni update\`. Fresh installs and \`bun add\` directly still drift. |
| **D — postinstall script (this PR)** | Fires on EVERY install: \`bun add\`, \`npm install\`, \`omni update\`, fresh setup, lockfile re-resolves. Operator does nothing. |

D also self-heals existing installs that already wrote \`^X.Y.Z\` to their global manifest — the next install of any kind will pin them.

## Why not deprecate/unpublish on registry

\`npm deprecate\` doesn't change semver resolution priorities (just adds a warning). \`npm unpublish\` requires admin override on versions >72h old. The user explicitly noted they can't merge to main right now — this fix ships on \`next\` only and doesn't touch \`main\`.

## Test coverage

```
8 pass / 0 fail / 15 expect() calls (postinstall-pin-version.test.ts)
```

| Scenario | Expected |
|---|---|
| Caret range present | rewritten to exact |
| Already exact | no change (idempotent) |
| Tilde range | rewritten to exact |
| Non-range spec (file:, git+, tarball URL) | left alone |
| OMNI_SKIP_POSTINSTALL_PIN=1 | short-circuits |
| Missing global manifest | no-op exit 0 |
| Malformed JSON manifest | no-op exit 0 (preserved) |
| Readonly manifest dir | still exit 0 |

## Verification

```bash
bun test packages/cli/__tests__/postinstall-pin-version.test.ts   # 8 pass
node packages/cli/scripts/postinstall-pin-version.cjs              # exit 0
bunx tsc --noEmit                                                   # clean
bunx biome check                                                    # clean
bunx knip                                                           # clean
```

## Test plan
- [ ] CI green
- [ ] After merge: install fresh in a temp HOME — \`HOME=/tmp/x bun add -g @automagik/omni@next\` → assert \`/tmp/x/.bun/install/global/package.json\` shows exact pin (no caret)
- [ ] On this server: \`bun add -g @automagik/omni@next\` → assert no caret in global package.json afterward

Refs: operator dogfood feedback 2026-04-30