### PR TITLE
feat(install): offer Claude Code plugin install in both install paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,6 +166,32 @@ ensure_pgserve() {
   fi
 }
 
+# Offer the Omni Claude Code plugin install when `claude` is available.
+# Mirrors genie's `offer_claude_plugin()` (genie/install.sh:563-591) so a
+# fresh `curl … | bash` end-to-end install gives the operator both the CLI
+# AND the `/omni:*` slash commands without a separate manual step.
+#
+# Marketplace: automagik-dev/omni → plugin name `omni@automagik-dev`
+# (matches packages/.claude-plugin/marketplace.json `name: "automagik-dev"`).
+#
+# Idempotent: claude plugin marketplace add + install both no-op when the
+# plugin is already registered. We never fail the install on a plugin error
+# — the CLI is functional without the plugin; the plugin is a DX upgrade.
+offer_omni_plugin() {
+  if ! has_cmd claude; then
+    info "Claude Code not found — skipping plugin install (you can install it later with: claude plugin install omni@automagik-dev)"
+    return 0
+  fi
+
+  info "Installing Omni plugin for Claude Code..."
+  claude plugin marketplace add automagik-dev/omni >/dev/null 2>&1 || true
+  if claude plugin install omni@automagik-dev >/dev/null 2>&1; then
+    ok "Omni Claude Code plugin installed (try /omni:omni-setup in a Claude session)"
+  else
+    warn "Plugin install failed — try manually: claude plugin install omni@automagik-dev"
+  fi
+}
+
 # ============================================================================
 # Install: CLI only
 # ============================================================================
@@ -178,6 +204,7 @@ install_cli_only() {
   info "Installing @automagik/omni@${channel} from npm..."
   if bun add -g "@automagik/omni@${channel}" 2>/dev/null && has_cmd omni; then
     ok "omni $(omni --version) installed from npm (channel: ${channel})"
+    offer_omni_plugin
     return 0
   fi
   fail "npm install failed. Check your network and try again: bun add -g @automagik/omni@${channel}"
@@ -203,6 +230,8 @@ install_full_server() {
 
   info "Running omni install (this will download NATS, configure PM2, etc.)..."
   omni install --non-interactive
+
+  offer_omni_plugin
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Closes Group 3 of the [omni-genie-onboarding wish](https://github.com/namastexlabs/genie-configure/blob/main/.genie/wishes/omni-genie-onboarding/WISH.md) — the only group still pending. Mirrors genie's proven `offer_claude_plugin()` pattern (genie/install.sh:563-591) so a fresh `curl … | bash` install gives operators both the omni CLI **and** the `/omni:*` slash commands without a separate manual step.

## Changes

- New `offer_omni_plugin()` function — detects `claude` on PATH, runs `claude plugin marketplace add automagik-dev/omni` followed by `claude plugin install omni@automagik-dev`. Idempotent (both subcommands no-op when already installed). Graceful skip with actionable hint when claude is missing. Never blocks the overall install.
- Wired into both `install_cli_only` (after `bun add -g` succeeds) and `install_full_server` (after `omni install --non-interactive` finishes).

## Why this shape

Marketplace metadata in `packages/.claude-plugin/marketplace.json` already declares the plugin as `omni@automagik-dev`. No marketplace.json changes needed — the install command resolves correctly out of the box.

The omni installer is npm-only (no `LOCAL_PATH` mode like genie has), so the simplified shape drops genie's local-symlink branch and keeps just the marketplace path.

## Wish acceptance criteria

From `.genie/wishes/omni-genie-onboarding/WISH.md` Group 3:

- [x] `install.sh` installs omni Claude Code plugin when claude is available
- [x] Graceful skip when claude is not installed
- [x] Plugin is functional after install (verified: `claude plugin list` shows `omni@automagik-dev` after smoke test)

Validation grep from the wish:
```bash
grep -q "omni.*plugin\|plugin.*omni" install.sh && echo PASS || echo FAIL
# → PASS
```

## Test plan

- [x] `bash -n install.sh` → clean (no syntax errors)
- [x] Function-only smoke test (claude-present path) → "OK installed" + plugin lands in `claude plugin list`
- [x] Function-only smoke test (claude-missing path, PATH stripped) → "skipping plugin install" with actionable hint, exit 0
- [ ] Manual end-to-end: fresh VM, `curl … | bash` from this branch → both CLI and plugin install
- [ ] Manual end-to-end: same VM without claude → CLI installs, plugin gracefully skipped, exit 0

## Non-goals

This change does **not** touch:
- The plugin SessionStart hook channel logic (separate concern, fixed in `aeab63df`)
- Local-mode plugin symlinking (omni install.sh is npm-only)