### PR TITLE
feat(update): unify omni update — VerifyResult, cleanup registry, maintenance hook, diagnostics, --no-verify, slim install.sh

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -67,7 +67,7 @@
         "hono": "^4.6.17",
         "lru-cache": "^11.2.6",
         "nats": "^2.29.3",
-        "pgserve": "^1.2.0",
+        "pgserve": "^2.1.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -86,7 +86,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -161,7 +161,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -195,7 +195,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -210,7 +210,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -230,7 +230,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -265,7 +265,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -280,7 +280,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -294,7 +294,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -312,7 +312,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -320,7 +320,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -334,7 +334,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260427.1",
+      "version": "2.260505.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",
@@ -466,13 +466,13 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wnswaF+uDvGeitqajJ8v8xOG4ttFrzixElwKNe2MIxBXSLWPV3xhi6tBY0Sjw8Lmiu6UG9vNLFZSjHPrIeokBg=="],
+    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.3.0-beta.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pvrej3Xz5flfyVc9mchVfekrKoTJyvPtM3U0vjuXamZkRKmi+inP2zRmnmzYecIVbr7Zhu82xbsCENMXrwMp9Q=="],
 
-    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-u9WtTPxRuO0uOny5IniXHSDaLmtOujwzDoExIV/jFT0Fu8SzpX7wdoPbsSPBLgyQWdr/nPA77K9QI4r6P1/fKA=="],
+    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.3.0-beta.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-MVWe+C47pPoMD9LlIWGQkvZ5Xsu3IBo54CYqnIps/Z1byMIUBNc7y/dZ3mfqEwiCbVDVqirG0CU462xnrSEfKA=="],
 
-    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.2.0-beta.16", "", { "os": "linux", "cpu": "x64" }, "sha512-BIt485ioL8/AwDgw37IcdraOfRgHNDOtGM6Hh63vnNaUAG4Z0qtJd5zXS5fr2wZTEsYHyC5PC60k7zkCRZXSzg=="],
+    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.3.0-beta.17", "", { "os": "linux", "cpu": "x64" }, "sha512-8orSD6NNopSLtjqir4dWQBrj+g8j1eJjWd9mB60A3xbWMzIBIPQpzT7XzbacW9YFSl/DejOLnRXfff+Wr13Tgw=="],
 
-    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.2.0-beta.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Sj6GhCZrvtMwchATEtWuEmexEBWpRNMHPTUHsqPuyDrHX/XgKfpIxz2/AMHa4sp7SZ0JOHGouH8AFIVsWQrQsQ=="],
+    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.3.0-beta.17", "", { "os": "win32", "cpu": "x64" }, "sha512-kDC5aBsmhWDjeQjj2V4g+Bk+pMeDU27b7l0rBbaKgtt2gsNmCB34ULg/5cqs2kqUKSk/tiGMHKCNE+zQZ+s4rg=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1854,7 +1854,7 @@
 
     "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
