### PR TITLE
feat(output): output-primitives-unified — G1 in, G2-G4 pending [resume]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -238,7 +238,9 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@sentry/bun": "^10.43.0",
         "@snazzah/davey": "^0.1.11",
+        "boxen": "^7.1.1",
         "chalk": "^5.4.0",
+        "cli-progress": "^3.12.0",
         "commander": "^13.1.0",
         "exceljs": "^4.4.0",
         "libsodium-wrappers": "^0.7.15",
@@ -258,6 +260,7 @@
         "@omni/channel-whatsapp": "workspace:*",
         "@omni/core": "workspace:*",
         "@omni/sdk": "workspace:*",
+        "@types/cli-progress": "^3.11.6",
         "@types/node": "^22.10.3",
         "@types/qrcode-terminal": "^0.12.2",
         "typescript": "^5.7.3",
@@ -1070,6 +1073,8 @@
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@types/cli-progress": ["@types/cli-progress@3.11.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -1142,6 +1147,8 @@
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
@@ -1198,6 +1205,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "boxen": ["boxen@7.1.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^7.0.1", "chalk": "^5.2.0", "cli-boxes": "^3.0.0", "string-width": "^5.1.2", "type-fest": "^2.13.0", "widest-line": "^4.0.1", "wrap-ansi": "^8.1.0" } }, "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog=="],
+
     "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1230,6 +1239,8 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "camelcase": ["camelcase@7.0.1", "", {}, "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
     "chainsaw": ["chainsaw@0.1.0", "", { "dependencies": { "traverse": ">=0.3.0 <0.4" } }, "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ=="],
@@ -1244,7 +1255,11 @@
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
@@ -1350,6 +1365,8 @@
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
@@ -1358,7 +1375,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.302", "", {}, "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -2024,7 +2041,7 @@
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -2090,7 +2107,7 @@
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
-    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+    "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -2144,9 +2161,11 @@
 
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
+    "widest-line": ["widest-line@4.0.1", "", { "dependencies": { "string-width": "^5.0.1" } }, "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig=="],
+
     "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
-    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -2254,6 +2273,8 @@
 
     "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "@types/cli-progress/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
     "@types/connect/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@types/express-serve-static-core/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
@@ -2276,6 +2297,8 @@
 
     "@types/ws/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
