### PR TITLE
fix(api): handoff disarm overrides non-terminal prior reason (#542)

### DIFF
--- a/packages/api/src/__tests__/follow-up-lifecycle.test.ts
+++ b/packages/api/src/__tests__/follow-up-lifecycle.test.ts
@@ -256,9 +256,9 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     expect(rows).toHaveLength(0);
   });
 
-  test('second disarm on an already-disarmed row is idempotent (no new event)', async () => {
-    // Non-handoff disarms remain strictly idempotent. A handoff override
-    // (#542) is exercised by the dedicated tests below.
+  test('second non-terminal disarm on an already-disarmed row is idempotent (no new event)', async () => {
+    // Non-terminal disarms remain strictly idempotent. Terminal overrides
+    // (#542) are exercised by the dedicated tests below.
     await service.armForOutbound({
       chatId: testChatId,
       instanceId: testInstanceId,
@@ -273,18 +273,21 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     });
     publishedEvents.length = 0;
 
-    // archived is non-handoff → respects the existing customer_replied row.
-    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'archived' });
+    // sequence_complete is non-terminal → respects the existing
+    // customer_replied row.
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'sequence_complete' });
     expect(publishedEvents).toHaveLength(0);
 
     const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
-    // Original reason preserved — non-handoff second disarm must not overwrite.
+    // Original reason preserved — non-terminal second disarm must not overwrite.
     expect(row.disarmReason).toBe('customer_replied');
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // #542 — handoff disarm must override non-terminal prior reasons so the
-  // terminal-disarm guard in armForOutbound blocks re-arming on tail streams.
+  // #542 — every terminal disarm reason must override non-terminal prior
+  // reasons so the terminal-disarm guard in armForOutbound blocks re-arming
+  // on tail streams. The "Mario leak" pattern is not specific to handoff —
+  // archived / session_cleared / window_expired share the same race.
   // ──────────────────────────────────────────────────────────────────────────
 
   test('#542 disarm(handoff) overrides existing customer_replied row', async () => {
@@ -340,7 +343,7 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
   });
 
   test('#542 disarm(handoff) does NOT downgrade an already-terminal session_cleared row', async () => {
-    // Strong reasons in HANDOFF_OVERRIDE_PROTECTED win — preserving the
+    // Strong reasons in TERMINAL_OVERRIDE_PROTECTED win — preserving the
     // semantically-stronger label and the original disarmedAt timestamp.
     await service.armForOutbound({
       chatId: testChatId,
@@ -415,6 +418,94 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     expect(row.disarmReason).toBe('handoff');
     expect(row.disarmedAt?.getTime()).toBe(before.disarmedAt?.getTime());
     expect(publishedEvents).toHaveLength(0);
+  });
+
+  test('#542 disarm(archived) overrides existing customer_replied row', async () => {
+    // gemini review: the Mario leak applies to every terminal reason, not
+    // just handoff. Archive on a customer_replied row must advance the
+    // disarm to `archived` so the terminal-disarm guard in armForOutbound
+    // refuses a tail message.sent.
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'customer_replied',
+    });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'archived' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('archived');
+    expect(row.nextFireAt).toBeNull();
+    expect(publishedEvents.map((e) => e.type)).toContain('follow_up.disarmed');
+  });
+
+  test('#542 disarm(session_cleared) overrides existing customer_replied row', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'customer_replied',
+    });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'session_cleared' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('session_cleared');
+  });
+
+  test('#542 disarm(window_expired) overrides existing sequence_complete row', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'sequence_complete',
+    });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'window_expired' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('window_expired');
+  });
+
+  test('#542 disarm(archived) does NOT downgrade a contact_closed row', async () => {
+    // contact_closed is in TERMINAL_OVERRIDE_PROTECTED — even another
+    // terminal reason cannot rewrite the audit label.
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'contact_closed' });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'archived' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('contact_closed');
   });
 
   test('#542 production scenario: customer_replied → handoff disarm → tail message.sent does NOT re-arm', async () => {

--- a/packages/api/src/__tests__/follow-up-lifecycle.test.ts
+++ b/packages/api/src/__tests__/follow-up-lifecycle.test.ts
@@ -257,6 +257,8 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
   });
 
   test('second disarm on an already-disarmed row is idempotent (no new event)', async () => {
+    // Non-handoff disarms remain strictly idempotent. A handoff override
+    // (#542) is exercised by the dedicated tests below.
     await service.armForOutbound({
       chatId: testChatId,
       instanceId: testInstanceId,
@@ -271,12 +273,192 @@ describeWithDb('FollowUpLifecycleService (integration)', () => {
     });
     publishedEvents.length = 0;
 
-    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+    // archived is non-handoff → respects the existing customer_replied row.
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'archived' });
     expect(publishedEvents).toHaveLength(0);
 
     const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
-    // Original reason preserved — the second disarm must not overwrite.
+    // Original reason preserved — non-handoff second disarm must not overwrite.
     expect(row.disarmReason).toBe('customer_replied');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // #542 — handoff disarm must override non-terminal prior reasons so the
+  // terminal-disarm guard in armForOutbound blocks re-arming on tail streams.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test('#542 disarm(handoff) overrides existing customer_replied row', async () => {
+    const armAt = new Date();
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: armAt,
+      config: config(),
+    });
+    const replyAt = new Date(armAt.getTime() + 30_000);
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'customer_replied',
+      lastInboundCustomerMessageAt: replyAt,
+    });
+    publishedEvents.length = 0;
+
+    // Operator initiates handoff while row is sitting in customer_replied.
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('handoff');
+    expect(row.nextFireAt).toBeNull();
+    expect(row.disarmedAt).not.toBeNull();
+    expect(publishedEvents.map((e) => e.type)).toContain('follow_up.disarmed');
+    const evt = publishedEvents.find((e) => e.type === 'follow_up.disarmed');
+    expect(evt?.payload.reason).toBe('handoff');
+  });
+
+  test('#542 disarm(handoff) overrides existing sequence_complete row', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'sequence_complete',
+    });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('handoff');
+    expect(row.nextFireAt).toBeNull();
+  });
+
+  test('#542 disarm(handoff) does NOT downgrade an already-terminal session_cleared row', async () => {
+    // Strong reasons in HANDOFF_OVERRIDE_PROTECTED win — preserving the
+    // semantically-stronger label and the original disarmedAt timestamp.
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'session_cleared' });
+    const [before] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('session_cleared');
+    expect(row.disarmedAt?.getTime()).toBe(before.disarmedAt?.getTime());
+    expect(publishedEvents.map((e) => e.type)).not.toContain('follow_up.disarmed');
+  });
+
+  test('#542 disarm(handoff) does NOT downgrade a contact_closed row', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'contact_closed' });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('contact_closed');
+    expect(publishedEvents.map((e) => e.type)).not.toContain('follow_up.disarmed');
+  });
+
+  test('#542 disarm(handoff) on a fresh armed row arms-down to handoff (NULL → handoff)', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('handoff');
+    expect(row.nextFireAt).toBeNull();
+    expect(publishedEvents.map((e) => e.type)).toContain('follow_up.disarmed');
+  });
+
+  test('#542 re-applying handoff to a handoff row stays idempotent (no duplicate event)', async () => {
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+    const [before] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    publishedEvents.length = 0;
+
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('handoff');
+    expect(row.disarmedAt?.getTime()).toBe(before.disarmedAt?.getTime());
+    expect(publishedEvents).toHaveLength(0);
+  });
+
+  test('#542 production scenario: customer_replied → handoff disarm → tail message.sent does NOT re-arm', async () => {
+    // Reproduces production case 5594992438493 from 2026-04-26: lead replied,
+    // operator handed off, but the row was sitting in customer_replied so the
+    // synchronous disarm was a no-op and a tail message.sent re-armed the
+    // sequence — a follow-up fired ~16 min later. Post-fix the row advances
+    // to handoff and the terminal-disarm guard refuses the re-arm.
+    //
+    // Real-world ordering: customer reply lands first (replyAt ≤ wall-clock),
+    // then handoff fires later. lastInboundCustomerMessageAt must therefore
+    // sit BEFORE both disarmedAt timestamps so the terminal-disarm guard
+    // ("customer hasn't returned since the disarm") fires correctly.
+    const replyAt = new Date(Date.now() - 30_000);
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(replyAt.getTime() - 60_000),
+      config: config(),
+    });
+    await service.disarm({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      reason: 'customer_replied',
+      lastInboundCustomerMessageAt: replyAt,
+    });
+    // Operator handoff fires after the customer reply — wall-clock now.
+    await service.disarm({ chatId: testChatId, instanceId: testInstanceId, reason: 'handoff' });
+    publishedEvents.length = 0;
+
+    // Tail-stream chunk lands after the handoff — message.sent fires armForOutbound.
+    await service.armForOutbound({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      lastAgentMessageAt: new Date(),
+      config: config(),
+    });
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('handoff');
+    expect(row.nextFireAt).toBeNull();
+    expect(publishedEvents.map((e) => e.type)).not.toContain('follow_up.armed');
   });
 
   test('resolveConfig returns null when no scope defines a config (G6 columns absent)', async () => {

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -38,7 +38,7 @@ import {
   chats,
   instances,
 } from '@omni/db';
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, notInArray, or, sql } from 'drizzle-orm';
 import { isChatInActiveCloseState } from '../lib/close-contact-state';
 
 const log = createLogger('follow-up-lifecycle');
@@ -61,6 +61,22 @@ const TERMINAL_DISARM_REASONS: ReadonlySet<FollowUpDisarmReason> = new Set<Follo
   'handoff',
   'archived',
   'window_expired',
+]);
+
+/**
+ * Reasons strong enough to refuse a handoff override (#542). The handoff
+ * disarm — fired synchronously by `POST /messages/send/handoff` — must
+ * advance a row whose prior reason is `customer_replied` or
+ * `sequence_complete` (those don't block re-arms via the terminal-disarm
+ * guard, so a later tail-stream chunk would resurrect the sequence).
+ * It must NOT downgrade a row that is already terminal-or-stronger:
+ * `TERMINAL_DISARM_REASONS` plus `contact_closed` (close-contact set the
+ * row deliberately; preserving the audit trail matters more than swapping
+ * the bookkeeping label to "handoff").
+ */
+const HANDOFF_OVERRIDE_PROTECTED: ReadonlySet<FollowUpDisarmReason> = new Set<FollowUpDisarmReason>([
+  ...TERMINAL_DISARM_REASONS,
+  'contact_closed',
 ]);
 
 /**
@@ -407,16 +423,28 @@ export class FollowUpLifecycleService {
       set.lastInboundCustomerMessageAt = lastInboundCustomerMessageAt;
     }
 
+    // Default disarm semantics are idempotent: only update when the row has
+    // no prior disarm reason. `handoff` is the exception (#542) — the
+    // synchronous disarm in `POST /messages/send/handoff` must override a
+    // row that's already disarmed with a non-terminal reason
+    // (`customer_replied`, `sequence_complete`, `agent_error`, `send_failed`),
+    // so the terminal-disarm guard in `armForOutbound` blocks a later tail
+    // chunk or NATS redelivery from re-arming the sequence. Strong reasons
+    // (`HANDOFF_OVERRIDE_PROTECTED`) still win — handoff never downgrades a
+    // session_cleared / archived / window_expired / contact_closed row, and
+    // re-applying handoff to an already-handoff row stays a no-op.
+    const reasonGuard =
+      reason === 'handoff'
+        ? or(
+            isNull(chatFollowUpState.disarmReason),
+            notInArray(chatFollowUpState.disarmReason, [...HANDOFF_OVERRIDE_PROTECTED]),
+          )
+        : isNull(chatFollowUpState.disarmReason);
+
     const result = await this.db
       .update(chatFollowUpState)
       .set(set)
-      .where(
-        and(
-          eq(chatFollowUpState.chatId, chatId),
-          eq(chatFollowUpState.instanceId, instanceId),
-          isNull(chatFollowUpState.disarmReason),
-        ),
-      )
+      .where(and(eq(chatFollowUpState.chatId, chatId), eq(chatFollowUpState.instanceId, instanceId), reasonGuard))
       .returning({ id: chatFollowUpState.id });
 
     return { disarmed: result.length > 0 };

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -64,20 +64,23 @@ const TERMINAL_DISARM_REASONS: ReadonlySet<FollowUpDisarmReason> = new Set<Follo
 ]);
 
 /**
- * Reasons strong enough to refuse a handoff override (#542). The handoff
- * disarm — fired synchronously by `POST /messages/send/handoff` — must
- * advance a row whose prior reason is `customer_replied` or
- * `sequence_complete` (those don't block re-arms via the terminal-disarm
- * guard, so a later tail-stream chunk would resurrect the sequence).
+ * Reasons strong enough to refuse a terminal override (#542 + gemini review).
+ * Any terminal disarm (`handoff`, `session_cleared`, `archived`,
+ * `window_expired`) must advance a row whose prior reason is non-terminal
+ * (e.g., `customer_replied`, `sequence_complete`, `agent_error`,
+ * `send_failed`) — those don't block re-arms via the terminal-disarm guard,
+ * so a later tail-stream chunk would resurrect the sequence (the "Mario leak"
+ * pattern).
+ *
  * It must NOT downgrade a row that is already terminal-or-stronger:
  * `TERMINAL_DISARM_REASONS` plus `contact_closed` (close-contact set the
  * row deliberately; preserving the audit trail matters more than swapping
- * the bookkeeping label to "handoff").
+ * the bookkeeping label).
+ *
+ * Held as an array (not a Set) so the `notInArray` query operator can use
+ * it directly without spreading on every disarm call.
  */
