### PR TITLE
fix(transport): UDS URL is plain @localhost/db — postgres.js rejects ?host=

### DIFF
--- a/packages/cli/src/__tests__/pgserve-transport.test.ts
+++ b/packages/cli/src/__tests__/pgserve-transport.test.ts
@@ -91,19 +91,16 @@ describe('socket path helpers', () => {
 });
 
 describe('buildDatabaseUrlForTransport', () => {
-  test('produces UDS shape with host+port query params (whatwg-url valid)', () => {
+  test('produces plain UDS shape (no libpq host= param — postgres.js rejects it)', () => {
     const url = buildDatabaseUrlForTransport({ kind: 'unix', socketDir: '/run/user/1000/pgserve', port: 5432 }, 'omni');
-    // postgres.js / libpq accepts host=<dir> in query params to dial a Unix
-    // socket at <dir>/.s.PGSQL.<port>. URLSearchParams encodes the slashes.
-    // The `localhost` placeholder host is required so Node's WHATWG URL
-    // constructor accepts the string (the previous `@/db` form rejected
-    // with "Invalid URL", crashlooping omni-api at startup).
-    expect(url).toBe('postgresql://postgres:postgres@localhost/omni?host=%2Frun%2Fuser%2F1000%2Fpgserve&port=5432');
-    // Smoke-test the whatwg parser explicitly so a future regression
-    // (e.g. dropping the placeholder host) is caught.
+    // postgres.js rejects URLs carrying the libpq `?host=` query param with
+    // "unrecognized configuration parameter host". Socket routing happens
+    // via the PGHOST/PGPORT env vars (buildRuntimeEnv); the URL itself is
+    // a plain `@localhost/db` form so postgres.js parses it without error.
+    expect(url).toBe('postgresql://postgres:postgres@localhost/omni');
+    // No query string at all — guards against a regression that adds one back.
     const parsed = new URL(url);
-    expect(parsed.searchParams.get('host')).toBe('/run/user/1000/pgserve');
-    expect(parsed.searchParams.get('port')).toBe('5432');
+    expect(parsed.search).toBe('');
   });
 
   test('produces TCP shape with explicit host:port', () => {

--- a/packages/cli/src/__tests__/runtime-env.test.ts
+++ b/packages/cli/src/__tests__/runtime-env.test.ts
@@ -182,18 +182,16 @@ describe('UDS-preference (pgserve-singleton-no-proxy G1)', () => {
     }
   });
 
-  test('buildCanonicalSocketDatabaseUrl produces a libpq-compat UDS shape (whatwg-url valid)', () => {
+  test('buildCanonicalSocketDatabaseUrl produces a plain @localhost/db form (no libpq host= param)', () => {
     process.env.XDG_RUNTIME_DIR = '/run/user/1000';
     const url = buildCanonicalSocketDatabaseUrl();
-    // Post WHATWG-URL-compat fix: placeholder `localhost` host required
-    // so Node's URL parser accepts the string. The previous form
-    // (`@/omni?...`) was libpq-valid but rejected by WHATWG, which
-    // crashlooped omni-api at startup. libpq still routes to the socket
-    // via the host= query param.
-    expect(url.startsWith('postgresql://postgres:postgres@localhost/omni?')).toBe(true);
+    // postgres.js rejects URLs carrying the libpq `?host=` query param
+    // ("unrecognized configuration parameter host"). Socket routing happens
+    // via the PGHOST/PGPORT env vars (buildRuntimeEnv); URL is a plain
+    // `@localhost/db` form so postgres.js parses it without error.
+    expect(url).toBe('postgresql://postgres:postgres@localhost/omni');
     const parsed = new URL(url);
-    expect(parsed.searchParams.get('host')).toBe('/run/user/1000/pgserve');
-    expect(parsed.searchParams.get('port')).toBe('5432');
+    expect(parsed.search).toBe('');
   });
 
   test('resolveDatabaseUrl falls back to TCP embedded URL when UDS is absent', () => {

--- a/packages/cli/src/lib/pgserve-transport.ts
+++ b/packages/cli/src/lib/pgserve-transport.ts
@@ -104,21 +104,25 @@ export function probeCanonicalSocketSync(): boolean {
 
 /**
  * Build a `postgresql://` URL pointing at the given transport, using the
- * supplied database name. Mirrors the URL shapes documented in
- * SHARED-DESIGN.md §5.3 (omni-side scope).
+ * supplied database name.
  *
- * UDS shape: `postgresql://postgres:postgres@localhost/omni?host=/run/user/1000/pgserve&port=5432`
+ * UDS shape: `postgresql://postgres:postgres@localhost/omni` (plain — no
+ *   libpq `?host=` query param). Socket routing happens via the
+ *   PGHOST/PGPORT env vars `buildRuntimeEnv` publishes alongside this URL.
  * TCP shape: `postgresql://postgres:postgres@127.0.0.1:5432/omni`
  *
- * UDS placeholder host (`localhost`) is intentional. The previous form
- * `postgresql://user:pass@/db?host=…` is libpq-valid but rejects when
- * parsed by Node's WHATWG `URL()` constructor with "Invalid URL"
- * (empty authority between `@` and `/`). omni-api's startup pipeline
- * runs `new URL(DATABASE_URL)` for validation/redaction, which
- * crashloops `omni-api` with `TypeError [ERR_INVALID_URL]` whenever
- * the canonical UDS is reachable. libpq still routes to the socket
- * because the `host=` query parameter overrides the URL host —
- * placeholder is never dialed.
+ * Why no `?host=` for UDS: postgres.js (omni-api's client) rejects URLs
+ * carrying the libpq `?host=` query parameter with the error
+ * `unrecognized configuration parameter "host"`. That parameter is a
+ * libpq-only convention; postgres.js parses URL query params strictly as
+ * connection options and bails. Earlier iterations of this helper tried
+ * three shapes that all failed for postgres.js:
+ *   - `postgresql://user:pass@/db?host=/sock` → Node WHATWG URL: Invalid URL
+ *   - `postgresql://user:pass@localhost/db?host=/sock` → postgres.js:
+ *     "unrecognized configuration parameter host"
+ * The working shape is the plain `@localhost/db` form, with the actual
+ * socket path supplied to postgres.js via PGHOST/PGPORT env vars (which
+ * postgres.js inherits as connection defaults).
  *
  * The username/password pair is preserved (not derived from the transport)
  * because omni's pgserve consumer keeps libpq peer-auth via password —
@@ -136,13 +140,10 @@ export function buildDatabaseUrlForTransport(
   const password = options.password ?? 'postgres';
   const auth = `${encodeURIComponent(username)}:${encodeURIComponent(password)}`;
   if (transport.kind === 'unix') {
-    const params = new URLSearchParams({
-      host: transport.socketDir,
-      port: String(transport.port),
-    });
-    // `localhost` is a WHATWG-URL-valid placeholder; libpq picks up the
-    // socket from the `host=` query param. See doc comment above.
-    return `postgresql://${auth}@localhost/${encodeURIComponent(database)}?${params.toString()}`;
+    // Plain `@localhost/db` form — postgres.js parses cleanly; PGHOST/PGPORT
+    // env vars (set by buildRuntimeEnv) route the actual connection to the
+    // canonical Unix socket. See doc comment above.
+    return `postgresql://${auth}@localhost/${encodeURIComponent(database)}`;
   }
   return `postgresql://${auth}@${transport.host}:${transport.port}/${encodeURIComponent(database)}`;
 }


### PR DESCRIPTION
Final layer of the postgres.js socket-routing fix. PR #644 set PGHOST/PGPORT in env, but postgres.js still rejected the URL because of the libpq `?host=` query parameter it carried.

```
postgres('postgresql://...@localhost/omni?host=%2F.../pgserve&port=5432')
  → FAIL "unrecognized configuration parameter host"

postgres('postgresql://...@localhost/omni')   // plain URL
  → SUCCESS (PGHOST/PGPORT in env route to socket)
```

Fix: `buildDatabaseUrlForTransport` UDS branch returns a plain `@localhost/db` URL with no query string. Socket routing happens via PGHOST/PGPORT.

Validated: bun test → 32 pass / 0 fail; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)