### PR TITLE
ci(version): use npm publish + explicit .npmrc to fix scoped 404

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -127,15 +127,21 @@ jobs:
       - name: Publish to npm (@${{ steps.context.outputs.npm_tag }})
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: "0"
         run: |
           if [ -z "$NPM_TOKEN" ]; then
             echo "⚠️ NPM_TOKEN not set — skipping publish"
             exit 0
           fi
+          # Write the canonical .npmrc for the @automagik scope. We rely on
+          # this rather than NPM_CONFIG_TOKEN env var because `bun publish`
+          # started returning `404 Not Found` for scoped packages when given
+          # only env-var auth (works fine through 2026-05-06, broke after —
+          # token + permissions verified independently). `npm publish` uses
+          # the same .npmrc and is the historically-stable path here. The
+          # Release workflow on main retags as @latest if this was first
+          # published as @next, so a promoted dev build never double-publishes.
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc"
+          echo "@automagik:registry=https://registry.npmjs.org/" >> "${HOME}/.npmrc"
           cd packages/cli
-          # Publish with the resolved tag. main → @latest; dev → @next.
-          # The Release workflow on main will retag as @latest if this was
-          # first published as @next, so a promoted dev build never double-publishes.
-          bun publish --access public --tag ${{ steps.context.outputs.npm_tag }}
+          npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}


### PR DESCRIPTION
## Summary

Fixes the broken @next publish channel that's been silently failing since 2026-05-06 evening.

## Symptom

`Auto Version` workflow's \"Publish to npm\" step has been failing with:

\`\`\`
Tag: next
Access: public
Registry: https://registry.npmjs.org/
404 Not Found: https://registry.npmjs.org/@automagik%2fomni
 - '@automagik/omni@<v>' does not exist in this registry
\`\`\`

Every Version run since 2.260506.1 has failed publish (2.260506.2, 2.260507.1, 2.260507.2, 2.260507.3 — none on npm).

## What's NOT broken

- ✅ NPM_TOKEN authenticates fine (\`npm whoami\` returns \`namastex888\`)
- ✅ Token has read+write access to @automagik/omni and @automagik org
- ✅ Workflow code unchanged across success→failure boundary
- ✅ Bun version unchanged (1.3.13+bf2e2cecf)
- ✅ Registry URL unchanged

So neither token, permissions, nor workflow drift is the cause — most likely a `bun publish` regression for scoped packages when given env-var auth only.

## Fix

Two changes, both canonical npm setup:

1. **Write `~/.npmrc`** explicitly with `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` and the @automagik scope mapping. This is npm's official auth-config path.
2. **Switch from `bun publish` to `npm publish`**. `npm publish` is the historically-stable publisher and emits clearer error messages.

Net behavior preserved: same package, same scope, same tag, same access mode. Only the publisher binary + auth wiring changed.

## Test plan

- [x] Diff verified: only `.github/workflows/version.yml` modified
- [ ] After merge: next Version workflow run should publish a new @next version successfully (will be 2.260507.4 or 2.260508.x)
- [ ] Verify `npm view @automagik/omni dist-tags.next` returns the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)