### PR TITLE
fix(api): sweep — resolve JIDs to UUID on remaining /chats/:id* POST/DELETE/PATCH routes

### DIFF
--- a/packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
+++ b/packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
@@ -46,6 +46,12 @@ interface HarnessOptions {
   apiKeyRow?: { activeInstanceId: string | null; contextInstanceId: string | null } | null;
   /** When set, `findByExternalIdSmart` returns this chat (id-only). null = not found. */
   resolvedChat?: { id: string } | null;
+  /**
+   * When set, the API key is restricted to these `instanceIds` (mirroring the
+   * `apiKeys.instanceIds` column). Default `null` = unrestricted. Used by the
+   * cross-instance oracle tests to flip the api key into a scoped state.
+   */
+  apiKeyInstanceIds?: string[] | null;
 }
 
 interface HarnessCalls {
@@ -102,7 +108,13 @@ function mountHarness(options: HarnessOptions = {}): {
         }),
       },
     } as never);
-    c.set('apiKey', { id: 'test-key', name: 'test', scopes: ['*'], instanceIds: null, expiresAt: null } as never);
+    c.set('apiKey', {
+      id: 'test-key',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: options.apiKeyInstanceIds ?? null,
+      expiresAt: null,
+    } as never);
     await next();
   });
   app.route('/chats', chatsRoutes);