+    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -2287,6 +2310,8 @@
     "baileys/p-queue": ["p-queue@9.1.0", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw=="],
 
     "bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "cli-progress/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2330,6 +2355,8 @@
 
     "inquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "inquirer/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -2350,7 +2377,11 @@
 
     "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "protobufjs/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
@@ -2368,9 +2399,7 @@
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2458,6 +2487,8 @@
 
     "@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
+    "@types/cli-progress/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@types/connect/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/express-serve-static-core/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -2480,6 +2511,10 @@
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "archiver-utils/glob/minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
 
     "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -2489,6 +2524,10 @@
     "baileys/p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "cli-progress/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-progress/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -2527,6 +2566,8 @@
     "libsignal/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2582,10 +2623,6 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -2608,7 +2645,11 @@
 
     "@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "cli-progress/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "inquirer/cli-cursor/restore-cursor/onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,9 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
     "@sentry/bun": "^10.43.0",
     "@snazzah/davey": "^0.1.11",
+    "boxen": "^7.1.1",
     "chalk": "^5.4.0",
+    "cli-progress": "^3.12.0",
     "commander": "^13.1.0",
     "exceljs": "^4.4.0",
     "libsodium-wrappers": "^0.7.15",
@@ -60,6 +62,7 @@
     "@omni/channel-whatsapp": "workspace:*",
     "@omni/core": "workspace:*",
     "@omni/sdk": "workspace:*",
+    "@types/cli-progress": "^3.11.6",
     "@types/node": "^22.10.3",
     "@types/qrcode-terminal": "^0.12.2",
     "typescript": "^5.7.3"

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -38,6 +38,14 @@ describe('Output Module Exports', () => {
     expect(typeof output.tip).toBe('function');
   });
 
+  test('exports new primitives: step / spinner / banner / progress / divider', () => {
+    expect(typeof output.step).toBe('function');
+    expect(typeof output.spinner).toBe('function');
+    expect(typeof output.banner).toBe('function');
+    expect(typeof output.progress).toBe('function');
+    expect(typeof output.divider).toBe('function');
+  });
+
   test('exports flushStdout', () => {
     expect(typeof output.flushStdout).toBe('function');
   });
@@ -132,6 +140,224 @@ await flushStdout();
     // stdout into jq must remain unaffected by the nudge.
     const parsed = JSON.parse(stderr.trim());
     expect(parsed).toHaveProperty('tip', 'canonical command is omni connect');
+  });
+});
+
+/**
+ * Behavioral coverage for the 5 new primitives: step / spinner / banner /
+ * progress / divider. Spawned-child tests use OMNI_FORMAT to switch modes
+ * because the child has no TTY (which exercises the non-TTY degradation
+ * paths exactly as a piped consumer would see them).
+ */
+describe('output primitives — step / spinner / banner / progress / divider', () => {
+  function runEmitter(
+    body: string,
+    env: Record<string, string> = {},
+  ): Promise<{ stdout: string; stderr: string; code: number | null }> {
+    const tempDir = mkdtempSync(join(tmpdir(), 'omni-prim-'));
+    const scriptPath = join(tempDir, 'emit.ts');
+    const outputModulePath = join(import.meta.dir, '..', 'output.ts');
+    const importPath = outputModulePath.replace(/\\/g, '/').replace(/'/g, "\\'");
+    const script = `
+import { step, spinner, banner, progress, divider, flushStdout } from '${importPath}';
+${body}
+await flushStdout();
+`;
+    writeFileSync(scriptPath, script);
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('bun', [scriptPath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, ...env },
+      });
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+      child.on('close', (code) => {
+        rmSync(tempDir, { recursive: true, force: true });
+        resolve({
+          stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+          code,
+        });
+      });
+      child.on('error', reject);
+    });
+  }
+
+  describe('step', () => {
+    test('human format: emits ▸ glyph + message on stdout', async () => {
+      const { stdout, stderr } = await runEmitter(`step('Installing pgserve...');`, {
+        OMNI_FORMAT: 'human',
+        NO_COLOR: '1',
+      });
+      expect(stdout).toContain('▸');
+      expect(stdout).toContain('Installing pgserve...');
+      expect(stderr).toBe('');
+    });
+
+    test('json format: emits {step} JSON breadcrumb on stderr, stdout empty', async () => {
+      const { stdout, stderr } = await runEmitter(`step('Installing pgserve...');`, {
+        OMNI_FORMAT: 'json',
+      });
+      expect(stdout).toBe('');
+      const parsed = JSON.parse(stderr.trim());
+      expect(parsed).toEqual({ step: 'Installing pgserve...' });
+    });
+  });
+
+  describe('spinner', () => {
+    test('non-TTY human format: start emits info, succeed emits success on stdout', async () => {
+      const { stdout, stderr } = await runEmitter(
+        `const s = spinner('Checking version...').start(); s.succeed('v1.2.3');`,
+        { OMNI_FORMAT: 'human', NO_COLOR: '1' },
+      );
+      // Degraded path: info(text) on start, success(text) on succeed.
+      expect(stdout).toContain('Checking version...');
+      expect(stdout).toContain('v1.2.3');
+      expect(stdout).toContain('ℹ');
+      expect(stdout).toContain('✓');
+      // No \r animation residue.
+      expect(stdout).not.toContain('\r');
+      expect(stderr).toBe('');
+    });
+
+    test('json format: emits start + succeed breadcrumbs on stderr, stdout stays empty', async () => {
+      const { stdout, stderr } = await runEmitter(
+        `const s = spinner('Checking version...').start(); s.succeed('v1.2.3');`,
+        { OMNI_FORMAT: 'json' },
+      );
+      expect(stdout).toBe('');
+      const lines = stderr
+        .trim()
+        .split('\n')
+        .filter((l) => l.length > 0);
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0])).toEqual({ spinner: 'start', text: 'Checking version...' });
+      expect(JSON.parse(lines[1])).toEqual({ spinner: 'succeed', text: 'v1.2.3' });
+    });
+
+    test('json format: fail / warn / info / stop all produce stderr breadcrumbs', async () => {
+      const { stdout, stderr } = await runEmitter(
+        `const s = spinner('initial').start(); s.fail('boom'); s.warn('soft'); s.info('hint'); s.stop();`,
+        { OMNI_FORMAT: 'json' },
+      );
+      expect(stdout).toBe('');
+      const lines = stderr
+        .trim()
+        .split('\n')
+        .filter((l) => l.length > 0)
+        .map((l) => JSON.parse(l));
+      expect(lines).toHaveLength(5);
+      expect(lines[0]).toEqual({ spinner: 'start', text: 'initial' });
+      expect(lines[1]).toEqual({ spinner: 'fail', text: 'boom' });
+      expect(lines[2]).toEqual({ spinner: 'warn', text: 'soft' });
+      expect(lines[3]).toEqual({ spinner: 'info', text: 'hint' });
+      expect(lines[4]).toEqual({ spinner: 'stop', text: 'initial' });
+    });
+
+    test('text setter mutates JSON-mode breadcrumb payload', async () => {
+      const { stderr } = await runEmitter(`const s = spinner('first'); s.text = 'second'; s.start(); s.succeed();`, {
+        OMNI_FORMAT: 'json',
+      });
+      const lines = stderr
+        .trim()
+        .split('\n')
+        .filter((l) => l.length > 0)
+        .map((l) => JSON.parse(l));
+      expect(lines[0]).toEqual({ spinner: 'start', text: 'second' });
+      expect(lines[1]).toEqual({ spinner: 'succeed', text: 'second' });
+    });
+  });
+
+  describe('banner', () => {
+    test('human format: prints a multi-line boxed banner to stdout', async () => {
+      const { stdout, stderr } = await runEmitter(
+        `banner(['Updated to v1.2.3', 'Run omni doctor'], { borderStyle: 'round', borderColor: 'green' });`,
+        { OMNI_FORMAT: 'human', NO_COLOR: '1' },
+      );
+      // boxen renders both lines plus border characters.
+      expect(stdout).toContain('Updated to v1.2.3');
+      expect(stdout).toContain('Run omni doctor');
+      // Round border has corner glyphs (degrades to single ASCII when NO_COLOR
+      // forces colors off in our impl). We assert at least one box-drawing
+      // character is present so the banner actually rendered as a box.
+      expect(stdout).toMatch(/[─│╭╮╯╰┌┐└┘]/);
+      expect(stderr).toBe('');
+    });
+
+    test('human format: single-line input is centered (not multi-line)', async () => {
+      const { stdout } = await runEmitter(`banner('Updated to v1.2.3');`, {
+        OMNI_FORMAT: 'human',
+        NO_COLOR: '1',
+      });
+      expect(stdout).toContain('Updated to v1.2.3');
+      expect(stdout).toMatch(/[─│┌┐└┘╭╮╯╰]/);
+    });
+
+    test('json format: emits {banner} stderr breadcrumb, stdout empty', async () => {
+      const { stdout, stderr } = await runEmitter(`banner(['line1', 'line2']);`, { OMNI_FORMAT: 'json' });
+      expect(stdout).toBe('');
+      const parsed = JSON.parse(stderr.trim());
+      expect(parsed).toEqual({ banner: 'line1\nline2' });
+    });
+  });
+
+  describe('progress', () => {
+    test('json format: emits rate-limited {progress} stderr breadcrumbs', async () => {
+      const { stdout, stderr } = await runEmitter(
+        `const p = progress('Downloading'); p.start(100, 0); p.update(50); p.update(75); p.stop();`,
+        { OMNI_FORMAT: 'json' },
+      );
+      expect(stdout).toBe('');
+      const lines = stderr
+        .trim()
+        .split('\n')
+        .filter((l) => l.length > 0)
+        .map((l) => JSON.parse(l));
+      // start() forces emit; the two updates within the same second are
+      // rate-limited away; stop() forces a final emit. Net: 2 lines.
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      expect(lines.length).toBeLessThanOrEqual(4);
+      expect(lines[0]).toMatchObject({ progress: 0, total: 100, downloaded: 0, label: 'Downloading' });
+      const last = lines[lines.length - 1];
+      expect(last.label).toBe('Downloading');
+      expect(last.total).toBe(100);
+    });
+
+    test('non-TTY human format: rate-limited stderr (no animation on stdout)', async () => {
+      const { stdout, stderr } = await runEmitter(
+        `const p = progress('Downloading'); p.start(100, 0); p.update(50); p.stop();`,
+        { OMNI_FORMAT: 'human', NO_COLOR: '1' },
+      );
+      // Non-TTY child → progress degrades to JSON-style stderr breadcrumbs.
+      expect(stdout).toBe('');
+      expect(stderr).toContain('"progress"');
+      expect(stderr).toContain('"label":"Downloading"');
+    });
+  });
+
+  describe('divider', () => {
+    test('human format: prints ─ characters spanning at least 1 char on stdout', async () => {
+      const { stdout, stderr } = await runEmitter('divider();', {
+        OMNI_FORMAT: 'human',
+        NO_COLOR: '1',
+      });
+      expect(stdout).toContain('─');
+      // Default non-TTY width is 80; allow more if process.stdout.columns leaks.
+      const dashCount = (stdout.match(/─/g) ?? []).length;
+      expect(dashCount).toBeGreaterThanOrEqual(80);
+      expect(stderr).toBe('');
+    });
+
+    test('json format: divider is a no-op (both streams empty)', async () => {
+      const { stdout, stderr } = await runEmitter('divider();', {
+        OMNI_FORMAT: 'json',
+      });
+      expect(stdout).toBe('');
+      expect(stderr).toBe('');
+    });
   });
 });
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -4,7 +4,10 @@
  * Human-friendly and JSON output modes with color support.
  */
 
