### PR TITLE
fix(transport): UDS database URL must parse with WHATWG URL parser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -235,7 +235,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -270,7 +270,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -286,7 +286,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -300,7 +300,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -318,7 +318,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -326,7 +326,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -340,7 +340,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260520.3",
+      "version": "2.260520.4",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/pgserve-transport.test.ts
+++ b/packages/cli/src/__tests__/pgserve-transport.test.ts
@@ -91,14 +91,19 @@ describe('socket path helpers', () => {
 });
 
 describe('buildDatabaseUrlForTransport', () => {
-  test('produces UDS shape with host+port query params', () => {
+  test('produces UDS shape with host+port query params (whatwg-url valid)', () => {
     const url = buildDatabaseUrlForTransport({ kind: 'unix', socketDir: '/run/user/1000/pgserve', port: 5432 }, 'omni');
     // postgres.js / libpq accepts host=<dir> in query params to dial a Unix
     // socket at <dir>/.s.PGSQL.<port>. URLSearchParams encodes the slashes.
-    expect(url).toContain('postgresql://postgres:postgres@/omni?');
-    const params = new URLSearchParams(url.split('?')[1]);
-    expect(params.get('host')).toBe('/run/user/1000/pgserve');
-    expect(params.get('port')).toBe('5432');
+    // The `localhost` placeholder host is required so Node's WHATWG URL
+    // constructor accepts the string (the previous `@/db` form rejected
+    // with "Invalid URL", crashlooping omni-api at startup).
+    expect(url).toBe('postgresql://postgres:postgres@localhost/omni?host=%2Frun%2Fuser%2F1000%2Fpgserve&port=5432');
+    // Smoke-test the whatwg parser explicitly so a future regression
+    // (e.g. dropping the placeholder host) is caught.
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('host')).toBe('/run/user/1000/pgserve');
+    expect(parsed.searchParams.get('port')).toBe('5432');
   });
 
   test('produces TCP shape with explicit host:port', () => {

--- a/packages/cli/src/lib/pgserve-transport.ts
+++ b/packages/cli/src/lib/pgserve-transport.ts
@@ -107,8 +107,18 @@ export function probeCanonicalSocketSync(): boolean {
  * supplied database name. Mirrors the URL shapes documented in
  * SHARED-DESIGN.md §5.3 (omni-side scope).
  *
- * UDS shape: `postgresql://postgres:postgres@/omni?host=/run/user/1000/pgserve&port=5432`
+ * UDS shape: `postgresql://postgres:postgres@localhost/omni?host=/run/user/1000/pgserve&port=5432`
  * TCP shape: `postgresql://postgres:postgres@127.0.0.1:5432/omni`
+ *
+ * UDS placeholder host (`localhost`) is intentional. The previous form
+ * `postgresql://user:pass@/db?host=…` is libpq-valid but rejects when
+ * parsed by Node's WHATWG `URL()` constructor with "Invalid URL"
+ * (empty authority between `@` and `/`). omni-api's startup pipeline
+ * runs `new URL(DATABASE_URL)` for validation/redaction, which
+ * crashloops `omni-api` with `TypeError [ERR_INVALID_URL]` whenever
+ * the canonical UDS is reachable. libpq still routes to the socket
+ * because the `host=` query parameter overrides the URL host —
+ * placeholder is never dialed.
  *
  * The username/password pair is preserved (not derived from the transport)
  * because omni's pgserve consumer keeps libpq peer-auth via password —
@@ -130,7 +140,9 @@ export function buildDatabaseUrlForTransport(
       host: transport.socketDir,
       port: String(transport.port),
     });
-    return `postgresql://${auth}@/${encodeURIComponent(database)}?${params.toString()}`;
+    // `localhost` is a WHATWG-URL-valid placeholder; libpq picks up the
+    // socket from the `host=` query param. See doc comment above.
+    return `postgresql://${auth}@localhost/${encodeURIComponent(database)}?${params.toString()}`;
   }
   return `postgresql://${auth}@${transport.host}:${transport.port}/${encodeURIComponent(database)}`;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260520.3",
+  "version": "2.260520.4",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## The bug
omni-api crashlooped on every install where the canonical pgserve UDS was reachable:
```
Failed to start API server: TypeError [ERR_INVALID_URL]: <redacted> cannot be parsed as a URL.
```
Discovered during the v2.260520.4 dogfood install on this host.

## Root cause
`buildDatabaseUrlForTransport` for UDS transports produced:
```
postgresql://postgres:postgres@/omni?host=/run/user/1000/pgserve&port=5432
```
libpq accepts this (empty authority + `host=` query param) but Node's WHATWG URL constructor rejects it with `Invalid URL` (empty authority between `@` and `/` is malformed per the URL spec). omni-api validates `DATABASE_URL` at startup via `new URL(...)`, so every retry hit the same error: 20+ restarts/min, never reached the database.

## Fix
Insert `localhost` as a placeholder host:
```
postgresql://postgres:postgres@localhost/omni?host=/run/user/1000/pgserve&port=5432
```
WHATWG-valid; libpq honors the `host=` query param (overrides the URL host), so the actual connection still dials the socket — placeholder is never reached. Net behavior unchanged at the postgres layer; net behavior fixed at the URL-validation layer.

Tests now assert exact UDS URL shape AND smoke-test `new URL(url)` so a regression that drops the placeholder is caught immediately.

## Validated
- `bun test pgserve-transport.test.ts` — 15 pass / 0 fail
- `bun run typecheck` — clean

## Dogfood impact
Once merged + released, the omni v2.260520.5 (or higher) install on this host will let omni-api actually start against the canonical pgserve UDS. Final piece to deliver autopg + genie + omni all healthy on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)