### PR TITLE
feat(release): canonical channel taxonomy stable/homolog/dev (drop beta/canary)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -60,10 +60,11 @@ on:
         required: true
         type: choice
         default: stable
+        # Canonical channel taxonomy (Felipe directive 2026-05-12,
+        # unified across pgserve/omni/genie). beta + canary retired.
         options:
           - stable
-          - beta
-          - canary
+          - homolog
           - dev
       draft:
         description: 'Create as draft (require manual promotion)?'
@@ -219,14 +220,32 @@ jobs:
           # same convention. A stable release advances BOTH latest.json and
           # dev.json (single-pipeline reality). channel=dev only advances
           # dev.json — latest.json stays at the prior stable.
+          # Canonical taxonomy: stable / homolog / dev.
+          # - stable advances latest.json + homolog.json + dev.json
+          #   (a stable release IS also the latest of every channel; the
+          #   reverse-flow promotion dev→homolog→main means stable
+          #   subsumes both downstream channels)
+          # - homolog advances homolog.json + dev.json (it's downstream
+          #   of stable but upstream of dev; promoting to homolog also
+          #   refreshes dev)
+          # - dev advances only dev.json
           declare -A MANIFEST_FILES=()
           case "$CHANNEL" in
             stable)
               MANIFEST_FILES[stable]="latest.json"
+              MANIFEST_FILES[homolog]="homolog.json"
+              MANIFEST_FILES[dev]="dev.json"
+              ;;
+            homolog)
+              MANIFEST_FILES[homolog]="homolog.json"
+              MANIFEST_FILES[dev]="dev.json"
+              ;;
+            dev)
               MANIFEST_FILES[dev]="dev.json"
               ;;
             *)
-              MANIFEST_FILES[$CHANNEL]="${CHANNEL}.json"
+              echo "::error::unknown channel: $CHANNEL (valid: stable, homolog, dev)"
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,15 @@ on:
         required: false
         type: choice
         default: stable
+        # Canonical channel taxonomy (Felipe directive 2026-05-12,
+        # unified across pgserve/omni/genie):
+        #   stable  → main branch  → .well-known/latest.json
+        #   homolog → homolog branch → .well-known/homolog.json
+        #   dev     → dev branch   → .well-known/dev.json
+        # beta + canary have been retired.
         options:
           - stable
-          - beta
-          - canary
+          - homolog
           - dev
 
 permissions:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,13 +8,17 @@ on:
   pull_request:
     types: [closed]
     branches: [dev]
-  # main-side promotion still arrives via CI-on-push (main IS in CI's push
+  # main-side promotion arrives via CI-on-push (main IS in CI's push
   # branches). Keep this path so release-to-@latest continues to trigger
-  # automatically when the rolling PR dev→main merges.
+  # automatically when the rolling PR dev→main merges. homolog branch
+  # added 2026-05-12 (Felipe directive) so promotions to homolog also
+  # auto-fire the version + release pipeline → .well-known/homolog.json
+  # advances. CI's push branches list must include `homolog` for this
+  # workflow_run trigger to fire from there.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, homolog]
   workflow_dispatch:
 
 permissions:
@@ -151,12 +155,23 @@ jobs:
           # semantics here mirror the npm_tag step above:
           #   workflow_run on main → main → stable
           #   pull_request close on dev / workflow_dispatch → dev
-          if [ "${{ github.event_name }}" = "workflow_run" ] && \
-             [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
-            CHANNEL="stable"
-          else
-            CHANNEL="dev"
+          # Canonical channel taxonomy (Felipe directive 2026-05-12,
+          # unified across pgserve/omni/genie):
+          #   main branch    → stable
+          #   homolog branch → homolog
+          #   dev branch     → dev (default fallback)
+          # The triggering branch comes from workflow_run.head_branch
+          # (for the workflow_run trigger path) or stays at the dev
+          # default for pull_request close + workflow_dispatch paths.
+          TRIGGER_BRANCH=""
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            TRIGGER_BRANCH="${{ github.event.workflow_run.head_branch }}"
           fi
+          case "${TRIGGER_BRANCH}" in
+            main)    CHANNEL="stable" ;;
+            homolog) CHANNEL="homolog" ;;
+            *)       CHANNEL="dev" ;;
+          esac
           echo "Dispatching release pipeline against ${TAG} (channel=${CHANNEL})..."
           if ! gh workflow run release.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}" --field version="${VERSION}" --field channel="${CHANNEL}"; then
             echo "::error ::release-trigger.dispatch_failed release.yml dispatch failed for ${TAG} — investigate gh CLI auth or workflow availability before re-running manually"


### PR DESCRIPTION
## Summary

Felipe directive 2026-05-12: unify the channel taxonomy across pgserve/omni/genie to `stable / homolog / dev`. Retires the historical `beta` + `canary` options.

| Branch | Channel | Manifest |
|---|---|---|
| `main` | `stable` | `.well-known/latest.json` |
| `homolog` | `homolog` | `.well-known/homolog.json` |
| `dev` | `dev` | `.well-known/dev.json` |

## Promotion semantics

stable subsumes downstream channels — a stable release IS also the latest of homolog + dev:

- `stable` advances `latest.json` + `homolog.json` + `dev.json`
- `homolog` advances `homolog.json` + `dev.json` (downstream of stable, upstream of dev)
- `dev` advances only `dev.json`

## Changes (3 files)

| File | Change |
|---|---|
| `.github/workflows/release.yml` | `workflow_dispatch` channel choices pruned to `stable / homolog / dev` |
| `.github/workflows/release-publish.yml` | Choices pruned + case-map expanded to handle homolog (advances homolog.json + dev.json); unknown channel fails fast |
| `.github/workflows/version.yml` | Branch-derive: `main→stable`, `homolog→homolog`, `dev/other→dev`; `workflow_run` trigger branches expanded to `[main, homolog]` |

## Note for the CI workflow

The `workflow_run` trigger in version.yml fires when CI completes on `[main, homolog]`. For homolog promotions to auto-fire the version pipeline, CI's `push:` branch list must include `homolog` (currently `[main, homolog]` per recent CI work). If missing, operators can add as follow-up.

## Cross-repo references

- pgserve PR #128 (Phase B — main-only/stable-only taxonomy, beta+canary dropped): https://github.com/namastexlabs/pgserve/pull/128
- Genie wish release-channel-dev (PR #2419 — `stable / dev` initially): https://github.com/automagik-dev/genie/pull/2419
- Omni PR #633 (Phase A — dev channel added): https://github.com/automagik-dev/omni/pull/633

This PR closes the third channel (homolog) for omni's promotion ladder. Felipe noted "only omni has the homolog branch up to date" — genie may follow with the same taxonomy refactor (homolog channel surface exists for cross-repo consistency even if their homolog branch is dormant).

## Test plan

- [x] `bash scripts/check-fingerprint-pinning.sh` still passes (4-channel pin guard unaffected)
- [x] YAML structure visual review
- [ ] Post-merge: a homolog-branch CI completion fires `workflow_run` → version.yml dispatches `release.yml` with `channel=homolog` → release-publish writes `.well-known/{homolog,dev}.json`
- [ ] Post-merge: a stable (main) release confirms it advances all three manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