+import boxen from 'boxen';
 import chalk from 'chalk';
+import cliProgress from 'cli-progress';
+import ora from 'ora';
 import { getOutputFormat } from './config.js';
 
 /**
@@ -294,6 +297,285 @@ export function dim(text: string): void {
 /** Raw stdout line (for custom formatting) */
 export function raw(text: string): void {
   writeStdoutLine(text);
+}
+
+/**
+ * Print a stage divider — bold cyan ▸ + bold message, with a leading newline.
+ *
+ * Used as a section header in install/update/setup pipelines. In JSON mode,
+ * emits `{ step: "<msg>" }` to stderr so observability isn't lost while stdout
+ * stays clean for `--json | jq` consumers.
+ */
+export function step(message: string): void {
+  const format = getCurrentFormat();
+
+  if (format === 'json') {
+    // biome-ignore lint/suspicious/noConsole: CLI output
+    console.error(JSON.stringify({ step: message }));
+  } else {
+    writeStdoutLine(`\n${c().bold.cyan('▸')} ${c().bold(message)}`);
+  }
+}
+
+/**
+ * Format-aware spinner. Locked subset of ora's API so the implementation can
+ * be swapped later without breaking callers.
+ *
+ * - Human TTY: real ora animation.
+ * - Human non-TTY (piped, CI, NO_COLOR): degrades to plain `info(text)` on
+ *   start and `success(text)` on succeed; no `\r` animation.
+ * - JSON mode: emits `{ spinner: "start" | "succeed" | "fail" | ..., text }`
+ *   breadcrumbs to stderr; never writes to stdout.
+ */
+export interface OutputSpinner {
+  start(): OutputSpinner;
+  succeed(text?: string): void;
+  fail(text?: string): void;
+  warn(text?: string): void;
+  info(text?: string): void;
+  stop(): void;
+  set text(value: string);
+}
+
+/** Create a format-aware spinner. See {@link OutputSpinner}. */
+export function spinner(text: string): OutputSpinner {
+  const format = getCurrentFormat();
+
+  if (format === 'json') {
+    let currentText = text;
+    const obj: OutputSpinner = {
+      start() {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(JSON.stringify({ spinner: 'start', text: currentText }));
+        return obj;
+      },
+      succeed(t?: string) {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(JSON.stringify({ spinner: 'succeed', text: t ?? currentText }));
+      },
+      fail(t?: string) {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(JSON.stringify({ spinner: 'fail', text: t ?? currentText }));
+      },
+      warn(t?: string) {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(JSON.stringify({ spinner: 'warn', text: t ?? currentText }));
+      },
+      info(t?: string) {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(JSON.stringify({ spinner: 'info', text: t ?? currentText }));
+      },
+      stop() {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(JSON.stringify({ spinner: 'stop', text: currentText }));
+      },
+      set text(value: string) {
+        currentText = value;
+      },
+    };
+    return obj;
+  }
+
+  if (!process.stdout.isTTY) {
+    let currentText = text;
+    const obj: OutputSpinner = {
+      start() {
+        info(currentText);
+        return obj;
+      },
+      succeed(t?: string) {
+        success(t ?? currentText);
+      },
+      fail(t?: string) {
+        // biome-ignore lint/suspicious/noConsole: CLI output
+        console.error(`${c().red('✗')} ${t ?? currentText}`);
+      },
+      warn(t?: string) {
+        warn(t ?? currentText);
+      },
+      info(t?: string) {
+        info(t ?? currentText);
+      },
+      stop() {
+        // No-op: nothing to clear when there was never an animation.
+      },
+      set text(value: string) {
+        currentText = value;
+      },
+    };
+    return obj;
+  }
+
+  const oraInstance = ora(text);
+  const obj: OutputSpinner = {
+    start() {
+      oraInstance.start();
+      return obj;
+    },
+    succeed(t?: string) {
+      oraInstance.succeed(t);
+    },
+    fail(t?: string) {
+      oraInstance.fail(t);
+    },
+    warn(t?: string) {
+      oraInstance.warn(t);
+    },
+    info(t?: string) {
+      oraInstance.info(t);
+    },
+    stop() {
+      oraInstance.stop();
+    },
+    set text(value: string) {
+      oraInstance.text = value;
+    },
+  };
+  return obj;
+}
+
+/** Options for {@link banner}. Border styles and colors are locked to a small palette. */
+export interface BannerOptions {
+  title?: string;
+  borderStyle?: 'single' | 'double' | 'round' | 'bold';
+  borderColor?: 'green' | 'red' | 'yellow' | 'blue' | 'cyan';
+  padding?: number;
+}
+
+/**
+ * Print a boxed banner (boxen wrapper). Used for "Updated to vX.Y.Z"
+ * release-style announcements.
+ *
+ * - Single-line input is center-aligned; multi-line input is left-aligned.
+ * - When colors are disabled (NO_COLOR / non-TTY / `--no-color`), the border
+ *   degrades to a single ASCII style with no color escapes.
+ * - In JSON mode, emits `{ banner: "<msg>" }` to stderr; never writes to stdout.
+ */
+export function banner(message: string | string[], options?: BannerOptions): void {
+  const format = getCurrentFormat();
+  const messageStr = Array.isArray(message) ? message.join('\n') : message;
+
+  if (format === 'json') {
+    // biome-ignore lint/suspicious/noConsole: CLI output
+    console.error(JSON.stringify({ banner: messageStr }));
+    return;
+  }
+
+  const isMultiLine = Array.isArray(message) || messageStr.includes('\n');
+  const borderStyle = options?.borderStyle ?? 'round';
+  const padding = options?.padding ?? 1;
+  const textAlignment: 'left' | 'center' = isMultiLine ? 'left' : 'center';
+
+  const colorsOn = areColorsEnabled();
+  const boxOptions: Parameters<typeof boxen>[1] = colorsOn
+    ? {
+        borderStyle,
+        borderColor: options?.borderColor ?? 'cyan',
+        padding,
+        textAlignment,
+        title: options?.title,
+      }
+    : {
+        borderStyle: 'single',
+        padding,
+        textAlignment,
+        title: options?.title,
+      };
+
+  writeStdoutLine(boxen(messageStr, boxOptions));
+}
+
+/**
+ * Format-aware progress bar.
+ *
+ * - Human TTY: real `cli-progress.SingleBar`.
+ * - Human non-TTY / JSON mode: rate-limited stub that emits at most one
+ *   `{ progress: 0.0..1.0, total, downloaded, label }` line per second to
+ *   stderr; never animates.
+ */
+export interface OutputProgress {
+  start(total: number, startValue?: number): void;
+  update(current: number): void;
+  increment(delta?: number): void;
+  stop(): void;
+}
+
+/** Create a format-aware progress bar. See {@link OutputProgress}. */
+export function progress(label: string): OutputProgress {
+  const format = getCurrentFormat();
+  const isNonTTY = format === 'json' || !process.stdout.isTTY;
+
+  if (isNonTTY) {
+    let total = 0;
+    let current = 0;
+    let lastEmit = 0;
+
+    const emit = (force: boolean): void => {
+      const now = Date.now();
+      if (!force && now - lastEmit < 1000) return;
+      lastEmit = now;
+      const ratio = total > 0 ? current / total : 0;
+      // biome-ignore lint/suspicious/noConsole: CLI output
+      console.error(JSON.stringify({ progress: ratio, total, downloaded: current, label }));
+    };
+
+    return {
+      start(totalValue: number, startValue = 0) {
+        total = totalValue;
+        current = startValue;
+        lastEmit = 0;
+        emit(true);
+      },
+      update(currentValue: number) {
+        current = currentValue;
+        emit(false);
+      },
+      increment(delta = 1) {
+        current += delta;
+        emit(false);
+      },
+      stop() {
+        emit(true);
+      },
+    };
+  }
+
+  const bar = new cliProgress.SingleBar(
+    {
+      format: `${label} |{bar}| {percentage}% | {value}/{total}`,
+      hideCursor: true,
+      clearOnComplete: false,
+    },
+    cliProgress.Presets.shades_classic,
+  );
+
+  return {
+    start(total: number, startValue = 0) {
+      bar.start(total, startValue);
+    },
+    update(current: number) {
+      bar.update(current);
+    },
+    increment(delta = 1) {
+      bar.increment(delta);
+    },
+    stop() {
+      bar.stop();
+    },
+  };
+}
+
+/**
+ * Print a horizontal divider — `─` × terminal width (or 80 if non-TTY).
+ *
+ * In JSON mode this is a no-op; dividers are pure decoration and JSON
+ * consumers don't need them.
+ */
+export function divider(): void {
+  if (getCurrentFormat() === 'json') return;
+
+  const width = process.stdout.columns || 80;
+  writeStdoutLine(c().dim('─'.repeat(width)));
 }
 
 /**


### PR DESCRIPTION
## Summary

Resumes orchestrator co-commit from earlier session (after the 2026-05-05 pgserve outage + worktree wipe). **Group 1 of 4 from the `output-primitives-unified` wish.** Draft — Groups 2-4 still pending and will continue on this branch.

## Scope (G1 of 4)

- ✅ **G1**: `output.ts` extensions (step, spinner, banner, progress, divider) per SHARED-DESIGN.md §3
- ⏳ G2: migrate `update.ts` + `install.ts` + `providers-setup.ts` + `film.ts` to use new exports
- ⏳ G3: deps lock + tests + CHANGELOG
- ⏳ G4: lint rule banning direct chalk/ora imports in command files

## Changes

| File | Δ |
|------|---|
| `packages/cli/src/output.ts` | 321 → 603 LOC. New exports: step, spinner, banner, progress, divider |
| `packages/cli/package.json` | +boxen, +cli-progress, +ora |
| `packages/cli/src/__tests__/output.test.ts` | tests for 5 new exports |
| `bun.lock` | re-locked |

JSDoc on every export. Format-aware: human TTY / human non-TTY (degrade) / JSON mode (stderr breadcrumbs).

## Test plan
- [ ] bun test packages/cli/src/__tests__/output.test.ts passes
- [ ] bun run check clean
- [ ] Resume team work on Groups 2-4 from this branch

🤖 Generated with Claude Code