### PR TITLE
feat(api): subscribe to omni.agent.heartbeat.* and reset turn activity

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -60,8 +60,9 @@ import {
 } from './plugins';
 import { getPlugin } from './plugins/loader';
 import { setupScheduler, stopScheduler } from './scheduler';
+import { closeAgentHeartbeat, initAgentHeartbeat } from './services/agent-heartbeat';
 import { ApiKeyService } from './services/api-keys';
-import { closeTurnEvents, initTurnEvents } from './services/turn-events';
+import { closeTurnEvents, getTurnEventsConnection, initTurnEvents } from './services/turn-events';
 import { TurnMonitor } from './services/turn-monitor';
 import { printStartupBanner } from './utils/startup-banner';
 
@@ -348,6 +349,9 @@ function setupShutdownHandlers(server: ReturnType<typeof Bun.serve>, earlyShutdo
         globalTurnMonitor.stop();
       }
 
+      shutdownLog.info('Stopping agent heartbeat consumer');
+      await closeAgentHeartbeat();
+
       shutdownLog.info('Closing turn events NATS');
       await closeTurnEvents();
 
@@ -593,6 +597,21 @@ async function setupEventBusServices(
     await initTurnEvents(NATS_URL);
   } catch (error) {
     log.error('Failed to initialize turn events', { error: String(error) });
+  }
+
+  // Agent heartbeat consumer — resets turns.lastActivityAt on inbound
+  // `omni.agent.heartbeat.*` events so the 120s nudge stays suppressed
+  // for actively-working Claude Code sessions. See wish
+  // automagik-dev/genie:omni-activity-heartbeat.
+  try {
+    const turnEventsConn = getTurnEventsConnection();
+    if (turnEventsConn) {
+      initAgentHeartbeat({ natsConnection: turnEventsConn, turnService: services.turns });
+    } else {
+      log.warn('Skipping agent heartbeat consumer: no NATS connection');
+    }
+  } catch (error) {
+    log.error('Failed to initialize agent heartbeat consumer', { error: String(error) });
   }
 
   // Turn monitor (polls for stale turns, emits nudge/timeout events)

