### PR TITLE
fix(api): handle string|undefined from c.req.param() in requireInstanceAccess

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -151,10 +151,10 @@ export function createApp(
     app.post(
       '/a2a/:instanceId',
       authMiddleware,
-      requireInstanceAccess((c) => c.req.param('instanceId')),
+      requireInstanceAccess((c) => c.req.param('instanceId') ?? ''),
       rateLimitMiddleware,
       async (c) => {
-        const instanceId = c.req.param('instanceId');
+        const instanceId = c.req.param('instanceId') ?? '';
         if (!UUID_REGEX.test(instanceId)) {
           return c.json({ error: 'Invalid instance ID format' }, 400);
         }

--- a/packages/api/src/routes/v2/agent-routes.ts
+++ b/packages/api/src/routes/v2/agent-routes.ts
@@ -11,7 +11,7 @@ import type { AppVariables } from '../../types';
 const routesRoutes = new Hono<{ Variables: AppVariables }>();
 
 // Instance access middleware for nested routes
-const instanceAccess = requireInstanceAccess((c) => c.req.param('instanceId'));
+const instanceAccess = requireInstanceAccess((c) => c.req.param('instanceId') ?? '');
 
 /**
  * GET /instances/:instanceId/routes - List routes for an instance

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -22,7 +22,7 @@ const log = createLogger('api:instances');
 const instancesRoutes = new Hono<{ Variables: AppVariables }>();
 
 // Instance access middleware for :id routes
-const instanceAccess = requireInstanceAccess((c) => c.req.param('id'));
+const instanceAccess = requireInstanceAccess((c) => c.req.param('id') ?? '');
 
 // Query params schema for list
 const listQuerySchema = z.object({


### PR DESCRIPTION
## Summary

Type-only fix unblocking the pre-push gate. `tsc --noEmit` was failing on three identical call sites where `c.req.param('xxx')` (returns `string | undefined` under stricter Hono typing) is passed to `requireInstanceAccess()` which expects a getter returning `string`.

- `packages/api/src/app.ts:154` — `/a2a/:instanceId`
- `packages/api/src/routes/v2/agent-routes.ts:14` — `/instances/:instanceId/routes`
- `packages/api/src/routes/v2/instances.ts:25` — `/instances/:id`

Each falls back to `''` when the param is undefined. **Behavior preserved**: empty string still fails the downstream `UUID_REGEX.test()` / `instanceAllowed()` checks just as a missing param would. No runtime change, no new tests needed (the type narrowing happens entirely at compile time).

## Why this PR

These errors were already on `dev` and were blocking the pre-push hook for unrelated PRs (specifically PR #610 silent-PreKeyError fix). Surfacing them as a standalone clean-up so other PRs can ship.

## Test plan

- [x] `bun run --cwd packages/api typecheck` — clean
- [x] Full `bun test` after stale PM2 daemon cleanup — 4091/4092 pass (1 skip is unrelated env issue, will green up in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)