### PR TITLE
feat(api,doctor): deprecate embedded pgserve mode (phase 1 — warn, no behavior change)

### DIFF
--- a/packages/api/src/__tests__/pgserve.test.ts
+++ b/packages/api/src/__tests__/pgserve.test.ts
@@ -421,7 +421,7 @@ describe('killOrphanedPostgres — postmaster.pid path (preserved legacy behavio
 
 describe('resolvePgserveConfig — #412 env surface', () => {
   const saved: Record<string, string | undefined> = {};
-  const keys = ['PGSERVE_DATA', 'PGSERVE_REQUIRE_EXISTING', 'PGSERVE_ALLOW_RELATIVE_DATA'];
+  const keys = ['PGSERVE_EMBEDDED', 'PGSERVE_DATA', 'PGSERVE_REQUIRE_EXISTING', 'PGSERVE_ALLOW_RELATIVE_DATA'];
 
   beforeEach(() => {
     for (const k of keys) {
@@ -451,6 +451,25 @@ describe('resolvePgserveConfig — #412 env surface', () => {
   test('reads PGSERVE_ALLOW_RELATIVE_DATA=true', () => {
     process.env.PGSERVE_ALLOW_RELATIVE_DATA = 'true';
     expect(resolvePgserveConfig().allowRelativeData).toBe(true);
+  });
+
+  // Phase 2 (2026-05-01): embedded mode is now an explicit opt-in.
+  // The default flipped from `(PGSERVE_EMBEDDED ?? 'true') === 'true'`
+  // (default ON) to `PGSERVE_EMBEDDED === 'true'` (default OFF).
+  test('embedded mode defaults to OFF when PGSERVE_EMBEDDED is unset (phase 2)', () => {
+    expect(resolvePgserveConfig().enabled).toBe(false);
+  });
+
+  test('embedded mode is OFF when PGSERVE_EMBEDDED is anything other than the literal "true"', () => {
+    for (const value of ['false', '0', '', 'TRUE', 'yes', 'no']) {
+      process.env.PGSERVE_EMBEDDED = value;
+      expect(resolvePgserveConfig().enabled).toBe(false);
+    }
+  });
+
+  test('embedded mode is ON only when PGSERVE_EMBEDDED is exactly "true"', () => {
+    process.env.PGSERVE_EMBEDDED = 'true';
+    expect(resolvePgserveConfig().enabled).toBe(true);
   });
 });
 

--- a/packages/api/src/pgserve.ts
+++ b/packages/api/src/pgserve.ts
@@ -6,7 +6,11 @@
  * separate PM2 service.
  *
  * Controlled by env vars:
- *   PGSERVE_EMBEDDED            — 'true' (default) to start in-process, 'false' to skip
+ *   PGSERVE_EMBEDDED            — 'true' to start in-process. ⚠️ DEPRECATED — phase
+ *                                 2 (2026-05-01) flipped the default to OFF.
+ *                                 Embedded mode is now an explicit opt-in;
+ *                                 unset / 'false' / any-other-value = canonical
+ *                                 (omni-api connects to DATABASE_URL).
  *   PGSERVE_PORT                — port for the embedded PostgreSQL proxy (default 8432)
  *   PGSERVE_DATA                — data directory path; defaults to ~/.omni/data/pgserve (set to empty string for memory mode)
  *   PGSERVE_ALLOW_RELATIVE_DATA — when 'true', allows PGSERVE_DATA to be a relative path (DANGEROUS — PM2 cwd drift can swap data dirs). Default: reject.
@@ -129,9 +133,16 @@ let serverInstance: PgserveInstance | null = null;
  * resolving so tests can exercise parsing independently from filesystem
  * checks. Falls back to the canonical `~/.omni/data/pgserve` when
  * `PGSERVE_DATA` is unset (the default is always absolute).
+ *
+ * Phase 2 default flip (2026-05-01): `PGSERVE_EMBEDDED` defaults to OFF
+ * when unset. Embedded mode is now an explicit opt-in (`PGSERVE_EMBEDDED=
+ * true`). The CLI's `buildRuntimeEnv` flips this var explicitly based on
+ * `serverConfig.useCanonicalPgserve`, so this default only matters when
+ * omni-api is launched directly (e.g., bare `bun packages/api/src/index.ts`)
+ * without the CLI's env wiring.
  */
 export function resolvePgserveConfig(): PgserveConfig {
-  const enabled = (process.env.PGSERVE_EMBEDDED ?? 'true') === 'true';
+  const enabled = process.env.PGSERVE_EMBEDDED === 'true';
   const port = Number.parseInt(process.env.PGSERVE_PORT ?? '8432', 10);
   const raw = process.env.PGSERVE_DATA;
   // Default to persistent storage inside ~/.omni/data/pgserve — never memory mode unless explicitly empty

--- a/packages/cli/src/__tests__/runtime-env.test.ts
+++ b/packages/cli/src/__tests__/runtime-env.test.ts
@@ -64,7 +64,7 @@ describe('resolveDatabaseUrl', () => {
 });
 
 describe('buildRuntimeEnv', () => {
-  test('produces the full hermetic env for embedded mode', () => {
+  test('produces the full hermetic env (canonical default — useCanonicalPgserve undefined)', () => {
     const serverConfig = {
       ...DEFAULT_SERVER_CONFIG,
       port: 8882,
@@ -82,12 +82,34 @@ describe('buildRuntimeEnv', () => {
     expect(env.OMNI_API_KEY).toBe('omni_sk_test-key');
     expect(env.MEDIA_STORAGE_PATH).toBe('/tmp/omni-test/media');
     expect(env.OMNI_PACKAGES_DIR).toBe('/tmp/omni-test/packages');
-    expect(env.PGSERVE_EMBEDDED).toBe('true');
+    // Phase 2 (2026-05-01): default flipped. Undefined useCanonicalPgserve
+    // now means CANONICAL, not embedded. Operators on legacy who want
+    // embedded must explicitly set `useCanonicalPgserve: false`.
+    expect(env.PGSERVE_EMBEDDED).toBe('false');
     expect(env.PGSERVE_DATA).toBe('/tmp/omni-test/pgserve');
     expect(env.PGSERVE_PORT).toBe(String(DEFAULT_PGSERVE_PORT));
     expect(env.NATS_URL).toBe('nats://localhost:4222');
     expect(env.NODE_ENV).toBe('production');
     expect(env.LOG_LEVEL).toBe('info');
+  });
+
+  test('PGSERVE_EMBEDDED=true only when useCanonicalPgserve is explicitly false (legacy opt-out)', () => {
+    const serverConfig = { ...DEFAULT_SERVER_CONFIG, useCanonicalPgserve: false };
+    const env = buildRuntimeEnv(serverConfig, { apiKey: 'k' });
+    expect(env.PGSERVE_EMBEDDED).toBe('true');
+  });
+
+  test('PGSERVE_EMBEDDED=false when useCanonicalPgserve is explicitly true', () => {
+    const serverConfig = { ...DEFAULT_SERVER_CONFIG, useCanonicalPgserve: true };
+    const env = buildRuntimeEnv(serverConfig, { apiKey: 'k' });
+    expect(env.PGSERVE_EMBEDDED).toBe('false');
+  });
+
+  test('PGSERVE_EMBEDDED=false when useCanonicalPgserve is undefined (default flipped in phase 2)', () => {
+    const serverConfig = { ...DEFAULT_SERVER_CONFIG };
+    expect(serverConfig.useCanonicalPgserve).toBeUndefined();
+    const env = buildRuntimeEnv(serverConfig, { apiKey: 'k' });
+    expect(env.PGSERVE_EMBEDDED).toBe('false');
   });
 
   test('respects an explicit external-DB URL from config', () => {

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -98,22 +98,36 @@ export function resolveDatabaseUrl(serverConfig: ServerConfig): string {
  *
  * All values come from `serverConfig` / `cliConfig`. No shell env reads.
  *
- * `PGSERVE_EMBEDDED` is flipped off when `serverConfig.useCanonicalPgserve`
- * is true — the omni-api code path in `packages/api/src/pgserve.ts` reads
- * this and skips its embedded pgserve startup, connecting instead to
- * whatever `DATABASE_URL` points at (typically the canonical pgserve
- * registered by `pgserve install` from pgserve@^2.1.0).
+ * `PGSERVE_EMBEDDED` semantics (Phase 2 of canonical-pgserve removal):
+ *   - serverConfig.useCanonicalPgserve === false  → 'true'  (embedded — explicit opt-in)
+ *   - serverConfig.useCanonicalPgserve === true   → 'false' (canonical — explicit opt-in)
+ *   - undefined / missing                          → 'false' (canonical — NEW DEFAULT)
+ *
+ * Phase 1 (omni#595, 2026-05-01) added the deprecation warning to
+ * `startEmbeddedPgserve`. Phase 2 (this file) flips the default for
+ * undefined values: legacy installs that never set the flag now get
+ * canonical instead of embedded. Operators on legacy embedded who
+ * haven't migrated must explicitly set `useCanonicalPgserve: false` in
+ * `~/.omni/config.json` (or run `omni doctor --fix` to migrate to
+ * canonical, the supported path).
+ *
+ * Phase 3 (future) deletes the embedded code entirely + drops the
+ * pgserve runtime dep from `packages/api`.
  */
 export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config): RuntimeEnv {
   const pgservePort = resolvePgservePort(serverConfig);
-  const useCanonical = serverConfig.useCanonicalPgserve === true;
+  // Embedded mode is now an explicit opt-OUT, not the default. Only when
+  // `useCanonicalPgserve` is explicitly false do we ask the API to spawn
+  // its embedded pgserve. Anything else (true OR undefined) flips embedded
+  // off and connects to the URL stored in serverConfig.databaseUrl.
+  const optOutOfCanonical = serverConfig.useCanonicalPgserve === false;
   return {
     API_PORT: String(serverConfig.port),
     DATABASE_URL: resolveDatabaseUrl(serverConfig),
     OMNI_API_KEY: cliConfig.apiKey ?? '',
     MEDIA_STORAGE_PATH: join(serverConfig.dataDir, 'media'),
     OMNI_PACKAGES_DIR: join(serverConfig.dataDir, 'packages'),
-    PGSERVE_EMBEDDED: useCanonical ? 'false' : 'true',
+    PGSERVE_EMBEDDED: optOutOfCanonical ? 'true' : 'false',
     PGSERVE_DATA: join(serverConfig.dataDir, 'pgserve'),
     PGSERVE_PORT: String(pgservePort),
     NATS_URL: 'nats://localhost:4222',


### PR DESCRIPTION
## Summary

Phase 1 of the embedded-pgserve removal plan: **visible deprecation without behavior change**. Operators on legacy embedded installs see the warning + the remediation path; operators already on canonical see no change.

## Why phase 1, not removal

Embedded mode is ~800 LOC of battle-hardened lifecycle code (libicu shim, port retry, orphan kill, cwd-drift guards, validatePgserveDataDir, startEmbeddedPgserve, stopEmbeddedPgserve, ensureInternalPortFree, etc.). Removing it in one PR would break every legacy install that hasn't yet run `omni doctor --fix`. Phased approach:

1. **THIS PR** — visible deprecation, no behavior change.
2. (later) — flip the default + bump major version.
3. (later) — delete embedded code + drop pgserve from `packages/api` runtime deps.

## What this PR adds

### `packages/api/src/pgserve.ts::startEmbeddedPgserve`

Loud deprecation banner via `log.warn` whenever embedded mode boots:

```
[api:pgserve] WARN  Embedded pgserve is DEPRECATED. Migrate to
canonical pgserve via `omni doctor --fix` (automated: pg_dump →
pgserve install → restore → relaunch). Set
OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true to silence.
{ deprecation: 'embedded-pgserve',
  recommendedAction: 'omni doctor --fix',
  scheduledRemovalAfter: 'fleet-canonical-adoption' }
```

- Surfaces in pm2's log feed every restart so operators see it without grepping or re-reading docs.
- Structured fields enable future log-based fleet inventories ("how many hosts still on embedded?").
- Suppression escape hatch: `OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true` for operators who can't migrate immediately and want a quieter log.
- Added a docblock comment explaining the deprecation path.

### `packages/cli/src/commands/doctor.ts::checkPgserveCanonical`

Strengthened the WARN detail message:

```
WARN  pgserve-canonical  using embedded pgserve — DEPRECATED. Canonical
pgserve@^2.1.0 is the supported path; embedded mode will be removed in
a future release. Run `omni doctor --fix` to migrate (idempotent;
pg_dump → pgserve install → restore → relaunch).
```

Still shows the same `omni doctor --fix` migration command as the resolution.

## Compatibility

Pure-additive: every code path behaves identically. Operators just see a louder warning. Existing tests pass unchanged (the WARN-level assertion in `doctor.test.ts` only checks for `embedded pgserve` + `omni doctor --fix` substrings, both still present).

## Test plan

- [x] `bun run typecheck` — green (turbo, all 21 packages)
- [x] `bun test packages/cli/src/__tests__/doctor.test.ts` — **39/39 pass**
- [ ] Manual on a legacy embedded host: restart omni-api, confirm WARN line appears in pm2 logs
- [ ] Manual on a canonical host: confirm NO warning appears (config.enabled is false → early return before the warn)

## Removal timeline (follow-up PRs)

After fleet adoption (operator surveys + log-based inventory of which hosts still run embedded), a follow-up PR removes:

- `startEmbeddedPgserve` + `stopEmbeddedPgserve` + libicu shim + validation guards (~800 LOC)
- `pgserve: "^2.1.0"` from `packages/api/package.json` runtime deps
- `useCanonicalPgserve` config flag (becomes meaningless)
- The `PGSERVE_EMBEDDED` env var consumer in `resolvePgserveConfig`
