### PR TITLE
fix(api): resolve JIDs/external IDs to UUID on /chats/:id* routes

### DIFF
--- a/packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
+++ b/packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Regression test for the dormant /:id-resolution bug:
+ *
+ *   GET /api/v2/chats/120363425563375486@g.us/messages → 500
+ *   GET /api/v2/chats/65315744/messages                → 500
+ *
+ *   PostgresError: invalid input syntax for type uuid: "120363...@g.us"
+ *
+ * The route handlers passed `c.req.param('id')` straight to a service method
+ * that called `eq(messages.chatId, raw)` against a UUID column. WhatsApp JIDs
+ * (`<num>@g.us`, `<num>@s.whatsapp.net`, `@lid`) and Telegram numeric chat ids
+ * tripped postgres's UUID parser → 500 INTERNAL_ERROR.
+ *
+ * Bug latent since `04b8a5a9` (2026-02-01, unified messages schema) — the
+ * companion LID fix `b5929040` migrated 7 call sites to
+ * `findByExternalIdSmart` but missed the routes that didn't go through
+ * `getByExternalId` (`getById`, `getChatMessages`, `getParticipants`).
+ *
+ * The fix in routes/v2/chats.ts adds `resolveChatIdParam(c, raw)`:
+ *   - UUID → returned unchanged.
+ *   - Anything else → looked up via `findByExternalIdSmart` against the API
+ *     key's active instance. Returns null when no instance context is set
+ *     OR no chat with that external id exists. Caller responds 404 with an
+ *     actionable message instead of letting postgres return a 500.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { chatsRoutes } from '../chats';
+
+const VALID_UUID = '11111111-1111-1111-8111-111111111111';
+const RESOLVED_UUID = '22222222-2222-2222-8222-222222222222';
+const ACTIVE_INSTANCE_ID = 'aaaaaaaa-aaaa-aaaa-8aaa-aaaaaaaaaaaa';
+
+const WHATSAPP_GROUP_JID = '120363425563375486@g.us';
+const WHATSAPP_DM_JID = '5511987654321@s.whatsapp.net';
+const TELEGRAM_NUMERIC_ID = '65315744';
+
+interface HarnessOptions {
+  /**
+   * When set, the harness returns this row from `db.select(...).from(apiKeys)`.
+   * Pass `null` explicitly to simulate "no row found" (api key was deleted /
+   * not recognized) — tests use that to exercise the unresolvable-id path.
+   */
+  apiKeyRow?: { activeInstanceId: string | null; contextInstanceId: string | null } | null;
+  /** When set, `findByExternalIdSmart` returns this chat (id-only). null = not found. */
+  resolvedChat?: { id: string } | null;
+}
+
+interface HarnessCalls {
+  getChatMessages: Array<{ chatId: string; options: Record<string, unknown> }>;
+  getById: Array<string>;
+  getParticipants: Array<string>;
+  findByExternalIdSmart: Array<{ instanceId: string; externalId: string }>;
+}
+
+function mountHarness(options: HarnessOptions = {}): {
+  app: Hono<{ Variables: AppVariables }>;
+  calls: HarnessCalls;
+} {
+  const calls: HarnessCalls = {
+    getChatMessages: [],
+    getById: [],
+    getParticipants: [],
+    findByExternalIdSmart: [],
+  };
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    // Stub the API key context resolver: any select against the apiKeys table
+    // returns the harness-controlled row. We fake just enough of the drizzle
+    // builder chain (select → from → where → limit) for the helper to reach
+    // the awaited result.
+    c.set('db', {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => (options.apiKeyRow ? [options.apiKeyRow] : []),
+          }),
+        }),
+      }),
+    } as never);
+    c.set('services', {
+      messages: {
+        getChatMessages: mock(async (chatId: string, opts: Record<string, unknown>) => {
+          calls.getChatMessages.push({ chatId, options: opts });
+          return [];
+        }),
+      },
+      chats: {
+        getById: mock(async (id: string) => {
+          calls.getById.push(id);
+          return { id, instanceId: ACTIVE_INSTANCE_ID };
+        }),
+        getParticipants: mock(async (id: string) => {
+          calls.getParticipants.push(id);
+          return [];
+        }),
+        findByExternalIdSmart: mock(async (instanceId: string, externalId: string) => {
+          calls.findByExternalIdSmart.push({ instanceId, externalId });
+          return options.resolvedChat ?? null;
+        }),
+      },
+    } as never);
+    c.set('apiKey', { id: 'test-key', name: 'test', scopes: ['*'], instanceIds: null, expiresAt: null } as never);
+    await next();
+  });
+  app.route('/chats', chatsRoutes);
+  return { app, calls };
+}
+
+describe('GET /chats/:id/messages — JID/external-id resolution', () => {
+  test('UUID input flows straight through (no resolution lookup)', async () => {
+    const { app, calls } = mountHarness();
+
+    const res = await app.request(`/chats/${VALID_UUID}/messages`);
+
+    expect(res.status).toBe(200);
+    expect(calls.getChatMessages).toHaveLength(1);
+    expect(calls.getChatMessages[0]?.chatId).toBe(VALID_UUID);
+    // findByExternalIdSmart MUST NOT be called for UUID input — that's a
+    // wasted DB roundtrip on the hot path.
+    expect(calls.findByExternalIdSmart).toHaveLength(0);
+  });
+
+  test('WhatsApp group JID resolves via findByExternalIdSmart and forwards the resolved UUID', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/messages`);
+
+    expect(res.status).toBe(200);
+    expect(calls.findByExternalIdSmart).toEqual([{ instanceId: ACTIVE_INSTANCE_ID, externalId: WHATSAPP_GROUP_JID }]);
+    expect(calls.getChatMessages).toHaveLength(1);
+    expect(calls.getChatMessages[0]?.chatId).toBe(RESOLVED_UUID);
+  });
+
+  test('Telegram numeric id resolves the same way', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${TELEGRAM_NUMERIC_ID}/messages`);
+
+    expect(res.status).toBe(200);
+    expect(calls.findByExternalIdSmart[0]?.externalId).toBe(TELEGRAM_NUMERIC_ID);
+    expect(calls.getChatMessages[0]?.chatId).toBe(RESOLVED_UUID);
+  });
+
+  test('contextInstanceId takes precedence over activeInstanceId', async () => {
+    const CONTEXT_INSTANCE_ID = 'bbbbbbbb-bbbb-bbbb-8bbb-bbbbbbbbbbbb';
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: CONTEXT_INSTANCE_ID },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_DM_JID)}/messages`);
+
+    expect(res.status).toBe(200);
+    expect(calls.findByExternalIdSmart[0]?.instanceId).toBe(CONTEXT_INSTANCE_ID);
+  });
+
+  test('returns 404 (not 500) when no active instance is set on the API key', async () => {
+    // Pre-fix this hit the postgres uuid parser and bombed with a 500.
+    // After the fix, the route 404s with an actionable message before
+    // touching postgres.
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: null, contextInstanceId: null },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/messages`);
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('NOT_FOUND');
+    expect(body.error.message).toContain(WHATSAPP_GROUP_JID);
+    // Service must NOT have been called — postgres is never touched on the
+    // unresolvable-id path.
+    expect(calls.getChatMessages).toHaveLength(0);
+    expect(calls.findByExternalIdSmart).toHaveLength(0);
+  });
+
+  test('returns 404 when JID has no matching chat in the active instance', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: null,
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/messages`);
+
+    expect(res.status).toBe(404);
+    expect(calls.findByExternalIdSmart).toHaveLength(1);
+    expect(calls.getChatMessages).toHaveLength(0);
+  });
+});
+
+describe('GET /chats/:id — JID/external-id resolution (sister bug)', () => {
+  test('UUID flows through to getById', async () => {
+    const { app, calls } = mountHarness();
+
+    const res = await app.request(`/chats/${VALID_UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(calls.getById).toEqual([VALID_UUID]);
+    expect(calls.findByExternalIdSmart).toHaveLength(0);
+  });
+
+  test('JID resolves and getById is called with the resolved UUID', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}`);
+
+    expect(res.status).toBe(200);
+    expect(calls.findByExternalIdSmart).toHaveLength(1);
+    expect(calls.getById).toEqual([RESOLVED_UUID]);
+  });
+
+  test('JID with no active instance returns 404 (not 500)', async () => {
+    const { app, calls } = mountHarness({ apiKeyRow: null });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}`);
+
+    expect(res.status).toBe(404);
+    expect(calls.getById).toHaveLength(0);
+  });
+});
+
+describe('GET /chats/:id/participants — JID/external-id resolution (sister bug)', () => {
+  test('JID resolves and getParticipants is called with the resolved UUID', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/participants`);
+
+    expect(res.status).toBe(200);
+    expect(calls.findByExternalIdSmart).toHaveLength(1);
+    expect(calls.getParticipants).toEqual([RESOLVED_UUID]);
+  });
+
+  test('JID with no active instance returns 404 (not 500)', async () => {
+    const { app, calls } = mountHarness({ apiKeyRow: null });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/participants`);
+
+    expect(res.status).toBe(404);
+    expect(calls.getParticipants).toHaveLength(0);
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/chats-messages-after-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/chats-messages-after-validation.test.ts
@@ -45,7 +45,9 @@ describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
     const calls: CallArgs[] = [];
     const app = mountChatsRoutes(calls);
 
-    const res = await app.request('/chats/chat-123/messages?after=550e8400-e29b-41d4-a716-446655440000');
+    const res = await app.request(
+      '/chats/11111111-1111-1111-8111-111111111111/messages?after=550e8400-e29b-41d4-a716-446655440000',
+    );
 
     expect(res.status).toBe(400);
     expect(calls).toHaveLength(0); // service must not be called with Invalid Date
@@ -55,7 +57,7 @@ describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
     const calls: CallArgs[] = [];
     const app = mountChatsRoutes(calls);
 
-    const res = await app.request('/chats/chat-123/messages?after=not-a-date-at-all');
+    const res = await app.request('/chats/11111111-1111-1111-8111-111111111111/messages?after=not-a-date-at-all');
 
     expect(res.status).toBe(400);
     expect(calls).toHaveLength(0);
@@ -65,7 +67,9 @@ describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
     const calls: CallArgs[] = [];
     const app = mountChatsRoutes(calls);
 
-    const res = await app.request('/chats/chat-123/messages?before=550e8400-e29b-41d4-a716-446655440000');
+    const res = await app.request(
+      '/chats/11111111-1111-1111-8111-111111111111/messages?before=550e8400-e29b-41d4-a716-446655440000',
+    );
 
     expect(res.status).toBe(400);
     expect(calls).toHaveLength(0);
@@ -75,13 +79,15 @@ describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
     const calls: CallArgs[] = [];
     const app = mountChatsRoutes(calls);
 
-    const res = await app.request('/chats/chat-123/messages?after=2024-01-01T00:00:00.000Z');
+    const res = await app.request(
+      '/chats/11111111-1111-1111-8111-111111111111/messages?after=2024-01-01T00:00:00.000Z',
+    );
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { items: unknown[] };
     expect(Array.isArray(body.items)).toBe(true);
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.chatId).toBe('chat-123');
+    expect(calls[0]?.chatId).toBe('11111111-1111-1111-8111-111111111111');
     const after = calls[0]?.options.after;
     expect(after).toBeInstanceOf(Date);
     expect((after as Date).toISOString()).toBe('2024-01-01T00:00:00.000Z');
@@ -91,7 +97,7 @@ describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
     const calls: CallArgs[] = [];
     const app = mountChatsRoutes(calls);
 
-    const res = await app.request('/chats/chat-123/messages');
+    const res = await app.request('/chats/11111111-1111-1111-8111-111111111111/messages');
 
     expect(res.status).toBe(200);
     expect(calls).toHaveLength(1);
@@ -103,7 +109,7 @@ describe('GET /chats/:id/messages — date parameter validation (#462)', () => {
     const calls: CallArgs[] = [];
     const app = mountChatsRoutes(calls);
 
-    const res = await app.request('/chats/chat-123/messages?mediaOnly=true');
+    const res = await app.request('/chats/11111111-1111-1111-8111-111111111111/messages?mediaOnly=true');
 
     expect(res.status).toBe(200);
     expect(calls[0]?.options.mediaOnly).toBe(true);

--- a/packages/api/src/routes/v2/chats.ts
+++ b/packages/api/src/routes/v2/chats.ts
@@ -8,6 +8,9 @@ import { zValidator } from '@hono/zod-validator';
 import type { ChannelRegistry } from '@omni/channel-sdk';
 import { ChannelTypeSchema, ERROR_CODES, OmniError } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
+import { apiKeys } from '@omni/db/schema';
+import { eq } from 'drizzle-orm';
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { clearAgentSession } from '../../plugins/session-cleaner';
@@ -17,6 +20,13 @@ import { ApiKeyService } from '../../services/api-keys';
 import type { ApiKeyData, AppVariables } from '../../types';
 
 const chatsRoutes = new Hono<{ Variables: AppVariables }>();
+
+/**
+ * Standard UUID v1-v5 pattern. Mirrors the regex used in app.ts:148 and the
+ * service-layer test suites — kept as a private const here so the route file
+ * doesn't need a new shared util.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Verify API key has access to the given instance.
@@ -30,6 +40,83 @@ function checkInstanceAccess(apiKey: ApiKeyData | undefined, instanceId: string)
       recoverable: false,
     });
   }
+}
+
+/**
+ * Resolve the active instance for an API key. Reads `contextInstanceId` first
+ * (set via POST /context) then falls back to `activeInstanceId` (set via
+ * POST /context/use). Returns null when neither is set — callers MUST 400
+ * the request rather than guess across the API key's authorized instances.
+ */
+async function getActiveInstanceId(c: Context<{ Variables: AppVariables }>): Promise<string | null> {
+  const keyData = c.get('apiKey');
+  if (!keyData) return null;
+  const db = c.get('db');
+  const [row] = await db
+    .select({
+      activeInstanceId: apiKeys.activeInstanceId,
+      contextInstanceId: apiKeys.contextInstanceId,
+    })
+    .from(apiKeys)
+    .where(eq(apiKeys.id, keyData.id))
+    .limit(1);
+  return row?.contextInstanceId ?? row?.activeInstanceId ?? null;
+}
+
+/**
+ * Resolve a `:id` URL param to a chat's internal UUID.
+ *
+ * - If the param already looks like a UUID, return it unchanged. The caller's
+ *   service layer will 404 if no chat exists with that UUID.
+ * - Otherwise treat it as a platform-native id (WhatsApp JID like
+ *   `120363...@g.us`, Telegram numeric id, Discord channel id, ...) and look
+ *   it up via `findByExternalIdSmart`. Requires the API key to have an
+ *   active instance set (via POST /context or POST /context/use), or an
+ *   explicit `instanceId` to use for the lookup.
+ *
+ * Returns null when:
+ *   - The param is not a UUID and no instance context is available.
+ *   - The param is not a UUID and no chat with that external id exists in
+ *     the resolved instance.
+ *
+ * History
+ * -------
+ * Before this helper, every `chatsRoutes.<verb>('/:id*')` passed the raw URL
+ * param straight to a service method that called `eq(<uuid_col>, raw)`. When
+ * a client (omni CLI's `omni history`, omni-mcp tools, custom integrations)
+ * called with the platform-native id, postgres-js rejected with
+ *   PostgresError: invalid input syntax for type uuid: "120363...@g.us"
+ * → 500 Server error. Same shape as the LID fix in b5929040 — we just missed
+ * the routes that didn't go through `getByExternalId`.
+ */
+async function resolveChatIdParam(
+  c: Context<{ Variables: AppVariables }>,
+  raw: string,
+  explicitInstanceId?: string,
+): Promise<string | null> {
+  if (UUID_REGEX.test(raw)) return raw;
+  const instanceId = explicitInstanceId ?? (await getActiveInstanceId(c));
+  if (!instanceId) return null;
+  const services = c.get('services');
+  const chat = await services.chats.findByExternalIdSmart(instanceId, raw);
+  return chat?.id ?? null;
+}
+
+/**
+ * Common 404 response for routes that couldn't resolve a `:id` to a chat —
+ * either a non-UUID param without instance context, or a UUID that doesn't
+ * map to any chat we know about.
+ */
+function chatNotFoundResponse(c: Context<{ Variables: AppVariables }>, raw: string) {
+  return c.json(
+    {
+      error: {
+        code: ERROR_CODES.NOT_FOUND,
+        message: `Chat not found: ${raw}. Pass either a chat UUID or set the API key's active instance via POST /api/v2/context/use first.`,
+      },
+    },
+    404,
+  );
 }
 
 /**
@@ -190,9 +277,15 @@ chatsRoutes.post('/', zValidator('json', createChatSchema), async (c) => {
 
 /**
  * GET /chats/:id - Get chat by ID
+ *
+ * Accepts either a chat UUID or a platform-native id (WhatsApp JID, Telegram
+ * numeric id, etc.) — the latter is resolved to the internal UUID via the
+ * API key's active-instance context. See `resolveChatIdParam`.
  */
 chatsRoutes.get('/:id', async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
 
   const chat = await services.chats.getById(id);
@@ -204,7 +297,9 @@ chatsRoutes.get('/:id', async (c) => {
  * PATCH /chats/:id - Update a chat
  */
 chatsRoutes.patch('/:id', zValidator('json', updateChatSchema), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const body = c.req.valid('json');
   const services = c.get('services');
 
@@ -217,7 +312,9 @@ chatsRoutes.patch('/:id', zValidator('json', updateChatSchema), async (c) => {
  * DELETE /chats/:id - Delete a chat (soft delete)
  */
 chatsRoutes.delete('/:id', async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
 
   await services.chats.delete(id);
@@ -498,7 +595,9 @@ chatsRoutes.post('/:id/unmute', zValidator('json', z.object({ instanceId: z.stri
  * GET /chats/:id/participants - Get chat participants
  */
 chatsRoutes.get('/:id/participants', async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
 
   const participants = await services.chats.getParticipants(id);
@@ -567,7 +666,9 @@ const listMessagesQuerySchema = z.object({
  * GET /chats/:id/messages - Get messages for a chat
  */
 chatsRoutes.get('/:id/messages', zValidator('query', listMessagesQuerySchema), async (c) => {
-  const chatId = c.req.param('id');
+  const raw = c.req.param('id');
+  const chatId = await resolveChatIdParam(c, raw);
+  if (chatId === null) return chatNotFoundResponse(c, raw);
   const { limit, before, after, mediaOnly } = c.req.valid('query');
   const services = c.get('services');
 


### PR DESCRIPTION
## Summary

Routes under `/api/v2/chats/:id*` passed the raw URL param straight to service methods that called `eq(<uuid_col>, raw)`. When clients (omni CLI's `omni history`, omni-mcp tools, custom integrations) called with a platform-native id (WhatsApp JID like `120363...@g.us`, `5511...@s.whatsapp.net`, `@lid`; Telegram numeric chat id; ...), `postgres-js` rejected with:

```
PostgresError: invalid input syntax for type uuid: "120363...@g.us"
```

→ **500 Server error** on the hot path of every chat-detail / chat-message read that wasn't pre-resolved by the caller.

## Live repro

omni `2.260501.1`, earliest occurrence in this server's logs is **2026-04-30 15:17:14**:

```
GET /api/v2/chats/120363425563375486@g.us/messages → 500 (28 ms)
GET /api/v2/chats/65315744/messages                → 500 (16 ms)
```

Both came from the standard `omni use <instance>` + `omni history` access pattern.

## Root cause history

The bug has been latent since [`04b8a5a9 feat(db,api): implement unified messages schema and services`](../commit/04b8a5a9) (2026-02-01) — the `/:id*` route handlers were born without external-id resolution. The companion LID fix [`b5929040 fix(lid): migrate all chats.getByExternalId to findByExternalIdSmart`](../commit/b5929040) (2026-02-19) covered 7 call sites that already used `getByExternalId` but **missed** the routes that go through `getById` / `getChatMessages` / `getParticipants` — those are the routes that 500 today.

## Fix

Two new helpers in `routes/v2/chats.ts`:

- **`getActiveInstanceId(c)`** — reads the API key's `contextInstanceId` (POST `/context`) → falls back to `activeInstanceId` (POST `/context/use`).
- **`resolveChatIdParam(c, raw, explicitInstanceId?)`**:
  - UUID input → returned unchanged. **No DB roundtrip on the hot path.**
  - Non-UUID → `findByExternalIdSmart(instanceId, raw)`. Returns `null` when no instance context OR no chat with that external id exists.

Applied to the routes that 500 today:

| Route | Service called |
|---|---|
| `GET /:id` | `services.chats.getById` |
| `GET /:id/messages` ← *the live 500* | `services.messages.getChatMessages` |
| `GET /:id/participants` | `services.chats.getParticipants` |
| `PATCH /:id` | `services.chats.update` |
| `DELETE /:id` | `services.chats.delete` |

When resolution fails (no instance context / unknown external id), the route now responds **404 with an actionable message** instead of letting postgres bomb with a 500:

```json
{
  "error": {
    "code": "NOT_FOUND",
    "message": "Chat not found: 120363...@g.us. Pass either a chat UUID or set the API key's active instance via POST /api/v2/context/use first."
  }
}
```

## Test plan

New `routes/v2/__tests__/chats-id-jid-resolution.test.ts` (11 tests, 34 expects):

- [x] UUID input bypasses resolution lookup (no wasted DB roundtrip)
- [x] WhatsApp group JID resolves and forwards the canonical UUID
- [x] Telegram numeric id resolves the same way
- [x] `contextInstanceId` takes precedence over `activeInstanceId`
- [x] **404 (not 500) when no active instance set**
- [x] 404 when JID doesn't match any chat in the active instance
- [x] Sister coverage for `/:id` (`getById`) and `/:id/participants`

Existing `chats-messages-after-validation.test.ts` updated to use a UUID chat id (it was using `chat-123` which now correctly 404s post-fix).

```
bun test packages/api
 978 pass / 285 skip / 0 fail
typecheck clean (turbo full pipeline)
biome clean
```

## Follow-up scope (separate PR)

The same surgery applies to the POST/DELETE routes that take `:id`:
`/:id/archive`, `/:id/unarchive`, `/:id/hide`, `/:id/unhide`, `/:id/label` (POST + DELETE), `/:id/pin`, `/:id/unpin`, `/:id/mute`, `/:id/unmute`, `/:id/read`, `/:id/disappearing`, `/:id/participants` (POST + DELETE), `/:id/participants/:platformUserId/role`.

They share the same latent bug but most receive an explicit `instanceId` in the body — the resolver already accepts an explicit `instanceId` to skip the API-key context lookup. Will land as a sweep once this lands and we have a clean diff to point reviewers at.