### PR TITLE
fix(automations): consumer-side stale-event gate for chat.idle_timeout

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -553,6 +553,14 @@ async function setupEventBusServices(
           },
         };
       },
+      // Consumer-side stale-event gate — see engine.handleEvent comment.
+      // Skips chat.idle_timeout events whose row has been disarmed since the
+      // sweeper published the event, or whose chat is in active close-contact
+      // state. Fail-open on errors so a flaky DB doesn't drop legitimate
+      // events.
+      staleIdleTimeoutGate: async (chatId, instanceId) => {
+        return services.followUpLifecycle.evaluateIdleTimeoutFreshness(chatId, instanceId);
+      },
     });
   } catch (error) {
     log.error('Failed to start automation engine', { error: String(error) });

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -49,6 +49,7 @@ export class AutomationService {
   async startEngine(deps?: {
     sendMessage?: (instanceId: string, to: string, content: string) => Promise<void>;
     callAgent?: (context: AgentCallContext, config: CallAgentActionConfig) => Promise<AgentRunResult>;
+    staleIdleTimeoutGate?: (chatId: string, instanceId: string) => Promise<{ skip: boolean; reason?: string }>;
   }): Promise<void> {
     if (!this.eventBus) {
       return;

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -374,6 +374,39 @@ export class FollowUpLifecycleService {
   }
 
   /**
+   * Consumer-side freshness check for `chat.idle_timeout` events. Mirrors
+   * the publish-time guards in the sweeper but runs at delivery time so the
+   * automation engine can drop events whose chat state has changed since
+   * the sweeper enqueued them — the case that bit us when the durable
+   * consumer's ack state was reset by a deploy and the SYSTEM stream
+   * replayed historical idle-timeout events from days ago (2026-05-01).
+   *
+   * Returns `{ skip: true, reason }` when the engine MUST drop the event:
+   *  - chat is in active close-contact state (`closed: true` or
+   *    `closeUntil` still in window) — agent should not nudge a closed chat
+   *  - follow-up row's `disarmReason` is set — sequence is in a terminal
+   *    state and any further fire would re-spam a chat the system already
+   *    finished/handed-off/archived
+   *
+   * Returns `{ skip: false }` when the event should proceed normally.
+   *
+   * Fail-open: callers should swallow exceptions from this method and let
+   * the event flow through. The engine logs the failure but doesn't drop —
+   * a flaky DB at consumer time is less harmful than silently dropping
+   * legitimate idle-timeout events.
+   */
+  async evaluateIdleTimeoutFreshness(chatId: string, instanceId: string): Promise<{ skip: boolean; reason?: string }> {
+    if (await this.isInActiveCloseState(chatId, instanceId)) {
+      return { skip: true, reason: 'chat_closed' };
+    }
+    const row = await this.readExistingRow(chatId, instanceId);
+    if (row?.disarmReason) {
+      return { skip: true, reason: `disarmed_${row.disarmReason}` };
+    }
+    return { skip: false };
+  }
+
+  /**
    * Read the minimum fields required by the terminal-disarm guard in
    * `armForOutbound`. Returns `null` when no row exists yet.
    */

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -67,6 +67,19 @@ export interface ActionDependencies {
    * The response is stored in variables for use in subsequent actions.
    */
   callAgent?: (context: AgentCallContext, config: CallAgentActionConfig) => Promise<AgentRunResult>;
+  /**
+   * Optional consumer-side stale-event gate. Invoked by the engine for
+   * `chat.idle_timeout` events before matching automations execute.
+   * Returns `{ skip: true, reason }` when the event is no longer relevant
+   * (chat in active close-contact state, follow-up row already disarmed,
+   * etc.). Defense-in-depth against NATS replay of historical idle-timeout
+   * events that the sweeper had already processed before a restart drained
+   * the durable consumer's ack state.
+   *
+   * Returning `{ skip: false }` (or omitting the gate entirely) lets the
+   * engine proceed with normal matching+execution.
+   */
+  staleIdleTimeoutGate?: (chatId: string, instanceId: string) => Promise<{ skip: boolean; reason?: string }>;
 }
 
 /**

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -120,6 +120,7 @@ export class AutomationEngine {
       eventBus,
       sendMessage: deps.sendMessage,
       callAgent: deps.callAgent,
+      staleIdleTimeoutGate: deps.staleIdleTimeoutGate,
     };
     this.automations = automations.filter((a) => a.enabled);
 
@@ -336,6 +337,51 @@ export class AutomationEngine {
   }
 
   /**
+   * Consumer-side stale-event gate for `chat.idle_timeout` — defense in depth
+   * against NATS replay of historical idle-timeout events whose chat state
+   * has since changed (sequence completed, customer replied, handoff,
+   * close-contact). The sweeper already filters these at publish time, but a
+   * durable-consumer reset (e.g. config-incompat delete+recreate on toggle
+   * or restart — see #546 follow-on) replays anything still in the SYSTEM
+   * stream's retention window. Without this gate the engine fires
+   * call_agent + send_message for every replayed event regardless of the
+   * chat's current state — the spam pattern reported on 2026-05-01.
+   *
+   * Returns `true` when the event should be dropped (gate said skip).
+   * Returns `false` when the event should proceed (no gate, missing payload
+   * fields, gate said proceed, or gate threw — fail-open by design).
+   */
+  private async shouldSkipStaleIdleTimeout(event: OmniEvent): Promise<boolean> {
+    if (event.type !== 'chat.idle_timeout' || !this.deps.staleIdleTimeoutGate) return false;
+    const payload = event.payload as { chatId?: string; instanceId?: string };
+    const chatId = payload?.chatId;
+    const payloadInstanceId = payload?.instanceId ?? event.metadata.instanceId;
+    if (!chatId || !payloadInstanceId) return false;
+
+    try {
+      const verdict = await this.deps.staleIdleTimeoutGate(chatId, payloadInstanceId);
+      if (verdict.skip) {
+        logger.info('Skipping stale chat.idle_timeout event', {
+          eventId: event.id,
+          chatId,
+          instanceId: payloadInstanceId,
+          reason: verdict.reason ?? 'unknown',
+        });
+        return true;
+      }
+    } catch (err) {
+      // Fail-open — better to fire a redundant follow-up than to silently
+      // drop legitimate events when the DB is flaky.
+      logger.warn('staleIdleTimeoutGate threw, proceeding without skip', {
+        eventId: event.id,
+        chatId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return false;
+  }
+
+  /**
    * Handle an incoming event
    */
   private async handleEvent(event: OmniEvent): Promise<void> {
@@ -346,6 +392,10 @@ export class AutomationEngine {
     const matchingAutomations = this.automations.filter((a) => a.triggerEventType === eventType);
 
     if (matchingAutomations.length === 0) {
+      return;
+    }
+
+    if (await this.shouldSkipStaleIdleTimeout(event)) {
       return;
     }
 


### PR DESCRIPTION
> **Status: draft, leaving open for live monitoring evidence to accumulate.** This patch is currently running in production at a downstream production tenant via a local dist swap; this PR is the upstream landing path. Will mark ready-for-review once the post-fix monitoring window is long enough to be conclusive.

## Summary

After a deploy that drains the durable consumer's ack state, the `automation-engine-chat-idle_timeout` durable replays historical `chat.idle_timeout` events from the SYSTEM stream. The automation engine has no chat-state check at delivery — it fires `call_agent` + `send_message` for every replayed event regardless of whether the chat has since been disarmed (`sequence_complete`, `customer_replied`, `handoff`, `contact_closed`) or closed via close-contact. Each replayed event becomes a follow-up to a chat that no longer wants one.

This adds a consumer-side stale-event gate, mirroring the publish-time guards the sweeper already applies.

## Repro path

1. Run a deploy that hits `client.ts:updateOrRecreateConsumer` (e.g. config diff that delete+recreates the durable).
2. Re-enable an automation that consumes `chat.idle_timeout`.
3. Engine drains the SYSTEM stream's retention buffer through the new consumer; every replayed event fires the automation regardless of current chat state.

We saw this on 2026-05-01 at 08:00 BRT after a normal toggle off → restart → toggle on cycle. ~3,300 follow-ups went out to chats whose sequences had completed days prior. The per-chat duplicate guard from #546 held throughout (zero <60s repeats), so this is a population-level regression, not a per-chat one.

## Fix

| file | change |
|---|---|
| `packages/core/src/automations/actions.ts` | new optional `staleIdleTimeoutGate` field on `ActionDependencies` |
| `packages/core/src/automations/engine.ts` | new `shouldSkipStaleIdleTimeout` helper called from `handleEvent` for `chat.idle_timeout` events. Fail-open on gate exceptions. |
| `packages/api/src/services/follow-up-lifecycle.ts` | new public `evaluateIdleTimeoutFreshness(chatId, instanceId)` checking `isInActiveCloseState` + `readExistingRow().disarmReason` |
| `packages/api/src/services/automations.ts` | `startEngine` deps signature accepts the new gate |
| `packages/api/src/index.ts` | wires the gate from API services into engine deps |

5 files, 105 lines added, 0 changed.

The gate logic is intentionally a duplicate of the publish-time guards already in the sweeper and lifecycle service — that's the point. Sweeper filtering is correct; the bug is that historical events bypass it on replay. This adds the same check at the delivery side.

## Why not "delete the consumer and clear the backlog instead"

Tempting, and would address this specific regression, but it doesn't help with the more general class of "events delayed long enough that the chat state has changed in the meantime" (NATS redelivery on transient handler failure, slow consumer catching up after backpressure, etc.). A consumer-side gate handles all of those cases; clearing the consumer only handles the deploy-restart case.

A defense-in-depth improvement to `updateOrRecreateConsumer` (preserve checkpoint or explicitly clear pending events) is reasonable as a follow-up, but should not block this fix.

## Validation

Running in production at a downstream production tenant since 2026-05-01 ~15:50 BRT. Live metrics:

```
post-fix slice (~2h):
  300+ fires, ALL active_at_fire (no fires after disarm)
  ~30/min stale events skipped via gate (backlog draining cleanly)
  0 close leaks, 0 handoff leaks, 0 per-session repeats <60s
```

## Test plan

- [x] \`bun typecheck\` clean (core + api)
- [x] \`bunx biome check\` clean
- [x] Full suite passes (3991 tests, pre-push gate green)
- [x] Live production validation (at a downstream production tenant, ~2h post-fix as of opening this PR — will extend before marking ready)
- [ ] Unit test in \`packages/core/src/automations/__tests__/engine.test.ts\` covering: stale event skip, fresh event proceed, gate exception fail-open
- [ ] Integration test in \`packages/api/src/__tests__/follow-up-e2e.test.ts\` covering: replay scenario after consumer recreate

## Refs

- Incident snapshot: \`namastexlabs/genie-at a downstream production tenant\` PR #38, \`brain/snapshots/deploy-2026-04-30/INCIDENT.md\`
- Related fixes already in dev: #546 (single-flight reconcile + recursive setTimeout), #535/#528 (handoff disarm), #559 (close-contact endpoint)