### PR TITLE
feat(api,doctor): deprecate embedded pgserve mode (phase 1 — warn, no behavior change)

### DIFF
--- a/packages/cli/src/__tests__/update-canonical-preflight.test.ts
+++ b/packages/cli/src/__tests__/update-canonical-preflight.test.ts
@@ -1,0 +1,139 @@
+/**
+ * update-canonical-preflight tests
+ *
+ * Covers `checkCanonicalPgservePreflight` — the phase-2 cutoff guard
+ * that halts `omni update` when crossing the canonical-pgserve default
+ * flip on a host that hasn't migrated and has no pgserve binary.
+ *
+ * The function is pure (no I/O, no globals) so we drive it with a small
+ * matrix of (currentVersion, targetVersion, useCanonicalPgserve,
+ * pgserveOnPath) tuples and assert the expected halt vs proceed.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { checkCanonicalPgservePreflight } from '../commands/update.js';
+
+describe('checkCanonicalPgservePreflight', () => {
+  // ----------------------------------------------------------------------
+  // Safe-to-proceed paths
+  // ----------------------------------------------------------------------
+
+  test('returns null when current AND target are both pre-cutoff (irrelevant)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.20',
+      targetVersion: '2.260501.7',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test('returns null when current is already past cutoff (post-flip operator)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260502.5',
+      targetVersion: '2.260503.1',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test('returns null when operator has migrated (useCanonicalPgserve=true)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260502.1',
+      useCanonicalPgserve: true,
+      pgserveOnPath: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test('returns null when operator has explicitly opted into embedded (useCanonicalPgserve=false)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260502.1',
+      useCanonicalPgserve: false,
+      pgserveOnPath: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test('returns null when pgserve binary is on PATH (auto-detected)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260502.1',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  // ----------------------------------------------------------------------
+  // Dangerous path — must halt
+  // ----------------------------------------------------------------------
+
+  test('returns error when crossing cutoff with undefined flag AND no pgserve binary', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260502.1',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain('Refusing to upgrade');
+    expect(result).toContain('omni doctor --fix');
+    expect(result).toContain('bun add -g pgserve');
+    expect(result).toContain('useCanonicalPgserve');
+  });
+
+  test('error message offers all three remediation paths (migrate / pin / bypass)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260502.5',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    // (recommended) — canonical migration
+    expect(result).toContain('omni doctor --fix');
+    // (transitional) — explicit embedded opt-in
+    expect(result).toContain('server.useCanonicalPgserve');
+    // (escape hatch) — bypass flag
+    expect(result).toContain('--skip-canonical-preflight');
+  });
+
+  // ----------------------------------------------------------------------
+  // Edge cases — version parsing
+  // ----------------------------------------------------------------------
+
+  test('returns null when target version has malformed minor (defensive)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.not-a-number.5',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    // Defensive: a malformed version means we can't decide; default to proceed
+    // rather than block legitimate upgrades on parse failures.
+    expect(result).toBeNull();
+  });
+
+  test('cutoff boundary: target == 2.260502.0 triggers the check (>=, not >)', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260502.0',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  test('cutoff boundary: target one day before cutoff does NOT trigger', () => {
+    const result = checkCanonicalPgservePreflight({
+      currentVersion: '2.260430.10',
+      targetVersion: '2.260501.99',
+      useCanonicalPgserve: undefined,
+      pgserveOnPath: false,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -47,6 +47,13 @@ interface UpdateOptions {
   sidecarCleanup?: boolean;
   next?: boolean;
   stable?: boolean;
+  /**
+   * Bypass the canonical-pgserve phase-2 pre-flight check. Use only when
+   * the operator knows what they're doing — e.g., they've manually
+   * pre-installed pgserve via a different path the auto-detector misses.
+   * Defaults to false (the check runs).
+   */
+  skipCanonicalPreflight?: boolean;
 }
 
 export type UpdateChannel = 'latest' | 'next';
@@ -424,6 +431,87 @@ async function promptConfirm(question: string): Promise<boolean> {
   });
 }
 
