### PR TITLE
ci(release): migrate npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@ on:
 
 permissions:
   contents: write
+  # OIDC token issuance for npm Trusted Publishing — pairs with the
+  # "Publish to npm via OIDC" step below. Without this, npm's publish
+  # client gets an empty placeholder token and the registry returns a
+  # misleading 404 instead of the real auth failure (the same trap
+  # version.yml hit before commit 01b55112). The release workflow's
+  # legacy NPM_TOKEN path was the source of the 2026-05-08 regression
+  # where `@automagik/omni@<version>` 404'd during `npm dist-tag add`.
+  id-token: write
 
 jobs:
   release:
@@ -16,7 +24,13 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted runner (not Blacksmith). The "Setup Node 24" step below
+    # writes Node into actions/setup-node's tool_cache; on the Blacksmith
+    # pool image that path resolves under /usr/local where the runner user
+    # gets EACCES. GitHub-hosted runners give the runner user write access
+    # to /usr/local. Same trade-off documented on version.yml (slower job
+    # startup vs. publish reliability).
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -108,26 +122,45 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         run: bunx turbo run build --filter=@automagik/omni
 
-      - name: Publish to npm (@latest, with @next promotion fallback)
+      # Auth: npm OIDC Trusted Publishing — same path as version.yml. Both
+      # version.yml AND release.yml publish on behalf of the same npm
+      # package, so both must be registered as Trusted Publishers at
+      # https://www.npmjs.com/package/@automagik/omni/access. If you rename
+      # this file, update that record or publishes will silently 404.
+      #
+      # Node 24 bundles npm 11.x; npm Trusted Publishing requires
+      # npm >= 11.5.1. Using Node 24 sidesteps the npm self-upgrade dance.
+      - name: Setup Node 24 (for npm OIDC publish)
+        if: steps.exists.outputs.skip != 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm via OIDC (@latest, with @next promotion fallback)
         if: steps.exists.outputs.skip != 'true'
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"
+          # npm auto-enables provenance in any CI env with `id-token: write`,
+          # regardless of the --provenance CLI flag. Self-hosted runners fail
+          # the server-side sigstore check with 422. Disable auto-provenance
+          # explicitly; OIDC token exchange still happens.
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "ERROR: NPM_TOKEN secret is not set. Cannot publish to npm." >&2
-            exit 1
-          fi
-
           VERSION="${{ steps.pkg.outputs.version }}"
           cd packages/cli
 
           # Try a fresh publish as @latest. If the version already exists on npm
           # (the Version workflow already published it as @next when this build
-          # came through dev first), promote it by retagging instead of failing.
-          if ! bun publish --access public --tag latest 2>&1; then
+          # came through dev first), promote it via OIDC-authed dist-tag add
+          # instead of failing.
+          #
+          # Both branches use the OIDC token issued by `id-token: write` —
+          # `npm dist-tag add` consumes the same registry-url + tool_cache
+          # auth that `npm publish` writes, so no manual ~/.npmrc plumbing
+          # is required.
+          if ! npm publish --access public --tag latest 2>&1; then
             echo "Publish failed — version may already exist from @next. Retagging as latest..."
-            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
             npm dist-tag add "@automagik/omni@${VERSION}" latest
           fi
 


### PR DESCRIPTION
## Summary
Fixes a regression introduced by 01b55112 (\`ci(version): switch npm publish to OIDC trusted publishing\`, 2026-05-07) where only \`version.yml\` was migrated to OIDC. After Trusted Publishing was registered for \`@automagik/omni\` on npmjs to support that change, \`release.yml\`'s legacy \`NPM_TOKEN\` path silently broke — npm now returns a 404 on the Release workflow's \`bun publish\` + \`npm dist-tag add\` fallback because the runner is effectively unauthenticated against the package.

The 404 is the same trap \`version.yml\`'s comment block warns about: when \`id-token: write\` is missing, npm's publish client gets an empty placeholder token and the registry returns a misleading 404 instead of the real auth failure.

## Failing run symptom
\`\`\`
Tag: latest
Access: public
Registry: https://registry.npmjs.org/
404 Not Found: https://registry.npmjs.org/@automagik%2fomni
'@automagik/omni@2.260508.1' does not exist in this registry
Error: Process completed with exit code 1
\`\`\`

## Changes (release.yml)
- Add \`id-token: write\` to the workflow's \`permissions\` block so the runner can mint OIDC tokens.
- Switch \`runs-on\` from \`blacksmith-4vcpu-ubuntu-2404\` to \`ubuntu-latest\`. \`actions/setup-node\`'s tool_cache resolves under \`/usr/local\` on the Blacksmith pool image where the runner user gets EACCES. Same trade-off already documented on \`version.yml\`.
- Add \`actions/setup-node@v5\` step with \`node-version: '24'\` and \`registry-url: 'https://registry.npmjs.org'\`. Node 24 ships npm 11.x; Trusted Publishing requires \`npm >= 11.5.1\`, sidestepping the npm self-upgrade dance.
- Replace \`bun publish\` with \`npm publish\`. Drop the manual \`~/.npmrc\` write and \`NPM_TOKEN\`/\`NPM_CONFIG_TOKEN\` env vars — OIDC handles auth for both \`npm publish\` and the \`npm dist-tag add\` retag fallback.
- Set \`NPM_CONFIG_PROVENANCE: \"false\"\`. npm auto-enables provenance whenever \`id-token\` is writable; the server-side sigstore check 422s for this package on GitHub-hosted runners.

## ⚠️ Operator action required (one time, on npmjs.com)
This workflow file is now a publisher of \`@automagik/omni\` from npm's perspective. Both \`version.yml\` AND \`release.yml\` must be registered as Trusted Publishers at:

  https://www.npmjs.com/package/@automagik/omni/access

If only \`version.yml\` is registered (current state), this PR will land but the next Release workflow run will still 404 with the same misleading message.

The included inline comment in the publish step calls this out so a future workflow rename does not silently re-introduce the regression.

## Why this is the right fix (vs. rotating NPM_TOKEN)
Once a package has a Trusted Publisher entry, npm's auth model treats OIDC as the canonical path. Continuing to depend on \`NPM_TOKEN\` for one of the two publishers is fragile: the token is a long-lived secret with broader scope than necessary, requires rotation, doesn't survive 2FA tightening, and (as this regression proves) silently degrades the moment OIDC is enabled for the package. Aligning both workflows on OIDC removes the dual-auth surface entirely.

## Test plan
- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"\` → valid
- [ ] After merge: register \`release.yml\` as a Trusted Publisher at \`https://www.npmjs.com/package/@automagik/omni/access\`
- [ ] After merge + Trusted Publisher setup: trigger \`workflow_dispatch\` on Release for the most recent tag and confirm \`npm publish\` (or the \`npm dist-tag add\` fallback) succeeds without a 404
- [ ] Confirm \`npm view @automagik/omni dist-tags\` shows both \`latest\` and \`next\` pointing at expected versions

## Related
- Companion PR #619: \`fix(cli): anchor pm2 --cwd to \$HOME so restarts cannot ENOENT\` — surfaced during the same trace investigation.
- Original OIDC migration: 01b55112 \`ci(version): switch npm publish to OIDC trusted publishing\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)