### PR TITLE
fix(api): re-arm stale customer_replied rows via sweeper pass (#624)

### DIFF
--- a/packages/api/src/__tests__/follow-up-sweeper.test.ts
+++ b/packages/api/src/__tests__/follow-up-sweeper.test.ts
@@ -14,6 +14,7 @@ import type { EventBus, FollowUpSequenceConfig } from '@omni/core';
 import type { Database } from '@omni/db';
 import { chatFollowUpState, chats, instances } from '@omni/db';
 import { eq, sql } from 'drizzle-orm';
+import { FollowUpLifecycleService } from '../services/follow-up-lifecycle';
 import { FollowUpSweeperService } from '../services/follow-up-sweeper';
 import { describeWithDb, getTestDb } from './db-helper';
 
@@ -79,6 +80,10 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     } as unknown as EventBus;
 
     service = new FollowUpSweeperService(db, eventBus);
+    // Wire lifecycle so the sweeper's stale-pause re-arm pass (#624) runs.
+    // Tests that don't exercise the re-arm path are unaffected — the new
+    // pass is a no-op when no `customer_replied` rows match its filters.
+    service.setLifecycle(new FollowUpLifecycleService(db, eventBus));
   });
 
   afterEach(async () => {
@@ -169,7 +174,14 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     expect(row.disarmedAt).not.toBeNull();
   });
 