-    "pgserve": ["pgserve@1.2.0", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-xXHcLYGekf2wTlhJk6hK4yJCoFBAIF9FPmKHGqKwrhoEZ0uXrVem/IWtrTEKku8XJWrx7ya/9s/ysbcH4o+DyQ=="],
+    "pgserve": ["pgserve@2.2.3", "", { "dependencies": { "bun": "^1.3.4", "react": "^18.3.1", "react-dom": "^18.3.1" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.3.0-beta.17", "@embedded-postgres/darwin-x64": "18.3.0-beta.17", "@embedded-postgres/linux-x64": "18.3.0-beta.17", "@embedded-postgres/windows-x64": "18.3.0-beta.17" }, "bin": { "autopg": "bin/autopg-wrapper.cjs", "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-j47sOW0dNavQuNJPi5ROK9t2YS/wrmyDpafcok2Emo4sRnbOYfFvupFy4t9X3DJnzD1myp1vxMSxw2LPXeq8lw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/install.sh
+++ b/install.sh
@@ -1,43 +1,32 @@
 #!/usr/bin/env bash
 # ============================================================================
-# Omni v2 — Universal Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/automagik-dev/omni/main/install.sh | bash
+# Omni v2 — Bootstrap installer
+#
+# Installs bun (if missing), the @automagik/omni CLI from npm on the channel
+# the operator last used (latest|next from ~/.omni/config.json), then hands
+# off to `omni install --non-interactive` for the rest of the setup wizard
+# (NATS download, PM2 process registration, pgserve canonical backbone,
+# instance prompts, AI provider config). Any future wizard work belongs in
+# the TS installer, NOT in this bash script.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/automagik-dev/omni/main/install.sh | bash
+#   curl -fsSL <…>/install.sh | bash -s -- --cli       # CLI only (no server bootstrap)
+#   curl -fsSL <…>/install.sh | bash -s -- --server    # Default; runs full wizard
 # ============================================================================
 set -euo pipefail
 
-VERSION="2.0.0"
-DEFAULT_API_URL="http://localhost:8882"
+PACKAGE='@automagik/omni'
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-DIM='\033[2m'
-NC='\033[0m'
+ok()   { printf "${GREEN}✓${NC}  %s\n" "$*"; }
+warn() { printf "${YELLOW}⚠${NC}  %s\n" "$*"; }
+fail() { printf "${RED}✗${NC}  %s\n" "$*"; exit 1; }
+has()  { command -v "$1" >/dev/null 2>&1; }
 
-# ============================================================================
-# Helpers — all I/O goes through /dev/tty, results go into $REPLY
-# This avoids $() subshell issues when running via curl|bash
-# ============================================================================
-
-REPLY=""
-
-info()    { printf "${BLUE}ℹ${NC}  %s\n" "$*"; }
-ok()      { printf "${GREEN}✓${NC}  %s\n" "$*"; }
-warn()    { printf "${YELLOW}⚠${NC}  %s\n" "$*"; }
-fail()    { printf "${RED}✗${NC}  %s\n" "$*"; exit 1; }
-step()    { printf "\n${BOLD}${CYAN}▸ %s${NC}\n" "$*"; }
-
-has_cmd() { command -v "$1" >/dev/null 2>&1; }
-
-# Read persisted update channel from ~/.omni/config.json. If the user previously
-# ran `omni update --next`, we honor that on reinstall instead of silently
-# downgrading them to @latest. Defaults to `latest` when no config exists or
-# the field is missing.
-omni_channel() {
+# Honor a previously-saved channel preference so reinstall doesn't silently
+# downgrade an operator from @next to @latest. Defaults to latest.
+resolve_channel() {
   local cfg="$HOME/.omni/config.json"
   if [[ -f "$cfg" ]] && grep -q '"updateChannel"[[:space:]]*:[[:space:]]*"next"' "$cfg" 2>/dev/null; then
     printf 'next'
@@ -46,548 +35,43 @@ omni_channel() {
   fi
 }
 
-ask_yn() {
-  local prompt="$1" default="${2:-y}" yn
-  if [[ "$default" == "y" ]]; then
-    printf "${BOLD}?${NC} %s ${DIM}[Y/n]${NC} " "$prompt" >/dev/tty
-  else
-    printf "${BOLD}?${NC} %s ${DIM}[y/N]${NC} " "$prompt" >/dev/tty
-  fi
-  read -r yn </dev/tty
-  yn="${yn:-$default}"
-  [[ "$yn" =~ ^[Yy] ]]
-}
-
-# ask_input "prompt" "default" → sets $REPLY
-ask_input() {
-  local prompt="$1" default="${2:-}"
-  if [[ -n "$default" ]]; then
-    printf "${BOLD}?${NC} %s ${DIM}[%s]${NC} " "$prompt" "$default" >/dev/tty
-  else
-    printf "${BOLD}?${NC} %s " "$prompt" >/dev/tty
-  fi
-  read -r REPLY </dev/tty
-  REPLY="${REPLY:-$default}"
-}
-
-# ask_secret "prompt" "default" → sets $REPLY
-ask_secret() {
-  local prompt="$1" default="${2:-}"
-  if [[ -n "$default" ]]; then
-    local masked="${default:0:10}...${default: -4}"
-    printf "${BOLD}?${NC} %s ${DIM}[%s]${NC} " "$prompt" "$masked" >/dev/tty
-  else
-    printf "${BOLD}?${NC} %s " "$prompt" >/dev/tty
-  fi
-  read -r REPLY </dev/tty
-  REPLY="${REPLY:-$default}"
-}
-
-# ask_choice "prompt" "opt1" "opt2" ... → sets $REPLY to number
-ask_choice() {
-  local prompt="$1"; shift
-  local options=("$@")
-  printf "${BOLD}?${NC} %s\n" "$prompt" >/dev/tty
-  local i=1
-  for opt in "${options[@]}"; do
-    printf "  ${CYAN}%d)${NC} %s\n" "$i" "$opt" >/dev/tty
-    ((i++))
-  done
-  printf "${BOLD}?${NC} ${DIM}[1-%d]${NC} " "${#options[@]}" >/dev/tty
-  read -r REPLY </dev/tty
-  REPLY="${REPLY:-1}"
-}
-
-banner() {
-  printf "\n"
-  printf "${BOLD}${CYAN}"
-  cat << 'EOF'
-   ___  __  __ _  _ ___
-  / _ \|  \/  | \| |_ _|
- | (_) | |\/| | .` || |
-  \___/|_|  |_|_|\_|___|
-
-EOF
-  printf "${NC}"
-  printf "  ${DIM}Universal Event-Driven Omnichannel Platform${NC}\n"
-  printf "  ${DIM}v%s — installer${NC}\n\n" "$VERSION"
-}
-
-# ============================================================================
-# Dependencies
-# ============================================================================
-
 ensure_bun() {
-  if has_cmd bun; then
-    ok "bun $(bun --version)"
-    return 0
-  fi
-  info "Installing bun..."
+  if has bun; then ok "bun $(bun --version)"; return 0; fi
+  printf "Installing bun...\n"
   curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
   export BUN_INSTALL="$HOME/.bun"
   export PATH="$BUN_INSTALL/bin:$PATH"
-  [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc" 2>/dev/null || true
-  if has_cmd bun; then
-    ok "bun $(bun --version) installed"
-  else
-    fail "Failed to install bun. Install manually: https://bun.sh"
-  fi
+  has bun || fail "bun install failed; install manually from https://bun.sh and re-run."
+  ok "bun $(bun --version) installed"
 }
 
-ensure_pm2() {
-  if has_cmd pm2; then
-    ok "pm2 $(pm2 --version 2>/dev/null || echo '?')"
-    return 0
-  fi
-  info "Installing PM2..."
-  bun add -g pm2 >/dev/null 2>&1
-  if has_cmd pm2; then
-    ok "pm2 installed"
-  else
-    warn "Could not install PM2 globally. Install manually: bun add -g pm2"
-  fi
-}
-
-# Canonical pgserve backbone (pgserve@^2.1.0) — shared by omni + genie + any
-# future automagik service that needs Postgres. `omni install` will register
-# it under pm2 via `pgserve install` (idempotent). We install the binary
-# globally up front so `omni install` can find it without a fallback.
-ensure_pgserve() {
-  if has_cmd pgserve; then
-    ok "pgserve $(pgserve --version 2>/dev/null || echo '?')"
-    return 0
-  fi
-  info "Installing pgserve@^2.1.0 (canonical Postgres backbone)..."
-  bun add -g pgserve@^2.1.0 >/dev/null 2>&1
-  if has_cmd pgserve; then
-    ok "pgserve installed"
-  else
-    warn "Could not install pgserve globally. omni install will fall back to embedded mode. To migrate later: bun add -g pgserve@^2.1.0 && omni doctor --fix"
-  fi
-}
-
-# Offer the Omni Claude Code plugin install when `claude` is available.
-# Mirrors genie's `offer_claude_plugin()` (genie/install.sh:563-591) so a
-# fresh `curl … | bash` end-to-end install gives the operator both the CLI
-# AND the `/omni:*` slash commands without a separate manual step.
-#
-# Marketplace: automagik-dev/omni → plugin name `omni@automagik-dev`
-# (matches packages/.claude-plugin/marketplace.json `name: "automagik-dev"`).
-#
-# Idempotent: claude plugin marketplace add + install both no-op when the
-# plugin is already registered. We never fail the install on a plugin error
-# — the CLI is functional without the plugin; the plugin is a DX upgrade.
-offer_omni_plugin() {
-  if ! has_cmd claude; then
-    info "Claude Code not found — skipping plugin install (you can install it later with: claude plugin install omni@automagik-dev)"
-    return 0
-  fi
-
-  info "Installing Omni plugin for Claude Code..."
-  claude plugin marketplace add automagik-dev/omni >/dev/null 2>&1 || true
-  if claude plugin install omni@automagik-dev >/dev/null 2>&1; then
-    ok "Omni Claude Code plugin installed (try /omni:omni-setup in a Claude session)"
-  else
-    warn "Plugin install failed — try manually: claude plugin install omni@automagik-dev"
-  fi
-}
-
-# ============================================================================
-# Install: CLI only
-# ============================================================================
-
-install_cli_only() {
-  step "Installing Omni CLI (global)"
-
-  local channel
-  channel="$(omni_channel)"
-  info "Installing @automagik/omni@${channel} from npm..."
-  if bun add -g "@automagik/omni@${channel}" 2>/dev/null && has_cmd omni; then
-    ok "omni $(omni --version) installed from npm (channel: ${channel})"
-    offer_omni_plugin
-    return 0
-  fi
-  fail "npm install failed. Check your network and try again: bun add -g @automagik/omni@${channel}"
-}
-
-# ============================================================================
-# Install: Full server
-# ============================================================================
-
-install_full_server() {
-  step "Installing Omni v2 (full server)"
-
-  ensure_pm2
-  ensure_pgserve
-
-  local channel
-  channel="$(omni_channel)"
-  info "Installing @automagik/omni@${channel} from npm..."
-  if ! bun add -g "@automagik/omni@${channel}" 2>/dev/null || ! has_cmd omni; then
-    fail "npm install failed. Check your network and try again: bun add -g @automagik/omni@${channel}"
-  fi
+install_cli() {
+  local channel="$1"
+  printf "Installing %s@%s...\n" "$PACKAGE" "$channel"
+  bun add -g "${PACKAGE}@${channel}" >/dev/null 2>&1 || fail "bun add -g ${PACKAGE}@${channel} failed"
+  has omni || fail "omni binary not on PATH after install; check \$PATH includes \$HOME/.bun/bin"
   ok "omni $(omni --version) installed (channel: ${channel})"
+}
 
-  info "Running omni install (this will download NATS, configure PM2, etc.)..."
+bootstrap_server() {
+  # Hand the wizard off to TS — `omni install --non-interactive` owns
+  # NATS download, PM2 registration, pgserve canonical backbone,
+  # instance/provider prompts, and writing ~/.omni/config.json.
+  printf "Running omni install --non-interactive...\n"
   omni install --non-interactive
-
-  offer_omni_plugin
 }
 
-# ============================================================================
-# Configure connection
-# ============================================================================
-
-configure_connection() {
-  step "Configure connection"
-
-  ask_input "Omni API URL:" "$DEFAULT_API_URL"
-  local api_url="$REPLY"
-
-  ask_secret "API Key (omni_sk_...):" ""
-  local api_key="$REPLY"
-
-  if [[ -z "$api_key" ]]; then
-    warn "No API key provided. Set later: omni auth login --api-key <key>"
-    return 1
+main() {
+  local mode="${1:-server}"
+  if [[ "$mode" == "--help" || "$mode" == "-h" ]]; then
+    printf "Usage: install.sh [--cli|--server]\n  --cli     CLI only (no server bootstrap)\n  --server  CLI + omni install --non-interactive (default)\n"
+    exit 0
   fi
-
-  mkdir -p "$HOME/.omni"
-  printf '{\n  "apiUrl": "%s",\n  "apiKey": "%s",\n  "format": "human"\n}\n' "$api_url" "$api_key" > "$HOME/.omni/config.json"
-  chmod 600 "$HOME/.omni/config.json"
-  ok "Config saved to ~/.omni/config.json"
-
-  info "Testing connection..."
-  local health
-  health=$(curl -s -H "Authorization: Bearer $api_key" "$api_url/api/v2/health" 2>/dev/null || echo "")
-  if echo "$health" | grep -q '"healthy"'; then
-    ok "Connected to Omni at $api_url"
-    return 0
-  else
-    warn "Could not connect to $api_url — check URL and API key"
-    return 1
-  fi
-}
-
-# ============================================================================
-# Setup wizard (optional post-install steps)
-# ============================================================================
-
-setup_wizard() {
-  local api_url api_key
-  api_url=$(grep -o '"apiUrl"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.omni/config.json" 2>/dev/null | cut -d'"' -f4)
-  api_key=$(grep -o '"apiKey"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.omni/config.json" 2>/dev/null | cut -d'"' -f4)
-
-  [[ -z "$api_url" || -z "$api_key" ]] && return 0
-
-  local auth_header="Authorization: Bearer $api_key"
-
-  # ── WhatsApp instance ─────────────────────────────────────────────
-  printf "\n"
-  if ask_yn "Create a WhatsApp instance?" "n"; then
-    step "Creating WhatsApp instance"
-
-    ask_input "Instance name:" "my-whatsapp"
-    local instance_name="$REPLY"
-
-    info "Creating instance '$instance_name'..."
-    local result
-    result=$(curl -s -X POST "$api_url/api/v2/instances" \
-      -H "$auth_header" \
-      -H "Content-Type: application/json" \
-      -d "{\"name\": \"$instance_name\", \"channel\": \"whatsapp-baileys\"}" 2>/dev/null)
-
-    local instance_id
-    instance_id=$(echo "$result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-
-    if [[ -n "$instance_id" ]]; then
-      ok "Instance created: $instance_id"
-
-      # Set as default instance in config
-      python3 -c "
-import json, sys
-try:
-    c = json.load(open('$HOME/.omni/config.json'))
-    c['defaultInstance'] = '$instance_id'
-    json.dump(c, open('$HOME/.omni/config.json', 'w'), indent=2)
-except: pass
-" 2>/dev/null
-      ok "Set as default instance"
-
-      # QR code pairing
-      if ask_yn "Pair via QR code now? (scan with WhatsApp)"; then
-        info "Fetching QR code..."
-        local qr_result
-        qr_result=$(curl -s "$api_url/api/v2/instances/$instance_id/qr" -H "$auth_header" 2>/dev/null)
-        local qr_code
-        qr_code=$(echo "$qr_result" | grep -o '"qr":"[^"]*"' | cut -d'"' -f4)
-
-        if [[ -n "$qr_code" ]]; then
-          if has_cmd bun; then
-            bun -e "const q=require('qrcode-terminal');q.generate('$qr_code',{small:true})" 2>/dev/null || printf "  QR: %s\n" "$qr_code"
-          else
-            printf "  QR: %s\n" "$qr_code"
-          fi
-          printf "\n"
-          info "Scan with WhatsApp > Linked Devices > Link a Device"
-          info "Press Enter when done..."
-          read -r </dev/tty
-
-          local status_result
-          status_result=$(curl -s "$api_url/api/v2/instances/$instance_id" -H "$auth_header" 2>/dev/null)
-          if echo "$status_result" | grep -q '"isActive":true'; then
-            ok "WhatsApp connected!"
-          else
-            warn "Not connected yet. Try later: omni instances qr $instance_id"
-          fi
-        else
-          warn "QR not available yet. Try: omni instances qr $instance_id"
-        fi
-      fi
-
-      # Phone number pairing (alternative)
-      if ask_yn "Pair via phone number instead?" "n"; then
-        ask_input "Phone number (e.g. +5511999999999):" ""
-        local phone="$REPLY"
-        if [[ -n "$phone" ]]; then
-          info "Requesting pairing code for $phone..."
-          local pair_result
-          pair_result=$(curl -s -X POST "$api_url/api/v2/instances/$instance_id/pair" \
-            -H "$auth_header" \
-            -H "Content-Type: application/json" \
-            -d "{\"phone\": \"$phone\"}" 2>/dev/null)
-          local pair_code
-          pair_code=$(echo "$pair_result" | grep -o '"code":"[^"]*"' | cut -d'"' -f4)
-          if [[ -n "$pair_code" ]]; then
-            printf "\n  ${BOLD}Pairing code: ${GREEN}%s${NC}\n\n" "$pair_code"
-            info "Enter this code in WhatsApp > Linked Devices > Link with phone number"
-          else
-            warn "Could not get pairing code. Try: omni instances pair $instance_id --phone $phone"
-          fi
-        fi
-      fi
-    else
-      warn "Failed to create instance"
-    fi
-  fi
-
-  # ── Discord instance ──────────────────────────────────────────────
-  if ask_yn "Create a Discord instance?" "n"; then
-    step "Creating Discord instance"
-
-    ask_input "Instance name:" "my-discord"
-    local discord_name="$REPLY"
-
-    ask_secret "Discord bot token:" ""
-    local discord_token="$REPLY"
-
-    if [[ -n "$discord_token" ]]; then
-      info "Creating Discord instance..."
-      local result
-      result=$(curl -s -X POST "$api_url/api/v2/instances" \
-        -H "$auth_header" \
-        -H "Content-Type: application/json" \
-        -d "{\"name\": \"$discord_name\", \"channel\": \"discord\", \"config\": {\"token\": \"$discord_token\"}}" 2>/dev/null)
-      if echo "$result" | grep -q '"id"'; then
-        ok "Discord instance created"
-      else
-        warn "Failed. Set up later: omni instances create --name $discord_name --channel discord"
-      fi
-    else
-      warn "No token. Create later: omni instances create --help"
-    fi
-  fi
-
-  # ── Output format ─────────────────────────────────────────────────
-  if ask_yn "Configure output format?" "n"; then
-    ask_choice "Output format:" "human (colored, tables)" "json (machine-readable)"
-    local fmt="human"
-    [[ "$REPLY" == "2" ]] && fmt="json"
-    python3 -c "
-import json
-c = json.load(open('$HOME/.omni/config.json'))
-c['format'] = '$fmt'
-json.dump(c, open('$HOME/.omni/config.json', 'w'), indent=2)
-" 2>/dev/null
-    ok "Output format: $fmt"
-  fi
-
-  # ── AI provider ──────────────────────────────────────────────────
-  if ask_yn "Configure an AI provider (for auto-replies)?" "n"; then
-    step "AI Provider setup"
-
-    ask_choice "Provider type:" "OpenAI" "Anthropic" "Custom"
-    local provider_choice="$REPLY"
-    local schema="openai" provider_name="" provider_url="" provider_key=""
-
-    case "$provider_choice" in
-      1)
-        schema="openai"
-        ask_input "Provider name:" "openai";           provider_name="$REPLY"
-        provider_url="https://api.openai.com/v1"
-        ask_secret "OpenAI API key:" "";               provider_key="$REPLY"
-        ;;
-      2)
-        schema="anthropic"
-        ask_input "Provider name:" "anthropic";        provider_name="$REPLY"
-        provider_url="https://api.anthropic.com"
-        ask_secret "Anthropic API key:" "";             provider_key="$REPLY"
-        ;;
-      3)
-        schema="openai"
-        ask_input "Provider name:" "my-provider";      provider_name="$REPLY"
-        ask_input "Base URL:" "";                      provider_url="$REPLY"
-        ask_secret "API key:" "";                      provider_key="$REPLY"
-        ;;
-    esac
-
-    if [[ -n "$provider_key" && -n "$provider_url" ]]; then
-      info "Creating provider '$provider_name'..."
-      local result
-      result=$(curl -s -X POST "$api_url/api/v2/providers" \
-        -H "$auth_header" \
-        -H "Content-Type: application/json" \
-        -d "{\"name\": \"$provider_name\", \"schema\": \"$schema\", \"baseUrl\": \"$provider_url\", \"apiKey\": \"$provider_key\"}" 2>/dev/null)
-      if echo "$result" | grep -q '"id"'; then
-        ok "Provider '$provider_name' created"
-      else
-        warn "Failed. Set up later: omni providers create --help"
-      fi
-    else
-      warn "Incomplete config. Set up later: omni providers create --help"
-    fi
-  fi
-
-  # ── Test message ──────────────────────────────────────────────────
-  local instances_json
-  instances_json=$(curl -s "$api_url/api/v2/instances" -H "$auth_header" 2>/dev/null)
-  local has_active
-  has_active=$(echo "$instances_json" | grep -c '"isActive":true' 2>/dev/null || echo "0")
-
-  if [[ "$has_active" -gt 0 ]]; then
-    if ask_yn "Send a test message?" "n"; then
-      ask_input "Send to (phone with country code):" ""
-      local test_to="$REPLY"
-
-      ask_input "Message:" "Hello from Omni! 🚀"
-      local test_text="$REPLY"
-
-      if [[ -n "$test_to" ]]; then
-        info "Sending..."
-        local send_result
-        send_result=$(curl -s -X POST "$api_url/api/v2/messages/send" \
-          -H "$auth_header" \
-          -H "Content-Type: application/json" \
-          -d "{\"to\": \"$test_to\", \"content\": {\"text\": \"$test_text\"}}" 2>/dev/null)
-        if echo "$send_result" | grep -q '"id"'; then
-          ok "Message sent!"
-        else
-          warn "Send failed"
-        fi
-      fi
-    fi
-  fi
-}
-
-# ============================================================================
-# Main wizard
-# ============================================================================
-
-wizard() {
-  banner
-
-  printf "${BOLD}What would you like to install?${NC}\n\n" >/dev/tty
-  printf "  ${CYAN}1)${NC} ${BOLD}CLI only${NC}       — Install from npm\n" >/dev/tty
-  printf "  ${CYAN}2)${NC} ${BOLD}Full server${NC}    — Install CLI + run omni install\n" >/dev/tty
-  printf "  ${CYAN}3)${NC} ${BOLD}CLI + connect${NC}  — Install CLI and configure remote server\n" >/dev/tty
-  printf "\n" >/dev/tty
-
-  ask_input "Choose [1/2/3]:" "1"
-  local choice="$REPLY"
-
-  step "Checking dependencies"
   ensure_bun
-
-  case "$choice" in
-    1)
-      install_cli_only
-      printf "\n"
-      if ask_yn "Configure connection to a remote server?"; then
-        if configure_connection; then
-          setup_wizard
-        fi
-      fi
-      ;;
-    2)
-      install_full_server
-      printf "\n"
-      if ask_yn "Run setup wizard?"; then
-        setup_wizard
-      fi
-      ;;
-    3)
-      install_cli_only
-      if configure_connection; then
-        setup_wizard
-      fi
-      ;;
-    *)
-      fail "Invalid choice: $choice"
-      ;;
-  esac
-
-  # ── Summary ───────────────────────────────────────────────────────
-  printf "\n"
-  printf "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "${BOLD}${GREEN}  ✓ Installation complete!${NC}\n"
-  printf "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "\n"
-
-  if [[ -f "$HOME/.omni/config.json" ]]; then
-    local saved_url saved_instance
-    saved_url=$(grep -o '"apiUrl"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.omni/config.json" | cut -d'"' -f4)
-    saved_instance=$(grep -o '"defaultInstance"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.omni/config.json" 2>/dev/null | cut -d'"' -f4)
-    printf "  ${DIM}Server:${NC}    %s\n" "${saved_url:-not configured}"
-    [[ -n "${saved_instance:-}" ]] && printf "  ${DIM}Instance:${NC}  %s\n" "$saved_instance"
-    printf "  ${DIM}Config:${NC}    ~/.omni/config.json\n"
-    printf "\n"
-  fi
-
-  printf "  ${BOLD}Commands:${NC}\n"
-  printf "    omni status              Check connection\n"
-  printf "    omni instances list      List channel instances\n"
-  printf "    omni chats list          List conversations\n"
-  printf "    omni send --help         Send a message\n"
-  printf "    omni --help              All commands\n"
-  printf "\n"
-  printf "  ${DIM}Docs: https://github.com/automagik-dev/omni${NC}\n"
-  printf "\n"
+  local channel; channel="$(resolve_channel)"
+  install_cli "$channel"
+  [[ "$mode" != "--cli" ]] && bootstrap_server
+  ok "Installation complete. Next: omni status, omni instances list, omni --help."
 }
 
-# ============================================================================
-# Non-interactive flags
-# ============================================================================
-
-if [[ "${1:-}" == "--cli" ]]; then
-  ensure_bun; install_cli_only
-  [[ -n "${2:-}" ]] && { DEFAULT_API_URL="$2"; configure_connection; }
-  exit 0
-fi
-
-if [[ "${1:-}" == "--server" ]]; then
-  ensure_bun; install_full_server
-  exit 0
-fi
-
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-  banner
-  printf "Usage:\n"
-  printf "  curl -fsSL <url>/install.sh | bash                             Interactive wizard\n"
-  printf "  curl -fsSL <url>/install.sh | bash -s -- --cli                 CLI only (npm)\n"
-  printf "  curl -fsSL <url>/install.sh | bash -s -- --cli <api-url>       CLI + configure\n"
-  printf "  curl -fsSL <url>/install.sh | bash -s -- --server              Full server\n"
-  printf "\n"
-  exit 0
-fi
-
-wizard
+main "$@"

--- a/packages/cli/src/__tests__/legacy-cleanup.test.ts
+++ b/packages/cli/src/__tests__/legacy-cleanup.test.ts
@@ -1,0 +1,224 @@
+/**
+ * legacy-cleanup tests
+ *
+ * Covers the registry-level orchestration. The day-one nats-reply-sidecar
+ * entry shells out to `pm2 jlist` / `pgrep`; we assert behavior through
+ * synthetic LegacyArtifact instances and through the REGISTRY's identity
+ * (it must contain a `nats-reply-sidecar` entry).
+ *
+ * Byte-identical formatCleanupSummary output is covered by
+ * `sidecar-cleanup.test.ts` — those tests still drive the rendering and
+ * remain unchanged.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { parseSkipCleanupList } from '../commands/update.js';
+import { type LegacyArtifact, REGISTRY, cleanupLegacyArtifacts } from '../legacy-cleanup.js';
+
+function fakeArtifact(overrides: Partial<LegacyArtifact> & Pick<LegacyArtifact, 'name'>): LegacyArtifact {
+  return {
+    name: overrides.name,
+    detect: overrides.detect ?? (async () => true),
+    cleanup: overrides.cleanup ?? (async () => ({ removed: [], warnings: [] })),
+    summary: overrides.summary ?? (() => ''),
+  };
+}
+
+describe('REGISTRY', () => {
+  test('contains the nats-reply-sidecar entry as the day-one artifact', () => {
+    const names = REGISTRY.map((a) => a.name);
+    expect(names).toContain('nats-reply-sidecar');
+  });
+
+  test('every entry exposes a stable string name', () => {
+    for (const artifact of REGISTRY) {
+      expect(typeof artifact.name).toBe('string');
+      expect(artifact.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('every entry exposes async detect / cleanup and a sync summary', () => {
+    for (const artifact of REGISTRY) {
+      expect(typeof artifact.detect).toBe('function');
+      expect(typeof artifact.cleanup).toBe('function');
+      expect(typeof artifact.summary).toBe('function');
+    }
+  });
+});
+
+describe('cleanupLegacyArtifacts — orchestration', () => {
+  // We swap REGISTRY contents by spying on a fresh array — but the public
+  // API uses the live constant. To exercise orchestration without touching
+  // the real nats-reply-sidecar, we drive the algorithm with synthetic
+  // artifacts via a helper that mirrors `cleanupLegacyArtifacts` semantics.
+
+  test('skips an artifact whose name is in skipList', async () => {
+    const calls: string[] = [];
+    const ran = fakeArtifact({
+      name: 'will-run',
+      detect: async () => {
+        calls.push('detect:will-run');
+        return true;
+      },
+      cleanup: async () => {
+        calls.push('cleanup:will-run');
+        return { removed: ['x'], warnings: [] };
+      },
+    });
+    const skipped = fakeArtifact({
+      name: 'will-skip',
+      detect: async () => {
+        calls.push('detect:will-skip');
+        return true;
+      },
+      cleanup: async () => {
+        calls.push('cleanup:will-skip');
+        return { removed: ['y'], warnings: [] };
+      },
+    });
+
+    const report = await runRegistry([ran, skipped], new Set(['will-skip']));
+
+    expect(calls).toEqual(['detect:will-run', 'cleanup:will-run']);
+    expect(report.skipped).toEqual(['will-skip']);
+    expect(report.outcomes).toHaveLength(2);
+    expect(report.outcomes[0]?.state).toBe('ran');
+    expect(report.outcomes[1]?.state).toBe('skipped');
+  });
+
+  test('records `not-detected` when detect() returns false', async () => {
+    const a = fakeArtifact({
+      name: 'absent',
+      detect: async () => false,
+    });
+    const report = await runRegistry([a], new Set());
+    expect(report.outcomes).toHaveLength(1);
+    expect(report.outcomes[0]?.state).toBe('not-detected');
+    expect(report.succeeded).toBe(true);
+  });
+
+  test('captures warnings into the outcome and flips `succeeded` to false', async () => {
+    const a = fakeArtifact({
+      name: 'partial-fail',
+      cleanup: async () => ({ removed: ['ok-1'], warnings: ['could-not-stop:pid=42'] }),
+      summary: () => 'partial summary',
+    });
+    const report = await runRegistry([a], new Set());
+    expect(report.outcomes[0]?.state).toBe('ran');
+    expect(report.outcomes[0]?.warnings).toEqual(['could-not-stop:pid=42']);
+    expect(report.outcomes[0]?.summary).toBe('partial summary');
+    expect(report.succeeded).toBe(false);
+  });
+
+  test('treats a thrown detect() as `errored` and records the message', async () => {
+    const a = fakeArtifact({
+      name: 'detect-throws',
+      detect: async () => {
+        throw new Error('boom');
+      },
+    });
+    const report = await runRegistry([a], new Set());
+    expect(report.outcomes[0]?.state).toBe('errored');
+    expect(report.outcomes[0]?.error).toBe('boom');
+    expect(report.succeeded).toBe(false);
+  });
+
+  test('treats a thrown cleanup() as `errored` and records the message', async () => {
+    const a = fakeArtifact({
+      name: 'cleanup-throws',
+      cleanup: async () => {
+        throw new Error('kaboom');
+      },
+    });
+    const report = await runRegistry([a], new Set());
+    expect(report.outcomes[0]?.state).toBe('errored');
+    expect(report.outcomes[0]?.error).toBe('kaboom');
+    expect(report.succeeded).toBe(false);
+  });
+
+  test('returns succeeded=true when every ran artifact had zero warnings', async () => {
+    const a = fakeArtifact({
+      name: 'clean-1',
+      cleanup: async () => ({ removed: ['a'], warnings: [] }),
+    });
+    const b = fakeArtifact({
+      name: 'clean-2',
+      cleanup: async () => ({ removed: ['b'], warnings: [] }),
+    });
+    const report = await runRegistry([a, b], new Set());
+    expect(report.succeeded).toBe(true);
+    expect(report.outcomes.map((o) => o.state)).toEqual(['ran', 'ran']);
+  });
+
+  test('runs entries sequentially in declaration order', async () => {
+    const trace: string[] = [];
+    const a = fakeArtifact({
+      name: 'first',
+      cleanup: async () => {
+        trace.push('first');
+        return { removed: [], warnings: [] };
+      },
+    });
+    const b = fakeArtifact({
+      name: 'second',
+      cleanup: async () => {
+        trace.push('second');
+        return { removed: [], warnings: [] };
+      },
+    });
+    await runRegistry([a, b], new Set());
+    expect(trace).toEqual(['first', 'second']);
+  });
+
+  test('runs the live REGISTRY end-to-end without throwing (smoke test)', async () => {
+    // The real cleanupSidecars() shells out to pm2/pgrep. On a clean test
+    // host neither finds anything, which is the byte-identical "empty
+    // summary" path — that's what we assert here.
+    const report = await cleanupLegacyArtifacts(new Set(['nats-reply-sidecar']));
+    expect(report.skipped).toContain('nats-reply-sidecar');
+    expect(report.outcomes.find((o) => o.name === 'nats-reply-sidecar')?.state).toBe('skipped');
+  });
+});
+
+describe('parseSkipCleanupList', () => {
+  test('returns empty set for undefined or empty input', () => {
+    expect(parseSkipCleanupList(undefined).size).toBe(0);
+    expect(parseSkipCleanupList('').size).toBe(0);
+    expect(parseSkipCleanupList('  ').size).toBe(0);
+  });
+
+  test('splits on commas and trims whitespace', () => {
+    const set = parseSkipCleanupList('a,b , c ,,d');
+    expect(set.has('a')).toBe(true);
+    expect(set.has('b')).toBe(true);
+    expect(set.has('c')).toBe(true);
+    expect(set.has('d')).toBe(true);
+    expect(set.size).toBe(4);
+  });
+
+  test('handles a single name', () => {
+    const set = parseSkipCleanupList('nats-reply-sidecar');
+    expect(set.has('nats-reply-sidecar')).toBe(true);
+    expect(set.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test helper: drive the same orchestration shape as cleanupLegacyArtifacts
+// against an arbitrary list of artifacts. This mirrors the algorithm so we
+// can exercise every branch without monkey-patching the live REGISTRY.
+// ---------------------------------------------------------------------------
+async function runRegistry(
+  artifacts: LegacyArtifact[],
+  skipList: Set<string>,
+): Promise<Awaited<ReturnType<typeof cleanupLegacyArtifacts>>> {
+  // We import the real implementation but feed it a list by temporarily
+  // splicing the live REGISTRY. Bun's test runner is single-threaded so
+  // the splice is safe across awaits within one test.
+  const saved = REGISTRY.splice(0, REGISTRY.length, ...artifacts);
+  try {
+    return await cleanupLegacyArtifacts(skipList);
+  } finally {
+    REGISTRY.splice(0, REGISTRY.length, ...saved);
+  }
+}

--- a/packages/cli/src/__tests__/update-diagnostics.test.ts
+++ b/packages/cli/src/__tests__/update-diagnostics.test.ts
@@ -1,0 +1,214 @@
+/**
+ * update-diagnostics tests
+ *
+ * Locks the on-disk shape of `~/.omni/logs/update-diagnostics-*.json`:
+ *   - schemaVersion is exactly 1 (per SHARED-DESIGN.md decision #4 — omni
+ *     starts at 1, asymmetric with genie's 2 by design).
+ *   - createDiagnostics produces an empty record with all per-stage slots
+ *     defaulted to null/false so a partial run (e.g. registry probe failed)
+ *     still serializes a complete snapshot.
+ *   - writeDiagnostics produces a file at the documented path with mode 0600
+ *     and parses back to the same object (round-trip).
+ *   - getDiagnosticsPath sanitizes ISO timestamps to filesystem-safe form.
+ *   - tailFileLines / collectRecentLogSignals never throw on missing files.
+ *
+ * Tests use OMNI_CONFIG_DIR override + Bun.file/tmp dirs to avoid touching
+ * the real $HOME/.omni/logs directory on the developer's box.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  UPDATE_DIAGNOSTICS_SCHEMA_VERSION,
+  collectRecentLogSignals,
+  createDiagnostics,
+  getDiagnosticsDir,
+  getDiagnosticsPath,
+  tailFileLines,
+  writeDiagnostics,
+} from '../update-diagnostics.js';
+
+let tmpHome: string;
+let originalConfigDir: string | undefined;
+
+beforeEach(() => {
+  originalConfigDir = process.env.OMNI_CONFIG_DIR;
+  tmpHome = mkdtempSync(join(tmpdir(), 'omni-diag-'));
+  process.env.OMNI_CONFIG_DIR = tmpHome;
+});
+
+afterEach(() => {
+  // biome-ignore lint/performance/noDelete: env-var cleanup must remove the key, not set it to "undefined" (string)
+  if (originalConfigDir === undefined) delete process.env.OMNI_CONFIG_DIR;
+  else process.env.OMNI_CONFIG_DIR = originalConfigDir;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('UPDATE_DIAGNOSTICS_SCHEMA_VERSION', () => {
+  test('is exactly 1 (omni starts at v1; genie at v2 — intentional asymmetry)', () => {
+    expect(UPDATE_DIAGNOSTICS_SCHEMA_VERSION).toBe(1);
+  });
+});
+
+describe('createDiagnostics', () => {
+  test('builds a complete record with safe defaults for every stage', () => {
+    const state = createDiagnostics({ runningVersion: '2.260505.1', channel: 'latest' });
+
+    expect(state.schemaVersion).toBe(1);
+    expect(typeof state.startedAt).toBe('string');
+    // ISO-8601: 2026-05-05T17:00:00.000Z
+    expect(state.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(state.cli).toEqual({ runningVersion: '2.260505.1', channel: 'latest' });
+
+    // Every per-stage slot starts at the "nothing happened" sentinel so a
+    // partial run still produces a parseable record.
+    expect(state.registry.latestVersion).toBeNull();
+    expect(state.preflight).toEqual({ ran: false, blocked: false });
+    expect(state.install).toEqual({ attempted: false, succeeded: null, targetVersion: null });
+    expect(state.restart).toEqual({ attempted: false, succeeded: null, services: [] });
+    expect(state.verify).toBeNull();
+    expect(state.cleanups).toBeNull();
+    expect(state.maintenance).toBeNull();
+    expect(state.parallelNpmGlobal).toBeNull();
+    expect(state.recentLogSignals).toEqual([]);
+    expect(state.exitCode).toBe(0);
+  });
+
+  test('respects the channel argument (latest|next round-trip)', () => {
+    expect(createDiagnostics({ runningVersion: 'x', channel: 'next' }).cli.channel).toBe('next');
+    expect(createDiagnostics({ runningVersion: 'x', channel: 'latest' }).cli.channel).toBe('latest');
+  });
+});
+
+describe('getDiagnosticsDir / getDiagnosticsPath', () => {
+  test('honors OMNI_CONFIG_DIR for the base directory', () => {
+    expect(getDiagnosticsDir()).toBe(join(tmpHome, 'logs'));
+  });
+
+  test('sanitizes ISO timestamps so they are safe as filenames', () => {
+    const path = getDiagnosticsPath('2026-05-05T17:00:00.000Z');
+    // colons are illegal on Windows / awkward on Unix → must be replaced
+    expect(path.includes(':')).toBe(false);
+    expect(path.endsWith('update-diagnostics-2026-05-05T17-00-00.000Z.json')).toBe(true);
+  });
+});
+
+describe('tailFileLines', () => {
+  test('returns [] for a missing file (never throws)', () => {
+    expect(tailFileLines(join(tmpHome, 'does-not-exist.log'), 10)).toEqual([]);
+  });
+
+  test('returns the last N lines, dropping the trailing newline-induced empty', () => {
+    const path = join(tmpHome, 'sample.log');
+    writeFileSync(path, 'a\nb\nc\nd\ne\n', 'utf8');
+    expect(tailFileLines(path, 3)).toEqual(['c', 'd', 'e']);
+  });
+
+  test('returns all lines when maxLines exceeds the file', () => {
+    const path = join(tmpHome, 'small.log');
+    writeFileSync(path, 'one\ntwo\n', 'utf8');
+    expect(tailFileLines(path, 100)).toEqual(['one', 'two']);
+  });
+
+  test('handles a file with no trailing newline', () => {
+    const path = join(tmpHome, 'no-newline.log');
+    writeFileSync(path, 'first\nsecond', 'utf8');
+    expect(tailFileLines(path, 10)).toEqual(['first', 'second']);
+  });
+});
+
+describe('collectRecentLogSignals', () => {
+  test('returns [] when no pm2 log files exist (best-effort, never throws)', () => {
+    // Inject a logPathsFor that points each process at a non-existent file
+    // in our tmp dir. We don't use the real getPm2LogPaths here because pm2
+    // logs intentionally live under ~/.omni/logs (no OMNI_CONFIG_DIR
+    // override) and tests should not depend on the developer's machine.
+    const result = collectRecentLogSignals(10, (name) => ({
+      out: join(tmpHome, `${name}-out.log`),
+      error: join(tmpHome, `${name}-error.log`),
+    }));
+    expect(result).toEqual([]);
+  });
+
+  test('captures the tail of each existing pm2 log file', () => {
+    const outPath = join(tmpHome, 'omni-api-out.log');
+    const errPath = join(tmpHome, 'omni-api-error.log');
+    writeFileSync(outPath, 'a\nb\nc\n', 'utf8');
+    writeFileSync(errPath, 'oops\n', 'utf8');
+
+    const result = collectRecentLogSignals(10, (name) =>
+      name === 'omni-api'
+        ? { out: outPath, error: errPath }
+        : { out: join(tmpHome, `${name}-out.log`), error: join(tmpHome, `${name}-error.log`) },
+    );
+    // Only the omni-api stub has files; other tracked processes contribute
+    // nothing because their tmp paths don't exist.
+    expect(result).toEqual([
+      { source: 'omni-api', stream: 'out', lines: ['a', 'b', 'c'] },
+      { source: 'omni-api', stream: 'error', lines: ['oops'] },
+    ]);
+  });
+});
+
+describe('writeDiagnostics', () => {
+  test('writes a file at the documented path and round-trips through JSON', () => {
+    const state = createDiagnostics({ runningVersion: '2.260505.1', channel: 'latest' });
+    state.registry.latestVersion = '2.260506.1';
+    state.install.attempted = true;
+    state.install.succeeded = true;
+    state.install.targetVersion = '2.260506.1';
+    // Pre-populate so the writer skips the (non-deterministic) pm2 log
+    // collection — that path is exercised separately above.
+    state.recentLogSignals = [{ source: 'omni-api', stream: 'out', lines: ['ready'] }];
+
+    const path = writeDiagnostics(state, 0);
+    expect(path).not.toBeNull();
+    if (path === null) return;
+    expect(existsSync(path)).toBe(true);
+    expect(path.startsWith(join(tmpHome, 'logs'))).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.exitCode).toBe(0);
+    expect(parsed.registry.latestVersion).toBe('2.260506.1');
+    expect(parsed.install).toEqual({
+      attempted: true,
+      succeeded: true,
+      targetVersion: '2.260506.1',
+    });
+    // finalize stamps the timestamp at write time
+    expect(typeof parsed.finishedAt).toBe('string');
+  });
+
+  test('captures the exit code passed by the caller', () => {
+    const state = createDiagnostics({ runningVersion: 'x', channel: 'latest' });
+    state.recentLogSignals = []; // ensure the collector path runs against an empty real dir
+    state.recentLogSignals.push({ source: 'stub', stream: 'out', lines: [] });
+    const path = writeDiagnostics(state, 42);
+    if (path === null) throw new Error('expected diagnostics path');
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    expect(parsed.exitCode).toBe(42);
+  });
+
+  test('creates the logs/ directory if it does not exist', () => {
+    const state = createDiagnostics({ runningVersion: 'x', channel: 'latest' });
+    state.recentLogSignals = [{ source: 'stub', stream: 'out', lines: [] }];
+    const dir = join(tmpHome, 'logs');
+    expect(existsSync(dir)).toBe(false);
+    const path = writeDiagnostics(state, 0);
+    expect(path).not.toBeNull();
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  test('returns null on a write failure (never throws)', () => {
+    // Point OMNI_CONFIG_DIR at a path that cannot be created — the parent
+    // `/proc/1` is a kernel-managed directory we cannot mkdir under as a
+    // non-root user. The writer should swallow the error and return null.
+    process.env.OMNI_CONFIG_DIR = '/proc/1/omni-diag-test';
+    const state = createDiagnostics({ runningVersion: 'x', channel: 'latest' });
+    expect(writeDiagnostics(state, 0)).toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/update-maintenance.test.ts
+++ b/packages/cli/src/__tests__/update-maintenance.test.ts
@@ -1,0 +1,281 @@
+/**
+ * update-maintenance tests
+ *
+ * Covers the post-update maintenance hook:
+ *   - `resolveMaintenanceSkipReason` precedence (verify-failed > cli-flag > env).
+ *   - `runPostUpdateMaintenance` skip / completed / failed paths.
+ *   - `formatMaintenanceSummary` exact one-line shape.
+ *   - `runDoctor({ dryRun: true })` contract — read-only even with fix=true.
+ *
+ * The actual `runDoctor` call is exercised via the helper's `runDoctorImpl`
+ * injection point so we never monkey-patch the doctor module — bun's
+ * `mock.module` leaks across test files and would corrupt `doctor.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { type DoctorDeps, type DoctorReport, runDoctor } from '../commands/doctor.js';
+import {
+  OMNI_UPDATE_SKIP_MAINTENANCE_ENV,
+  formatMaintenanceSummary,
+  resolveMaintenanceSkipReason,
+  runPostUpdateMaintenance,
+} from '../commands/update.js';
+import type { Config, ServerConfig } from '../config.js';
+
+// -----------------------------------------------------------------------------
+// resolveMaintenanceSkipReason — pure precedence logic
+// -----------------------------------------------------------------------------
+
+describe('resolveMaintenanceSkipReason', () => {
+  test('returns null when verify is ok and no opt-out is set', () => {
+    expect(
+      resolveMaintenanceSkipReason({
+        verifyOk: true,
+        skipMaintenance: undefined,
+        env: {},
+      }),
+    ).toBeNull();
+  });
+
+  test('returns "verify-failed" first, ignoring flag and env', () => {
+    expect(
+      resolveMaintenanceSkipReason({
+        verifyOk: false,
+        skipMaintenance: true,
+        env: { [OMNI_UPDATE_SKIP_MAINTENANCE_ENV]: '1' },
+      }),
+    ).toBe('verify-failed');
+  });
+
+  test('returns "cli-flag" when verify ok and --skip-maintenance set', () => {
+    expect(
+      resolveMaintenanceSkipReason({
+        verifyOk: true,
+        skipMaintenance: true,
+        env: {},
+      }),
+    ).toBe('cli-flag');
+  });
+
+  test('returns "env" when verify ok, no flag, env set to "1"', () => {
+    expect(
+      resolveMaintenanceSkipReason({
+        verifyOk: true,
+        skipMaintenance: undefined,
+        env: { [OMNI_UPDATE_SKIP_MAINTENANCE_ENV]: '1' },
+      }),
+    ).toBe('env');
+  });
+
+  test('returns "env" for any non-empty truthy env value', () => {
+    for (const value of ['1', 'true', 'yes', 'on', 'TRUE']) {
+      expect(
+        resolveMaintenanceSkipReason({
+          verifyOk: true,
+          skipMaintenance: undefined,
+          env: { [OMNI_UPDATE_SKIP_MAINTENANCE_ENV]: value },
+        }),
+      ).toBe('env');
+    }
+  });
+
+  test('returns null for env "0" / "false" / empty string', () => {
+    for (const value of ['0', 'false', 'False', 'FALSE', '']) {
+      expect(
+        resolveMaintenanceSkipReason({
+          verifyOk: true,
+          skipMaintenance: undefined,
+          env: { [OMNI_UPDATE_SKIP_MAINTENANCE_ENV]: value },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test('cli-flag wins over env when both set and verify ok', () => {
+    expect(
+      resolveMaintenanceSkipReason({
+        verifyOk: true,
+        skipMaintenance: true,
+        env: { [OMNI_UPDATE_SKIP_MAINTENANCE_ENV]: '1' },
+      }),
+    ).toBe('cli-flag');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// runPostUpdateMaintenance — skip / completed / failed paths
+// -----------------------------------------------------------------------------
+
+describe('runPostUpdateMaintenance', () => {
+  const baseReport: DoctorReport = {
+    checks: [],
+    summary: { ok: 12, warn: 0, fail: 0 },
+    fixesApplied: [],
+  };
+
+  test('returns { outcome: "skipped" } when skipReason is set, never calls runDoctor', async () => {
+    let called = false;
+    const report = await runPostUpdateMaintenance({
+      skipReason: 'cli-flag',
+      runDoctorImpl: async () => {
+        called = true;
+        return baseReport;
+      },
+    });
+    expect(report.outcome).toBe('skipped');
+    expect(report.skipReason).toBe('cli-flag');
+    expect(report.durationMs).toBe(0);
+    expect(called).toBe(false);
+  });
+
+  test('returns { outcome: "completed", doctorReport } when runDoctor succeeds', async () => {
+    const report = await runPostUpdateMaintenance({
+      skipReason: null,
+      runDoctorImpl: async () => baseReport,
+    });
+    expect(report.outcome).toBe('completed');
+    expect(report.doctorReport).toBe(baseReport);
+    expect(typeof report.durationMs).toBe('number');
+    expect(report.durationMs).toBeGreaterThanOrEqual(0);
+    expect(report.skipReason).toBeUndefined();
+    expect(report.error).toBeUndefined();
+  });
+
+  test('returns { outcome: "failed", error } when runDoctor throws', async () => {
+    const report = await runPostUpdateMaintenance({
+      skipReason: null,
+      runDoctorImpl: async () => {
+        throw new Error('pgserve unreachable');
+      },
+    });
+    expect(report.outcome).toBe('failed');
+    expect(report.error).toBe('pgserve unreachable');
+    expect(report.doctorReport).toBeUndefined();
+    expect(typeof report.durationMs).toBe('number');
+  });
+
+  test('captures non-Error throw values via String() coercion', async () => {
+    const report = await runPostUpdateMaintenance({
+      skipReason: null,
+      runDoctorImpl: async () => {
+        throw 'string-thrown';
+      },
+    });
+    expect(report.outcome).toBe('failed');
+    expect(report.error).toBe('string-thrown');
+  });
+
+  test('passes { json: true, dryRun: true } to the injected runDoctor', async () => {
+    let captured: { json?: boolean; dryRun?: boolean; fix?: boolean } | null = null;
+    await runPostUpdateMaintenance({
+      skipReason: null,
+      runDoctorImpl: async (opts) => {
+        captured = opts;
+        return baseReport;
+      },
+    });
+    expect(captured).not.toBeNull();
+    expect(captured?.json).toBe(true);
+    expect(captured?.dryRun).toBe(true);
+    // fix must NOT be set — the post-update probe stays read-only.
+    expect(captured?.fix).toBeUndefined();
+  });
+
+  test('skip reasons round-trip correctly', async () => {
+    for (const reason of ['verify-failed', 'cli-flag', 'env'] as const) {
+      const report = await runPostUpdateMaintenance({ skipReason: reason });
+      expect(report.outcome).toBe('skipped');
+      expect(report.skipReason).toBe(reason);
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// formatMaintenanceSummary — exact line-shape lock
+// -----------------------------------------------------------------------------
+
+describe('formatMaintenanceSummary', () => {
+  test('renders the documented "Maintenance: X ok, Y warn, Z fail" line', () => {
+    const report: DoctorReport = {
+      checks: [],
+      summary: { ok: 12, warn: 0, fail: 0 },
+      fixesApplied: [],
+    };
+    expect(formatMaintenanceSummary(report)).toBe('Maintenance: 12 ok, 0 warn, 0 fail');
+  });
+
+  test('renders zero counts cleanly', () => {
+    const report: DoctorReport = {
+      checks: [],
+      summary: { ok: 0, warn: 0, fail: 0 },
+      fixesApplied: [],
+    };
+    expect(formatMaintenanceSummary(report)).toBe('Maintenance: 0 ok, 0 warn, 0 fail');
+  });
+
+  test('renders mixed counts in the correct order', () => {
+    const report: DoctorReport = {
+      checks: [],
+      summary: { ok: 8, warn: 2, fail: 1 },
+      fixesApplied: [],
+    };
+    expect(formatMaintenanceSummary(report)).toBe('Maintenance: 8 ok, 2 warn, 1 fail');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// runDoctor dryRun contract — defeats accidental fix:true injection
+// -----------------------------------------------------------------------------
+
+describe('runDoctor dryRun contract', () => {
+  // Build a minimal deps stub. Any pm2/config mutation method throws so
+  // a regression that lets fix handlers run will fail loudly.
+  function makeReadOnlyDeps(): DoctorDeps {
+    const serverConfig: ServerConfig = {
+      port: 8882,
+      databaseUrl: 'postgres://localhost/omni',
+      useCanonicalPgserve: true,
+    } as ServerConfig;
+    const cliConfig: Config = { apiKey: 'k', apiUrl: 'http://localhost:8882' } as Config;
+    return {
+      getPm2Processes: async () => [],
+      canConnect: async () => true,
+      omniDbExists: async () => true,
+      findOrphanedDataDirs: () => [],
+      fetchHealthVersion: async () => '0.0.0-test',
+      validateStoredKey: async () => true,
+      loadState: () => ({ serverConfig, cliConfig }),
+      runPm2: async () => {
+        throw new Error('runPm2 must NOT be called in dry-run');
+      },
+      saveCliConfig: () => {
+        throw new Error('saveCliConfig must NOT be called in dry-run');
+      },
+      reloadCliConfig: () => cliConfig,
+      generateApiKey: () => 'rotated',
+      sleepMs: async () => {},
+      capturePm2Conf: async () => 'pm2-logrotate compress true rotateInterval 0 0 * * * max_size 10M retain 30',
+      listLockedInstances: async () => [],
+      cliHasSigningKey: () => true,
+      setupCanonicalPgserve: async () => 'postgres://localhost/omni',
+      dumpEmbeddedDb: async () => ({ status: 'no-embedded-data' }),
+      restoreSnapshotToCanonical: async () => ({ status: 'skipped' }),
+      getCanonicalPgserveDataDir: () => '/tmp/canonical',
+      saveServerConfig: () => {
+        throw new Error('saveServerConfig must NOT be called in dry-run');
+      },
+    };
+  }
+
+  test('runDoctor with dryRun=true does not invoke fix handlers even when fix=true', async () => {
+    const deps = makeReadOnlyDeps();
+    const report = await runDoctor({ json: true, dryRun: true, fix: true }, deps);
+    expect(report.fixesApplied).toEqual([]);
+  });
+
+  test('runDoctor without dryRun honors fix=false (no fix handlers run)', async () => {
+    const deps = makeReadOnlyDeps();
+    const report = await runDoctor({ json: true, fix: false }, deps);
+    expect(report.fixesApplied).toEqual([]);
+  });
+});

--- a/packages/cli/src/__tests__/update-parallel-install.test.ts
+++ b/packages/cli/src/__tests__/update-parallel-install.test.ts
@@ -1,0 +1,81 @@
+/**
+ * detectParallelNpmGlobalInstall tests
+ *
+ * Pure-ish unit tests for the parallel-npm-global-install probe used by
+ * `omni update`. Omni installs via `bun add -g`; an npm-global install of
+ * `@automagik/omni` shadows the bun binary on PATH and confuses
+ * `which omni`. The probe runs early in `omni update` to surface this with
+ * a one-line warning + the offending path.
+ *
+ * Tests inject a stubbed `npmRoot()` + `exists()` so we never spawn `npm`
+ * or touch the developer's actual filesystem.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { detectParallelNpmGlobalInstall } from '../commands/update.js';
+
+describe('detectParallelNpmGlobalInstall', () => {
+  test('returns { detected: true, path } when @automagik/omni exists in npm root', () => {
+    const result = detectParallelNpmGlobalInstall({
+      npmRoot: () => '/usr/lib/node_modules',
+      exists: (p) => p === '/usr/lib/node_modules/@automagik/omni',
+    });
+    expect(result.detected).toBe(true);
+    expect(result.path).toBe('/usr/lib/node_modules/@automagik/omni');
+    expect(result.skipped).toBeUndefined();
+  });
+
+  test('returns { detected: false } when npm root exists but no @automagik/omni present', () => {
+    const result = detectParallelNpmGlobalInstall({
+      npmRoot: () => '/usr/lib/node_modules',
+      exists: () => false,
+    });
+    expect(result.detected).toBe(false);
+    expect(result.path).toBeUndefined();
+    expect(result.skipped).toBeUndefined();
+  });
+
+  test('returns { detected: false, skipped: "npm-not-on-path" } when npm root is null', () => {
+    const result = detectParallelNpmGlobalInstall({
+      npmRoot: () => null,
+      exists: () => false,
+    });
+    expect(result.detected).toBe(false);
+    expect(result.skipped).toBe('npm-not-on-path');
+  });
+
+  test('returns { detected: false, skipped: "npm-not-on-path" } when npm root is empty string', () => {
+    const result = detectParallelNpmGlobalInstall({
+      npmRoot: () => '',
+      exists: () => false,
+    });
+    expect(result.detected).toBe(false);
+    expect(result.skipped).toBe('npm-not-on-path');
+  });
+
+  test('returns { detected: false, skipped: "npm-root-failed" } when npmRoot throws', () => {
+    const result = detectParallelNpmGlobalInstall({
+      npmRoot: () => {
+        throw new Error('npm not found');
+      },
+      exists: () => false,
+    });
+    expect(result.detected).toBe(false);
+    expect(result.skipped).toBe('npm-root-failed');
+  });
+
+  test('checks the canonical sub-path <root>/@automagik/omni (joined with platform separator)', () => {
+    let probedPath = '';
+    detectParallelNpmGlobalInstall({
+      npmRoot: () => '/opt/npm/global',
+      exists: (p) => {
+        probedPath = p;
+        return false;
+      },
+    });
+    // join() collapses separators; just check both segments are present
+    expect(probedPath).toContain('/opt/npm/global');
+    expect(probedPath).toContain('@automagik');
+    expect(probedPath).toContain('omni');
+  });
+});

--- a/packages/cli/src/__tests__/update-verify.test.ts
+++ b/packages/cli/src/__tests__/update-verify.test.ts
@@ -1,9 +1,10 @@
 /**
  * update-verify tests
  *
- * Covers the pure `decideUpdateVerify` decision function that drives the
- * 3-step post-update verification. We do NOT spin up pm2 or a real server
- * here — the caller (runUpdate) is what ties this into the outside world.
+ * Covers the pure `decideVerify` decision function (and its deprecated
+ * alias `decideUpdateVerify`) that drives the 3-step post-update
+ * verification. We do NOT spin up pm2 or a real server here — the caller
+ * (runUpdate) is what ties this into the outside world.
  *
  * Error message strings are also asserted so the exact user-facing text
  * in the wish ("Server version mismatch: ... Run: omni doctor" and
@@ -14,6 +15,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   UPDATE_ERROR_AUTH_INVALID,
   decideUpdateVerify,
+  decideVerify,
   normalizeVersion,
   resolveChannel,
   updateErrorVersionMismatch,
@@ -96,6 +98,37 @@ describe('decideUpdateVerify', () => {
       keyValid: false,
     });
     expect(result).toEqual({ kind: 'auth-invalid' });
+  });
+});
+
+describe('decideVerify (canonical name) — public-shape parity', () => {
+  test('decideUpdateVerify is a pointer-equal alias of decideVerify', () => {
+    expect(decideUpdateVerify).toBe(decideVerify);
+  });
+
+  test('returns skipped { reason: "no-restart" } when skipReason is set', () => {
+    const result = decideVerify({ skipReason: 'no-restart' });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-restart' });
+  });
+
+  test('returns skipped { reason: "no-verify-flag" } when --no-verify is wired in', () => {
+    const result = decideVerify({ skipReason: 'no-verify-flag' });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-verify-flag' });
+  });
+
+  test('returns skipped { reason: "no-running-services" } when no pm2 services were online', () => {
+    const result = decideVerify({ skipReason: 'no-running-services' });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-running-services' });
+  });
+
+  test('full-args path produces same result as decideUpdateVerify (byte-identical)', () => {
+    const args = {
+      latest: '2.20260218.18',
+      apiPort: 8882,
+      healthBody: { status: 'healthy', version: '2.20260218.18' },
+      keyValid: true,
+    } as const;
+    expect(decideVerify(args)).toEqual(decideUpdateVerify(args));
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -104,6 +104,14 @@ export interface DoctorOptions {
   fix?: boolean;
   json?: boolean;
   verbose?: boolean;
+  /**
+   * Force read-only mode. When true, any `fix: true` is suppressed and
+   * `runDoctor` only collects the check report. Used by `omni update`'s
+   * post-update maintenance hook (`runPostUpdateMaintenance`) so the
+   * probe stays read-only — `omni doctor --fix` remains the explicit
+   * operator action for repair.
+   */
+  dryRun?: boolean;
 }
 
 /**
@@ -1014,7 +1022,10 @@ export async function runDoctor(options: DoctorOptions, depsOverride?: DoctorDep
   let checks = await runAllChecks(deps);
   const fixesApplied: string[] = [];
 
-  if (options.fix) {
+  // dryRun is the explicit "read-only" lever used by `omni update`'s
+  // post-update maintenance hook. It defeats any caller-supplied
+  // `fix: true` so the probe never mutates pm2 / config / DB state.
+  if (options.fix && options.dryRun !== true) {
     const phase1 = await runPhase1MigrationFix(deps, checks, fixesApplied);
     checks = phase1.checks;
     await runPhase2Fixes(deps, checks, phase1.canonicalFailed, fixesApplied);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -21,6 +21,8 @@
  * when the stored key no longer validated.
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { createInterface } from 'node:readline';
 import { createOmniClient } from '@omni/sdk';
 import chalk from 'chalk';
@@ -32,7 +34,14 @@ import { type CleanupReport, cleanupLegacyArtifacts } from '../legacy-cleanup.js
 import * as output from '../output.js';
 import { PM2_PROCESSES } from '../pm2.js';
 import { buildRuntimeEnv } from '../runtime-env.js';
+import {
+  type ParallelInstallReport,
+  type UpdateDiagnostics,
+  createDiagnostics,
+  writeDiagnostics,
+} from '../update-diagnostics.js';
 import { VERSION } from '../version.js';
+import { type DoctorReport, runDoctor } from './doctor.js';
 
 const PACKAGE_NAME = '@automagik/omni';
 
@@ -80,6 +89,16 @@ interface UpdateOptions {
    * pipelines that run their own health probe).
    */
   skipMaintenance?: boolean;
+  /**
+   * Restart services but skip the post-restart probe. Useful when a release
+   * has a broken `/api/v2/health` and operators need to roll forward
+   * without the verify gate failing the run. Distinct from `--no-restart`,
+   * which skips the entire post-install path. With `--no-verify`, services
+   * still restart, the legacy-cleanup registry still runs, and the verify
+   * outcome lands in diagnostics as
+   * `{ kind: 'skipped', reason: 'no-verify-flag' }`.
+   */
+  verify?: boolean;
 }
 
 export type UpdateChannel = 'latest' | 'next';
@@ -393,6 +412,73 @@ function printVerifyBanner(latest: string): void {
 }
 
 /**
+ * Variant of `printVerifyBanner` used when the operator passed `--no-verify`.
+ * The CLI line stays a green check (we know our own version), but the server
+ * and auth lines are tagged `(skipped)` in yellow so operators don't misread
+ * the output as a confirmed match. Format matches the wish acceptance
+ * criteria: "emits `Server: v… (skipped)` in the banner".
+ */
+function printVerifySkippedBanner(latest: string): void {
+  // biome-ignore lint/suspicious/noConsole: CLI output — banner is the product
+  console.log(`${chalk.green('✓')} CLI:    v${latest}`);
+  // biome-ignore lint/suspicious/noConsole: CLI output
+  console.log(`${chalk.yellow('-')} Server: v${latest} (skipped)`);
+  // biome-ignore lint/suspicious/noConsole: CLI output
+  console.log(`${chalk.yellow('-')} Auth:   skipped`);
+}
+
+/**
+ * Detect a parallel npm-global install of `@automagik/omni`. Omni doesn't
+ * support npm-global server (we install via `bun add -g`), but a parallel
+ * install hides stale binaries on PATH and confuses `which omni`. When
+ * detected, the operator gets a one-line warning naming the offending path
+ * with the recommended remediation: `npm uninstall -g @automagik/omni`.
+ *
+ * Pure-ish: probes `npm root -g`, then checks if `<root>/@automagik/omni`
+ * exists. Never throws — when `npm` is absent the probe simply reports
+ * `skipped: 'npm-not-on-path'` and the warning never fires.
+ *
+ * Exported for tests so we can exercise both paths without spawning npm.
+ */
+export function detectParallelNpmGlobalInstall(deps?: {
+  npmRoot?: () => string | null;
+  exists?: (p: string) => boolean;
+}): ParallelInstallReport {
+  const npmRootFn = deps?.npmRoot ?? defaultNpmRoot;
+  const existsFn = deps?.exists ?? existsSync;
+  let root: string | null;
+  try {
+    root = npmRootFn();
+  } catch {
+    return { detected: false, skipped: 'npm-root-failed' };
+  }
+  if (root === null || root.length === 0) {
+    return { detected: false, skipped: 'npm-not-on-path' };
+  }
+  const candidate = join(root, '@automagik', 'omni');
+  if (existsFn(candidate)) {
+    return { detected: true, path: candidate };
+  }
+  return { detected: false };
+}
+
+function defaultNpmRoot(): string | null {
+  try {
+    const result = Bun.spawnSync({
+      cmd: ['npm', 'root', '-g'],
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 5000,
+    });
+    if (result.exitCode !== 0) return null;
+    const text = new TextDecoder().decode(result.stdout).trim();
+    return text.length > 0 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Run every registered legacy-artifact cleanup that isn't in `skipList`.
  * Always returns — never throws.
  *
@@ -424,25 +510,164 @@ async function runLegacyCleanup(skipList: Set<string>): Promise<CleanupReport> {
 }
 
 /**
+ * Reasons the post-update maintenance hook can be skipped.
+ *
+ * - `cli-flag`:      operator passed `--skip-maintenance`.
+ * - `env`:           `OMNI_UPDATE_SKIP_MAINTENANCE` was set in the environment.
+ * - `verify-failed`: upstream `decideVerify` outcome was not `ok`, so probing
+ *                    further is pointless (the operator already has a
+ *                    `Run: omni doctor` pointer from the verify step).
+ */
+export type MaintenanceSkipReason = 'cli-flag' | 'env' | 'verify-failed';
+
+/**
+ * Outcome of a single post-update maintenance run. Public-shape parity with
+ * the genie wish — the same field names land in diagnostics so a shared
+ * consumer can read either CLI's output uniformly.
+ *
+ * - `completed`: `runDoctor` returned a report (regardless of WARN/FAIL counts).
+ * - `failed`:    `runDoctor` threw; the call was non-blocking, exit code stays 0.
+ * - `skipped`:   maintenance was opted out (flag/env) or upstream verify wasn't OK.
+ */
+export type MaintenanceOutcome = 'completed' | 'failed' | 'skipped';
+
+/**
+ * Captured shape of the post-update maintenance hook. Always populated, even
+ * when skipped — diagnostics (Group 4) consumes the same struct on every
+ * code path so the JSON file shape is invariant.
+ */
+export interface MaintenanceReport {
+  outcome: MaintenanceOutcome;
+  /** Wall time spent inside `runDoctor` (or 0 when skipped). */
+  durationMs: number;
+  /** Present only when `outcome === 'completed'`. */
+  doctorReport?: DoctorReport;
+  /** Present only when `outcome === 'skipped'`. */
+  skipReason?: MaintenanceSkipReason;
+  /** Present only when `outcome === 'failed'` — the thrown error message. */
+  error?: string;
+}
+
+/** Env-var name that opts out of the post-update maintenance hook. */
+export const OMNI_UPDATE_SKIP_MAINTENANCE_ENV = 'OMNI_UPDATE_SKIP_MAINTENANCE';
+
+/**
+ * Resolve the effective skip reason for the post-update maintenance hook.
+ * Returns `null` when maintenance should run. Pure — exported for tests so
+ * we can exercise the precedence logic without spinning up `runDoctor`.
+ *
+ * Precedence (first match wins):
+ *   1. `verify-failed` — upstream verify wasn't `ok`; nothing to probe.
+ *   2. `cli-flag`      — operator passed `--skip-maintenance`.
+ *   3. `env`           — `OMNI_UPDATE_SKIP_MAINTENANCE` is set to a truthy value.
+ *
+ * The truthy check for the env var matches the same loose semantics as
+ * `--yes`/CI flags elsewhere: any non-empty value other than `0`/`false`
+ * counts as opt-out.
+ */
+export function resolveMaintenanceSkipReason(args: {
+  verifyOk: boolean;
+  skipMaintenance: boolean | undefined;
+  env: Record<string, string | undefined>;
+}): MaintenanceSkipReason | null {
+  if (!args.verifyOk) return 'verify-failed';
+  if (args.skipMaintenance === true) return 'cli-flag';
+  const raw = args.env[OMNI_UPDATE_SKIP_MAINTENANCE_ENV];
+  if (raw !== undefined && raw !== '' && raw !== '0' && raw.toLowerCase() !== 'false') {
+    return 'env';
+  }
+  return null;
+}
+
+/**
+ * Format the one-line summary printed after a completed maintenance run.
+ * Pure — exported so tests can lock the exact shape and so diagnostics
+ * (Group 4) can reuse it without re-deriving the format.
+ *
+ * Shape: `Maintenance: <ok> ok, <warn> warn, <fail> fail`.
+ */
+export function formatMaintenanceSummary(report: DoctorReport): string {
+  const { ok, warn, fail } = report.summary;
+  return `Maintenance: ${ok} ok, ${warn} warn, ${fail} fail`;
+}
+
+/**
+ * Run the post-update maintenance hook — a read-only `omni doctor` sweep
+ * that captures a `DoctorReport` for diagnostics.
+ *
+ * The call is non-blocking by contract: any thrown error is captured into
+ * the returned `MaintenanceReport` (`outcome: 'failed'`) and the caller
+ * proceeds with exit code 0. This matches the shared exit-code contract
+ * (see `SHARED-DESIGN.md` §4.5: "Maintenance failed (non-blocking) → 0,
+ * with banner warning").
+ *
+ * `runDoctor({ json: true, dryRun: true })` is the canonical call shape:
+ * `dryRun: true` defeats any accidental `fix: true` injection so the probe
+ * never mutates pm2 / config / DB state. `omni doctor --fix` remains the
+ * explicit operator action for repair (decision #4).
+ *
+ * `runDoctorImpl` is injected for tests so we can stub the doctor surface
+ * without monkey-patching the module — module-level mocks leak across
+ * test files in bun and would pollute `doctor.test.ts`.
+ */
+export async function runPostUpdateMaintenance(args: {
+  skipReason: MaintenanceSkipReason | null;
+  runDoctorImpl?: typeof runDoctor;
+}): Promise<MaintenanceReport> {
+  if (args.skipReason !== null) {
+    return { outcome: 'skipped', durationMs: 0, skipReason: args.skipReason };
+  }
+  const impl = args.runDoctorImpl ?? runDoctor;
+  const startedAt = Date.now();
+  try {
+    const doctorReport = await impl({ json: true, dryRun: true });
+    return {
+      outcome: 'completed',
+      durationMs: Date.now() - startedAt,
+      doctorReport,
+    };
+  } catch (err) {
+    return {
+      outcome: 'failed',
+      durationMs: Date.now() - startedAt,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
  * Restart selected services, then run the three-step verification.
  *
  * The orchestration here is impure (spawns pm2, fetches, exits) but the
  * decision logic lives in `decideVerify` so tests can exercise every
- * branch without spinning up the network.
+ * branch without spinning up the network. The provided `diagnostics`
+ * accumulator is mutated in place so the eventual `update-diagnostics-*.json`
+ * file captures restart / cleanup / verify / maintenance outcomes regardless
+ * of which exit branch this function takes.
  */
 async function restartServicesAndVerify(
   servicesToRestart: Pm2ProcessName[],
   latest: string,
-  options: { legacyCleanup: boolean; skipList: Set<string> },
+  options: {
+    legacyCleanup: boolean;
+    skipList: Set<string>;
+    skipMaintenance: boolean;
+    skipVerify: boolean;
+  },
+  diagnostics: UpdateDiagnostics,
+  finalize: (exitCode: number) => never,
 ): Promise<void> {
   const apiPort = loadServerConfig().port;
+  diagnostics.restart.attempted = true;
+  diagnostics.restart.services = [...servicesToRestart];
   const restartSpinner = ora('Restarting services...').start();
   const restartSucceeded = await restartPm2Services(servicesToRestart);
   restartSpinner.stop();
+  diagnostics.restart.succeeded = restartSucceeded;
 
   if (!restartSucceeded) {
     output.warn(`omni CLI updated to v${latest}, but one or more service restarts failed. Run \`omni status\`.`);
-    process.exit(1);
+    finalize(1);
   }
 
   // Run registry-based legacy artifact cleanup AFTER the restart so any
@@ -453,6 +678,30 @@ async function restartServicesAndVerify(
   let cleanupReport: CleanupReport | null = null;
   if (options.legacyCleanup) {
     cleanupReport = await runLegacyCleanup(options.skipList);
+    diagnostics.cleanups = cleanupReport;
+  }
+
+  // --no-verify path: short-circuit to the `skipped` variant. Banner shows
+  // the new CLI version on both lines but tags the server line as skipped
+  // so operators don't mis-read it as a confirmed match.
+  if (options.skipVerify) {
+    const result = decideVerify({ skipReason: 'no-verify-flag' });
+    diagnostics.verify = result;
+    printVerifySkippedBanner(latest);
+    if (cleanupReport !== null && !cleanupReport.succeeded) {
+      output.warn(
+        'One or more legacy artifacts could not be cleaned up automatically. ' +
+          'See messages above and docs/migration/nats-genie-sidecar-decommission.md.',
+      );
+    }
+    // Maintenance also auto-skips when verify is not OK (see
+    // resolveMaintenanceSkipReason — `verify-failed` precedence wins). The
+    // skip reason is `verify-failed` rather than `cli-flag` because the
+    // user-visible explanation is "we never confirmed health, so probing
+    // doctor would be misleading".
+    const maintenance = await runPostUpdateMaintenance({ skipReason: 'verify-failed' });
+    diagnostics.maintenance = maintenance;
+    return;
   }
 
   const verifySpinner = ora('Verifying server version...').start();
@@ -464,9 +713,10 @@ async function restartServicesAndVerify(
   const keyValid = healthBody !== null ? await validateStoredKey(apiPort) : false;
 
   const result = decideVerify({ latest, apiPort, healthBody, keyValid });
+  diagnostics.verify = result;
 
   switch (result.kind) {
-    case 'ok':
+    case 'ok': {
       printVerifyBanner(result.cliVersion);
       // If a legacy-artifact cleanup partially failed we still consider the
       // update healthy (server is up + auth works), but warn loudly so the
@@ -477,22 +727,39 @@ async function restartServicesAndVerify(
             'See messages above and docs/migration/nats-genie-sidecar-decommission.md.',
         );
       }
+      // Post-update maintenance (read-only `omni doctor` sweep). Non-blocking
+      // by contract — the report is consumed by Group 4 (diagnostics) and
+      // surfaced inline as a one-line summary. A failing doctor never
+      // changes the exit code (see SHARED-DESIGN.md §4.5).
+      const skipReason = resolveMaintenanceSkipReason({
+        verifyOk: true,
+        skipMaintenance: options.skipMaintenance,
+        env: process.env,
+      });
+      const maintenance = await runPostUpdateMaintenance({ skipReason });
+      diagnostics.maintenance = maintenance;
+      if (maintenance.outcome === 'completed' && maintenance.doctorReport) {
+        output.info(formatMaintenanceSummary(maintenance.doctorReport));
+      } else if (maintenance.outcome === 'failed') {
+        output.warn(`Maintenance: skipped (runDoctor failed: ${maintenance.error ?? 'unknown error'})`);
+      }
       return;
+    }
     case 'health-unreachable':
       output.warn(
         `omni CLI updated to v${latest}, but health check failed on port ${result.apiPort}. Run \`omni status\`.`,
       );
-      process.exit(1);
+      finalize(1);
       break;
     case 'version-mismatch':
       // biome-ignore lint/suspicious/noConsole: CLI output — user-facing failure marker
       console.error(`${chalk.red('✗')} ${updateErrorVersionMismatch(result.cliVersion, result.serverVersion)}`);
-      process.exit(1);
+      finalize(1);
       break;
     case 'auth-invalid':
       // biome-ignore lint/suspicious/noConsole: CLI output — user-facing failure marker
       console.error(`${chalk.red('✗')} ${UPDATE_ERROR_AUTH_INVALID}`);
-      process.exit(1);
+      finalize(1);
       break;
   }
 }
@@ -603,24 +870,49 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
     persistChannel(channel);
   }
 
+  // Diagnostics accumulator — mutated in place as the run advances. Written
+  // out to ~/.omni/logs/update-diagnostics-*.json on every exit (success,
+  // failure, or operator cancel) via `finalize()`.
+  const currentClean = VERSION.split('+')[0];
+  const diagnostics = createDiagnostics({ runningVersion: currentClean, channel });
+
+  // `finalize` wraps `process.exit` so every termination path persists
+  // diagnostics. Typed `never` to satisfy control-flow on the exit branches.
+  const finalize = (exitCode: number): never => {
+    const path = writeDiagnostics(diagnostics, exitCode);
+    if (path !== null && process.env.OMNI_UPDATE_DIAGNOSTICS_VERBOSE === '1') {
+      output.info(`Diagnostics written: ${path}`);
+    }
+    process.exit(exitCode);
+  };
+
+  // Parallel npm-global install — warn early so the operator can act on the
+  // smoking-gun PATH conflict before the install runs. Recorded in
+  // diagnostics either way.
+  const parallelInstall = detectParallelNpmGlobalInstall();
+  diagnostics.parallelNpmGlobal = parallelInstall;
+  if (parallelInstall.detected && parallelInstall.path) {
+    output.warn(
+      `Parallel npm-global install of ${PACKAGE_NAME} detected at ${parallelInstall.path}. This may shadow the bun-installed binary on PATH. Recommended: npm uninstall -g ${PACKAGE_NAME}`,
+    );
+  }
+
   output.info(`Channel: ${channel}${channel === 'next' ? ' (dev builds)' : ' (stable)'}`);
 
   // Check latest version on the resolved channel
   const versionSpinner = ora(`Checking ${channel} version of ${PACKAGE_NAME}...`).start();
   const latest = await fetchLatestVersion(channel);
   versionSpinner.stop();
+  diagnostics.registry.latestVersion = latest;
 
   if (latest === null) {
     output.warn('Could not reach npm registry. Check your network connection and try again.');
-    process.exit(1);
+    return finalize(1);
   }
-
-  // Strip any git hash suffix (e.g. "2.20260218.18+abc1234" → "2.20260218.18") for comparison
-  const currentClean = VERSION.split('+')[0];
 
   if (currentClean === latest) {
     output.success(`Already up to date (v${latest}, channel: ${channel})`);
-    process.exit(0);
+    return finalize(0);
   }
 
   // Pre-flight: refuse to cross the phase-2 cutoff on legacy embedded hosts
@@ -628,6 +920,7 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
   // path BEFORE the install completes (vs discovering the boot failure
   // hours later when omni-api restarts).
   if (!options.skipCanonicalPreflight) {
+    diagnostics.preflight.ran = true;
     const serverConfig = loadServerConfig();
     const preflightError = checkCanonicalPgservePreflight({
       currentVersion: currentClean,
@@ -636,8 +929,10 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
       pgserveOnPath: isPgserveOnPath(),
     });
     if (preflightError !== null) {
+      diagnostics.preflight.blocked = true;
+      diagnostics.preflight.reason = preflightError.split('\n')[0];
       output.warn(preflightError);
-      process.exit(1);
+      return finalize(1);
     }
   }
 
@@ -647,19 +942,22 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
     const confirmed = await promptConfirm(`Update from v${currentClean} to v${latest}? [Y/n] `);
     if (!confirmed) {
       output.info('Update cancelled.');
-      process.exit(0);
+      return finalize(0);
     }
   }
 
   const servicesToRestart = options.restart !== false ? getRunningPm2Services() : [];
 
   const installSpinner = ora(`Updating ${PACKAGE_NAME}@${channel}...`).start();
+  diagnostics.install.attempted = true;
+  diagnostics.install.targetVersion = latest;
   const installed = await installLatest(channel);
   installSpinner.stop();
+  diagnostics.install.succeeded = installed;
 
   if (!installed) {
     output.warn(`Installation failed. Your current version (v${currentClean}) is still intact.`);
-    process.exit(1);
+    return finalize(1);
   }
 
   // Resolve the legacy-cleanup flag set. `--no-sidecar-cleanup` is the
@@ -674,21 +972,31 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
   const skipList = parseSkipCleanupList(options.skipCleanup);
 
   if (servicesToRestart.length > 0) {
-    // On success, restartServicesAndVerify prints the three-line banner and
-    // returns. On failure it exits non-zero before returning here, so we
-    // deliberately skip the legacy `omni updated` summary in that path.
-    await restartServicesAndVerify(servicesToRestart, latest, {
-      legacyCleanup: legacyCleanupEnabled,
-      skipList,
-    });
-    return;
+    // On success, restartServicesAndVerify prints the success banner (or the
+    // skipped-banner when `--no-verify` is set) and returns. On failure it
+    // calls finalize(1) before returning so diagnostics is persisted.
+    await restartServicesAndVerify(
+      servicesToRestart,
+      latest,
+      {
+        legacyCleanup: legacyCleanupEnabled,
+        skipList,
+        skipMaintenance: options.skipMaintenance === true,
+        skipVerify: options.verify === false,
+      },
+      diagnostics,
+      finalize,
+    );
+    return finalize(0);
   }
 
   // --no-restart path: nothing to verify server-side. We deliberately skip
   // legacy-artifact cleanup here too — `--no-restart` means "don't touch
   // services" and the registry entries are services. Operators using
   // `--no-restart` are expected to manage them themselves.
+  diagnostics.verify = decideVerify({ skipReason: 'no-restart' });
   output.success(`omni updated to v${latest}`);
+  return finalize(0);
 }
 
 /**
@@ -709,6 +1017,10 @@ export function createUpdateCommand(): Command {
     .description(`Update ${PACKAGE_NAME} to the latest version (restart only services already running)`)
     .option('-y, --yes', 'Skip confirmation prompts (non-interactive)')
     .option('--no-restart', 'Update CLI only; skip service restarts and verification')
+    .option(
+      '--no-verify',
+      'Restart services but skip the post-restart probe (use when a release ships a broken /api/v2/health and operators need to roll forward)',
+    )
     .option('--no-legacy-cleanup', 'Skip every registered legacy-artifact cleanup (e.g. nats-reply-sidecar)')
     .option('--no-sidecar-cleanup', 'Deprecated alias for --no-legacy-cleanup')
     .option(
@@ -720,6 +1032,10 @@ export function createUpdateCommand(): Command {
     .option(
       '--skip-canonical-preflight',
       'Bypass the canonical-pgserve phase-2 pre-flight (NOT recommended; for operators who pre-installed pgserve via a path the auto-detector misses)',
+    )
+    .option(
+      '--skip-maintenance',
+      `Skip the post-update maintenance hook (read-only \`omni doctor\` sweep). Also honored via the ${OMNI_UPDATE_SKIP_MAINTENANCE_ENV} env var.`,
     )
     .addHelpText(
       'after',
@@ -760,6 +1076,27 @@ Behavior:
       docs/migration/nats-genie-sidecar-decommission.md
   - Use --no-restart to skip restart + verification entirely. --no-restart
     also skips legacy-artifact cleanup; manage those services manually.
+  - Use --no-verify to restart services but skip the post-restart probe.
+    The banner shows the new CLI version on both lines but tags Server /
+    Auth as "(skipped)"; maintenance is auto-skipped because verify never
+    confirmed health.
+  - Detects parallel npm-global installs of ${PACKAGE_NAME} (omni installs
+    via bun-global; an npm-global install hides stale binaries on PATH and
+    confuses 'which omni'). When found, prints a one-line warning naming
+    the offending path; recommended remediation: npm uninstall -g ${PACKAGE_NAME}.
+  - Every invocation writes a diagnostics record to
+    ~/.omni/logs/update-diagnostics-<iso>.json (schemaVersion: 1). Captures
+    install attempt, registry probe, restart outcome, verify result, cleanup
+    registry result, maintenance hook, and a tail of pm2 log signals. Set
+    OMNI_UPDATE_DIAGNOSTICS_VERBOSE=1 to print the path on completion. A
+    failed write never changes the update exit code.
+  - On a successful restart + verify, runs a post-update maintenance hook:
+    a read-only \`omni doctor\` sweep that prints a one-line summary
+    ("Maintenance: <ok> ok, <warn> warn, <fail> fail"). The probe never
+    mutates pm2 / config / DB state (\`omni doctor --fix\` remains the
+    explicit operator action for repair). A failing maintenance call is
+    non-fatal — exit code stays 0 with a banner warning. Skip with
+    --skip-maintenance or ${OMNI_UPDATE_SKIP_MAINTENANCE_ENV}=1.
   - Verify runtime health after update with: omni status
 `,
     )

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -28,10 +28,10 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { type Config, loadConfig, loadServerConfig, saveConfig } from '../config.js';
 import { getHealthCheckUrl } from '../health.js';
+import { type CleanupReport, cleanupLegacyArtifacts } from '../legacy-cleanup.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES } from '../pm2.js';
 import { buildRuntimeEnv } from '../runtime-env.js';
-import { type CleanupResult, cleanupSidecars, cleanupSucceeded, formatCleanupSummary } from '../sidecar-cleanup.js';
 import { VERSION } from '../version.js';
 
 const PACKAGE_NAME = '@automagik/omni';
@@ -44,7 +44,24 @@ const VERIFY_POLL_INTERVAL_MS = 500;
 interface UpdateOptions {
   yes?: boolean;
   restart?: boolean;
+  /**
+   * Primary name for the post-restart legacy artifact cleanup. Default true.
+   * When false, the registry call is skipped entirely.
+   */
+  legacyCleanup?: boolean;
+  /**
+   * Deprecated alias of `legacyCleanup`. Retained so existing scripts /
+   * runbooks referencing `--no-sidecar-cleanup` keep working. When the
+   * operator passes `--no-sidecar-cleanup`, commander surfaces this as
+   * `sidecarCleanup === false`; we forward the value to `legacyCleanup`
+   * and emit a one-line deprecation note.
+   */
   sidecarCleanup?: boolean;
+  /**
+   * Comma-separated list of registry entry names to skip. Empty / undefined
+   * means "skip nothing". Names are matched against `LegacyArtifact.name`.
+   */
+  skipCleanup?: string;
   next?: boolean;
   stable?: boolean;
   /**
@@ -54,6 +71,15 @@ interface UpdateOptions {
    * Defaults to false (the check runs).
    */
   skipCanonicalPreflight?: boolean;
+  /**
+   * Skip the post-update maintenance hook (read-only `omni doctor` sweep
+   * that runs after a successful restart + verify). Also honored via the
+   * `OMNI_UPDATE_SKIP_MAINTENANCE` env var. The flag is non-fatal in
+   * either direction — a failing maintenance call already exits 0 with a
+   * banner warning; this flag suppresses the call entirely (e.g. CI
+   * pipelines that run their own health probe).
+   */
+  skipMaintenance?: boolean;
 }
 
 export type UpdateChannel = 'latest' | 'next';
@@ -217,27 +243,68 @@ export function normalizeVersion(version: string): string {
 }
 
 /**
+ * Reasons the verify step can be skipped without a server probe. Aligned
+ * byte-for-byte with the genie-side `VerifyResult.skipped.reason` shape so
+ * cross-CLI diagnostics tooling can read either repo's output uniformly
+ * (see `.genie/wishes/update-unify-stages/SHARED-DESIGN.md`).
+ *
+ * - `no-restart`: operator passed `--no-restart`, so no service was touched.
+ * - `no-verify-flag`: operator passed `--no-verify`, restart ran but probe was suppressed.
+ * - `no-running-services`: no tracked PM2 services were online before the install.
+ */
+export type VerifySkipReason = 'no-restart' | 'no-verify-flag' | 'no-running-services';
+
+/**
  * Result of the pure 3-step update verification. Exported so tests can
  * exercise the logic without mocking pm2 / fetch / process.exit.
+ *
+ * Public-shape parity with the genie wish — each variant's keys match
+ * `automagik-dev/genie` exactly so a shared diagnostics consumer can decode
+ * either CLI's output without per-repo branching.
  */
-export type UpdateVerifyResult =
+export type VerifyResult =
   | { kind: 'ok'; cliVersion: string; serverVersion: string }
   | { kind: 'health-unreachable'; apiPort: number }
   | { kind: 'version-mismatch'; cliVersion: string; serverVersion: string | null }
-  | { kind: 'auth-invalid' };
+  | { kind: 'auth-invalid' }
+  | { kind: 'skipped'; reason: VerifySkipReason };
+
+/**
+ * @deprecated Use {@link VerifyResult}. Retained for backward compatibility
+ * with any external consumer that imported the original name.
+ */
+export type UpdateVerifyResult = VerifyResult;
+
+/**
+ * Args accepted by {@link decideVerify}. Either `skipReason` is set (the
+ * verify step short-circuits to `{ kind: 'skipped' }`) or all of `latest` /
+ * `apiPort` / `healthBody` / `keyValid` are provided for the full decision.
+ */
+export type DecideVerifyArgs =
+  | {
+      latest: string;
+      apiPort: number;
+      healthBody: HealthBody | null;
+      keyValid: boolean;
+      skipReason?: undefined;
+    }
+  | { skipReason: VerifySkipReason };
 
 /**
  * Pure decision function for update verification. Given the raw inputs
  * (health body + key-valid flag + CLI version + port), return a tagged
  * union describing the outcome. The caller decides how to render and
  * whether to exit non-zero.
+ *
+ * When `skipReason` is provided, the function short-circuits to
+ * `{ kind: 'skipped', reason }` without inspecting the other fields. This
+ * is the path used by `--no-restart`, `--no-verify`, and the
+ * no-running-services case.
  */
-export function decideUpdateVerify(args: {
-  latest: string;
-  apiPort: number;
-  healthBody: HealthBody | null;
-  keyValid: boolean;
-}): UpdateVerifyResult {
+export function decideVerify(args: DecideVerifyArgs): VerifyResult {
+  if (args.skipReason !== undefined) {
+    return { kind: 'skipped', reason: args.skipReason };
+  }
   const cliVersion = normalizeVersion(args.latest);
   if (args.healthBody === null) {
     return { kind: 'health-unreachable', apiPort: args.apiPort };
@@ -251,6 +318,13 @@ export function decideUpdateVerify(args: {
   }
   return { kind: 'ok', cliVersion, serverVersion };
 }
+
+/**
+ * @deprecated Use {@link decideVerify}. Pointer-equal alias retained for
+ * backward compatibility with any external consumer that imported the
+ * original name.
+ */
+export const decideUpdateVerify = decideVerify;
 
 /** Error message strings — exported for tests and documentation. */
 export function updateErrorVersionMismatch(cli: string, server: string | null): string {
@@ -319,8 +393,13 @@ function printVerifyBanner(latest: string): void {
 }
 
 /**
- * Run the legacy `nats-reply-sidecar.mjs` cleanup. Detects pm2-managed and
- * raw sidecar processes and stops them. Always returns — never throws.
+ * Run every registered legacy-artifact cleanup that isn't in `skipList`.
+ * Always returns — never throws.
+ *
+ * Day-one registry entry is `nats-reply-sidecar`, which detects pm2-managed
+ * and raw sidecar processes and stops them. The output of
+ * `formatCleanupSummary()` is preserved byte-for-byte via
+ * `LegacyArtifact.summary()`.
  *
  * This runs AFTER the restart so the new in-process subscription is already
  * active when the sidecar exits. The brief overlap (typically <2s) produces
@@ -330,30 +409,31 @@ function printVerifyBanner(latest: string): void {
  * See docs/migration/nats-genie-sidecar-decommission.md for the manual
  * runbook operators can fall back to.
  */
-async function runSidecarCleanup(): Promise<CleanupResult> {
-  const cleanupSpinner = ora('Checking for legacy nats-reply-sidecar processes...').start();
-  const result = await cleanupSidecars();
+async function runLegacyCleanup(skipList: Set<string>): Promise<CleanupReport> {
+  const cleanupSpinner = ora('Checking for legacy artifacts to clean up...').start();
+  const report = await cleanupLegacyArtifacts(skipList);
   cleanupSpinner.stop();
 
-  const summary = formatCleanupSummary(result);
-  if (summary.length > 0) {
-    // biome-ignore lint/suspicious/noConsole: CLI output — operator-visible cleanup report
-    console.log(summary);
+  for (const outcome of report.outcomes) {
+    if (outcome.state === 'ran' && outcome.summary.length > 0) {
+      // biome-ignore lint/suspicious/noConsole: CLI output — operator-visible cleanup report
+      console.log(outcome.summary);
+    }
   }
-  return result;
+  return report;
 }
 
 /**
  * Restart selected services, then run the three-step verification.
  *
  * The orchestration here is impure (spawns pm2, fetches, exits) but the
- * decision logic lives in `decideUpdateVerify` so tests can exercise every
+ * decision logic lives in `decideVerify` so tests can exercise every
  * branch without spinning up the network.
  */
 async function restartServicesAndVerify(
   servicesToRestart: Pm2ProcessName[],
   latest: string,
-  options: { sidecarCleanup: boolean },
+  options: { legacyCleanup: boolean; skipList: Set<string> },
 ): Promise<void> {
   const apiPort = loadServerConfig().port;
   const restartSpinner = ora('Restarting services...').start();
@@ -365,12 +445,14 @@ async function restartServicesAndVerify(
     process.exit(1);
   }
 
-  // Stop the legacy sidecar AFTER the restart so the new in-process
-  // subscription is already handling replies — prevents silent loss during
-  // the cleanup window. This block is opt-out via --no-sidecar-cleanup.
-  let sidecarCleanupResult: CleanupResult | null = null;
-  if (options.sidecarCleanup) {
-    sidecarCleanupResult = await runSidecarCleanup();
+  // Run registry-based legacy artifact cleanup AFTER the restart so any
+  // freshly-started in-process subscriptions are already handling traffic
+  // before legacy backstops are stopped — prevents silent loss during
+  // the cleanup window. This block is opt-out via --no-legacy-cleanup
+  // (or its deprecated alias --no-sidecar-cleanup).
+  let cleanupReport: CleanupReport | null = null;
+  if (options.legacyCleanup) {
+    cleanupReport = await runLegacyCleanup(options.skipList);
   }
 
   const verifySpinner = ora('Verifying server version...').start();
@@ -381,17 +463,17 @@ async function restartServicesAndVerify(
   // calling /auth/validate against a server that isn't up.
   const keyValid = healthBody !== null ? await validateStoredKey(apiPort) : false;
 
-  const result = decideUpdateVerify({ latest, apiPort, healthBody, keyValid });
+  const result = decideVerify({ latest, apiPort, healthBody, keyValid });
 
   switch (result.kind) {
     case 'ok':
       printVerifyBanner(result.cliVersion);
-      // If the sidecar cleanup partially failed we still consider the
-      // update healthy (server is up + auth works), but warn loudly so
-      // the operator can finish the manual cleanup.
-      if (sidecarCleanupResult !== null && !cleanupSucceeded(sidecarCleanupResult)) {
+      // If a legacy-artifact cleanup partially failed we still consider the
+      // update healthy (server is up + auth works), but warn loudly so the
+      // operator can finish the manual cleanup.
+      if (cleanupReport !== null && !cleanupReport.succeeded) {
         output.warn(
-          'One or more legacy nats-reply-sidecar processes could not be stopped automatically. ' +
+          'One or more legacy artifacts could not be cleaned up automatically. ' +
             'See messages above and docs/migration/nats-genie-sidecar-decommission.md.',
         );
       }
@@ -580,21 +662,46 @@ async function runUpdate(options: UpdateOptions): Promise<void> {
     process.exit(1);
   }
 
+  // Resolve the legacy-cleanup flag set. `--no-sidecar-cleanup` is the
+  // deprecated alias of `--no-legacy-cleanup`; if the operator passed it
+  // (commander sets `sidecarCleanup === false`) we honor the value and emit
+  // a one-line deprecation note exactly once.
+  const sidecarCleanupExplicit = options.sidecarCleanup === false;
+  if (sidecarCleanupExplicit) {
+    output.info('--no-sidecar-cleanup (deprecated alias for --no-legacy-cleanup)');
+  }
+  const legacyCleanupEnabled = options.legacyCleanup !== false && options.sidecarCleanup !== false;
+  const skipList = parseSkipCleanupList(options.skipCleanup);
+
   if (servicesToRestart.length > 0) {
     // On success, restartServicesAndVerify prints the three-line banner and
     // returns. On failure it exits non-zero before returning here, so we
     // deliberately skip the legacy `omni updated` summary in that path.
     await restartServicesAndVerify(servicesToRestart, latest, {
-      sidecarCleanup: options.sidecarCleanup !== false,
+      legacyCleanup: legacyCleanupEnabled,
+      skipList,
     });
     return;
   }
 
   // --no-restart path: nothing to verify server-side. We deliberately skip
-  // sidecar cleanup here too — `--no-restart` means "don't touch services"
-  // and the sidecar is a service. Operators using `--no-restart` are
-  // expected to manage the sidecar themselves.
+  // legacy-artifact cleanup here too — `--no-restart` means "don't touch
+  // services" and the registry entries are services. Operators using
+  // `--no-restart` are expected to manage them themselves.
   output.success(`omni updated to v${latest}`);
+}
+
+/**
+ * Parse the `--skip-cleanup=name1,name2` value into a Set. Empty / undefined
+ * yields an empty set. Whitespace and empty entries are tolerated.
+ */
+export function parseSkipCleanupList(value: string | undefined): Set<string> {
+  if (!value) return new Set();
+  const names = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return new Set(names);
 }
 
 export function createUpdateCommand(): Command {
@@ -602,7 +709,12 @@ export function createUpdateCommand(): Command {
     .description(`Update ${PACKAGE_NAME} to the latest version (restart only services already running)`)
     .option('-y, --yes', 'Skip confirmation prompts (non-interactive)')
     .option('--no-restart', 'Update CLI only; skip service restarts and verification')
-    .option('--no-sidecar-cleanup', 'Skip the legacy nats-reply-sidecar.mjs cleanup step')
+    .option('--no-legacy-cleanup', 'Skip every registered legacy-artifact cleanup (e.g. nats-reply-sidecar)')
+    .option('--no-sidecar-cleanup', 'Deprecated alias for --no-legacy-cleanup')
+    .option(
+      '--skip-cleanup <names>',
+      'Comma-separated list of legacy-cleanup registry entries to skip (e.g. "nats-reply-sidecar")',
+    )
     .option('--next', 'Switch to dev builds (npm @next tag) and persist as default')
     .option('--stable', 'Switch to stable releases (npm @latest tag) and persist as default')
     .option(
@@ -637,14 +749,17 @@ Behavior:
       "Server version mismatch: cli=v<X> server=v<Y>. Run: omni doctor"
   - On auth failure, exits non-zero with:
       "Auth key invalid after restart. Run: omni doctor --fix"
-  - After a successful restart, scans for any legacy nats-reply-sidecar.mjs
-    process (PM2-managed or raw) and stops it. The sidecar was an external
-    workaround for bugs that were fixed in #362; leaving it running causes
-    every agent reply to be delivered twice. Skippable with
-    --no-sidecar-cleanup. Manual runbook:
+  - After a successful restart, runs every registered legacy-artifact cleanup.
+    The day-one entry is nats-reply-sidecar: it scans for any legacy
+    nats-reply-sidecar.mjs process (PM2-managed or raw) and stops it. The
+    sidecar was an external workaround for bugs that were fixed in #362;
+    leaving it running causes every agent reply to be delivered twice.
+    Skip every cleanup with --no-legacy-cleanup, or skip a single registry
+    entry with --skip-cleanup=<name1,name2>. The deprecated alias
+    --no-sidecar-cleanup still works and behaves identically. Manual runbook:
       docs/migration/nats-genie-sidecar-decommission.md
   - Use --no-restart to skip restart + verification entirely. --no-restart
-    also skips sidecar cleanup; manage the sidecar manually.
+    also skips legacy-artifact cleanup; manage those services manually.
   - Verify runtime health after update with: omni status
 `,
     )

--- a/packages/cli/src/legacy-cleanup.ts
+++ b/packages/cli/src/legacy-cleanup.ts
@@ -1,0 +1,214 @@
+/**
+ * Legacy artifact cleanup registry.
+ *
+ * Generalizes the bespoke `cleanupSidecars()` step in `omni update` into a
+ * registry of `LegacyArtifact` entries so future deprecation cleanups (e.g.
+ * obsolete WhatsApp baileys session formats, dead pm2 process names, stale
+ * config files) drop in without code changes to the update orchestration.
+ *
+ * The day-one entry is `nats-reply-sidecar`, which wraps the existing
+ * `cleanupSidecars()` / `cleanupSucceeded()` / `formatCleanupSummary()`
+ * helpers in `sidecar-cleanup.ts`. Operator-facing output is byte-identical
+ * to the pre-registry behavior — the registry only changes the dispatch.
+ *
+ * Public shape mirrors the genie wish (independent code, identical signature
+ * per SHARED-DESIGN.md decision #3).
+ */
+
+import {
+  type CleanupResult as SidecarCleanupResult,
+  cleanupSidecars,
+  formatCleanupSummary as formatSidecarSummary,
+} from './sidecar-cleanup.js';
+
+/**
+ * One legacy artifact eligible for cleanup. Implementations are stateful:
+ * `cleanup()` may stash the raw result so `summary()` can render it.
+ */
+export interface LegacyArtifact {
+  readonly name: string;
+  /**
+   * Best-effort fast probe — return true if cleanup() should be run. Returning
+   * false is reserved for hard short-circuits (e.g. the artifact's namespace
+   * doesn't exist on this OS). If detection itself is cheap relative to
+   * cleanup, implementations may simply return true and let the empty-case
+   * path in cleanup() produce an empty summary.
+   */
+  detect(): Promise<boolean>;
+  /**
+   * Run the cleanup. Returns the user-visible artifacts (`removed`) and any
+   * non-fatal problems (`warnings`). Implementations should never throw —
+   * the registry treats a thrown error as "warning, succeeded=false".
+   */
+  cleanup(): Promise<{ removed: string[]; warnings: string[] }>;
+  /**
+   * Human-readable multi-line summary of the most recent cleanup() call.
+   * Empty string when nothing happened (so the caller can suppress the block).
+   */
+  summary(): string;
+}
+
+/**
+ * Per-artifact outcome captured in the report.
+ */
+export interface ArtifactOutcome {
+  readonly name: string;
+  readonly state: 'ran' | 'skipped' | 'not-detected' | 'errored';
+  readonly removed: string[];
+  readonly warnings: string[];
+  readonly summary: string;
+  readonly error?: string;
+}
+
+/**
+ * Aggregate cleanup outcome across the registry. Consumed by diagnostics
+ * (Group 4) and by the update banner ("warn loudly when a cleanup partially
+ * failed").
+ */
+export interface CleanupReport {
+  readonly outcomes: ArtifactOutcome[];
+  /** True iff every ran artifact reported zero warnings AND nothing errored. */
+  readonly succeeded: boolean;
+  /** Names that were skipped via `skipList`. */
+  readonly skipped: string[];
+}
+
+/**
+ * Build the day-one nats-reply-sidecar artifact. Wraps the existing
+ * sidecar-cleanup module without modifying its public API.
+ *
+ * `detect()` always returns true — the underlying `cleanupSidecars()` is
+ * idempotent and produces an empty `formatCleanupSummary()` when nothing is
+ * present, which is exactly the byte-identical "no sidecars found" path the
+ * acceptance criteria require.
+ */
+function createNatsReplySidecarArtifact(): LegacyArtifact {
+  let lastResult: SidecarCleanupResult | null = null;
+
+  return {
+    name: 'nats-reply-sidecar',
+    async detect() {
+      return true;
+    },
+    async cleanup() {
+      const result = await cleanupSidecars();
+      lastResult = result;
+
+      const removed: string[] = [];
+      const warnings: string[] = [];
+
+      for (const m of result.pm2Stopped) {
+        removed.push(`pm2:${m.name.length > 0 ? m.name : `pm_id=${m.pmId}`}`);
+      }
+      for (const m of result.rawKilled) {
+        removed.push(`pid:${m.pid}`);
+      }
+      for (const m of result.pm2Failed) {
+        warnings.push(`pm2-failed:${m.name.length > 0 ? m.name : `pm_id=${m.pmId}`}`);
+      }
+      for (const m of result.rawFailed) {
+        warnings.push(`raw-failed:pid=${m.pid}`);
+      }
+
+      return { removed, warnings };
+    },
+    summary() {
+      return lastResult === null ? '' : formatSidecarSummary(lastResult);
+    },
+  };
+}
+
+/**
+ * The live registry. Order matters — artifacts run sequentially so an earlier
+ * cleanup's side effects are visible to a later one (e.g. stopping a process
+ * before deleting its config file).
+ *
+ * To add a new artifact:
+ *   1. Implement `LegacyArtifact` (idempotent, never-throws).
+ *   2. Append a factory call below.
+ *   3. Add a unit test that runs the registry round-trip.
+ *   4. Document the deprecation in `docs/migration/`.
+ */
+export const REGISTRY: LegacyArtifact[] = [createNatsReplySidecarArtifact()];
+
+/**
+ * Run every registry entry whose name is not in `skipList`. Never throws —
+ * an artifact whose `detect()` or `cleanup()` rejects is recorded as
+ * `state: 'errored'` and contributes a warning to the aggregate report.
+ *
+ * Returns a `CleanupReport` capturing what ran, what was skipped, and the
+ * per-artifact summaries. The caller decides how to render them (typically
+ * `console.log(outcome.summary)` for each `state === 'ran'`).
+ */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function erroredOutcome(name: string, phase: 'detect' | 'cleanup', error: unknown): ArtifactOutcome {
+  const message = errorMessage(error);
+  return {
+    name,
+    state: 'errored',
+    removed: [],
+    warnings: [`${phase}-threw:${message}`],
+    summary: '',
+    error: message,
+  };
+}
+
+async function runArtifact(artifact: LegacyArtifact): Promise<ArtifactOutcome> {
+  let detected: boolean;
+  try {
+    detected = await artifact.detect();
+  } catch (error) {
+    return erroredOutcome(artifact.name, 'detect', error);
+  }
+
+  if (!detected) {
+    return {
+      name: artifact.name,
+      state: 'not-detected',
+      removed: [],
+      warnings: [],
+      summary: '',
+    };
+  }
+
+  try {
+    const { removed, warnings } = await artifact.cleanup();
+    return {
+      name: artifact.name,
+      state: 'ran',
+      removed,
+      warnings,
+      summary: artifact.summary(),
+    };
+  } catch (error) {
+    return erroredOutcome(artifact.name, 'cleanup', error);
+  }
+}
+
+export async function cleanupLegacyArtifacts(skipList: Set<string>): Promise<CleanupReport> {
+  const outcomes: ArtifactOutcome[] = [];
+  const skipped: string[] = [];
+
+  for (const artifact of REGISTRY) {
+    if (skipList.has(artifact.name)) {
+      skipped.push(artifact.name);
+      outcomes.push({
+        name: artifact.name,
+        state: 'skipped',
+        removed: [],
+        warnings: [],
+        summary: '',
+      });
+      continue;
+    }
+
+    outcomes.push(await runArtifact(artifact));
+  }
+
+  const succeeded = outcomes.every((o) => o.state !== 'errored' && (o.state !== 'ran' || o.warnings.length === 0));
+
+  return { outcomes, succeeded, skipped };
+}

--- a/packages/cli/src/update-diagnostics.ts
+++ b/packages/cli/src/update-diagnostics.ts
@@ -1,0 +1,217 @@
+/**
+ * Update diagnostics capture.
+ *
+ * Every `omni update` invocation writes a structured JSON report to
+ * `~/.omni/logs/update-diagnostics-<iso>.json` capturing the install attempt,
+ * registry probe, restart, verify outcome, cleanup registry result,
+ * maintenance hook, and a tail of recent pm2 log signals. The file is the
+ * canonical post-mortem artifact: operators paste it into bug reports; the
+ * shape mirrors the genie wish (independent code, parity per
+ * `SHARED-DESIGN.md` decision #3) so a shared diagnostics consumer can read
+ * either CLI's output uniformly. omni starts at `schemaVersion: 1` (decision
+ * #4 in the wish: per-repo schema versions are intentionally asymmetric).
+ *
+ * The writer is best-effort: any failure (no perms, disk full, etc.) is
+ * swallowed so update never exits non-zero because diagnostics couldn't be
+ * persisted.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { MaintenanceReport, UpdateChannel, VerifyResult } from './commands/update.js';
+import type { CleanupReport } from './legacy-cleanup.js';
+import { PM2_PROCESSES } from './pm2.js';
+import { getPm2LogPaths } from './pm2.js';
+
+/** Stable schema version for omni-side update diagnostics. */
+export const UPDATE_DIAGNOSTICS_SCHEMA_VERSION = 1 as const;
+
+/** Captured tail of one pm2 log file (best-effort). */
+export interface LogSignal {
+  /** Tracked pm2 process name (e.g. `omni-v2-api`). */
+  source: string;
+  /** Which file (`out` or `error`). */
+  stream: 'out' | 'error';
+  /** Up to N most recent lines, oldest first. Empty when the file does not exist. */
+  lines: string[];
+}
+
+/**
+ * Outcome of the parallel npm-global install probe (Group 5a). Omni doesn't
+ * support npm-global server, but a parallel install hides stale binaries on
+ * PATH and confuses `which omni`. Captured here so a future bug report
+ * includes the smoking-gun path.
+ */
+export interface ParallelInstallReport {
+  detected: boolean;
+  /** Filesystem path to the parallel install (when detected). */
+  path?: string;
+  /** Reason detection couldn't run, e.g. `npm` not on PATH. */
+  skipped?: string;
+}
+
+/** Top-level diagnostics record. */
+export interface UpdateDiagnostics {
+  readonly schemaVersion: typeof UPDATE_DIAGNOSTICS_SCHEMA_VERSION;
+  /** ISO-8601 timestamp the run started at (filename derives from this). */
+  startedAt: string;
+  /** ISO-8601 timestamp diagnostics was finalized (= just before write). */
+  finishedAt: string;
+  cli: {
+    /** CLI version executing this update (the previous one — install hasn't restarted us). */
+    runningVersion: string;
+    channel: UpdateChannel;
+  };
+  registry: {
+    latestVersion: string | null;
+  };
+  preflight: {
+    /** Did the canonical-pgserve phase-2 check run? False when `--skip-canonical-preflight`. */
+    ran: boolean;
+    /** Did the check return a blocking error? When true, the run aborted. */
+    blocked: boolean;
+    /** First line of the rendered error message, when blocked. */
+    reason?: string;
+  };
+  install: {
+    attempted: boolean;
+    succeeded: boolean | null;
+    targetVersion: string | null;
+  };
+  restart: {
+    attempted: boolean;
+    succeeded: boolean | null;
+    services: string[];
+  };
+  verify: VerifyResult | null;
+  cleanups: CleanupReport | null;
+  maintenance: MaintenanceReport | null;
+  parallelNpmGlobal: ParallelInstallReport | null;
+  recentLogSignals: LogSignal[];
+  /** Final exit code — populated by the writer; useful for bug-report triage. */
+  exitCode: number;
+}
+
+/**
+ * Build a fresh diagnostics state with the invariant fields populated.
+ * Mutated in-place by `runUpdate` as it advances through the pipeline.
+ */
+export function createDiagnostics(args: {
+  runningVersion: string;
+  channel: UpdateChannel;
+}): UpdateDiagnostics {
+  const startedAt = new Date().toISOString();
+  return {
+    schemaVersion: UPDATE_DIAGNOSTICS_SCHEMA_VERSION,
+    startedAt,
+    finishedAt: startedAt,
+    cli: { runningVersion: args.runningVersion, channel: args.channel },
+    registry: { latestVersion: null },
+    preflight: { ran: false, blocked: false },
+    install: { attempted: false, succeeded: null, targetVersion: null },
+    restart: { attempted: false, succeeded: null, services: [] },
+    verify: null,
+    cleanups: null,
+    maintenance: null,
+    parallelNpmGlobal: null,
+    recentLogSignals: [],
+    exitCode: 0,
+  };
+}
+
+/** Get the directory diagnostics are written to. Honors `OMNI_CONFIG_DIR`. */
+export function getDiagnosticsDir(): string {
+  const base = process.env.OMNI_CONFIG_DIR ?? join(homedir(), '.omni');
+  return join(base, 'logs');
+}
+
+/**
+ * Compute the canonical filename for a diagnostics record. The ISO timestamp
+ * is sanitized to be filename-safe (`:` → `-`).
+ */
+export function getDiagnosticsPath(startedAt: string): string {
+  const safe = startedAt.replace(/:/g, '-');
+  return join(getDiagnosticsDir(), `update-diagnostics-${safe}.json`);
+}
+
+/**
+ * Read the last `maxLines` lines of a UTF-8 text file. Best-effort: returns
+ * an empty array on any error (missing file, perms, decoding issue).
+ *
+ * Implementation notes:
+ *   - We slurp the whole file (pm2 log files are small in steady state and
+ *     log-rotated by pm2-logrotate; reading the whole thing is simpler than
+ *     a reverse-byte tail and avoids edge cases on multi-byte UTF-8).
+ *   - Trailing empty line from a trailing newline is dropped.
+ */
+export function tailFileLines(path: string, maxLines: number): string[] {
+  if (!existsSync(path)) return [];
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const lines = raw.split(/\r?\n/);
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+    return lines.slice(-maxLines);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collect the most recent log lines from each tracked pm2 process. Skips
+ * processes whose log files don't exist (i.e. that have never run on this
+ * host). Limited to `maxLinesPerStream` per file to keep diagnostics small.
+ *
+ * `logPathsFor` is injectable so tests can point at a tmp dir without
+ * touching the developer's real `~/.omni/logs` (pm2 log paths don't honor
+ * `OMNI_CONFIG_DIR` and we'd rather not change that surface here).
+ *
+ * This is best-effort and called from the diagnostics writer; never throws.
+ */
+export function collectRecentLogSignals(
+  maxLinesPerStream = 30,
+  logPathsFor: (name: string) => { out: string; error: string } = getPm2LogPaths,
+): LogSignal[] {
+  const signals: LogSignal[] = [];
+  for (const name of Object.values(PM2_PROCESSES)) {
+    const { out, error } = logPathsFor(name);
+    const outLines = tailFileLines(out, maxLinesPerStream);
+    if (outLines.length > 0) {
+      signals.push({ source: name, stream: 'out', lines: outLines });
+    }
+    const errLines = tailFileLines(error, maxLinesPerStream);
+    if (errLines.length > 0) {
+      signals.push({ source: name, stream: 'error', lines: errLines });
+    }
+  }
+  return signals;
+}
+
+/**
+ * Persist the diagnostics record to `~/.omni/logs/update-diagnostics-*.json`.
+ * Returns the path that was written (or null on failure). Never throws —
+ * diagnostics is observability, not load-bearing for the update outcome.
+ *
+ * The exit code is captured into `state.exitCode` and the timestamp into
+ * `state.finishedAt` before serialization so the JSON file is a complete
+ * snapshot at write time.
+ */
+export function writeDiagnostics(state: UpdateDiagnostics, exitCode: number): string | null {
+  state.exitCode = exitCode;
+  state.finishedAt = new Date().toISOString();
+  if (state.recentLogSignals.length === 0) {
+    state.recentLogSignals = collectRecentLogSignals();
+  }
+  const dir = getDiagnosticsDir();
+  const path = getDiagnosticsPath(state.startedAt);
+  try {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+    return path;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Implements all five groups of the [`update-unify-stages` wish](.genie/wishes/update-unify-stages/WISH.md) — converging `omni update` onto the shared 14-stage pipeline that the genie wish ships in parallel. Two commits land the wish:

- **`a5e59e2`** — Groups 1+2: `VerifyResult` tagged-union + `cleanupLegacyArtifacts` registry
- **`ad2d166`** — Groups 3+4+5: maintenance hook + diagnostics JSON + `--no-verify` + parallel-install detection + `install.sh` slim (593→77 LOC)

Cross-CLI public-shape parity per [`SHARED-DESIGN.md`](.genie/wishes/update-unify-stages/SHARED-DESIGN.md) decision #3 (independent code; identical flag names, `VerifyResult`, `LegacyArtifact`, diagnostics field names). Diagnostics `schemaVersion: 1` is intentionally asymmetric with genie's `2` (decision #4).

### What's new

| Surface | Change |
|---|---|
| `decideVerify` | New canonical name; `decideUpdateVerify` retained as pointer-equal `@deprecated` alias. New `skipped` variant with reasons `no-restart`, `no-verify-flag`, `no-running-services`. |
| `cleanupLegacyArtifacts()` | Registry pattern; day-one entry `nats-reply-sidecar`. Flags `--no-legacy-cleanup` (with `--no-sidecar-cleanup` retained as alias) and `--skip-cleanup=<csv>`. |
| `runPostUpdateMaintenance()` | Calls `runDoctor({ json: true, dryRun: true })` after a successful restart + verify. Non-blocking. Gated by `--skip-maintenance` and `OMNI_UPDATE_SKIP_MAINTENANCE`. |
| Diagnostics JSON | Every `omni update` writes `~/.omni/logs/update-diagnostics-<iso>.json` capturing install attempt, registry probe, restart, verify, cleanups, maintenance, parallel-install probe, and a tail of pm2 log signals. |
| `--no-verify` flag | Restart services but skip the post-restart probe. Banner shows yellow `Server: v… (skipped)` / `Auth: skipped`. Maintenance auto-skips. |
| Parallel npm-global detection | Probes `npm root -g` for a stale `@automagik/omni` install and warns with the offending path + `npm uninstall -g @automagik/omni` recommendation. |
| `install.sh` | Slimmed from 593 → 77 LOC. Bootstrap-only: `ensure_bun` → resolve channel → `bun add -g @automagik/omni@<channel>` → `omni install --non-interactive`. All wizard prompts moved to TS. |

### Locked invariants (no changes)

- `decideUpdateVerify`'s existing return shapes are byte-identical (`ok` / `health-unreachable` / `version-mismatch` / `auth-invalid`).
- Locked error strings preserved: `Server version mismatch: cli=v… server=v…. Run: omni doctor` and `Auth key invalid after restart. Run: omni doctor --fix`.
- PM2 hermetic env construction (`buildRuntimeEnv`) untouched — the 2026-04-06 cross-DB incident root cause stays fixed.
- Phase-2 canonical-pgserve preflight (commit `ddebb05f`) is recognized as Stage 2.5 of the shared pipeline; no behavior change.

## Test plan

- [x] `bun test packages/cli/src/__tests__/update-verify.test.ts` — existing assertions byte-identical, new `skipped` variants covered
- [x] `bun test packages/cli/src/__tests__/update-maintenance.test.ts` — 16 tests
- [x] `bun test packages/cli/src/__tests__/update-diagnostics.test.ts` — 14 tests
- [x] `bun test packages/cli/src/__tests__/update-parallel-install.test.ts` — 6 tests
- [x] `bun test packages/cli/src/__tests__/legacy-cleanup.test.ts` — registry roundtrip
- [x] Full CLI suite: 343/343 pass
- [x] Repo-wide `bun test`: 3806 pass, 285 skip (cli leak-guard required killing a pre-existing stale PM2 daemon from PID 402966 — unrelated to this work)
- [x] `bunx tsc --noEmit -p packages/cli` clean
- [x] `bunx biome check` clean on all changed files
- [x] `wc -l install.sh` = 77 (≤80 target)
- [x] `bash -n install.sh` — syntax OK
- [ ] Fresh-box smoke test of `bash install.sh --server` (deferred — needs a clean VM; covered by acceptance criterion in WISH.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)