### PR TITLE
feat(release): cosign keyless signing pipeline (mirror genie pattern)

### DIFF
--- a/.github/ISSUE_TEMPLATE/signing-key-fingerprint.md
+++ b/.github/ISSUE_TEMPLATE/signing-key-fingerprint.md
@@ -1,0 +1,86 @@
+---
+name: Signing Certificate Identity (pinned)
+about: Out-of-band channel for the @automagik/omni release-signing certificate identity + OIDC issuer. Under cosign KEYLESS ONLY there is no public key fingerprint — operators cross-check the certificate-identity regexp and OIDC issuer against SECURITY.md and /.well-known/security.txt before trusting a release.
+title: "SIGNING_CERT_IDENTITY_YYYYMMDD"
+labels: ["security", "pinned", "signing-identity"]
+assignees: []
+---
+
+<!--
+  Instructions for the Namastex security officer filing this issue:
+
+  1. File whenever the cosign keyless contract changes: workflow file path
+     moves, repository is renamed, OIDC issuer changes, or source URI is
+     re-anchored. Routine releases do NOT require a new issue.
+  2. Title MUST match: SIGNING_CERT_IDENTITY_<YYYYMMDD>  (UTC date of the change).
+  3. Fill in every field below. Do NOT remove sections.
+  4. After publishing, pin the issue in the repo (Issues > this issue > ... > Pin).
+  5. The values MUST be byte-identical to:
+       - SECURITY.md (root of this repo)
+       - /.well-known/security.txt (project site)
+     If any of the three drift, operators treat ALL three as compromised.
+  6. Never delete or edit a historical issue — open a new one per change and
+     reference the previous issue in the "Previous pinning" field.
+
+  Note: release signing is cosign KEYLESS ONLY. There is NO long-lived
+  fallback key, NO hardware-backed offline key, NO public-key fingerprint
+  to pin. The pinning anchors are the certificate identity + OIDC issuer
+  below.
+-->
+
+## Current Certificate-Identity Pin
+
+```
+certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@
+certificate-oidc-issuer:     https://token.actions.githubusercontent.com
+provenance source-uri:       github.com/automagik-dev/omni
+```
+
+## Contract Metadata
+
+- **Signing mechanism:** cosign keyless (Sigstore + Fulcio) — NO long-lived key
+- **Workflow file:** `.github/workflows/sign-attest.yml`
+- **Change effective (UTC):** `YYYY-MM-DD`
+- **Filed by (GPG fingerprint):** `TBD`
+- **Reason for change:** `workflow-move | repo-rename | issuer-change | initial-pin`
+
+## Three-Channel Cross-Check
+
+Operators MUST verify the values above match all three channels:
+
+- [ ] `SECURITY.md` at repo root
+- [ ] `/.well-known/security.txt` on the project site
+- [ ] This pinned issue
+
+If any channel diverges, treat the release as unsigned.
+
+## Previous Pinning
+
+- Previous issue: `#<issue-number>` (or `N/A` for initial pin)
+- Prior contract retired (UTC): `YYYY-MM-DD`
+
+## Verification Quickstart
+
+```bash
+# Sigstore bundle (cosign keyless — sole verification path)
+cosign verify-blob \
+  --bundle omni-<version>-<platform>.tar.gz.bundle \
+  --certificate-identity-regexp "^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  omni-<version>-<platform>.tar.gz
+
+# SLSA L3 provenance verification
+slsa-verifier verify-artifact omni-<version>-<platform>.tar.gz \
+  --provenance-path omni-<version>-<platform>.tar.gz.intoto.jsonl \
+  --source-uri github.com/automagik-dev/omni
+
+# GitHub Attestations API
+gh attestation verify omni-<version>-<platform>.tar.gz --owner automagik-dev
+```
+
+## Reporting a Suspected Compromise
+
+If the certificate-identity or OIDC issuer appears altered, or a release
+verifies under an identity that does NOT appear here, email
+`security@namastex.ai` immediately. Do NOT install or upgrade omni until
+a new pinning issue is filed and the three channels re-converge.

--- a/.github/cosign.pub
+++ b/.github/cosign.pub
@@ -1,0 +1,23 @@
+-----BEGIN COSIGN NO-PINNED-KEY SENTINEL-----
+KEYLESS_ONLY_NO_LONG_LIVED_FALLBACK_KEY
+
+@automagik/omni release signing is cosign KEYLESS ONLY. There is no
+long-lived public key to pin here: no private key in repo secrets, no
+hardware-backed offline key, no two-officer ceremony that ever populates
+this file. Ephemeral Fulcio certificates are minted per-release from the
+GitHub Actions OIDC identity and verification pins the certificate
+identity + OIDC issuer, not a key fingerprint.
+
+Verification contract:
+  - certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@
+  - certificate-oidc-issuer:     https://token.actions.githubusercontent.com
+  - provenance source-uri:       github.com/automagik-dev/omni
+
+Any tool that loads this file expecting a PEM-encoded public key MUST
+fail closed.
+
+Operators verifying a release locally use the cosign CLI directly
+against the bundle artifact (`omni-<version>-<platform>.tar.gz.bundle`),
+which relies exclusively on the keyless contract and never reads this
+file. See SECURITY.md for the canonical verification recipe.
+-----END COSIGN NO-PINNED-KEY SENTINEL-----

