### PR TITLE
fix(install): route omni pgserve consumers through autopg-v3 resolver

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -889,7 +889,7 @@ async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
     // Bring omni-api back up on embedded — operator isn't left dead.
     await deps.runPm2(['start', PM2_PROCESSES.api]);
     throw new Error(
-      'canonical pgserve setup failed (pgserve binary unavailable or install failed) — install manually: bun add -g pgserve@^2.1.0',
+      'canonical pgserve setup failed (autopg v3 / pgserve v2 binary unavailable or install failed) — install autopg:\n  curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash\nthen re-run: omni doctor --fix',
     );
   }
 

--- a/packages/cli/src/lib/canonical-pgserve-binary.ts
+++ b/packages/cli/src/lib/canonical-pgserve-binary.ts
@@ -1,0 +1,80 @@
+/**
+ * Canonical pgserve binary resolver — mirror of the genie-side resolver
+ * shipped in genie@4.260520.3 (`src/lib/canonical-pgserve-binary.ts`).
+ *
+ * Background
+ * ----------
+ * The autopg-distribution-cutover-finalize wish (autopg repo) renamed the
+ * published v3 binary from `pgserve` to `autopg`. Both binaries expose an
+ * identical command surface (`install`, `port`, `url`, `status`, `restart`);
+ * only the on-disk name differs. Every omni consumer that historically
+ * hardcoded `'pgserve'` in a spawn arg now routes through this resolver
+ * so v3-only hosts (which have `autopg` on PATH but no `pgserve`) succeed
+ * instead of falling out as "binary unavailable".
+ *
+ * Resolution policy
+ * -----------------
+ *   - Prefer `autopg` (v3 canonical) when present.
+ *   - Fall back to `pgserve` (v2 legacy) for cutover hosts.
+ *   - Return null when neither is on PATH — caller surfaces the canonical
+ *     install hint via {@link canonicalPgserveInstallHint}.
+ *
+ * Lifecycle
+ * ---------
+ *   - Memoized; cached value persists for the process lifetime.
+ *   - {@link _resetPgserveBinaryCache} invalidates for tests.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+export const CANONICAL_PGSERVE_BINARY = 'autopg';
+export const LEGACY_PGSERVE_BINARY = 'pgserve';
+
+let cached: string | null | undefined;
+
+function which(cmd: string): string | null {
+  try {
+    const result = execFileSync('which', [cmd], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return result.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the canonical pgserve binary on this host. Memoized.
+ */
+export function resolvePgserveBinary(): string | null {
+  if (cached !== undefined) return cached;
+  if (which(CANONICAL_PGSERVE_BINARY)) {
+    cached = CANONICAL_PGSERVE_BINARY;
+    return cached;
+  }
+  if (which(LEGACY_PGSERVE_BINARY)) {
+    cached = LEGACY_PGSERVE_BINARY;
+    return cached;
+  }
+  cached = null;
+  return cached;
+}
+
+/**
+ * Copy-paste recovery commands for the "binary not found" path. Points
+ * at the autopg v3 installer; ordered so the operator runs them
+ * top-to-bottom.
+ */
+export function canonicalPgserveInstallHint(): string[] {
+  return [
+    '  curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash',
+    '  omni install     # OR: omni doctor --fix',
+  ];
+}
+
+/** Reset memoization. Test-only. */
+export function _resetPgserveBinaryCache(): void {
+  cached = undefined;
+}

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -31,18 +31,11 @@ import { gunzipSync, gzipSync } from 'node:zlib';
 
 import { loadServerConfig } from '../config.js';
 import * as output from '../output.js';
