### PR TITLE
feat(doctor): pg_dump/psql migration of embedded data to canonical pgserve

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -74,6 +74,33 @@ interface HarnessState {
   canonicalPgserveSetupCalled: boolean;
   /** Recorded saveServerConfig calls — tests assert what migration persists. */
   savedServerConfigs: Array<Partial<ServerConfig>>;
+  /**
+   * Result the stubbed `dumpEmbeddedDb()` returns. Default matches a fresh
+   * install (`no-embedded-data`). Tests can override to exercise the
+   * dumped or invalid paths.
+   */
+  dumpResult:
+    | { status: 'no-embedded-data'; embeddedDir: string }
+    | { status: 'embedded-data-invalid'; embeddedDir: string }
+    | { status: 'dumped'; embeddedDir: string; snapshotPath: string; bytes: number };
+  /** When set, the stubbed dump throws this error (simulates pg_dump failure). */
+  dumpError: Error | null;
+  /** Set to true the first time `dumpEmbeddedDb()` is called. */
+  dumpCalled: boolean;
+  /** When set, the stubbed restore throws this error (simulates psql failure). */
+  restoreError: Error | null;
+  /** Set to true the first time `restoreSnapshotToCanonical()` is called. */
+  restoreCalled: boolean;
+  /** Canonical data dir reported by the stubbed `getCanonicalPgserveDataDir()`. */
+  canonicalDataDir: string;
+  /**
+   * Records the order in which fix-handler dependencies were invoked, so
+   * tests can assert the correct dump → stop → install → restore → delete
+   * → start sequence.
+   */
+  callOrder: Array<
+    'pm2-stop-api' | 'dump-embedded' | 'setup-canonical' | 'restore-snapshot' | 'pm2-start-api' | 'pm2-delete-api'
+  >;
 }
 
 /** Canonical healthy `pm2 conf` output — matches PM2_LOGROTATE_SETTINGS. */
@@ -124,8 +151,47 @@ function mkHarness(overrides?: Partial<HarnessState>): HarnessState {
     canonicalPgserveSetupResult: 'postgresql://postgres:postgres@localhost:8432/omni',
     canonicalPgserveSetupCalled: false,
     savedServerConfigs: [],
+    dumpResult: { status: 'no-embedded-data', embeddedDir: '/tmp/omni-test/embedded' },
+    dumpError: null,
+    dumpCalled: false,
+    restoreError: null,
+    restoreCalled: false,
+    canonicalDataDir: '/tmp/omni-test/canonical',
+    callOrder: [],
     ...overrides,
   };
