### PR TITLE
fix(ci): pin pgserve to ~2.4 + use `serve` subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,17 @@ jobs:
           done
           echo "Database failed to start" && exit 1
 
+      - name: Create omni database
+        # pgserve@~2.4 `serve` is the consumer-only singleton supervisor: it
+        # boots the postmaster with the default postgres/template DBs only —
+        # it does NOT auto-provision per-app databases the way the legacy 2.3
+        # multi-tenant router did. omni-api connects to `…/omni`, so create
+        # it explicitly here. In production this is owned by `pgserve install`
+        # / `omni doctor --fix` (see pgserve-singleton-no-proxy wish G2/G5).
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -p 8432 -U postgres -c "CREATE DATABASE omni"
+
       - name: Build all packages
         run: bun run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,10 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Start pgserve
-        run: bunx pgserve --port 8432 --data .pgserve-data --no-cluster &
+        # Pin to ~2.4 (the singleton supervisor entry); pgserve 2.4 dropped
+        # the bare `pgserve --port ... --no-cluster` legacy form (which now
+        # only prints a help banner) in favour of `pgserve serve`.
+        run: bunx pgserve@~2.4.0 serve --port 8432 --data .pgserve-data &
 
       - name: Start NATS
         run: ./bin/nats-server -js -p 4222 &
@@ -146,7 +149,10 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Start pgserve
-        run: bunx pgserve --port 8432 --data .pgserve-data --no-cluster &
+        # Pin to ~2.4 (the singleton supervisor entry); pgserve 2.4 dropped
+        # the bare `pgserve --port ... --no-cluster` legacy form (which now
+        # only prints a help banner) in favour of `pgserve serve`.
+        run: bunx pgserve@~2.4.0 serve --port 8432 --data .pgserve-data &
 
       - name: Start NATS
         run: ./bin/nats-server -js -p 4222 &

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -26,6 +26,14 @@ import { type DoctorDeps, runDoctor } from '../commands/doctor.js';
 import type { Config, ServerConfig } from '../config.js';
 import { DEFAULT_PGSERVE_PORT, buildRuntimeEnv } from '../runtime-env.js';
 
+// Neutralize host XDG_RUNTIME_DIR so the synchronous canonical-pgserve socket
+// probe in runtime-env.ts (`probeCanonicalSocketSync`) returns false. Without
+// this pin, the suite emits the UDS-form DATABASE_URL on dev hosts that have
+// `pgserve install`-ed locally, and the legacy-fallback (TCP `:8432/omni`)
+// assertions below fail. CI runners have no canonical socket so they were
+// always green; this just makes dev hosts match.
+process.env.XDG_RUNTIME_DIR = join(tmpdir(), 'omni-doctor-test-no-xdg');
+
 // ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- CI's `Start pgserve` step (`bunx pgserve --port 8432 --data .pgserve-data --no-cluster &`) silently no-ops on pgserve@2.4+, which dropped the bare positional invocation in favour of the explicit singleton supervisor entry (`pgserve serve` / `pgserve postmaster`). The legacy form now just prints a help banner and exits — `pg_isready -h localhost -p 8432` then times out and the `Wait for database` step kills the whole quality-gate / smoke-test job. This blocks every PR to `dev`, including #547.
- Pin to `bunx pgserve@~2.4.0 serve --port 8432 --data .pgserve-data &` in both CI jobs. `serve` is supported on 2.4 / 2.5 / 2.6, the `~2.4.0` band keeps us off accidental majors, and locally `pg_isready` reports ready in 1s.
- Bonus: fix a host-dependent assertion in `doctor.test.ts` that fails on dev hosts with a canonical pgserve socket present (`probeCanonicalSocketSync()` returns true → UDS-form `DATABASE_URL` → assertion expects TCP `:8432/omni`). Pin `XDG_RUNTIME_DIR` at module load so the suite stays host-independent under the phase-3 UDS-first runtime-env contract. CI was always green here; this just lets the same suite pass under the local pre-push hook.

## Test plan

- [x] `bunx pgserve@~2.4.0 serve --port 8432 --data .pgserve-data` binds TCP 8432 + UDS — `pg_isready` ready in ~1s locally
- [x] `bun run typecheck` — 21/21 packages pass
- [x] `bun test --env-file=.env` — 3839 pass / 290 skip / **0 fail** (was 2 host-only fails)
- [x] `bun test packages/cli/src/__tests__/doctor.test.ts` — 49/49 (was 48/49 on this host)
- [ ] CI Quality Gate green
- [ ] CI Smoke Test green