+import { canonicalPgserveInstallHint, resolvePgserveBinary } from './canonical-pgserve-binary.js';
 
 /**
- * Minimum pgserve binary version required for the canonical install
- * subcommands (`install`, `url`, `port`, `status`). Wave 1 of the
- * canonical-pgserve-pm2-supervision wish landed in 2.1.0; anything older
- * lacks the install command.
- */
-const PGSERVE_REQUIRED_VERSION = '^2.1.0';
-
-/**
- * Probe the `pgserve` binary by running its `--help` subcommand. Returns
- * true when the binary is callable.
+ * Probe the canonical pgserve binary (autopg v3 or pgserve v2 fallback)
+ * by running its `--help` subcommand. Returns true when callable.
  *
  * History
  * -------
@@ -67,8 +60,10 @@ const PGSERVE_REQUIRED_VERSION = '^2.1.0';
  *    flow.
  */
 async function isPgserveInstalled(): Promise<boolean> {
+  const bin = resolvePgserveBinary();
+  if (!bin) return false;
   try {
-    const code = await Bun.spawn({ cmd: ['pgserve', '--help'], stdout: 'pipe', stderr: 'pipe' }).exited;
+    const code = await Bun.spawn({ cmd: [bin, '--help'], stdout: 'pipe', stderr: 'pipe' }).exited;
     return code === 0;
   } catch {
     return false;
@@ -76,27 +71,27 @@ async function isPgserveInstalled(): Promise<boolean> {
 }
 
 /**
- * Ensure the global `pgserve` binary is installed and on PATH. Best-effort:
- * - If already installed, return true immediately.
- * - Otherwise try `bun add -g pgserve@<PGSERVE_REQUIRED_VERSION>`.
- * - Returns false on failure (caller decides whether to fall back to
- *   embedded or fail hard).
+ * Ensure the canonical pgserve binary (autopg v3 — or pgserve v2 on
+ * legacy hosts) is installed and on PATH.
+ *
+ * Post v2 → v3 cutover, the recovery path is the autopg install.sh
+ * one-liner. The previous behavior shelled out to
+ * `bun add -g pgserve@^2.1.0` — that pulled the obsolete v2 npm
+ * package onto v3 hosts, which is exactly the kind of "fix made it
+ * worse" UX we don't want. So we no longer auto-install; instead the
+ * caller (omni install) falls back to embedded mode while surfacing
+ * an actionable hint that points at the canonical installer.
+ *
+ * Returns false on missing binary so the embedded-fallback path stays
+ * unchanged — operator data is preserved either way.
  */
 async function ensurePgserveBinary(): Promise<boolean> {
   if (await isPgserveInstalled()) return true;
-  output.raw(`  Installing pgserve@${PGSERVE_REQUIRED_VERSION} globally (bun add -g)...`);
-  const installCode = await Bun.spawn({
-    cmd: ['bun', 'add', '-g', `pgserve@${PGSERVE_REQUIRED_VERSION}`],
-    stdout: 'inherit',
-    stderr: 'inherit',
-  }).exited;
-  if (installCode !== 0) {
-    output.warn(`bun add -g pgserve@${PGSERVE_REQUIRED_VERSION} exited with code ${installCode}`);
-    return false;
+  output.warn('Canonical pgserve (autopg v3 / pgserve v2) not found on PATH. To enable canonical mode:');
+  for (const cmd of canonicalPgserveInstallHint()) {
+    output.warn(cmd);
   }
-  // Re-probe — bun's global bin may not be on PATH yet for the running shell
-  // but `pgserve --version` should still resolve via the absolute global path.
-  return isPgserveInstalled();
+  return false;
 }
 
 /**
@@ -104,10 +99,15 @@ async function ensurePgserveBinary(): Promise<boolean> {
  * on subsequent invocations). Returns true on success.
  */
 async function runPgserveInstall(): Promise<boolean> {
-  output.raw('  Registering canonical pgserve under pm2 (idempotent)...');
-  const installCode = await Bun.spawn({ cmd: ['pgserve', 'install'], stdout: 'inherit', stderr: 'inherit' }).exited;
+  const bin = resolvePgserveBinary();
+  if (!bin) {
+    output.warn('Canonical pgserve binary unavailable for install step.');
+    return false;
+  }
+  output.raw(`  Registering canonical pgserve under pm2 via \`${bin} install\` (idempotent)...`);
+  const installCode = await Bun.spawn({ cmd: [bin, 'install'], stdout: 'inherit', stderr: 'inherit' }).exited;
   if (installCode !== 0) {
-    output.warn(`pgserve install exited with code ${installCode}`);
+    output.warn(`${bin} install exited with code ${installCode}`);
     return false;
   }
   return true;
@@ -136,16 +136,18 @@ const OMNI_DATABASE_NAME = 'omni';
  * the embedded path used.
  */
 async function readPgservePort(): Promise<number | null> {
-  const proc = Bun.spawn({ cmd: ['pgserve', 'port'], stdout: 'pipe', stderr: 'inherit' });
+  const bin = resolvePgserveBinary();
+  if (!bin) return null;
+  const proc = Bun.spawn({ cmd: [bin, 'port'], stdout: 'pipe', stderr: 'inherit' });
   const stdout = await new Response(proc.stdout).text();
   const code = await proc.exited;
   if (code !== 0) {
-    output.warn(`pgserve port exited with code ${code}`);
+    output.warn(`${bin} port exited with code ${code}`);
     return null;
   }
   const port = Number.parseInt(stdout.trim(), 10);
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
-    output.warn(`pgserve port returned unexpected output ("${stdout.trim()}")`);
+    output.warn(`${bin} port returned unexpected output ("${stdout.trim()}")`);
     return null;
   }
   return port;
@@ -169,7 +171,9 @@ function buildOmniDatabaseUrl(port: number): string {
  */
 export async function setupCanonicalPgserve(): Promise<string | null> {
   if (!(await ensurePgserveBinary())) {
-    output.warn('Canonical pgserve binary unavailable — install manually: bun add -g pgserve@^2.1.0');
+    // ensurePgserveBinary already emitted the actionable autopg
+    // install.sh hint. Bare warn here just labels the abort surface.
+    output.warn('Canonical pgserve setup skipped — staying on embedded mode.');
     return null;
   }
   if (!(await runPgserveInstall())) return null;

--- a/packages/cli/src/lib/pgserve-transport.ts
+++ b/packages/cli/src/lib/pgserve-transport.ts
@@ -32,6 +32,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import { join } from 'node:path';
+import { resolvePgserveBinary } from './canonical-pgserve-binary.js';
 
 /** Canonical postgres port the postmaster binds when pgserve@>=2.3 runs in singleton mode. */
 export const CANONICAL_PG_PORT = 5432;
@@ -192,10 +193,12 @@ function parseExplicitTcpPort(raw: string | undefined): number | null {
 }
 
 async function discoverTcpPgservePort(): Promise<number | null> {
+  const bin = resolvePgserveBinary();
+  if (!bin) return null;
   return new Promise((resolve) => {
     let settled = false;
     let stdout = '';
-    const proc = spawn('pgserve', ['port'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const proc = spawn(bin, ['port'], { stdio: ['ignore', 'pipe', 'ignore'] });
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;


### PR DESCRIPTION
## Summary
Mirror of [genie#2465](https://github.com/automagik-dev/genie/pull/2465) — closes the omni-install gap on every v3-only host. Each spawn/which site that used to hardcode the v2 binary `'pgserve'` now routes through a single resolver that prefers `autopg` (v3) and falls back to `pgserve` (v2) for cutover hosts.

## The gap
Pre-fix, on a v3-only host (`autopg` on PATH, no `pgserve`):
- `omni install` → `Canonical pgserve binary unavailable — install manually: bun add -g pgserve@^2.1.0` → falls back to embedded mode + tells operator to install the **obsolete v2 npm package**
- `omni doctor --fix` → same hint
- TCP port discovery in `pgserve-transport.ts` → silent null return (transport falls back to UDS only)

## Changes
- **NEW** `packages/cli/src/lib/canonical-pgserve-binary.ts` — `resolvePgserveBinary()`, `canonicalPgserveInstallHint()`. Memoized; tests can invalidate via `_resetPgserveBinaryCache`.
- `canonical-pgserve.ts` — `isPgserveInstalled`, `runPgserveInstall`, `readPgservePort`, `ensurePgserveBinary` route through the resolver. The bun-add auto-install path is **retired** (it pulled v2 onto v3 hosts); replaced with a surfaced hint pointing at `curl ...autopg/main/install.sh | bash`.
- `pgserve-transport.ts` — `discoverTcpPgservePort` uses the resolver.
- `doctor.ts` — `--fix` error message points at the autopg installer.
- Removed unused `PGSERVE_REQUIRED_VERSION` constant.

## Compatibility matrix
| Host state | omni install (canonical mode) |
|---|---|
| autopg v3 only | ✅ uses `autopg` |
| pgserve v2 only | ✅ uses `pgserve` |
| both installed | ✅ prefers `autopg` |
| neither | ⚠️ falls back to embedded + actionable autopg-installer hint (operator data preserved either way) |

## Data preservation
- Embedded fallback preserves operator data in the embedded postgres dir (unchanged behavior).
- Canonical-mode `omni` database lives in the autopg-supervised postgres — also unchanged; resolver just picks the binary, doesn't touch the database.

## Validated
- `bun test doctor.test.ts` — 49 pass / 0 fail
- `bun run typecheck` — clean
- `biome check` on all touched files — clean

## Test plan
- [ ] omni dev CI green
- [ ] dev release publishes
- [ ] Felipe dogfood: `omni install` walks autopg path (no embedded fallback) on this host
- [ ] Merge to main — opens the install-order combinations validation:
  - autopg → genie → omni
  - autopg → omni → genie
  - omni alone (embedded fallback + autopg hint)
  - genie alone (embedded fallback + autopg hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)