### PR TITLE
feat(install): opt-in canonical pgserve via --canonical-pgserve

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -32,6 +32,7 @@ import {
 } from '../config.js';
 import { DEFAULT_API_PORT, HEALTH_TIMEOUT_MS, waitForHealth } from '../health.js';
 import { detectReinstall, installPm2Logrotate, writeSystemdUnit } from '../install-helpers.js';
+import { maybeSwitchToCanonicalPgserve } from '../lib/canonical-pgserve.js';
 import { NATS_BINARY_PATH, ensureNats } from '../nats-install.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, isPm2Available, runPm2 } from '../pm2.js';
@@ -66,6 +67,8 @@ interface InstallOptions {
   databaseUrl?: string;
   apiKey?: string;
   forceCleanup?: boolean;
+  /** Wave 3 of canonical-pgserve-pm2 (pgserve#55) — see lib/canonical-pgserve.ts. */
+  canonicalPgserve?: boolean;
 }
 
 interface ResolvedConfig {
@@ -158,14 +161,20 @@ function resolveReinstallConfig(options: InstallOptions): ResolvedConfig {
   };
 }
 
-function buildInstallRuntimeEnv(cfg: ResolvedConfig, forceCleanup: boolean): Record<string, string> {
+function buildInstallRuntimeEnv(
+  cfg: ResolvedConfig,
+  forceCleanup: boolean,
+  useCanonicalPgserve = false,
+): Record<string, string> {
   const serverConfig: ServerConfig = {
     ...DEFAULT_SERVER_CONFIG,
     port: cfg.port,
     databaseUrl: cfg.databaseUrl,
     dataDir: cfg.dataDir,
   };
-  const env = buildRuntimeEnv(serverConfig, { apiKey: cfg.apiKey } as Config) as Record<string, string>;
+  const env = buildRuntimeEnv(serverConfig, { apiKey: cfg.apiKey } as Config, {
+    useCanonicalPgserve,
+  }) as Record<string, string>;
   if (forceCleanup) env.OMNI_PGSERVE_FORCE_CLEANUP = 'true';
   return env;
 }
@@ -174,7 +183,12 @@ function buildInstallRuntimeEnv(cfg: ResolvedConfig, forceCleanup: boolean): Rec
 // Service start
 // ----------------------------------------------------------------------------
 
-async function startServices(cfg: ResolvedConfig, forceCleanup: boolean, forceSystemd: boolean): Promise<boolean> {
+async function startServices(
+  cfg: ResolvedConfig,
+  forceCleanup: boolean,
+  forceSystemd: boolean,
+  useCanonicalPgserve = false,
+): Promise<boolean> {
   if (forceSystemd) {
     writeSystemdUnit(cfg.dataDir);
     return false;
@@ -196,7 +210,7 @@ async function startServices(cfg: ResolvedConfig, forceCleanup: boolean, forceSy
   mkdirSync(getPm2LogDir(), { recursive: true });
   await installPm2Logrotate();
 
-  const runtimeEnv = buildInstallRuntimeEnv(cfg, forceCleanup);
+  const runtimeEnv = buildInstallRuntimeEnv(cfg, forceCleanup, useCanonicalPgserve);
 
   // Delete existing processes so the new hardened flags take effect (reinstall path).
   await runPm2(['delete', PM2_PROCESSES.api]);
@@ -239,7 +253,7 @@ async function startServices(cfg: ResolvedConfig, forceCleanup: boolean, forceSy
 // Persistence, health, handoff
 // ----------------------------------------------------------------------------
 
-function writeConfigFile(cfg: ResolvedConfig): void {
+function writeConfigFile(cfg: ResolvedConfig, useCanonicalPgserve = false): void {
   const existing = loadConfig();
   saveConfig({
     ...existing,
@@ -247,7 +261,14 @@ function writeConfigFile(cfg: ResolvedConfig): void {
     apiKey: cfg.apiKey,
     format: existing.format ?? 'human',
   });
-  saveServerConfig({ port: cfg.port, databaseUrl: cfg.databaseUrl, dataDir: cfg.dataDir });
+  saveServerConfig({
+    port: cfg.port,
+    databaseUrl: cfg.databaseUrl,
+    dataDir: cfg.dataDir,
+    // Persist canonical-pgserve choice so subsequent omni restart / doctor
+    // commands honor it without operator passing the flag again.
+    useCanonicalPgserve,
+  });
 }
 
 async function checkHealth(port: number): Promise<boolean> {
@@ -345,10 +366,13 @@ async function runInstall(options: InstallOptions): Promise<void> {
   }
 
   await runSystemChecks(cfg.port);
+  // Wave 3 (pgserve#55): opt-in canonical pgserve. Best-effort — falls
+  // back to embedded with a warn when pgserve isn't installed globally.
+  const useCanonicalPgserve = await maybeSwitchToCanonicalPgserve(options, cfg);
   await ensureNats();
-  const servicesStarted = await startServices(cfg, forceCleanup, forceSystemd);
+  const servicesStarted = await startServices(cfg, forceCleanup, forceSystemd, useCanonicalPgserve);
 
-  writeConfigFile(cfg);
+  writeConfigFile(cfg, useCanonicalPgserve);
   output.success(`Config written to ${getConfigPath()}`);
 
   if (servicesStarted) await checkHealth(cfg.port);
@@ -365,6 +389,10 @@ export function createInstallCommand(): Command {
     .option('--api-key <key>', 'Explicit API key (default: generate a new one)')
     .option('--systemd', 'Write systemd units instead of using pm2 (requires sudo)')
     .option('--force-cleanup', 'Allow pgserve startup to kill orphan postgres processes on the internal port')
+    .option(
+      '--canonical-pgserve',
+      'Register pgserve under pm2 separately (canonical-pgserve-pm2 wave 3) and connect omni-api to it instead of spawning an embedded pgserve. Idempotent.',
+    )
     .option('--non-interactive', '[deprecated] silent no-op — install is always non-interactive')
     .action(runInstall);
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,6 +18,18 @@ export interface ServerConfig {
   dataDir: string;
   logLevel: string;
   nodeEnv: string;
+  /**
+   * When true, omni-api connects to an externally-managed pgserve (the
+   * canonical pgserve registered by `pgserve install` per the
+   * canonical-pgserve-pm2-supervision wish) and SKIPS spawning its own
+   * embedded pgserve. Persisted by `omni install --canonical-pgserve`
+   * so subsequent `omni restart` / `omni doctor --fix` commands honor
+   * the choice across reinstalls and reboots.
+   *
+   * Default false: existing operators keep the embedded-pgserve behavior
+   * they already have. Opt-in only.
+   */
+  useCanonicalPgserve?: boolean;
 }
 
 /** Valid config keys (top-level and dot-notation server.* keys) */

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -1,0 +1,85 @@
+/**
+ * Canonical pgserve setup — Wave 3 of the canonical-pgserve-pm2-supervision
+ * wish (pgserve#55). Extracted from `commands/install.ts` to keep that
+ * file under the 400-line target.
+ *
+ * Used only by `omni install --canonical-pgserve`. Probes the global
+ * `pgserve` binary, runs `pgserve install` (idempotent), and reads
+ * `pgserve url` to discover the canonical connection string. Returns
+ * null on any failure so the caller can fall back to embedded pgserve
+ * with a warning instead of breaking the install.
+ */
+
+import * as output from '../output.js';
+
+/**
+ * Probe + register canonical pgserve under pm2 + return its URL.
+ * Returns null when pgserve isn't installed globally OR when one of
+ * the probe/install/url calls fails — caller falls back to embedded.
+ */
+export async function setupCanonicalPgserve(): Promise<string | null> {
+  if (!(await isPgserveInstalled())) {
+    output.warn(
+      '`pgserve` binary not found in PATH. Install with: bun add -g pgserve  (then re-run `omni install --canonical-pgserve`)',
+    );
+    return null;
+  }
+
+  output.raw('  Registering canonical pgserve under pm2 (idempotent)...');
+  const installCode = await Bun.spawn({ cmd: ['pgserve', 'install'], stdout: 'inherit', stderr: 'inherit' }).exited;
+  if (installCode !== 0) {
+    output.warn(`pgserve install exited with code ${installCode} — falling back to embedded pgserve`);
+    return null;
+  }
+
+  // Read the canonical URL via the discovery API. Caller writes this into
+  // serverConfig.databaseUrl so omni-api connects there.
+  const urlProc = Bun.spawn({ cmd: ['pgserve', 'url'], stdout: 'pipe', stderr: 'inherit' });
+  const stdout = await new Response(urlProc.stdout).text();
+  const urlCode = await urlProc.exited;
+  if (urlCode !== 0) {
+    output.warn(`pgserve url exited with code ${urlCode} — falling back to embedded pgserve`);
+    return null;
+  }
+  const url = stdout.trim();
+  if (!url.startsWith('postgres://') && !url.startsWith('postgresql://')) {
+    output.warn(`pgserve url returned unexpected output ("${url}") — falling back to embedded pgserve`);
+    return null;
+  }
+  return url;
+}
+
+async function isPgserveInstalled(): Promise<boolean> {
+  try {
+    const code = await Bun.spawn({ cmd: ['pgserve', '--version'], stdout: 'pipe', stderr: 'pipe' }).exited;
+    return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convenience wrapper used by `omni install`. When the operator passed
+ * `--canonical-pgserve`, mutates `cfg.databaseUrl` to the canonical url
+ * (on success) and returns true so the caller can pass `useCanonicalPgserve:
+ * true` to `buildRuntimeEnv`. Returns false when the operator didn't pass
+ * the flag OR when canonical setup failed and we're falling back to embedded.
+ */
+export async function maybeSwitchToCanonicalPgserve(
+  options: { canonicalPgserve?: boolean },
+  cfg: { databaseUrl: string },
+): Promise<boolean> {
+  if (options.canonicalPgserve !== true) return false;
+  output.raw('  Canonical pgserve mode (--canonical-pgserve)');
+  const url = await setupCanonicalPgserve();
+  if (!url) {
+    output.warn('Canonical pgserve setup did not complete — proceeding with embedded pgserve.');
+    output.raw('');
+    return false;
+  }
+  cfg.databaseUrl = url;
+  output.raw(`    ✓ omni-api will connect to ${url}`);
+  output.raw('    ✓ embedded pgserve will be skipped (PGSERVE_EMBEDDED=false)');
+  output.raw('');
+  return true;
+}

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -94,19 +94,56 @@ export function resolveDatabaseUrl(serverConfig: ServerConfig): string {
 }
 
 /**
+ * Optional flags consumed by `buildRuntimeEnv`. Today's only opt-in:
+ * `useCanonicalPgserve` flips PGSERVE_EMBEDDED off and points DATABASE_URL
+ * at an externally-managed pgserve (typically the one registered by
+ * `pgserve install` per the canonical-pgserve-pm2-supervision wish).
+ */
+export interface BuildRuntimeEnvOptions {
+  /**
+   * When true, omni-api will SKIP starting its own embedded pgserve and
+   * connect to the URL stored in `serverConfig.databaseUrl`. The caller
+   * (typically `omni install --canonical-pgserve`) is responsible for
+   * making sure that URL points at a reachable pgserve and that
+   * `serverConfig.databaseUrl` was populated from `pgserve url`.
+   *
+   * When false / undefined, behavior is the historical default: omni-api
+   * spawns its own pgserve under `~/.omni/data/pgserve/`.
+   */
+  useCanonicalPgserve?: boolean;
+}
+
+/**
  * Build the complete runtime env for the omni-api process.
  *
  * All values come from `serverConfig` / `cliConfig`. No shell env reads.
  */
-export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config): RuntimeEnv {
+export function buildRuntimeEnv(
+  serverConfig: ServerConfig,
+  cliConfig: Config,
+  options: BuildRuntimeEnvOptions = {},
+): RuntimeEnv {
   const pgservePort = resolvePgservePort(serverConfig);
+  // Persisted choice on serverConfig wins; the explicit option is for
+  // first-install (when the persisted value hasn't been written yet).
+  // Either flag flips PGSERVE_EMBEDDED off and points at the canonical pgserve.
+  const useCanonical = serverConfig.useCanonicalPgserve === true || options.useCanonicalPgserve === true;
   return {
     API_PORT: String(serverConfig.port),
+    // When canonical pgserve is on, the stored databaseUrl IS the
+    // canonical url (omni install set it from `pgserve url`). The
+    // existing resolver still applies — this lets operators override
+    // both the canonical default AND the embedded default with a
+    // future external Postgres if they want.
     DATABASE_URL: resolveDatabaseUrl(serverConfig),
     OMNI_API_KEY: cliConfig.apiKey ?? '',
     MEDIA_STORAGE_PATH: join(serverConfig.dataDir, 'media'),
     OMNI_PACKAGES_DIR: join(serverConfig.dataDir, 'packages'),
-    PGSERVE_EMBEDDED: 'true',
+    // PGSERVE_EMBEDDED='false' tells the api in
+    // packages/api/src/pgserve.ts:resolvePgserveConfig to skip spawning
+    // its own pgserve. The api then reads DATABASE_URL and connects to
+    // whatever's there. Canonical pgserve under pm2 fills that role.
+    PGSERVE_EMBEDDED: useCanonical ? 'false' : 'true',
     PGSERVE_DATA: join(serverConfig.dataDir, 'pgserve'),
     PGSERVE_PORT: String(pgservePort),
     NATS_URL: 'nats://localhost:4222',


### PR DESCRIPTION
## Summary

Wave 3 of [canonical-pgserve-pm2-supervision](https://github.com/namastexlabs/pgserve/issues/55). Lets `omni install` consume the canonical pm2-supervised pgserve registered by Wave 1 (`pgserve install`) instead of always spawning its own embedded pgserve.

- New flag: `omni install --canonical-pgserve`
- New helper: `packages/cli/src/lib/canonical-pgserve.ts` (`setupCanonicalPgserve`, `maybeSwitchToCanonicalPgserve`)
- Plumbs `useCanonicalPgserve` through `runtime-env.ts` → flips `PGSERVE_EMBEDDED=false` and points `DATABASE_URL` at the external pgserve
- Persists the choice on `serverConfig.useCanonicalPgserve` so `omni restart` / `omni doctor` honor it without re-passing the flag
- Falls back to embedded with a warn when the `pgserve` binary isn't on PATH — never breaks the install

## Compatibility

Default behavior unchanged. `--canonical-pgserve` is opt-in. Existing installs keep embedded pgserve until the operator opts in. **No data migration in this PR** — that's an operator-driven follow-up per the wish (out of scope; can be a future fast-follow).

## Wave context

| Wave | Repo | PR | Status |
|------|------|----|--------|
| 1 — pgserve foundation | namastexlabs/pgserve | #57 | merged |
| 2 — `genie install` | automagik-dev/genie | #1578 | merged |
| **3 — omni install reconfig** | **automagik-dev/omni** | **this PR** | open |
| 4 — brain entries | namastexlabs/genie-configure | TBD | pending |

## Test plan

- [x] `bun test src/__tests__/install.test.ts` — 24/24 pass (incl. `install.ts <400 lines` gate)
- [x] `bun test` (CLI package) — 352/352 pass
- [x] `bun run typecheck` — green
- [x] `bunx biome check` on changed files — clean
- [ ] Manual e2e on this server after merge: `omni install --canonical-pgserve` → confirm pgserve + omni-api + omni-nats all online via pm2, omni-api connects to canonical port (8432), `omni doctor` green
- [ ] Idempotency: re-run `omni install --canonical-pgserve` → no-op success
- [ ] Fallback: rename pgserve binary, run `omni install --canonical-pgserve` → see warn, embedded pgserve takes over