### PR TITLE
fix(automations): also gate replayed events by sequenceIndex

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -562,8 +562,8 @@ async function setupEventBusServices(
       // sweeper published the event, or whose chat is in active close-contact
       // state. Fail-open on errors so a flaky DB doesn't drop legitimate
       // events.
-      staleIdleTimeoutGate: async (chatId, instanceId) => {
-        return services.followUpLifecycle.evaluateIdleTimeoutFreshness(chatId, instanceId);
+      staleIdleTimeoutGate: async (chatId, instanceId, eventSequenceIndex) => {
+        return services.followUpLifecycle.evaluateIdleTimeoutFreshness(chatId, instanceId, eventSequenceIndex);
       },
     });
   } catch (error) {

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -49,7 +49,11 @@ export class AutomationService {
   async startEngine(deps?: {
     sendMessage?: (instanceId: string, to: string, content: string) => Promise<void>;
     callAgent?: (context: AgentCallContext, config: CallAgentActionConfig) => Promise<AgentRunResult>;
-    staleIdleTimeoutGate?: (chatId: string, instanceId: string) => Promise<{ skip: boolean; reason?: string }>;
+    staleIdleTimeoutGate?: (
+      chatId: string,
+      instanceId: string,
+      eventSequenceIndex: number | null,
+    ) => Promise<{ skip: boolean; reason?: string }>;
   }): Promise<void> {
     if (!this.eventBus) {
       return;

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -387,6 +387,12 @@ export class FollowUpLifecycleService {
    *  - follow-up row's `disarmReason` is set — sequence is in a terminal
    *    state and any further fire would re-spam a chat the system already
    *    finished/handed-off/archived
+   *  - row's `sequenceIndex` is strictly greater than the event's
+   *    `eventSequenceIndex` — the row already advanced via a more recent
+   *    sweeper tick. Catches the regression class where a row stays
+   *    nominally active (no `disarmReason`) but a replayed event
+   *    references an older sequence position. Without this check, replays
+   *    of events 0..N-1 keep firing while the row is at sequenceIndex N.
    *
    * Returns `{ skip: false }` when the event should proceed normally.
    *
@@ -395,13 +401,28 @@ export class FollowUpLifecycleService {
    * a flaky DB at consumer time is less harmful than silently dropping
    * legitimate idle-timeout events.
    */
-  async evaluateIdleTimeoutFreshness(chatId: string, instanceId: string): Promise<{ skip: boolean; reason?: string }> {
+  async evaluateIdleTimeoutFreshness(
+    chatId: string,
+    instanceId: string,
+    eventSequenceIndex: number | null,
+  ): Promise<{ skip: boolean; reason?: string }> {
     if (await this.isInActiveCloseState(chatId, instanceId)) {
       return { skip: true, reason: 'chat_closed' };
     }
     const row = await this.readExistingRow(chatId, instanceId);
     if (row?.disarmReason) {
       return { skip: true, reason: `disarmed_${row.disarmReason}` };
+    }
+    if (
+      row !== null &&
+      typeof eventSequenceIndex === 'number' &&
+      typeof row.sequenceIndex === 'number' &&
+      row.sequenceIndex > eventSequenceIndex
+    ) {
+      return {
+        skip: true,
+        reason: `sequence_advanced_row_at_${row.sequenceIndex}_event_${eventSequenceIndex}`,
+      };
     }
     return { skip: false };
   }
@@ -417,12 +438,14 @@ export class FollowUpLifecycleService {
     disarmReason: FollowUpDisarmReason | null;
     disarmedAt: Date | null;
     lastInboundCustomerMessageAt: Date | null;
+    sequenceIndex: number;
   } | null> {
     const [row] = await this.db
       .select({
         disarmReason: chatFollowUpState.disarmReason,
         disarmedAt: chatFollowUpState.disarmedAt,
         lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
+        sequenceIndex: chatFollowUpState.sequenceIndex,
       })
       .from(chatFollowUpState)
       .where(and(eq(chatFollowUpState.chatId, chatId), eq(chatFollowUpState.instanceId, instanceId)))
@@ -433,6 +456,7 @@ export class FollowUpLifecycleService {
       disarmReason: (row.disarmReason ?? null) as FollowUpDisarmReason | null,
       disarmedAt: row.disarmedAt ?? null,
       lastInboundCustomerMessageAt: row.lastInboundCustomerMessageAt ?? null,
+      sequenceIndex: row.sequenceIndex,
     };
   }
 

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -70,16 +70,33 @@ export interface ActionDependencies {
   /**
    * Optional consumer-side stale-event gate. Invoked by the engine for
    * `chat.idle_timeout` events before matching automations execute.
-   * Returns `{ skip: true, reason }` when the event is no longer relevant
-   * (chat in active close-contact state, follow-up row already disarmed,
-   * etc.). Defense-in-depth against NATS replay of historical idle-timeout
-   * events that the sweeper had already processed before a restart drained
-   * the durable consumer's ack state.
+   * Returns `{ skip: true, reason }` when the event is no longer relevant:
+   *   - chat in active close-contact state (`closed:true` or
+   *     `closeUntil` still in window)
+   *   - follow-up row already disarmed (`sequence_complete`,
+   *     `customer_replied`, `handoff`, `contact_closed`, etc.)
+   *   - row has advanced past the event's `sequenceIndex` (event is a
+   *     replay or redelivery from before the row's last sweeper tick)
+   *
+   * Defense-in-depth against NATS replay of historical or duplicate
+   * idle-timeout events that the sweeper had already processed before a
+   * restart drained the durable consumer's ack state, or that NATS
+   * redelivered after a transient handler failure.
+   *
+   * `eventSequenceIndex` is the `sequenceIndex` field from the
+   * `chat.idle_timeout` payload at publish time. The row's current
+   * `sequence_index` is read by the gate; if it is strictly greater than
+   * the event's value, the row has already advanced via a more recent
+   * sweep and this event is stale.
    *
    * Returning `{ skip: false }` (or omitting the gate entirely) lets the
    * engine proceed with normal matching+execution.
    */
-  staleIdleTimeoutGate?: (chatId: string, instanceId: string) => Promise<{ skip: boolean; reason?: string }>;
+  staleIdleTimeoutGate?: (
+    chatId: string,
+    instanceId: string,
+    eventSequenceIndex: number | null,
+  ) => Promise<{ skip: boolean; reason?: string }>;
 }
 
 /**

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -353,18 +353,20 @@ export class AutomationEngine {
    */
   private async shouldSkipStaleIdleTimeout(event: OmniEvent): Promise<boolean> {
     if (event.type !== 'chat.idle_timeout' || !this.deps.staleIdleTimeoutGate) return false;
-    const payload = event.payload as { chatId?: string; instanceId?: string };
+    const payload = event.payload as { chatId?: string; instanceId?: string; sequenceIndex?: number };
     const chatId = payload?.chatId;
     const payloadInstanceId = payload?.instanceId ?? event.metadata.instanceId;
     if (!chatId || !payloadInstanceId) return false;
+    const eventSequenceIndex = typeof payload?.sequenceIndex === 'number' ? payload.sequenceIndex : null;
 
     try {
-      const verdict = await this.deps.staleIdleTimeoutGate(chatId, payloadInstanceId);
+      const verdict = await this.deps.staleIdleTimeoutGate(chatId, payloadInstanceId, eventSequenceIndex);
       if (verdict.skip) {
         logger.info('Skipping stale chat.idle_timeout event', {
           eventId: event.id,
           chatId,
           instanceId: payloadInstanceId,
+          eventSequenceIndex,
           reason: verdict.reason ?? 'unknown',
         });
         return true;


### PR DESCRIPTION
> Follow-up to #593. Same author, same incident — the original PR merged before this second iteration was discovered + pushed.

## Summary

#593 closed the disarmed-row replay class (event arrives for a chat whose row is now `disarmReason IS NOT NULL`). Live monitoring at a production tenant ~7h after that fix landed surfaced a second class the gate didn't catch:

- A chat got 12 follow-ups in 6 hours despite `maxFollowUps=3`
- Row stayed nominally active (no `disarmReason`), `sequence_index=2`, `next_fire_at` 1h in the future
- Last `updated_at` was 2h before the most recent fires
- The replayed events carried OLDER `sequenceIndex` payloads (0 and 1) than the row's current position (2) — the row had already advanced via earlier sweeper ticks but the events weren't fully consumed

The original gate's `disarm_reason IS NULL` check let these through because the row hadn't reached `sequence_complete` yet.

## Fix

Extends the gate plumbing (engine → API service) to also accept the event's `sequenceIndex` from the payload, and skip with reason `sequence_advanced_row_at_N_event_M` when `row.sequenceIndex > eventSequenceIndex`.

| file | change |
|---|---|
| `packages/core/src/automations/actions.ts` | gate signature accepts third `eventSequenceIndex: number \| null` param |
| `packages/core/src/automations/engine.ts` | extract `payload.sequenceIndex` from `chat.idle_timeout` events, pass to gate |
| `packages/api/src/services/follow-up-lifecycle.ts` | `evaluateIdleTimeoutFreshness` signature + new check, `readExistingRow` returns `sequenceIndex` |
| `packages/api/src/services/automations.ts` | `startEngine` deps signature update |
| `packages/api/src/index.ts` | wires the third arg through |

5 files, +59/-12 lines. Cherry-picked clean from the post-#593 commit on the original branch.

## Validation

Running in production at a downstream tenant since the iter-2 deploy — ~50h of continuous post-fix telemetry:

```
2,127 fires bucketed:
  1,353 disarmed_after_fire (legit, customer reply / close)
    591 fire_during_disarm_race (legit, sweeper publish/commit race)
    183 active_at_fire (legit, earlier-attempt fires)
      0 TRUE_LEAK

5,082 stale events caught by the gate:
  2,318 disarmed_sequence_complete (the iter-1 class)
  1,377 sequence_advanced_row_at_1_event_0 (THIS PR's class)
  1,357 sequence_advanced_row_at_2_event_1 (THIS PR's class)
     26 chat_closed
      4 disarmed_handoff

per-session repeats <60s = 0
close-leaks since fix = 0
handoff-leaks since fix = 0
```

The two `sequence_advanced_*` reason classes account for ~54% of the gate's skip volume — substantial, and a real protection against this NATS replay pattern.

## Test plan

- [x] `bun typecheck` clean (core + api)
- [x] `bunx biome check` clean
- [x] Full suite passes (4052 tests, pre-push gate green)
- [x] Live production validation (~50h)
- [ ] Unit test in `packages/core/src/automations/__tests__/engine.test.ts` covering: stale event with older sequenceIndex skipped, equal sequenceIndex proceeds, gate exception fail-open
- [ ] Integration test in `packages/api/src/__tests__/follow-up-e2e.test.ts` covering: replayed event for a row that has advanced

## Refs

Closes the gap left by #593.