### PR TITLE
fix(doctor): probe via --help + cascade-gate Phase 2 on canonical FAIL

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -841,4 +841,44 @@ describe('runDoctor — pgserve-canonical check', () => {
     expect(failedFix).toBeDefined();
     expect(failedFix).toContain('canonical pgserve setup failed');
   });
+
+  test('--fix does NOT rotate cli-key when canonical-pgserve fix returned FAILED (cascade gating)', async () => {
+    // Companion to the success-path cascade test above. When canonical
+    // migration FAILS (setupCanonicalPgserve returns null), Phase 2 must
+    // skip cascade-prone fixes that depend on omni-api being reachable
+    // and DB+env in sync. Without this gating, cli-key-valid rotates the
+    // key while api is still recovering from the failed migration,
+    // leaving pm2 env out of sync with the DB hash — exact reproduction
+    // of the pre-#580 cascade. See omni#583.
+    const { VERSION } = await import('../version.js');
+    const state = mkHarness({ serverVersion: VERSION });
+    state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
+    // Phase 1 will FAIL: setupCanonicalPgserve returns null -> "FAILED pgserve-canonical: ..."
+    state.canonicalPgserveSetupResult = null;
+    // cli-key-valid stays FAIL across Phase 1's recovery restart (the
+    // live bug: api was actually unreachable, keyValid stayed false even
+    // after pm2 start). With keyValidAfterFix=false the harness keeps
+    // returning false from validateStoredKey, so Phase 2 sees the check
+    // still FAIL and would normally invoke fixCliKeyValid — which is
+    // exactly the cascade we are gating against.
+    state.keyValid = false;
+    state.keyValidAfterFix = false;
+
+    const report = await runDoctor({ fix: true }, mkDeps(state));
+
+    // Phase 1 attempted and FAILED.
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    const failedFix = report.fixesApplied.find((f) => f.startsWith('FAILED pgserve-canonical'));
+    expect(failedFix).toBeDefined();
+
+    // cli-key-valid fix MUST NOT have run — no rotation message present.
+    const rotatedKey = report.fixesApplied.find((f) => typeof f === 'string' && f.includes('rotated CLI key'));
+    expect(rotatedKey).toBeUndefined();
+
+    // SKIPPED entry recorded for cli-key-valid so the operator sees an
+    // actionable explanation instead of a destructive rotation.
+    const skippedKey = report.fixesApplied.find((f) => f.startsWith('SKIPPED cli-key-valid'));
+    expect(skippedKey).toBeDefined();
+    expect(skippedKey).toContain('failed canonical-pgserve migration');
+  });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -860,6 +860,69 @@ function summarizeChecks(checks: CheckResult[]): { ok: number; warn: number; fai
 }
 
 /**
+ * Cascade-prone fix ids: each depends on omni-api being reachable and on
+ * DB+env being in sync. When the canonical-pgserve migration FAILS,
+ * omni-api is still recovering on embedded; running these would rotate
+ * keys / restart with bad env and reproduce the pre-#580 401-cascade.
+ * See omni#583.
+ */
+const CASCADE_PRONE_FIXES: ReadonlySet<CheckId> = new Set<CheckId>([
+  'cli-key-valid',
+  'omni-db-exists',
+  'pgserve-reachable',
+]);
+
+/**
+ * Phase 1 of `runDoctor` --fix: run the canonical-pgserve migration in
+ * isolation, then re-evaluate all checks against the post-migration
+ * state. Returns whether the migration FAILED (so Phase 2 can gate
+ * cascade-prone fixes) plus the refreshed check list.
+ */
+async function runPhase1MigrationFix(
+  deps: DoctorDeps,
+  checks: CheckResult[],
+  fixesApplied: string[],
+): Promise<{ canonicalFailed: boolean; checks: CheckResult[] }> {
+  const canonicalCheck = checks.find((c) => c.id === 'pgserve-canonical');
+  if (!canonicalCheck || canonicalCheck.level === 'OK') {
+    return { canonicalFailed: false, checks };
+  }
+  const result = await applyFix(deps, canonicalCheck);
+  if (result !== null) fixesApplied.push(result);
+  const canonicalFailed = typeof result === 'string' && result.startsWith('FAILED ');
+  // Re-run all checks against the post-migration state before any other
+  // fix gets to see them.
+  const refreshed = await runAllChecks(deps);
+  return { canonicalFailed, checks: refreshed };
+}
+
+/**
+ * Phase 2 of `runDoctor` --fix: iterate the remaining failing checks and
+ * apply each fix. When Phase 1 reported FAILED, cascade-prone fixes are
+ * skipped with an actionable message — without this gating, cli-key-valid
+ * (and friends) rotate destructively while the API is still recovering.
+ */
+async function runPhase2Fixes(
+  deps: DoctorDeps,
+  checks: CheckResult[],
+  canonicalFailed: boolean,
+  fixesApplied: string[],
+): Promise<void> {
+  for (const check of checks) {
+    if (check.level === 'OK') continue;
+    if (check.id === 'pgserve-canonical') continue; // already handled in Phase 1
+    if (canonicalFailed && CASCADE_PRONE_FIXES.has(check.id)) {
+      fixesApplied.push(
+        `SKIPPED ${check.id}: blocked by failed canonical-pgserve migration — fix manually after \`pgserve install\``,
+      );
+      continue;
+    }
+    const result = await applyFix(deps, check);
+    if (result !== null) fixesApplied.push(result);
+  }
+}
+
+/**
  * Run all checks and optionally apply fixes. Returns a structured
  * DoctorReport — the caller decides how to render it (human vs. JSON).
  */