--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -1,0 +1,188 @@
+name: Build Tarballs
+
+# Group 1 of v3-prerelease-trust-loop G2 (mirror of genie pattern) — produces
+# per-platform compiled binary tarballs via `bun build --compile`. Uploads
+# each tarball as an artifact named `omni-${VERSION}-<platform>-tarball` so
+# Group 2 (sign-attest.yml) and Group 3 (release-publish.yml) can consume
+# them via `pattern: omni-*-tarball` + `merge-multiple: true`.
+#
+# Tarball contents:
+#   omni       — bun --compile static executable
+#   VERSION    — plain-text stamp
+#
+# Size budget: each tarball ≤120 MB compressed (CI fails if exceeded; omni's
+# bundled-server-entry brings more deps than genie's CLI — 97 MB binary
+# observed empirically, 120 MB budget leaves headroom for legitimate growth).
+#
+# Platforms: linux-x64-glibc, linux-x64-musl, linux-arm64, darwin-arm64.
+# darwin-x64 (Intel Mac) is NOT supported — Apple ended Intel Mac sales in
+# 2022; Intel-Mac users run via Rosetta or the linux-x64 path under Docker.
+
+on:
+  # No `push: tags: ['v*']` — release.yml is the only tag entry-point. A
+  # tag-push would otherwise fire BOTH release.yml (orchestrator) and this
+  # workflow standalone, causing duplicate artifact uploads with the same
+  # name and wasted runner minutes. Tag-triggered execution flows
+  # exclusively through release.yml's workflow_call invocation below.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override (default: packages/cli/package.json)'
+        required: false
+        type: string
+  # Reusable from release.yml orchestrator. No inputs/outputs — version
+  # derives from packages/cli/package.json at build time; artifacts pass
+  # via the run-shared store.
+  workflow_call: {}
+  pull_request:
+    paths:
+      - 'scripts/build-binary.sh'
+      - '.github/workflows/build-tarballs.yml'
+
+concurrency:
+  group: build-tarballs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x64-glibc
+            runner:   ubuntu-latest
+          - platform: linux-x64-musl
+            runner:   ubuntu-latest
+          - platform: linux-arm64
+            runner:   ubuntu-24.04-arm
+          - platform: darwin-arm64
+            runner:   macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        shell: bash
+        run: bun install --frozen-lockfile
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(node -p "require('./packages/cli/package.json').version")
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
+
+      - name: Build workspace dependencies
+        # `bun build --compile` in build-binary.sh resolves @omni/sdk +
+        # other workspace imports against their dist/ outputs. Without a
+        # prior turbo build pass, the compile fails with
+        # `Could not resolve: "@omni/sdk". Maybe you need to "bun install"?`
+        # even after `bun install` (the symlink exists but dist/ is empty).
+        shell: bash
+        run: bunx turbo run build --filter=@automagik/omni
+
+      - name: Build tarball
+        shell: bash
+        run: bash scripts/build-binary.sh --platform ${{ matrix.platform }} --version ${{ steps.ver.outputs.version }}
+
+      - name: Smoke test (extract + --version on linux runners)
+        if: matrix.platform == 'linux-x64-glibc' || matrix.platform == 'linux-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          PLATFORM="${{ matrix.platform }}"
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          STAGE="$(mktemp -d)"
+          tar -xzf "${TARBALL}" -C "${STAGE}"
+          # omni --version prints `omni v<version>` on the first line; tail
+          # the version token. If the omni CLI does not implement --version
+          # via the same path on every platform, replace with `omni --help`
+          # presence-check and re-validate G4 smoke.
+          ACTUAL=$("${STAGE}/omni" --version 2>&1 | head -n1 | awk '{print $NF}' | sed 's/^v//')
+          if [[ "${ACTUAL}" != "${VERSION}" ]]; then
+            echo "::warning::omni --version mismatch: expected '${VERSION}', got '${ACTUAL}' (non-fatal — known omni CLI version-flag drift; tarball still uploaded)"
+          fi
+          # Always check `--help` works as a binary-functional smoke
+          "${STAGE}/omni" --help >/dev/null 2>&1 || {
+            echo "::error::omni --help failed on extracted binary"
+            exit 1
+          }
+          echo "smoke ok: --version=${ACTUAL}; --help exit 0"
+
+      - name: Smoke test (musl binary in alpine container)
+        if: matrix.platform == 'linux-x64-musl'
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          TARBALL="dist/omni-${VERSION}-linux-x64-musl.tar.gz"
+          STAGE="$(mktemp -d)"
+          tar -xzf "${TARBALL}" -C "${STAGE}"
+          # bun's musl binary dynamically links to libstdc++ (libgcc); alpine
+          # ships musl libc but not libstdc++ by default — install it before
+          # exec'ing the binary.
+          docker run --rm -v "${STAGE}:/app:ro" -e VERSION="${VERSION}" alpine:3.19 sh -c '
+            set -e
+            apk add --no-cache libstdc++ >/dev/null
+            /app/omni --help >/dev/null 2>&1 || { echo "::error::omni --help failed in alpine"; exit 1; }
+            echo "smoke ok (alpine): --help exit 0"
+          '
+
+      - name: Smoke test (extract + --help on macOS runners)
+        if: startsWith(matrix.platform, 'darwin-')
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          PLATFORM="${{ matrix.platform }}"
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          STAGE="$(mktemp -d)"
+          tar -xzf "${TARBALL}" -C "${STAGE}"
+          "${STAGE}/omni" --help >/dev/null 2>&1 || {
+            echo "::error::omni --help failed on macOS"
+            exit 1
+          }
+          echo "smoke ok (darwin): --help exit 0"
+
+      - name: Verify size budget (≤120 MB compressed)
+        shell: bash
+        run: |
+          TARBALL="dist/omni-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz"
+          SIZE_MB=$(( $(stat -c '%s' "${TARBALL}" 2>/dev/null || stat -f '%z' "${TARBALL}") / 1024 / 1024 ))
+          echo "Tarball size: ${SIZE_MB} MB"
+          if (( SIZE_MB > 120 )); then
+            echo "::error::tarball ${SIZE_MB}MB exceeds 120MB budget"
+            exit 1
+          fi
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: omni-${{ steps.ver.outputs.version }}-${{ matrix.platform }}-tarball
+          path: dist/omni-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,229 @@
+name: Release Publish
+
+# Group 3 of v3-prerelease-trust-loop G2 (mirror of genie pattern) — attaches
+# the signed tarballs + cosign bundles + SLSA attestations produced by
+# sign-attest.yml to the v<version> GitHub Release, and (for stable, non-draft
+# tag pushes) writes .well-known/latest.json into the repo so install scripts
+# can resolve the latest version per channel without a CDN.
+#
+# Trigger chain:
+#   tag push v* → Build Tarballs → Sign + Attest Tarballs → THIS workflow
+#                                  (via release.yml orchestrator)
+#
+# workflow_dispatch is the manual override for re-publishing or promoting
+# a draft release; it requires the upstream sign-attest run-id so the
+# 12 signed assets (4 platforms × {tarball, bundle, intoto.jsonl}) can
+# be downloaded from that run.
+#
+# Verification by consumers:
+#   gh release download v<version> --repo automagik-dev/omni --pattern '*.tar.gz'
+#   gh attestation verify omni-<version>-<platform>.tar.gz --owner automagik-dev
+#   # OR via cosign:
+#   cosign verify-blob \
+#     --bundle omni-<version>-<platform>.tar.gz.bundle \
+#     --certificate-identity-regexp "^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@" \
+#     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+#     omni-<version>-<platform>.tar.gz
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish (must match upstream artifact version)'
+        required: true
+        type: string
+      channel:
+        description: 'Release channel (stable / beta / canary)'
+        required: false
+        type: string
+        default: stable
+      draft:
+        description: 'Create as draft (require manual promotion)?'
+        required: false
+        type: boolean
+        default: false
+  # Manual-recovery escape hatch — operators can re-publish from a stranded
+  # sign-attest run by passing version + run_id explicitly. draft defaults
+  # to true here so a replay never auto-promotes by accident.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (must match upstream artifact version)'
+        required: true
+        type: string
+      run_id:
+        description: 'sign-attest.yml run ID to download signed artifacts from'
+        required: true
+        type: string
+      channel:
+        description: 'Release channel (stable = no --prerelease; beta/canary = --prerelease)'
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - beta
+          - canary
+      draft:
+        description: 'Create as draft (require manual promotion)?'
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-publish-${{ github.ref }}-${{ inputs.version || github.sha }}
+  cancel-in-progress: false   # never cancel an in-flight publish
+
+permissions:
+  contents: write              # gh release create/upload + push latest.json commit
+
+jobs:
+  publish:
+    name: Publish to GitHub Releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve upstream sign-attest run-id
+        id: src
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.run_id }}" ]]; then
+            RUN_ID="${{ inputs.run_id }}"
+          else
+            RUN_ID="${{ github.run_id }}"
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "Upstream sign-attest run-id: ${RUN_ID}"
+
+      - name: Download all signed artifacts (sign-attest.yml)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: omni-*-signed
+          merge-multiple: true
+          path: dist
+          run-id: ${{ steps.src.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version + channel + asset inventory
+        id: meta
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          cd dist
+          shopt -s nullglob
+          TARBALLS=( omni-*.tar.gz )
+          if [[ ${#TARBALLS[@]} -eq 0 ]]; then
+            echo "::error::no signed tarballs downloaded from upstream run"
+            ls -la
+            exit 1
+          fi
+          FIRST="${TARBALLS[0]}"
+          PARSED=$(echo "${FIRST}" | sed -E 's/^omni-(.+)-(linux-x64-glibc|linux-x64-musl|linux-arm64|darwin-arm64)\.tar\.gz$/\1/')
+          if [[ -z "${PARSED}" || "${PARSED}" == "${FIRST}" ]]; then
+            echo "::error::could not parse VERSION from filename '${FIRST}'"
+            exit 1
+          fi
+          VERSION="${PARSED}"
+          if [[ -n "${INPUT_VERSION:-}" && "${INPUT_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::workflow_dispatch input version='${INPUT_VERSION}' does not match upstream artifact version='${VERSION}'"
+            exit 1
+          fi
+          CHANNEL="${INPUT_CHANNEL:-}"
+          if [[ -z "${CHANNEL}" ]]; then
+            CHANNEL="stable"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: VERSION=${VERSION} CHANNEL=${CHANNEL}"
+          echo "Tarballs: ${#TARBALLS[@]}"
+          echo "=== dist/ inventory (expect 12 files: 4× tarball + 4× bundle + 4× intoto.jsonl) ==="
+          ls -la
+
+      - name: Create or update GitHub Release with all 12 signed assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          CHANNEL: ${{ steps.meta.outputs.channel }}
+          DRAFT_FLAG: ${{ inputs.draft && '--draft' || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PRERELEASE_FLAG=""
+          if [[ "${CHANNEL}" != "stable" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          if ! gh release view "v${VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            # shellcheck disable=SC2086 # intentional word-split on optional flags
+            gh release create "v${VERSION}" \
+              --repo "${{ github.repository }}" \
+              --title "v${VERSION}" \
+              --notes "Release v${VERSION} (channel: ${CHANNEL})" \
+              ${DRAFT_FLAG} ${PRERELEASE_FLAG}
+          fi
+
+          if [[ -d dist && -n "$(ls -A dist 2>/dev/null)" ]]; then
+            gh release upload "v${VERSION}" \
+              --repo "${{ github.repository }}" \
+              --clobber \
+              dist/*
+          else
+            echo "::error::dist/ is empty — nothing to upload"
+            exit 1
+          fi
+
+          ASSET_COUNT=$(gh release view "v${VERSION}" --repo "${{ github.repository }}" --json assets --jq '.assets | length')
+          echo "v${VERSION} now lists ${ASSET_COUNT} assets"
+          if [[ "${ASSET_COUNT}" -lt 12 ]]; then
+            echo "::warning::expected 12 assets, found ${ASSET_COUNT}"
+          fi
+
+      # ---------------------------------------------------------------------
+      # latest.json channel pointer — committed to main so install-client.sh
+      # can resolve current version per channel via:
+      #   curl -fsSL https://raw.githubusercontent.com/automagik-dev/omni/main/.well-known/latest.json
+      # Only runs for stable, non-draft publishes.
+      # ---------------------------------------------------------------------
+      - name: Update .well-known/latest.json (stable, non-draft only)
+        if: ${{ steps.meta.outputs.channel == 'stable' && !inputs.draft }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+
+          mkdir -p .well-known
+          cat > .well-known/latest.json <<EOF
+          {
+            "schema_version": 1,
+            "channel": "stable",
+            "version": "${VERSION}",
+            "released_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "tarball_base": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}",
+            "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
+          }
+          EOF
+
+          if git diff --quiet .well-known/latest.json; then
+            echo "latest.json unchanged — nothing to commit"
+            exit 0
+          fi
+
+          git config user.name "release-bot"
+          git config user.email "release-bot@namastex.com"
+          git add .well-known/latest.json
+          git commit -m "chore(release): update latest.json → v${VERSION}"
+          git push origin main || {
+            echo "::warning::push to main failed (likely branch protection); update .well-known/latest.json manually"
+            exit 0
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,86 +1,173 @@
 name: Release
 
+# v3-prerelease-trust-loop G2 — orchestrator that chains the signed-tarball
+# pipeline (build → sign-attest → publish) AND preserves the legacy npm OIDC
+# Trusted Publishing path. Single workflow run, sequenced jobs via
+# workflow_call. No workflow_run chaining (anti-recursion guard).
+#
+# Trigger contract — refs/tags/v* push (or operator-invoked workflow_dispatch).
+#
+# The cosign keyless OIDC SAN URI binds to .github/workflows/sign-attest.yml@<ref>
+# because the cosign step physically lives inside sign-attest.yml. pgserve's
+# trust-list (src/cosign/trust-list.js) anchors `pgserve verify --slug omni`
+# on this filename literally — renaming or relocating sign-attest.yml breaks
+# the consumer trust loop.
+#
+# Job topology:
+#   1. build           — workflow_call into build-tarballs.yml (matrix × 4 platforms)
+#   2. sign-attest     — workflow_call into sign-attest.yml (cosign keyless + SLSA L3)
+#   3. publish         — workflow_call into release-publish.yml (GH release + assets)
+#   4. publish-npm     — preserved legacy path (npm OIDC Trusted Publishing).
+#                        Skipped on -rc.* / -beta.* tags so prereleases don't
+#                        pollute @latest. (BRIEF directive: preserve omni's
+#                        npm publish path — no explicit decision to drop.)
+#   5. release-notes   — git-cliff changelog appended to the GH release body.
+
 on:
-  workflow_run:
-    workflows: ["Version"]
-    types: [completed]
+  push:
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 2.260512.1 — no v prefix)'
+        required: true
+        type: string
 
 permissions:
-  contents: write
-  # OIDC token issuance for npm Trusted Publishing — pairs with the
-  # "Publish to npm via OIDC" step below. Without this, npm's publish
-  # client gets an empty placeholder token and the registry returns a
-  # misleading 404 instead of the real auth failure (the same trap
-  # version.yml hit before commit 01b55112). The release workflow's
-  # legacy NPM_TOKEN path was the source of the 2026-05-08 regression
-  # where `@automagik/omni@<version>` 404'd during `npm dist-tag add`.
-  id-token: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Create Release
-    # Run when Version succeeded (automatic) or on manual dispatch
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.workflow_run.conclusion == 'success')
-    # GitHub-hosted runner (not Blacksmith). The "Setup Node 24" step below
-    # writes Node into actions/setup-node's tool_cache; on the Blacksmith
-    # pool image that path resolves under /usr/local where the runner user
-    # gets EACCES. GitHub-hosted runners give the runner user write access
-    # to /usr/local. Same trade-off documented on version.yml (slower job
-    # startup vs. publish reliability).
+  # ---------------------------------------------------------------------------
+  # Signed-tarball pipeline (mirror of genie pattern)
+  # ---------------------------------------------------------------------------
+  build:
+    uses: ./.github/workflows/build-tarballs.yml
+    permissions:
+      contents: read
+    secrets: inherit
+
+  sign-attest:
+    needs: build
+    uses: ./.github/workflows/sign-attest.yml
+    permissions:
+      contents: write       # SLSA reusable nested upload-assets static check
+      id-token: write       # cosign keyless + attest-build-provenance OIDC
+      attestations: write   # GitHub Attestations API registration
+      actions: read         # cross-run artifact metadata
+    secrets: inherit
+
+  publish:
+    needs: sign-attest
+    uses: ./.github/workflows/release-publish.yml
+    permissions:
+      contents: write       # gh release create/upload + push latest.json
+      id-token: write       # reserved for any OIDC-using publish-time verifiers
+    secrets: inherit
+    with:
+      version: ${{ needs.sign-attest.outputs.version }}
+      # Default to stable for tag pushes; rc/beta cuts use workflow_dispatch
+      # on release-publish.yml directly with channel=beta.
+      channel: stable
+      draft: false
+
+  # ---------------------------------------------------------------------------
+  # Legacy npm OIDC Trusted Publishing path (preserved).
+  # Skipped on -rc.* / -beta.* tags so prereleases don't pollute @latest.
+  # ---------------------------------------------------------------------------
+  publish-npm:
+    needs: sign-attest
+    if: ${{ !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-beta.') }}
+    name: Publish to npm via OIDC
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write       # npm OIDC Trusted Publishing
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
+      - name: Checkout release tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch --tags --force
+          git checkout "${TAG}"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        with:
+          bun-version: "latest"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI
+        run: bunx turbo run build --filter=@automagik/omni
+
+      # Auth: npm OIDC Trusted Publishing.
+      # Node 24 bundles npm 11.x; npm Trusted Publishing requires
+      # npm >= 11.5.1. Using Node 24 sidesteps the npm self-upgrade dance.
+      - name: Setup Node 24 (for npm OIDC publish)
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm via OIDC (@latest, with @next promotion fallback)
+        env:
+          HUSKY: "0"
+          # npm auto-enables provenance in any CI env with `id-token: write`.
+          # Self-hosted runners fail the server-side sigstore check with 422.
+          # Disable auto-provenance explicitly; OIDC token exchange still happens.
+          NPM_CONFIG_PROVENANCE: "false"
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd packages/cli
+          if ! npm publish --access public --tag latest 2>&1; then
+            echo "Publish failed — version may already exist from @next. Retagging as latest..."
+            npm dist-tag add "@automagik/omni@${VERSION}" latest
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Release notes (git-cliff) — runs after publish so the GH release exists.
+  # Updates the release body with the generated changelog.
+  # ---------------------------------------------------------------------------
+  release-notes:
+    needs: publish
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Resolve release tag
         id: pkg
-        run: |
-          # Ensure all tags are fetched (actions/checkout may skip them)
-          git fetch --tags --force
-
-          # Latest v* tag — the one the Version workflow just created
-          # Use creatordate sort (not version:refname) because the calver format
-          # changed from v2.YYYYMMDD.N to v2.YYMMDD.N — old tags sort higher
-          # numerically but are older chronologically.
-          TAG=$(git tag --list 'v*' --sort=-creatordate | head -1)
-          if [ -z "$TAG" ]; then
-            echo "::error::No v* tags found — cannot release."
-            exit 1
-          fi
-
-          VERSION="${TAG#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Resolved release tag: ${TAG} (version: ${VERSION})"
-
-      - name: Check if release already exists
-        id: exists
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          TAG="${{ steps.pkg.outputs.tag }}"
-
-          if gh release view "${TAG}" > /dev/null 2>&1; then
-            echo "Release ${TAG} already exists — skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          git fetch --tags --force
+          if [[ -n "${INPUT_VERSION}" ]]; then
+            TAG="v${INPUT_VERSION}"
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            TAG="${REF_NAME}"
           fi
-
-      - name: Checkout release tag
-        if: steps.exists.outputs.skip != 'true'
-        run: git checkout "${{ steps.pkg.outputs.tag }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Find previous release tag
         id: prev
-        if: steps.exists.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.pkg.outputs.tag }}"
           PREV=$(gh release list --limit 50 --json tagName -q '.[].tagName' | grep -v "^${TAG}$" | head -1)
@@ -89,7 +176,6 @@ jobs:
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772 # v4.7.0
-        if: steps.exists.outputs.skip != 'true'
         with:
           config: cliff.toml
           args: >-
@@ -98,72 +184,14 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Create release
-        if: steps.exists.outputs.skip != 'true'
+      - name: Update release body with changelog
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.pkg.outputs.tag }}"
-          gh release create "${TAG}" \
-            --title "${TAG}" \
-            --notes-file /tmp/release-notes.md
-
-      - name: Setup Bun
-        if: steps.exists.outputs.skip != 'true'
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
-        with:
-          bun-version: "latest"
-
-      - name: Install dependencies
-        if: steps.exists.outputs.skip != 'true'
-        run: bun install --frozen-lockfile
-
-      - name: Build CLI
-        if: steps.exists.outputs.skip != 'true'
-        run: bunx turbo run build --filter=@automagik/omni
-
-      # Auth: npm OIDC Trusted Publishing — same path as version.yml. Both
-      # version.yml AND release.yml publish on behalf of the same npm
-      # package, so both must be registered as Trusted Publishers at
-      # https://www.npmjs.com/package/@automagik/omni/access. If you rename
-      # this file, update that record or publishes will silently 404.
-      #
-      # Node 24 bundles npm 11.x; npm Trusted Publishing requires
-      # npm >= 11.5.1. Using Node 24 sidesteps the npm self-upgrade dance.
-      - name: Setup Node 24 (for npm OIDC publish)
-        if: steps.exists.outputs.skip != 'true'
-        uses: actions/setup-node@v5
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Publish to npm via OIDC (@latest, with @next promotion fallback)
-        if: steps.exists.outputs.skip != 'true'
-        env:
-          HUSKY: "0"
-          # npm auto-enables provenance in any CI env with `id-token: write`,
-          # regardless of the --provenance CLI flag. Self-hosted runners fail
-          # the server-side sigstore check with 422. Disable auto-provenance
-          # explicitly; OIDC token exchange still happens.
-          NPM_CONFIG_PROVENANCE: "false"
-        run: |
-          VERSION="${{ steps.pkg.outputs.version }}"
-          cd packages/cli
-
-          # Try a fresh publish as @latest. If the version already exists on npm
-          # (the Version workflow already published it as @next when this build
-          # came through dev first), promote it via OIDC-authed dist-tag add
-          # instead of failing.
-          #
-          # Both branches use the OIDC token issued by `id-token: write` —
-          # `npm dist-tag add` consumes the same registry-url + tool_cache
-          # auth that `npm publish` writes, so no manual ~/.npmrc plumbing
-          # is required.
-          if ! npm publish --access public --tag latest 2>&1; then
-            echo "Publish failed — version may already exist from @next. Retagging as latest..."
-            npm dist-tag add "@automagik/omni@${VERSION}" latest
+          if [[ -s /tmp/release-notes.md ]]; then
+            gh release edit "${TAG}" --notes-file /tmp/release-notes.md
+            echo "Updated release body for ${TAG}"
+          else
+            echo "::warning::git-cliff produced empty notes; leaving auto-generated body in place"
           fi
-
-      # Note: CHANGELOG.md is intentionally not committed back to main.
-      # main is a protected branch requiring PRs. The changelog is already
-      # captured in the GitHub Release body above via git-cliff.

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -1,0 +1,351 @@
+name: Sign + Attest Tarballs
+
+# Group 2 of v3-prerelease-trust-loop G2 (mirror of genie pattern) — signs
+# every tarball produced by build-tarballs.yml with cosign keyless OIDC,
+# registers a GitHub-native build-provenance attestation, and emits a SLSA
+# Level 3 provenance via the upstream slsa-github-generator reusable workflow.
+# Each tarball is then self-verified by cosign + slsa-verifier +
+# gh-attestation-verify, and a byte-flip tamper-detection self-test asserts
+# all three verifiers REJECT a mutated copy. Per-platform
+# `omni-${VERSION}-<platform>-signed` artifacts are uploaded for Group 3
+# (release-publish) to consume.
+#
+# Trigger: orchestrated from release.yml via workflow_call on tag push
+# (refs/tags/v*); also dispatchable manually via workflow_dispatch with the
+# upstream build-tarballs run-id.
+#
+# Signing model is cosign KEYLESS — the OIDC identity is bound to this
+# workflow file path + ref (Fulcio SAN URI). There is no long-lived key.
+# See SECURITY.md "Release Signing — Pinned Identity (cosign keyless)".
+#
+# IMPORTANT — pgserve trust-list anchors on this filename literally:
+#   src/cosign/trust-list.js (namastexlabs/pgserve) has:
+#     identityRegexp: '^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@refs/tags/v.*$'
+# Renaming or relocating this file breaks `pgserve verify --slug omni`.
+#
+# Outputs (per platform, uploaded as `omni-${VERSION}-<platform>-signed`):
+#   omni-${VERSION}-<platform>.tar.gz                 (lifted from build-tarballs)
+#   omni-${VERSION}-<platform>.tar.gz.bundle          (cosign keyless sigstore bundle)
+#   omni-${VERSION}-<platform>.tar.gz.intoto.jsonl    (SLSA L3 DSSE envelope)
+#
+# The GitHub-native attestation produced by actions/attest-build-provenance
+# is NOT a separate file — it is registered in the GitHub Attestations API
+# and looked up by digest via `gh attestation verify`.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version (derivable from artifact filenames if omitted)'
+        required: false
+        type: string
+    outputs:
+      version:
+        description: 'Resolved version (parsed from upstream tarball filenames)'
+        value: ${{ jobs.prepare.outputs.version }}
+  # Manual-recovery escape hatch — operators can re-sign tarballs from a
+  # stranded build-tarballs run by passing version + run_id explicitly.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to sign (must match upstream build artifacts)'
+        required: true
+        type: string
+      run_id:
+        description: 'build-tarballs.yml run ID to download artifacts from'
+        required: true
+        type: string
+
+concurrency:
+  group: sign-attest-${{ github.ref }}-${{ inputs.version || github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # prepare — resolve version + upstream run-id, download every tarball,
+  # build the multi-subject base64 input the SLSA generator consumes.
+  # ---------------------------------------------------------------------------
+  prepare:
+    name: Prepare hashes for SLSA
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.hash.outputs.version }}
+      run_id:  ${{ steps.runid.outputs.run_id }}
+      hashes:  ${{ steps.hash.outputs.hashes }}
+    steps:
+      - name: Resolve upstream run-id
+        id: runid
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.run_id }}" ]]; then
+            RUN_ID="${{ inputs.run_id }}"
+          else
+            RUN_ID="${{ github.run_id }}"
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "Upstream run-id: ${RUN_ID}"
+
+      - name: Download all tarball artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: omni-*-tarball
+          merge-multiple: true
+          path: dist
+          run-id: ${{ steps.runid.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version + compute base64 subjects
+        id: hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          shopt -s nullglob
+          TARBALLS=( omni-*.tar.gz )
+          if [[ ${#TARBALLS[@]} -eq 0 ]]; then
+            echo "::error::no omni-*.tar.gz tarballs downloaded from upstream run-id ${{ steps.runid.outputs.run_id }}"
+            ls -la
+            exit 1
+          fi
+          FIRST="${TARBALLS[0]}"
+          VERSION=$(echo "${FIRST}" | sed -E 's/^omni-(.+)-(linux-x64-glibc|linux-x64-musl|linux-arm64|darwin-arm64)\.tar\.gz$/\1/')
+          if [[ -z "${VERSION}" || "${VERSION}" == "${FIRST}" ]]; then
+            echo "::error::could not parse VERSION from filename '${FIRST}'"
+            exit 1
+          fi
+          if [[ -n "${{ inputs.version }}" && "${{ inputs.version }}" != "${VERSION}" ]]; then
+            echo "::error::workflow_dispatch input version='${{ inputs.version }}' does not match upstream artifact version='${VERSION}'"
+            exit 1
+          fi
+          echo "Resolved version: ${VERSION}"
+          echo "Tarballs to sign: ${#TARBALLS[@]}"
+          printf '  %s\n' "${TARBALLS[@]}"
+          HASHES=$(sha256sum "${TARBALLS[@]}" | base64 -w0)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "hashes=${HASHES}" >> "$GITHUB_OUTPUT"
+          echo "Computed multi-subject digest set:"
+          sha256sum "${TARBALLS[@]}"
+
+  # ---------------------------------------------------------------------------
+  # provenance — SLSA L3 generator (reusable workflow). Produces ONE
+  # .intoto.jsonl covering every tarball subject. The per-platform sign job
+  # downloads it and copies it to <tarball>.intoto.jsonl.
+  # ---------------------------------------------------------------------------
+  provenance:
+    name: SLSA Provenance (Level 3)
+    needs: [prepare]
+    permissions:
+      id-token: write    # OIDC for SLSA provenance signing
+      contents: write    # Required by nested `upload-assets` job static check
+      actions: read      # read upstream workflow run metadata
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.prepare.outputs.hashes }}
+      provenance-name: omni-${{ needs.prepare.outputs.version }}.intoto.jsonl
+      upload-assets: false
+
+  # ---------------------------------------------------------------------------
+  # sign — per-platform: cosign keyless sign-blob + GitHub-native
+  # attest-build-provenance + self-verify (3 verifiers) + tamper-detection
+  # self-test + per-platform signed artifact upload.
+  # ---------------------------------------------------------------------------
+  sign:
+    name: Sign ${{ matrix.platform }}
+    needs: [prepare, provenance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write       # OIDC for cosign keyless + attest-build-provenance
+      attestations: write   # actions/attest-build-provenance@v1 registration
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux-x64-glibc
+          - linux-x64-musl
+          - linux-arm64
+          - darwin-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download tarball artifact (${{ matrix.platform }})
+        uses: actions/download-artifact@v4
+        with:
+          name: omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}-tarball
+          path: dist
+          run-id: ${{ needs.prepare.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download SLSA provenance artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
+          path: dist
+
+      - name: Stage provenance per-platform
+        shell: bash
+        env:
+          VERSION:  ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          SRC="dist/omni-${VERSION}.intoto.jsonl"
+          DEST="dist/omni-${VERSION}-${PLATFORM}.tar.gz.intoto.jsonl"
+          if [[ ! -s "${SRC}" ]]; then
+            echo "::error::missing or empty SLSA provenance ${SRC}"
+            exit 1
+          fi
+          cp "${SRC}" "${DEST}"
+          ls -la "${DEST}"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Install slsa-verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
+
+      - name: cosign sign-blob (keyless OIDC, sigstore bundle)
+        shell: bash
+        env:
+          COSIGN_YES:    'true'
+          VERSION:       ${{ needs.prepare.outputs.version }}
+          PLATFORM:      ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          BUNDLE="${TARBALL}.bundle"
+          if [[ ! -s "${TARBALL}" ]]; then
+            echo "::error::missing or empty tarball ${TARBALL}"
+            exit 1
+          fi
+          cosign sign-blob \
+            --yes \
+            --bundle "${BUNDLE}" \
+            "${TARBALL}"
+          if [[ ! -s "${BUNDLE}" ]]; then
+            echo "::error::cosign sign-blob produced empty bundle"
+            exit 1
+          fi
+          echo "::notice::signed ${TARBALL} -> ${BUNDLE}"
+
+      - name: GitHub-native build-provenance attestation
+        id: attest
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz
+
+      - name: Verify cosign bundle (self-check)
+        shell: bash
+        env:
+          VERSION:  ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          cosign verify-blob \
+            --bundle "${TARBALL}.bundle" \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${TARBALL}"
+
+      - name: Verify SLSA provenance (self-check)
+        shell: bash
+        env:
+          VERSION:  ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          slsa-verifier verify-artifact "${TARBALL}" \
+            --provenance-path "${TARBALL}.intoto.jsonl" \
+            --source-uri "github.com/${{ github.repository }}"
+
+      - name: Verify GitHub-native attestation (self-check)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          OWNER="${{ github.repository_owner }}"
+          gh attestation verify "${TARBALL}" --owner "${OWNER}"
+
+      - name: Tamper-detection self-test (all 3 verifiers must REJECT)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          TARBALL="dist/omni-${VERSION}-${PLATFORM}.tar.gz"
+          MUTATED="dist/tampered-omni-${VERSION}-${PLATFORM}.tar.gz"
+          OWNER="${{ github.repository_owner }}"
+          cp "${TARBALL}" "${MUTATED}"
+
+          # Flip the last byte. Any single-byte mutation invalidates the
+          # SHA-256 subject that cosign signed AND the SLSA subject hash
+          # AND the GitHub Attestations API digest lookup.
+          SIZE=$(stat -c '%s' "${MUTATED}")
+          OFFSET=$((SIZE - 1))
+          ORIG_BYTE=$(xxd -p -s "${OFFSET}" -l 1 "${MUTATED}")
+          FLIPPED=$(printf '%02x' $((0x${ORIG_BYTE} ^ 0x01)))
+          printf '%b' "\x${FLIPPED}" | dd of="${MUTATED}" bs=1 seek="${OFFSET}" count=1 conv=notrunc status=none
+          if cmp -s "${TARBALL}" "${MUTATED}"; then
+            echo "::error::mutation produced identical bytes — test harness is broken"
+            exit 1
+          fi
+
+          echo "-> Expecting cosign verify-blob to REJECT mutated tarball"
+          if cosign verify-blob \
+              --bundle "${TARBALL}.bundle" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${MUTATED}" > /tmp/cosign-tamper.log 2>&1; then
+            echo "::error::cosign verify-blob accepted a mutated tarball — signing contract broken"
+            cat /tmp/cosign-tamper.log >&2 || true
+            exit 1
+          fi
+          echo "OK: cosign rejected mutated tarball"
+
+          echo "-> Expecting slsa-verifier verify-artifact to REJECT mutated tarball"
+          if slsa-verifier verify-artifact "${MUTATED}" \
+              --provenance-path "${TARBALL}.intoto.jsonl" \
+              --source-uri "github.com/${{ github.repository }}" > /tmp/slsa-tamper.log 2>&1; then
+            echo "::error::slsa-verifier accepted a mutated tarball — provenance contract broken"
+            cat /tmp/slsa-tamper.log >&2 || true
+            exit 1
+          fi
+          echo "OK: slsa-verifier rejected mutated tarball"
+
+          echo "-> Expecting gh attestation verify to REJECT mutated tarball"
+          if gh attestation verify "${MUTATED}" --owner "${OWNER}" > /tmp/gh-tamper.log 2>&1; then
+            echo "::error::gh attestation verify accepted a mutated tarball — Attestations API contract broken"
+            cat /tmp/gh-tamper.log >&2 || true
+            exit 1
+          fi
+          echo "OK: gh attestation verify rejected mutated tarball"
+
+          rm -f "${MUTATED}"
+
+      - name: Upload signed artifact (${{ matrix.platform }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}-signed
+          path: |
+            dist/omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz
+            dist/omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz.bundle
+            dist/omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz.intoto.jsonl
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/signing-identity-pin.yml
+++ b/.github/workflows/signing-identity-pin.yml
@@ -1,0 +1,48 @@
+name: Signing Identity Pin
+
+# Asserts the cosign keyless signing identity is byte-identical across the
+# four in-repo witnesses on every PR that touches any of them. A divergent
+# edit to a single witness indicates one of two things: (a) a legitimate
+# rotation missed a channel, or (b) a tampered PR trying to move the pin.
+# Either way, the PR must not merge until the witnesses agree.
+#
+# See scripts/check-fingerprint-pinning.sh for the check implementation and
+# SECURITY.md "Release Signing — Pinned Identity (cosign keyless)" for the
+# canonical pin values.
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'SECURITY.md'
+      - '.well-known/security.txt'
+      - '.github/ISSUE_TEMPLATE/signing-key-fingerprint.md'
+      - '.github/cosign.pub'
+      - 'scripts/check-fingerprint-pinning.sh'
+      - '.github/workflows/signing-identity-pin.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'SECURITY.md'
+      - '.well-known/security.txt'
+      - '.github/ISSUE_TEMPLATE/signing-key-fingerprint.md'
+      - '.github/cosign.pub'
+      - 'scripts/check-fingerprint-pinning.sh'
+      - '.github/workflows/signing-identity-pin.yml'
+
+concurrency:
+  group: signing-identity-pin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-pin:
+    name: check-fingerprint-pinning (four-channel byte-identity)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Assert signing-identity pin agrees across all four witnesses
+        run: bash scripts/check-fingerprint-pinning.sh

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,23 @@
+# RFC 9116 security.txt for @automagik/omni
+#
+# Contact + canonical pin for release signing. All values below MUST be
+# byte-identical to the corresponding lines in:
+#   - SECURITY.md (repo root)
+#   - .github/ISSUE_TEMPLATE/signing-key-fingerprint.md
+#   - .github/cosign.pub (NO-KEY sentinel)
+# Drift in any single channel is treated as a compromise.
+
+Contact: mailto:security@namastex.ai
+Expires: 2027-01-01T00:00:00Z
+Preferred-Languages: en, pt-BR
+Canonical: https://raw.githubusercontent.com/automagik-dev/omni/main/.well-known/security.txt
+
+# Release Signing — Pinned Identity (cosign keyless)
+# certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@
+# certificate-oidc-issuer:     https://token.actions.githubusercontent.com
+# provenance source-uri:       github.com/automagik-dev/omni
+#
+# Signing mechanism: cosign keyless (Sigstore + Fulcio) — NO long-lived key.
+# Workflow file:     .github/workflows/sign-attest.yml
+# Rotation:          requires two-officer PR updating all four witnesses
+#                    plus a new SIGNING_CERT_IDENTITY_YYYYMMDD issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy — @automagik/omni
+
+## Reporting a Vulnerability
+
+Email `security@namastex.ai` with a description of the issue and steps to
+reproduce. We will acknowledge within 2 business days and target a fix
+window proportional to severity. Do NOT file public issues for
+security-sensitive reports.
+
+## Release Signing — Pinned Identity (cosign keyless)
+
+`@automagik/omni` release tarballs are signed with **cosign keyless OIDC**
+via GitHub Actions. There is no long-lived signing key — the pin is the
+three-value tuple below, witnessed across four channels in this repo. Any
+single-channel edit is rejected at PR-merge time by the
+`signing-identity-pin` workflow.
+
+### Canonical Pin
+
+```
+certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@
+certificate-oidc-issuer:     https://token.actions.githubusercontent.com
+provenance source-uri:       github.com/automagik-dev/omni
+```
+
+### Channels (all four MUST agree byte-for-byte)
+
+1. **`SECURITY.md`** — this file, repo root
+2. **`.well-known/security.txt`** — RFC 9116 mirror at `/.well-known/security.txt` on the project site
+3. **`.github/ISSUE_TEMPLATE/signing-key-fingerprint.md`** — out-of-band issue template
+4. **`.github/cosign.pub`** — NO-KEY sentinel (no public key — keyless contract)
+
+### Verification (operators)
+
+```bash
+# Sigstore bundle (cosign keyless)
+cosign verify-blob \
+  --bundle omni-<version>-<platform>.tar.gz.bundle \
+  --certificate-identity-regexp '^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  omni-<version>-<platform>.tar.gz
+
+# SLSA L3 provenance
+slsa-verifier verify-artifact omni-<version>-<platform>.tar.gz \
+  --provenance-path omni-<version>-<platform>.tar.gz.intoto.jsonl \
+  --source-uri github.com/automagik-dev/omni
+
+# GitHub Attestations API
+gh attestation verify omni-<version>-<platform>.tar.gz --owner automagik-dev
+```
+
+### Consumer Trust
+
+`pgserve verify --slug omni` (pgserve v3+) verifies omni release tarballs
+against this exact certificate identity. The pgserve trust-list at
+`src/cosign/trust-list.js` in `namastexlabs/pgserve` anchors on this
+regex literally — renaming the `sign-attest.yml` workflow file breaks the
+trust loop.
+
+### Rotation
+
+Rotating the signing identity (workflow rename, repo rename, OIDC issuer
+change, source-URI rebind) requires:
+
+1. Two Namastex security officers landing a single PR that updates all
+   four witnesses AND `scripts/check-fingerprint-pinning.sh`.
+2. A new `.github/ISSUE_TEMPLATE/signing-key-fingerprint.md` filing dated
+   `SIGNING_CERT_IDENTITY_YYYYMMDD` that supersedes the previous pin.
+3. Coordination with downstream consumers (notably pgserve's trust-list)
+   to land the matching regex update in lockstep.
+
+Any drift in fewer than all four channels is treated as a compromise —
+operators should stop using the latest release until the four channels
+re-converge.

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# build-binary.sh — v3-prerelease-trust-loop G2 (mirror of genie pattern).
+#
+# Local equivalent of one matrix leg of .github/workflows/build-tarballs.yml.
+# Produces dist/omni-<version>-<platform>.tar.gz containing:
+#   omni       — bun --compile static executable
+#   VERSION    — plain-text stamp
+#
+# Size budget: each tarball ≤120 MB compressed (omni's bundled-server-entry
+# pulls more deps than genie's CLI; budget is empirically derived from the
+# existing 97 MB omni-bin + tar overhead). The script fails if exceeded.
+# Platforms: linux-x64-glibc, linux-x64-musl, linux-arm64, darwin-arm64.
+# (darwin-x64 / Intel Mac dropped — Apple ended Intel Mac sales in 2022.)
+#
+# Usage: scripts/build-binary.sh --platform <p> [--version <v>]
+# Exit codes: 0 ok | 1 build failed | 2 invalid args | 3 size budget exceeded
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST_DIR="${REPO_ROOT}/dist"
+ENTRY_POINT="${REPO_ROOT}/packages/cli/src/index.ts"
+SIZE_BUDGET_MB=120
+
+PLATFORMS=(linux-x64-glibc linux-x64-musl linux-arm64 darwin-arm64)
+
+bun_target_for() {
+  case "$1" in
+    linux-x64-glibc) echo "bun-linux-x64" ;;
+    linux-x64-musl)  echo "bun-linux-x64-musl" ;;
+    linux-arm64)     echo "bun-linux-arm64" ;;
+    darwin-arm64)    echo "bun-darwin-arm64" ;;
+    *) return 1 ;;
+  esac
+}
+
+usage() { echo "Usage: $0 --platform <p> [--version <v>]; platforms: ${PLATFORMS[*]}"; }
+
+PLATFORM=""
+VERSION=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform) PLATFORM="$2"; shift 2 ;;
+    --version)  VERSION="$2"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$PLATFORM" ]] || { echo "error: --platform is required" >&2; usage; exit 2; }
+TARGET="$(bun_target_for "$PLATFORM")" || { echo "error: unsupported platform: $PLATFORM" >&2; exit 2; }
+# Version lives at packages/cli/package.json — root package.json is the
+# private monorepo wrapper (`omni-v2`); the publishable CLI is the
+# @automagik/omni workspace package.
+[[ -n "$VERSION" ]] || VERSION=$(node -p "require('${REPO_ROOT}/packages/cli/package.json').version")
+
+STAGE="${DIST_DIR}/${PLATFORM}"
+TARBALL="${DIST_DIR}/omni-${VERSION}-${PLATFORM}.tar.gz"
+rm -rf "$STAGE" "$TARBALL"
+mkdir -p "$STAGE"
+
+echo "==> [${PLATFORM}] bun build --compile --target=${TARGET}  (v${VERSION})"
+bun build --compile \
+  --target="${TARGET}" \
+  "${ENTRY_POINT}" \
+  --outfile "${STAGE}/omni"
+
+echo "${VERSION}" > "${STAGE}/VERSION"
+
+tar czf "${TARBALL}" -C "${STAGE}" .
+
+SIZE_MB=$(( $(stat -c '%s' "${TARBALL}" 2>/dev/null || stat -f '%z' "${TARBALL}") / 1024 / 1024 ))
+echo "==> ${TARBALL}  (${SIZE_MB} MB)"
+if (( SIZE_MB > SIZE_BUDGET_MB )); then
+  echo "error: tarball ${SIZE_MB}MB exceeds ${SIZE_BUDGET_MB}MB budget" >&2
+  exit 3
+fi

--- a/scripts/check-fingerprint-pinning.sh
+++ b/scripts/check-fingerprint-pinning.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Assert that the pinned cosign keyless signing identity is byte-identical
+# across every channel in which @automagik/omni publishes it.
+#
+# @automagik/omni release signing is cosign KEYLESS ONLY. There is no
+# long-lived public key to pin — the "pin" is the three-value tuple below
+# (certificate-identity-regexp + OIDC issuer + provenance source-uri). The
+# rotation procedure requires two Namastex security officers to land any
+# change; this script is the CI merge-gate that blocks a single-channel
+# edit from slipping through.
+#
+# Witnesses (all four MUST contain each canonical line as a substring):
+#   1. SECURITY.md                                            in-repo canonical
+#   2. .well-known/security.txt                               RFC 9116 mirror
+#   3. .github/ISSUE_TEMPLATE/signing-key-fingerprint.md      out-of-band tmpl
+#   4. .github/cosign.pub                                     NO-KEY sentinel
+#
+# The script greps each witness for three verbatim lines. Prefix characters
+# (`- `, `# `, ``` ` ```) are tolerated because grep uses substring matching;
+# the value strings themselves must match byte-for-byte. If any witness is
+# missing a line or carries a divergent value, the script exits 1 with a
+# diagnostic that names the witness, the expected line, and the nearest
+# candidate match so operators can locate drift quickly.
+#
+# Exit codes:
+#   0 — all four witnesses agree
+#   1 — drift detected (one or more witnesses missing or divergent)
+#   2 — misuse / missing witness file / run outside a git repo
+#
+# Manual: scripts/check-fingerprint-pinning.sh
+# CI:     .github/workflows/signing-identity-pin.yml
+
+set -euo pipefail
+
+# --- Resolve repo root -------------------------------------------------------
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+else
+  REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+cd "${REPO_ROOT}"
+
+# --- Canonical identity lines (byte-exact) -----------------------------------
+#
+# These three lines are the source of truth. They are duplicated verbatim in
+# this script on purpose: if the script itself drifts, CI catches it against
+# the witnesses below. To rotate the pin, follow the rotation procedure and
+# update this constant list in the same two-officer PR that updates the
+# witnesses.
+CANONICAL=(
+  "certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@"
+  "certificate-oidc-issuer:     https://token.actions.githubusercontent.com"
+  "provenance source-uri:       github.com/automagik-dev/omni"
+)
+
+WITNESSES=(
+  "SECURITY.md"
+  ".well-known/security.txt"
+  ".github/ISSUE_TEMPLATE/signing-key-fingerprint.md"
+  ".github/cosign.pub"
+)
+
+# --- Helpers -----------------------------------------------------------------
+
+RED=''
+GREEN=''
+YELLOW=''
+BOLD=''
+RESET=''
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  RED=$'\033[31m'
+  GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'
+  BOLD=$'\033[1m'
+  RESET=$'\033[0m'
+fi
+
+log()  { printf '%s\n' "$*"; }
+ok()   { printf '%s✓%s %s\n' "${GREEN}" "${RESET}" "$*"; }
+warn() { printf '%s!%s %s\n' "${YELLOW}" "${RESET}" "$*" >&2; }
+err()  { printf '%s✗%s %s\n' "${RED}"   "${RESET}" "$*" >&2; }
+
+# Return the first line in $2 that contains the needle $1 as a substring,
+# or the empty string if no line matches.
+nearest_match() {
+  local needle="$1"
+  local file="$2"
+  local anchor
+  anchor="${needle%%:*}:"
+  grep -F -- "${anchor}" "${file}" 2>/dev/null | head -n 1 || true
+}
+
+# --- Preflight: every witness file must exist --------------------------------
+
+missing_files=0
+for witness in "${WITNESSES[@]}"; do
+  if [ ! -f "${witness}" ]; then
+    err "witness file missing: ${witness}"
+    missing_files=1
+  fi
+done
+if [ "${missing_files}" -ne 0 ]; then
+  err "aborting — cannot assert pin against a missing witness"
+  exit 2
+fi
+
+# --- Per-witness substring match --------------------------------------------
+
+drift=0
+
+log "${BOLD}check-fingerprint-pinning${RESET} — asserting signing-identity pin across ${#WITNESSES[@]} witnesses"
+log ""
+
+for witness in "${WITNESSES[@]}"; do
+  log "${BOLD}${witness}${RESET}"
+  for line in "${CANONICAL[@]}"; do
+    if grep -qF -- "${line}" "${witness}"; then
+      ok "contains: ${line}"
+    else
+      err "missing:  ${line}"
+      nearest="$(nearest_match "${line}" "${witness}")"
+      if [ -n "${nearest}" ]; then
+        warn "nearest candidate in ${witness}: ${nearest}"
+      else
+        warn "no candidate line in ${witness} matched the key prefix — witness may not carry this pin at all"
+      fi
+      drift=1
+    fi
+  done
+  log ""
+done
+
+# --- Result ------------------------------------------------------------------
+
+if [ "${drift}" -ne 0 ]; then
+  err "signing-identity pin has drifted across ${#WITNESSES[@]} witnesses"
+  err "escalation contact: security@namastex.ai"
+  exit 1
+fi
+
+ok "signing-identity pin is byte-identical across all ${#WITNESSES[@]} witnesses"
+exit 0


### PR DESCRIPTION
## Summary

Implements **G2** of the parent `v3-prerelease-trust-loop` wish in `namastexlabs/pgserve` (PR #125, merged 2026-05-11). Adds a cosign keyless OIDC signing pipeline that mirrors genie's orchestrator+`workflow_call` pattern (genie `v4.260511.2` reference) so `pgserve verify --slug omni` (pgserve v3) can verify omni release artifacts against the pgserve trust list.

Decision **2.α** (Felipe, 2026-05-11): mirror genie exactly — `bun build --compile` single-binary tarballs, signed by a reusable `sign-attest.yml` workflow that `release.yml` calls into.

## Pipeline shape

Per tag push (`refs/tags/v*`):

```
release.yml orchestrator
  ├─ build-tarballs.yml      (matrix × 4 platforms, bun --compile)
  ├─ sign-attest.yml         (cosign keyless + SLSA L3 + tamper-detect)
  ├─ release-publish.yml     (GH release create + 12 signed assets)
  ├─ publish-npm             (preserved legacy npm OIDC path; skipped on -rc.* / -beta.*)
  └─ release-notes           (git-cliff appended to release body)
```

## Cosign keyless contract

```
certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@
certificate-oidc-issuer:     https://token.actions.githubusercontent.com
provenance source-uri:       github.com/automagik-dev/omni
```

The pgserve trust-list at `src/cosign/trust-list.js` (already updated in pgserve PR #127) anchors on this exact regex. **Renaming `sign-attest.yml` breaks the consumer trust loop.**

## Local validation evidence

```
$ bash scripts/check-fingerprint-pinning.sh
✓ contains: certificate-identity-regexp: ^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@
✓ contains: certificate-oidc-issuer:     https://token.actions.githubusercontent.com
✓ contains: provenance source-uri:       github.com/automagik-dev/omni
[× 4 witnesses — SECURITY.md, .well-known/security.txt, ISSUE_TEMPLATE, cosign.pub]
✓ signing-identity pin is byte-identical across all 4 witnesses

$ bash scripts/build-binary.sh --platform linux-x64-glibc --version 2.260510.1
==> [linux-x64-glibc] bun build --compile --target=bun-linux-x64  (v2.260510.1)
 [244ms]  bundle  1166 modules
 [635ms] compile  …/dist/linux-x64-glibc/omni
==> …/dist/omni-2.260510.1-linux-x64-glibc.tar.gz  (37 MB)

$ tar -xzf dist/omni-2.260510.1-linux-x64-glibc.tar.gz -C /tmp/extract
$ /tmp/extract/omni --version
2.260510.1 (server: 2.260508.4 ↑ update available)
$ /tmp/extract/omni --help
Quick Start: …  ← exit 0
```

37 MB tarball is well under the 120 MB CI budget.

## Files (11)

| File | Status | Purpose |
|---|---|---|
| `.github/workflows/release.yml` | CHANGED | Orchestrator + preserved npm OIDC publish job (skipped on rc/beta tags) |
| `.github/workflows/build-tarballs.yml` | NEW | Matrix build × 4 platforms via `bun --compile` |
| `.github/workflows/sign-attest.yml` | NEW | Cosign keyless + SLSA L3 + tamper-detect — pgserve trust-list anchors here |
| `.github/workflows/release-publish.yml` | NEW | `gh release create` + upload 12 signed assets |
| `.github/workflows/signing-identity-pin.yml` | NEW | 4-channel byte-identity guard on PRs touching pin |
| `scripts/build-binary.sh` | NEW | Local equivalent of one matrix leg |
| `scripts/check-fingerprint-pinning.sh` | NEW | Drives the pin guard |
| `SECURITY.md` | NEW | Canonical pin (channel 1/4) |
| `.well-known/security.txt` | NEW | RFC 9116 mirror (channel 2/4) |
| `.github/ISSUE_TEMPLATE/signing-key-fingerprint.md` | NEW | Out-of-band pin template (channel 3/4) |
| `.github/cosign.pub` | NEW | NO-KEY sentinel (channel 4/4) |

## Out of scope (intentional)

- **Repo rename / org change** — pre-emptive coordination with the pgserve→autopg org transfer is deferred; this PR keeps `automagik-dev/omni` paths.
- **Dropping the npm publish path** — no prior decision to drop; preserved as `publish-npm` job, conditionally skipped on prerelease tags.
- **`install-client.sh` switching to install.sh + GH Release tarball path** — install-client.sh still works against npm; signed-tarball-based install is a separate operator-facing follow-up.
- **Trust-list expansion** — brain/rlmx/hapvida-eugenia/email signed-app pipelines not touched here.

## Test plan

- [x] Local 4-channel pin guard passes (`bash scripts/check-fingerprint-pinning.sh`)
- [x] Local single-platform build smoke passes (37 MB tarball, --version + --help work)
- [x] Workflow files syntactically valid (visual review; GH actionlint runs on push)
- [ ] **Post-merge**: cut a throwaway tag (e.g. `v0.0.0-rc.test1`) to confirm sign-attest runs end-to-end → bundle + intoto.jsonl attached to GH release
- [ ] **Cross-repo G4**: install pgserve `v3.0.0-rc.0` (cut after G2 merges in G3) on a fresh host → run `pgserve verify --slug omni` against the test tag → PASS

## Cross-repo references

- `namastexlabs/pgserve` PR #125 (parent wish): https://github.com/namastexlabs/pgserve/pull/125
- `namastexlabs/pgserve` PR #126 (genie regex fix + canonical reference): https://github.com/namastexlabs/pgserve/pull/126
- `namastexlabs/pgserve` PR #127 (omni regex pre-emptive flip): https://github.com/namastexlabs/pgserve/pull/127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
