### PR TITLE
feat(install,doctor): canonical pgserve@^2.1.0 backbone, default for fresh installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,24 @@ ensure_pm2() {
   fi
 }
 
+# Canonical pgserve backbone (pgserve@^2.1.0) — shared by omni + genie + any
+# future automagik service that needs Postgres. `omni install` will register
+# it under pm2 via `pgserve install` (idempotent). We install the binary
+# globally up front so `omni install` can find it without a fallback.
+ensure_pgserve() {
+  if has_cmd pgserve; then
+    ok "pgserve $(pgserve --version 2>/dev/null || echo '?')"
+    return 0
+  fi
+  info "Installing pgserve@^2.1.0 (canonical Postgres backbone)..."
+  bun add -g pgserve@^2.1.0 >/dev/null 2>&1
+  if has_cmd pgserve; then
+    ok "pgserve installed"
+  else
+    warn "Could not install pgserve globally. omni install will fall back to embedded mode. To migrate later: bun add -g pgserve@^2.1.0 && omni doctor --fix"
+  fi
+}
+
 # ============================================================================
 # Install: CLI only
 # ============================================================================
@@ -173,6 +191,7 @@ install_full_server() {
   step "Installing Omni v2 (full server)"
 
   ensure_pm2
+  ensure_pgserve
 
   local channel
   channel="$(omni_channel)"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,7 +43,7 @@
     "hono": "^4.6.17",
     "lru-cache": "^11.2.6",
     "nats": "^2.29.3",
-    "pgserve": "^1.2.0",
+    "pgserve": "^2.1.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -64,6 +64,16 @@ interface HarnessState {
   lockedInstances: Array<{ id: string; name: string }>;
   /** Whether cliHasSigningKey() returns true. */
   cliHasSigningKey: boolean;
+  /**
+   * Result the stubbed `setupCanonicalPgserve()` returns when fixPgserveCanonical
+   * is invoked. Default: a fake canonical url. Tests can override to null
+   * to exercise the error path.
+   */
+  canonicalPgserveSetupResult: string | null;
+  /** Set to true the first time `setupCanonicalPgserve()` is called. */
+  canonicalPgserveSetupCalled: boolean;
+  /** Recorded saveServerConfig calls — tests assert what migration persists. */
+  savedServerConfigs: Array<Partial<ServerConfig>>;
 }
 
 /** Canonical healthy `pm2 conf` output — matches PM2_LOGROTATE_SETTINGS. */
@@ -93,6 +103,10 @@ function mkHarness(overrides?: Partial<HarnessState>): HarnessState {
       dataDir: join(tmpdir(), 'omni-doctor-test'),
       logLevel: 'info',
       nodeEnv: 'production',
+      // Default healthy harness: canonical pgserve already adopted (matches
+      // the new fresh-install default). Tests that exercise the legacy
+      // embedded path explicitly override `useCanonicalPgserve: false`.
+      useCanonicalPgserve: true,
     },
     cliConfig: { apiKey: 'omni_sk_test-key' },
     fixesInvoked: [],
@@ -107,6 +121,9 @@ function mkHarness(overrides?: Partial<HarnessState>): HarnessState {
     // ("nothing to assert"). Tests opt into the WARN path explicitly.
     lockedInstances: [],
     cliHasSigningKey: false,
+    canonicalPgserveSetupResult: 'postgresql://postgres:postgres@localhost:8432/omni',
+    canonicalPgserveSetupCalled: false,
+    savedServerConfigs: [],
     ...overrides,
   };
 }
@@ -189,6 +206,14 @@ function mkDeps(state: HarnessState): DoctorDeps {
     capturePm2Conf: async () => state.pm2ConfOutput,
     listLockedInstances: async () => [...state.lockedInstances],
     cliHasSigningKey: () => state.cliHasSigningKey,
+    setupCanonicalPgserve: async () => {
+      state.canonicalPgserveSetupCalled = true;
+      return state.canonicalPgserveSetupResult;
+    },
+    saveServerConfig: (partial) => {
+      state.serverConfig = { ...state.serverConfig, ...partial };
+      state.savedServerConfigs.push({ ...partial });
+    },
   };
 }
 
