### PR TITLE
fix(api): close-contact end-to-end — drop redirected_sac escalation, gate follow-up arm by active close state

### DIFF
--- a/packages/api/src/__tests__/follow-up-lifecycle.test.ts
+++ b/packages/api/src/__tests__/follow-up-lifecycle.test.ts
@@ -453,4 +453,59 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     const rows = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
     expect(rows).toHaveLength(0);
   });
+
+  test('close-contact guard: armForOutbound refuses to arm when closeOutcome is set', async () => {
+    // Simulate a chat that was deliberately closed via /messages/send/close-contact
+    // (e.g. encerrar_atendimento with `redirected_sac`). closeOutcome is the
+    // canonical marker; the dispatcher gate already reads it and now the
+    // follow-up arm path must too. Without this guard, a customer return that
+    // the reactive agent answers would re-arm a sequence and the sweeper would
+    // nudge a customer the seller agent already redirected to support.
+    await db
+      .update(chats)
+      .set({ settings: { followUpConfig: config(), closeOutcome: 'redirected_sac' } })
+      .where(eq(chats.id, testChatId));
+
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+    });
+
+    const rows = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  test('close-contact guard: clearing closeOutcome (reopen-contact) restores arm', async () => {
+    // First put the chat into close-contact state and confirm no arm.
+    await db
+      .update(chats)
+      .set({ settings: { followUpConfig: config(), closeOutcome: 'redirected_sac' } })
+      .where(eq(chats.id, testChatId));
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+    });
+    expect(await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId))).toHaveLength(0);
+
+    // Simulate /chats/:id/reopen-contact: closeOutcome cleared.
+    await db
+      .update(chats)
+      .set({ settings: { followUpConfig: config(), closeOutcome: null } })
+      .where(eq(chats.id, testChatId));
+
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+    });
+
+    const rows = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].disarmReason).toBeNull();
+  });
 });

--- a/packages/api/src/__tests__/follow-up-lifecycle.test.ts
+++ b/packages/api/src/__tests__/follow-up-lifecycle.test.ts
@@ -454,16 +454,13 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     expect(rows).toHaveLength(0);
   });
 