+}
+
+/**
+ * Record a stubbed pm2 invocation. Mirrors the side-effects the real fix
+ * handlers expect (key rotation, env drift clearing, logrotate keys) and
+ * appends a coarse call-order trace so canonical-pgserve tests can assert
+ * the stop → migrate → install → delete → start ordering. Extracted from
+ * `mkDeps` so the dep closure stays under biome's complexity ceiling.
+ */
+async function recordPm2(state: HarnessState, args: string[], env?: Record<string, string>): Promise<number> {
+  state.pm2Calls.push({ args, env });
+
+  // Coarse ordering trace for the canonical-pgserve migration tests.
+  if (args[0] === 'stop' && args[1] === 'omni-api') state.callOrder.push('pm2-stop-api');
+  else if (args[0] === 'start' && args[1] === 'omni-api') state.callOrder.push('pm2-start-api');
+  else if (args[0] === 'delete' && args[1] === 'omni-api') state.callOrder.push('pm2-delete-api');
+
+  // The cli-key-valid fix handler uses runPm2 to restart; flipping
+  // keyFixApplied here lets the recheck pick up the "fixed" state.
+  if (args[0] === 'restart' || args[0] === 'start') {
+    state.keyFixApplied = true;
+    if (state.pm2DriftAfterFix) state.pm2Drift = false;
+    if (state.maxRestartsAfterFix !== undefined) state.apiMaxRestarts = state.maxRestartsAfterFix;
+  }
+
+  // The pm2-logrotate-installed fix re-runs `pm2 set pm2-logrotate:*`;
+  // flip pm2ConfOutput to the post-fix state when the last key is set.
+  if (args[0] === 'set' && args[1]?.startsWith('pm2-logrotate:') && state.pm2ConfAfterFix !== null) {
+    state.pm2ConfOutput = state.pm2ConfAfterFix;
+  }
+
+  return state.pm2ExitCode;
 }
 
 function mkDeps(state: HarnessState): DoctorDeps {
@@ -175,26 +241,7 @@ function mkDeps(state: HarnessState): DoctorDeps {
     },
     loadState: () => ({ serverConfig: state.serverConfig, cliConfig: state.cliConfig }),
     // Stubbed side-effects. Tests record pm2 calls here instead of spawning pm2.
-    runPm2: async (args: string[], env?: Record<string, string>) => {
-      state.pm2Calls.push({ args, env });
-      // The cli-key-valid fix handler uses runPm2 to restart; flipping
-      // keyFixApplied here lets the recheck pick up the "fixed" state.
-      if (args[0] === 'restart' || args[0] === 'start') {
-        state.keyFixApplied = true;
-        if (state.pm2DriftAfterFix) {
-          state.pm2Drift = false;
-        }
-        if (state.maxRestartsAfterFix !== undefined) {
-          state.apiMaxRestarts = state.maxRestartsAfterFix;
-        }
-      }
-      // The pm2-logrotate-installed fix re-runs `pm2 set pm2-logrotate:*`;
-      // flip pm2ConfOutput to the post-fix state when the last key is set.
-      if (args[0] === 'set' && args[1]?.startsWith('pm2-logrotate:') && state.pm2ConfAfterFix !== null) {
-        state.pm2ConfOutput = state.pm2ConfAfterFix;
-      }
-      return state.pm2ExitCode;
-    },
+    runPm2: async (args: string[], env?: Record<string, string>) => recordPm2(state, args, env),
     saveCliConfig: (config: Config) => {
       state.cliConfig = { ...state.cliConfig, ...config };
     },
@@ -208,8 +255,24 @@ function mkDeps(state: HarnessState): DoctorDeps {
     cliHasSigningKey: () => state.cliHasSigningKey,
     setupCanonicalPgserve: async () => {
       state.canonicalPgserveSetupCalled = true;
+      state.callOrder.push('setup-canonical');
       return state.canonicalPgserveSetupResult;
     },
+    dumpEmbeddedDb: async (_currentUrl: string) => {
+      state.dumpCalled = true;
+      state.callOrder.push('dump-embedded');
+      if (state.dumpError) throw state.dumpError;
+      return state.dumpResult;
+    },
+    restoreSnapshotToCanonical: async (dump, _canonicalUrl: string) => {
+      state.restoreCalled = true;
+      state.callOrder.push('restore-snapshot');
+      if (state.restoreError) throw state.restoreError;
+      return dump.status === 'dumped'
+        ? { status: 'restored' as const, snapshotPath: dump.snapshotPath }
+        : { status: 'skipped' as const };
+    },
+    getCanonicalPgserveDataDir: () => state.canonicalDataDir,
     saveServerConfig: (partial) => {
       state.serverConfig = { ...state.serverConfig, ...partial };
       state.savedServerConfigs.push({ ...partial });
@@ -880,5 +943,139 @@ describe('runDoctor — pgserve-canonical check', () => {
     const skippedKey = report.fixesApplied.find((f) => f.startsWith('SKIPPED cli-key-valid'));
     expect(skippedKey).toBeDefined();
     expect(skippedKey).toContain('failed canonical-pgserve migration');
+  });
+
+  // -------------------------------------------------------------------------
+  // Embedded → canonical data migration via pg_dump + psql (issue #584)
+  //
+  // Before the data-migration step landed, `omni doctor --fix` flipped
+  // `databaseUrl` to canonical without moving the existing PG cluster.
+  // Operators with non-trivial data ended up on an empty canonical DB even
+  // though their messages/chats/etc. were still on disk under
+  // `~/.omni/data/pgserve/`. These tests pin the new ordering — mirroring
+  // genie's `db backup` / `db restore` pattern (pg_dump → gzip → psql):
+  //   dump (while embedded live) → stop omni-api → install canonical →
+  //   restore snapshot → persist → relaunch.
+  // -------------------------------------------------------------------------
+
+  test('--fix runs dump → stop → install → restore → delete → start in that order', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.dumpResult = {
+      status: 'dumped',
+      embeddedDir: '/home/operator/.omni/data/pgserve',
+      snapshotPath: '/home/operator/.omni/backups/embedded-migration-2026-04-30T23-30-00-000Z.sql.gz',
+      bytes: 42_000_000,
+    };
+    state.canonicalDataDir = '/home/operator/.pgserve/data';
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // All four side-effects ran
+    expect(state.dumpCalled).toBe(true);
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    expect(state.restoreCalled).toBe(true);
+
+    // Required ordering: dump must come BEFORE stop (embedded must be live
+    // for pg_dump). install must come BEFORE restore (canonical must exist
+    // for psql to write into).
+    const dumpIdx = state.callOrder.indexOf('dump-embedded');
+    const stopIdx = state.callOrder.indexOf('pm2-stop-api');
+    const setupIdx = state.callOrder.indexOf('setup-canonical');
+    const restoreIdx = state.callOrder.indexOf('restore-snapshot');
+    expect(dumpIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeGreaterThan(dumpIdx);
+    expect(setupIdx).toBeGreaterThan(stopIdx);
+    expect(restoreIdx).toBeGreaterThan(setupIdx);
+
+    // Final result message surfaces the snapshot path AND the canonical data
+    // dir so the operator can verify the destination without grepping logs.
+    const fix = report.fixesApplied.find((f) => f.includes('canonical pgserve'));
+    expect(fix).toBeDefined();
+    expect(fix).toContain('embedded-migration-2026-04-30T23-30-00-000Z.sql.gz');
+    expect(fix).toContain('/home/operator/.pgserve/data');
+    expect(fix).toContain('postgresql://postgres:postgres@localhost:8432/omni');
+  });
+
+  test('--fix on a fresh install (no embedded data) skips dump+restore and proceeds', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.canonicalDataDir = '/home/operator/.pgserve/data';
+    // Default dumpResult is already 'no-embedded-data'; explicit for readability.
+    state.dumpResult = { status: 'no-embedded-data', embeddedDir: '/home/operator/.omni/data/pgserve' };
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // Dump probe ran (so we don't second-guess) but returned no-op.
+    expect(state.dumpCalled).toBe(true);
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    // Restore was still called but skipped internally (status === 'skipped')
+    // because dump status was no-embedded-data.
+    expect(state.restoreCalled).toBe(true);
+    expect(state.savedServerConfigs).toHaveLength(1);
+    const fix = report.fixesApplied.find((f) => f.includes('canonical pgserve'));
+    expect(fix).toContain('no embedded data to migrate; canonical started empty');
+    expect(fix).toContain('/home/operator/.pgserve/data');
+  });
+
+  test('--fix rolls back omni-api to embedded when pg_dump throws (omni-api never stopped)', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.dumpError = new Error('pg_dump not found in PATH — install postgresql-client');
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    expect(state.dumpCalled).toBe(true);
+    // We never proceeded past dump — no stop, no setup, no restore.
+    expect(state.callOrder).not.toContain('pm2-stop-api');
+    expect(state.canonicalPgserveSetupCalled).toBe(false);
+    expect(state.restoreCalled).toBe(false);
+    expect(state.savedServerConfigs).toHaveLength(0);
+
+    const failedFix = report.fixesApplied.find((f) => f.startsWith('FAILED pgserve-canonical'));
+    expect(failedFix).toBeDefined();
+    expect(failedFix).toContain('pg_dump of embedded omni DB failed');
+    expect(failedFix).toContain('postgresql-client');
+  });
+
+  test('--fix rolls back to embedded + preserves snapshot when restore fails', async () => {
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    state.dumpResult = {
+      status: 'dumped',
+      embeddedDir: '/home/op/.omni/data/pgserve',
+      snapshotPath: '/home/op/.omni/backups/embedded-migration-2026-04-30T23-31-00-000Z.sql.gz',
+      bytes: 12_345_678,
+    };
+    state.restoreError = new Error('ERROR: relation "messages" already exists');
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // Sequence reached restore but failed there
+    expect(state.dumpCalled).toBe(true);
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    expect(state.restoreCalled).toBe(true);
+
+    // omni-api must have been brought back up so operator isn't dead.
+    expect(state.callOrder).toContain('pm2-stop-api');
+    expect(state.callOrder).toContain('pm2-start-api');
+    const stopIdx = state.callOrder.indexOf('pm2-stop-api');
+    const startIdx = state.callOrder.indexOf('pm2-start-api');
+    expect(startIdx).toBeGreaterThan(stopIdx);
+
+    // No config write — embedded mode preserved.
+    expect(state.savedServerConfigs).toHaveLength(0);
+
+    // Failure message includes the snapshot path so operators can replay
+    // manually with `gunzip -c <path> | psql <canonical-url>`.
+    const failedFix = report.fixesApplied.find((f) => f.startsWith('FAILED pgserve-canonical'));
+    expect(failedFix).toBeDefined();
+    expect(failedFix).toContain('psql restore into canonical pgserve failed');
+    expect(failedFix).toContain('snapshot preserved at /home/op/.omni/backups/embedded-migration-');
+    expect(failedFix).toContain('relation "messages" already exists');
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -52,7 +52,13 @@ import {
 } from '../config.js';
 import { getHealthCheckUrl } from '../health.js';
 import { PM2_LOGROTATE_SETTINGS } from '../install-helpers.js';
-import { setupCanonicalPgserve } from '../lib/canonical-pgserve.js';
+import {
+  type EmbeddedDumpResult,
+  dumpEmbeddedDb,
+  getCanonicalPgserveDataDir,
+  restoreSnapshotToCanonical,
+  setupCanonicalPgserve,
+} from '../lib/canonical-pgserve.js';
 import * as output from '../output.js';
 import { PM2_HARDENED_DEFAULTS, PM2_PROCESSES, buildPm2StartArgs, capturePm2, isPm2Available, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv, resolvePgservePort } from '../runtime-env.js';
@@ -210,6 +216,24 @@ export interface DoctorDeps {
    */
   setupCanonicalPgserve: () => Promise<string | null>;
   /**
+   * `pg_dump` the embedded omni DB → gzip → snapshot file. Called BEFORE
+   * the caller stops omni-api so the embedded pgserve is still live for
+   * pg_dump to connect. Returns a status so the caller can decide whether
+   * to attempt a restore later. Stubbed in tests.
+   */
+  dumpEmbeddedDb: (currentDatabaseUrl: string) => Promise<EmbeddedDumpResult>;
+  /**
+   * Pipe a dumped snapshot into the canonical pgserve via `psql`. Called
+   * AFTER `pgserve install` has brought canonical online. No-op when the
+   * dump status was anything but `dumped`. Stubbed in tests.
+   */
+  restoreSnapshotToCanonical: (
+    dump: EmbeddedDumpResult,
+    canonicalDatabaseUrl: string,
+  ) => Promise<{ status: 'restored' | 'skipped'; snapshotPath?: string }>;
+  /** Resolve canonical pgserve's on-disk data dir for operator-facing logs. */
+  getCanonicalPgserveDataDir: () => string;
+  /**
    * Persist a partial server config (merges with existing). Stubbed in
    * tests so the canonical-pgserve fix can be validated without writing
    * to ~/.omni/config.json.
@@ -326,6 +350,9 @@ function productionDeps(): DoctorDeps {
     },
     cliHasSigningKey: () => loadSigningContext() !== null,
     setupCanonicalPgserve,
+    dumpEmbeddedDb,
+    restoreSnapshotToCanonical,
+    getCanonicalPgserveDataDir,
     saveServerConfig,
   };
 }
@@ -666,44 +693,87 @@ async function fixCliKeyValid(deps: DoctorDeps): Promise<string> {
 }
 
 /**
- * Migrate an embedded install onto canonical pgserve. Runs `pgserve install`,
- * reads the canonical url, persists `useCanonicalPgserve: true` +
- * `databaseUrl`, then relaunches omni-api so it picks up `PGSERVE_EMBEDDED=false`.
+ * Migrate an embedded install onto canonical pgserve via `pg_dump` + `psql`,
+ * mirroring genie's `db backup` / `db restore` pattern.
  *
- * SAFETY: Never deletes the embedded data dir. Operator can roll back by
- * editing `~/.omni/config.json` and removing the canonical url. Embedded
- * postgres data stays intact at `~/.omni/data/pgserve/`.
+ * Sequence:
+ *   1. Pre-flight: dump the embedded `omni` DB to a gzipped snapshot at
+ *      `~/.omni/backups/embedded-migration-<ISO>.sql.gz`. omni-api MUST be
+ *      running here so pg_dump can connect — that's why dump is step 1, not
+ *      step 3.
+ *   2. Stop omni-api → frees :8432 + releases the embedded data dir's locks.
+ *   3. `pgserve install` → canonical pgserve at canonical data dir
+ *      (`~/.pgserve/data` by default; surfaced explicitly to the operator).
+ *   4. Restore the snapshot into canonical via `psql ON_ERROR_STOP=1`.
+ *   5. Persist `useCanonicalPgserve: true` + canonical `databaseUrl`.
+ *   6. Relaunch omni-api with the new env so `PGSERVE_EMBEDDED=false` takes
+ *      effect.
  *
- * On any failure (pgserve binary unavailable, install failed, omni-api
- * relaunch failed), config is NOT persisted — the operator stays on
- * embedded and can retry.
+ * SAFETY:
+ *   - Embedded data dir at `~/.omni/data/pgserve` is never modified. On
+ *     any failure the operator can roll back by removing
+ *     `useCanonicalPgserve` from `~/.omni/config.json` and restarting
+ *     omni-api — embedded mode picks the data right back up.
+ *   - The snapshot is preserved at the path printed at step 1. If restore
+ *     fails, operators can replay it manually with
+ *     `gunzip -c <snapshot> | psql <canonical-url>` once they've fixed
+ *     whatever blocked psql.
+ *
+ * On any failure (dump error, pgserve install failed, restore failed,
+ * omni-api relaunch failed) we restart omni-api on embedded so operators
+ * are not left with a dead API. Config is only persisted after the
+ * complete dump → install → restore → relaunch chain succeeds.
  */
 async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
   const { serverConfig, cliConfig } = deps.loadState();
 
-  // Step 1: stop omni-api FIRST so the embedded pgserve releases port 8432.
-  // pgserve@2.1.0's `pgserve install` will then bind that port for the
-  // canonical instance. If we did this in the opposite order, `pgserve
-  // install` would fail with EADDRINUSE and the migration would abort with
-  // omni-api still on embedded but no canonical registered.
+  // Step 1: dump embedded DB FIRST while omni-api (and its embedded pgserve)
+  // is still running. pg_dump needs a live target. The snapshot is written
+  // outside any pgserve data dir so it survives the migration regardless of
+  // outcome.
+  let dumpResult: EmbeddedDumpResult;
+  try {
+    dumpResult = await deps.dumpEmbeddedDb(serverConfig.databaseUrl);
+  } catch (err) {
+    throw new Error(
+      `pg_dump of embedded omni DB failed (${err instanceof Error ? err.message : String(err)}); omni-api still running on embedded — install postgresql-client (apt install postgresql-client) if pg_dump is missing, then retry`,
+    );
+  }
+
+  // Step 2: stop omni-api so the embedded pgserve releases port 8432 AND
+  // the data dir's postmaster lock. After this point the embedded DB is no
+  // longer reachable; we rely on the snapshot from step 1.
   await deps.runPm2(['stop', PM2_PROCESSES.api]);
 
-  // Step 2: provision canonical pgserve and read its port.
+  // Step 3: provision canonical pgserve.
   const url = await deps.setupCanonicalPgserve();
   if (!url) {
-    // Bring omni-api back up on embedded so the operator isn't left with a
-    // dead API. They can retry the migration later.
+    // Bring omni-api back up on embedded — operator isn't left dead.
     await deps.runPm2(['start', PM2_PROCESSES.api]);
     throw new Error(
       'canonical pgserve setup failed (pgserve binary unavailable or install failed) — install manually: bun add -g pgserve@^2.1.0',
     );
   }
 
-  // Step 3: persist config first so a relaunch failure leaves the operator
+  // Step 4: restore the snapshot. No-op when nothing was dumped (fresh
+  // install). On failure: rollback omni-api to embedded, preserve the
+  // snapshot path so operators can investigate / replay manually.
+  let restoreOutcome: { status: 'restored' | 'skipped'; snapshotPath?: string };
+  try {
+    restoreOutcome = await deps.restoreSnapshotToCanonical(dumpResult, url);
+  } catch (err) {
+    await deps.runPm2(['start', PM2_PROCESSES.api]);
+    const snapshotHint = dumpResult.status === 'dumped' ? ` snapshot preserved at ${dumpResult.snapshotPath}` : '';
+    throw new Error(
+      `psql restore into canonical pgserve failed (${err instanceof Error ? err.message : String(err)}); omni-api restarted on embedded —${snapshotHint} retry by replaying the dump manually or re-running \`omni doctor --fix\``,
+    );
+  }
+
+  // Step 5: persist config first so a relaunch failure leaves the operator
   // on canonical (the new recommended state) rather than half-migrated.
   deps.saveServerConfig({ databaseUrl: url, useCanonicalPgserve: true });
 
-  // Step 4: relaunch omni-api with the new env so PGSERVE_EMBEDDED=false
+  // Step 6: relaunch omni-api with the new env so PGSERVE_EMBEDDED=false
   // takes effect. delete + start (instead of restart) so the new env is
   // picked up — pm2's restart preserves stored env in some configurations.
   const env = buildRuntimeEnv({ ...serverConfig, databaseUrl: url, useCanonicalPgserve: true }, cliConfig);
@@ -718,7 +788,20 @@ async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
   if (startCode !== 0) {
     throw new Error(`pm2 start ${PM2_PROCESSES.api} exited ${startCode} after canonical migration`);
   }
-  return `migrated to canonical pgserve@^2.1.0; omni-api now connects to ${url}`;
+
+  // Compose a result message that surfaces every concrete path so the
+  // operator can verify the migration without grepping logs:
+  //   - canonical data dir (where the cluster lives on disk)
+  //   - canonical URL (where omni-api connects)
+  //   - snapshot path (rollback artifact)
+  const canonicalDir = deps.getCanonicalPgserveDataDir();
+  const dataNote =
+    dumpResult.status === 'dumped' && restoreOutcome.status === 'restored'
+      ? `restored ${dumpResult.snapshotPath} into ${canonicalDir} (omni-api → ${url})`
+      : dumpResult.status === 'no-embedded-data'
+        ? `no embedded data to migrate; canonical started empty at ${canonicalDir} (omni-api → ${url})`
+        : `embedded data dir invalid; canonical started empty at ${canonicalDir} (omni-api → ${url})`;
+  return `migrated to canonical pgserve@^2.1.0; ${dataNote}`;
 }
 
 /** Print `rm -rf` instructions for orphaned dirs — we never auto-delete. */

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -23,6 +23,12 @@
  * installs default to canonical.
  */
 
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync, gzipSync } from 'node:zlib';
+
 import { loadServerConfig } from '../config.js';
 import * as output from '../output.js';
 
@@ -218,4 +224,259 @@ export async function resolveCanonicalPgservePreference(
   output.raw('    ✓ embedded pgserve will be skipped (PGSERVE_EMBEDDED=false)');
   output.raw('');
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// Embedded → canonical data migration (pg_dump + psql, mirrors genie pattern)
+// ---------------------------------------------------------------------------
+//
+// `pgserve install` boots an empty postgres cluster at the canonical data
+// dir (default `~/.pgserve/data`, override via `pgserve install --data`).
+// For operators upgrading from embedded mode we have to ETL the existing
+// `omni` database from the embedded pgserve into the canonical one —
+// otherwise omni-api connects to a freshly-provisioned empty database and
+// the operator stares at zero messages.
+//
+// We use `pg_dump --clean --if-exists --no-owner --no-acl` → gzip → `psql
+// ON_ERROR_STOP=1`, the same pattern as `genie db backup` / `genie db
+// restore` (`packages/cli/src/lib/db-backup.ts` in the genie repo). Why:
+//
+//   - Standard Postgres tooling. Battle-tested, schema-aware, version-tolerant.
+//   - `--clean --if-exists` makes restore idempotent: the dump's prelude
+//     drops every object before recreating it, so a partial-restore retry
+//     is safe and a non-empty canonical target is fine (we DON'T need to
+//     dance around archiving the canonical data dir before the copy).
+//   - Compressed snapshot is preserved at a known path for rollback /
+//     forensics — no data ever sits ONLY in the canonical cluster's heap
+//     pages mid-migration.
+//   - System pg_dump / psql are required (`apt install postgresql-client`).
+//     genie has the same dependency. We pre-flight-check both.
+//
+// Sequence (caller is doctor.fixPgserveCanonical):
+//   1. Caller verifies omni-api is running with embedded pgserve at :8432.
+//   2. dumpEmbeddedDb(currentUrl) → snapshot at ~/.omni/backups/migration-<ts>.sql.gz.
+//      Embedded MUST still be running here so pg_dump can connect.
+//   3. Caller stops omni-api → frees :8432 → embedded pgserve dies.
+//   4. Caller runs `pgserve install` → canonical pgserve at :8432 (empty).
+//   5. restoreSnapshotToCanonical(snapshotPath, canonicalUrl) →
+//      gunzip + psql against the canonical URL. Auto-provisions the
+//      `omni` database via pgserve's connect-time provisioning if the
+//      restore connects to it, then pipes the dump.
+//   6. Caller persists config + restarts omni-api on the canonical URL.
+//
+// SAFETY: the embedded data dir at `~/.omni/data/pgserve` is never touched
+// by this module. If anything fails, embedded is intact and the operator
+// rolls back by removing `useCanonicalPgserve` from `~/.omni/config.json`
+// and restarting omni-api. The snapshot file is preserved on every
+// successful dump — operators can replay it manually if needed.
+
+const OMNI_EMBEDDED_PGSERVE_DATA_DIR = join(homedir(), '.omni', 'data', 'pgserve');
+const PGSERVE_DEFAULT_DATA_DIR = join(homedir(), '.pgserve', 'data');
+const PGSERVE_CONFIG_PATH = join(homedir(), '.pgserve', 'config.json');
+const OMNI_BACKUPS_DIR = join(homedir(), '.omni', 'backups');
+
+/** Path of omni's embedded pgserve data dir. Surfaced in operator output. */
+function getEmbeddedPgserveDataDir(): string {
+  return OMNI_EMBEDDED_PGSERVE_DATA_DIR;
+}
+
+/**
+ * Resolve the canonical pgserve data dir from `~/.pgserve/config.json`.
+ * pgserve writes `{dataDir, port, registeredAt}` during `pgserve install`.
+ * Falls back to `~/.pgserve/data` (pgserve's documented default) when the
+ * config file doesn't exist yet.
+ *
+ * Surfaced in operator output so the migration's destination is explicit:
+ * the operator can `du -sh` and `ls` that path post-migration to verify
+ * the cluster is on disk where they expect.
+ */
+export function getCanonicalPgserveDataDir(): string {
+  if (!existsSync(PGSERVE_CONFIG_PATH)) return PGSERVE_DEFAULT_DATA_DIR;
+  try {
+    const raw = readFileSync(PGSERVE_CONFIG_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as { dataDir?: unknown };
+    return typeof parsed.dataDir === 'string' && parsed.dataDir.length > 0 ? parsed.dataDir : PGSERVE_DEFAULT_DATA_DIR;
+  } catch {
+    return PGSERVE_DEFAULT_DATA_DIR;
+  }
+}
+
+/** Quick sanity check that a path looks like a real Postgres data dir. */
+function looksLikePgDataDir(path: string): boolean {
+  return existsSync(join(path, 'PG_VERSION')) && existsSync(join(path, 'base'));
+}
+
+/** Resolve the snapshot path for this migration. ISO timestamp keeps history. */
+function getSnapshotPath(timestamp: Date = new Date()): string {
+  const ts = timestamp.toISOString().replace(/[:.]/g, '-');
+  return join(OMNI_BACKUPS_DIR, `embedded-migration-${ts}.sql.gz`);
+}
+
+/** Test whether `cmd` is on PATH and returns 0 to its --version probe. */
+function commandIsAvailable(cmd: string): boolean {
+  try {
+    const result = spawnSync(cmd, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'], timeout: 3000 });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse a postgres URL into libpq env. Skips PGPASSWORD if absent so callers
+ * can rely on .pgpass / peer auth for daemon-mode connections.
+ */
+function pgEnvFromUrl(url: string): Record<string, string> {
+  const parsed = new URL(url);
+  const env: Record<string, string> = {
+    PGHOST: parsed.hostname,
+    PGUSER: decodeURIComponent(parsed.username || 'postgres'),
+    PGDATABASE: parsed.pathname.replace(/^\//, '') || 'omni',
+  };
+  if (parsed.port) env.PGPORT = parsed.port;
+  if (parsed.password) env.PGPASSWORD = decodeURIComponent(parsed.password);
+  return env;
+}
+
+/**
+ * Outcome of the dump step. Caller decides whether to proceed with restore.
+ */
+export type EmbeddedDumpResult =
+  | { status: 'no-embedded-data'; embeddedDir: string }
+  | { status: 'embedded-data-invalid'; embeddedDir: string }
+  | { status: 'dumped'; embeddedDir: string; snapshotPath: string; bytes: number };
+
+/**
+ * Dump the embedded `omni` database to a gzipped SQL snapshot. Called BEFORE
+ * the caller stops omni-api — embedded pgserve must still be live so pg_dump
+ * can connect.
+ *
+ * Returns:
+ *   - `no-embedded-data` when there's no embedded data dir (fresh install
+ *     case — caller proceeds with an empty canonical).
+ *   - `embedded-data-invalid` when the dir exists but isn't a Postgres data
+ *     dir (corrupt / partial init — caller warns + proceeds empty).
+ *   - `dumped` with snapshot path + size on success.
+ *
+ * Throws when pg_dump is missing from PATH or exits non-zero. Caller is
+ * responsible for catching and rolling back omni-api to embedded.
+ */
+export async function dumpEmbeddedDb(currentDatabaseUrl: string): Promise<EmbeddedDumpResult> {
+  const embeddedDir = getEmbeddedPgserveDataDir();
+
+  if (!existsSync(embeddedDir)) {
+    return { status: 'no-embedded-data', embeddedDir };
+  }
+  if (!looksLikePgDataDir(embeddedDir)) {
+    output.warn(
+      `Embedded pgserve dir at ${embeddedDir} is missing PG_VERSION or base/ — does not look like a Postgres data dir. Skipping dump; canonical will start empty.`,
+    );
+    return { status: 'embedded-data-invalid', embeddedDir };
+  }
+
+  if (!commandIsAvailable('pg_dump')) {
+    throw new Error(
+      'pg_dump not found in PATH — install postgresql-client (apt install postgresql-client / brew install postgresql) and retry',
+    );
+  }
+
+  const snapshotPath = getSnapshotPath();
+  mkdirSync(OMNI_BACKUPS_DIR, { recursive: true, mode: 0o700 });
+
+  output.raw('  Dumping embedded database via pg_dump...');
+  output.raw(`    source data dir: ${embeddedDir}`);
+  output.raw(`    snapshot:        ${snapshotPath}`);
+
+  // `--clean --if-exists` makes the restore self-contained — drops every
+  // object idempotently before recreating, so the canonical target can be
+  // empty (fresh install) or non-empty (retry / pre-existing) and the
+  // restore converges to the embedded snapshot regardless. No DROP DATABASE
+  // dance needed. Mirrors genie's db-backup.ts.
+  // `--no-owner --no-acl` strips ownership/grants so a restore against a
+  // different superuser (canonical's `postgres`) doesn't fail on missing
+  // roles.
+  const result = spawnSync('pg_dump', ['--no-owner', '--no-acl', '--clean', '--if-exists'], {
+    env: { ...process.env, ...pgEnvFromUrl(currentDatabaseUrl) },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 600_000,
+    maxBuffer: 1024 * 1024 * 1024 * 4, // 4 GB; should be enough for any single omni DB
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString().trim() || 'unknown error';
+    throw new Error(`pg_dump failed (exit ${result.status}): ${stderr}`);
+  }
+
+  // Compress with node:zlib (synchronous — data already in memory) and write
+  // atomically (.tmp → rename) so a partial dump never lands at the final path.
+  const compressed = gzipSync(result.stdout);
+  const tmpPath = `${snapshotPath}.tmp`;
+  writeFileSync(tmpPath, compressed, { mode: 0o600 });
+  // Atomic on POSIX since both paths are on the same filesystem.
+  renameSync(tmpPath, snapshotPath);
+
+  const bytes = statSync(snapshotPath).size;
+  output.raw(`    snapshot size:   ${formatBytes(bytes)}`);
+
+  // Promise return shape kept so DoctorDeps.dumpEmbeddedDb and its test stubs
+  // share one signature, even though spawnSync + writeFileSync are sync.
+  await Promise.resolve();
+  return { status: 'dumped', embeddedDir, snapshotPath, bytes };
+}
+
+/**
+ * Restore a dumped snapshot into the canonical pgserve. Called AFTER the
+ * caller has run `pgserve install` and confirmed canonical is reachable
+ * at the URL. No-op when the snapshot status was anything but `dumped`.
+ *
+ * Uses `psql ON_ERROR_STOP=1` so a partial failure surfaces a non-zero exit
+ * instead of leaving the canonical DB half-restored. Throws on any psql
+ * error — caller rolls back to embedded.
+ */
+export async function restoreSnapshotToCanonical(
+  dump: EmbeddedDumpResult,
+  canonicalDatabaseUrl: string,
+): Promise<{ status: 'restored' | 'skipped'; snapshotPath?: string }> {
+  if (dump.status !== 'dumped') {
+    return { status: 'skipped' };
+  }
+
+  if (!commandIsAvailable('psql')) {
+    throw new Error(
+      'psql not found in PATH — install postgresql-client (apt install postgresql-client / brew install postgresql) and retry',
+    );
+  }
+
+  output.raw('  Restoring snapshot into canonical pgserve via psql...');
+  output.raw(`    snapshot:           ${dump.snapshotPath}`);
+  output.raw(`    canonical data dir: ${getCanonicalPgserveDataDir()}`);
+  output.raw(`    canonical URL:      ${canonicalDatabaseUrl}`);
+
+  const compressed = readFileSync(dump.snapshotPath);
+  const sql = gunzipSync(compressed);
+
+  const result = spawnSync('psql', ['-v', 'ON_ERROR_STOP=1'], {
+    env: { ...process.env, ...pgEnvFromUrl(canonicalDatabaseUrl) },
+    input: sql,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 600_000,
+    maxBuffer: 1024 * 1024 * 1024 * 4,
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString().trim() || 'unknown error';
+    throw new Error(`psql restore failed (exit ${result.status}): ${stderr}`);
+  }
+
+  // Promise return shape kept so DoctorDeps.restoreSnapshotToCanonical and
+  // its test stubs share one signature, even though spawnSync is sync.
+  await Promise.resolve();
+  return { status: 'restored', snapshotPath: dump.snapshotPath };
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }


### PR DESCRIPTION
Closes automagik-dev/omni#584.

## Summary

`omni doctor --fix`'s canonical-pgserve migration flipped `databaseUrl` to canonical and restarted omni-api with `PGSERVE_EMBEDDED=false` — but it never moved the existing PG cluster from `~/.omni/data/pgserve` into the canonical data dir. Operators with non-trivial data ended up on an empty canonical DB even though their messages, chats, etc. were still on disk.

This PR adds the data migration step using **`pg_dump` → gzip → `psql`**, mirroring genie's `db backup` / `db restore` pattern (`packages/cli/src/lib/db-backup.ts` in the genie repo), and surfaces every concrete path so operators know exactly where their data is going.

## Live repro (from #584)

Server with `@automagik/omni@2.260430.15` + `pgserve@2.1.x`:
- Embedded held 2201 messages, 2285 `omni_events`, 2313 `processed_events`, 14 persons, 9 chats, 1 connected WhatsApp instance — 39 populated tables
- `omni doctor --fix` flipped config; canonical provisioned fresh; omni-api connected to empty DB; drizzle ran from scratch; operator stared at zero messages
- Rolled back; pre vs post row-count diff identical (only `sync_jobs +1` from natural scheduling), proving the embedded data was preserved on disk and just unreachable

## Why pg_dump (not filesystem copy)

Earlier revs of this PR used a filesystem copy of `~/.omni/data/pgserve` → canonical data dir. Reworked to use `pg_dump`/`psql` because:

- **Schema-aware.** `pg_dump --clean --if-exists` makes restore idempotent — drops objects before recreate, so retry against a non-empty canonical target works without dancing around archive directories.
- **Version-tolerant.** Future pgserve PG-version bumps don't break migration. Filesystem copy is byte-locked to a single `embedded-postgres` major version.
- **Standard tooling.** `genie db backup` already requires `postgresql-client` (apt or brew). Same dependency for omni keeps the canonical stack uniform.
- **Compressed snapshot persists** at a known path for rollback / forensics. On any post-stop failure, operators can replay manually with `gunzip -c <path> | psql <url>`.

## Sequence

```
1. pg_dump embedded → ~/.omni/backups/embedded-migration-<ISO>.sql.gz
   (omni-api still running so pg_dump can connect)
2. Stop omni-api  (frees :8432 + releases embedded data dir locks)
3. pgserve install  (canonical at ~/.pgserve/data by default)
4. psql restore the snapshot into canonical
5. Persist useCanonicalPgserve: true + canonical databaseUrl
6. delete + start omni-api with PGSERVE_EMBEDDED=false
```

Each step has its own rollback. Dump failure → omni-api untouched. Install / restore / relaunch failure → restart omni-api on embedded; embedded data dir is never modified.

## Operator-facing path clarity (#584's second ask)

Pre-flight log lines name every load-bearing path:

```
Dumping embedded database via pg_dump...
  source data dir: /home/op/.omni/data/pgserve
  snapshot:        /home/op/.omni/backups/embedded-migration-2026-04-30T23-30-00-000Z.sql.gz
  snapshot size:   42.0 MB
Restoring snapshot into canonical pgserve via psql...
  snapshot:           /home/op/.omni/backups/embedded-migration-2026-04-30T23-30-00-000Z.sql.gz
  canonical data dir: /home/op/.pgserve/data
  canonical URL:      postgresql://postgres:postgres@localhost:8432/omni
```

Final result message includes the snapshot path AND the canonical data dir AND the URL:

```
migrated to canonical pgserve@^2.1.0; restored
/home/op/.omni/backups/embedded-migration-<ts>.sql.gz into
/home/op/.pgserve/data (omni-api → postgresql://postgres:postgres@localhost:8432/omni)
```

## Test plan

- [x] `bun test packages/cli/src/__tests__/doctor.test.ts` — 38/38 pass
    - `--fix runs dump → stop → install → restore → delete → start in that order` (asserts the new sequence)
    - `--fix on a fresh install (no embedded data) skips dump+restore and proceeds` (no regression for new installs; surfaces canonical data dir in the result)
    - `--fix rolls back omni-api to embedded when pg_dump throws (omni-api never stopped)` (asserts no half-state when dump fails)
    - `--fix rolls back to embedded + preserves snapshot when restore fails` (asserts snapshot path is in the failure message so operators can replay manually)
- [x] `bun test packages/cli` — 363/363 pass
- [x] `bun run typecheck` — clean
- [x] `make lint` (biome) — clean
- [x] `bunx knip` — no new findings

## Dependency note

Requires `pg_dump` and `psql` on PATH (system `postgresql-client` package). Already a dependency for genie's db backup/restore — installing via:

- Debian/Ubuntu: `apt install postgresql-client`
- macOS: `brew install postgresql`

Pre-flight checks fail fast with that hint when either binary is missing.

## Companion PRs (already merged)

- [pgserve#59](https://github.com/namastexlabs/pgserve/pull/59) — drop `--min-uptime` for pm2 6.x
- [pgserve#62](https://github.com/namastexlabs/pgserve/pull/62) — `pgserve install` foreground mode

With those + this PR, end-to-end canonical adoption works on populated servers without manual data shuffling.