### PR TITLE
fix(db): timestamptz everywhere — kills turn-monitor false-stale (3h offset)

### DIFF
--- a/packages/db/drizzle/0036_timestamptz_migration.sql
+++ b/packages/db/drizzle/0036_timestamptz_migration.sql
@@ -1,0 +1,150 @@
+-- Migration 0036: Convert all TZ-naive timestamps to timestamptz
+-- 
+-- ROOT CAUSE: timestamp without time zone strips offset on write.
+-- PG NOW() in session TZ + JS new Date() in UTC produced literal wall-clock
+-- values 3h apart on canonical pgserve (America/Sao_Paulo).
+-- Symptom: turn-monitor read closed_at - started_at = 10800s and force-closed
+-- every fresh turn before the agent could respond.
+--
+-- USING strategy per column:
+--   defaultNow() columns -> wall-clock is in current session TZ -> AT TIME ZONE current_setting('TimeZone')
+--   nullable columns set by JS -> wall-clock is UTC -> AT TIME ZONE 'UTC'
+
+BEGIN;
+
+-- Table: access_rules
+ALTER TABLE "access_rules" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "access_rules" ALTER COLUMN "expires_at" TYPE timestamptz USING "expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "access_rules" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: agent_providers
+ALTER TABLE "agent_providers" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "agent_providers" ALTER COLUMN "last_health_check" TYPE timestamptz USING "last_health_check" AT TIME ZONE 'UTC';
+ALTER TABLE "agent_providers" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: agent_routes
+ALTER TABLE "agent_routes" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "agent_routes" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: agent_sessions
+ALTER TABLE "agent_sessions" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "agent_sessions" ALTER COLUMN "expires_at" TYPE timestamptz USING "expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "agent_sessions" ALTER COLUMN "last_used_at" TYPE timestamptz USING "last_used_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "agent_sessions" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: agent_tasks
+ALTER TABLE "agent_tasks" ALTER COLUMN "completed_at" TYPE timestamptz USING "completed_at" AT TIME ZONE 'UTC';
+ALTER TABLE "agent_tasks" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "agent_tasks" ALTER COLUMN "started_at" TYPE timestamptz USING "started_at" AT TIME ZONE 'UTC';
+-- Table: agents
+ALTER TABLE "agents" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "agents" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: api_key_audit_logs
+ALTER TABLE "api_key_audit_logs" ALTER COLUMN "timestamp" TYPE timestamptz USING "timestamp" AT TIME ZONE current_setting('TimeZone');
+-- Table: api_keys
+ALTER TABLE "api_keys" ALTER COLUMN "context_updated_at" TYPE timestamptz USING "context_updated_at" AT TIME ZONE 'UTC';
+ALTER TABLE "api_keys" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "api_keys" ALTER COLUMN "expires_at" TYPE timestamptz USING "expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "api_keys" ALTER COLUMN "last_used_at" TYPE timestamptz USING "last_used_at" AT TIME ZONE 'UTC';
+ALTER TABLE "api_keys" ALTER COLUMN "revoked_at" TYPE timestamptz USING "revoked_at" AT TIME ZONE 'UTC';
+ALTER TABLE "api_keys" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: automation_logs
+ALTER TABLE "automation_logs" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: automations
+ALTER TABLE "automations" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "automations" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: batch_jobs
+ALTER TABLE "batch_jobs" ALTER COLUMN "completed_at" TYPE timestamptz USING "completed_at" AT TIME ZONE 'UTC';
+ALTER TABLE "batch_jobs" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "batch_jobs" ALTER COLUMN "started_at" TYPE timestamptz USING "started_at" AT TIME ZONE 'UTC';
+-- Table: chat_id_mappings
+ALTER TABLE "chat_id_mappings" ALTER COLUMN "discovered_at" TYPE timestamptz USING "discovered_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: chat_participants
+ALTER TABLE "chat_participants" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "chat_participants" ALTER COLUMN "joined_at" TYPE timestamptz USING "joined_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "chat_participants" ALTER COLUMN "last_seen_at" TYPE timestamptz USING "last_seen_at" AT TIME ZONE 'UTC';
+ALTER TABLE "chat_participants" ALTER COLUMN "left_at" TYPE timestamptz USING "left_at" AT TIME ZONE 'UTC';
+ALTER TABLE "chat_participants" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: chats
+ALTER TABLE "chats" ALTER COLUMN "archived_at" TYPE timestamptz USING "archived_at" AT TIME ZONE 'UTC';
+ALTER TABLE "chats" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "chats" ALTER COLUMN "deleted_at" TYPE timestamptz USING "deleted_at" AT TIME ZONE 'UTC';
+ALTER TABLE "chats" ALTER COLUMN "last_message_at" TYPE timestamptz USING "last_message_at" AT TIME ZONE 'UTC';
+ALTER TABLE "chats" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: consumer_offsets
+ALTER TABLE "consumer_offsets" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: conversations
+ALTER TABLE "conversations" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "conversations" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: dead_letter_events
+ALTER TABLE "dead_letter_events" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "dead_letter_events" ALTER COLUMN "last_retry_at" TYPE timestamptz USING "last_retry_at" AT TIME ZONE 'UTC';
+ALTER TABLE "dead_letter_events" ALTER COLUMN "next_auto_retry_at" TYPE timestamptz USING "next_auto_retry_at" AT TIME ZONE 'UTC';
+ALTER TABLE "dead_letter_events" ALTER COLUMN "resolved_at" TYPE timestamptz USING "resolved_at" AT TIME ZONE 'UTC';
+-- Table: event_payloads
+ALTER TABLE "event_payloads" ALTER COLUMN "deleted_at" TYPE timestamptz USING "deleted_at" AT TIME ZONE 'UTC';
+ALTER TABLE "event_payloads" ALTER COLUMN "timestamp" TYPE timestamptz USING "timestamp" AT TIME ZONE current_setting('TimeZone');
+-- Table: genie_hosts
+ALTER TABLE "genie_hosts" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "genie_hosts" ALTER COLUMN "last_seen_at" TYPE timestamptz USING "last_seen_at" AT TIME ZONE 'UTC';
+ALTER TABLE "genie_hosts" ALTER COLUMN "revoked_at" TYPE timestamptz USING "revoked_at" AT TIME ZONE 'UTC';
+ALTER TABLE "genie_hosts" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: global_settings
+ALTER TABLE "global_settings" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "global_settings" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: handoff_logs
+ALTER TABLE "handoff_logs" ALTER COLUMN "sent_at" TYPE timestamptz USING "sent_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: instances
+ALTER TABLE "instances" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "instances" ALTER COLUMN "last_message_at" TYPE timestamptz USING "last_message_at" AT TIME ZONE 'UTC';
+ALTER TABLE "instances" ALTER COLUMN "last_seen_at" TYPE timestamptz USING "last_seen_at" AT TIME ZONE 'UTC';
+ALTER TABLE "instances" ALTER COLUMN "profile_synced_at" TYPE timestamptz USING "profile_synced_at" AT TIME ZONE 'UTC';
+ALTER TABLE "instances" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: media_content
+ALTER TABLE "media_content" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: messages
+ALTER TABLE "messages" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "messages" ALTER COLUMN "deleted_at" TYPE timestamptz USING "deleted_at" AT TIME ZONE 'UTC';
+ALTER TABLE "messages" ALTER COLUMN "edited_at" TYPE timestamptz USING "edited_at" AT TIME ZONE 'UTC';
+ALTER TABLE "messages" ALTER COLUMN "platform_timestamp" TYPE timestamptz USING "platform_timestamp" AT TIME ZONE 'UTC';
+ALTER TABLE "messages" ALTER COLUMN "received_at" TYPE timestamptz USING "received_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "messages" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: omni_events
+ALTER TABLE "omni_events" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "omni_events" ALTER COLUMN "delivered_at" TYPE timestamptz USING "delivered_at" AT TIME ZONE 'UTC';
+ALTER TABLE "omni_events" ALTER COLUMN "processed_at" TYPE timestamptz USING "processed_at" AT TIME ZONE 'UTC';
+ALTER TABLE "omni_events" ALTER COLUMN "read_at" TYPE timestamptz USING "read_at" AT TIME ZONE 'UTC';
+ALTER TABLE "omni_events" ALTER COLUMN "received_at" TYPE timestamptz USING "received_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: omni_groups
+ALTER TABLE "omni_groups" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "omni_groups" ALTER COLUMN "synced_at" TYPE timestamptz USING "synced_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "omni_groups" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: payload_storage_config
+ALTER TABLE "payload_storage_config" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "payload_storage_config" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: persons
+ALTER TABLE "persons" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "persons" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: platform_identities
+ALTER TABLE "platform_identities" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "platform_identities" ALTER COLUMN "first_seen_at" TYPE timestamptz USING "first_seen_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "platform_identities" ALTER COLUMN "last_seen_at" TYPE timestamptz USING "last_seen_at" AT TIME ZONE 'UTC';
+ALTER TABLE "platform_identities" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: plugin_storage
+ALTER TABLE "plugin_storage" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "plugin_storage" ALTER COLUMN "expires_at" TYPE timestamptz USING "expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "plugin_storage" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: processed_events
+ALTER TABLE "processed_events" ALTER COLUMN "processed_at" TYPE timestamptz USING "processed_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: setting_change_history
+ALTER TABLE "setting_change_history" ALTER COLUMN "changed_at" TYPE timestamptz USING "changed_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: sync_jobs
+ALTER TABLE "sync_jobs" ALTER COLUMN "completed_at" TYPE timestamptz USING "completed_at" AT TIME ZONE 'UTC';
+ALTER TABLE "sync_jobs" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "sync_jobs" ALTER COLUMN "started_at" TYPE timestamptz USING "started_at" AT TIME ZONE 'UTC';
+-- Table: turns
+ALTER TABLE "turns" ALTER COLUMN "closed_at" TYPE timestamptz USING "closed_at" AT TIME ZONE 'UTC';
+ALTER TABLE "turns" ALTER COLUMN "last_activity_at" TYPE timestamptz USING "last_activity_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "turns" ALTER COLUMN "started_at" TYPE timestamptz USING "started_at" AT TIME ZONE current_setting('TimeZone');
+-- Table: webhook_sources
+ALTER TABLE "webhook_sources" ALTER COLUMN "created_at" TYPE timestamptz USING "created_at" AT TIME ZONE current_setting('TimeZone');
+ALTER TABLE "webhook_sources" ALTER COLUMN "last_received_at" TYPE timestamptz USING "last_received_at" AT TIME ZONE 'UTC';
+ALTER TABLE "webhook_sources" ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at" AT TIME ZONE current_setting('TimeZone');
+
+COMMIT;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1777770000000,
       "tag": "0035_unstick_redirected_sac_terminals",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1777860000000,
