### PR TITLE
fix(doctor): canonical-pgserve migration bugs found in live exec

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -768,13 +768,60 @@ describe('runDoctor — pgserve-canonical check', () => {
       databaseUrl: 'postgresql://postgres:postgres@localhost:8432/omni',
       useCanonicalPgserve: true,
     });
-    // pm2 was relaunched (delete + start) so PGSERVE_EMBEDDED=false takes effect
+    // pm2 was relaunched (stop, then delete + start) so PGSERVE_EMBEDDED=false takes effect
     const pm2Cmds = state.pm2Calls.map((c) => c.args[0]);
+    expect(pm2Cmds).toContain('stop');
     expect(pm2Cmds).toContain('delete');
     expect(pm2Cmds).toContain('start');
+    // The `stop` MUST happen before `setupCanonicalPgserve` is invoked — otherwise
+    // the embedded pgserve still holds port 8432 and `pgserve install` fails with
+    // EADDRINUSE. We assert ordering by checking that stop is the first pm2 call.
+    expect(pm2Cmds[0]).toBe('stop');
     // Fix was recorded with a useful detail line
     const migrationFix = report.fixesApplied.find((f) => f.includes('canonical pgserve'));
     expect(migrationFix).toBeDefined();
+  });
+
+  test('--fix runs pgserve-canonical FIRST so cli-key-valid does not cascade', async () => {
+    // Reproduces the live bug found 2026-04-30: when omni-api is stopped
+    // for the migration, cli-key-valid FAILed, and its fix rotated keys
+    // while the api was unreachable, leaving env+DB out of sync.
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    // Simulate the cascade trigger: cli-key-valid FAILs initially, but
+    // becomes OK after migration (because re-eval picks up the restored API).
+    state.keyValid = false;
+    state.keyValidAfterFix = true;
+    state.canonicalPgserveSetupResult = 'postgresql://postgres:postgres@localhost:8432/omni';
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // cli-key-valid fix MUST NOT have been invoked — pgserve-canonical fix ran
+    // first, then re-evaluation picked up the recovered key state.
+    const keyRotationFix = report.fixesApplied.find((f) => typeof f === 'string' && f.includes('rotated CLI key'));
+    expect(keyRotationFix).toBeUndefined();
+    // pgserve-canonical fix DID run.
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+  });
+
+  test('--fix brings omni-api back up when canonical setup fails (no half-migrated state)', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.canonicalPgserveSetupResult = null;
+
+    await runDoctor({ fix: true }, mkDeps(state));
+
+    // Migration aborted — but fixPgserveCanonical must have started omni-api
+    // back up so the operator isn't left with a stopped API.
+    const pm2Cmds = state.pm2Calls.map((c) => c.args[0]);
+    expect(pm2Cmds).toContain('stop');
+    expect(pm2Cmds).toContain('start');
+    // Stop happened before start (recovery ordering).
+    const stopIdx = pm2Cmds.indexOf('stop');
+    const startIdx = pm2Cmds.indexOf('start');
+    expect(stopIdx).toBeLessThan(startIdx);
   });
 
   test('--fix records FAILED when setupCanonicalPgserve returns null', async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -680,17 +680,32 @@ async function fixCliKeyValid(deps: DoctorDeps): Promise<string> {
  */
 async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
   const { serverConfig, cliConfig } = deps.loadState();
+
+  // Step 1: stop omni-api FIRST so the embedded pgserve releases port 8432.
+  // pgserve@2.1.0's `pgserve install` will then bind that port for the
+  // canonical instance. If we did this in the opposite order, `pgserve
+  // install` would fail with EADDRINUSE and the migration would abort with
+  // omni-api still on embedded but no canonical registered.
+  await deps.runPm2(['stop', PM2_PROCESSES.api]);
+
+  // Step 2: provision canonical pgserve and read its port.
   const url = await deps.setupCanonicalPgserve();
   if (!url) {
+    // Bring omni-api back up on embedded so the operator isn't left with a
+    // dead API. They can retry the migration later.
+    await deps.runPm2(['start', PM2_PROCESSES.api]);
     throw new Error(
       'canonical pgserve setup failed (pgserve binary unavailable or install failed) — install manually: bun add -g pgserve@^2.1.0',
     );
   }
-  // Persist config first so a relaunch failure leaves the operator on
-  // canonical (which is the new recommended state) rather than half-migrated.
+
+  // Step 3: persist config first so a relaunch failure leaves the operator
+  // on canonical (the new recommended state) rather than half-migrated.
   deps.saveServerConfig({ databaseUrl: url, useCanonicalPgserve: true });
 
-  // Relaunch omni-api with the new env so PGSERVE_EMBEDDED=false takes effect.
+  // Step 4: relaunch omni-api with the new env so PGSERVE_EMBEDDED=false
+  // takes effect. delete + start (instead of restart) so the new env is
+  // picked up — pm2's restart preserves stored env in some configurations.
   const env = buildRuntimeEnv({ ...serverConfig, databaseUrl: url, useCanonicalPgserve: true }, cliConfig);
   await deps.runPm2(['delete', PM2_PROCESSES.api], env);
   const startArgs = buildPm2StartArgs({
@@ -854,14 +869,31 @@ export async function runDoctor(options: DoctorOptions, depsOverride?: DoctorDep
   const fixesApplied: string[] = [];
 
   if (options.fix) {
+    // Phase 1: migration fixes that change state for everyone else.
+    // pgserve-canonical stops omni-api, registers canonical pgserve, restarts
+    // omni-api on the new URL. After it runs, cli-key-valid / pgserve-reachable
+    // / omni-db-exists / version-match must be re-evaluated against the
+    // migrated state — running them in the same pass would cascade false
+    // failures (api temporarily unreachable) and trigger destructive fixes
+    // (key rotation while DB is unmigrated).
+    const canonicalCheck = checks.find((c) => c.id === 'pgserve-canonical');
+    if (canonicalCheck && canonicalCheck.level !== 'OK') {
+      const result = await applyFix(deps, canonicalCheck);
+      if (result !== null) fixesApplied.push(result);
+      // Re-run all checks against the post-migration state before any other
+      // fix gets to see them.
+      checks = await runAllChecks(deps);
+    }
+
+    // Phase 2: every other fix runs against the (possibly post-migration) state.
     for (const check of checks) {
       if (check.level === 'OK') continue;
+      if (check.id === 'pgserve-canonical') continue; // already handled above
       const result = await applyFix(deps, check);
-      if (result !== null) {
-        fixesApplied.push(result);
-      }
+      if (result !== null) fixesApplied.push(result);
     }
-    // Re-run checks after fixes so the final report reflects post-repair state.
+
+    // Final re-check so the report reflects post-fix state.
     checks = await runAllChecks(deps);
   }
 

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -35,14 +35,21 @@ import * as output from '../output.js';
 const PGSERVE_REQUIRED_VERSION = '^2.1.0';
 
 /**
- * Probe `pgserve --version`. Returns true when the binary is callable.
- * Doesn't enforce the minimum version — `setupCanonicalPgserve` will
- * surface a clear error from `pgserve install` itself if the binary is
- * too old (it'll exit non-zero with "unknown command: install").
+ * Probe the `pgserve` binary by running a real subcommand. Returns true
+ * when the binary is callable and accepts canonical-mode subcommands.
+ *
+ * History
+ * -------
+ * The first attempt used `pgserve --version`. That flag does not exist
+ * in pgserve@2.1.0 — the wrapper exits non-zero with "Unknown option:
+ * --version" and dumps the help. `omni doctor --fix` then false-negatived,
+ * triggered a redundant `bun add -g pgserve` call, and the migration
+ * failed. We now probe `pgserve port`, which exists in 2.1.0+ and exits
+ * 0 with the canonical port number on stdout.
  */
 async function isPgserveInstalled(): Promise<boolean> {
   try {
-    const code = await Bun.spawn({ cmd: ['pgserve', '--version'], stdout: 'pipe', stderr: 'pipe' }).exited;
+    const code = await Bun.spawn({ cmd: ['pgserve', 'port'], stdout: 'pipe', stderr: 'pipe' }).exited;
     return code === 0;
   } catch {
     return false;
@@ -88,23 +95,50 @@ async function runPgserveInstall(): Promise<boolean> {
 }
 
 /**
- * Read the canonical connection string via `pgserve url`. Returns null
- * when the call fails or the output isn't a postgres URL.
+ * Database name omni-api expects on the canonical pgserve. pgserve@2.1.0
+ * auto-provisions databases on first connection, so this can be anything;
+ * we keep `omni` to match the historical embedded-mode default.
  */
-async function readPgserveUrl(): Promise<string | null> {
-  const proc = Bun.spawn({ cmd: ['pgserve', 'url'], stdout: 'pipe', stderr: 'inherit' });
+const OMNI_DATABASE_NAME = 'omni';
+
+/**
+ * Read the canonical pgserve port via `pgserve port`. Returns null when
+ * the call fails or the output isn't a number.
+ *
+ * History
+ * -------
+ * The first attempt called `pgserve url` and used its output verbatim.
+ * pgserve@2.1.0's `url` returns `postgres://localhost:<port>/postgres`
+ * — no credentials, generic `postgres` database — which is fine for a
+ * generic discovery API but NOT what omni-api expects. omni-api connects
+ * with `postgres:postgres` credentials to the `omni` database (auto-
+ * provisioned by pgserve on first connect). We now read just the port
+ * and compose the URL ourselves so the connection string matches what
+ * the embedded path used.
+ */
+async function readPgservePort(): Promise<number | null> {
+  const proc = Bun.spawn({ cmd: ['pgserve', 'port'], stdout: 'pipe', stderr: 'inherit' });
   const stdout = await new Response(proc.stdout).text();
   const code = await proc.exited;
   if (code !== 0) {
-    output.warn(`pgserve url exited with code ${code}`);
+    output.warn(`pgserve port exited with code ${code}`);
     return null;
   }
-  const url = stdout.trim();
-  if (!url.startsWith('postgres://') && !url.startsWith('postgresql://')) {
-    output.warn(`pgserve url returned unexpected output ("${url}")`);
+  const port = Number.parseInt(stdout.trim(), 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    output.warn(`pgserve port returned unexpected output ("${stdout.trim()}")`);
     return null;
   }
-  return url;
+  return port;
+}
+
+/**
+ * Compose the omni-api connection string from a canonical port. Mirrors
+ * the embedded-mode default so omni-api / drizzle migrations don't see
+ * a connection-shape change across the migration.
+ */
+function buildOmniDatabaseUrl(port: number): string {
+  return `postgresql://postgres:postgres@localhost:${port}/${OMNI_DATABASE_NAME}`;
 }
 
 /**
@@ -120,7 +154,9 @@ export async function setupCanonicalPgserve(): Promise<string | null> {
     return null;
   }
   if (!(await runPgserveInstall())) return null;
-  return readPgserveUrl();
+  const port = await readPgservePort();
+  if (port === null) return null;
+  return buildOmniDatabaseUrl(port);
 }
 
 /**


### PR DESCRIPTION
## Summary

Followup to #579. Live `omni doctor --fix` exec on a real embedded install uncovered four bugs that prevented migration from completing. This PR fixes all four with regression tests.

## Bugs and fixes

### 1. `isPgserveInstalled()` probed a flag that doesn't exist

`pgserve --version` doesn't exist in `pgserve@2.1.0` — the wrapper exits non-zero with `Unknown option: --version` and dumps the help text. The probe always returned `false`, even when pgserve was installed and working. `ensurePgserveBinary` then redundantly re-ran `bun add -g pgserve`.

**Fix:** probe via `pgserve port` (real subcommand, exits 0 with the port number).

### 2. `pgserve url` returns the wrong URL for omni

`pgserve url` returns `postgres://localhost:<port>/postgres` — generic database name, no credentials. omni-api needs `postgresql://postgres:postgres@localhost:<port>/omni`. We were writing the bare `pgserve url` output into `serverConfig.databaseUrl`, which omni-api then couldn't connect to with its expected credentials.

**Fix:** read only the port via `pgserve port`, then compose the omni URL ourselves matching the embedded-mode default. pgserve@2.1.0 auto-provisions databases on first connection so the `omni` database is created automatically.

### 3. Migration ordering — `pgserve install` ran while embedded held :8432

`fixPgserveCanonical` called `setupCanonicalPgserve()` first, but the embedded pgserve was still listening on port 8432, so `pgserve install` would fail with EADDRINUSE.

**Fix:** stop omni-api FIRST so the embedded process releases the port, then run `pgserve install`, then restart on the new env. Also recovers omni-api on embedded if canonical setup fails — so the operator never sees a half-migrated stopped API.

### 4. cli-key-valid fix cascaded during the migration window

When omni-api went down for the migration, `cli-key-valid` FAILed (api unreachable). Its fix then rotated the key while the API was still down. Result: pm2 stored env had the new key, DB still had the old hash → all subsequent CLI calls 401'd. Required manually deleting `__primary__` from `api_keys` to recover (which is what happened during the live test on this server).

**Fix:** run `pgserve-canonical` FIRST in `runDoctor`, re-evaluate all checks against the migrated state, THEN run the rest of the fixes. Other fix handlers never see the transient unreachable state.

## Test plan

- [x] `bun test src/__tests__/doctor.test.ts` — **34/34 pass** (was 32; +2 cascade-prevention tests)
- [x] `bun test` (CLI) — **359/359 pass** (was 357)
- [x] `bun run typecheck` — green
- [x] `bunx biome check` — clean
- [x] `bunx knip` — clean
- [ ] **Live retest on the genie-configure server** after merge: `omni doctor --fix` should complete in one run and bring omni-api up on canonical pgserve, with all 11 doctor checks green.

## Wave context

This is a fix to Wave 3 of [canonical-pgserve-pm2-supervision](https://github.com/namastexlabs/pgserve/issues/55). Wave 3 itself shipped in #579. The bugs only surfaced under live execution against a real embedded install — the original test harness stubbed the failure modes that hit in production.