@@ -197,7 +222,7 @@ function mkDeps(state: HarnessState): DoctorDeps {
 // ---------------------------------------------------------------------------
 
 describe('runDoctor — read-only mode', () => {
-  test('reports all 10 checks with OK when state is healthy', async () => {
+  test('reports all 11 checks with OK when state is healthy', async () => {
     // Match the harness version to whatever the CLI currently reports so
     // `version-match` is OK without hard-coding the CLI version here.
     const { VERSION } = await import('../version.js');
@@ -206,7 +231,7 @@ describe('runDoctor — read-only mode', () => {
 
     const report = await runDoctor({ fix: false }, deps);
 
-    expect(report.checks).toHaveLength(10);
+    expect(report.checks).toHaveLength(11);
     const ids = report.checks.map((c) => c.id);
     expect(ids).toEqual([
       'pm2-env-drift',
@@ -219,11 +244,12 @@ describe('runDoctor — read-only mode', () => {
       'pm2-max-restarts',
       'pm2-logrotate-installed',
       'cli-signing-key-for-locked-instances',
+      'pgserve-canonical',
     ]);
     for (const check of report.checks) {
       expect(check.level).toBe('OK');
     }
-    expect(report.summary).toEqual({ ok: 10, warn: 0, fail: 0 });
+    expect(report.summary).toEqual({ ok: 11, warn: 0, fail: 0 });
     expect(report.fixesApplied).toEqual([]);
   });
 
@@ -670,5 +696,102 @@ describe('runDoctor — mutation safety', () => {
     for (const name of ['postgresql.conf', 'pg_hba.conf', 'PG_VERSION', 'base.tar', 'global.tar']) {
       expect(existsSync(join(FIXTURE_DIR, name))).toBe(true);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pgserve-canonical (canonical-pgserve-pm2-supervision wave 3)
+// ---------------------------------------------------------------------------
+
+describe('runDoctor — pgserve-canonical check', () => {
+  test('OK when serverConfig.useCanonicalPgserve === true', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    // mkHarness defaults useCanonicalPgserve: true; this test asserts the
+    // healthy path explicitly so the contract is captured even if the
+    // default flips later.
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: true };
+
+    const report = await runDoctor({ fix: false }, mkDeps(state));
+    const check = report.checks.find((c) => c.id === 'pgserve-canonical');
+
+    expect(check?.level).toBe('OK');
+    expect(check?.detail).toContain('canonical pgserve');
+  });
+
+  test('WARN when useCanonicalPgserve is undefined (legacy embedded install)', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    // Strip the canonical flag to simulate a pre-existing embedded install.
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: undefined };
+
+    const report = await runDoctor({ fix: false }, mkDeps(state));
+    const check = report.checks.find((c) => c.id === 'pgserve-canonical');
+
+    expect(check?.level).toBe('WARN');
+    expect(check?.detail).toContain('embedded pgserve');
+    expect(check?.detail).toContain('omni doctor --fix');
+  });
+
+  test('WARN when useCanonicalPgserve is explicitly false', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({
+      serverVersion: VERSION,
+      serverConfig: {
+        port: 8882,
+        databaseUrl: 'postgresql://postgres:postgres@localhost:8432/omni',
+        dataDir: join(tmpdir(), 'omni-doctor-test'),
+        logLevel: 'info',
+        nodeEnv: 'production',
+        useCanonicalPgserve: false,
+      },
+    });
+
+    const report = await runDoctor({ fix: false }, mkDeps(state));
+    const check = report.checks.find((c) => c.id === 'pgserve-canonical');
+    expect(check?.level).toBe('WARN');
+  });
+
+  test('--fix migrates embedded → canonical: setup, persist, relaunch', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.canonicalPgserveSetupResult = 'postgresql://postgres:postgres@localhost:8432/omni';
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // setupCanonicalPgserve was invoked
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    // ServerConfig persisted with the canonical flag + url
+    expect(state.savedServerConfigs).toHaveLength(1);
+    expect(state.savedServerConfigs[0]).toMatchObject({
+      databaseUrl: 'postgresql://postgres:postgres@localhost:8432/omni',
+      useCanonicalPgserve: true,
+    });
+    // pm2 was relaunched (delete + start) so PGSERVE_EMBEDDED=false takes effect
+    const pm2Cmds = state.pm2Calls.map((c) => c.args[0]);
+    expect(pm2Cmds).toContain('delete');
+    expect(pm2Cmds).toContain('start');
+    // Fix was recorded with a useful detail line
+    const migrationFix = report.fixesApplied.find((f) => f.includes('canonical pgserve'));
+    expect(migrationFix).toBeDefined();
+  });
+
+  test('--fix records FAILED when setupCanonicalPgserve returns null', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.canonicalPgserveSetupResult = null;
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // Setup was attempted
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    // No config write — operator stays on embedded
+    expect(state.savedServerConfigs).toHaveLength(0);
+    // Fix recorded as failed (so the operator sees the actionable error)
+    const failedFix = report.fixesApplied.find((f) => f.startsWith('FAILED pgserve-canonical'));
+    expect(failedFix).toBeDefined();
+    expect(failedFix).toContain('canonical pgserve setup failed');
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -42,9 +42,17 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { createOmniClient } from '@omni/sdk';
 import { Command } from 'commander';
-import { type Config, type ServerConfig, loadConfig, loadServerConfig, saveConfig } from '../config.js';
+import {
+  type Config,
+  type ServerConfig,
+  loadConfig,
+  loadServerConfig,
+  saveConfig,
+  saveServerConfig,
+} from '../config.js';
 import { getHealthCheckUrl } from '../health.js';
 import { PM2_LOGROTATE_SETTINGS } from '../install-helpers.js';
+import { setupCanonicalPgserve } from '../lib/canonical-pgserve.js';
 import * as output from '../output.js';
 import { PM2_HARDENED_DEFAULTS, PM2_PROCESSES, buildPm2StartArgs, capturePm2, isPm2Available, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv, resolvePgservePort } from '../runtime-env.js';
@@ -71,7 +79,8 @@ export type CheckId =
   | 'pm2-status'
   | 'pm2-max-restarts'
   | 'pm2-logrotate-installed'
-  | 'cli-signing-key-for-locked-instances';
+  | 'cli-signing-key-for-locked-instances'
+  | 'pgserve-canonical';
 
 export interface CheckResult {
   id: CheckId;
@@ -194,6 +203,18 @@ export interface DoctorDeps {
    * that as a WARN so it's caught before the operator hits the wall.
    */
   cliHasSigningKey: () => boolean;
+  /**
+   * Run canonical pgserve setup (probe binary → `pgserve install` →
+   * `pgserve url`). Returns the canonical URL on success or null on
+   * failure. Stubbed in tests.
+   */
+  setupCanonicalPgserve: () => Promise<string | null>;
+  /**
+   * Persist a partial server config (merges with existing). Stubbed in
+   * tests so the canonical-pgserve fix can be validated without writing
+   * to ~/.omni/config.json.
+   */
+  saveServerConfig: (partial: Partial<ServerConfig>) => void;
 }
 
 /** Default production deps — each is a thin shim around the real call. */
@@ -304,6 +325,8 @@ function productionDeps(): DoctorDeps {
       }
     },
     cliHasSigningKey: () => loadSigningContext() !== null,
+    setupCanonicalPgserve,
+    saveServerConfig,
   };
 }
 
@@ -642,6 +665,47 @@ async function fixCliKeyValid(deps: DoctorDeps): Promise<string> {
   return 'rotated CLI key and re-validated';
 }
 
+/**
+ * Migrate an embedded install onto canonical pgserve. Runs `pgserve install`,
+ * reads the canonical url, persists `useCanonicalPgserve: true` +
+ * `databaseUrl`, then relaunches omni-api so it picks up `PGSERVE_EMBEDDED=false`.
+ *
+ * SAFETY: Never deletes the embedded data dir. Operator can roll back by
+ * editing `~/.omni/config.json` and removing the canonical url. Embedded
+ * postgres data stays intact at `~/.omni/data/pgserve/`.
+ *
+ * On any failure (pgserve binary unavailable, install failed, omni-api
+ * relaunch failed), config is NOT persisted — the operator stays on
+ * embedded and can retry.
+ */
+async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
+  const { serverConfig, cliConfig } = deps.loadState();
+  const url = await deps.setupCanonicalPgserve();
+  if (!url) {
+    throw new Error(
+      'canonical pgserve setup failed (pgserve binary unavailable or install failed) — install manually: bun add -g pgserve@^2.1.0',
+    );
+  }
+  // Persist config first so a relaunch failure leaves the operator on
+  // canonical (which is the new recommended state) rather than half-migrated.
+  deps.saveServerConfig({ databaseUrl: url, useCanonicalPgserve: true });
+
+  // Relaunch omni-api with the new env so PGSERVE_EMBEDDED=false takes effect.
+  const env = buildRuntimeEnv({ ...serverConfig, databaseUrl: url, useCanonicalPgserve: true }, cliConfig);
+  await deps.runPm2(['delete', PM2_PROCESSES.api], env);
+  const startArgs = buildPm2StartArgs({
+    kind: 'api',
+    script: getServerLauncherPath(),
+    name: PM2_PROCESSES.api,
+    interpreter: 'bash',
+  });
+  const startCode = await deps.runPm2(startArgs, env);
+  if (startCode !== 0) {
+    throw new Error(`pm2 start ${PM2_PROCESSES.api} exited ${startCode} after canonical migration`);
+  }
+  return `migrated to canonical pgserve@^2.1.0; omni-api now connects to ${url}`;
+}
+
 /** Print `rm -rf` instructions for orphaned dirs — we never auto-delete. */
 function fixOrphanedDataDirs(deps: DoctorDeps): string {
   const found = deps.findOrphanedDataDirs();
@@ -701,6 +765,37 @@ async function checkSigningKeyForLockedInstances(deps: DoctorDeps): Promise<Chec
   };
 }
 
+/**
+ * Check 11: pgserve has grown up — operators on embedded mode get a WARN
+ * pointing them at the canonical-pgserve@^2.1.0 path. `--fix` migrates by
+ * running `pgserve install`, writing the canonical url into config, and
+ * relaunching omni-api with `PGSERVE_EMBEDDED=false`.
+ *
+ * Three states:
+ *   - `useCanonicalPgserve === true`           → OK (already canonical).
+ *   - field absent OR `false`                  → WARN with the migration hint.
+ *
+ * The check NEVER fails — embedded still works; canonical is the
+ * recommended path. We will tighten this to FAIL once canonical is proven
+ * across the fleet.
+ */
+function checkPgserveCanonical(deps: DoctorDeps): CheckResult {
+  const { serverConfig } = deps.loadState();
+  if (serverConfig.useCanonicalPgserve === true) {
+    return {
+      id: 'pgserve-canonical',
+      level: 'OK',
+      detail: 'using canonical pgserve@^2.1.0 (single shared backbone with genie + others)',
+    };
+  }
+  return {
+    id: 'pgserve-canonical',
+    level: 'WARN',
+    detail:
+      'using embedded pgserve — pgserve@^2.1.0 has grown up and is now the recommended shared backbone. Run `omni doctor --fix` to migrate (idempotent; preserves all data).',
+  };
+}
+
 // ============================================================================
 // MAIN
 // ============================================================================
@@ -718,6 +813,7 @@ async function runAllChecks(deps: DoctorDeps): Promise<CheckResult[]> {
     await checkPm2MaxRestarts(deps),
     await checkPm2LogrotateInstalled(deps),
     await checkSigningKeyForLockedInstances(deps),
+    checkPgserveCanonical(deps),
   ];
 }
 
@@ -729,6 +825,7 @@ async function applyFix(deps: DoctorDeps, check: CheckResult): Promise<string | 
     if (check.id === 'orphaned-data-dirs') return fixOrphanedDataDirs(deps);
     if (check.id === 'pm2-max-restarts') return await fixPm2MaxRestarts(deps);
     if (check.id === 'pm2-logrotate-installed') return await fixPm2LogrotateInstalled(deps);
+    if (check.id === 'pgserve-canonical') return await fixPgserveCanonical(deps);
     return null;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -815,6 +912,7 @@ Checks:
   pm2-status               omni-api and omni-nats both online in pm2
   pm2-max-restarts         omni-api max_restarts is in the hardened range
   pm2-logrotate-installed  pm2-logrotate module installed with expected settings
+  pgserve-canonical        using canonical pgserve@^2.1.0 (shared backbone) vs. embedded
 
 Safety:
   --fix NEVER touches ~/.omni/data/pgserve — it only operates on the pm2

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -32,6 +32,7 @@ import {
 } from '../config.js';
 import { DEFAULT_API_PORT, HEALTH_TIMEOUT_MS, waitForHealth } from '../health.js';
 import { detectReinstall, installPm2Logrotate, writeSystemdUnit } from '../install-helpers.js';
+import { resolveCanonicalPgservePreference } from '../lib/canonical-pgserve.js';
 import { NATS_BINARY_PATH, ensureNats } from '../nats-install.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, isPm2Available, runPm2 } from '../pm2.js';
@@ -158,12 +159,17 @@ function resolveReinstallConfig(options: InstallOptions): ResolvedConfig {
   };
 }
 
-function buildInstallRuntimeEnv(cfg: ResolvedConfig, forceCleanup: boolean): Record<string, string> {
+function buildInstallRuntimeEnv(
+  cfg: ResolvedConfig,
+  forceCleanup: boolean,
+  useCanonicalPgserve: boolean,
+): Record<string, string> {
   const serverConfig: ServerConfig = {
     ...DEFAULT_SERVER_CONFIG,
     port: cfg.port,
     databaseUrl: cfg.databaseUrl,
     dataDir: cfg.dataDir,
+    useCanonicalPgserve,
   };
   const env = buildRuntimeEnv(serverConfig, { apiKey: cfg.apiKey } as Config) as Record<string, string>;
   if (forceCleanup) env.OMNI_PGSERVE_FORCE_CLEANUP = 'true';
@@ -174,7 +180,12 @@ function buildInstallRuntimeEnv(cfg: ResolvedConfig, forceCleanup: boolean): Rec
 // Service start
 // ----------------------------------------------------------------------------
 
-async function startServices(cfg: ResolvedConfig, forceCleanup: boolean, forceSystemd: boolean): Promise<boolean> {
+async function startServices(
+  cfg: ResolvedConfig,
+  forceCleanup: boolean,
+  forceSystemd: boolean,
+  useCanonicalPgserve: boolean,
+): Promise<boolean> {
   if (forceSystemd) {
     writeSystemdUnit(cfg.dataDir);
     return false;
@@ -196,7 +207,7 @@ async function startServices(cfg: ResolvedConfig, forceCleanup: boolean, forceSy
   mkdirSync(getPm2LogDir(), { recursive: true });
   await installPm2Logrotate();
 
-  const runtimeEnv = buildInstallRuntimeEnv(cfg, forceCleanup);
+  const runtimeEnv = buildInstallRuntimeEnv(cfg, forceCleanup, useCanonicalPgserve);
 
   // Delete existing processes so the new hardened flags take effect (reinstall path).
   await runPm2(['delete', PM2_PROCESSES.api]);
@@ -239,7 +250,7 @@ async function startServices(cfg: ResolvedConfig, forceCleanup: boolean, forceSy
 // Persistence, health, handoff
 // ----------------------------------------------------------------------------
 
-function writeConfigFile(cfg: ResolvedConfig): void {
+function writeConfigFile(cfg: ResolvedConfig, useCanonicalPgserve: boolean): void {
   const existing = loadConfig();
   saveConfig({
     ...existing,
@@ -247,7 +258,14 @@ function writeConfigFile(cfg: ResolvedConfig): void {
     apiKey: cfg.apiKey,
     format: existing.format ?? 'human',
   });
-  saveServerConfig({ port: cfg.port, databaseUrl: cfg.databaseUrl, dataDir: cfg.dataDir });
+  saveServerConfig({
+    port: cfg.port,
+    databaseUrl: cfg.databaseUrl,
+    dataDir: cfg.dataDir,
+    // Persist canonical-pgserve choice so subsequent omni restart / doctor
+    // commands honor it without operator passing flags or env vars.
+    useCanonicalPgserve,
+  });
 }
 
 async function checkHealth(port: number): Promise<boolean> {
@@ -345,10 +363,16 @@ async function runInstall(options: InstallOptions): Promise<void> {
   }
 
   await runSystemChecks(cfg.port);
-  await ensureNats();
-  const servicesStarted = await startServices(cfg, forceCleanup, forceSystemd);
 
-  writeConfigFile(cfg);
+  // Canonical pgserve (pgserve@^2.1.0): fresh installs default to canonical;
+  // reinstalls preserve the operator's existing choice. Doctor `--fix` is the
+  // way to migrate an embedded install onto canonical later.
+  const useCanonicalPgserve = await resolveCanonicalPgservePreference(signals.isReinstall, cfg);
+
+  await ensureNats();
+  const servicesStarted = await startServices(cfg, forceCleanup, forceSystemd, useCanonicalPgserve);
+
+  writeConfigFile(cfg, useCanonicalPgserve);
   output.success(`Config written to ${getConfigPath()}`);
 
   if (servicesStarted) await checkHealth(cfg.port);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,6 +18,17 @@ export interface ServerConfig {
   dataDir: string;
   logLevel: string;
   nodeEnv: string;
+  /**
+   * When true, omni-api connects to an externally-managed canonical pgserve
+   * (the one registered by `pgserve install` from pgserve@^2.1.0) and SKIPS
+   * its embedded pgserve startup path. Persisted by `omni install` (default
+   * true on fresh installs; preserved on reinstalls) and by
+   * `omni doctor --fix` when migrating an embedded install onto canonical.
+   *
+   * Default behavior on legacy configs (field absent): treated as false →
+   * embedded mode continues. Operators migrate via `omni doctor --fix`.
+   */
+  useCanonicalPgserve?: boolean;
 }
 
 /** Valid config keys (top-level and dot-notation server.* keys) */

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -32,7 +32,7 @@ import * as output from '../output.js';
  * canonical-pgserve-pm2-supervision wish landed in 2.1.0; anything older
  * lacks the install command.
  */
-export const PGSERVE_REQUIRED_VERSION = '^2.1.0';
+const PGSERVE_REQUIRED_VERSION = '^2.1.0';
 
 /**
  * Probe `pgserve --version`. Returns true when the binary is callable.
@@ -40,7 +40,7 @@ export const PGSERVE_REQUIRED_VERSION = '^2.1.0';
  * surface a clear error from `pgserve install` itself if the binary is
  * too old (it'll exit non-zero with "unknown command: install").
  */
-export async function isPgserveInstalled(): Promise<boolean> {
+async function isPgserveInstalled(): Promise<boolean> {
   try {
     const code = await Bun.spawn({ cmd: ['pgserve', '--version'], stdout: 'pipe', stderr: 'pipe' }).exited;
     return code === 0;
@@ -56,7 +56,7 @@ export async function isPgserveInstalled(): Promise<boolean> {
  * - Returns false on failure (caller decides whether to fall back to
  *   embedded or fail hard).
  */
-export async function ensurePgserveBinary(): Promise<boolean> {
+async function ensurePgserveBinary(): Promise<boolean> {
   if (await isPgserveInstalled()) return true;
   output.raw(`  Installing pgserve@${PGSERVE_REQUIRED_VERSION} globally (bun add -g)...`);
   const installCode = await Bun.spawn({

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -1,0 +1,172 @@
+/**
+ * Canonical pgserve helpers — single shared pgserve@^2.1.0 backbone.
+ *
+ * Background
+ * ----------
+ * Up through omni 2.260430, omni-api spawned its own embedded pgserve
+ * via `await import('pgserve')`. That worked, but every other service
+ * (genie-serve, future agents) that wanted Postgres span its own copy,
+ * so a single host could end up with 3+ pgserve instances on different
+ * ports with scattered data dirs. Canonical pgserve fixes this:
+ *
+ *   - `pgserve install` (from pgserve@^2.1.0) registers ONE pm2-supervised
+ *     pgserve instance on the canonical port (8432).
+ *   - `pgserve url` returns its connection string — every downstream
+ *     service (omni, genie, ...) reads this and connects there.
+ *   - `omni install` calls `pgserve install` first, writes the URL into
+ *     `~/.omni/config.json`, and starts omni-api with `PGSERVE_EMBEDDED=false`
+ *     so the API skips its own embedded boot path.
+ *
+ * Embedded mode is NOT removed. It stays as the active path on existing
+ * installs (where `serverConfig.useCanonicalPgserve` is undefined or
+ * false) until the operator opts in via `omni doctor --fix`. Fresh
+ * installs default to canonical.
+ */
+
+import { loadServerConfig } from '../config.js';
+import * as output from '../output.js';
+
+/**
+ * Minimum pgserve binary version required for the canonical install
+ * subcommands (`install`, `url`, `port`, `status`). Wave 1 of the
+ * canonical-pgserve-pm2-supervision wish landed in 2.1.0; anything older
+ * lacks the install command.
+ */
+export const PGSERVE_REQUIRED_VERSION = '^2.1.0';
+
+/**
+ * Probe `pgserve --version`. Returns true when the binary is callable.
+ * Doesn't enforce the minimum version — `setupCanonicalPgserve` will
+ * surface a clear error from `pgserve install` itself if the binary is
+ * too old (it'll exit non-zero with "unknown command: install").
+ */
+export async function isPgserveInstalled(): Promise<boolean> {
+  try {
+    const code = await Bun.spawn({ cmd: ['pgserve', '--version'], stdout: 'pipe', stderr: 'pipe' }).exited;
+    return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure the global `pgserve` binary is installed and on PATH. Best-effort:
+ * - If already installed, return true immediately.
+ * - Otherwise try `bun add -g pgserve@<PGSERVE_REQUIRED_VERSION>`.
+ * - Returns false on failure (caller decides whether to fall back to
+ *   embedded or fail hard).
+ */
+export async function ensurePgserveBinary(): Promise<boolean> {
+  if (await isPgserveInstalled()) return true;
+  output.raw(`  Installing pgserve@${PGSERVE_REQUIRED_VERSION} globally (bun add -g)...`);
+  const installCode = await Bun.spawn({
+    cmd: ['bun', 'add', '-g', `pgserve@${PGSERVE_REQUIRED_VERSION}`],
+    stdout: 'inherit',
+    stderr: 'inherit',
+  }).exited;
+  if (installCode !== 0) {
+    output.warn(`bun add -g pgserve@${PGSERVE_REQUIRED_VERSION} exited with code ${installCode}`);
+    return false;
+  }
+  // Re-probe — bun's global bin may not be on PATH yet for the running shell
+  // but `pgserve --version` should still resolve via the absolute global path.
+  return isPgserveInstalled();
+}
+
+/**
+ * Run `pgserve install` (idempotent — exits 0 with "already installed"
+ * on subsequent invocations). Returns true on success.
+ */
+async function runPgserveInstall(): Promise<boolean> {
+  output.raw('  Registering canonical pgserve under pm2 (idempotent)...');
+  const installCode = await Bun.spawn({ cmd: ['pgserve', 'install'], stdout: 'inherit', stderr: 'inherit' }).exited;
+  if (installCode !== 0) {
+    output.warn(`pgserve install exited with code ${installCode}`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Read the canonical connection string via `pgserve url`. Returns null
+ * when the call fails or the output isn't a postgres URL.
+ */
+async function readPgserveUrl(): Promise<string | null> {
+  const proc = Bun.spawn({ cmd: ['pgserve', 'url'], stdout: 'pipe', stderr: 'inherit' });
+  const stdout = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  if (code !== 0) {
+    output.warn(`pgserve url exited with code ${code}`);
+    return null;
+  }
+  const url = stdout.trim();
+  if (!url.startsWith('postgres://') && !url.startsWith('postgresql://')) {
+    output.warn(`pgserve url returned unexpected output ("${url}")`);
+    return null;
+  }
+  return url;
+}
+
+/**
+ * Full canonical pgserve setup: ensure binary → `pgserve install` → read
+ * the canonical url. Returns the URL on success, null on any failure.
+ *
+ * The caller (omni install) writes this URL into serverConfig.databaseUrl
+ * so omni-api connects there with `PGSERVE_EMBEDDED=false`.
+ */
+export async function setupCanonicalPgserve(): Promise<string | null> {
+  if (!(await ensurePgserveBinary())) {
+    output.warn('Canonical pgserve binary unavailable — install manually: bun add -g pgserve@^2.1.0');
+    return null;
+  }
+  if (!(await runPgserveInstall())) return null;
+  return readPgserveUrl();
+}
+
+/**
+ * Decide whether an install run should use canonical pgserve and, when yes,
+ * mutate `cfg.databaseUrl` to the canonical url.
+ *
+ * Semantics:
+ *   - Fresh install → ALWAYS canonical (auto-installs `pgserve` globally
+ *     when missing, runs `pgserve install`, reads `pgserve url`). If
+ *     canonical setup completely fails, falls back to embedded with a warn
+ *     — the install still completes.
+ *   - Reinstall → preserves the operator's existing
+ *     `serverConfig.useCanonicalPgserve`. If `true`, re-runs setup
+ *     (idempotent) to refresh the canonical url. If `false`/undefined,
+ *     leaves embedded mode alone — operator migrates via `omni doctor --fix`.
+ */
+export async function resolveCanonicalPgservePreference(
+  isReinstall: boolean,
+  cfg: { databaseUrl: string },
+): Promise<boolean> {
+  if (isReinstall) {
+    const existing = loadServerConfig().useCanonicalPgserve === true;
+    if (!existing) return false;
+    output.raw('  Canonical pgserve mode (preserved from previous install)');
+    const url = await setupCanonicalPgserve();
+    if (!url) {
+      output.warn('Canonical pgserve refresh failed — keeping previous databaseUrl.');
+      return true;
+    }
+    cfg.databaseUrl = url;
+    output.raw(`    ✓ omni-api will connect to ${url}`);
+    output.raw('');
+    return true;
+  }
+  output.raw('  Canonical pgserve mode (default for new installs)');
+  const url = await setupCanonicalPgserve();
+  if (!url) {
+    output.warn(
+      'Canonical pgserve setup did not complete — falling back to embedded pgserve. Run `omni doctor --fix` later to migrate.',
+    );
+    output.raw('');
+    return false;
+  }
+  cfg.databaseUrl = url;
+  output.raw(`    ✓ omni-api will connect to ${url}`);
+  output.raw('    ✓ embedded pgserve will be skipped (PGSERVE_EMBEDDED=false)');
+  output.raw('');
+  return true;
+}

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -97,16 +97,23 @@ export function resolveDatabaseUrl(serverConfig: ServerConfig): string {
  * Build the complete runtime env for the omni-api process.
  *
  * All values come from `serverConfig` / `cliConfig`. No shell env reads.
+ *
+ * `PGSERVE_EMBEDDED` is flipped off when `serverConfig.useCanonicalPgserve`
+ * is true — the omni-api code path in `packages/api/src/pgserve.ts` reads
+ * this and skips its embedded pgserve startup, connecting instead to
+ * whatever `DATABASE_URL` points at (typically the canonical pgserve
+ * registered by `pgserve install` from pgserve@^2.1.0).
  */
 export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config): RuntimeEnv {
   const pgservePort = resolvePgservePort(serverConfig);
+  const useCanonical = serverConfig.useCanonicalPgserve === true;
   return {
     API_PORT: String(serverConfig.port),
     DATABASE_URL: resolveDatabaseUrl(serverConfig),
     OMNI_API_KEY: cliConfig.apiKey ?? '',
     MEDIA_STORAGE_PATH: join(serverConfig.dataDir, 'media'),
     OMNI_PACKAGES_DIR: join(serverConfig.dataDir, 'packages'),
-    PGSERVE_EMBEDDED: 'true',
+    PGSERVE_EMBEDDED: useCanonical ? 'false' : 'true',
     PGSERVE_DATA: join(serverConfig.dataDir, 'pgserve'),
     PGSERVE_PORT: String(pgservePort),
     NATS_URL: 'nats://localhost:4222',


### PR DESCRIPTION
## Summary

Drops the opt-in \`--canonical-pgserve\` flag (closed PR #578) and makes canonical pgserve the **default** path for fresh installs. Existing embedded installs migrate via \`omni doctor --fix\` when ready. Single shared pgserve@^2.1.0 backbone for both omni + genie + future automagik services.

This is Wave 3 of [canonical-pgserve-pm2-supervision](https://github.com/namastexlabs/pgserve/issues/55), redesigned per operator feedback: \"genie and omni must live happily sharing the same pgserve backbone, both on same version.\"

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Fresh install | embedded pgserve | **canonical pgserve** (auto-installs binary if missing) |
| Reinstall (was embedded) | embedded preserved | embedded preserved (operator opts in via doctor) |
| Reinstall (was canonical) | n/a | refreshes canonical URL idempotently |
| \`omni doctor\` | no canonical check | **WARN** when embedded, with one-line migration hint |
| \`omni doctor --fix\` | no migration | **migrates** embedded → canonical, relaunches omni-api |

Embedded \`startEmbeddedPgserve\` code stays intact in \`packages/api/src/pgserve.ts\` — it's the active path on existing installs and the safety net if canonical setup fails. Will be removed in a follow-up once canonical is proven.

## Changes

- **\`packages/api/package.json\`** — \`pgserve\` dep \`^1.2.0\` → \`^2.1.0\` (matches genie pin)
- **\`install.sh\`** — \`ensure_pgserve()\` step installs \`pgserve@^2.1.0\` globally before \`omni install\`
- **\`packages/cli/src/lib/canonical-pgserve.ts\`** (new) — \`setupCanonicalPgserve()\`, \`ensurePgserveBinary()\`, \`resolveCanonicalPgservePreference()\`
- **\`packages/cli/src/commands/install.ts\`** — fresh installs default to canonical; reinstalls preserve operator's flag; no opt-in flag
- **\`packages/cli/src/runtime-env.ts\`** — \`PGSERVE_EMBEDDED\` flips off when \`useCanonicalPgserve === true\`
- **\`packages/cli/src/config.ts\`** — \`ServerConfig.useCanonicalPgserve?: boolean\`
- **\`packages/cli/src/commands/doctor.ts\`** — new check \`pgserve-canonical\` + fix \`fixPgserveCanonical\`

## Wave context

| Wave | Repo | Status |
|------|------|--------|
| 1 — pgserve foundation | namastexlabs/pgserve#57 | merged → 2.1.0 published |
| 2 — \`genie install\` | automagik-dev/genie#1578 | merged |
| **3 — omni canonical-by-default** | **automagik-dev/omni#this** | **open** |
| 4 — brain entries | namastexlabs/genie-configure | pending |

## Test plan

- [x] \`bun run typecheck\` — green
- [x] \`bun test\` (CLI) — **357/357 pass** (was 352; +5 new doctor tests)
- [x] \`bunx biome check\` on changed files — clean
- [x] \`install.ts\` line-count gate (<400) — at 394
- [ ] Manual e2e on this server after merge:
  - [ ] \`omni install\` (fresh) — pgserve registered under pm2, omni-api connects to canonical port
  - [ ] \`omni install\` (reinstall on canonical) — idempotent, refreshes URL
  - [ ] \`omni install\` (reinstall on embedded) — preserves embedded
  - [ ] \`omni doctor\` on embedded install — shows WARN with migration hint
  - [ ] \`omni doctor --fix\` on embedded install — migrates to canonical, omni-api restarts, data preserved
  - [ ] \`pm2 list\` — pgserve + omni-api + omni-nats all online