+      "tag": "0036_timestamptz_migration",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,8 +17,9 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && bun run scripts/check-tz-naive.ts",
     "test": "bun test",
+    "lint:tz": "bun run scripts/check-tz-naive.ts",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun run src/migrate.ts",

--- a/packages/db/scripts/check-tz-naive.ts
+++ b/packages/db/scripts/check-tz-naive.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * Build-time guard against TZ-naive timestamps.
+ *
+ * Fails CI if any `timestamp(...)` declaration in src/schema.ts is missing
+ * `withTimezone: true`. Background: PG `timestamp without time zone` strips
+ * the offset on write — a session-TZ value from `defaultNow()` and a UTC value
+ * from JS `new Date()` then diverge by the session offset, producing the
+ * 3h false-stale bug fixed in migration 0036.
+ *
+ * Usage:
+ *   bun run packages/db/scripts/check-tz-naive.ts
+ *   (also wired into package.json `lint:tz` script)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schemaPath = join(here, '..', 'src', 'schema.ts');
+const source = readFileSync(schemaPath, 'utf-8');
+
+const violations: { line: number; text: string }[] = [];
+
+source.split('\n').forEach((text, i) => {
+  // Match `timestamp('name')` with no second argument.
+  // The schema convention is to always pass `{ withTimezone: true }` as opts.
+  const match = text.match(/timestamp\('[^']+'\)(?!\s*,)/);
+  if (match) {
+    violations.push({ line: i + 1, text: text.trim() });
+  }
+});
+
+if (violations.length > 0) {
+  console.error('\n❌ TZ-naive timestamp(s) found in schema.ts:\n');
+  for (const v of violations) {
+    console.error(`  schema.ts:${v.line}`);
+    console.error(`    ${v.text}`);
+  }
+  console.error(
+    '\nAll timestamp columns must use `{ withTimezone: true }` to avoid the\n' +
+      'session-TZ vs UTC strip bug (see migration 0036_timestamptz_migration.sql).\n',
+  );
+  process.exit(1);
+}
+
+console.log('✅ All timestamp columns use { withTimezone: true }');

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -302,12 +302,12 @@ export const agentProviders = pgTable(
 
     // Health tracking
     isActive: boolean('is_active').notNull().default(true),
-    lastHealthCheck: timestamp('last_health_check'),
+    lastHealthCheck: timestamp('last_health_check', { withTimezone: true }),
     lastHealthStatus: varchar('last_health_status', { length: 20 }), // 'healthy' | 'unhealthy' | 'error'
     lastHealthError: text('last_health_error'),
 
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     nameIdx: index('agent_providers_name_idx').on(table.name),
@@ -344,8 +344,8 @@ export const agents = pgTable(
     agentCard: jsonb('agent_card').$type<Record<string, unknown>>(),
     /** Idle-chat follow-up config at the agent scope (broadest). @see issue #404 */
     followUpConfig: jsonb('follow_up_config').$type<FollowUpSequenceConfig>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     nameIdx: index('agents_name_idx').on(table.name),
@@ -424,8 +424,8 @@ export const agentRoutes = pgTable(
     isActive: boolean('is_active').notNull().default(true),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     // Constraints
@@ -479,11 +479,11 @@ export const agentSessions = pgTable(
     providerSessionData: jsonb('provider_session_data').notNull().$type<Record<string, unknown>>(),
 
     // TTL management
-    lastUsedAt: timestamp('last_used_at').notNull().defaultNow(),
-    expiresAt: timestamp('expires_at'), // null = never expires
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }), // null = never expires
 
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     // Unique constraint: one session per instance+key
@@ -548,15 +548,15 @@ export const apiKeys = pgTable(
     rateLimit: integer('rate_limit'),
 
     // Expiration (null = never expires)
-    expiresAt: timestamp('expires_at'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
 
     // Audit
-    lastUsedAt: timestamp('last_used_at'),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
     lastUsedIp: varchar('last_used_ip', { length: 45 }), // IPv6 max length
     usageCount: integer('usage_count').notNull().default(0),
 
     // Revocation
-    revokedAt: timestamp('revoked_at'),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
     revokedBy: varchar('revoked_by', { length: 255 }),
     revokeReason: text('revoke_reason'),
 
@@ -565,12 +565,12 @@ export const apiKeys = pgTable(
     contextInstanceId: uuid('context_instance_id'),
     contextChatId: uuid('context_chat_id'),
     contextMessageId: uuid('context_message_id'),
-    contextUpdatedAt: timestamp('context_updated_at'),
+    contextUpdatedAt: timestamp('context_updated_at', { withTimezone: true }),
 
     // Timestamps
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     createdBy: varchar('created_by', { length: 255 }),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     keyPrefixIdx: index('api_keys_key_prefix_idx').on(table.keyPrefix),
@@ -604,7 +604,7 @@ export const apiKeyAuditLogs = pgTable(
     ipAddress: varchar('ip_address', { length: 45 }),
     userAgent: text('user_agent'),
     responseTimeMs: integer('response_time_ms'),
-    timestamp: timestamp('timestamp').notNull().defaultNow(),
+    timestamp: timestamp('timestamp', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     apiKeyIdx: index('api_key_audit_logs_api_key_idx').on(table.apiKeyId),
@@ -724,7 +724,7 @@ export const instances = pgTable(
     profilePicUrl: text('profile_pic_url'),
     profileBio: text('profile_bio'),
     profileMetadata: jsonb('profile_metadata').$type<Record<string, unknown>>(), // Platform-specific: phone, isBusiness, etc.
-    profileSyncedAt: timestamp('profile_synced_at'),
+    profileSyncedAt: timestamp('profile_synced_at', { withTimezone: true }),
     ownerIdentifier: varchar('owner_identifier', { length: 255 }), // JID for WhatsApp, user ID for Discord, etc.
 
     // ---- Sync Settings ----
@@ -825,13 +825,13 @@ export const instances = pgTable(
 
     // ---- Message Tracking ----
     /** Timestamp of last processed message (for reconnect gap detection) */
-    lastMessageAt: timestamp('last_message_at'),
+    lastMessageAt: timestamp('last_message_at', { withTimezone: true }),
 
     // ---- Agent Replay ----
     /** When true (default), automatically replay missed messages on reconnect */
     replayEnabled: boolean('replay_enabled').notNull().default(true),
     /** Timestamp of when the instance was last seen connected (used as replay window start) */
-    lastSeenAt: timestamp('last_seen_at'),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }),
 
     // ---- Agent Stalled-Turn Detection (internal event only — no channel message) ----
     /** Idle threshold in ms before a stalled turn emits the internal turn.stalled event */
@@ -883,8 +883,8 @@ export const instances = pgTable(
     requireGenieSignature: boolean('require_genie_signature').notNull().default(false),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     nameIdx: uniqueIndex('instances_name_idx').on(table.name),
@@ -915,8 +915,8 @@ export const persons = pgTable(
     primaryEmail: varchar('primary_email', { length: 255 }),
     avatarUrl: text('avatar_url'),
     metadata: jsonb('metadata').$type<Record<string, unknown>>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     phoneIdx: uniqueIndex('persons_phone_idx').on(table.primaryPhone),
@@ -950,8 +950,8 @@ export const platformIdentities = pgTable(
 
     // ---- Activity Tracking ----
     messageCount: integer('message_count').notNull().default(0),
-    lastSeenAt: timestamp('last_seen_at'),
-    firstSeenAt: timestamp('first_seen_at').notNull().defaultNow(),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }),
+    firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).notNull().defaultNow(),
 
     // ---- Linking Metadata ----
     linkedBy: varchar('linked_by', { length: 50 }), // 'auto' | 'manual' | 'phone_match' | 'initial'
@@ -959,8 +959,8 @@ export const platformIdentities = pgTable(
     linkReason: text('link_reason'),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     personIdx: index('platform_identities_person_idx').on(table.personId),
@@ -993,8 +993,8 @@ export const conversations = pgTable(
     title: varchar('title', { length: 500 }),
     summary: text('summary'),
     state: jsonb('state').$type<Record<string, unknown>>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     createdAtIdx: index('conversations_created_at_idx').on(table.createdAt),
@@ -1044,7 +1044,7 @@ export const chats = pgTable(
     unreadCount: integer('unread_count').notNull().default(0),
 
     // ---- Activity ----
-    lastMessageAt: timestamp('last_message_at'),
+    lastMessageAt: timestamp('last_message_at', { withTimezone: true }),
     lastMessagePreview: text('last_message_preview'),
     lastMessageFromMe: boolean('last_message_from_me'),
     visibility: varchar('visibility', { length: 20 }).notNull().default('visible'),
@@ -1060,10 +1060,10 @@ export const chats = pgTable(
     conversationId: uuid('conversation_id').references(() => conversations.id, { onDelete: 'set null' }),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
-    archivedAt: timestamp('archived_at'),
-    deletedAt: timestamp('deleted_at'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    archivedAt: timestamp('archived_at', { withTimezone: true }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (table) => ({
     instanceExternalIdx: uniqueIndex('chats_instance_external_idx').on(table.instanceId, table.externalId),
@@ -1110,19 +1110,19 @@ export const chatParticipants = pgTable(
 
     // ---- Status ----
     isActive: boolean('is_active').notNull().default(true),
-    joinedAt: timestamp('joined_at').notNull().defaultNow(),
-    leftAt: timestamp('left_at'),
+    joinedAt: timestamp('joined_at', { withTimezone: true }).notNull().defaultNow(),
+    leftAt: timestamp('left_at', { withTimezone: true }),
 
     // ---- Activity ----
-    lastSeenAt: timestamp('last_seen_at'),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }),
     messageCount: integer('message_count').notNull().default(0),
 
     // ---- Platform metadata ----
     platformMetadata: jsonb('platform_metadata').$type<Record<string, unknown>>(),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     chatUserIdx: uniqueIndex('chat_participants_chat_user_idx').on(table.chatId, table.platformUserId),
@@ -1173,9 +1173,9 @@ export const omniGroups = pgTable(
     platformMetadata: jsonb('platform_metadata').$type<Record<string, unknown>>(),
 
     // ---- Sync tracking ----
-    syncedAt: timestamp('synced_at').notNull().defaultNow(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    syncedAt: timestamp('synced_at', { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     instanceExternalIdx: uniqueIndex('omni_groups_instance_external_idx').on(table.instanceId, table.externalId),
@@ -1270,8 +1270,8 @@ export const messages = pgTable(
     originalText: text('original_text'), // First version (for quick access)
     editHistory: jsonb('edit_history').$type<EditHistoryEntry[]>(),
     // [{ text: "Hello!", at: "2024-01-01T12:00:00Z" }, ...]
-    editedAt: timestamp('edited_at'),
-    deletedAt: timestamp('deleted_at'),
+    editedAt: timestamp('edited_at', { withTimezone: true }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
 
     // === REACTIONS (JSONB - no separate table) ===
     reactions: jsonb('reactions').$type<ReactionInfo[]>(),
@@ -1289,10 +1289,10 @@ export const messages = pgTable(
     // NULL for synced messages - they have no events!
 
     // === TIMESTAMPS ===
-    platformTimestamp: timestamp('platform_timestamp').notNull(), // When platform says sent
-    receivedAt: timestamp('received_at').notNull().defaultNow(), // When we got it
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    platformTimestamp: timestamp('platform_timestamp', { withTimezone: true }).notNull(), // When platform says sent
+    receivedAt: timestamp('received_at', { withTimezone: true }).notNull().defaultNow(), // When we got it
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     chatExternalIdx: uniqueIndex('messages_chat_external_idx').on(table.chatId, table.externalId),
@@ -1368,10 +1368,10 @@ export const omniEvents = pgTable(
     errorStage: varchar('error_stage', { length: 50 }),
 
     // ---- Timing ----
-    receivedAt: timestamp('received_at').notNull().defaultNow(),
-    processedAt: timestamp('processed_at'),
-    deliveredAt: timestamp('delivered_at'),
-    readAt: timestamp('read_at'),
+    receivedAt: timestamp('received_at', { withTimezone: true }).notNull().defaultNow(),
+    processedAt: timestamp('processed_at', { withTimezone: true }),
+    deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+    readAt: timestamp('read_at', { withTimezone: true }),
 
     // ---- Processing Metrics ----
     processingTimeMs: integer('processing_time_ms'),
@@ -1385,7 +1385,7 @@ export const omniEvents = pgTable(
 
     // ---- Metadata ----
     metadata: jsonb('metadata').$type<Record<string, unknown>>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     externalIdIdx: index('omni_events_external_id_idx').on(table.externalId),
@@ -1424,7 +1424,7 @@ export const handoffLogs = pgTable(
     agentId: uuid('agent_id').references(() => agents.id, { onDelete: 'set null' }),
     externalMessageId: varchar('external_message_id', { length: 255 }), // Gupshup message ID
     handoffFields: jsonb('handoff_fields').$type<Record<string, unknown>>(), // structured fields for Gupshup flow variables
-    sentAt: timestamp('sent_at').notNull().defaultNow(),
+    sentAt: timestamp('sent_at', { withTimezone: true }).notNull().defaultNow(),
     metadata: jsonb('metadata').$type<Record<string, unknown>>(), // extensible
   },
   (table) => ({
@@ -1529,7 +1529,7 @@ export const accessRules = pgTable(
     priority: integer('priority').notNull().default(0),
     enabled: boolean('enabled').notNull().default(true),
     reason: text('reason'),
-    expiresAt: timestamp('expires_at'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
 
     // ---- Action ----
     action: varchar('action', { length: 20 }).notNull().default('block'), // 'block' | 'allow' | 'silent_block'
@@ -1539,8 +1539,8 @@ export const accessRules = pgTable(
     metadata: jsonb('metadata').$type<Record<string, unknown>>(),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     instanceIdx: index('access_rules_instance_idx').on(table.instanceId),
@@ -1573,8 +1573,8 @@ export const globalSettings = pgTable(
     isRequired: boolean('is_required').notNull().default(false),
     defaultValue: text('default_value'),
     validationRules: jsonb('validation_rules').$type<Record<string, unknown>>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
     createdBy: varchar('created_by', { length: 255 }),
     updatedBy: varchar('updated_by', { length: 255 }),
   },
@@ -1599,7 +1599,7 @@ export const settingChangeHistory = pgTable(
     oldValue: text('old_value'),
     newValue: text('new_value'),
     changedBy: varchar('changed_by', { length: 255 }),
-    changedAt: timestamp('changed_at').notNull().defaultNow(),
+    changedAt: timestamp('changed_at', { withTimezone: true }).notNull().defaultNow(),
     changeReason: text('change_reason'),
   },
   (table) => ({
@@ -1644,9 +1644,9 @@ export const batchJobs = pgTable(
     errors: jsonb('errors').$type<Array<{ itemId: string; error: string }>>(),
 
     // ---- Timing ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    startedAt: timestamp('started_at'),
-    completedAt: timestamp('completed_at'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
   },
   (table) => ({
     statusIdx: index('batch_jobs_status_idx').on(table.status),
@@ -1715,9 +1715,9 @@ export const syncJobs = pgTable(
     errorMessage: text('error_message'),
 
     // ---- Timing ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    startedAt: timestamp('started_at'),
-    completedAt: timestamp('completed_at'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
   },
   (table) => ({
     instanceIdx: index('sync_jobs_instance_idx').on(table.instanceId),
@@ -1760,7 +1760,7 @@ export const mediaContent = pgTable(
     batchJobId: uuid('batch_job_id').references(() => batchJobs.id, { onDelete: 'set null' }),
     processingTimeMs: integer('processing_time_ms'),
 
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     eventIdx: index('media_content_event_idx').on(table.eventId),
@@ -1786,7 +1786,7 @@ export const chatIdMappings = pgTable(
       .references(() => instances.id, { onDelete: 'cascade' }),
     lidId: varchar('lid_id', { length: 255 }).notNull(), // @lid format
     phoneId: varchar('phone_id', { length: 255 }).notNull(), // @s.whatsapp.net format
-    discoveredAt: timestamp('discovered_at').notNull().defaultNow(),
+    discoveredAt: timestamp('discovered_at', { withTimezone: true }).notNull().defaultNow(),
     discoveredFrom: varchar('discovered_from', { length: 50 }), // 'message_key' | 'sender_match' | 'manual'
   },
   (table) => ({
@@ -1810,9 +1810,9 @@ export const pluginStorage = pgTable(
     pluginId: varchar('plugin_id', { length: 100 }).notNull(),
     key: varchar('key', { length: 500 }).notNull(),
     value: text('value').notNull(), // JSON serialized
-    expiresAt: timestamp('expires_at'),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     pluginKeyIdx: uniqueIndex('plugin_storage_plugin_key_idx').on(table.pluginId, table.key),
@@ -2126,15 +2126,15 @@ export const deadLetterEvents = pgTable(
     // Retry tracking
     autoRetryCount: integer('auto_retry_count').notNull().default(0),
     manualRetryCount: integer('manual_retry_count').notNull().default(0),
-    nextAutoRetryAt: timestamp('next_auto_retry_at'), // null = no more auto-retries
+    nextAutoRetryAt: timestamp('next_auto_retry_at', { withTimezone: true }), // null = no more auto-retries
 
     // Status tracking
     status: varchar('status', { length: 20 }).notNull().default('pending').$type<DeadLetterStatus>(),
 
     // Timestamps
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    lastRetryAt: timestamp('last_retry_at'),
-    resolvedAt: timestamp('resolved_at'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    lastRetryAt: timestamp('last_retry_at', { withTimezone: true }),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
     resolvedBy: varchar('resolved_by', { length: 100 }), // manual resolution note
   },
   (table) => ({
@@ -2173,8 +2173,8 @@ export const payloadStorageConfig = pgTable(
     storeError: boolean('store_error').notNull().default(true),
 
     retentionDays: integer('retention_days').notNull().default(14),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     eventTypeIdx: uniqueIndex('payload_storage_config_event_type_idx').on(table.eventType),
@@ -2206,12 +2206,12 @@ export const eventPayloads = pgTable(
     payloadSizeCompressed: integer('payload_size_compressed'),
 
     // Metadata
-    timestamp: timestamp('timestamp').notNull().defaultNow(),
+    timestamp: timestamp('timestamp', { withTimezone: true }).notNull().defaultNow(),
     containsMedia: boolean('contains_media').notNull().default(false),
     containsBase64: boolean('contains_base64').notNull().default(false),
 
     // Soft-delete for audit trail
-    deletedAt: timestamp('deleted_at'),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
     deletedBy: varchar('deleted_by', { length: 100 }),
     deleteReason: varchar('delete_reason', { length: 255 }),
   },
@@ -2252,12 +2252,12 @@ export const webhookSources = pgTable(
     enabled: boolean('enabled').notNull().default(true),
 
     // Stats
-    lastReceivedAt: timestamp('last_received_at'),
+    lastReceivedAt: timestamp('last_received_at', { withTimezone: true }),
     totalReceived: integer('total_received').notNull().default(0),
 
     // Timestamps
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     nameIdx: uniqueIndex('webhook_sources_name_idx').on(table.name),
@@ -2418,8 +2418,8 @@ export const automations = pgTable(
     priority: integer('priority').notNull().default(0), // Higher = runs first
 
     // Timestamps
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     nameIdx: index('automations_name_idx').on(table.name),
@@ -2476,7 +2476,7 @@ export const automationLogs = pgTable(
     executionTimeMs: integer('execution_time_ms'),
 
     // Timestamps
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     automationIdx: index('automation_logs_automation_idx').on(table.automationId),
@@ -2502,7 +2502,7 @@ export const consumerOffsets = pgTable('consumer_offsets', {
   streamName: varchar('stream_name', { length: 50 }).notNull(),
   lastSequence: integer('last_sequence').notNull().default(0),
   lastEventId: uuid('last_event_id'),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
 export type ConsumerOffset = typeof consumerOffsets.$inferSelect;
@@ -2667,9 +2667,9 @@ export const agentTasks = pgTable(
     completedSubtaskCount: integer('completed_subtask_count').notNull().default(0),
 
     // ---- Timestamps ----
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    startedAt: timestamp('started_at'),
-    completedAt: timestamp('completed_at'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
   },
   (table) => ({
     agentIdIdx: index('agent_tasks_agent_id_idx').on(table.agentId),
@@ -2755,9 +2755,9 @@ export const turns = pgTable(
     messagesSent: integer('messages_sent').notNull().default(0),
 
     // ---- Timestamps ----
-    startedAt: timestamp('started_at').notNull().defaultNow(),
-    lastActivityAt: timestamp('last_activity_at').notNull().defaultNow(),
-    closedAt: timestamp('closed_at'),
+    startedAt: timestamp('started_at', { withTimezone: true }).notNull().defaultNow(),
+    lastActivityAt: timestamp('last_activity_at', { withTimezone: true }).notNull().defaultNow(),
+    closedAt: timestamp('closed_at', { withTimezone: true }),
 
     // ---- Close info ----
     closedReason: text('closed_reason'),
@@ -2923,7 +2923,7 @@ export const processedEvents = pgTable(
   {
     eventId: varchar('event_id', { length: 255 }).notNull(),
     handler: varchar('handler', { length: 100 }).notNull(),
-    processedAt: timestamp('processed_at').notNull().defaultNow(),
+    processedAt: timestamp('processed_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.eventId, table.handler], name: 'processed_events_pk' }),
@@ -2988,13 +2988,13 @@ export const genieHosts = pgTable(
     scopes: text('scopes').array().notNull().default(sql`ARRAY['*']::text[]`),
 
     /** Set by the verification middleware on every successful signed request. */
-    lastSeenAt: timestamp('last_seen_at'),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }),
 
     /** Set by `omni trust revoke <id>`. Revoked hosts cannot pass verification. */
-    revokedAt: timestamp('revoked_at'),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
 
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     pubkeyUq: index('genie_hosts_pubkey_idx').on(table.pubkey),


### PR DESCRIPTION
## Summary

Fixes a production-impacting bug where the turn-monitor force-closed every fresh turn within seconds.

**Root cause:** PG `timestamp without time zone` strips the offset on write. With canonical pgserve at `TimeZone = America/Sao_Paulo`:
- `defaultNow()` (PG NOW) wrote `started_at` as literal BRT wall-clock.
- `new Date()` (JS) wrote `closed_at` as literal UTC wall-clock.
- The two columns differed by 3h → `getStale()` saw every fresh `last_activity_at` as 10800s old → instant force-close.

**Live DB before fix:** `diff_sec = 10804.88, 10804.01, 10808.88` (3h offset)
**Live DB after fix:**  `diff_sec = 4.88, 4.01, 8.88` (real durations)

## Changes

- `packages/db/src/schema.ts` — 99 timestamps now pass `{ withTimezone: true }`. All 109 columns TZ-aware.
- `packages/db/drizzle/0036_timestamptz_migration.sql` — `ALTER TABLE` for every column with per-column `USING`: `defaultNow()` → `AT TIME ZONE current_setting('TimeZone')`, JS-set → `AT TIME ZONE 'UTC'`.
- `packages/db/drizzle/meta/_journal.json` — register migration 0036.
- `packages/db/scripts/check-tz-naive.ts` + `package.json` — build-time guard wired into typecheck.

## Constraints honored
- NOT `ALTER DATABASE SET timezone` — works in any system TZ.
- Schema-level root fix, not turn-monitor workaround.
- All 22 affected tables converted in one migration.

## Test plan
- [x] db typecheck (includes lint:tz) — pass
- [x] `bun test`: 3743 pass / 0 fail / 285 skip
- [x] Live migration apply: 37/37; fresh insert `init_diff_sec = 0.0`
- [x] Negative test of guard: catches reintroduced TZ-naive timestamps with file:line
- [ ] Soak in dev for 1h, verify real WhatsApp DM round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)