-  test('already disarmed rows are not swept', async () => {
+  test('terminal-disarmed rows (handoff) are not swept by either pass', async () => {
+    // The original "already disarmed rows are not swept" test asserted this
+    // for `customer_replied` too — that assumption was the buggy behavior
+    // documented in #624. After the fix, terminal disarms (`handoff`,
+    // `session_cleared`, `archived`, `window_expired`) still skip both the
+    // fire-due pass AND the stale-pause re-arm pass; non-terminal
+    // `customer_replied` is now eligible for re-arm (covered by the new
+    // tests below).
     const past = new Date(Date.now() - 60_000);
 
     await db.insert(chatFollowUpState).values({
@@ -180,12 +192,14 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
       sequenceIndex: 1,
       lastAgentMessageAt: new Date(Date.now() - 60 * MS_PER_MINUTE),
       nextFireAt: past,
-      disarmReason: 'customer_replied',
+      disarmReason: 'handoff',
       disarmedAt: new Date(Date.now() - 30_000),
+      lastInboundCustomerMessageAt: new Date(Date.now() - 20 * MS_PER_MINUTE),
     });
 
     const stats = await service.sweep();
     expect(stats.scanned).toBe(0);
+    expect(stats.rearmed).toBe(0);
     expect(publishedEvents).toHaveLength(0);
   });
 
@@ -256,6 +270,197 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
 
     const noBusService = new FollowUpSweeperService(db, null);
     const stats = await noBusService.sweep();
-    expect(stats).toEqual({ scanned: 0, fired: 0, disarmed: 0, skipped: 0 });
+    expect(stats).toEqual({ scanned: 0, fired: 0, disarmed: 0, skipped: 0, rearmed: 0 });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // #624 — Stale-pause re-arm tests
+  //
+  // The fix from #624 adds a sweeper pass that re-arms `customer_replied`
+  // rows whose customer-inbound timestamp has aged past the configured first
+  // interval. Without this pass, any chat where the agent stops responding
+  // after a customer reply stays disarmed indefinitely (~65% of FU-eligible
+  // sessions in production observed before the fix).
+  //
+  // The 5 cases below exercise the boundary conditions:
+  //   1. Aged past first interval → re-arm.
+  //   2. Aged past max-pause → DO NOT re-arm (lead too cold).
+  //   3. Terminal disarm reasons → DO NOT re-arm (terminal-guard wins).
+  //   4. Active close-contact state → DO NOT re-arm (gate at lifecycle).
+  //   5. agentPaused chat → DO NOT re-arm (parity with #528 race fix).
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test('#624 customer_replied row aged past first interval is re-armed by the sweeper', async () => {
+    const cfg = config({ schedule: { kind: 'fixed', intervalsMinutes: [3, 5, 30] } });
+    // Inbound 10 min ago — past the 3-min first interval.
+    const inboundAt = new Date(Date.now() - 10 * MS_PER_MINUTE);
+
+    await db.insert(chatFollowUpState).values({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      sequenceConfig: cfg,
+      sequenceIndex: 2, // mid-sequence at disarm time
+      lastAgentMessageAt: new Date(Date.now() - 30 * MS_PER_MINUTE),
+      nextFireAt: null,
+      disarmReason: 'customer_replied',
+      disarmedAt: inboundAt,
+      lastInboundCustomerMessageAt: inboundAt,
+    });
+
+    const stats = await service.sweep();
+    expect(stats.rearmed).toBe(1);
+
+    // Row was reset: disarm cleared, sequence back to 0, nextFireAt anchored
+    // on the inbound timestamp + first interval.
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBeNull();
+    expect(row.disarmedAt).toBeNull();
+    expect(row.sequenceIndex).toBe(0);
+    expect(row.nextFireAt).not.toBeNull();
+    // First fire = inbound + 3 min — already in the past, so the next sweep
+    // tick will pick it up via the original fire-due pass.
+    const expectedFire = inboundAt.getTime() + 3 * MS_PER_MINUTE;
+    expect(row.nextFireAt.getTime()).toBeGreaterThanOrEqual(expectedFire - 2000);
+    expect(row.nextFireAt.getTime()).toBeLessThanOrEqual(expectedFire + 2000);
+
+    // follow_up.armed event was emitted by the lifecycle service.
+    const types = publishedEvents.map((e) => e.type);
+    expect(types).toContain('follow_up.armed');
+  });
+
+  test('#624 customer_replied row aged past max-pause (7d) is NOT re-armed', async () => {
+    const cfg = config({ schedule: { kind: 'fixed', intervalsMinutes: [3, 5, 30] } });
+    const inboundAt = new Date(Date.now() - 8 * 24 * 60 * MS_PER_MINUTE); // 8 days ago
+
+    await db.insert(chatFollowUpState).values({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      sequenceConfig: cfg,
+      sequenceIndex: 1,
+      lastAgentMessageAt: inboundAt,
+      nextFireAt: null,
+      disarmReason: 'customer_replied',
+      disarmedAt: inboundAt,
+      lastInboundCustomerMessageAt: inboundAt,
+    });
+
+    const stats = await service.sweep();
+    expect(stats.rearmed).toBe(0);
+
+    // Row remains disarmed.
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('customer_replied');
+    expect(row.nextFireAt).toBeNull();
+  });
+
+  test('#624 terminal disarm reasons are NOT re-armed even when inbound is recent', async () => {
+    // Iterate the four terminal reasons; each must stay disarmed after a
+    // sweep tick despite an inbound that would re-arm a `customer_replied`.
+    const cfg = config({ schedule: { kind: 'fixed', intervalsMinutes: [3, 5, 30] } });
+    const inboundAt = new Date(Date.now() - 10 * MS_PER_MINUTE);
+
+    for (const reason of ['handoff', 'session_cleared', 'archived', 'window_expired'] as const) {
+      // Reset between iterations.
+      await db.delete(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId));
+      publishedEvents.length = 0;
+
+      await db.insert(chatFollowUpState).values({
+        chatId: testChatId,
+        instanceId: testInstanceId,
+        agentId: null,
+        sequenceConfig: cfg,
+        sequenceIndex: 1,
+        lastAgentMessageAt: inboundAt,
+        nextFireAt: null,
+        disarmReason: reason,
+        disarmedAt: inboundAt,
+        lastInboundCustomerMessageAt: inboundAt,
+      });
+
+      const stats = await service.sweep();
+      expect(stats.rearmed).toBe(0);
+
+      const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+      expect(row.disarmReason).toBe(reason);
+    }
+  });
+
+  test('#624 chat in active close-contact state is NOT re-armed', async () => {
+    const cfg = config({ schedule: { kind: 'fixed', intervalsMinutes: [3, 5, 30] } });
+    const inboundAt = new Date(Date.now() - 10 * MS_PER_MINUTE);
+
+    // Mark chat as deliberately closed via the close-contact mechanism.
+    // Mirrors the shape `POST /messages/send/close-contact` writes.
+    await db
+      .update(chats)
+      .set({
+        settings: sql`jsonb_set(COALESCE(${chats.settings}, '{}'::jsonb), '{closed}', 'true'::jsonb)`,
+      })
+      .where(eq(chats.id, testChatId));
+
+    await db.insert(chatFollowUpState).values({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      sequenceConfig: cfg,
+      sequenceIndex: 1,
+      lastAgentMessageAt: inboundAt,
+      nextFireAt: null,
+      disarmReason: 'customer_replied',
+      disarmedAt: inboundAt,
+      lastInboundCustomerMessageAt: inboundAt,
+    });
+
+    const stats = await service.sweep();
+    expect(stats.rearmed).toBe(0);
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('customer_replied');
+    expect(row.nextFireAt).toBeNull();
+
+    // Cleanup the close-contact marker so subsequent tests get a fresh chat.
+    await db
+      .update(chats)
+      .set({ settings: sql`${chats.settings} - 'closed'` })
+      .where(eq(chats.id, testChatId));
+  });
+
+  test('#624 agentPaused chat with stale customer_replied is NOT re-armed', async () => {
+    // Parity with #528 race fix — `findAndLockDue` skips paused chats and
+    // the stale-pause re-arm pass must do the same. Without this filter,
+    // we would re-arm a row that the operator just paused, defeating the
+    // explicit pause.
+    const cfg = config({ schedule: { kind: 'fixed', intervalsMinutes: [3, 5, 30] } });
+    const inboundAt = new Date(Date.now() - 10 * MS_PER_MINUTE);
+
+    await db
+      .update(chats)
+      .set({
+        settings: sql`jsonb_set(COALESCE(${chats.settings}, '{}'::jsonb), '{agentPaused}', 'true'::jsonb)`,
+      })
+      .where(eq(chats.id, testChatId));
+
+    await db.insert(chatFollowUpState).values({
+      chatId: testChatId,
+      instanceId: testInstanceId,
+      agentId: null,
+      sequenceConfig: cfg,
+      sequenceIndex: 1,
+      lastAgentMessageAt: inboundAt,
+      nextFireAt: null,
+      disarmReason: 'customer_replied',
+      disarmedAt: inboundAt,
+      lastInboundCustomerMessageAt: inboundAt,
+    });
+
+    const stats = await service.sweep();
+    expect(stats.rearmed).toBe(0);
+
+    const [row] = await db.select().from(chatFollowUpState).where(eq(chatFollowUpState.chatId, testChatId)).limit(1);
+    expect(row.disarmReason).toBe('customer_replied');
+    expect(row.nextFireAt).toBeNull();
+    // `afterEach` strips agentPaused.
   });
 });