@@ -869,30 +932,9 @@ export async function runDoctor(options: DoctorOptions, depsOverride?: DoctorDep
   const fixesApplied: string[] = [];
 
   if (options.fix) {
-    // Phase 1: migration fixes that change state for everyone else.
-    // pgserve-canonical stops omni-api, registers canonical pgserve, restarts
-    // omni-api on the new URL. After it runs, cli-key-valid / pgserve-reachable
-    // / omni-db-exists / version-match must be re-evaluated against the
-    // migrated state — running them in the same pass would cascade false
-    // failures (api temporarily unreachable) and trigger destructive fixes
-    // (key rotation while DB is unmigrated).
-    const canonicalCheck = checks.find((c) => c.id === 'pgserve-canonical');
-    if (canonicalCheck && canonicalCheck.level !== 'OK') {
-      const result = await applyFix(deps, canonicalCheck);
-      if (result !== null) fixesApplied.push(result);
-      // Re-run all checks against the post-migration state before any other
-      // fix gets to see them.
-      checks = await runAllChecks(deps);
-    }
-
-    // Phase 2: every other fix runs against the (possibly post-migration) state.
-    for (const check of checks) {
-      if (check.level === 'OK') continue;
-      if (check.id === 'pgserve-canonical') continue; // already handled above
-      const result = await applyFix(deps, check);
-      if (result !== null) fixesApplied.push(result);
-    }
-
+    const phase1 = await runPhase1MigrationFix(deps, checks, fixesApplied);
+    checks = phase1.checks;
+    await runPhase2Fixes(deps, checks, phase1.canonicalFailed, fixesApplied);
     // Final re-check so the report reflects post-fix state.
     checks = await runAllChecks(deps);
   }

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -35,21 +35,34 @@ import * as output from '../output.js';
 const PGSERVE_REQUIRED_VERSION = '^2.1.0';
 
 /**
- * Probe the `pgserve` binary by running a real subcommand. Returns true
- * when the binary is callable and accepts canonical-mode subcommands.
+ * Probe the `pgserve` binary by running its `--help` subcommand. Returns
+ * true when the binary is callable.
  *
  * History
  * -------
- * The first attempt used `pgserve --version`. That flag does not exist
- * in pgserve@2.1.0 — the wrapper exits non-zero with "Unknown option:
- * --version" and dumps the help. `omni doctor --fix` then false-negatived,
- * triggered a redundant `bun add -g pgserve` call, and the migration
- * failed. We now probe `pgserve port`, which exists in 2.1.0+ and exits
- * 0 with the canonical port number on stdout.
+ * 1. First attempt used `pgserve --version`. That flag does not exist in
+ *    pgserve@2.1.0 — the wrapper exits non-zero with "Unknown option:
+ *    --version" and dumps the help. False-negatived on every install.
+ *    Replaced with `pgserve port` in the followup.
+ *
+ * 2. `pgserve port` exits 0 ONLY when pgserve has been registered under
+ *    pm2 via `pgserve install`. On a clean machine right after
+ *    `bun add -g pgserve@^2.1.0`, the binary IS callable but `pgserve
+ *    port` exits non-zero with "pgserve: not installed (run: pgserve
+ *    install)". `ensurePgserveBinary()` then never reaches
+ *    `runPgserveInstall()`, `setupCanonicalPgserve()` returns null, and
+ *    the migration aborts with the misleading "Canonical pgserve binary
+ *    unavailable" error. See omni#582.
+ *
+ * 3. `pgserve --help` exits 0 whenever the binary is on PATH and runnable,
+ *    regardless of registration state. We probe with that — any further
+ *    capability (registration, port discovery) is asserted by the
+ *    subsequent `pgserve install` and `pgserve port` calls in the setup
+ *    flow.
  */
 async function isPgserveInstalled(): Promise<boolean> {
   try {
-    const code = await Bun.spawn({ cmd: ['pgserve', 'port'], stdout: 'pipe', stderr: 'pipe' }).exited;
+    const code = await Bun.spawn({ cmd: ['pgserve', '--help'], stdout: 'pipe', stderr: 'pipe' }).exited;
     return code === 0;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Two followup bugs surfaced by the live exec of #580 on the genie-configure server (closes #582, closes #583):

### Bug 1 — `isPgserveInstalled()` probe semantics (#582)

#580 swapped `pgserve --version` for `pgserve port`. But `pgserve port` exits non-zero **until pgserve has been registered under pm2** via `pgserve install`. On a clean machine right after `bun add -g pgserve@^2.1.0`, the binary is callable but `pgserve port` returns:

```
pgserve: not installed (run: pgserve install)
[exit 1]
```

`ensurePgserveBinary()` re-probed via the same call, kept returning false, never reached `runPgserveInstall()`, and `setupCanonicalPgserve()` returned null with the misleading `Canonical pgserve binary unavailable` error.

**Fix:** probe via `pgserve --help` (exits 0 whenever the binary is on PATH and runnable, regardless of registration). Subsequent `pgserve install` and `pgserve port` calls in the setup flow assert further capabilities.

### Bug 2 — Phase 1/Phase 2 cascade still reproduces on FAIL path (#583)

#580 added a Phase 1 / Phase 2 split so cli-key-valid wouldn't rotate keys mid-migration. The split protected the **success** path — when canonical setup succeeded, re-eval cleared cli-key-valid. But when `setupCanonicalPgserve()` returned null (the FAIL path triggered by Bug 1), Phase 2 still iterated and ran cli-key-valid, omni-db-exists, pgserve-reachable fixes against a transiently unreachable api. cli-key-valid rotated the stored key while DB still had the old hash → exact 401 cascade #580 set out to fix. Manual recovery still required `DELETE FROM api_keys WHERE id='__primary__'`.

**Fix:** track whether Phase 1 returned a `FAILED ` result; gate cascade-prone fixes (`cli-key-valid`, `omni-db-exists`, `pgserve-reachable`) in Phase 2 with a `SKIPPED <id>: blocked by failed canonical-pgserve migration — fix manually after \`pgserve install\`` entry. Operator sees an actionable explanation instead of a destructive rotation.

## Refactor

`runDoctor` body extracted into `runPhase1MigrationFix` + `runPhase2Fixes` helpers — biome flagged complexity 24 (max 20) after the gating logic; refactor brings it back under the cap and makes the two phases read at a glance.

## Test plan

- [x] `bun test src/__tests__/doctor.test.ts` — **35/35 pass** (was 34; +1 cascade-on-FAIL test)
- [x] `bun test` (CLI suite) — **360/360 pass** (was 359)
- [x] `bun run typecheck` — green (21 tasks)
- [x] `bunx biome check` on changed files — clean (post-refactor)
- [ ] **Live retest on the genie-configure server** after merge: `omni doctor --fix` should complete migration in one run; idempotent on second run; canonical pgserve registered under pm2 on `:8432`.

## Repro

Earlier today on the genie-configure server (post #580 merge):

```
$ omni doctor --fix
[PM2] [omni-api](1) ✓                         <- correct ordering from #580
Installing pgserve@^2.1.0 globally (bun add -g)...
+ @automagik/rlmx@0.260421.2
installed pgserve@2.1.0 with binaries: pgserve
3 packages installed
⚠ Canonical pgserve binary unavailable        <- Bug 1: probe false-negatives
[PM2] Applying action restartProcessId on app [omni-api](ids: [ 1 ])
$ pm2 set omni-api:OMNI_API_KEY omni_sk_ca102d1d57e46f73f8418c6f90f0d2fa  <- Bug 2: rotation cascade
[PM2] Module omni-api restarted

  fixes applied:
    - FAILED pgserve-canonical: canonical pgserve setup failed (pgserve binary unavailable or install failed)
    - FAILED cli-key-valid: rotated key does not validate; manually delete __primary__ from api_keys and rerun
```

After this PR: probe passes after `bun add -g`, `runPgserveInstall()` runs (idempotent), `pgserve port` then returns the canonical port. If for any other reason the canonical migration fails, Phase 2 skips the cascade-prone fixes with a clear `SKIPPED` message and no destructive rotation.

## Wave context

Closes the live-retest gap of Wave 3 (canonical-pgserve-pm2-supervision):

| Wave | Repo | Status |
|------|------|--------|
| 1 — pgserve foundation | namastexlabs/pgserve#57 | merged → 2.1.0 published |
| 2 — `genie install` | automagik-dev/genie#1578 | merged |
| 3 — omni canonical-by-default | automagik-dev/omni#579 | merged |
| 3-fix-1 — bugs from live exec | #580 | merged |
| **3-fix-2 — bugs from live exec of #580** | **this PR** | **open** |
| 4 — brain entries | namastexlabs/genie-configure | pending |
