### PR TITLE
fix(cli): anchor pm2 --cwd to $HOME so restarts cannot ENOENT

### DIFF
--- a/packages/cli/src/__tests__/start.test.ts
+++ b/packages/cli/src/__tests__/start.test.ts
@@ -14,7 +14,14 @@
 import { describe, expect, test } from 'bun:test';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { PM2_HARDENED_DEFAULTS, PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, getPm2LogPaths } from '../pm2.js';
+import {
+  PM2_HARDENED_DEFAULTS,
+  PM2_PROCESSES,
+  buildPm2StartArgs,
+  getPm2AnchorCwd,
+  getPm2LogDir,
+  getPm2LogPaths,
+} from '../pm2.js';
 
 describe('PM2_HARDENED_DEFAULTS', () => {
   test('maxRestarts is in the hardened range', () => {
@@ -39,6 +46,19 @@ describe('PM2_HARDENED_DEFAULTS', () => {
     // (packages/api/src/index.ts:327). pm2 must wait at least that long
     // before SIGKILL or it kills the process mid-drain.
     expect(PM2_HARDENED_DEFAULTS.killTimeoutMs).toBeGreaterThanOrEqual(15000);
+  });
+});
+
+describe('getPm2AnchorCwd', () => {
+  test('returns $HOME so pm2 chdir cannot ENOENT on a transient cwd', () => {
+    // Regression: 2026-05-07 incident — `omni update --next` ran from a
+    // shell whose cwd was `repos/pgserve` (later removed), and pm2 baked
+    // that path as the omni-api entry's cwd. Subsequent pm2 restarts
+    // failed with `Error: spawn bash ENOENT` because pm2 chdir'd into
+    // the missing directory before exec. Anchoring to $HOME — which
+    // exists for the lifetime of the user account — eliminates that
+    // class of failure entirely.
+    expect(getPm2AnchorCwd()).toBe(homedir());
   });
 });
 
@@ -116,6 +136,17 @@ describe('buildPm2StartArgs — api launch', () => {
     expect(apiArgs[idx + 1]).toBe('20000');
   });
 
+  test('includes --cwd anchored to $HOME so pm2 chdir cannot ENOENT', () => {
+    // Regression: pm2 inherits the calling shell's cwd unless `--cwd` is
+    // passed explicitly. If the inherited cwd is later removed, every
+    // restart fails silently with `Error: spawn bash ENOENT`. Pinning
+    // to `$HOME` keeps pm2's chdir target stable for the life of the
+    // user account.
+    expect(apiArgs).toContain('--cwd');
+    const idx = apiArgs.indexOf('--cwd');
+    expect(apiArgs[idx + 1]).toBe(homedir());
+  });
+
   test('includes --interpreter bash when provided', () => {
     expect(apiArgs).toContain('--interpreter');
     const idx = apiArgs.indexOf('--interpreter');
@@ -149,6 +180,12 @@ describe('buildPm2StartArgs — nats launch', () => {
     expect(natsArgs).toContain('--kill-timeout');
     const idx = natsArgs.indexOf('--kill-timeout');
     expect(natsArgs[idx + 1]).toBe('20000');
+  });
+
+  test('includes --cwd anchored to $HOME for nats too', () => {
+    expect(natsArgs).toContain('--cwd');
+    const idx = natsArgs.indexOf('--cwd');
+    expect(natsArgs[idx + 1]).toBe(homedir());
   });
 
   test('forwards scriptArgs after a "--" separator', () => {

--- a/packages/cli/src/pm2.ts
+++ b/packages/cli/src/pm2.ts
@@ -41,6 +41,27 @@ export function getPm2LogDir(): string {
   return join(homedir(), '.omni', 'logs');
 }
 
+/**
+ * Stable cwd to anchor pm2-managed processes against. Defaults to `$HOME`,
+ * which is guaranteed to exist for the lifetime of the user account.
+ *
+ * Without this anchor, `pm2 start` inherits the calling shell's `process.cwd()`
+ * and bakes it into the pm2 entry. If that directory is later removed (e.g.
+ * a transient build dir, a deleted submodule, a switched git branch) every
+ * subsequent `pm2 restart` fails with `Error: spawn bash ENOENT` because pm2
+ * tries to `chdir()` into the missing path before exec. The omni-api launcher
+ * (`bin/omni-server`) does its own `cd "$(dirname "$0")/../dist/server"`, so
+ * pm2's cwd does not need to point anywhere meaningful — it just needs to
+ * point somewhere that exists.
+ *
+ * See: 2026-05-07 incident where `omni update --next` poisoned the omni-api
+ * pm2 entry with `repos/pgserve` (a directory that no longer existed),
+ * causing silent crash loops with no log output.
+ */
+export function getPm2AnchorCwd(): string {
+  return homedir();
+}
+
 /** Hardened log path for a given pm2 process name. */
 export function getPm2LogPaths(processName: string): { out: string; error: string } {
   const dir = getPm2LogDir();
@@ -84,6 +105,8 @@ export function buildPm2StartArgs(options: Pm2StartArgsOptions): string[] {
     script,
     '--name',
     name,
+    '--cwd',
+    getPm2AnchorCwd(),
     '--max-restarts',
     String(PM2_HARDENED_DEFAULTS.maxRestarts),
     '--restart-delay',


### PR DESCRIPTION
## Summary
- `buildPm2StartArgs` did not pass `--cwd`, so pm2 inherited the calling shell's `process.cwd()` and baked it into the omni-api / omni-nats entries.
- When that directory was later removed (transient build dir, deleted submodule, switched git branch), every `pm2 restart` failed silently with `Error: spawn bash ENOENT` because pm2 chdir'd into the missing path before exec.
- Fix: introduce `getPm2AnchorCwd()` returning `homedir()` and pass `--cwd <anchor>` from `buildPm2StartArgs`. Single change covers `startServices` (install/update), `fixPgserveCanonical`, `fixPm2EnvDrift`, and `fixPm2MaxRestarts`.

## Background — 2026-05-07 incident on khal-os
1. `omni update --next` (2.260505.2 → 2.260507.9) ran from a shell whose cwd was `/home/genie/workspace/agents/genie-configure/repos/pgserve` — a leftover canonical-pgserve experiment directory.
2. `startServices` did `pm2 delete omni-api && pm2 start <launcher> --name omni-api ...` with no `--cwd`. PM2 baked `repos/pgserve` as the entry's exec cwd.
3. The directory was later removed (canonical-pgserve cleanup / branch switch).
4. Subsequent restarts (SessionStart hook, `omni doctor --fix`, pm2 max_restarts backoff) all silently died:
   - `~/.pm2/pm2.log`: `PM2 error: Error: spawn bash ENOENT`
   - `~/.omni/logs/omni-api-*.log`: zero new bytes — the bash launcher never ran.
   - `pm2 list`: status `online`, `pid: None` (the lying-online state).
5. `omni doctor` reported `cli-key-valid` ✗, `omni-db-exists` ✗, `version-match` ⚠ — all of which actually probe `/api/v2/health`, which had no listener.
6. `omni doctor --fix` rotated the CLI key, then validated against the still-down API → reported `rotated key does not validate; manually delete __primary__ from api_keys and rerun` (which is also a real bug — separate issue worth filing).

## Why `$HOME`
The omni-server launcher (`bin/omni-server`) does its own `cd "$(dirname "$0")/../dist/server"` at line 6, so pm2's cwd does not need to point anywhere meaningful — it just needs to point somewhere that exists for the lifetime of the user account. `$HOME` is the obvious anchor.

## Changes
- `packages/cli/src/pm2.ts`
  - new exported `getPm2AnchorCwd()` returning `homedir()` (with a long-form comment explaining the failure mode).
  - `buildPm2StartArgs` injects `--cwd <anchor>` for both `api` and `nats` kinds.
- `packages/cli/src/__tests__/start.test.ts`
  - new `getPm2AnchorCwd` block (regression note baked into the test).
  - api launch test: asserts `--cwd === homedir()`.
  - nats launch test: asserts `--cwd === homedir()`.

## Test plan
- [x] `bun test packages/cli/src/__tests__/start.test.ts` — 28/28 pass
- [x] `bun test` (cli package) — 438/438 pass
- [x] `bun run typecheck` — clean (`tsc --noEmit`)
- [x] `bunx biome check packages/cli/src/{pm2.ts,__tests__/start.test.ts}` — clean
- [ ] Smoke test on a real install:
  ```bash
  cd /tmp && omni install   # was previously broken because /tmp could be wiped
  ls -d "$(pm2 describe omni-api | grep 'exec cwd' | awk -F'│' '{print $3}' | xargs)"  # must exist
  ```

## Follow-ups (not in this PR)
1. **`omni doctor --fix` for `cli-key-valid` is broken at the DB layer.** It rotates `config.json` + `pm2 set OMNI_API_KEY`, then validates against the API — but never updates `api_keys.__primary__.key_hash`. The escape hatch message ("manually delete `__primary__` from api_keys and rerun") is the user being asked to work around the bug. The fixer should either `DELETE` + restart so the API re-seeds the row, or do an `UPDATE … RETURNING` after generating the new key.
2. **`omni-db-exists` doctor check is misnamed.** It probes `/api/v2/health`, not the DB. During the incident the DB on `:8432` was healthy throughout; the API on `:8882` wasn't. Suggest renaming to `omni-api-reachable` or splitting into two checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)