-const HANDOFF_OVERRIDE_PROTECTED: ReadonlySet<FollowUpDisarmReason> = new Set<FollowUpDisarmReason>([
-  ...TERMINAL_DISARM_REASONS,
-  'contact_closed',
-]);
+const TERMINAL_OVERRIDE_PROTECTED: FollowUpDisarmReason[] = [...TERMINAL_DISARM_REASONS, 'contact_closed'];
 
 /**
  * Typed reads across the three storage locations — the resolver is DB-agnostic,
@@ -424,22 +427,22 @@ export class FollowUpLifecycleService {
     }
 
     // Default disarm semantics are idempotent: only update when the row has
-    // no prior disarm reason. `handoff` is the exception (#542) — the
-    // synchronous disarm in `POST /messages/send/handoff` must override a
-    // row that's already disarmed with a non-terminal reason
+    // no prior disarm reason. Terminal reasons are the exception (#542 +
+    // gemini review on PR #588): any reason in `TERMINAL_DISARM_REASONS`
+    // (`handoff`, `session_cleared`, `archived`, `window_expired`) must
+    // override a row that's already disarmed with a non-terminal reason
     // (`customer_replied`, `sequence_complete`, `agent_error`, `send_failed`),
     // so the terminal-disarm guard in `armForOutbound` blocks a later tail
     // chunk or NATS redelivery from re-arming the sequence. Strong reasons
-    // (`HANDOFF_OVERRIDE_PROTECTED`) still win — handoff never downgrades a
-    // session_cleared / archived / window_expired / contact_closed row, and
-    // re-applying handoff to an already-handoff row stays a no-op.
-    const reasonGuard =
-      reason === 'handoff'
-        ? or(
-            isNull(chatFollowUpState.disarmReason),
-            notInArray(chatFollowUpState.disarmReason, [...HANDOFF_OVERRIDE_PROTECTED]),
-          )
-        : isNull(chatFollowUpState.disarmReason);
+    // (`TERMINAL_OVERRIDE_PROTECTED`) still win — a terminal disarm never
+    // downgrades another terminal row or a `contact_closed` row, and
+    // re-applying the same reason stays a no-op.
+    const reasonGuard = TERMINAL_DISARM_REASONS.has(reason)
+      ? or(
+          isNull(chatFollowUpState.disarmReason),
+          notInArray(chatFollowUpState.disarmReason, TERMINAL_OVERRIDE_PROTECTED),
+        )
+      : isNull(chatFollowUpState.disarmReason);
 
     const result = await this.db
       .update(chatFollowUpState)


### PR DESCRIPTION
## Summary

- Fixes the Mario leak (production case 5594992438493 on 2026-04-26): a follow-up message fired ~16 min after a handoff because the `chat_follow_up_state` row was already disarmed with `customer_replied` 1 min before the handoff. The synchronous disarm shipped in #535 became a no-op, the row stayed in `customer_replied` (not in `TERMINAL_DISARM_REASONS`), and `armForOutbound` re-armed the sequence on a tail `message.sent`.
- Special-cases `reason === 'handoff'` in `disarmActive()` (`packages/api/src/services/follow-up-lifecycle.ts`): drop the `disarmReason IS NULL` guard, but still refuse to downgrade strong existing reasons (`HANDOFF_OVERRIDE_PROTECTED` = `TERMINAL_DISARM_REASONS` ∪ `contact_closed`). All other reasons keep the original idempotent semantics.
- After the fix, `disarm_reason` advances to `handoff` on top of `customer_replied` / `sequence_complete`, the terminal-disarm guard in `armForOutbound` triggers, and re-arm is refused.

## Test plan
- [x] New: customer_replied → handoff override (row advances to `handoff`)
- [x] New: sequence_complete → handoff override
- [x] New: session_cleared / contact_closed NOT downgraded by handoff
- [x] New: NULL → handoff fresh disarm (existing path still works)
- [x] New: handoff → handoff idempotent
- [x] New: full production scenario — customer_replied → handoff disarm → tail `armForOutbound` refused
- [x] `bun test packages/api/src/__tests__/follow-up-lifecycle.test.ts` — 26 pass
- [x] Full pre-push gate (`make typecheck` + `bun test`) — 3698 pass / 0 fail

Refs: #528, #535, #538, #539
Closes: #542