### PR TITLE
docs(shared-design): add §4.6 transport-discovery contract

### DIFF
--- a/.genie/wishes/update-unify-stages/SHARED-DESIGN.md
+++ b/.genie/wishes/update-unify-stages/SHARED-DESIGN.md
@@ -180,6 +180,40 @@ Both write `~/.<cli>/logs/update-diagnostics-<iso>.json` with a versioned schema
 | Verify mismatch / auth-invalid / health-unreachable | 1 |
 | Maintenance failed (non-blocking) | 0, with banner warning |
 
+### 4.6 Transport discovery — shared shape (added 2026-05-05 per autopg-cutover transport-absorb)
+
+Consumers (genie + omni) connect to pgserve/autopg-server via a tagged-union transport resolver:
+
+```ts
+type PgserveTransport =
+  | { kind: 'unix'; socketDir: string; port: number }
+  | { kind: 'tcp'; host: string; port: number };
+
+async function resolvePgserveTransport(): Promise<PgserveTransport>;
+```
+
+**Probe order (UDS-first, TCP-fallback):**
+
+1. **Canonical Unix socket** at `$XDG_RUNTIME_DIR/<server>/.s.PGSQL.<port>` (or `/tmp/<server>/` fallback when XDG_RUNTIME_DIR unset). `<server>` is `pgserve` for legacy hosts, `autopg` for cutover hosts. Greet the postmaster (Postgres SSLRequest → expect 'N' or 'S' first byte) within `PGSERVE_GREET_TIMEOUT_MS` (1s) to confirm liveness. If reachable, return `{ kind: 'unix', socketDir, port }`.
+2. **TCP fallback** via the published discovery primitive: shell out to `<server> port` (read-only, returns the active TCP port number). Compose `{ kind: 'tcp', host: '127.0.0.1', port }`. Caller's libpq client dials `127.0.0.1:<port>`.
+3. **Both unreachable** → throw a typed error mentioning both probe attempts and the recovery hint (`pm2 status`, `<server> install`, `<server> daemon`).
+
+**Force-flag overrides** (legacy contract preserved, new flag added):
+- `GENIE_PG_FORCE_TCP=1` — skip UDS probe (legacy test/CI escape hatch).
+- `GENIE_PG_FORCE_SOCKET=1` — skip TCP fallback (UDS-only for diagnostics; new).
+- `OMNI_PG_FORCE_TCP=1` / `OMNI_PG_FORCE_SOCKET=1` — same shape for omni.
+
+**Server-side responsibility:**
+- pgserve@2.x daemon mode already writes `<canonical-socket-dir>/admin.json` post-greet — consumers read it for the live socketDir. Foreground/install mode (TCP-only, ephemeral pid-stamped socketDir) is the historical gap that broke this contract.
+- autopg-server (post-cutover) writes `admin.json` AND binds UDS at the canonical path from `autopg serve` (Group 11.5) — closes the gap for both transports under one supervised process.
+
+**Credential vs. transport split** — env files (`~/.<server>/<app>.env`) carry SCRAM credentials only (`PGUSER`, `PGPASSWORD`, `PGDATABASE`). Transport is discovered at runtime via the resolver above. Coupling them recreates the lockfile-drift problem this design kills.
+
+**Implementations:**
+- genie: `automagik-dev/genie #1667` — `src/lib/db.ts` `resolvePgserveTransport()` + `discoverTcpPgservePort()` + `PgserveTransport` tagged union.
+- omni: TODO sibling on omni's `update-unify-stages` follow-up (mirror the shape).
+- autopg-server: TODO Group 11.5 — `autopg serve` binds dual transports + writes `admin.json` so consumers' UDS probes succeed without globbing `/tmp/<server>-sock-<pid>-<ts>/`.
+
 ---
 
 ## 5. PR plan — `automagik-dev/genie` → `dev`


### PR DESCRIPTION
## Summary

Mirrors [`namastexlabs/pgserve#71`](https://github.com/namastexlabs/pgserve/pull/71) and [`automagik-dev/genie#1668`](https://github.com/automagik-dev/genie/pull/1668) — keeps `SHARED-DESIGN.md` byte-identical across **all 3 sibling repos** (genie + omni + pgserve). Adds a new §4.6 codifying the `PgserveTransport` tagged-union contract, UDS-first / TCP-fallback probe order, force-flag overrides, server-side `admin.json` responsibility, and the credential-vs-transport split.

The reference implementation already shipped at [`automagik-dev/genie #1667`](https://github.com/automagik-dev/genie/pull/1667). The **omni mirror** is intentionally listed as TODO in §4.6 — that's a separate follow-up against omni's `_buildConnection` to adopt the same UDS-first / TCP-fallback pattern. This PR only syncs the design doc; no `_buildConnection` changes here.

## What's added

```diff
### 4.5 Exit-code contract (shared)
... (unchanged) ...

+### 4.6 Transport discovery — shared shape (added 2026-05-05 per autopg-cutover transport-absorb)
+
+Consumers (genie + omni) connect to pgserve/autopg-server via a tagged-union transport resolver:
+
+\`\`\`ts
+type PgserveTransport =
+  | { kind: 'unix'; socketDir: string; port: number }
+  | { kind: 'tcp'; host: string; port: number };
+\`\`\`
+
+(probe order, force-flags, server responsibility, creds vs transport split,
+implementations table — full text in the diff)

---

## 5. PR plan — automagik-dev/genie → dev
... (unchanged) ...
```

## Byte-equality verification

`md5sum` on lines 183-216 of all 3 sibling files (`SHARED-DESIGN.md` §4.6):
```
ccc9d5119739d940b61eab8de0ca6a33  /home/genie/.genie/worktrees/genie/unify-genie/.genie/wishes/update-unify-stages/SHARED-DESIGN.md
ccc9d5119739d940b61eab8de0ca6a33  /home/genie/workspace/repos/pgserve/.genie/wishes/autopg-distribution-cutover/SHARED-DESIGN.md
ccc9d5119739d940b61eab8de0ca6a33  /home/genie/workspace/repos/omni/.genie/wishes/update-unify-stages/SHARED-DESIGN.md
```

All three identical.

## Test plan

- [ ] CI: docs-only PR; expect typecheck/lint/dead-code/tests to pass identically to baseline
- [ ] Reviewer confirms §4.6 matches genie#1668 §4.6 and pgserve#71 §4.6 byte-for-byte
- [ ] Follow-up: omni `_buildConnection` adopts UDS-first / TCP-fallback (separate PR)

## Backstory

Series of PRs unifying pgserve transport contract across the three sibling repos:
- [`automagik-dev/genie #1665`](https://github.com/automagik-dev/genie/pull/1665) (merged) — `update-unify-stages` (G1-G5)
- [`automagik-dev/genie #1667`](https://github.com/automagik-dev/genie/pull/1667) (open) — UDS-first / TCP-fallback resolver implementation
- [`namastexlabs/pgserve #71`](https://github.com/namastexlabs/pgserve/pull/71) (open) — wish-doc absorb of transport-discovery into autopg-distribution-cutover
- [`automagik-dev/genie #1668`](https://github.com/automagik-dev/genie/pull/1668) (open) — genie SHARED-DESIGN.md sync
- **THIS PR** — omni SHARED-DESIGN.md sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)