--- a/packages/api/src/__tests__/follow-up-sweeper.test.ts
+++ b/packages/api/src/__tests__/follow-up-sweeper.test.ts
@@ -174,14 +174,25 @@ describeWithDb('FollowUpSweeperService (integration)', () => {
     expect(row.disarmedAt).not.toBeNull();
   });
 
-  test('terminal-disarmed rows (handoff) are not swept by either pass', async () => {
+  test('disarm guard skips terminal-disarmed rows even when nextFireAt is stale (race-condition defense)', async () => {
     // The original "already disarmed rows are not swept" test asserted this
     // for `customer_replied` too — that assumption was the buggy behavior
     // documented in #624. After the fix, terminal disarms (`handoff`,
-    // `session_cleared`, `archived`, `window_expired`) still skip both the
-    // fire-due pass AND the stale-pause re-arm pass; non-terminal
-    // `customer_replied` is now eligible for re-arm (covered by the new
-    // tests below).
+    // `session_cleared`, `archived`, `window_expired`) still skip both
+    // passes; non-terminal `customer_replied` is now eligible for re-arm
+    // (covered by the #624 tests below).
+    //
+    // Why the artificial-looking fixture (nextFireAt: past + disarmReason
+    // set): production `disarmActive()` always nulls `nextFireAt` when it
+    // disarms, so this combination only arises during the narrow race
+    // where the sweeper has SELECTed a row, and a disarm event commits
+    // before the sweeper actually fires. The `isNull(disarmReason)` clause
+    // in `findAndLockDue` is what protects against a stale fire in that
+    // window — without it, a row could be fired AFTER it was disarmed.
+    // This test exercises that guard specifically; without an artificial
+    // stale `nextFireAt`, the date filter would short-circuit before the
+    // disarm guard ran and the test would not catch a regression in the
+    // guard.
     const past = new Date(Date.now() - 60_000);
 
     await db.insert(chatFollowUpState).values({

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -193,6 +193,86 @@ export class FollowUpLifecycleService {
   }
 
   /**
+   * Re-arm a `customer_replied` row anchored on the customer's last inbound
+   * timestamp. Used by the sweeper's stale-pause pass (#624): when the
+   * customer replied, the row was disarmed with `reason='customer_replied'`,
+   * but if the agent never produced a follow-up `message.sent` (any
+   * combination of `senderAgentId` plumbing skip, dispatcher error, content
+   * filter reject, manual pause without `chat.handoff_activated`, chatId
+   * mismatch from #536, or condition-engine silent skip from #566), the row
+   * stays disarmed indefinitely and the lead is silently abandoned.
+   *
+   * Mirrors `armForOutbound`'s gates: close-state, config resolution,
+   * terminal-disarm guard. Differs in two ways:
+   *  - The schedule anchor is the customer's inbound timestamp, not an
+   *    outbound — there is no fresh `message.sent` event driving this path.
+   *    `lastAgentMessageAt` on the persisted row is set to the inbound
+   *    timestamp; the next genuine outbound (if any) overwrites it.
+   *  - There is no per-message staleness check — the sweeper applies a
+   *    `<max_pause>` upper bound at the SQL level so this method only sees
+   *    rows fresh enough to re-arm.
+   *
+   * The terminal-disarm guard already short-circuits when the row's
+   * `disarmReason` is in `TERMINAL_DISARM_REASONS` (handoff / archived /
+   * session_cleared / window_expired). `customer_replied` is intentionally
+   * NOT terminal — see lifecycle.ts:54-58 — so the guard returns false and
+   * we proceed to re-arm.
+   */
+  async armForInbound(input: {
+    chatId: string;
+    instanceId: string;
+    agentId: string | null;
+    config?: FollowUpSequenceConfig;
+    lastInboundCustomerMessageAt: Date;
+  }): Promise<void> {
+    if (!this.eventBus) return;
+
+    if (await this.isInActiveCloseState(input.chatId, input.instanceId)) return;
+
+    const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId));
+    if (!config || config.enabled === false) return;
+
+    if (
+      await this.shouldRefuseForTerminalDisarm({
+        chatId: input.chatId,
+        instanceId: input.instanceId,
+        lastAgentMessageAt: input.lastInboundCustomerMessageAt,
+      })
+    ) {
+      return;
+    }
+
+    try {
+      await armSequence(
+        { repo: this.repo, eventBus: this.eventBus, logger: this.logger },
+        {
+          chatId: input.chatId,
+          instanceId: input.instanceId,
+          agentId: input.agentId,
+          config,
+          // Anchor the schedule on the inbound timestamp. The persisted
+          // `lastAgentMessageAt` will reflect this; that's intentional —
+          // `nextFireAt = inbound + intervalsMinutes[0]` is what matters
+          // for the sweeper, and the field's name lies for at most one
+          // outbound, which then overwrites it via `armForOutbound`.
+          lastAgentMessageAt: input.lastInboundCustomerMessageAt,
+        },
+      );
+      this.logger.info('follow-up lifecycle: re-armed from inbound', {
+        chatId: input.chatId,
+        instanceId: input.instanceId,
+        lastInboundCustomerMessageAt: input.lastInboundCustomerMessageAt.toISOString(),
+      });
+    } catch (err) {
+      this.logger.error('follow-up lifecycle: armForInbound failed', {
+        chatId: input.chatId,
+        instanceId: input.instanceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
    * Record an inbound customer message timestamp on an existing row
    * regardless of its disarm state. Used by the inbound hook so a
    * terminally-disarmed row can be "reactivated" for arming when the

--- a/packages/api/src/services/follow-up-sweeper.ts
+++ b/packages/api/src/services/follow-up-sweeper.ts
@@ -17,6 +17,7 @@ import {
   type AdvanceInput,
   type ChannelType,
   type EventBus,
+  type FollowUpSequenceConfig,
   type FollowUpStateRepo,
   type FollowUpStateRow,
   type Logger,
@@ -27,13 +28,50 @@ import {
 } from '@omni/core';
 import type { Database } from '@omni/db';
 import { chatFollowUpState, chats, instances } from '@omni/db';
-import { and, eq, isNull, lte, sql } from 'drizzle-orm';
+import { and, eq, gt, isNull, lt, lte, sql } from 'drizzle-orm';
+import type { FollowUpLifecycleService } from './follow-up-lifecycle';
 
 const log = createLogger('follow-up-sweeper');
+
+/**
+ * Upper bound on how stale a `customer_replied` row may be before the
+ * stale-pause pass refuses to re-arm it. 7 days matches typical inbound
+ * recency cutoffs across our deployed sequences (longest first interval
+ * we have observed is ~24h; 7d gives ~7x safety margin) without re-engaging
+ * leads who have effectively gone cold.
+ */
+const STALE_PAUSE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Lower bound — only consider rows whose customer-inbound timestamp is at
+ * least this old. Smaller than every plausible first interval (the smallest
+ * we have observed in production is 1 minute) so the per-row check on the
+ * row's actual `firstIntervalMinutes` is the binding gate; this just keeps
+ * the SQL set small when many chats are in flight.
+ */
+const STALE_PAUSE_MIN_AGE_MS = 60_000;
+
+/**
+ * Cap on rows examined per tick. Picked to bound query+rearm latency at
+ * sweeper cadence (15s) — a backlog drains over multiple ticks.
+ */
+const STALE_PAUSE_MAX_PER_TICK = 100;
+
+export interface SweepStats {
+  scanned: number;
+  fired: number;
+  disarmed: number;
+  skipped: number;
+  rearmed: number;
+  // Index signature so this satisfies `Record<string, unknown>` for the
+  // logger's structured-context parameter without a cast at the call site.
+  [key: string]: number;
+}
 
 export class FollowUpSweeperService {
   private readonly repo: FollowUpStateRepo;
   private readonly messagingWindowProbe: MessagingWindowProbe;
+  private lifecycle: FollowUpLifecycleService | null = null;
 
   constructor(
     private db: Database,
@@ -59,19 +97,130 @@ export class FollowUpSweeperService {
   }
 
   /**
-   * Run a single sweep tick. Returns the stats for observability/logging.
+   * Inject the lifecycle service after construction. Required for the
+   * stale-pause re-arm pass introduced in #624 — wired by `services/index.ts`
+   * after both services exist (avoids a constructor-time circular dep).
+   * Calls without lifecycle injected gracefully skip the re-arm pass.
+   */
+  setLifecycle(lifecycle: FollowUpLifecycleService): void {
+    this.lifecycle = lifecycle;
+  }
+
+  /**
+   * Run a single sweep tick. Two passes per tick:
+   *  1. Re-arm stale `customer_replied` rows whose customer-inbound
+   *     timestamp has aged past the configured first interval — closes the
+   *     hole described in #624 where a sequence stays disarmed indefinitely
+   *     when the agent never produces a follow-up outbound.
+   *  2. Fire due rows + advance/disarm them — the original sweeper behavior.
+   *
    * No-ops when the event bus is not connected.
    */
-  async sweep(): Promise<{ scanned: number; fired: number; disarmed: number; skipped: number }> {
+  async sweep(): Promise<SweepStats> {
     if (!this.eventBus) {
-      return { scanned: 0, fired: 0, disarmed: 0, skipped: 0 };
+      return { scanned: 0, fired: 0, disarmed: 0, skipped: 0, rearmed: 0 };
     }
-    return sweepFollowUps({
+    // Pass 1 — re-arm stale customer_replied pauses (#624).
+    // Runs before the fire-due pass so any row that newly transitions back
+    // to armed is eligible immediately on the next tick.
+    const rearmed = await this.sweepStaleCustomerReplied();
+    // Pass 2 — original fire-due sweep.
+    const fireStats = await sweepFollowUps({
       repo: this.repo,
       eventBus: this.eventBus,
       logger: this.logger,
       messagingWindowProbe: this.messagingWindowProbe,
     });
+    return { ...fireStats, rearmed };
+  }
+
+  /**
+   * Re-arm `customer_replied` rows whose customer-inbound timestamp has
+   * aged past the row's configured first interval. Called from `sweep()`
+   * (#624). Does NOT run when the lifecycle service hasn't been wired —
+   * keeps the sweeper compatible with bare-bones constructions (tests that
+   * don't exercise this path can omit `setLifecycle`).
+   *
+   * Gates (matched against `findAndLockDue` so we don't re-introduce the
+   * #528 race in chats that were paused after the disarm):
+   *  - `disarm_reason = 'customer_replied'`
+   *  - `last_inbound_customer_message_at` set, and within
+   *    `[STALE_PAUSE_MIN_AGE_MS, STALE_PAUSE_MAX_AGE_MS]`
+   *  - `chats.settings->>'agentPaused'` not `'true'`
+   *
+   * Per-row it then defers to `lifecycle.armForInbound`, which checks
+   * close-state, resolves config, runs the terminal-disarm guard, and emits
+   * `follow_up.armed`. Rows whose first interval is larger than the actual
+   * inbound age are skipped (will be picked up next tick).
+   */
+  private async sweepStaleCustomerReplied(): Promise<number> {
+    if (!this.lifecycle) return 0;
+
+    const now = new Date();
+    const minBoundary = new Date(now.getTime() - STALE_PAUSE_MAX_AGE_MS);
+    const maxBoundary = new Date(now.getTime() - STALE_PAUSE_MIN_AGE_MS);
+
+    const candidates = await this.db
+      .select({
+        chatId: chatFollowUpState.chatId,
+        instanceId: chatFollowUpState.instanceId,
+        agentId: chatFollowUpState.agentId,
+        sequenceConfig: chatFollowUpState.sequenceConfig,
+        lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
+      })
+      .from(chatFollowUpState)
+      .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
+      .where(
+        and(
+          eq(chatFollowUpState.disarmReason, 'customer_replied'),
+          gt(chatFollowUpState.lastInboundCustomerMessageAt, minBoundary),
+          lt(chatFollowUpState.lastInboundCustomerMessageAt, maxBoundary),
+          // Same null-safe agentPaused gate as `findAndLockDue` — preserves
+          // the #528 race fix for the re-arm path.
+          sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
+        ),
+      )
+      .orderBy(chatFollowUpState.lastInboundCustomerMessageAt)
+      .limit(STALE_PAUSE_MAX_PER_TICK);
+
+    let rearmed = 0;
+    for (const row of candidates) {
+      if (!row.lastInboundCustomerMessageAt) continue;
+      const config = row.sequenceConfig as FollowUpSequenceConfig | null;
+      if (!config) continue;
+
+      const firstIntervalMinutes =
+        config.schedule.kind === 'fixed' ? config.schedule.intervalsMinutes[0] : config.schedule.initialMinutes;
+      if (typeof firstIntervalMinutes !== 'number' || firstIntervalMinutes <= 0) continue;
+
+      const ageMs = now.getTime() - row.lastInboundCustomerMessageAt.getTime();
+      if (ageMs < firstIntervalMinutes * 60_000) {
+        // Row's customer inbound is more recent than the row's own first
+        // interval — not stale enough for THIS row's config. Will surface
+        // again on a future tick once the threshold elapses.
+        continue;
+      }
+
+      try {
+        await this.lifecycle.armForInbound({
+          chatId: row.chatId,
+          instanceId: row.instanceId,
+          agentId: row.agentId,
+          config,
+          lastInboundCustomerMessageAt: row.lastInboundCustomerMessageAt,
+        });
+        rearmed += 1;
+      } catch (err) {
+        // Swallow — failure of one row must not abort the rest of the pass.
+        // `armForInbound` already logs internally.
+        this.logger.warn('follow-up sweeper: stale-pause re-arm failed for row', {
+          chatId: row.chatId,
+          instanceId: row.instanceId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return rearmed;
   }
 
   /**

--- a/packages/api/src/services/follow-up-sweeper.ts
+++ b/packages/api/src/services/follow-up-sweeper.ts
@@ -160,28 +160,48 @@ export class FollowUpSweeperService {
     const minBoundary = new Date(now.getTime() - STALE_PAUSE_MAX_AGE_MS);
     const maxBoundary = new Date(now.getTime() - STALE_PAUSE_MIN_AGE_MS);
 
-    const candidates = await this.db
-      .select({
-        chatId: chatFollowUpState.chatId,
-        instanceId: chatFollowUpState.instanceId,
-        agentId: chatFollowUpState.agentId,
-        sequenceConfig: chatFollowUpState.sequenceConfig,
-        lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
-      })
-      .from(chatFollowUpState)
-      .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
-      .where(
-        and(
-          eq(chatFollowUpState.disarmReason, 'customer_replied'),
-          gt(chatFollowUpState.lastInboundCustomerMessageAt, minBoundary),
-          lt(chatFollowUpState.lastInboundCustomerMessageAt, maxBoundary),
-          // Same null-safe agentPaused gate as `findAndLockDue` — preserves
-          // the #528 race fix for the re-arm path.
-          sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
-        ),
-      )
-      .orderBy(chatFollowUpState.lastInboundCustomerMessageAt)
-      .limit(STALE_PAUSE_MAX_PER_TICK);
+    // Wrap the SELECT in a transaction with `FOR UPDATE SKIP LOCKED` to
+    // mirror `findAndLockDue` (line ~100). Two reasons:
+    //  1. Concurrent workers (multiple API instances OR overlapping ticks
+    //     within a single instance when sweep latency exceeds the 15s
+    //     cadence) would otherwise both read the same `customer_replied`
+    //     rows and both call `armForInbound` on each. The DB write is
+    //     idempotent (`upsertArmed` is `INSERT ... ON CONFLICT DO UPDATE`)
+    //     but `armSequence` publishes `follow_up.armed` once per call —
+    //     two workers ⇒ duplicate observability events.
+    //  2. Architectural parity with `findAndLockDue`: both passes claim
+    //     work units from the same table; both should use the same
+    //     concurrency primitive so a future maintainer doesn't have to
+    //     reason about two different locking models.
+    const candidates = await this.db.transaction(async (tx) => {
+      return (
+        tx
+          .select({
+            chatId: chatFollowUpState.chatId,
+            instanceId: chatFollowUpState.instanceId,
+            agentId: chatFollowUpState.agentId,
+            sequenceConfig: chatFollowUpState.sequenceConfig,
+            lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
+          })
+          .from(chatFollowUpState)
+          .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
+          .where(
+            and(
+              eq(chatFollowUpState.disarmReason, 'customer_replied'),
+              gt(chatFollowUpState.lastInboundCustomerMessageAt, minBoundary),
+              lt(chatFollowUpState.lastInboundCustomerMessageAt, maxBoundary),
+              // Same null-safe agentPaused gate as `findAndLockDue` —
+              // preserves the #528 race fix for the re-arm path.
+              sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
+            ),
+          )
+          .orderBy(chatFollowUpState.lastInboundCustomerMessageAt)
+          .limit(STALE_PAUSE_MAX_PER_TICK)
+          // Lock only the state row, not the joined chat row — `FOR UPDATE`
+          // can't be applied to the nullable side of an outer join.
+          .for('update', { of: chatFollowUpState, skipLocked: true })
+      );
+    });
 
     let rearmed = 0;
     for (const row of candidates) {

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -117,6 +117,14 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
   providerRegistry.register('videogen', 'gemini', new GeminiVideoGenProvider(settings));
   providerRegistry.register('vision', 'gemini', new GeminiVisionProvider(settings));
 
+  // #624 — wire sweeper to lifecycle so the stale-pause re-arm pass can
+  // defer per-row arming to the central lifecycle gates. Built outside
+  // the literal to avoid forward-referencing `services.X` inside its own
+  // initializer.
+  const followUpLifecycle__624 = new FollowUpLifecycleService(db, eventBus);
+  const followUpSweeper__624 = new FollowUpSweeperService(db, eventBus);
+  followUpSweeper__624.setLifecycle(followUpLifecycle__624);
+
   return {
     agents: new AgentService(db, eventBus),
     agentState: new AgentStateService(eventBus),
@@ -145,8 +153,8 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
     tts,
     turns: new TurnService(db),
     consumerOffsets: new ConsumerOffsetService(db),
-    followUpLifecycle: new FollowUpLifecycleService(db, eventBus),
-    followUpSweeper: new FollowUpSweeperService(db, eventBus),
+    followUpLifecycle: followUpLifecycle__624,
+    followUpSweeper: followUpSweeper__624,
     genieHosts: new GenieHostsService(db),
     eventBus,
   };

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -121,9 +121,9 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
   // defer per-row arming to the central lifecycle gates. Built outside
   // the literal to avoid forward-referencing `services.X` inside its own
   // initializer.
-  const followUpLifecycle__624 = new FollowUpLifecycleService(db, eventBus);
-  const followUpSweeper__624 = new FollowUpSweeperService(db, eventBus);
-  followUpSweeper__624.setLifecycle(followUpLifecycle__624);
+  const followUpLifecycle = new FollowUpLifecycleService(db, eventBus);
+  const followUpSweeper = new FollowUpSweeperService(db, eventBus);
+  followUpSweeper.setLifecycle(followUpLifecycle);
 
   return {
     agents: new AgentService(db, eventBus),
@@ -153,8 +153,8 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
     tts,
     turns: new TurnService(db),
     consumerOffsets: new ConsumerOffsetService(db),
-    followUpLifecycle: followUpLifecycle__624,
-    followUpSweeper: followUpSweeper__624,
+    followUpLifecycle,
+    followUpSweeper,
     genieHosts: new GenieHostsService(db),
     eventBus,
   };


### PR DESCRIPTION
## Summary

- Fixes #624: a `customer_replied` row stays disarmed indefinitely if the agent never produces a follow-up `message.sent` after the customer's reply. In production we observed ~65% of FU-eligible chats over a 30-day window receiving zero follow-ups for this reason — far beyond what the existing escape hatches (handoff override #542, terminal-disarm guard #419) can cover, since none of them re-engage a row whose only transition since disarm has been operator/agent silence.
- Adds `armForInbound` to `FollowUpLifecycleService` (`packages/api/src/services/follow-up-lifecycle.ts`): mirrors `armForOutbound`'s gates (close-state, config resolution, terminal-disarm guard) but anchors the schedule on the customer's last inbound timestamp. The terminal-disarm guard already short-circuits for `handoff` / `archived` / `session_cleared` / `window_expired` (the ones in `TERMINAL_DISARM_REASONS`), so this method only re-arms rows the existing intent rules permit.
- Adds a `sweepStaleCustomerReplied` pass to `FollowUpSweeperService` (`packages/api/src/services/follow-up-sweeper.ts`). Runs before the existing fire-due pass on every 15s tick. Selects rows where `disarm_reason='customer_replied'`, `last_inbound_customer_message_at` is between 60s and 7d ago, and `chats.settings->>'agentPaused'` is not `'true'` (parity with `findAndLockDue`'s pause filter — preserves the #528 race fix on the re-arm path). Per-row, defers to `lifecycle.armForInbound` and skips when the row's own `firstIntervalMinutes` hasn't elapsed yet.
- Wires lifecycle into the sweeper via a `setLifecycle` setter (constructed outside the services literal in `packages/api/src/services/index.ts` to avoid a forward reference). Sweeper gracefully no-ops the new pass if lifecycle isn't injected — keeps the bare-bones constructions used by tests valid.
- `SweepStats` gains a `rearmed` field and an index signature so the existing logger call site in `scheduler.ts` keeps compiling.

## Test plan
- [x] Existing "already disarmed rows are not swept" test rewritten as "terminal-disarmed rows (handoff) are not swept by either pass" — that test's prior assertion for `customer_replied` was the buggy behavior this PR fixes.
- [x] New: `customer_replied` aged past first interval → row is re-armed (sequenceIndex back to 0, `nextFireAt = inbound + intervalsMinutes[0]`, `follow_up.armed` emitted)
- [x] New: `customer_replied` aged past max-pause (7d) → row stays disarmed
- [x] New: each of the four terminal disarm reasons (`handoff`, `session_cleared`, `archived`, `window_expired`) with same inbound age → row stays disarmed (terminal guard wins)
- [x] New: `customer_replied` row in active close-contact state (`settings.closed=true`) → row stays disarmed (close-state gate wins)
- [x] New: `customer_replied` row with `settings.agentPaused=true` → row stays disarmed (parity with #528)
- [x] `sweep is a no-op when eventBus is null` updated to expect the new `rearmed: 0` field.
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — 0 errors.
- [x] `bunx biome check` on the four touched files — 0 fixes needed.
- [x] `bun test packages/core/src/automations/follow-up/__tests__/` — 72 pass / 0 fail (sanity: core lifecycle untouched).
- [x] `bun test packages/api/src/__tests__/follow-up-sweeper.test.ts` — 13 collected (8 originals + 5 new), all skipped without `ENABLE_DB_TESTS=1` (CI runs them with the real DB).

Refs: #419, #528, #535, #536, #542, #550, #566, #588
Closes: #624