-  test('close-contact guard: armForOutbound refuses to arm when closeOutcome is set', async () => {
-    // Simulate a chat that was deliberately closed via /messages/send/close-contact
-    // (e.g. encerrar_atendimento with `redirected_sac`). closeOutcome is the
-    // canonical marker; the dispatcher gate already reads it and now the
-    // follow-up arm path must too. Without this guard, a customer return that
-    // the reactive agent answers would re-arm a sequence and the sweeper would
-    // nudge a customer the seller agent already redirected to support.
+  test('close-contact guard: hard terminal (closed=true) refuses to arm', async () => {
+    // won/lost outcomes flip closed=true and the dispatcher gate skip is
+    // permanent. The follow-up arm path must also refuse for these so a
+    // tail-stream chunk or NATS redelivery cannot resurrect a sequence.
     await db
       .update(chats)
-      .set({ settings: { followUpConfig: config(), closeOutcome: 'redirected_sac' } })
+      .set({ settings: { followUpConfig: config(), closed: true, closeOutcome: 'lost' } })
       .where(eq(chats.id, testChatId));
 
     await service.armForOutbound({
@@ -477,24 +474,51 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     expect(rows).toHaveLength(0);
   });
 
-  test('close-contact guard: clearing closeOutcome (reopen-contact) restores arm', async () => {
-    // First put the chat into close-contact state and confirm no arm.
+  test('close-contact guard: soft cooldown still in window refuses to arm', async () => {
+    // redirected_sac (and other soft outcomes) set closeUntil=now+24h. The
+    // reactive agent stays open per #575, but proactive follow-up nudges
+    // must stay off until the cooldown expires.
+    const closeUntilFuture = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString(); // +6h
     await db
       .update(chats)
-      .set({ settings: { followUpConfig: config(), closeOutcome: 'redirected_sac' } })
+      .set({
+        settings: {
+          followUpConfig: config(),
+          closeUntil: closeUntilFuture,
+          closeOutcome: 'redirected_sac',
+        },
+      })
       .where(eq(chats.id, testChatId));
+
     await service.armForOutbound({
       chatId: testChatId,
       instanceId: testInstanceId,
       agentId: null,
       lastAgentMessageAt: new Date(),
     });
-    expect(await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId))).toHaveLength(0);
 
-    // Simulate /chats/:id/reopen-contact: closeOutcome cleared.
+    const rows = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  test('close-contact guard: expired cooldown allows arm even with leftover closeOutcome', async () => {
+    // Once the dispatcher gate observes closeUntil expired it clears the
+    // field; closeOutcome stays as audit data. A customer return after that
+    // is a legitimate new conversation — Eugenia answering it should arm
+    // follow-up like any other reply. The original (closeOutcome-based) check
+    // would have permanently silenced follow-ups on every Hapvida client who
+    // ever hit redirected_sac, even months later when they came back wanting
+    // to buy a brand-new plan.
     await db
       .update(chats)
-      .set({ settings: { followUpConfig: config(), closeOutcome: null } })
+      .set({
+        settings: {
+          followUpConfig: config(),
+          closed: false,
+          closeUntil: null,
+          closeOutcome: 'redirected_sac', // audit only — predicate ignores this
+        },
+      })
       .where(eq(chats.id, testChatId));
 
     await service.armForOutbound({

--- a/packages/api/src/lib/__tests__/close-contact-state.test.ts
+++ b/packages/api/src/lib/__tests__/close-contact-state.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for `isChatInActiveCloseState`.
+ *
+ * Pure predicate — no DB, no event bus. Asserts the same shape the
+ * dispatcher's `applyCloseContactGate` skip logic uses, plus the
+ * deliberate non-coverage of `closeOutcome` (audit data, not active state).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ChatSettings } from '@omni/db';
+import { isChatInActiveCloseState } from '../close-contact-state';
+
+const HOUR = 60 * 60 * 1000;
+
+const settings = (overrides: Partial<ChatSettings> & Record<string, unknown>): ChatSettings =>
+  ({ ...overrides }) as ChatSettings;
+
+describe('isChatInActiveCloseState', () => {
+  test('null/undefined settings → false (open chat)', () => {
+    expect(isChatInActiveCloseState(null)).toBe(false);
+    expect(isChatInActiveCloseState(undefined)).toBe(false);
+  });
+
+  test('empty settings → false', () => {
+    expect(isChatInActiveCloseState(settings({}))).toBe(false);
+  });
+
+  test('closed: true → true (hard terminal — won/lost or auto-promoted soft)', () => {
+    expect(isChatInActiveCloseState(settings({ closed: true }))).toBe(true);
+  });
+
+  test('closed: false alone → false', () => {
+    expect(isChatInActiveCloseState(settings({ closed: false }))).toBe(false);
+  });
+
+  test('closeUntil in the future → true (soft cooldown active)', () => {
+    const future = new Date(Date.now() + HOUR).toISOString();
+    expect(isChatInActiveCloseState(settings({ closeUntil: future }))).toBe(true);
+  });
+
+  test('closeUntil in the past → false (cooldown expired, dispatcher gate will clear it on next inbound)', () => {
+    const past = new Date(Date.now() - HOUR).toISOString();
+    expect(isChatInActiveCloseState(settings({ closeUntil: past }))).toBe(false);
+  });
+
+  test('closeUntil empty string → false', () => {
+    expect(isChatInActiveCloseState(settings({ closeUntil: '' }))).toBe(false);
+  });
+
+  test('closeUntil malformed string → false (rejects invalid timestamps)', () => {
+    expect(isChatInActiveCloseState(settings({ closeUntil: 'not-a-date' }))).toBe(false);
+  });
+
+  test('closeOutcome alone (audit leftover after expired cooldown) → false', () => {
+    // This is the regression the predicate is built around. closeOutcome is
+    // preserved across cooldown expiry by `applyCloseContactGate`; using it
+    // as the gate would permanently silence follow-up on every chat that
+    // ever hit a soft close, even months later when the customer returns
+    // with a brand-new sales intent.
+    expect(isChatInActiveCloseState(settings({ closeOutcome: 'redirected_sac' }))).toBe(false);
+    expect(isChatInActiveCloseState(settings({ closeOutcome: 'unqualified' }))).toBe(false);
+  });
+
+  test('closed: true takes precedence over an expired closeUntil', () => {
+    const past = new Date(Date.now() - HOUR).toISOString();
+    expect(isChatInActiveCloseState(settings({ closed: true, closeUntil: past }))).toBe(true);
+  });
+
+  test('soft cooldown active alongside closeOutcome → true (active state, not just audit)', () => {
+    const future = new Date(Date.now() + HOUR).toISOString();
+    expect(isChatInActiveCloseState(settings({ closeUntil: future, closeOutcome: 'redirected_sac' }))).toBe(true);
+  });
+});

--- a/packages/api/src/lib/close-contact-state.ts
+++ b/packages/api/src/lib/close-contact-state.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared predicate for "chat is currently in an active close-contact state."
+ *
+ * `chats.settings.closeOutcome` is audit data — set when a close-contact fires,
+ * preserved across cooldown expiry, only cleared by `POST /chats/:id/reopen-contact`.
+ * It is NOT a reliable signal of "the chat is currently muted" because the
+ * dispatcher's close-contact gate (`applyCloseContactGate` in
+ * `plugins/agent-dispatcher.ts`) auto-clears `closeUntil` when the soft cooldown
+ * expires while leaving `closeOutcome` in place for BI consumers.
+ *
+ * The semantically correct predicate for "should I treat this chat as closed
+ * right now?" mirrors the dispatcher gate's skip conditions:
+ *
+ *   - `closed === true`  → hard terminal (`won` / `lost`, or auto-promoted soft).
+ *                          Only `/reopen-contact` clears it.
+ *   - `closeUntil > now` → soft cooldown still in window. Auto-clears when the
+ *                          dispatcher next observes it expired.
+ *
+ * Anything else (cleared `closeUntil`, no `closed`, leftover `closeOutcome` audit)
+ * means the chat is already operating normally; the only thing left from the
+ * close is the audit trail. A subsequent agent reply that follows a customer
+ * comeback after expiry should arm follow-up like any other normal reply.
+ *
+ * Keep this in sync with the dispatcher gate predicate at
+ * `plugins/agent-dispatcher.ts:applyCloseContactGate` (TODO: refactor that path
+ * to call this helper directly to remove the duplication).
+ */
+
+import type { ChatSettings } from '@omni/db';
+
+export function isChatInActiveCloseState(settings: ChatSettings | null | undefined): boolean {
+  if (!settings) return false;
+  if ((settings as { closed?: unknown }).closed === true) return true;
+  const closeUntil = (settings as { closeUntil?: unknown }).closeUntil;
+  if (typeof closeUntil === 'string' && closeUntil.length > 0) {
+    const ms = new Date(closeUntil).getTime();
+    if (Number.isFinite(ms) && Date.now() < ms) return true;
+  }
+  return false;
+}

--- a/packages/api/src/routes/v2/__tests__/close-contact-config.test.ts
+++ b/packages/api/src/routes/v2/__tests__/close-contact-config.test.ts
@@ -29,11 +29,16 @@ describe('DEFAULT_CLOSE_CONTACT_CONFIG', () => {
     });
   });
 
-  test('redirected_sac uses 24h cooldown / threshold 2 / 7d window', () => {
+  test('redirected_sac uses 24h cooldown and never auto-escalates', () => {
+    // Active Hapvida clients legitimately hit `redirected_sac` repeatedly
+    // (every post-sale topic ends here). Auto-promoting the soft close to a
+    // hard terminal would silence the reactive agent for normal client
+    // activity — see the comment on DEFAULT_CLOSE_CONTACT_CONFIG.redirected_sac
+    // for the full rationale.
     expect(DEFAULT_CLOSE_CONTACT_CONFIG.redirected_sac).toEqual({
       cooldownMs: 24 * HOUR,
-      escalationThreshold: 2,
-      escalationWindowMs: 7 * DAY,
+      escalationThreshold: null,
+      escalationWindowMs: null,
     });
   });
 

--- a/packages/api/src/routes/v2/_close-contact-config.ts
+++ b/packages/api/src/routes/v2/_close-contact-config.ts
@@ -39,7 +39,18 @@ const DAY = 24 * HOUR;
 export const DEFAULT_CLOSE_CONTACT_CONFIG: CloseContactConfig = {
   won: { cooldownMs: null, escalationThreshold: null, escalationWindowMs: null },
   lost: { cooldownMs: null, escalationThreshold: null, escalationWindowMs: null },
-  redirected_sac: { cooldownMs: 24 * HOUR, escalationThreshold: 2, escalationWindowMs: 7 * DAY },
+  // `redirected_sac` is the canonical outcome for an active Hapvida client
+  // reaching the seller agent (appointments, billing, doctor lookup,
+  // authorization — anything post-sale). Each new conversation legitimately
+  // ends in a SAC redirect, so the same client returning several times in a
+  // week is expected behaviour, not a signal that the redirect is failing.
+  // Auto-escalating to a hard terminal silences the reactive agent for a
+  // customer whose every interaction is, by design, a SAC redirect. The 24h
+  // cooldown stays so the proactive Haiku follow-up keeps disarmed in the
+  // immediate window, but the soft close never auto-promotes. Operators can
+  // still close manually with `won`/`lost`, and per-instance overrides via
+  // `instance.settings.closeContactConfig` remain available.
+  redirected_sac: { cooldownMs: 24 * HOUR, escalationThreshold: null, escalationWindowMs: null },
   unqualified: { cooldownMs: 7 * DAY, escalationThreshold: 3, escalationWindowMs: 30 * DAY },
   no_response: { cooldownMs: 48 * HOUR, escalationThreshold: 3, escalationWindowMs: 30 * DAY },
   other: { cooldownMs: 24 * HOUR, escalationThreshold: 2, escalationWindowMs: 14 * DAY },

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -123,6 +123,9 @@ export class FollowUpLifecycleService {
   async armForOutbound(input: Omit<ArmSequenceInput, 'config'> & { config?: FollowUpSequenceConfig }): Promise<void> {
     if (!this.eventBus) return;
 
+    // Close-contact guard — see `isChatCloseContacted` for the rationale.
+    if (await this.isChatCloseContacted(input.chatId, input.instanceId)) return;
+
     const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId ?? null));
     if (!config || config.enabled === false) return;
 
@@ -147,29 +150,7 @@ export class FollowUpLifecycleService {
       }
     }
 
-    // Terminal-disarm guard (#419): if the chat was disarmed with a terminal
-    // intent (user cleared the session, operator took handoff, chat archived,
-    // or the messaging window expired), refuse to re-arm unless the customer
-    // has actually sent a new message since the disarm. Without this check,
-    // any agent-origin `message.sent` that lands after the disarm (tail stream
-    // chunks, split-message tails, NATS redelivery of in-flight events) will
-    // resurrect a sequence the user explicitly terminated.
-    const existing = await this.readExistingRow(input.chatId, input.instanceId);
-    if (existing?.disarmReason && TERMINAL_DISARM_REASONS.has(existing.disarmReason) && existing.disarmedAt) {
-      const lastInbound = existing.lastInboundCustomerMessageAt?.getTime() ?? 0;
-      const disarmedAt = existing.disarmedAt.getTime();
-      if (lastInbound <= disarmedAt) {
-        this.logger.info('follow-up lifecycle: refusing to arm — terminal disarm awaiting customer return', {
-          chatId: input.chatId,
-          instanceId: input.instanceId,
-          disarmReason: existing.disarmReason,
-          disarmedAt: existing.disarmedAt.toISOString(),
-          lastAgentMessageAt: input.lastAgentMessageAt.toISOString(),
-          lastInboundCustomerMessageAt: existing.lastInboundCustomerMessageAt?.toISOString() ?? null,
-        });
-        return;
-      }
-    }
+    if (await this.shouldRefuseForTerminalDisarm(input)) return;
 
     try {
       await armSequence(
@@ -231,6 +212,72 @@ export class FollowUpLifecycleService {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  /**
+   * Returns true when the chat has been deliberately closed via
+   * `POST /messages/send/close-contact` (any outcome — `redirected_sac`,
+   * `unqualified`, `no_response`, `other`, `won`, `lost`). Callers that arm
+   * a proactive follow-up must short-circuit on `true`: nudging a customer
+   * the seller agent already redirected to support is exactly what the
+   * close-contact endpoint exists to prevent.
+   *
+   * Why a dedicated guard instead of relying on `disarm({reason:'contact_closed'})`:
+   * the inline disarm in the close-contact handler only kills the *current*
+   * row. Any later `message.sent` (a customer comeback that the reactive
+   * agent answers, a tail-stream chunk, a NATS redelivery) re-enters
+   * `armForOutbound` and re-arms a fresh sequence — `TERMINAL_DISARM_REASONS`
+   * does not cover `contact_closed`, and even when it did the guard would
+   * let re-arms through whenever the customer's last inbound is more recent
+   * than the disarm timestamp, which is the comeback case.
+   *
+   * The canonical close marker is `chats.settings.closeOutcome`. The
+   * dispatcher's `applyCloseContactGate` already reads it; the follow-up arm
+   * path now does too. `POST /chats/:id/reopen-contact` clears it,
+   * restoring proactive follow-up alongside the reactive agent.
+   */
+  /**
+   * Terminal-disarm guard (#419): if the chat was disarmed with a terminal
+   * intent (user cleared the session, operator took handoff, chat archived,
+   * or the messaging window expired), refuse to re-arm unless the customer
+   * has actually sent a new message since the disarm. Without this check,
+   * any agent-origin `message.sent` that lands after the disarm (tail stream
+   * chunks, split-message tails, NATS redelivery of in-flight events) will
+   * resurrect a sequence the user explicitly terminated.
+   */
+  private async shouldRefuseForTerminalDisarm(
+    input: Pick<ArmSequenceInput, 'chatId' | 'instanceId' | 'lastAgentMessageAt'>,
+  ): Promise<boolean> {
+    const existing = await this.readExistingRow(input.chatId, input.instanceId);
+    if (!existing?.disarmReason || !existing.disarmedAt) return false;
+    if (!TERMINAL_DISARM_REASONS.has(existing.disarmReason)) return false;
+    const lastInbound = existing.lastInboundCustomerMessageAt?.getTime() ?? 0;
+    if (lastInbound > existing.disarmedAt.getTime()) return false;
+    this.logger.info('follow-up lifecycle: refusing to arm — terminal disarm awaiting customer return', {
+      chatId: input.chatId,
+      instanceId: input.instanceId,
+      disarmReason: existing.disarmReason,
+      disarmedAt: existing.disarmedAt.toISOString(),
+      lastAgentMessageAt: input.lastAgentMessageAt.toISOString(),
+      lastInboundCustomerMessageAt: existing.lastInboundCustomerMessageAt?.toISOString() ?? null,
+    });
+    return true;
+  }
+
+  private async isChatCloseContacted(chatId: string, instanceId: string): Promise<boolean> {
+    const [chatRow] = await this.db
+      .select({ settings: chats.settings })
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .limit(1);
+    const closeOutcome = (chatRow?.settings as ChatSettings | null | undefined)?.closeOutcome;
+    if (!closeOutcome) return false;
+    this.logger.info('follow-up lifecycle: refusing to arm — chat has close-contact outcome', {
+      chatId,
+      instanceId,
+      closeOutcome,
+    });
+    return true;
   }
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -39,6 +39,7 @@ import {
   instances,
 } from '@omni/db';
 import { and, eq, isNull, sql } from 'drizzle-orm';
+import { isChatInActiveCloseState } from '../lib/close-contact-state';
 
 const log = createLogger('follow-up-lifecycle');
 
@@ -123,8 +124,8 @@ export class FollowUpLifecycleService {
   async armForOutbound(input: Omit<ArmSequenceInput, 'config'> & { config?: FollowUpSequenceConfig }): Promise<void> {
     if (!this.eventBus) return;
 
-    // Close-contact guard — see `isChatCloseContacted` for the rationale.
-    if (await this.isChatCloseContacted(input.chatId, input.instanceId)) return;
+    // Close-contact guard — see `isInActiveCloseState` for the rationale.
+    if (await this.isInActiveCloseState(input.chatId, input.instanceId)) return;
 
     const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId ?? null));
     if (!config || config.enabled === false) return;
@@ -264,18 +265,41 @@ export class FollowUpLifecycleService {
     return true;
   }
 
-  private async isChatCloseContacted(chatId: string, instanceId: string): Promise<boolean> {
+  /**
+   * Returns true when the chat is *currently* in an active close-contact
+   * state (hard terminal `closed: true` OR soft cooldown `closeUntil` still
+   * in window). Mirrors the dispatcher's `applyCloseContactGate` predicate
+   * — see `lib/close-contact-state.ts` for the rationale and why
+   * `closeOutcome` (audit data, preserved across cooldown expiry) is the
+   * wrong signal for this gate.
+   *
+   * Why a guard here: the inline `disarm({reason:'contact_closed'})` in the
+   * close-contact handler only kills the *current* row. Any later
+   * `message.sent` from the reactive agent (a customer comeback the agent
+   * answers within the cooldown, a tail-stream chunk, a NATS redelivery)
+   * re-enters armForOutbound and re-arms a fresh sequence — `TERMINAL_DISARM_REASONS`
+   * does not include `'contact_closed'`, and even when it did the
+   * existing terminal-disarm guard lets re-arms through whenever the
+   * customer's last inbound is newer than the disarm timestamp (which is
+   * exactly the comeback case). Once the cooldown expires the dispatcher
+   * gate clears `closeUntil`, this predicate flips to false, and a future
+   * agent reply legitimately re-arms.
+   */
+  private async isInActiveCloseState(chatId: string, instanceId: string): Promise<boolean> {
     const [chatRow] = await this.db
       .select({ settings: chats.settings })
       .from(chats)
       .where(eq(chats.id, chatId))
       .limit(1);
-    const closeOutcome = (chatRow?.settings as ChatSettings | null | undefined)?.closeOutcome;
-    if (!closeOutcome) return false;
-    this.logger.info('follow-up lifecycle: refusing to arm — chat has close-contact outcome', {
+    const settings = chatRow?.settings as ChatSettings | null | undefined;
+    if (!isChatInActiveCloseState(settings)) return false;
+    const closeOutcome = (settings as { closeOutcome?: unknown } | null | undefined)?.closeOutcome;
+    this.logger.info('follow-up lifecycle: refusing to arm — chat in active close-contact state', {
       chatId,
       instanceId,
-      closeOutcome,
+      closed: (settings as { closed?: unknown } | null | undefined)?.closed === true,
+      closeUntil: (settings as { closeUntil?: unknown } | null | undefined)?.closeUntil ?? null,
+      closeOutcome: closeOutcome ?? null,
     });
     return true;
   }

--- a/packages/db/drizzle/0035_unstick_redirected_sac_terminals.sql
+++ b/packages/db/drizzle/0035_unstick_redirected_sac_terminals.sql
@@ -1,26 +1,47 @@
--- Backfill: unstick chats that were auto-promoted to a hard terminal by
--- the redirected_sac escalation rule. The companion fix in
--- packages/api/src/routes/v2/_close-contact-config.ts removes the
--- escalation for `redirected_sac` going forward (an active Hapvida client
--- legitimately ends every conversation with a SAC redirect, so counting
--- repeats and silencing the agent at threshold == 2 produced false
--- positives that left real customers without a reply).
+-- Backfill: chats that auto-promoted to a hard terminal under the old
+-- `redirected_sac` escalation rule (escalationThreshold=2 over 7 days) get
+-- `chats.settings.closed` flipped back to false. Companion to the config
+-- fix in `packages/api/src/routes/v2/_close-contact-config.ts` which drops
+-- the escalation going forward — an active customer ending every
+-- conversation with a support-channel redirect is normal account activity,
+-- not a signal worth silencing the reactive agent over.
 --
--- This migration flips `chats.settings.closed` back to false for any chat
--- whose closeOutcome is `redirected_sac`. Other settings (`closeUntil`,
--- `closeOutcome`, `closeContactLogs` audit history) are left intact —
--- this is the minimum write required to let the dispatcher's
--- close-contact gate stop returning `skip` (it gates on `closed === true`)
--- so reactive replies resume.
+-- `closeUntil`, `closeOutcome`, and `close_contact_logs` are deliberately
+-- left intact so reporting and downstream BI consumers see no change.
+-- Hard terminals from `won`/`lost` outcomes are not touched.
 --
--- Hard terminals from `won`/`lost` are not touched: they are intentionally
--- terminal and only `/chats/:id/reopen-contact` should clear them.
+-- Hand-written (not `drizzle-kit generate`) because this is a JSONB merge
+-- with a filter predicate that `drizzle-kit` cannot emit directly.
 --
--- Hand-written (not `drizzle-kit generate`) because the change is a JSONB
--- merge on the existing settings column with a filtered predicate, which
--- drizzle-kit cannot emit directly.
+-- Performance note: there is no index on `chats.settings->>'closed'` or
+-- `closeOutcome`, so the predicate is evaluated via a sequential scan.
+-- The expected blast radius is small (only chats that previously hit
+-- `redirected_sac` twice within a 7-day window), but on very large
+-- `chats` tables a single UPDATE would still hold row locks for the
+-- entire matched set in one transaction. Batched into 1000-row chunks so
+-- each iteration acquires a bounded number of row locks; once a chat is
+-- flipped to `closed: false` it stops matching the predicate, so
+-- subsequent iterations naturally narrow.
 
-UPDATE "chats"
-SET "settings" = "settings" - 'closed' || jsonb_build_object('closed', false)
-WHERE ("settings"->>'closed')::boolean IS TRUE
-  AND "settings"->>'closeOutcome' = 'redirected_sac';
+DO $$
+DECLARE
+  rows_updated INT;
+BEGIN
+  LOOP
+    WITH candidates AS (
+      SELECT "id"
+      FROM "chats"
+      WHERE ("settings"->>'closed')::boolean IS TRUE
+        AND "settings"->>'closeOutcome' = 'redirected_sac'
+      LIMIT 1000
+    )
+    UPDATE "chats" AS c
+    SET "settings" = c."settings" - 'closed' || jsonb_build_object('closed', false)
+    FROM candidates
+    WHERE c."id" = candidates."id";
+
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    EXIT WHEN rows_updated = 0;
+  END LOOP;
+END
+$$;

--- a/packages/db/drizzle/0035_unstick_redirected_sac_terminals.sql
+++ b/packages/db/drizzle/0035_unstick_redirected_sac_terminals.sql
@@ -1,0 +1,26 @@
+-- Backfill: unstick chats that were auto-promoted to a hard terminal by
+-- the redirected_sac escalation rule. The companion fix in
+-- packages/api/src/routes/v2/_close-contact-config.ts removes the
+-- escalation for `redirected_sac` going forward (an active Hapvida client
+-- legitimately ends every conversation with a SAC redirect, so counting
+-- repeats and silencing the agent at threshold == 2 produced false
+-- positives that left real customers without a reply).
+--
+-- This migration flips `chats.settings.closed` back to false for any chat
+-- whose closeOutcome is `redirected_sac`. Other settings (`closeUntil`,
+-- `closeOutcome`, `closeContactLogs` audit history) are left intact —
+-- this is the minimum write required to let the dispatcher's
+-- close-contact gate stop returning `skip` (it gates on `closed === true`)
+-- so reactive replies resume.
+--
+-- Hard terminals from `won`/`lost` are not touched: they are intentionally
+-- terminal and only `/chats/:id/reopen-contact` should clear them.
+--
+-- Hand-written (not `drizzle-kit generate`) because the change is a JSONB
+-- merge on the existing settings column with a filtered predicate, which
+-- drizzle-kit cannot emit directly.
+
+UPDATE "chats"
+SET "settings" = "settings" - 'closed' || jsonb_build_object('closed', false)
+WHERE ("settings"->>'closed')::boolean IS TRUE
+  AND "settings"->>'closeOutcome' = 'redirected_sac';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1777680000000,
       "tag": "0034_instances_require_genie_signature",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1777770000000,
+      "tag": "0035_unstick_redirected_sac_terminals",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Defect

Two related regressions in the close-contact path, both surfaced while exercising `redirected_sac` end-to-end in homolog with a returning customer:

### Bug 1 — `redirected_sac` auto-promotes to a hard terminal

`POST /messages/send/close-contact` runs `computeCloseContactTerminalState()`, which counts prior occurrences of the same outcome on the same chat inside an outcome-specific window. For `redirected_sac` the threshold was `2` repeats in `7 days`. Once a chat hit that threshold, the soft cooldown was auto-promoted to a hard terminal (`closed: true`); from that point on the dispatcher's close-contact gate skipped every inbound, only `POST /chats/:id/reopen-contact` could revert it.

That heuristic does not match how `redirected_sac` is actually used. The seller agent's canonical outcome for an active customer is a redirect to the support channel — every post-sale topic (consultations, billing, prior auth, network, doctor lookup) legitimately ends here. A returning customer triggering it 3–5× in a week is normal client activity, not a signal the redirect is failing. The threshold rule assumed repeats meant escalation to a human, but for this outcome there is no sales-side human to escalate to and the customer is exactly who we want the agent to keep talking to. The escalation still makes sense for `unqualified` / `no_response` / `other` (repeats there are real signal), so this PR drops it only for `redirected_sac`.

### Bug 2 — follow-up arm path was unaware of close-contact state

Even after Bug 1 is fixed and the dispatcher gate stops skipping replies, the follow-up arm path had no awareness of close state. The chain went:

1. Agent calls `encerrar_atendimento` → close-contact handler runs `followUpLifecycle.disarm({reason: 'contact_closed'})`. The current `chat_follow_up_state` row is disarmed.
2. The customer comes back later. Dispatcher gate passes (soft cooldown still in window — see #575). The reactive agent answers.
3. That agent reply emits `message.sent`. The follow-up hook calls `armForOutbound`. `armForOutbound` checks the existing row, sees `disarmReason: 'contact_closed'`, runs the `TERMINAL_DISARM_REASONS` guard from #419 — `'contact_closed'` is not in that set. Falls through.
4. Even if it were in the set, the guard's "let re-arms through when `lastInboundCustomerMessageAt > disarmedAt`" carve-out would also let the comeback case through, because that is exactly the comeback case.
5. New sequence armed. Sweeper fires the proactive nudge ~1 min later — to a customer the seller already redirected to support. The nudge re-arms on every subsequent agent reply.

Initial fix attempt used `chats.settings.closeOutcome` as the gate. Wrong: that field is **audit data**. `applyCloseContactGate` clears `closeUntil` and `agentPaused` when the soft cooldown expires but deliberately preserves `closeOutcome` for BI consumers, and only `/reopen-contact` ever clears it. Net effect of that approach: every customer who ever hit `redirected_sac` would have follow-up permanently silenced, even months later when they returned with a fresh sales intent. Reactive agent still answers; only the proactive follow-up is silently lost. Caught in review.

The correct predicate mirrors the dispatcher gate: `closed === true` (hard terminal) or `closeUntil` still in the future (soft cooldown active). Once the dispatcher observes the cooldown expired and clears `closeUntil`, the predicate flips false and a future agent reply legitimately re-arms.

## Scope of change

This PR is the omni-side fix for both bugs. It does not address two separate observations from the same investigation:

- **NATS replay on restart**: messages that the gate skipped during a previous closed=true window can be redelivered after a process restart. The skip path acks correctly today, but a webhook-layer or consumer-config quirk caused some replays. Out of scope here — needs its own investigation, will be a separate PR.
- **GupShup-side split**: when the customer comes back after `CLOSING` is sent on the wire, GupShup's Welcome Journey re-enters and does its own split between the seller and a sequential flow. That is partner-side behaviour and intentionally outside our control.

Hard terminals (`won`/`lost`) remain unchanged in both bugs: they are intentionally permanent and only `/chats/:id/reopen-contact` should clear them.

## Repro

**Bug 1** (smallest reliable case):
1. Open a fresh chat against a `redirected_sac`-routing seller agent.
2. Trigger `encerrar_atendimento` with `outcome: redirected_sac`. Soft cooldown active, dispatcher still answers inbound.
3. Within 7 days, trigger it again on the same chat.
4. `chats.settings.closed` flips to `true`. `close_contact_logs` second row has `escalated: true`. Dispatcher logs `Chat closed (terminal), skipping dispatch` for any subsequent inbound. Recovery requires manual `/reopen-contact`.

**Bug 2**:
1. Encerrar (any soft outcome) on a chat with follow-up enabled.
2. Customer sends a reply within the cooldown window.
3. Reactive agent answers.
4. Within ~1 minute, the proactive follow-up sweeper fires a Haiku nudge — the customer the seller just redirected gets pinged by the seller's follow-up scheduler.

## Before vs after

| step | before | after |
|---|---|---|
| 1st `redirected_sac` | soft 24h cooldown, agent reactive, follow-up disarmed | same |
| 2nd `redirected_sac` (within 7d) | **auto-promoted to terminal**, agent silenced, recovery only via `/reopen-contact` | soft cooldown refreshed, agent reactive, follow-up disarmed |
| inbound during cooldown | agent reply fires; follow-up arm hook **re-arms** the just-killed sequence; sweeper fires Haiku nudge ~1 min later | agent reply fires; arm hook checks active close state, refuses to arm; follow-up stays off |
| inbound after cooldown expires | dispatcher clears `closeUntil`, agent reply fires; follow-up arms normally | same |
| `/chats/:id/reopen-contact` | clears `closed`, `closeUntil`, `agentPaused`, `closeOutcome` | unchanged |

## Changes

**`packages/api/src/routes/v2/_close-contact-config.ts`**
- `redirected_sac.escalationThreshold` and `redirected_sac.escalationWindowMs` go from `2` / `7 days` to `null` / `null`.
- `cooldownMs` stays at 24h (the proactive follow-up disarm window is unaffected).
- Inline comment captures the rationale so a future operator does not reintroduce the escalation.
- The existing branch in `computeCloseContactTerminalState()` already handles the null case (it is what `won`/`lost` rely on), so no logic change is needed.

**`packages/api/src/lib/close-contact-state.ts`** (new)
- Pure predicate `isChatInActiveCloseState(settings)` — `closed === true` OR `closeUntil` in the future. Mirrors the dispatcher's `applyCloseContactGate` skip conditions and is the canonical way to ask "is this chat currently treated as closed". A TODO points at a follow-up to wire `applyCloseContactGate` through this helper as well; deliberately not done here to keep this PR contained.

**`packages/api/src/services/follow-up-lifecycle.ts`**
- `armForOutbound` consults `isChatInActiveCloseState` before resolving config; refuses to arm while the chat is in active close state, logs the decision with the relevant settings.
- The existing #419 terminal-disarm guard was extracted into `shouldRefuseForTerminalDisarm` to keep `armForOutbound` under the cognitive complexity ceiling. Behaviour identical.

**`packages/api/src/lib/__tests__/close-contact-state.test.ts`** (new)
- Pure-function unit tests covering: empty/null settings, `closed: true`, future / past / empty / malformed `closeUntil`, `closeOutcome` alone (the regression case — must NOT block), `closed` precedence over expired `closeUntil`, soft cooldown alongside `closeOutcome`.

**`packages/api/src/routes/v2/__tests__/close-contact-config.test.ts`**
- Updates the `redirected_sac` default-config test to assert the new shape with a comment pointing at the why. Other outcome tests untouched.

**`packages/api/src/__tests__/follow-up-lifecycle.test.ts`**
- Three integration tests: hard terminal blocks arm; soft cooldown in window blocks arm; expired cooldown allows arm even with leftover `closeOutcome` audit (the case the first attempt got wrong).

**`packages/db/drizzle/0035_unstick_redirected_sac_terminals.sql`** (new, hand-written)
- Backfill: any chat sitting at `closed: true` with `closeOutcome = 'redirected_sac'` is flipped back to `closed: false`. `closeUntil`, `closeOutcome`, and `close_contact_logs` audit history stay intact, so reporting is unaffected.
- Batched inside a `DO` block in 1000-row chunks so each iteration acquires a bounded number of row locks; once a chat flips, it stops matching the predicate and subsequent iterations narrow naturally. Idempotent — re-running on already-fixed chats is a no-op.
- Hand-written like `0034` because this is a JSONB merge with a filter predicate that `drizzle-kit generate` cannot emit directly.

**`packages/db/drizzle/meta/_journal.json`**
- Adds the `0035` entry.

## What does NOT change

- `won` / `lost` semantics — still hard terminal, still only reopened via `/chats/:id/reopen-contact`.
- `unqualified`, `no_response`, `other` thresholds and windows — untouched.
- Follow-up disarm at close-contact time — still fires inline + via `chat.closed` subscriber. The new guard sits on the *arm* side; disarm is unaffected.
- Agent-pause logic from #575 — untouched. `agentPaused` is still set only on `lost`.
- Audit trail — `close_contact_logs` rows are not deleted; the migration only flips the chat-level `closed` flag.
- Per-instance overrides — `instance.settings.closeContactConfig` still wins. Operators can dial escalation back on for a specific instance if they want it.

## Risks and rollback

- **Rollback**: revert the commits and re-run `drizzle-kit migrate`. The backfill is idempotent — re-applying on already-fixed rows is a no-op. Reverting the config or the lifecycle change without the migration revert is also safe; previously-unstuck chats stay unstuck.
- **Loss of escalation signal for `redirected_sac`**: a pathological case where the support channel really is broken and the same customer returns 50× no longer surfaces as a hard close. Visibility belongs in metrics/alerting on `close_contact_logs`, not in a customer-facing silence gate.
- **One extra DB round-trip on every outbound**: `armForOutbound` now reads `chats.settings`. Hot path is still O(1) per send and uses an existing index. Could be optimised later by sharing the read with `resolveConfig` (also reads `chats`), but kept independent here for clarity.
- **Existing `won`/`lost` chats**: untouched. Migration filter is explicit on `closeOutcome = 'redirected_sac'`.

## Test plan

- [x] `bun test packages/api/src/lib/__tests__/close-contact-state.test.ts` — 11/11 pass.
- [x] `bun test packages/api/src/routes/v2/__tests__/close-contact-config.test.ts` — 18/18 pass.
- [x] Pre-push gate (full `bun test` + biome) — 3690 pass / 0 fail / 274 skip on the latest commit.
- [x] Apply migration in homolog and verify previously-stuck chats receive replies on subsequent inbound.
- [x] Run `redirected_sac` flow 2× on a fresh chat — confirm second `encerrar_atendimento` does not auto-promote and reactive agent keeps replying.
- [x] During soft cooldown, customer comeback + agent reply — confirm follow-up arm path logs `refusing to arm — chat in active close-contact state` and no nudge fires within the next sweeper window.
- [ ] After cooldown expires, customer comeback + agent reply — follow-up arms normally (covered by integration test, not yet exercised live).
- [x] Verify gupshup wire `msg_type: 'CLOSING'` is sent on encerrar so the partner-side Welcome Journey re-enters on next inbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)