--- a/packages/api/src/services/__tests__/agent-heartbeat.test.ts
+++ b/packages/api/src/services/__tests__/agent-heartbeat.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Agent heartbeat consumer tests.
+ *
+ * Contract: incoming `omni.agent.heartbeat.*` events convert into exactly one
+ * `turnService.recordActivity(turnId)` call per valid event. Malformed events
+ * never crash the consumer, never call recordActivity, and emit a warning.
+ * Unknown turn IDs (rejection from recordActivity) are swallowed.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { AgentHeartbeatConsumer } from '../agent-heartbeat';
+import type { AgentHeartbeatEvent } from '../turn-events';
+
+type Msg = { subject: string; data: Uint8Array };
+
+interface FakeNats {
+  isClosed(): boolean;
+  subscribe(subject: string): FakeSubscription;
+  __push(msg: Msg): void;
+  __end(): void;
+  __subscribedTo: string | null;
+  __unsubscribed: boolean;
+}
+
+interface FakeSubscription {
+  unsubscribe(): void;
+  [Symbol.asyncIterator](): AsyncIterator<Msg>;
+}
+
+function createFakeNats(): FakeNats {
+  const queue: Msg[] = [];
+  const waiters: Array<(value: IteratorResult<Msg>) => void> = [];
+  let ended = false;
+  let closed = false;
+  let subscribedTo: string | null = null;
+  let unsubscribed = false;
+
+  const drainOne = () => {
+    while (waiters.length > 0 && queue.length > 0) {
+      const w = waiters.shift()!;
+      w({ value: queue.shift()!, done: false });
+    }
+    if (ended) {
+      while (waiters.length > 0) {
+        const w = waiters.shift()!;
+        w({ value: undefined as never, done: true });
+      }
+    }
+  };
+
+  const subscription: FakeSubscription = {
+    unsubscribe() {
+      unsubscribed = true;
+      ended = true;
+      drainOne();
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<Msg>> {
+          if (queue.length > 0) {
+            return Promise.resolve({ value: queue.shift()!, done: false });
+          }
+          if (ended) {
+            return Promise.resolve({ value: undefined as never, done: true });
+          }
+          return new Promise<IteratorResult<Msg>>((resolve) => waiters.push(resolve));
+        },
+        return(): Promise<IteratorResult<Msg>> {
+          ended = true;
+          drainOne();
+          return Promise.resolve({ value: undefined as never, done: true });
+        },
+      };
+    },
+  };
+
+  return {
+    isClosed: () => closed,
+    subscribe(subject: string) {
+      subscribedTo = subject;
+      return subscription;
+    },
+    __push(msg: Msg) {
+      queue.push(msg);
+      drainOne();
+    },
+    __end() {
+      ended = true;
+      drainOne();
+      closed = true;
+    },
+    get __subscribedTo() {
+      return subscribedTo;
+    },
+    get __unsubscribed() {
+      return unsubscribed;
+    },
+  };
+}
+
+function encode(payload: unknown): Uint8Array {
+  return new TextEncoder().encode(typeof payload === 'string' ? payload : JSON.stringify(payload));
+}
+
+function makeEvent(overrides: Partial<AgentHeartbeatEvent> = {}): AgentHeartbeatEvent {
+  return {
+    turnId: 'turn-abc',
+    instanceId: 'inst-1',
+    chatId: 'chat-1',
+    timestamp: '2026-04-30T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// Wait for the consumer's async loop to process all queued messages.
+async function flush() {
+  // Two ticks: one for the Promise.resolve queued by the iterator, one for
+  // the synchronous mock call inside the consumer.
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('AgentHeartbeatConsumer', () => {
+  let consumer: AgentHeartbeatConsumer;
+  let nats: FakeNats;
+
+  beforeEach(() => {
+    consumer = new AgentHeartbeatConsumer();
+    nats = createFakeNats();
+  });
+
+  afterEach(async () => {
+    nats.__end();
+    await consumer.stop();
+  });
+
+  test('subscribes to omni.agent.heartbeat.> on start', () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+    expect(nats.__subscribedTo).toBe('omni.agent.heartbeat.>');
+  });
+
+  test('valid heartbeat → recordActivity called once with turnId', async () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    const event = makeEvent({ turnId: 'turn-xyz' });
+    nats.__push({
+      subject: 'omni.agent.heartbeat.inst-1.chat-1',
+      data: encode(event),
+    });
+
+    await flush();
+
+    expect(recordActivity).toHaveBeenCalledTimes(1);
+    expect(recordActivity).toHaveBeenCalledWith('turn-xyz');
+  });
+
+  test('malformed JSON → recordActivity NOT called, no crash', async () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    nats.__push({
+      subject: 'omni.agent.heartbeat.inst-1.chat-1',
+      data: encode('not-json{'),
+    });
+
+    await flush();
+
+    expect(recordActivity).not.toHaveBeenCalled();
+  });
+
+  test('missing turnId → recordActivity NOT called', async () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    nats.__push({
+      subject: 'omni.agent.heartbeat.inst-1.chat-1',
+      data: encode({ instanceId: 'inst-1', chatId: 'chat-1', timestamp: 'now' }),
+    });
+
+    await flush();
+
+    expect(recordActivity).not.toHaveBeenCalled();
+  });
+
+  test('non-object payload → recordActivity NOT called', async () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    nats.__push({
+      subject: 'omni.agent.heartbeat.inst-1.chat-1',
+      data: encode(42),
+    });
+
+    await flush();
+
+    expect(recordActivity).not.toHaveBeenCalled();
+  });
+
+  test('unknown turnId (recordActivity rejects) is swallowed, consumer keeps processing', async () => {
+    const calls: string[] = [];
+    const recordActivity = mock(async (turnId: string) => {
+      calls.push(turnId);
+      if (turnId === 'turn-missing') {
+        throw new Error('turn not found');
+      }
+    });
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    nats.__push({
+      subject: 'omni.agent.heartbeat.inst-1.chat-1',
+      data: encode(makeEvent({ turnId: 'turn-missing' })),
+    });
+    nats.__push({
+      subject: 'omni.agent.heartbeat.inst-1.chat-1',
+      data: encode(makeEvent({ turnId: 'turn-good' })),
+    });
+
+    await flush();
+
+    expect(calls).toEqual(['turn-missing', 'turn-good']);
+  });
+
+  test('multiple heartbeats in sequence → recordActivity called once per event', async () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      nats.__push({
+        subject: `omni.agent.heartbeat.inst-1.chat-${i}`,
+        data: encode(makeEvent({ turnId: `turn-${i}`, chatId: `chat-${i}` })),
+      });
+    }
+
+    await flush();
+
+    expect(recordActivity).toHaveBeenCalledTimes(5);
+  });
+
+  test('start is idempotent — second start while running is a no-op', () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+    const firstSub = nats.__subscribedTo;
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    expect(nats.__subscribedTo).toBe(firstSub);
+  });
+
+  test('stop unsubscribes and cleans up', async () => {
+    const recordActivity = mock(async () => {});
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    await consumer.stop();
+    expect(nats.__unsubscribed).toBe(true);
+  });
+
+  test('stop is safe when consumer was never started', async () => {
+    await expect(consumer.stop()).resolves.toBeUndefined();
+  });
+
+  test('start no-ops when NATS connection is already closed', () => {
+    nats.__end();
+    const recordActivity = mock(async () => {});
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: { recordActivity } as never,
+    });
+
+    expect(nats.__subscribedTo).toBeNull();
+  });
+});

