### PR TITLE
fix(automations): reconcile NATS subscriptions on toggle and dead-iterator (#546)

### DIFF
--- a/packages/core/src/automations/__tests__/engine-reconcile.test.ts
+++ b/packages/core/src/automations/__tests__/engine-reconcile.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression test for #546 — automation engine NATS subscription becomes
+ * stale after a disable→enable cycle (or NATS server reset), leaving the
+ * automation marked enabled in the API but silently not consuming events.
+ *
+ * Verifies that the engine:
+ *  - Re-subscribes after a disable→enable toggle (reload path).
+ *  - Re-subscribes when the underlying iterator dies (reconciler path).
+ *  - Does not leak duplicate subscriptions on no-op reconciles.
+ *  - Cleans up subscriptions when the last automation for a trigger is
+ *    disabled.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { EventBus, GenericEventHandler, SubscribeOptions, Subscription } from '../../events/bus';
+import { createAutomationEngine } from '../engine';
+import type { Automation } from '../types';
+
+function makeAutomation(triggerEventType: string, id = 'auto-1', enabled = true): Automation {
+  return {
+    id,
+    name: `Auto ${id}`,
+    enabled,
+    priority: 0,
+    triggerEventType,
+    triggerConditions: [],
+    conditionLogic: 'and',
+    actions: [],
+    debounce: { mode: 'none' },
+  } as unknown as Automation;
+}
+
+interface FakeSubscription extends Subscription {
+  alive: boolean;
+}
+
+interface BusHarness {
+  bus: EventBus;
+  subscribeCalls: Array<{ pattern: string; options: SubscribeOptions }>;
+  liveSubs: FakeSubscription[];
+}
+
+function makeBus(): BusHarness {
+  const subscribeCalls: Array<{ pattern: string; options: SubscribeOptions }> = [];
+  const liveSubs: FakeSubscription[] = [];
+
+  const bus = {
+    connect: mock(async () => {}),
+    publish: mock(async () => ({ id: '', sequence: 0, stream: '' })),
+    publishGeneric: mock(async () => ({ id: '', sequence: 0, stream: '' })),
+    subscribe: mock(async () => ({ id: 'x', pattern: '*', unsubscribe: async () => {} }) as Subscription),
+    subscribePattern: mock(async (pattern: string, _handler: GenericEventHandler, options?: SubscribeOptions) => {
+      subscribeCalls.push({ pattern, options: options ?? {} });
+      const sub: FakeSubscription = {
+        id: `sub-${subscribeCalls.length}`,
+        pattern,
+        alive: true,
+        isAlive() {
+          return this.alive;
+        },
+        async unsubscribe() {
+          this.alive = false;
+        },
+      };
+      liveSubs.push(sub);
+      return sub;
+    }),
+    subscribeMany: mock(async () => ({ id: 'x', pattern: '*', unsubscribe: async () => {} }) as Subscription),
+    subscribeAll: mock(async () => ({ id: 'x', pattern: '*', unsubscribe: async () => {} }) as Subscription),
+    close: mock(async () => {}),
+    isConnected: mock(() => true),
+  } as unknown as EventBus;
+
+  return { bus, subscribeCalls, liveSubs };
+}
+
+describe('AutomationEngine — reconcile + toggle (#546)', () => {
+  let engine: ReturnType<typeof createAutomationEngine>;
+  let harness: BusHarness;
+
+  beforeEach(() => {
+    // reconcileIntervalMs=0 disables the periodic timer so tests drive
+    // reconcile() explicitly.
+    engine = createAutomationEngine({ defaultConcurrency: 1, reconcileIntervalMs: 0 });
+    harness = makeBus();
+  });
+
+  afterEach(async () => {
+    await engine.stop();
+  });
+
+  test('disable→enable toggle re-subscribes the durable consumer', async () => {
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+
+    await engine.start(harness.bus, [auto]);
+    expect(harness.subscribeCalls).toHaveLength(1);
+    expect(harness.subscribeCalls[0]?.options.durable).toBe('automation-engine-chat-idle_timeout');
+
+    // Simulate PATCH enabled=false: reload with empty enabled set.
+    await engine.reload([{ ...auto, enabled: false } as Automation]);
+
+    // The previous subscription must be unsubscribed so we don't leak
+    // handlers.
+    expect(harness.liveSubs[0]?.alive).toBe(false);
+
+    // Simulate PATCH enabled=true: reload with the automation re-enabled.
+    await engine.reload([auto]);
+
+    // A fresh subscription must have been created — this is the bug from
+    // #546: previously the engine could end up with no live subscription,
+    // and the only recovery was `pm2 restart omni-api`.
+    expect(harness.subscribeCalls).toHaveLength(2);
+    expect(harness.subscribeCalls[1]?.options.durable).toBe('automation-engine-chat-idle_timeout');
+    expect(harness.liveSubs[1]?.alive).toBe(true);
+  });
+
+  test('reconcile re-subscribes when the underlying iterator dies', async () => {
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+    await engine.start(harness.bus, [auto]);
+    expect(harness.subscribeCalls).toHaveLength(1);
+
+    // Simulate the iterator dying (NATS server reset, consumer GC'd) —
+    // before #546, this dead subscription was never replaced and events
+    // silently stopped flowing.
+    const sub = harness.liveSubs[0];
+    if (!sub) throw new Error('expected a live sub');
+    sub.alive = false;
+
+    await engine.reconcile();
+
+    expect(harness.subscribeCalls).toHaveLength(2);
+    expect(harness.liveSubs[1]?.alive).toBe(true);
+  });
+
+  test('reconcile is idempotent when subscriptions are healthy', async () => {
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+    await engine.start(harness.bus, [auto]);
+    expect(harness.subscribeCalls).toHaveLength(1);
+
+    await engine.reconcile();
+    await engine.reconcile();
+    await engine.reconcile();
+
+    // Still only one subscribePattern call — no leaks from healthy reconciles.
+    expect(harness.subscribeCalls).toHaveLength(1);
+  });
+
+  test('reload drops subscriptions for triggers with no enabled automations', async () => {
+    const idleAuto = makeAutomation('chat.idle_timeout', 'a1', true);
+    const archivedAuto = makeAutomation('chat.archived', 'a2', true);
+
+    await engine.start(harness.bus, [idleAuto, archivedAuto]);
+    expect(harness.subscribeCalls).toHaveLength(2);
+
+    // Disable the chat.archived automation — its subscription should be
+    // unsubscribed.
+    await engine.reload([idleAuto, { ...archivedAuto, enabled: false } as Automation]);
+
+    const idleSub = harness.liveSubs.find((s) => s.pattern === 'chat.idle_timeout.>');
+    const archivedSub = harness.liveSubs.find((s) => s.pattern === 'chat.archived.>');
+    expect(idleSub?.alive).toBe(true);
+    expect(archivedSub?.alive).toBe(false);
+  });
+
+  test('reload preserves a healthy subscription instead of churning it', async () => {
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+    await engine.start(harness.bus, [auto]);
+    expect(harness.subscribeCalls).toHaveLength(1);
+    const originalSub = harness.liveSubs[0];
+
+    // Reload with the same automation — no toggle, no change. The existing
+    // healthy subscription must be reused; no extra subscribePattern call.
+    await engine.reload([auto]);
+
+    expect(harness.subscribeCalls).toHaveLength(1);
+    expect(originalSub?.alive).toBe(true);
+  });
+
+  test('reload from never-started engine seeds automations without subscribing', async () => {
+    // Some startup paths may call reload before start; this should not
+    // throw nor create subscriptions until start() runs.
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+    await engine.reload([auto]);
+    expect(harness.subscribeCalls).toHaveLength(0);
+  });
+});

--- a/packages/core/src/automations/__tests__/engine-reconcile.test.ts
+++ b/packages/core/src/automations/__tests__/engine-reconcile.test.ts
@@ -183,4 +183,52 @@ describe('AutomationEngine — reconcile + toggle (#546)', () => {
     await engine.reload([auto]);
     expect(harness.subscribeCalls).toHaveLength(0);
   });
+
+  test('concurrent reconcile() calls fold into a single in-flight pass', async () => {
+    // Gemini review on PR #587: without single-flight, two reconcilers could
+    // see the same dead subscription, both unsubscribe + re-subscribe, and
+    // leak one of the two new handles. The second caller must await the
+    // ongoing pass instead of mutating the Map in parallel.
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+    await engine.start(harness.bus, [auto]);
+    expect(harness.subscribeCalls).toHaveLength(1);
+
+    // Kill the iterator so reconcile has actual work to do (otherwise the
+    // healthy path short-circuits and the race is moot).
+    const sub = harness.liveSubs[0];
+    if (!sub) throw new Error('expected a live sub');
+    sub.alive = false;
+
+    // Five concurrent reconcile calls: only one re-subscribe should happen.
+    await Promise.all([
+      engine.reconcile(),
+      engine.reconcile(),
+      engine.reconcile(),
+      engine.reconcile(),
+      engine.reconcile(),
+    ]);
+
+    expect(harness.subscribeCalls).toHaveLength(2);
+    expect(harness.liveSubs[1]?.alive).toBe(true);
+  });
+
+  test('reconcile() racing reload() does not leak duplicate subscriptions', async () => {
+    // Gemini review on PR #587: timer tick + reload from a PATCH must not
+    // both mutate the subscriptions Map in parallel.
+    const auto = makeAutomation('chat.idle_timeout', 'a1', true);
+    await engine.start(harness.bus, [auto]);
+    expect(harness.subscribeCalls).toHaveLength(1);
+
+    const sub = harness.liveSubs[0];
+    if (!sub) throw new Error('expected a live sub');
+    sub.alive = false;
+
+    // Start a reconcile and a reload in parallel against the dead sub.
+    await Promise.all([engine.reconcile(), engine.reload([auto])]);
+
+    // Exactly one new subscription — not two.
+    expect(harness.subscribeCalls).toHaveLength(2);
+    const aliveCount = harness.liveSubs.filter((s) => s.alive).length;
+    expect(aliveCount).toBe(1);
+  });
 });

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -99,7 +99,9 @@ export class AutomationEngine {
   private eventBus: EventBus | null = null;
   private deps: ActionDependencies;
   private logger: ExecutionLogger | null = null;
-  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private reconcileTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconcileEnabled = false;
+  private reconcilePromise: Promise<void> | null = null;
 
   constructor(private config: EngineConfig) {
     this.deps = {
@@ -191,8 +193,23 @@ export class AutomationEngine {
    * Diff expected (from current automations) vs active subscriptions and
    * subscribe / unsubscribe to converge. Also re-subscribes any subscription
    * whose underlying iterator has died (e.g., NATS server reset).
+   *
+   * Single-flight: concurrent callers (periodic timer, manual reconcile(),
+   * reload()) await the same in-flight pass instead of mutating the
+   * subscriptions Map in parallel — without this guard a timer tick that
+   * overlaps a reload could double-subscribe a trigger and leak the second
+   * handle. See gemini review on PR #587.
    */
   private async reconcileSubscriptions(): Promise<void> {
+    if (!this.eventBus) return;
+    if (this.reconcilePromise) return this.reconcilePromise;
+    this.reconcilePromise = this.doReconcileSubscriptions().finally(() => {
+      this.reconcilePromise = null;
+    });
+    return this.reconcilePromise;
+  }
+
+  private async doReconcileSubscriptions(): Promise<void> {
     if (!this.eventBus) return;
 
     const expectedTriggers = new Set(this.automations.map((a) => a.triggerEventType));
@@ -274,24 +291,46 @@ export class AutomationEngine {
     }
   }
 
+  /**
+   * Start the periodic reconciler.
+   *
+   * Recursive setTimeout pattern (not setInterval) so a slow reconcile cannot
+   * stack ticks — the next tick is only scheduled after the current pass
+   * resolves. Combined with the single-flight guard in reconcileSubscriptions,
+   * this gives at-most-one in-flight reconcile across all callers. See gemini
+   * review on PR #587.
+   */
   private startReconcileTimer(): void {
     this.stopReconcileTimer();
     const intervalMs = this.config.reconcileIntervalMs ?? 30_000;
     if (intervalMs <= 0) return;
-    this.reconcileTimer = setInterval(() => {
-      this.reconcileSubscriptions().catch((err) => {
-        logger.error('Reconciler tick failed', { error: String(err) });
-      });
+    this.reconcileEnabled = true;
+    this.scheduleNextReconcile(intervalMs);
+  }
+
+  private scheduleNextReconcile(intervalMs: number): void {
+    if (!this.reconcileEnabled) return;
+    this.reconcileTimer = setTimeout(() => {
+      // Run the reconcile then schedule the next tick. We chain in finally so
+      // a thrown error doesn't stop the loop — only stopReconcileTimer does.
+      this.reconcileSubscriptions()
+        .catch((err) => {
+          logger.error('Reconciler tick failed', { error: String(err) });
+        })
+        .finally(() => {
+          this.scheduleNextReconcile(intervalMs);
+        });
     }, intervalMs);
     // Don't keep the process alive just for the reconciler.
-    if (typeof this.reconcileTimer === 'object' && 'unref' in this.reconcileTimer) {
+    if (typeof this.reconcileTimer === 'object' && this.reconcileTimer && 'unref' in this.reconcileTimer) {
       (this.reconcileTimer as { unref: () => void }).unref();
     }
   }
 
   private stopReconcileTimer(): void {
+    this.reconcileEnabled = false;
     if (this.reconcileTimer) {
-      clearInterval(this.reconcileTimer);
+      clearTimeout(this.reconcileTimer);
       this.reconcileTimer = null;
     }
   }

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -62,6 +62,16 @@ export interface EngineConfig {
   instanceConcurrencyOverrides?: Record<string, number>;
   /** Maximum pending items per queue before applying backpressure (default: 100) */
   maxQueueDepth?: number;
+  /**
+   * Interval in milliseconds for the subscription reconciler to verify each
+   * enabled trigger has a live subscription and re-subscribe if missing or
+   * dead. Default: 30_000ms. Set to 0 to disable (tests).
+   *
+   * The reconciler closes the gap diagnosed in #546 where a disable→enable
+   * toggle (or NATS server reset) leaves the engine without a working
+   * subscription even though the API reports the automation as enabled.
+   */
+  reconcileIntervalMs?: number;
 }
 
 /**
@@ -82,13 +92,14 @@ export class QueueFullError extends Error {
  * Automation Engine
  */
 export class AutomationEngine {
-  private subscriptions: Subscription[] = [];
+  private subscriptions = new Map<string, Subscription>();
   private instanceQueues = new Map<string, InstanceQueue>();
   private debounceManagers = new Map<string, DebounceManager>(); // automationId -> manager
   private automations: Automation[] = [];
   private eventBus: EventBus | null = null;
   private deps: ActionDependencies;
   private logger: ExecutionLogger | null = null;
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private config: EngineConfig) {
     this.deps = {
@@ -110,37 +121,9 @@ export class AutomationEngine {
     };
     this.automations = automations.filter((a) => a.enabled);
 
-    // Subscribe to all unique trigger event types
-    const triggerTypes = new Set(this.automations.map((a) => a.triggerEventType));
-
-    for (const eventType of triggerTypes) {
-      // Durable consumer name — ephemeral consumers are GC'd by NATS after 5s
-      // idle, which silently stops automations with low-frequency triggers
-      // (chat.idle_timeout, chat.archived, handoff, etc.). See #445.
-      const durable = `automation-engine-${eventType.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
-      const subscription = await eventBus.subscribePattern(
-        `${eventType}.>`,
-        async (event) => {
-          await this.handleEvent(event);
-        },
-        {
-          durable,
-          queue: 'automation-engine',
-          startFrom: 'new',
-          maxRetries: 3,
-          retryDelayMs: 1000,
-        },
-      );
-      this.subscriptions.push(subscription);
-      logger.info(`Subscribed to ${eventType}.*`, { durable });
-    }
-
-    // Set up debounce managers for automations that have debounce config
-    for (const automation of this.automations) {
-      if (automation.debounce && automation.debounce.mode !== 'none') {
-        this.setupDebounceManager(automation);
-      }
-    }
+    await this.reconcileSubscriptions();
+    this.rebuildDebounceManagers();
+    this.startReconcileTimer();
 
     logger.info(`Automation engine started with ${this.automations.length} automations`);
   }
@@ -149,11 +132,13 @@ export class AutomationEngine {
    * Stop the engine
    */
   async stop(): Promise<void> {
+    this.stopReconcileTimer();
+
     // Unsubscribe from all events
-    for (const subscription of this.subscriptions) {
+    for (const subscription of this.subscriptions.values()) {
       await subscription.unsubscribe();
     }
-    this.subscriptions = [];
+    this.subscriptions.clear();
 
     // Flush all debounce windows
     for (const manager of this.debounceManagers.values()) {
@@ -173,11 +158,141 @@ export class AutomationEngine {
 
   /**
    * Reload automations (e.g., when CRUD changes)
+   *
+   * Reconciles subscriptions in place rather than tearing down and rebuilding,
+   * so the durable consumer's iterator is preserved when the trigger set is
+   * unchanged. The reconciler is also responsible for re-creating subscriptions
+   * for triggers that became enabled (toggle false→true) and dropping
+   * subscriptions for triggers that became orphaned (last automation disabled).
+   * See #546.
    */
   async reload(automations: Automation[]): Promise<void> {
-    await this.stop();
-    if (this.eventBus) {
-      await this.start(this.eventBus, automations, this.deps);
+    if (!this.eventBus) {
+      // Engine never started — nothing to do.
+      this.automations = automations.filter((a) => a.enabled);
+      return;
+    }
+    this.automations = automations.filter((a) => a.enabled);
+    await this.reconcileSubscriptions();
+    this.rebuildDebounceManagers();
+  }
+
+  /**
+   * Run the subscription reconciler on demand.
+   *
+   * Public so operators / health checks can force a sync. Idempotent.
+   */
+  async reconcile(): Promise<void> {
+    if (!this.eventBus) return;
+    await this.reconcileSubscriptions();
+  }
+
+  /**
+   * Diff expected (from current automations) vs active subscriptions and
+   * subscribe / unsubscribe to converge. Also re-subscribes any subscription
+   * whose underlying iterator has died (e.g., NATS server reset).
+   */
+  private async reconcileSubscriptions(): Promise<void> {
+    if (!this.eventBus) return;
+
+    const expectedTriggers = new Set(this.automations.map((a) => a.triggerEventType));
+
+    // Drop subscriptions whose trigger is no longer enabled.
+    for (const [eventType, subscription] of this.subscriptions) {
+      if (!expectedTriggers.has(eventType)) {
+        await subscription.unsubscribe().catch((err) => {
+          logger.warn('Failed to unsubscribe orphan trigger', { eventType, error: String(err) });
+        });
+        this.subscriptions.delete(eventType);
+        logger.info(`Unsubscribed from ${eventType}.* (no enabled automations)`);
+      }
+    }
+
+    // Subscribe (or re-subscribe if dead) for each expected trigger.
+    for (const eventType of expectedTriggers) {
+      const existing = this.subscriptions.get(eventType);
+      if (existing && this.isSubscriptionAlive(existing)) {
+        continue;
+      }
+      if (existing) {
+        // Stale handle — best-effort unsubscribe before replacing.
+        await existing.unsubscribe().catch(() => {});
+        this.subscriptions.delete(eventType);
+        logger.warn('Replacing dead subscription', { eventType });
+      }
+      const subscription = await this.subscribeForTrigger(eventType);
+      this.subscriptions.set(eventType, subscription);
+    }
+  }
+
+  /**
+   * Create one durable subscription for a trigger event type.
+   */
+  private async subscribeForTrigger(eventType: string): Promise<Subscription> {
+    if (!this.eventBus) {
+      throw new Error('Event bus not initialized');
+    }
+    // Durable consumer name — ephemeral consumers are GC'd by NATS after 5s
+    // idle, which silently stops automations with low-frequency triggers
+    // (chat.idle_timeout, chat.archived, handoff, etc.). See #445.
+    const durable = `automation-engine-${eventType.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+    const subscription = await this.eventBus.subscribePattern(
+      `${eventType}.>`,
+      async (event) => {
+        await this.handleEvent(event);
+      },
+      {
+        durable,
+        queue: 'automation-engine',
+        startFrom: 'new',
+        maxRetries: 3,
+        retryDelayMs: 1000,
+      },
+    );
+    logger.info(`Subscribed to ${eventType}.*`, { durable });
+    return subscription;
+  }
+
+  private isSubscriptionAlive(subscription: Subscription): boolean {
+    // Default to alive when the bus implementation does not expose liveness.
+    return subscription.isAlive ? subscription.isAlive() : true;
+  }
+
+  private rebuildDebounceManagers(): void {
+    // Drop debounce managers whose automation is no longer enabled.
+    const enabledIds = new Set(this.automations.map((a) => a.id));
+    for (const id of this.debounceManagers.keys()) {
+      if (!enabledIds.has(id)) {
+        this.debounceManagers.get(id)?.flushAll();
+        this.debounceManagers.delete(id);
+      }
+    }
+    for (const automation of this.automations) {
+      if (automation.debounce && automation.debounce.mode !== 'none' && !this.debounceManagers.has(automation.id)) {
+        this.setupDebounceManager(automation);
+      }
+    }
+  }
+
+  private startReconcileTimer(): void {
+    this.stopReconcileTimer();
+    const intervalMs = this.config.reconcileIntervalMs ?? 30_000;
+    if (intervalMs <= 0) return;
+    this.reconcileTimer = setInterval(() => {
+      this.reconcileSubscriptions().catch((err) => {
+        logger.error('Reconciler tick failed', { error: String(err) });
+      });
+    }, intervalMs);
+    // Don't keep the process alive just for the reconciler.
+    if (typeof this.reconcileTimer === 'object' && 'unref' in this.reconcileTimer) {
+      (this.reconcileTimer as { unref: () => void }).unref();
+    }
+  }
+
+  private stopReconcileTimer(): void {
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
     }
   }
 

--- a/packages/core/src/events/bus.ts
+++ b/packages/core/src/events/bus.ts
@@ -140,6 +140,19 @@ export interface Subscription {
 
   /** Unsubscribe from events */
   unsubscribe(): Promise<void>;
+
+  /**
+   * Whether the underlying consumer/iterator is still delivering events.
+   *
+   * Returns false when the iterator has exited (server-side consumer GC'd,
+   * NATS reset, stream deleted, …). Callers — most importantly the
+   * automation engine reconciler (#546) — use this to detect silently dead
+   * subscriptions and re-subscribe.
+   *
+   * Optional for compatibility with mock buses; defaults to alive when
+   * unimplemented.
+   */
+  isAlive?(): boolean;
 }
 
 /**

--- a/packages/core/src/events/nats/subscription.ts
+++ b/packages/core/src/events/nats/subscription.ts
@@ -169,6 +169,9 @@ export function createSubscription(options: SubscriptionWrapperOptions): Subscri
   return {
     id: subscriptionId,
     pattern,
+    isAlive(): boolean {
+      return isActive;
+    },
     async unsubscribe(): Promise<void> {
       isActive = false;
       abortController.abort();


### PR DESCRIPTION
## Summary

Fixes #546.

The automation engine kept its NATS subscriptions in a flat array and rebuilt them naively via `stop()` + `start()` inside `reload()`. After a disable→enable PATCH cycle (or a NATS server reset) the durable consumer's iterator could end up dead while the engine still considered itself subscribed. The API reported `enabled=true` and health reported `nats.connected=true`, yet no `chat.idle_timeout` events were processed and `pm2 restart omni-api` was the only known recovery — hit twice in 24h in production on a follow-up automation.

### Leak point

`packages/core/src/automations/engine.ts` (pre-fix `start()` / `reload()` / `stop()` around the old `subscriptions: Subscription[]` array, lines 85, 116–136, 151–164, 177–182):

- `reload()` called `stop()` then `start()`, which delegated subscription recreation to `eventBus.subscribePattern` against an already-existing durable. The bus path goes through `ensureConsumer` → `updateOrRecreateConsumer`. When this happens twice on the same durable across a toggle, the new client iterator can land in a state where it never receives deliveries — and the engine had no way to detect or recover from that.
- `Subscription` carried no liveness signal, so a dead iterator looked identical to a healthy one to the engine. The only \"recovery\" was the next process restart re-running `start()` from scratch.

### Fix

- Track subscriptions in a `Map<triggerEventType, Subscription>` instead of a flat array.
- Add a reconcile loop that:
  - drops subscriptions for triggers with no enabled automations,
  - re-subscribes when a subscription's iterator reports `!isAlive()`,
  - is idempotent on healthy state (no leaked handlers).
- Extend `Subscription` with an optional `isAlive()` probe and expose the NATS subscription wrapper's existing `isActive` flag through it (`packages/core/src/events/nats/subscription.ts`).
- Run the reconciler on `reload()` and on a 30s timer (`reconcileIntervalMs`, configurable, set to `0` in tests). Timer is `unref()`'d so it never blocks process shutdown.
- `reload()` now reconciles in place rather than tearing down and rebuilding, so a healthy subscription survives reloads where the trigger set hasn't changed (no churn on the durable consumer).

### Test coverage

`packages/core/src/automations/__tests__/engine-reconcile.test.ts`:

- disable→enable re-subscribes the durable consumer
- reconcile re-subscribes when the iterator dies
- reconcile is idempotent when subscriptions are healthy
- reload drops orphan-trigger subscriptions
- reload preserves a healthy subscription instead of churning it
- reload from never-started engine seeds automations without subscribing

The existing `engine-durable.test.ts` (#445 regression) still passes — durable name, queue, `startFrom=new`, and dedup-by-trigger semantics are unchanged.

## Test plan

- [x] \`bun test packages/core/src/automations/\` — 279 pass, 0 fail
- [x] \`bun test packages/core/src/events\` — 136 pass, 0 fail
- [x] \`bun test packages/api/src\` — 967 pass, 0 fail
- [x] \`bun test\` (full suite) — 3704 pass, 0 fail
- [x] \`make typecheck\` — clean
- [x] \`make lint\` — clean