### PR TITLE
fix(api): close-contact não pausa mais o agente em outcomes soft

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -2637,10 +2637,25 @@ interface ChatSettingsForGate {
 /**
  * Close-contact gate. Returns:
  *   - `skip`        → caller must `ackHandle.remove()` and return.
- *   - `reopened`    → cooldown expired; state flipped back to active. Fall
- *                     through to dispatch normally; the handoff gate after
- *                     this should NOT also block on a stale `agentPaused`.
- *   - `pass`        → no close-contact state; defer to subsequent gates.
+ *   - `reopened`    → soft cooldown expired; state cleaned up. Fall through
+ *                     to dispatch normally; the handoff gate after this
+ *                     should NOT also block on a stale `agentPaused`.
+ *   - `pass`        → no terminal state and no agent-pause requirement;
+ *                     defer to subsequent gates.
+ *
+ * Two distinct mechanisms — keep them decoupled (matching the write side
+ * in `POST /messages/send/close-contact`):
+ *
+ *   - `closed === true` is a HARD terminal (`won`/`lost` outcomes): skip
+ *     permanently. Only `/chats/:id/reopen-contact` clears it.
+ *   - `closeUntil` set + future timestamp is a SOFT cooldown
+ *     (`redirected_sac`, `unqualified`, `no_response`, `other`). The
+ *     follow-up Haiku is disarmed for that window, but the reactive agent
+ *     stays available for inbound replies — a customer asking "I couldn't
+ *     reach the SAC number" deserves a reply, not silence. Pass through.
+ *   - `closeUntil` set + past timestamp: cooldown expired, clean it up
+ *     and report `reopened` so the handoff gate ignores any residual
+ *     `agentPaused` flag.
  *
  * Single-writer principle: the dispatcher is the only path that mutates
  * state on cooldown expiry, and it's also the only consumer that needs to
@@ -2666,18 +2681,22 @@ async function applyCloseContactGate(
   const closeUntilMs = new Date(chatSettings.closeUntil).getTime();
   if (!Number.isFinite(closeUntilMs)) return 'pass';
   if (Date.now() < closeUntilMs) {
-    log.debug('Chat in close cooldown, skipping dispatch', {
+    // Soft cooldown active: follow-up disarmed, reactive agent stays open.
+    log.debug('Chat in soft close cooldown, follow-up disarmed but agent reactive', {
       instanceId,
       chatId,
       closeUntil: chatSettings.closeUntil,
       outcome: chatSettings.closeOutcome ?? null,
     });
-    return 'skip';
+    return 'pass';
   }
   if (!chatRecordId) return 'pass';
 
-  // Cooldown expired — flip state back to active and report 'reopened' so
-  // the caller knows to bypass the handoff/agentPaused gate that follows.
+  // Cooldown expired — clear closeUntil so the gate stops firing and any
+  // residual `agentPaused` (legacy chats from before the decoupling, or
+  // chats where a real human handoff happened on top of a close) gets
+  // explicitly cleared. Report `reopened` so the handoff gate ignores any
+  // stale flag.
   try {
     await services.chats.update(chatRecordId, {
       settings: {
@@ -2687,7 +2706,7 @@ async function applyCloseContactGate(
         agentResumedAt: new Date().toISOString(),
       } as Record<string, unknown>,
     });
-    log.info('Close cooldown expired, agent reopened', {
+    log.info('Close cooldown expired, state cleaned', {
       instanceId,
       chatId,
       closeOutcome: chatSettings.closeOutcome ?? null,

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1754,10 +1754,29 @@ messagesRoutes.post('/send/close-contact', zValidator('json', sendCloseContactSc
   );
 
   // ── 4. Update chat settings — emits chat.closed via chats service ────────
+  //
+  // Two distinct mechanisms — keep them decoupled:
+  //
+  //   - Follow-up disarm (always): the proactive Haiku follow-up is killed
+  //     for every close-contact outcome. That's the whole point of this
+  //     endpoint and is handled by the explicit `followUpLifecycle.disarm`
+  //     call right below + the `chat.closed` event subscriber.
+  //
+  //   - Agent pause (only when the customer asked for silence): blocks the
+  //     reactive agent from replying to inbound messages. We only set this
+  //     on `lost` (lead explicitly told us to stop). For soft cooldowns
+  //     (redirected_sac, unqualified, no_response, other) and the won
+  //     terminal, the customer can still come back and reach the agent —
+  //     a customer asking "I couldn't reach the SAC number" deserves a
+  //     reply, not 24h of silence.
+  //
+  // The dispatcher's close-contact gate honours `closed === true` (hard
+  // terminal) for skip and treats a pure soft cooldown as pass.
+  const shouldPauseAgent = outcome === 'lost';
   const closedAt = new Date();
   await services.chats.update(data.chatId, {
     settings: {
-      agentPaused: true,
+      ...(shouldPauseAgent ? { agentPaused: true } : {}),
       closed: terminal,
       closeUntil: closeUntil?.toISOString() ?? null,
       closeOutcome: outcome,
@@ -1771,9 +1790,12 @@ messagesRoutes.post('/send/close-contact', zValidator('json', sendCloseContactSc
     reason: 'contact_closed',
   });
 
-  // Emit chat.closed explicitly — the chats service emits chat.handoff_activated
-  // on agentPaused flip, which is fine for the follow-up lifecycle (both subscribers
-  // disarm the row), but BI/audit consumers want the explicit terminal signal.
+  // Emit chat.closed explicitly. For `lost` (the only outcome that flips
+  // agentPaused: false → true here) the chats service also emits
+  // chat.handoff_activated, which is fine — both subscribers disarm the
+  // row idempotently and the explicit `followUpLifecycle.disarm` call above
+  // already covered it. For all other outcomes only chat.closed fires, which
+  // is what BI/audit consumers want anyway.
   if (services.eventBus) {
     const payload: ChatClosedPayload = {
       chatId: data.chatId,


### PR DESCRIPTION
## Resumo

O endpoint `POST /messages/send/close-contact` estava setando `agentPaused: true` pra todo outcome, e o `applyCloseContactGate()` no dispatcher skipava toda mensagem inbound enquanto `closeUntil` estava no futuro. Resultado prático: cliente confirma cliente Hapvida + motivo (caso `redirected_sac`), recebe os 3 canais de SAC dentro da `tool.text`, e fica 24h sem resposta no chat — mesmo voltando pra dizer "não consegui contato com esse número".

Dois mecanismos diferentes estavam colapsados em um:

1. **Desarmar follow-up** — matar o follow-up Haiku pra ele não disparar venda 2–4h depois. É o objetivo central do close-contact, sempre necessário.
2. **Pausar o agente reativo** — bloquear inbound. Só faz sentido pra `lost` (cliente pediu silêncio explicitamente).

Esse PR separa os dois.

## Mudanças

**`packages/api/src/routes/v2/messages.ts`**
- `agentPaused: true` só é setado quando `outcome === 'lost'`. Pros outros outcomes (`redirected_sac`, `unqualified`, `no_response`, `other`, `won`) o flag fica intocado, então o agente continua reativo via dispatcher.
- `closeUntil` e `closeOutcome` continuam sendo escritos normalmente — o gate e os consumidores de BI seguem com os dados que precisam.

**`packages/api/src/plugins/agent-dispatcher.ts`**
- `applyCloseContactGate()` retorna `'pass'` em vez de `'skip'` enquanto o cooldown soft está ativo.
- Skip permanente continua gated em `closed === true` (hard terminals: `won` e `lost`).
- Comentário do método reescrito documentando o decoupling.

## Comportamento por outcome

| outcome         | closed | agentPaused | gate result | follow-up | inbound da Eugenia |
|-----------------|:------:|:-----------:|:-----------:|:---------:|:------------------:|
| redirected_sac  | false  | (unset)     | pass        | disarmed  | responde           |
| unqualified     | false  | (unset)     | pass        | disarmed  | responde           |
| no_response     | false  | (unset)     | pass        | disarmed  | responde           |
| other           | false  | (unset)     | pass        | disarmed  | responde           |
| won             | true   | (unset)     | skip        | disarmed  | n/a                |
| lost            | true   | true        | skip        | disarmed  | n/a                |

## Riscos

- **Chats já fechados antes desse deploy** continuam com `agentPaused: true` no estado legado. O fluxo `reopened` do gate (cooldown expirado) já limpa isso — comportamento mantido. Pra chats que voltarem inbound antes da expiração, agora a Eugenia responde, que é o que a gente quer.
- O evento `chat.handoff_activated` deixa de ser disparado pra outcomes soft (porque `agentPaused` não vira mais `false → true` neles). O `chat.closed` continua sendo emitido em todo close e cobre os consumidores de follow-up + BI/audit. Se alguma automação estiver escutando `chat.handoff_activated` especificamente pra close-contact (não pra handoff humano), precisa migrar pra `chat.closed`.