--- a/packages/api/src/services/agent-heartbeat.ts
+++ b/packages/api/src/services/agent-heartbeat.ts
@@ -1,0 +1,155 @@
+/**
+ * Agent heartbeat consumer — converts inbound `omni.agent.heartbeat.*` events
+ * into `turnService.recordActivity(turnId)` calls.
+ *
+ * Background: omni's turn-monitor decides "idle" by reading `lastActivityAt`,
+ * which auth middleware bumps on every API call from the scoped key. Real
+ * Claude Code work (tool calls, file edits, internal SDK loops) does not
+ * round-trip through omni, so a 200s busy session looks identical to a 200s
+ * idle session and trips the 120s nudge threshold incorrectly.
+ *
+ * The genie heartbeat publisher (see `automagik-dev/genie` wish
+ * `omni-activity-heartbeat`) emits one event per active session every 30s on
+ * `omni.agent.heartbeat.{instanceId}.{chatId}`. This consumer subscribes,
+ * validates the payload, and calls `recordActivity(turnId)` — the same field
+ * that gates the existing nudge logic. Genuinely idle sessions still nudge;
+ * actively-working sessions stay below threshold.
+ *
+ * Backward compatibility: pre-publisher genie clients keep the current
+ * behavior (they trip nudges); newer clients suppress their own false nudges.
+ * No flag day.
+ */
+
+import { createLogger } from '@omni/core';
+import type { NatsConnection, Subscription } from 'nats';
+import { StringCodec } from 'nats';
+import type { AgentHeartbeatEvent } from './turn-events';
+import type { TurnService } from './turns';
+
+const log = createLogger('agent-heartbeat');
+const sc = StringCodec();
+
+const HEARTBEAT_SUBJECT = 'omni.agent.heartbeat.>';
+
+export interface AgentHeartbeatStartOptions {
+  natsConnection: NatsConnection;
+  turnService: TurnService;
+}
+
+export class AgentHeartbeatConsumer {
+  private subscription: Subscription | null = null;
+  private loop: Promise<void> | null = null;
+
+  start(options: AgentHeartbeatStartOptions): void {
+    if (this.subscription) return;
+
+    const { natsConnection, turnService } = options;
+
+    if (natsConnection.isClosed()) {
+      log.warn('Cannot start agent-heartbeat: NATS connection is closed');
+      return;
+    }
+
+    this.subscription = natsConnection.subscribe(HEARTBEAT_SUBJECT);
+    log.info('Agent heartbeat consumer started', { subject: HEARTBEAT_SUBJECT });
+
+    const sub = this.subscription;
+    this.loop = (async () => {
+      for await (const msg of sub) {
+        try {
+          const raw = sc.decode(msg.data);
+          const parsed = parseHeartbeat(raw);
+          if (!parsed) {
+            log.warn('Discarded malformed agent heartbeat', {
+              subject: msg.subject,
+              raw: raw.slice(0, 200),
+            });
+            continue;
+          }
+
+          turnService.recordActivity(parsed.turnId).catch((error) => {
+            log.warn('recordActivity failed for heartbeat (turn likely closed)', {
+              turnId: parsed.turnId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+
+          log.debug('Agent heartbeat applied', {
+            turnId: parsed.turnId,
+            instanceId: parsed.instanceId,
+            chatId: parsed.chatId,
+          });
+        } catch (error) {
+          log.warn('Failed to process agent heartbeat', {
+            subject: msg.subject,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    })();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.subscription) return;
+    this.subscription.unsubscribe();
+    this.subscription = null;
+    try {
+      await this.loop;
+    } catch {
+      // loop iterator throws on connection drain — already logged above
+    } finally {
+      this.loop = null;
+      log.info('Agent heartbeat consumer stopped');
+    }
+  }
+}
+
+function parseHeartbeat(raw: string): AgentHeartbeatEvent | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== 'object') return null;
+
+  const obj = value as Record<string, unknown>;
+  const { turnId, instanceId, chatId, timestamp } = obj;
+
+  if (
+    typeof turnId !== 'string' ||
+    turnId.length === 0 ||
+    typeof instanceId !== 'string' ||
+    instanceId.length === 0 ||
+    typeof chatId !== 'string' ||
+    chatId.length === 0 ||
+    typeof timestamp !== 'string' ||
+    timestamp.length === 0
+  ) {
+    return null;
+  }
+
+  return { turnId, instanceId, chatId, timestamp };
+}
+
+// Module-level singleton wired into API startup (mirrors initTurnEvents shape).
+let consumer: AgentHeartbeatConsumer | null = null;
+
+/**
+ * Initialise the agent heartbeat consumer using the shared turn-events NATS
+ * connection. Returns silently when no connection is available.
+ */
+export function initAgentHeartbeat(options: AgentHeartbeatStartOptions): void {
+  if (consumer) return;
+  consumer = new AgentHeartbeatConsumer();
+  consumer.start(options);
+}
+
+/**
+ * Stop the agent heartbeat consumer. Safe to call when not running.
+ */
+export async function closeAgentHeartbeat(): Promise<void> {
+  if (!consumer) return;
+  await consumer.stop();
+  consumer = null;
+}

--- a/packages/api/src/services/turn-events.ts
+++ b/packages/api/src/services/turn-events.ts
@@ -9,6 +9,9 @@
  *   omni.turn.done.{instanceId}.{chatId}
  *   omni.turn.nudge.{instanceId}.{chatId}
  *   omni.turn.timeout.{instanceId}.{chatId}
+ *
+ * Inbound events (consumed elsewhere, see agent-heartbeat.ts):
+ *   omni.agent.heartbeat.{instanceId}.{chatId}
  */
 
 import { createLogger } from '@omni/core';
@@ -18,6 +21,14 @@ const log = createLogger('turn-events');
 const sc = StringCodec();
 
 let nc: NatsConnection | null = null;
+
+/**
+ * Get the shared turn-events NATS connection (initialised by initTurnEvents).
+ * Returns null when NATS is unavailable.
+ */
+export function getTurnEventsConnection(): NatsConnection | null {
+  return nc && !nc.isClosed() ? nc : null;
+}
 
 /**
  * Initialize the turn events NATS connection.
@@ -129,4 +140,21 @@ export function publishTurnTimeout(instanceId: string, chatId: string, event: Tu
   const topic = `omni.turn.timeout.${instanceId}.${chatId}`;
   publish(topic, event);
   log.debug('Published turn.timeout', { turnId: event.turnId, instanceId });
+}
+
+// ============================================================================
+// Inbound event types
+// ============================================================================
+
+/**
+ * Inbound event published by genie executors while a Claude Code session is
+ * actively working. Consumed by `agent-heartbeat.ts` to reset
+ * `turns.lastActivityAt`, which suppresses the 120s idle nudge for genuinely
+ * busy sessions. Topic: `omni.agent.heartbeat.{instanceId}.{chatId}`.
+ */
+export interface AgentHeartbeatEvent {
+  turnId: string;
+  instanceId: string;
+  chatId: string;
+  timestamp: string;
 }


### PR DESCRIPTION
## Summary

- New consumer service `packages/api/src/services/agent-heartbeat.ts` subscribing to `omni.agent.heartbeat.>`.
- Each valid event calls `turnService.recordActivity(turnId)`; malformed payloads or unknown turns are swallowed (warning logged) so the consumer never crashes.
- Wired into API startup next to `initTurnEvents` so it shares the same NATS connection lifecycle (clean shutdown on server stop).
- New `AgentHeartbeatEvent` interface in `packages/api/src/services/turn-events.ts`.
- Pairs with genie-side publisher in automagik-dev/genie. Order of merging does not matter — by Decision 6 in the wish, missing heartbeats fall back to current 120s-nudge behavior.

Wish: tracked in companion repo at `.genie/wishes/omni-activity-heartbeat/WISH.md`.

## Test plan

- [x] \`bun test packages/api/src/services/__tests__/agent-heartbeat.test.ts\` — 11/11 pass (happy path, malformed payload, unknown turnId, NATS-closed start, lifecycle stop)
- [ ] Smoke: trigger a heartbeat from genie publisher and verify \`lastActivityAt\` advances on the corresponding turn row
- [ ] Regression: orphaned session (no agent activity) still triggers \`turn.nudge\` at 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)