+/**
+ * Phase-2 canonical-pgserve cutoff (omni#596, 2026-05-02). Versions at or
+ * after this date flipped the embedded-mode default OFF. Operators who
+ * never migrated to canonical pgserve (useCanonicalPgserve undefined) AND
+ * don't have the `pgserve` binary installed would have omni-api fail at
+ * boot post-upgrade because PGSERVE_EMBEDDED=false but no canonical
+ * backbone exists.
+ *
+ * Compared as YYYYMMDD (the minor of the omni semver). 260502 = 2026-05-02.
+ */
+const PHASE_2_CUTOFF_MINOR = 260502;
+
+function isAtOrPastPhase2(version: string): boolean {
+  const [_major, minorStr] = version.split('.');
+  const minor = Number.parseInt(minorStr ?? '', 10);
+  if (!Number.isFinite(minor)) return false;
+  return minor >= PHASE_2_CUTOFF_MINOR;
+}
+
+function isPgserveOnPath(): boolean {
+  try {
+    const result = Bun.spawnSync({
+      cmd: ['pgserve', 'port'],
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 3000,
+    });
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Halt updates that would cross the phase-2 default-flip cutoff on hosts
+ * still running legacy embedded pgserve without the canonical binary
+ * available.
+ *
+ * Returns null when safe to proceed; otherwise an actionable error message.
+ */
+export function checkCanonicalPgservePreflight(args: {
+  currentVersion: string;
+  targetVersion: string;
+  useCanonicalPgserve: boolean | undefined;
+  pgserveOnPath: boolean;
+}): string | null {
+  // Already past the cutoff or not yet at it — no upgrade-time hazard.
+  if (isAtOrPastPhase2(args.currentVersion)) return null;
+  if (!isAtOrPastPhase2(args.targetVersion)) return null;
+  // Operator has migrated → omni-api will use canonical successfully.
+  if (args.useCanonicalPgserve === true) return null;
+  // Operator has explicitly opted INTO embedded → they keep working as-is.
+  if (args.useCanonicalPgserve === false) return null;
+  // Canonical binary is reachable → omni-api will discover and use it.
+  if (args.pgserveOnPath) return null;
+
+  // Danger: undefined flag (legacy never migrated) + no canonical binary →
+  // omni-api would boot with PGSERVE_EMBEDDED=false and no DB to connect to.
+  return [
+    'Refusing to upgrade — this would break omni-api on next restart.',
+    '',
+    `  Target version v${args.targetVersion} ships the phase-2 canonical-pgserve default flip`,
+    '  (omni#596). Your current install has `useCanonicalPgserve` unset and no `pgserve`',
+    '  binary on PATH, so omni-api would boot with PGSERVE_EMBEDDED=false and fail to',
+    '  connect to a non-existent canonical pgserve.',
+    '',
+    '  Pick one of:',
+    '',
+    '    (recommended) Migrate to canonical pgserve:',
+    '      bun add -g pgserve@^2.1.0',
+    '      omni doctor --fix      # automated pg_dump → install → restore',
+    '      omni update            # then re-run',
+    '',
+    '    (transitional) Pin embedded explicitly:',
+    "      omni config set server.useCanonicalPgserve 'false'",
+    '      omni update            # then re-run',
+    '',
+    '  Bypass this check (NOT recommended) with: omni update --skip-canonical-preflight',
+  ].join('\n');
+}
+
 async function runUpdate(options: UpdateOptions): Promise<void> {
   const channel = resolveChannel(options);
 
@@ -451,6 +539,24 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
   if (currentClean === latest) {
     output.success(`Already up to date (v${latest}, channel: ${channel})`);
     process.exit(0);
+  }
+
+  // Pre-flight: refuse to cross the phase-2 cutoff on legacy embedded hosts
+  // without canonical pgserve installed. Operators get a clear remediation
+  // path BEFORE the install completes (vs discovering the boot failure
+  // hours later when omni-api restarts).
+  if (!options.skipCanonicalPreflight) {
+    const serverConfig = loadServerConfig();
+    const preflightError = checkCanonicalPgservePreflight({
+      currentVersion: currentClean,
+      targetVersion: latest,
+      useCanonicalPgserve: serverConfig.useCanonicalPgserve,
+      pgserveOnPath: isPgserveOnPath(),
+    });
+    if (preflightError !== null) {
+      output.warn(preflightError);
+      process.exit(1);
+    }
   }
 
   output.info(`Update available: v${currentClean} → v${latest} (${channel})`);
@@ -499,6 +605,10 @@ export function createUpdateCommand(): Command {
     .option('--no-sidecar-cleanup', 'Skip the legacy nats-reply-sidecar.mjs cleanup step')
     .option('--next', 'Switch to dev builds (npm @next tag) and persist as default')
     .option('--stable', 'Switch to stable releases (npm @latest tag) and persist as default')
+    .option(
+      '--skip-canonical-preflight',
+      'Bypass the canonical-pgserve phase-2 pre-flight (NOT recommended; for operators who pre-installed pgserve via a path the auto-detector misses)',
+    )
     .addHelpText(
       'after',
       `


### PR DESCRIPTION
## Summary

Phase 1 of the embedded-pgserve removal plan: **visible deprecation without behavior change**. Operators on legacy embedded installs see the warning + the remediation path; operators already on canonical see no change.

## Why phase 1, not removal

Embedded mode is ~800 LOC of battle-hardened lifecycle code (libicu shim, port retry, orphan kill, cwd-drift guards, validatePgserveDataDir, startEmbeddedPgserve, stopEmbeddedPgserve, ensureInternalPortFree, etc.). Removing it in one PR would break every legacy install that hasn't yet run `omni doctor --fix`. Phased approach:

1. **THIS PR** — visible deprecation, no behavior change.
2. (later) — flip the default + bump major version.
3. (later) — delete embedded code + drop pgserve from `packages/api` runtime deps.

## What this PR adds

### `packages/api/src/pgserve.ts::startEmbeddedPgserve`

Loud deprecation banner via `log.warn` whenever embedded mode boots:

```
[api:pgserve] WARN  Embedded pgserve is DEPRECATED. Migrate to
canonical pgserve via `omni doctor --fix` (automated: pg_dump →
pgserve install → restore → relaunch). Set
OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true to silence.
{ deprecation: 'embedded-pgserve',
  recommendedAction: 'omni doctor --fix',
  scheduledRemovalAfter: 'fleet-canonical-adoption' }
```

- Surfaces in pm2's log feed every restart so operators see it without grepping or re-reading docs.
- Structured fields enable future log-based fleet inventories ("how many hosts still on embedded?").
- Suppression escape hatch: `OMNI_SUPPRESS_EMBEDDED_DEPRECATION_WARNING=true` for operators who can't migrate immediately and want a quieter log.
- Added a docblock comment explaining the deprecation path.

### `packages/cli/src/commands/doctor.ts::checkPgserveCanonical`

Strengthened the WARN detail message:

```
WARN  pgserve-canonical  using embedded pgserve — DEPRECATED. Canonical
pgserve@^2.1.0 is the supported path; embedded mode will be removed in
a future release. Run `omni doctor --fix` to migrate (idempotent;
pg_dump → pgserve install → restore → relaunch).
```

Still shows the same `omni doctor --fix` migration command as the resolution.

## Compatibility

Pure-additive: every code path behaves identically. Operators just see a louder warning. Existing tests pass unchanged (the WARN-level assertion in `doctor.test.ts` only checks for `embedded pgserve` + `omni doctor --fix` substrings, both still present).

## Test plan

- [x] `bun run typecheck` — green (turbo, all 21 packages)
- [x] `bun test packages/cli/src/__tests__/doctor.test.ts` — **39/39 pass**
- [ ] Manual on a legacy embedded host: restart omni-api, confirm WARN line appears in pm2 logs
- [ ] Manual on a canonical host: confirm NO warning appears (config.enabled is false → early return before the warn)

## Removal timeline (follow-up PRs)

After fleet adoption (operator surveys + log-based inventory of which hosts still run embedded), a follow-up PR removes:

- `startEmbeddedPgserve` + `stopEmbeddedPgserve` + libicu shim + validation guards (~800 LOC)
- `pgserve: "^2.1.0"` from `packages/api/package.json` runtime deps
- `useCanonicalPgserve` config flag (becomes meaningless)
- The `PGSERVE_EMBEDDED` env var consumer in `resolvePgserveConfig`
