### PR TITLE
feat(api,doctor): deprecate embedded pgserve mode (phase 1 — warn, no behavior change)

### DIFF
--- a/packages/api/src/pgserve.ts
+++ b/packages/api/src/pgserve.ts
@@ -707,12 +707,39 @@ async function tryStartOnPort(startFn: StartServerFn, port: number, config: Pgse
  *
  * Returns the DATABASE_URL to use for connections.
  * If PGSERVE_EMBEDDED is false, returns the existing DATABASE_URL / default.
+ *
+ * DEPRECATION (2026-05-01)
+ * ------------------------
+ * Embedded mode is on the deprecation path. The canonical replacement is a
+ * pm2-supervised pgserve registered via `pgserve install` (Wave 1 of the
+ * canonical-pgserve-pm2-supervision wish, pgserve@^2.1.0). Operators still
+ * on embedded should migrate via `omni doctor --fix`, which runs the full
+ * pg_dump → install → pg_restore → relaunch chain. Embedded code will be
+ * removed once canonical is proven across the fleet — see the LOUD warning
+ * surfaced below on every embedded boot.
  */
 export async function startEmbeddedPgserve(config: PgserveConfig): Promise<string> {
   if (!config.enabled) {
     const url = process.env.DATABASE_URL ?? getDefaultDatabaseUrl();
     log.info('Embedded pgserve disabled, using external database', { url: url.replace(/\/\/.*@/, '//***@') });
     return url;
+  }
+
+  // Loud deprecation banner — surfaces in pm2's log feed every time omni-api
+  // boots on embedded so operators see it without having to read this file.
+  // Suppressible via OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true for
+  // operators who can't migrate immediately and want a quieter log.
+  if (process.env.OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING !== 'true') {
+    log.warn(
+      'Embedded pgserve is DEPRECATED. Migrate to canonical pgserve via `omni doctor --fix` ' +
+        '(automated: pg_dump → pgserve install → restore → relaunch). Set ' +
+        'OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true to silence.',
+      {
+        deprecation: 'embedded-pgserve',
+        recommendedAction: 'omni doctor --fix',
+        scheduledRemovalAfter: 'fleet-canonical-adoption',
+      },
+    );
   }
 
   // Validate PGSERVE_DATA before doing anything else. Throws PgserveRelativeDataPathError

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -890,7 +890,7 @@ function checkPgserveCanonical(deps: DoctorDeps): CheckResult {
     id: 'pgserve-canonical',
     level: 'WARN',
     detail:
-      'using embedded pgserve — pgserve@^2.1.0 has grown up and is now the recommended shared backbone. Run `omni doctor --fix` to migrate (idempotent; preserves all data).',
+      'using embedded pgserve — DEPRECATED. Canonical pgserve@^2.1.0 is the supported path; embedded mode will be removed in a future release. Run `omni doctor --fix` to migrate (idempotent; pg_dump → pgserve install → restore → relaunch).',
   };
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the embedded-pgserve removal plan: **visible deprecation without behavior change**. Operators on legacy embedded installs see the warning + the remediation path; operators already on canonical see no change.

## Why phase 1, not removal

Embedded mode is ~800 LOC of battle-hardened lifecycle code (libicu shim, port retry, orphan kill, cwd-drift guards, validatePgserveDataDir, startEmbeddedPgserve, stopEmbeddedPgserve, ensureInternalPortFree, etc.). Removing it in one PR would break every legacy install that hasn't yet run `omni doctor --fix`. Phased approach:

1. **THIS PR** — visible deprecation, no behavior change.
2. (later) — flip the default + bump major version.
3. (later) — delete embedded code + drop pgserve from `packages/api` runtime deps.

## What this PR adds

### `packages/api/src/pgserve.ts::startEmbeddedPgserve`

Loud deprecation banner via `log.warn` whenever embedded mode boots:

```
[api:pgserve] WARN  Embedded pgserve is DEPRECATED. Migrate to
canonical pgserve via `omni doctor --fix` (automated: pg_dump →
pgserve install → restore → relaunch). Set
OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true to silence.
{ deprecation: 'embedded-pgserve',
  recommendedAction: 'omni doctor --fix',
  scheduledRemovalAfter: 'fleet-canonical-adoption' }
```

- Surfaces in pm2's log feed every restart so operators see it without grepping or re-reading docs.
- Structured fields enable future log-based fleet inventories ("how many hosts still on embedded?").
- Suppression escape hatch: `OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true` for operators who can't migrate immediately and want a quieter log.
- Added a docblock comment explaining the deprecation path.

### `packages/cli/src/commands/doctor.ts::checkPgserveCanonical`

Strengthened the WARN detail message:

```
WARN  pgserve-canonical  using embedded pgserve — DEPRECATED. Canonical
pgserve@^2.1.0 is the supported path; embedded mode will be removed in
a future release. Run `omni doctor --fix` to migrate (idempotent;
pg_dump → pgserve install → restore → relaunch).
```

Still shows the same `omni doctor --fix` migration command as the resolution.

## Compatibility

Pure-additive: every code path behaves identically. Operators just see a louder warning. Existing tests pass unchanged (the WARN-level assertion in `doctor.test.ts` only checks for `embedded pgserve` + `omni doctor --fix` substrings, both still present).

## Test plan

- [x] `bun run typecheck` — green (turbo, all 21 packages)
- [x] `bun test packages/cli/src/__tests__/doctor.test.ts` — **39/39 pass**
- [ ] Manual on a legacy embedded host: restart omni-api, confirm WARN line appears in pm2 logs
- [ ] Manual on a canonical host: confirm NO warning appears (config.enabled is false → early return before the warn)

## Removal timeline (follow-up PRs)

After fleet adoption (operator surveys + log-based inventory of which hosts still run embedded), a follow-up PR removes:

- `startEmbeddedPgserve` + `stopEmbeddedPgserve` + libicu shim + validation guards (~800 LOC)
- `pgserve: "^2.1.0"` from `packages/api/package.json` runtime deps
- `useCanonicalPgserve` config flag (becomes meaningless)
- The `PGSERVE_EMBEDDED` env var consumer in `resolvePgserveConfig`