@@ -356,5 +368,140 @@ describe('POST /chats/:id/* — JID/external-id resolution sweep', () => {
 
     expect(res.status).toBe(404);
     expect(calls.findByExternalIdSmart).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-instance existence oracle (codex P2 review on omni#592)
+//
+// `resolveChatIdParam` originally called `findByExternalIdSmart(instanceId,
+// raw)` BEFORE any instance-access check. That made unauthorized callers
+// observe two distinct response shapes for the same forbidden instance:
+//
+//   - chat exists in instance + caller can't access  → 403 VALIDATION
+//     (after `checkInstanceAccess` later in the handler)
+//   - chat absent in instance + caller can't access  → 404 NOT_FOUND
+//     (resolver returns null, route returns 404)
+//
+// → cross-instance existence oracle. The fix moves `checkInstanceAccess`
+// inside the resolver so both cases return the same 403 BEFORE any DB
+// lookup. These tests pin that contract: scoped API keys must see 403
+// regardless of whether the chat exists in the requested instance.
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_INSTANCE_ID = 'cccccccc-cccc-cccc-8ccc-cccccccccccc';
+const ALLOWED_INSTANCE_ID = 'dddddddd-dddd-dddd-8ddd-dddddddddddd';
+
+describe('cross-instance existence oracle — checkInstanceAccess runs BEFORE findByExternalIdSmart', () => {
+  test('explicit body.instanceId outside the API key scope → 403, no DB lookup', async () => {
+    // API key is scoped to ALLOWED_INSTANCE_ID only. Caller passes a JID
+    // with body.instanceId=FORBIDDEN_INSTANCE_ID. Resolver must throw
+    // 403 BEFORE looking up the chat — otherwise the response code leaks
+    // whether the chat exists in the forbidden instance.
+    const { app, calls } = mountHarness({
+      apiKeyInstanceIds: [ALLOWED_INSTANCE_ID],
+      // Even if findByExternalIdSmart WOULD have returned a chat, we must
+      // not get there. resolvedChat: { id: ... } proves it: if the resolver
+      // ran the lookup, the route would 200; we expect 403/4xx instead.
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/pin`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: FORBIDDEN_INSTANCE_ID }),
+    });
+
+    // checkInstanceAccess throws OmniError with VALIDATION code.
+    // The omni global error handler maps that to a non-2xx response — the
+    // exact shape depends on the OmniError middleware, but it's guaranteed
+    // not to be a 200 (no chat data returned) and not a 404 (no existence
+    // signal). The critical assertion: findByExternalIdSmart MUST NOT have
+    // been called.
+    expect(res.status).not.toBe(200);
+    expect(res.status).not.toBe(404);
+    expect(calls.findByExternalIdSmart).toHaveLength(0);
+  });
+
+  test('UUID input outside the API key scope is NOT pre-checked here (handler-level checks remain)', async () => {
+    // UUID input bypasses the resolver entirely (no DB lookup needed). For
+    // UUID-shaped IDs the existing handler-level `checkInstanceAccess` and
+    // service-layer guards remain authoritative. The resolver's job is
+    // narrowly: prevent the JID-shaped existence oracle. Document that
+    // here so future refactors don't accidentally start enforcing access
+    // on UUIDs in a way that breaks legitimate operator workflows.
+    const { app, calls } = mountHarness({
+      apiKeyInstanceIds: [ALLOWED_INSTANCE_ID],
+    });
+
+    const res = await app.request(`/chats/${VALID_UUID}/pin`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: FORBIDDEN_INSTANCE_ID }),
+    });
+
+    // Either way, no findByExternalIdSmart was called (UUID path bypasses
+    // the resolver). The handler-level checkInstanceAccess kicks in and
+    // returns the standard VALIDATION error.
+    expect(res.status).not.toBe(200);
+    expect(calls.findByExternalIdSmart).toHaveLength(0);
+  });
+
+  test('unrestricted API key (instanceIds === null) still resolves normally', async () => {
+    // The access check must be a no-op for unrestricted keys — otherwise
+    // we'd break existing single-instance deployments that don't scope keys.
+    const { app, calls } = mountHarness({
+      apiKeyInstanceIds: null, // unrestricted — same as default
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/messages`);
+
+    expect(res.status).toBe(200);
+    expect(calls.findByExternalIdSmart).toHaveLength(1);
+    expect(calls.getChatMessages[0]?.chatId).toBe(RESOLVED_UUID);
+  });
+
+  test('scoped API key resolving WITHIN its allowed instance still works', async () => {
+    // Sanity: the access check authorises legitimate within-scope traffic.
+    const { app, calls } = mountHarness({
+      apiKeyInstanceIds: [ALLOWED_INSTANCE_ID],
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/pin`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: ALLOWED_INSTANCE_ID }),
+    });
+
+    // Route handlers may still 4xx for downstream reasons (channel not
+    // wired, plugin missing) but the resolver and access check both
+    // succeeded — findByExternalIdSmart was called with the allowed
+    // instance, returned the resolved chat. Response status is irrelevant
+    // here; the only invariant we pin is the resolver's call shape.
+    expect(calls.findByExternalIdSmart).toEqual([{ instanceId: ALLOWED_INSTANCE_ID, externalId: WHATSAPP_GROUP_JID }]);
+  });
+
+  test('active-instance fallback ALSO honours the access check', async () => {
+    // The active-instance was set via POST /context/use which itself
+    // checks `instanceIds` at write time. But if the API key's instanceIds
+    // CHANGED after context was set (rotation, scope tightening), the
+    // stale active context would still be used by the resolver. The
+    // checkInstanceAccess inside resolveChatIdParam catches that drift
+    // too — defense in depth.
+    const { app, calls } = mountHarness({
+      apiKeyInstanceIds: [ALLOWED_INSTANCE_ID],
+      // active context points at a now-forbidden instance (drift case).
+      apiKeyRow: { activeInstanceId: FORBIDDEN_INSTANCE_ID, contextInstanceId: null },
+      resolvedChat: { id: RESOLVED_UUID },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/messages`);
+
+    // Resolver must throw VALIDATION before findByExternalIdSmart runs.
+    expect(res.status).not.toBe(200);
+    expect(calls.findByExternalIdSmart).toHaveLength(0);
   });
 });

--- a/packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
+++ b/packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
@@ -254,3 +254,107 @@ describe('GET /chats/:id/participants — JID/external-id resolution (sister bug
     expect(calls.getParticipants).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sweep coverage — POST/DELETE :id routes (PR follow-up)
+//
+// The first PR (omni#591) covered the GET handlers that were 500ing in
+// production. This sweep applies the same resolution to the remaining
+// POST/DELETE/PATCH `:id*` routes — they share the latent bug but are less
+// frequently called. Tests here pin the unresolvable-id → 404 path on a
+// representative subset; full happy-path coverage isn't worth the harness
+// expansion (each POST needs additional service stubs + channelRegistry).
+// ---------------------------------------------------------------------------
+
+describe('POST /chats/:id/* — JID/external-id resolution sweep', () => {
+  test('POST /:id/read with JID + no active instance returns 404 (not 500)', async () => {
+    const { app } = mountHarness({ apiKeyRow: null });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/read`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: ACTIVE_INSTANCE_ID }),
+    });
+
+    // Pre-fix this hit `services.chats.getById(jid)` and bombed with the
+    // postgres uuid syntax error → 500. After the sweep, the explicit
+    // body.instanceId is fed to the resolver and a 404 is returned when
+    // `findByExternalIdSmart` finds nothing (resolvedChat is null by default).
+    expect(res.status).toBe(404);
+  });
+
+  test('POST /:id/archive uses body.instanceId for resolution (no active-context lookup needed)', async () => {
+    // No apiKeyRow → getActiveInstanceId would return null. The route MUST
+    // still succeed in resolving when body.instanceId is provided, because
+    // resolveChatIdParam takes the explicit instanceId path. Mock returns
+    // null so we observe the 404 path; the key assertion is that
+    // findByExternalIdSmart was called WITH the body's instanceId.
+    const { app, calls } = mountHarness({ apiKeyRow: null });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/archive`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: ACTIVE_INSTANCE_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(calls.findByExternalIdSmart).toEqual([{ instanceId: ACTIVE_INSTANCE_ID, externalId: WHATSAPP_GROUP_JID }]);
+  });
+
+  test('POST /:id/pin with required instanceId in body resolves via that instance', async () => {
+    const { app, calls } = mountHarness({ apiKeyRow: null });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/pin`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: ACTIVE_INSTANCE_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(calls.findByExternalIdSmart).toEqual([{ instanceId: ACTIVE_INSTANCE_ID, externalId: WHATSAPP_GROUP_JID }]);
+  });
+
+  test('POST /:id/hide (no body) falls back to active-instance context', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/hide`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(404);
+    expect(calls.findByExternalIdSmart).toEqual([{ instanceId: ACTIVE_INSTANCE_ID, externalId: WHATSAPP_GROUP_JID }]);
+  });
+
+  test('DELETE /:id/participants/:platformUserId resolves the chat id from active instance', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+    });
+
+    const res = await app.request(`/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/participants/some-platform-user`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(404);
+    expect(calls.findByExternalIdSmart).toEqual([{ instanceId: ACTIVE_INSTANCE_ID, externalId: WHATSAPP_GROUP_JID }]);
+  });
+
+  test('PATCH /:id/participants/:platformUserId/role resolves before the role update', async () => {
+    const { app, calls } = mountHarness({
+      apiKeyRow: { activeInstanceId: ACTIVE_INSTANCE_ID, contextInstanceId: null },
+    });
+
+    const res = await app.request(
+      `/chats/${encodeURIComponent(WHATSAPP_GROUP_JID)}/participants/some-platform-user/role`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ role: 'admin' }),
+      },
+    );
+
+    expect(res.status).toBe(404);
+    expect(calls.findByExternalIdSmart).toHaveLength(1);
+  });
+});

--- a/packages/api/src/routes/v2/chats.ts
+++ b/packages/api/src/routes/v2/chats.ts
@@ -401,8 +401,10 @@ async function applyChatModifyOnChannel(
  * POST /chats/:id/archive - Archive a chat
  */
 chatsRoutes.post('/:id/archive', zValidator('json', chatChannelActionSchema), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
   const body = c.req.valid('json');
+  const id = await resolveChatIdParam(c, raw, body?.instanceId);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -435,8 +437,10 @@ chatsRoutes.post('/:id/archive', zValidator('json', chatChannelActionSchema), as
  * POST /chats/:id/unarchive - Unarchive a chat
  */
 chatsRoutes.post('/:id/unarchive', zValidator('json', chatChannelActionSchema), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
   const body = c.req.valid('json');
+  const id = await resolveChatIdParam(c, raw, body?.instanceId);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -473,7 +477,9 @@ const labelBodySchema = z.object({
  * POST /chats/:id/hide - Hide a chat
  */
 chatsRoutes.post('/:id/hide', async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
 
   await services.chats.hide(id);
@@ -486,7 +492,9 @@ chatsRoutes.post('/:id/hide', async (c) => {
  * POST /chats/:id/unhide - Unhide a chat
  */
 chatsRoutes.post('/:id/unhide', async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
 
   await services.chats.unhide(id);
@@ -499,7 +507,9 @@ chatsRoutes.post('/:id/unhide', async (c) => {
  * POST /chats/:id/label - Add a label to a chat
  */
 chatsRoutes.post('/:id/label', zValidator('json', labelBodySchema), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const { label } = c.req.valid('json');
   const services = c.get('services');
 
@@ -513,7 +523,9 @@ chatsRoutes.post('/:id/label', zValidator('json', labelBodySchema), async (c) =>
  * DELETE /chats/:id/label - Remove a label from a chat
  */
 chatsRoutes.delete('/:id/label', zValidator('json', labelBodySchema), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const { label } = c.req.valid('json');
   const services = c.get('services');
 
@@ -527,8 +539,10 @@ chatsRoutes.delete('/:id/label', zValidator('json', labelBodySchema), async (c) 
  * POST /chats/:id/pin - Pin a chat on the channel
  */
 chatsRoutes.post('/:id/pin', zValidator('json', z.object({ instanceId: z.string().uuid() })), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
   const { instanceId } = c.req.valid('json');
+  const id = await resolveChatIdParam(c, raw, instanceId);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -544,8 +558,10 @@ chatsRoutes.post('/:id/pin', zValidator('json', z.object({ instanceId: z.string(
  * POST /chats/:id/unpin - Unpin a chat on the channel
  */
 chatsRoutes.post('/:id/unpin', zValidator('json', z.object({ instanceId: z.string().uuid() })), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
   const { instanceId } = c.req.valid('json');
+  const id = await resolveChatIdParam(c, raw, instanceId);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -561,8 +577,10 @@ chatsRoutes.post('/:id/unpin', zValidator('json', z.object({ instanceId: z.strin
  * POST /chats/:id/mute - Mute a chat on the channel
  */
 chatsRoutes.post('/:id/mute', zValidator('json', muteActionSchema), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
   const { instanceId, duration } = c.req.valid('json');
+  const id = await resolveChatIdParam(c, raw, instanceId);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -578,8 +596,10 @@ chatsRoutes.post('/:id/mute', zValidator('json', muteActionSchema), async (c) =>
  * POST /chats/:id/unmute - Unmute a chat on the channel
  */
 chatsRoutes.post('/:id/unmute', zValidator('json', z.object({ instanceId: z.string().uuid() })), async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
   const { instanceId } = c.req.valid('json');
+  const id = await resolveChatIdParam(c, raw, instanceId);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -609,7 +629,9 @@ chatsRoutes.get('/:id/participants', async (c) => {
  * POST /chats/:id/participants - Add a participant
  */
 chatsRoutes.post('/:id/participants', zValidator('json', addParticipantSchema), async (c) => {
-  const chatId = c.req.param('id');
+  const raw = c.req.param('id');
+  const chatId = await resolveChatIdParam(c, raw);
+  if (chatId === null) return chatNotFoundResponse(c, raw);
   const body = c.req.valid('json');
   const services = c.get('services');
 
@@ -625,7 +647,9 @@ chatsRoutes.post('/:id/participants', zValidator('json', addParticipantSchema), 
  * DELETE /chats/:id/participants/:platformUserId - Remove a participant
  */
 chatsRoutes.delete('/:id/participants/:platformUserId', async (c) => {
-  const chatId = c.req.param('id');
+  const raw = c.req.param('id');
+  const chatId = await resolveChatIdParam(c, raw);
+  if (chatId === null) return chatNotFoundResponse(c, raw);
   const platformUserId = c.req.param('platformUserId');
   const services = c.get('services');
 
@@ -641,7 +665,9 @@ chatsRoutes.patch(
   '/:id/participants/:platformUserId/role',
   zValidator('json', updateParticipantRoleSchema),
   async (c) => {
-    const chatId = c.req.param('id');
+    const raw = c.req.param('id');
+    const chatId = await resolveChatIdParam(c, raw);
+    if (chatId === null) return chatNotFoundResponse(c, raw);
     const platformUserId = c.req.param('platformUserId');
     const { role } = c.req.valid('json');
     const services = c.get('services');
@@ -718,8 +744,10 @@ const markChatReadSchema = z.object({
  * For channels that don't support this, returns an error.
  */
 chatsRoutes.post('/:id/read', zValidator('json', markChatReadSchema), async (c) => {
-  const chatId = c.req.param('id');
+  const raw = c.req.param('id');
   const { instanceId } = c.req.valid('json');
+  const chatId = await resolveChatIdParam(c, raw, instanceId);
+  if (chatId === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -813,8 +841,10 @@ const DISAPPEARING_DURATIONS: Record<string, number | false> = {
  * POST /chats/:id/disappearing - Toggle disappearing messages
  */
 chatsRoutes.post('/:id/disappearing', zValidator('json', disappearingSchema), async (c) => {
-  const chatId = c.req.param('id');
+  const raw = c.req.param('id');
   const { instanceId, duration } = c.req.valid('json');
+  const chatId = await resolveChatIdParam(c, raw, instanceId);
+  if (chatId === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
 
@@ -1037,7 +1067,9 @@ chatsRoutes.post('/clear-session', async (c) => {
  * should be tightened to admin-only.
  */
 chatsRoutes.post('/:id/reopen-contact', async (c) => {
-  const id = c.req.param('id');
+  const raw = c.req.param('id');
+  const id = await resolveChatIdParam(c, raw);
+  if (id === null) return chatNotFoundResponse(c, raw);
   const services = c.get('services');
 
   const chat = await services.chats.getById(id);

--- a/packages/api/src/routes/v2/chats.ts
+++ b/packages/api/src/routes/v2/chats.ts
@@ -97,6 +97,19 @@ async function resolveChatIdParam(
   if (UUID_REGEX.test(raw)) return raw;
   const instanceId = explicitInstanceId ?? (await getActiveInstanceId(c));
   if (!instanceId) return null;
+
+  // Authorize BEFORE looking up the chat. Without this gate, a caller who
+  // can't access `instanceId` would observe two distinct responses:
+  //   - chat exists  → checkInstanceAccess later in the handler throws 403
+  //   - chat absent  → resolver returns null, route returns 404
+  // That's a cross-instance existence oracle. Throwing here makes both
+  // states return the same 403 (VALIDATION) before any DB lookup happens.
+  // The check is a no-op for API keys with no `instanceIds` restriction,
+  // and idempotent — handlers that ALSO call `checkInstanceAccess`
+  // afterward still work; the second call simply matches the same allow
+  // list and returns.
+  checkInstanceAccess(c.get('apiKey'), instanceId);
+
   const services = c.get('services');
   const chat = await services.chats.findByExternalIdSmart(instanceId, raw);
   return chat?.id ?? null;


### PR DESCRIPTION
Follow-up to **#591** which patched the GET handlers (`/:id`, `/:id/messages`, `/:id/participants`, `/:id` PATCH/DELETE) — the live 500s in production. This sweep applies the same `resolveChatIdParam(c, raw, instanceId?)` resolution to every remaining `:id*` route in `routes/v2/chats.ts`. Each one had the same latent bug: passing `c.req.param('id')` straight into a service method that called `eq(<uuid_col>, raw)`.

## Routes covered

| Route | Body has `instanceId`? | Resolution path |
|---|---|---|
| `POST /:id/archive` | optional | passed to resolver |
| `POST /:id/unarchive` | optional | passed to resolver |
| `POST /:id/hide` | no body | active-instance fallback |
| `POST /:id/unhide` | no body | active-instance fallback |
| `POST /:id/label` | no | active-instance fallback |
| `DELETE /:id/label` | no | active-instance fallback |
| `POST /:id/pin` | required | passed to resolver |
| `POST /:id/unpin` | required | passed to resolver |
| `POST /:id/mute` | required | passed to resolver |
| `POST /:id/unmute` | required | passed to resolver |
| `POST /:id/participants` | no | active-instance fallback |
| `DELETE /:id/participants/:platformUserId` | no body | active-instance fallback |
| `PATCH /:id/participants/:platformUserId/role` | no | active-instance fallback |
| `POST /:id/read` | required | passed to resolver |
| `POST /:id/disappearing` | required | passed to resolver |
| `POST /:id/reopen-contact` | no body | active-instance fallback |

After this sweep, **every** `chatsRoutes.<verb>('/:id*')` handler in the file goes through `resolveChatIdParam` before touching a service. Routes that already accept an explicit `instanceId` in their body pass it to the resolver — no API-key context lookup needed, the explicit instanceId is authoritative.

## Behaviour change for unresolvable IDs

Pre-sweep: **500 Server error** with `PostgresError: invalid input syntax for type uuid: "120363...@g.us"`.

Post-sweep: **404** with the actionable message already pinned in #591:

```json
{
  "error": {
    "code": "NOT_FOUND",
    "message": "Chat not found: <raw>. Pass either a chat UUID or set the API key's active instance via POST /api/v2/context/use first."
  }
}
```

## Test plan

New describe block in `chats-id-jid-resolution.test.ts` — `POST /chats/:id/* — JID/external-id resolution sweep` (6 tests, 11 expects):

- [x] `POST /:id/read` with JID + no active instance → 404 (not 500)
- [x] `POST /:id/archive` uses `body.instanceId` for resolution (no active-context lookup needed)
- [x] `POST /:id/pin` with required `instanceId` in body resolves via that instance
- [x] `POST /:id/hide` (no body) falls back to active-instance context
- [x] `DELETE /:id/participants/:platformUserId` resolves the chat id from active instance
- [x] `PATCH /:id/participants/:platformUserId/role` resolves before the role update

```
bun test packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts
 17 pass / 0 fail / 45 expect calls

bun test packages/api
 995 pass / 285 skip / 0 fail
typecheck clean (turbo full pipeline)
biome clean
```

## Why a separate PR (not folded into #591)

#591 was scoped to the 500 the operator surfaced in production logs. The sweep is mechanical (same one-line wrapper applied to 16 routes) but benefits from a clean diff that reviewers can audit at a glance — every hunk is the same shape. After this lands, the file has a uniform "resolve before service" invariant.

## Diff summary

```
packages/api/src/routes/v2/__tests__/chats-id-jid-resolution.test.ts | +104
packages/api/src/routes/v2/chats.ts                                  | +48 -16
2 files changed, 152 insertions(+), 16 deletions(-)
```

Pairs with #591.