### PR TITLE
docs(wish): draft output-primitives-unified — extend output.ts surface

### DIFF
--- a/.genie/wishes/output-primitives-unified/SHARED-DESIGN.md
+++ b/.genie/wishes/output-primitives-unified/SHARED-DESIGN.md
@@ -1,0 +1,282 @@
+# SHARED-DESIGN: Unified output primitives across genie + omni CLIs
+
+**Status**: design locked 2026-05-04. Companion wishes: `automagik-dev/genie#output-primitives-unified` + `automagik/omni#output-primitives-unified`. Both wishes share this document byte-identically.
+
+**Goal**: One PR per CLI (against `dev`) that converges genie's and omni's command output on a single shared surface — `output.ts` — with identical function names, identical glyphs, identical color semantics, identical JSON-mode dual-output, identical pipe-flush behavior.
+
+---
+
+## 1. Audit at design time (2026-05-04)
+
+### genie (`automagik-dev/genie`, `origin/dev`)
+
+| Path | Files | console.log/error/warn | ANSI escapes (`\x1b[`) | chalk | ora | Centralized helper |
+|------|------:|----------------------:|----------------------:|------:|----:|--------------------|
+| `src/genie-commands/*.ts` | 11 | **175+** across 7 files | **115+** across 7 files | 0 | 0 | **none** |
+| Worst offenders | — | `setup.ts` (66), `doctor.ts` (62), `update.ts` (46), `uninstall.ts` (28), `perf-check.ts` (20), `session.ts` (17), `shortcuts.ts` (9) | `setup.ts` (38), `doctor.ts` (33), `uninstall.ts` (18), `perf-check.ts` (11), `update.ts` (9), `shortcuts.ts` (6) | — | — | — |
+
+**Pattern in genie today** (literal from `src/genie-commands/update.ts`):
+```ts
+function log(message: string): void {
+  console.log(`\x1b[32m▸\x1b[0m ${message}`);
+}
+function success(message: string): void {
+  console.log(`\x1b[32m✔\x1b[0m ${message}`);
+}
+function error(message: string): void {
+  console.log(`\x1b[31m✖\x1b[0m ${message}`);
+}
+```
+
+Each command file has its own variant. No `--json` mode. No `NO_COLOR` honoring. No pipe-buffer drain. Glyph drift between files (some use `▸`, others `→`, others bare text).
+
+### omni (`automagik/omni`, `origin/dev`)
+
+| Path | Files | uses `output.*` already | direct chalk | direct ora | bare ANSI |
+|------|------:|------------------------:|-------------:|-----------:|----------:|
+| `packages/cli/src/commands/*.ts` | 54 | **47 files** | `update.ts` (5 calls) | `update.ts` (5), `install.ts` (3), `providers-setup.ts` (1), `film.ts` (1) | 0 |
+| Helper file | 1 | — | — | — | — |
+
+**Existing `packages/cli/src/output.ts`** (322 LOC, 11 exports):
+- `success(msg, data?)`, `error(msg, details?, exitCode?)`, `warn(msg)`, `tip(msg)`, `info(msg)`
+- `data(value)` — auto-detects array → `printTable`, object → `printObject`, primitive → `String(...)`.
+- `list(items, opts?)` — table render with empty-message fallback.
+- `keyValue(key, value)`, `header(title)`, `dim(text)`, `raw(text)`.
+- `disableColors()`, `areColorsEnabled()`, `getCurrentFormat() → 'human' | 'json'`.
+- `flushStdout()` — pipe-buffer drain via `process.stdout.write(chunk, cb)` so `omni xxx --json | cat > file.json` doesn't truncate at 64KB on Linux.
+
+**Already canonical**. The 9 direct `chalk`/`ora` usages in `update.ts` and `install.ts` are the outliers — explained by the fact that `output.ts` does not yet expose `step` / `spinner` / `banner` / `progress` / `divider` primitives that those flows need.
+
+---
+
+## 2. The asymmetry — what each wish actually has to do
+
+| Work | genie | omni |
+|------|-------|------|
+| Create `output.ts` from scratch | **YES** (new file) | NO (already exists, 322 LOC) |
+| Add `chalk` + `ora` deps to `package.json` | **YES** (zero today) | NO (both already in `packages/cli/package.json`) |
+| Add `boxen` + `cli-progress` deps | YES | YES |
+| Migrate 7 command files from bare ANSI / `console.log` to `output.*` | **YES** (~290 call sites) | NO (already migrated) |
+| Migrate `update.ts` direct chalk/ora to `output.*` | YES (Group 5 of `update-unify-stages` already proposes this; this wish closes the loop) | YES (5 chalk + 5 ora call sites) |
+| Migrate `install.ts` direct ora to `output.spinner` | YES (when it lands) | YES (3 ora call sites) |
+| Migrate `providers-setup.ts` direct ora | — | YES (1 ora call site) |
+| Migrate `film.ts` direct ora | — | YES (1 ora call site) |
+| Add `step` / `spinner` / `banner` / `progress` / `divider` to `output.ts` surface | YES | YES |
+| JSON mode behavior | YES (new) | already there |
+| `NO_COLOR` / TTY auto-detect | YES (new) | already there |
+| Pipe-buffer drain (`flushStdout`) | YES (new — Bun on Linux truncates >64KB pipe writes) | already there |
+
+Estimate: genie ≈ 4-6 engineer-days; omni ≈ 1-2 engineer-days.
+
+---
+
+## 3. The shared surface — what `output.ts` exports in BOTH repos
+
+**Existing in omni (preserved byte-identically)**:
+```ts
+export function success(message: string, data?: unknown): void;
+export function error(message: string, details?: unknown, exitCode?: number): never;
+export function warn(message: string): void;
+export function tip(message: string): void;
+export function info(message: string): void;
+export function data(value: unknown): void;
+export function list<T>(items: T[], options?: { emptyMessage?: string; rawData?: unknown[] }): void;
+export function keyValue(key: string, value: unknown): void;
+export function header(title: string): void;
+export function dim(text: string): void;
+export function raw(text: string): void;
+export function disableColors(): void;
+export function areColorsEnabled(): boolean;
+export function getCurrentFormat(): 'human' | 'json';
+export function flushStdout(): Promise<void>;
+export function setMaxCellWidth(width: number): void;
+```
+
+**NEW additions (both repos add these — identical signatures)**:
+```ts
+/**
+ * Print a stage divider — bold cyan ▸ + bold message + newline above.
+ * In JSON mode: emits `{ step: "<msg>" }` to stderr.
+ * Replaces ad-hoc `console.log("\n\x1b[1;36m▸ <msg>\x1b[0m\n")` patterns.
+ */
+export function step(message: string): void;
+
+/**
+ * Wrap an `ora` spinner with format-awareness.
+ * - Human mode: returns a thin proxy over the real `ora` spinner.
+ * - JSON mode: returns a stub that emits `{ spinner: "start", text }` /
+ *   `{ spinner: "succeed", text }` to stderr but never writes to stdout.
+ *   Stdout stays clean for JSON consumers.
+ * - Non-TTY (`--no-color`, piped, CI): the spinner degrades to plain
+ *   `info(text)` on start and `success(text)` on succeed; no \r animation.
+ */
+export interface OutputSpinner {
+  start(): OutputSpinner;
+  succeed(text?: string): void;
+  fail(text?: string): void;
+  warn(text?: string): void;
+  info(text?: string): void;
+  stop(): void;
+  set text(value: string);
+}
+export function spinner(text: string): OutputSpinner;
+
+/**
+ * Print a boxed banner (boxen wrapper). Used for "Updated to vX.Y.Z"
+ * release-style announcements. Single-line input is centered; multi-line
+ * is left-aligned. Honors NO_COLOR (degrades to ASCII box). In JSON mode
+ * emits `{ banner: "<msg>" }` to stderr.
+ */
+export interface BannerOptions {
+  title?: string;
+  borderStyle?: 'single' | 'double' | 'round' | 'bold';
+  borderColor?: 'green' | 'red' | 'yellow' | 'blue' | 'cyan';
+  padding?: number;
+}
+export function banner(message: string | string[], options?: BannerOptions): void;
+
+/**
+ * Wrap `cli-progress` with format-awareness.
+ * - Human mode TTY: returns the real `cli-progress.SingleBar`.
+ * - JSON mode / non-TTY: returns a stub that emits one
+ *   `{ progress: 0.42, total: 8000000, downloaded: 3360000 }` line per
+ *   second (rate-limited) to stderr; never animates.
+ */
+export interface OutputProgress {
+  start(total: number, startValue?: number): void;
+  update(current: number): void;
+  increment(delta?: number): void;
+  stop(): void;
+}
+export function progress(label: string): OutputProgress;
+
+/**
+ * Print a horizontal divider — `─` × terminal width (or 80 if non-TTY).
+ * In JSON mode: no-op (dividers are decoration; consumers don't need them).
+ */
+export function divider(): void;
+```
+
+**Glyph table (locked)**:
+
+| Severity | Glyph | Color | Usage |
+|----------|-------|-------|-------|
+| step | ▸ | bold cyan | section headers in install/update/setup pipelines |
+| info | ℹ | blue | informational lines (channel, version, path) |
+| ok / success | ✓ | green | step-completed line |
+| warn | ⚠ | yellow | recoverable issue |
+| fail / error | ✗ | red | terminal failure |
+| tip | 💡 | cyan | always-stderr nudges (non-blocking) |
+| dim | — | dim grey | secondary text (paths, dates, timestamps) |
+
+`figures` (transitive dep via `ora`) provides the cross-platform fallback. `boxen` provides the borders. `cli-progress` provides the bars.
+
+---
+
+## 4. New deps both repos add (locked versions)
+
+| Dep | Version | Why | Bundle cost |
+|-----|---------|-----|-------------|
+| `chalk` | `^5.4.0` | Already in omni; genie adds. Same major. | ~22 KB |
+| `ora` | `^8.1.1` | Already in omni; genie adds. Same major. | ~37 KB (includes figures) |
+| `boxen` | `^7.1.1` | Banner rendering with locked border styles. | ~24 KB |
+| `cli-progress` | `^3.12.0` | Download progress bar (used by self-update / install when fetching binaries). | ~18 KB |
+
+All four are pure-JS, zero native deps, ESM-compatible. Combined: ~100 KB additional install size. Both CLIs already weigh several MB; this is rounding error.
+
+**Optional** (deferred, not in v1):
+- `terminal-link` — clickable hyperlinks in iTerm/kitty/wezterm. Add only when a concrete use case appears.
+
+---
+
+## 5. JSON mode contract
+
+When `getCurrentFormat() === 'json'`:
+- `success` writes valid JSON to stdout.
+- `error` writes valid JSON to stderr; exits non-zero.
+- `warn`, `info`, `tip` write valid JSON to **stderr** (so a `--json | jq` consumer of stdout still parses).
+- `step`, `spinner.start/succeed/fail/warn/info`, `banner` emit `{ step|spinner|banner: "..." }` to **stderr**.
+- `progress` emits `{ progress: 0.0–1.0, total, downloaded }` to **stderr** at most once per second.
+- `divider`, `dim`, `header` are **no-ops**.
+- `data`, `list`, `keyValue` write canonical JSON to stdout.
+
+This is the contract omni already implements; genie adopts byte-for-byte.
+
+---
+
+## 6. NO_COLOR / TTY contract
+
+- `NO_COLOR=1` env var → `disableColors()` called at startup; chalk auto-detects via its own NO_COLOR support.
+- `process.stdout.isTTY === false` (piped output) → spinners degrade to `info` lines; progress bars degrade to per-second JSON lines.
+- `--no-color` CLI flag → calls `disableColors()` on each command.
+- `FORCE_COLOR=1` → forces colors even on non-TTY (useful for CI logs that render ANSI). Honored by chalk natively.
+
+---
+
+## 7. Migration order (within each repo)
+
+1. **Land `output.ts` extensions first** (`step`, `spinner`, `banner`, `progress`, `divider`) — additive, no caller changes.
+2. **Migrate the highest-traffic command** (genie: `update.ts` ; omni: `update.ts`) — proves the API in production.
+3. **Migrate the install path** (genie: `install.ts`, `setup.ts` ; omni: `install.ts`).
+4. **Migrate doctor + setup-adjacent commands** (`doctor.ts`, `perf-check.ts`, `uninstall.ts`, `shortcuts.ts`).
+5. **Lint rule** — add a Biome / ESLint custom rule that fails on `console.log` / `console.error` / `console.warn` outside of `output.ts` itself (genie wish G6 ; omni already has an analogous rule via comment-based suppressions, formalize it).
+
+---
+
+## 8. Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Independent implementations per repo (no shared package) | Same as `update-unify-stages` — coupling cost > duplication cost. |
+| 2 | omni's existing `output.ts` is the reference; genie absorbs byte-for-byte | omni has 322 LOC of battle-tested code (JSON mode, pipe-flush, table render). Don't reinvent. |
+| 3 | Add `step`, `spinner`, `banner`, `progress`, `divider` to BOTH `output.ts` files in the same wish | Locks the surface; prevents future drift. |
+| 4 | Glyphs locked in §3 table | Operators learn one set; cross-CLI muscle memory. |
+| 5 | JSON-mode emits stderr breadcrumbs for spinners/banners/progress | Stdout stays clean for `--json | jq` consumers; observability not lost. |
+| 6 | `figures` (transitive via ora) handles cross-platform glyph fallback | No additional dep needed; macOS/Linux/Windows behave consistently. |
+| 7 | Lint rule banning bare `console.log` outside `output.ts` lands in v1 | Without enforcement, drift returns. |
+| 8 | `terminal-link` deferred to v2 | Optional polish; no current use case justifies the dep. |
+| 9 | Glyph + color choices map 1:1 to the bash `install.sh` helpers | bash and TS sides should look identical to the operator. |
+| 10 | `flushStdout()` is exported and called from each CLI's main entry on exit | Otherwise large `--json` payloads truncate at 64KB on Linux pipes. |
+
+---
+
+## 9. Exit code contract (additive — does not modify existing exit codes)
+
+- `output.error(...)` exits 1 by default; takes optional `exitCode` parameter.
+- `output.spinner(text).fail(...)` does NOT exit on its own; caller chooses.
+- All other output functions never exit.
+
+---
+
+## 10. Tests both repos must ship
+
+- `output.success` / `error` / `warn` / `info` / `tip` shape in human + JSON modes (snapshot or string-match).
+- `output.step` glyph + color + JSON-mode stderr emission.
+- `output.spinner` returns the right type per format mode; non-TTY degradation path.
+- `output.banner` border styles render; multi-line input handled; JSON-mode stderr.
+- `output.progress` rate-limited stderr in JSON mode; TTY animation path.
+- `output.divider` no-op in JSON mode; correct width on TTY.
+- `disableColors()` flips `areColorsEnabled()` and chalk respects it.
+- `flushStdout()` drains pending writes before resolving.
+- Lint rule (Biome custom or grep-based) catches a regression bare-console-log added to a non-`output.ts` file.
+
+---
+
+## 11. Out of scope
+
+- Ink. Not adding. Output is streaming linear; Ink is for componentized TUIs.
+- OpenTUI for non-TUI commands. Not adding. Same reason.
+- Internationalization. Glyphs and color are universal; messages are English-only (matches both CLIs today).
+- Telemetry hooks on output. Separate concern.
+- Replacing `commander`'s built-in help text styling. Help text is commander's surface; not this wish.
+- Cross-CLI shared package. Per Decision #1.
+
+---
+
+## 12. Definition of done (cross-repo)
+
+- Both PRs merged to their respective `dev` branches.
+- `output.ts` exports the same surface in both repos (`diff <(grep -E "^export" genie/output.ts) <(grep -E "^export" omni/output.ts)` is empty modulo path-only differences).
+- Glyph table from §3 produces byte-identical lines for the same logical event in both CLIs.
+- `genie update --json | jq` and `omni update --json | jq` both parse cleanly with no stderr leakage to stdout.
+- Lint rule active in both CLIs; PRs touching command files cannot bypass without explicit `// biome-ignore` comment.

--- a/.genie/wishes/output-primitives-unified/WISH.md
+++ b/.genie/wishes/output-primitives-unified/WISH.md
@@ -1,0 +1,284 @@
+# Wish: Unified output primitives (omni side)
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `output-primitives-unified` |
+| **Date** | 2026-05-04 |
+| **Author** | Felipe Rosa <felipe@namastex.ai> |
+| **Appetite** | small (~1–2 engineer-days) |
+| **Branch** | `wish/output-primitives-unified` |
+| **Repos touched** | `automagik/omni` |
+| **Design** | [SHARED-DESIGN.md](./SHARED-DESIGN.md) |
+
+> **Companion document:** [SHARED-DESIGN.md](./SHARED-DESIGN.md) — cross-repo unification spec (byte-identical to `automagik-dev/genie#output-primitives-unified` SHARED-DESIGN.md).
+> **Sibling wish:** [`automagik-dev/genie#output-primitives-unified`](../../../../genie/.genie/wishes/output-primitives-unified/WISH.md) — both wishes ship in parallel; this repo's `output.ts` is the **reference implementation** that genie absorbs byte-for-byte.
+
+## Summary
+
+omni already has the canonical output helper at `packages/cli/src/output.ts` (322 LOC, 11 functions, JSON+human dual-mode, NO_COLOR-aware, pipe-flush-aware). 47 of 54 command files in `packages/cli/src/commands/` route through it. The remaining 9 direct usages of `chalk` and `ora` (across `update.ts`, `install.ts`, `providers-setup.ts`, `film.ts`) exist because `output.ts` doesn't yet expose `step` / `spinner` / `banner` / `progress` / `divider` primitives that those flows need.
+
+This wish closes the gap: extend `output.ts` with the 5 new primitives per `SHARED-DESIGN.md` §3, migrate the 9 direct chalk/ora call sites, add `boxen` + `cli-progress` as new deps, and lock the contract so the genie sibling has a stable byte-reference to copy. No regression of any current behavior.
+
+## Scope
+
+### IN
+
+**Group 1 — Extend `output.ts` surface**
+- Add `step(message): void` — bold cyan ▸ stage divider; JSON-mode emits `{ step: "..." }` to stderr.
+- Add `spinner(text): OutputSpinner` — ora wrapper with format-aware degradation (TTY animation / non-TTY plain `info`+`success` / JSON-mode stderr breadcrumb).
+- Add `banner(message, options?): void` — boxen wrapper with locked border/color options.
+- Add `progress(label): OutputProgress` — cli-progress wrapper rate-limited to 1 stderr line/sec in non-TTY/JSON mode.
+- Add `divider(): void` — `─` × terminal width (or 80 if non-TTY); no-op in JSON mode.
+- All 5 follow the existing `output.ts` style (TypeScript types exported, JSDoc on every function, `getCurrentFormat()` switch).
+
+**Group 2 — Migrate direct chalk/ora call sites**
+- `packages/cli/src/commands/update.ts` — 5 chalk + 5 ora call sites → `output.banner` (the 3-line success banner) + `output.spinner` (each ora step).
+- `packages/cli/src/commands/install.ts` — 3 ora call sites → `output.spinner`.
+- `packages/cli/src/commands/providers-setup.ts` — 1 ora call site → `output.spinner`.
+- `packages/cli/src/commands/film.ts` — 1 ora call site → `output.spinner`.
+- After migration, `grep -E "import.*from 'ora'\\|import.*from 'chalk'" packages/cli/src/commands/*.ts | wc -l` is 0 (the only chalk/ora imports left are inside `output.ts` itself).
+
+**Group 3 — Deps + tests + CHANGELOG**
+- Add `boxen@^7.1.1` and `cli-progress@^3.12.0` to `packages/cli/package.json`.
+- Tests at `packages/cli/src/__tests__/output.test.ts` (extend existing if it exists; create if not):
+  - `step` — glyph + color in human; `{ step: "..." }` to stderr in JSON.
+  - `spinner` — ora animation in TTY; degradation to `info`+`success` in non-TTY; stderr breadcrumb in JSON.
+  - `banner` — borders render; multi-line input handled; stderr breadcrumb in JSON.
+  - `progress` — rate-limited stderr in JSON; cli-progress instance returned in TTY.
+  - `divider` — width correct; no-op in JSON.
+- `CHANGELOG.md` entry: *"Output helper extended with `step`, `spinner`, `banner`, `progress`, `divider` primitives. Direct `chalk` and `ora` usage in command files migrated; only `output.ts` imports them now. Genie CLI absorbs the same surface — see `automagik-dev/genie#output-primitives-unified`."*
+
+**Group 4 — Lint enforcement**
+- Formalize the existing `// biome-ignore lint/suspicious/noConsole: CLI output` pattern: a regex-based lint script (`scripts/lint/no-bare-output-imports.cjs`) that fails CI when any file under `packages/cli/src/commands/` imports `chalk` or `ora` directly (i.e., not via `output.ts`).
+- `output.ts` is the single allowlisted file.
+- Wire into `bun run lint` and `bun run check`.
+
+### OUT
+
+- **Modifying the existing 16 baseline `output.ts` exports.** They stay byte-identical; only additions.
+- **Migrating commands that already use `output.*`.** They're done. This wish is laser-focused on the 4 outlier files.
+- **Ink, OpenTUI, Solid for command output.** Per `SHARED-DESIGN.md` §11.
+- **Internationalization.** Out of scope.
+- **Telemetry hooks on output.** Separate wish.
+- **Cross-CLI shared package.** Independent implementations per `SHARED-DESIGN.md` decision #1.
+- **Replacing commander help-text styling.** Commander owns it.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Extensions only — zero changes to existing 16 exports | Backwards compatible. 47 callers already depend on the current shapes. |
+| 2 | `OutputSpinner` interface is a **subset** of ora's API | Lock only what we use (`start`, `succeed`, `fail`, `warn`, `info`, `stop`, `text`); leaves room to swap implementation later. |
+| 3 | `boxen` + `cli-progress` as new deps | Small (~42 KB combined), pure-JS, ESM. No native deps. |
+| 4 | Genie absorbs THIS file as reference | Per `SHARED-DESIGN.md` decision #2. After both wishes merge, `diff` of exports is empty. |
+| 5 | Lint rule formalized in same wish as the migration | Without it, drift returns. Same logic as the genie sibling wish Group 6. |
+| 6 | `// biome-ignore lint/suspicious/noConsole: CLI output` comments inside `output.ts` are kept | They're correct — `output.ts` IS the single permitted place to call `console.error` directly. |
+
+## Success Criteria
+
+- [ ] `packages/cli/src/output.ts` exports `step`, `spinner`, `banner`, `progress`, `divider` per `SHARED-DESIGN.md` §3.
+- [ ] All 5 new exports have full JSDoc + TypeScript types.
+- [ ] `boxen@^7.1.1` and `cli-progress@^3.12.0` are in `packages/cli/package.json`.
+- [ ] `update.ts` no longer imports `chalk` or `ora` directly. The 3-line success banner uses `output.banner`. Each ora step uses `output.spinner`.
+- [ ] `install.ts`, `providers-setup.ts`, `film.ts` no longer import `ora` directly.
+- [ ] `grep -lE "from 'ora'\\|from 'chalk'" packages/cli/src/commands/*.ts | wc -l` → 0.
+- [ ] All 16 baseline `output.ts` exports continue to work byte-identically (existing tests pass).
+- [ ] New tests cover: TTY path, non-TTY path, JSON-mode breadcrumbs, NO_COLOR for every new export.
+- [ ] Lint rule fails CI on a deliberate `import ora from 'ora'` added to a fixture file under `packages/cli/src/commands/`.
+- [ ] CHANGELOG entry present.
+- [ ] `bun test packages/cli/src/__tests__/output.test.ts` passes.
+- [ ] `bun run check` passes.
+
+## Execution Strategy
+
+### Wave 1 — Extensions (parallel)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Add `step`, `spinner`, `banner`, `progress`, `divider` to `output.ts`. Tests for every new export. |
+
+### Wave 2 — Migration (sequential after Wave 1)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 2 | engineer | Migrate `update.ts` + `install.ts` + `providers-setup.ts` + `film.ts` to use the new primitives. |
+
+### Wave 3 — Deps + tests + lint (parallel)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 3 | engineer | Add deps + tests + CHANGELOG entry. |
+| 4 | engineer | Lint rule + wiring. |
+
+## Execution Groups
+
+### Group 1: Extend `output.ts` surface
+
+**Goal:** Add the 5 new primitives. Pure additions, zero behavior change to existing exports.
+
+**Deliverables:**
+1. `packages/cli/src/output.ts` extended with the 5 new exports per `SHARED-DESIGN.md` §3.
+2. JSDoc + types for each new export.
+3. JSON-mode behavior per `SHARED-DESIGN.md` §5.
+4. NO_COLOR / non-TTY degradation per `SHARED-DESIGN.md` §6.
+5. New deps added to `packages/cli/package.json` (boxen, cli-progress).
+
+**Acceptance Criteria:**
+- [ ] `import { step, spinner, banner, progress, divider } from '../output.js'` resolves and typechecks.
+- [ ] `step('Installing...')` emits bold-cyan `▸ Installing...` in human mode; `{ step: "Installing..." }` to stderr in JSON.
+- [ ] `spinner('Checking version...').start().succeed('v1.2.3')` produces a real ora animation in TTY; degrades to `info` + `success` in non-TTY.
+- [ ] `banner('Updated to v1.2.3', { borderStyle: 'double', borderColor: 'green' })` produces a 3-line boxed banner; emits `{ banner: "..." }` to stderr in JSON.
+- [ ] `progress('Downloading')` returns a working `cli-progress.SingleBar` in TTY; rate-limits to ≤1 line/sec to stderr in JSON.
+- [ ] `divider()` prints `─` × `process.stdout.columns || 80` in human mode; no-op in JSON mode.
+
+**Validation:**
+```bash
+bun test packages/cli/src/__tests__/output.test.ts -t "step\|spinner\|banner\|progress\|divider"
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Migrate `update.ts` + `install.ts` + `providers-setup.ts` + `film.ts`
+
+**Goal:** Eliminate all direct `chalk` / `ora` imports in command files. The 3-line success banner in `update.ts` becomes a single `output.banner` call.
+
+**Deliverables:**
+1. `packages/cli/src/commands/update.ts`:
+   - Remove `import chalk from 'chalk'` and `import ora from 'ora'`.
+   - 5 `chalk.green('✓')` / `chalk.red('✗')` / `chalk.bold(...)` calls → equivalent `output.success` / `output.error` / `output.banner` calls.
+   - 5 `ora(...)` calls → `output.spinner(...)`.
+   - The 3-line success block (`✓ CLI: v…`, `✓ Server: v…`, `✓ Auth: …`) → `output.banner([cliLine, serverLine, authLine], { borderStyle: 'round', borderColor: 'green' })`.
+2. `packages/cli/src/commands/install.ts` — 3 ora call sites → `output.spinner`.
+3. `packages/cli/src/commands/providers-setup.ts` — 1 ora call site → `output.spinner`.
+4. `packages/cli/src/commands/film.ts` — 1 ora call site → `output.spinner`.
+5. All locked error strings preserved byte-identically.
+
+**Acceptance Criteria:**
+- [ ] `grep -lE "from 'ora'\\|from 'chalk'" packages/cli/src/commands/*.ts | wc -l` → 0.
+- [ ] `bun test packages/cli/src/__tests__/update-verify.test.ts` passes byte-identically.
+- [ ] Visual diff of `omni update --yes` output before/after migration: same glyphs, same colors, same line count.
+- [ ] `omni update --json | jq` parses cleanly; spinners/banners go to stderr.
+
+**Validation:**
+```bash
+grep -lE "from 'ora'\\|from 'chalk'" packages/cli/src/commands/*.ts || echo "OK no direct imports"
+bun test packages/cli/src/__tests__/update-verify.test.ts
+bun test packages/cli/src/__tests__/install.test.ts
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Deps + tests + CHANGELOG
+
+**Goal:** Lock the deps, lock the tests, document the contract.
+
+**Deliverables:**
+1. `packages/cli/package.json` updated with `boxen@^7.1.1`, `cli-progress@^3.12.0`. `bun install` re-locks.
+2. Tests at `packages/cli/src/__tests__/output.test.ts` — comprehensive coverage of every new export (TTY / non-TTY / JSON mode / NO_COLOR / FORCE_COLOR for each).
+3. `CHANGELOG.md` entry per Scope IN.
+
+**Acceptance Criteria:**
+- [ ] `bun install` succeeds; lock file changes reviewable.
+- [ ] `bun test packages/cli/src/__tests__/output.test.ts` passes; coverage ≥90% on the 5 new exports.
+- [ ] `grep -F "Output helper extended with" CHANGELOG.md` matches.
+
+**Validation:**
+```bash
+bun install && bun test packages/cli/src/__tests__/output.test.ts
+grep -F "Output helper extended with" CHANGELOG.md
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 4: Lint rule
+
+**Goal:** Make a regression a CI fail.
+
+**Deliverables:**
+1. `scripts/lint/no-bare-output-imports.cjs` — Node script scanning `packages/cli/src/commands/`; fails on any `import .* from 'ora'` or `import .* from 'chalk'` (allowing the existing `from 'chalk'` inside `output.ts` since that file is not under `commands/`).
+2. Wire into `package.json` scripts (`"lint:output": "node scripts/lint/no-bare-output-imports.cjs"`) and into `bun run check`.
+3. Fixture-based negative test: a file at `packages/cli/src/commands/.test-fixtures/lint-regression.ts` with a deliberate `import ora from 'ora'` plus a unit test that runs the lint and asserts non-zero exit.
+
+**Acceptance Criteria:**
+- [ ] `bun run lint:output` passes on the migrated tree.
+- [ ] `bun run lint:output` fails (exit 1) on the deliberately-bad fixture.
+- [ ] `bun run check` includes the new lint step.
+
+**Validation:**
+```bash
+bun run lint:output && echo "OK clean"
+bun run check
+```
+
+**depends-on:** Group 2
+
+---
+
+## Cross-wish dependencies
+
+- **paired-with** [`automagik-dev/genie#output-primitives-unified`](../../../../genie/.genie/wishes/output-primitives-unified/WISH.md) — both wishes ship in parallel against their respective `dev` branches. omni's `output.ts` is the byte-reference; genie absorbs it.
+- **closes-the-loop-on** `update-unify-stages` (omni side, already merged) — that wish established the unified update pipeline; this wish makes its visual layer consistent with the rest of the CLI.
+
+## QA Criteria
+
+_What must be verified on `dev` after merge._
+
+- [ ] Functional — `omni update`, `omni install`, `omni providers add`, `omni film` all visually identical post-migration (or differences explainable + intentional).
+- [ ] Functional — `--json` mode works for every migrated subcommand; stdout valid JSON; stderr has all human breadcrumbs.
+- [ ] Functional — `--no-color` produces zero ANSI for every migrated subcommand.
+- [ ] Integration — `omni update --json | jq` parses cleanly.
+- [ ] Integration — `boxen` borders render correctly in iTerm, kitty, GNOME Terminal, Windows Terminal.
+- [ ] Regression — All current tests pass.
+- [ ] Regression — Locked error strings in `update-verify.test.ts` byte-identical.
+- [ ] Regression — Lint rule fails CI on a deliberate bare-import regression.
+- [ ] Cross-CLI parity — `diff <(grep -E "^export" packages/cli/src/output.ts | sort) <(grep -E "^export" ../../genie/src/lib/output.ts | sort)` produces zero meaningful differences after both wishes ship.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `boxen` ESM compat issue with the omni CLI bundle | Low | boxen is fully ESM since v6; we're on v7. Verify bundle output in Group 3. |
+| `cli-progress` adds enough perceptible startup latency to cold-start an `omni status` | Low | cli-progress is lazy-imported only inside `progress()`. Other call sites pay zero cost. Benchmark in Group 1. |
+| Visual diff between pre-migration ora and post-migration `output.spinner` is non-zero | Medium | Wrap ora 1:1; the visible behavior is identical. Snapshot test pins it. |
+| `output.banner` for the 3-line success block looks worse than the current 3 separate `console.log` lines | Medium | Group 2 acceptance includes a visual review; if the boxed banner is uglier, fall back to 3 separate `output.success` lines (still avoids direct chalk import). |
+| Lint rule misfires on a legitimate ora/chalk import in a future test fixture | Low | Allowlist `packages/cli/src/__tests__/` and `packages/cli/src/commands/.test-fixtures/`. |
+| External consumers depend on stderr-vs-stdout split that this wish formalizes | Low | The split was already the contract per omni's existing `output.ts`; this wish only extends it. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+# Modify
+packages/cli/src/output.ts
+packages/cli/src/__tests__/output.test.ts
+packages/cli/src/commands/update.ts
+packages/cli/src/commands/install.ts
+packages/cli/src/commands/providers-setup.ts
+packages/cli/src/commands/film.ts
+packages/cli/package.json                                     # +boxen +cli-progress
+package.json                                                  # script wiring if monorepo-level
+CHANGELOG.md
+
+# Create
+scripts/lint/no-bare-output-imports.cjs
+packages/cli/src/commands/.test-fixtures/lint-regression.ts   # for the lint negative test
+
+# Reference (read-only)
+.genie/wishes/output-primitives-unified/SHARED-DESIGN.md
+```


### PR DESCRIPTION
## Summary

Authors the omni sibling of `automagik-dev/genie#output-primitives-unified`. Both wishes ship in parallel; omni's existing `output.ts` (322 LOC, in production, used by 47 of 54 command files) is the byte-reference. This wish extends it with the 5 new primitives that the genie sibling will absorb byte-for-byte.

## Audit findings (2026-05-04, origin/dev)

| Metric | Value |
|--------|------:|
| Command files | 54 |
| Files routing through `output.*` helpers | **47** ✅ |
| Direct `chalk` imports in command files | 1 (`update.ts`, 5 calls) |
| Direct `ora` imports in command files | 4 (`update.ts` 5 calls, `install.ts` 3, `providers-setup.ts` 1, `film.ts` 1) |
| Hardcoded ANSI escapes | 0 |

omni is **80% there**. The 9 outlier call sites exist because `output.ts` doesn't yet expose `step` / `spinner` / `banner` / `progress` / `divider` — flows that need them reach for `chalk`/`ora` directly.

## Scope (4 groups, 3 waves)

**Wave 1**
- **G1** Add `step` / `spinner` / `banner` / `progress` / `divider` to `output.ts` per `SHARED-DESIGN.md` §3. Add `boxen` + `cli-progress` deps.

**Wave 2**
- **G2** Migrate the 4 outlier files. Remove all `chalk`/`ora` imports from `packages/cli/src/commands/`.

**Wave 3**
- **G3** Tests + CHANGELOG.
- **G4** Lint rule banning `chalk`/`ora` imports in command files (allowlist `output.ts`).

## Pure addition

Zero changes to the existing 16 baseline exports. The 47 callers already routing through `output.*` are untouched. Locked error strings preserved byte-identically.

## Cross-repo shape

After both wishes merge: \`diff <(grep -E "^export" packages/cli/src/output.ts | sort) <(grep -E "^export" genie/src/lib/output.ts | sort)\` produces zero meaningful differences.

## Estimated effort

~1-2 engineer-days. Small surface, mostly additive.

## Test plan

- [ ] `wishes:lint` passes on the new wish
- [ ] `SHARED-DESIGN.md` byte-identical to `automagik-dev/genie#output-primitives-unified`'s copy
- [ ] No code changes — doc-only PR; CI green

## Companion PR

`automagik-dev/genie#output-primitives-unified` opens in parallel (the bigger of the two — genie has 4-6 days of migration ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)