### PR TITLE
feat(install): omni dedicated-role cutover — scoped non-superuser identity

### DIFF
--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -32,6 +32,8 @@ import { gunzipSync, gzipSync } from 'node:zlib';
 import { loadServerConfig } from '../config.js';
 import * as output from '../output.js';
 import { canonicalPgserveInstallHint, resolvePgserveBinary } from './canonical-pgserve-binary.js';
+import { resolvePgserveSocketDir } from './pgserve-transport.js';
+import { ensureOmniScopedRole } from './role-cutover.js';
 
 /**
  * Probe the canonical pgserve binary (autopg v3 or pgserve v2 fallback)
@@ -288,6 +290,20 @@ export async function setupCanonicalPgserve(): Promise<string | null> {
   // can rerun `omni doctor --fix` later. The URL is still returned so
   // the caller persists the correct port even when DB creation lags.
   await ensureOmniDatabaseExists(port);
+  // Provision the dedicated non-superuser role scoped to the omni DB.
+  // Best-effort: failure logs a warning and falls back to legacy
+  // postgres:postgres at omni-api startup via the sentinel-missing path
+  // in buildRuntimeEnv. Kill switch: OMNI_ROLE_CUTOVER=0.
+  const cutover = await ensureOmniScopedRole({
+    socketDir: resolvePgserveSocketDir(),
+    port,
+    database: OMNI_DATABASE_NAME,
+  });
+  if (cutover.status === 'provisioned' || cutover.status === 'refreshed') {
+    output.raw(`  Scoped role \`${cutover.roleName}\` ${cutover.status} — omni-api will connect as non-superuser.`);
+  } else if (cutover.status === 'skipped' && cutover.reason !== 'disabled') {
+    output.warn(`Scoped-role cutover skipped: ${cutover.reason} — omni-api falls back to postgres superuser.`);
+  }
   return buildOmniDatabaseUrl(port);
 }
 

--- a/packages/cli/src/lib/role-cutover.ts
+++ b/packages/cli/src/lib/role-cutover.ts
@@ -1,0 +1,336 @@
+/**
+ * Dedicated-role cutover — omni-side scoped non-superuser identity.
+ *
+ * Wish parity: mirrors genie's `src/lib/role-cutover.ts` (the
+ * `genie-dedicated-role-cutover` wish). Omni historically connected to
+ * canonical pgserve/autopg as the cluster superuser `postgres:postgres`.
+ * A bad omni migration or a compromised omni-api could therefore
+ * `DROP DATABASE genie`, exhaust the cluster, create roles, etc. —
+ * the same blast-radius problem genie solved with role-cutover.
+ *
+ * This module provisions a dedicated NON-superuser role scoped to omni's
+ * own `omni` database, persists the credential in a sentinel file, and
+ * is consumed by `buildRuntimeEnv` to rewrite `DATABASE_URL` to the
+ * scoped role at omni-api startup.
+ *
+ * Scope (MVP):
+ *   - Provision `pgserve_omni_<fp12>_role` with grants scoped to `omni` DB
+ *   - Generate a random password at provisioning, persist in sentinel
+ *   - Idempotent: existing role → refresh grants, regenerate sentinel from
+ *     password (preserves the operator-visible role identifier)
+ *   - Kill switch: `OMNI_ROLE_CUTOVER=0` forces legacy `postgres`/`postgres`
+ *   - Best-effort: any failure logs a warning and falls back to legacy creds
+ *
+ * Out of scope (deferred to a follow-up wish, matching genie's groups):
+ *   - Advisory-lock concurrency guards (multi-host simultaneous installs)
+ *   - Full event sink with audit log + sentinel rotation
+ *   - Per-tenant fingerprint stability handling beyond package.json
+ *   - doctor.ts validation that the scoped role is in active use
+ *   - Migration of pre-cutover objects' ownership to the scoped role
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// ============================================================================
+// Naming
+// ============================================================================
+
+const NAME_PREFIX = 'pgserve_';
+const ROLE_SUFFIX = '_role';
+const POSTGRES_MAX_IDENT = 63;
+const FINGERPRINT_HEX_LEN = 12;
+const OMNI_PUBLISHER = 'omni';
+
+const SAFE_IDENT = /^[a-z_][a-z0-9_]*$/;
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+function sanitizeSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/__+/g, '_');
+}
+
+/**
+ * Compute the scoped role name for an omni install. Deterministic — same
+ * install always produces the same role name across reruns.
+ */
+export function deriveOmniScopedRoleName(): string {
+  // Stable fingerprint: sha256 of the @automagik/omni package name. omni is
+  // single-publisher (unlike genie which can be installed in multiple
+  // workspace contexts), so we don't need to walk to find a package dir.
+  // If multi-install support is needed later, hash the install dir too.
+  const fp = sha256Hex('@automagik/omni').slice(0, FINGERPRINT_HEX_LEN);
+  const slug = sanitizeSlug(OMNI_PUBLISHER);
+  const budget = POSTGRES_MAX_IDENT - NAME_PREFIX.length - 1 - fp.length - ROLE_SUFFIX.length;
+  const truncated = slug.slice(0, Math.max(0, budget));
+  return `${NAME_PREFIX}${truncated}_${fp}${ROLE_SUFFIX}`;
+}
+
+function assertSafeIdent(label: string, value: string): void {
+  if (!SAFE_IDENT.test(value)) {
+    throw new Error(`role-cutover: unsafe ${label} identifier: ${JSON.stringify(value)}`);
+  }
+}
+
+function assertSafePassword(value: string): void {
+  // Lock down to alphanumeric only — we generate the password ourselves,
+  // so this is a defense-in-depth check before string-interpolating into
+  // SQL. Real-world the regex matches base64url-without-padding.
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new Error('role-cutover: generated password contains unsafe characters');
+  }
+}
+
+// ============================================================================
+// Sentinel: persist the provisioned credential for buildRuntimeEnv
+// ============================================================================
+
+export interface OmniRoleCutoverSentinel {
+  /** The provisioned role name (matches deriveOmniScopedRoleName output). */
+  roleName: string;
+  /** Database the role is scoped to (always `omni`). */
+  database: string;
+  /** Generated password (alphanumeric). */
+  password: string;
+  /** ISO timestamp of provisioning. */
+  provisionedAt: string;
+}
+
+function sentinelDir(): string {
+  return join(homedir(), '.omni');
+}
+
+function sentinelPath(): string {
+  return join(sentinelDir(), 'scoped-role.json');
+}
+
+export function readOmniCutoverSentinel(): OmniRoleCutoverSentinel | null {
+  const path = sentinelPath();
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as OmniRoleCutoverSentinel;
+    if (
+      typeof parsed.roleName === 'string' &&
+      typeof parsed.database === 'string' &&
+      typeof parsed.password === 'string' &&
+      typeof parsed.provisionedAt === 'string'
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Malformed sentinel — treat as missing.
+  }
+  return null;
+}
+
+function writeOmniCutoverSentinel(data: OmniRoleCutoverSentinel): void {
+  const dir = sentinelDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = sentinelPath();
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function clearOmniCutoverSentinel(): void {
+  try {
+    unlinkSync(sentinelPath());
+  } catch {
+    // Already gone — nothing to clear.
+  }
+}
+
+// ============================================================================
+// Kill-switch
+// ============================================================================
+
+export function isOmniRoleCutoverEnabled(): boolean {
+  return process.env.OMNI_ROLE_CUTOVER !== '0';
+}
+
+// ============================================================================
+// Provisioning
+// ============================================================================
+
+function generatePassword(): string {
+  // 32 bytes → 43 chars base64url (no padding). Always alphanumeric + `_-`.
+  return randomBytes(32).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export interface EnsureOmniScopedRoleOptions {
+  /** Path to autopg's canonical Unix socket dir (e.g. /run/user/1000/pgserve). */
+  socketDir: string;
+  /** Canonical port (default 5432). */
+  port?: number;
+  /** Database to scope grants to (default 'omni'). */
+  database?: string;
+  /** Force-enable bypassing the OMNI_ROLE_CUTOVER kill switch (tests). */
+  enabled?: boolean;
+}
+
+export type EnsureOmniScopedRoleResult =
+  | { status: 'provisioned' | 'refreshed'; roleName: string }
+  | { status: 'skipped'; reason: string };
+
+/**
+ * Idempotently provision omni's scoped role + grants on canonical pgserve.
+ *
+ * Side effects:
+ *   - CREATE ROLE if not exists (or ALTER PASSWORD if exists to keep sentinel in sync)
+ *   - GRANTs scoped to the omni database
+ *   - Sentinel written at ~/.omni/scoped-role.json
+ *
+ * Failure mode: best-effort. Any psql / spawn failure returns
+ * `{ status: 'skipped', reason }` and emits a stderr warn. omni-api
+ * continues with the legacy `postgres:postgres` path.
+ */
+export async function ensureOmniScopedRole(opts: EnsureOmniScopedRoleOptions): Promise<EnsureOmniScopedRoleResult> {
+  const enabled = opts.enabled ?? isOmniRoleCutoverEnabled();
+  if (!enabled) {
+    return { status: 'skipped', reason: 'disabled' };
+  }
+  const database = opts.database ?? 'omni';
+  const port = opts.port ?? 5432;
+  const roleName = deriveOmniScopedRoleName();
+  try {
+    assertSafeIdent('role', roleName);
+    assertSafeIdent('database', database);
+  } catch (err) {
+    return { status: 'skipped', reason: (err as Error).message };
+  }
+  // Reuse existing sentinel password when the role already exists, so we
+  // don't have to ALTER PASSWORD every install (less log noise, no race
+  // window where the sentinel and server are out of sync).
+  const existing = readOmniCutoverSentinel();
+  const password =
+    existing && existing.roleName === roleName && existing.database === database
+      ? existing.password
+      : generatePassword();
+  try {
+    assertSafePassword(password);
+  } catch (err) {
+    return { status: 'skipped', reason: (err as Error).message };
+  }
+  const sqlScript = [
+    // Idempotent role creation with password set inline. ALTER ROLE updates
+    // the password when the role already exists — keeps sentinel + server
+    // synchronized even if the operator regenerated the sentinel.
+    `DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${roleName}') THEN
+    CREATE ROLE "${roleName}" WITH LOGIN PASSWORD '${password}'
+      NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+  ELSE
+    ALTER ROLE "${roleName}" WITH LOGIN PASSWORD '${password}'
+      NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+  END IF;
+END
+$$;`,
+    // Database-level grants.
+    `GRANT CONNECT, TEMPORARY ON DATABASE "${database}" TO "${roleName}";`,
+  ];
+  // Run the role + database-grants script on the postgres database.
+  const dbCreateOk = await runPsql(sqlScript.join('\n'), { socketDir: opts.socketDir, port, database: 'postgres' });
+  if (!dbCreateOk) {
+    return { status: 'skipped', reason: 'psql role provisioning failed' };
+  }
+  // Schema/object grants must be applied inside the target database.
+  const grantsScript = [
+    `GRANT USAGE, CREATE ON SCHEMA public TO "${roleName}";`,
+    `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${roleName}";`,
+    `GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO "${roleName}";`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${roleName}";`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO "${roleName}";`,
+    `ALTER DEFAULT PRIVILEGES FOR ROLE "${roleName}" IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${roleName}";`,
+    `ALTER DEFAULT PRIVILEGES FOR ROLE "${roleName}" IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO "${roleName}";`,
+  ].join('\n');
+  const grantsOk = await runPsql(grantsScript, { socketDir: opts.socketDir, port, database });
+  if (!grantsOk) {
+    return { status: 'skipped', reason: 'psql grant step failed' };
+  }
+  writeOmniCutoverSentinel({
+    roleName,
+    database,
+    password,
+    provisionedAt: new Date().toISOString(),
+  });
+  return existing && existing.roleName === roleName
+    ? { status: 'refreshed', roleName }
+    : { status: 'provisioned', roleName };
+}
+
+interface PsqlOptions {
+  socketDir: string;
+  port: number;
+  database: string;
+}
+
+async function runPsql(sql: string, opts: PsqlOptions): Promise<boolean> {
+  const proc = Bun.spawn({
+    cmd: [
+      'psql',
+      '-h',
+      opts.socketDir,
+      '-p',
+      String(opts.port),
+      '-U',
+      'postgres',
+      '-d',
+      opts.database,
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-c',
+      sql,
+    ],
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, PGPASSWORD: 'postgres' },
+  });
+  const stderr = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  if (code !== 0) {
+    process.stderr.write(`role-cutover: psql exited ${code}: ${stderr.trim()}\n`);
+    return false;
+  }
+  return true;
+}
+
+// ============================================================================
+// Runtime credential resolution (consumed by buildRuntimeEnv)
+// ============================================================================
+
+export interface ScopedCredentialOverride {
+  username: string;
+  password: string;
+  roleName: string;
+}
+
+/**
+ * Returns the scoped-role credentials to override `postgres:postgres` with
+ * at runtime, or null when cutover is disabled / sentinel missing / kill
+ * switch active. Pure: no DB roundtrip.
+ *
+ * Consumed by buildRuntimeEnv when constructing DATABASE_URL.
+ */
+export function resolveOmniScopedCredentials(): ScopedCredentialOverride | null {
+  if (!isOmniRoleCutoverEnabled()) return null;
+  const sentinel = readOmniCutoverSentinel();
+  if (!sentinel) return null;
+  const expected = deriveOmniScopedRoleName();
+  if (sentinel.roleName !== expected) {
+    // Stale sentinel from an old install — ignore until next provisioning.
+    return null;
+  }
+  return {
+    username: sentinel.roleName,
+    password: sentinel.password,
+    roleName: sentinel.roleName,
+  };
+}

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -34,6 +34,7 @@ import {
   probeCanonicalSocketSync,
   resolvePgserveSocketDir,
 } from './lib/pgserve-transport.js';
+import { resolveOmniScopedCredentials } from './lib/role-cutover.js';
 
 /**
  * Environment object suitable for passing to `runPm2` as `envOverrides`
@@ -175,6 +176,24 @@ export function resolveDatabaseUrl(serverConfig: ServerConfig): string {
 }
 
 /**
+ * Replace the userinfo in a postgresql:// URL with the scoped-role
+ * credentials. Returns the URL unchanged when `creds` is null. Pure;
+ * URL-safe via WHATWG URL.
+ */
+export function applyScopedCredentials(url: string, creds: { username: string; password: string } | null): string {
+  if (!creds) return url;
+  try {
+    const parsed = new URL(url);
+    parsed.username = encodeURIComponent(creds.username);
+    parsed.password = encodeURIComponent(creds.password);
+    return parsed.toString();
+  } catch {
+    // Malformed URL — return as-is rather than risk a startup-time throw.
+    return url;
+  }
+}
+
+/**
  * Build the complete runtime env for the omni-api process.
  *
  * All values come from `serverConfig` / `cliConfig`. No shell env reads.
@@ -200,9 +219,15 @@ export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config): 
   const udsActive = probeCanonicalSocketSync();
   const pgHost = udsActive ? resolvePgserveSocketDir() : '';
   const pgPort = udsActive ? String(CANONICAL_PG_PORT) : '';
+  // Dedicated-role cutover (mirror of genie's role-cutover): when the
+  // scoped role has been provisioned and the sentinel is present, swap
+  // `postgres:postgres` for `<scoped_role>:<scoped_password>` in
+  // DATABASE_URL. Falls back to the legacy superuser path when the
+  // sentinel is absent or OMNI_ROLE_CUTOVER=0.
+  const scopedCreds = resolveOmniScopedCredentials();
   return {
     API_PORT: String(serverConfig.port),
-    DATABASE_URL: resolveDatabaseUrl(serverConfig),
+    DATABASE_URL: applyScopedCredentials(resolveDatabaseUrl(serverConfig), scopedCreds),
     PGHOST: pgHost,
     PGPORT: pgPort,
     OMNI_API_KEY: cliConfig.apiKey ?? '',


### PR DESCRIPTION
## Goal
Mirror genie's role-cutover for omni. omni-api previously connected as cluster superuser `postgres:postgres` — a bad migration could `DROP DATABASE genie`, exhaust the cluster, etc. This delivers genie's defense-in-depth for omni.

## What lands
- NEW `packages/cli/src/lib/role-cutover.ts` (~280 lines — MVP subset of genie's 737-line module: single-tenant, simpler fingerprint)
- Provisions `pgserve_omni_<fp12>_role` with `NOSUPERUSER NOCREATEDB NOCREATEROLE`, grants scoped to the `omni` database
- Generates random 32-byte base64url password at provisioning; persists to `~/.omni/scoped-role.json` (mode 0600)
- Idempotent via `DO ... IF NOT EXISTS` block + set-style grants
- Kill switch: `OMNI_ROLE_CUTOVER=0`
- Best-effort: any psql failure → `{ status: skipped }` + stderr warn → omni-api continues on legacy creds

## Wiring
- `setupCanonicalPgserve` calls `ensureOmniScopedRole` after `ensureOmniDatabaseExists`
- `buildRuntimeEnv` reads sentinel via `resolveOmniScopedCredentials` and swaps URL userinfo via new `applyScopedCredentials` helper. Falls back unchanged when sentinel absent / kill-switch / stale.

## Out of scope (deliberate; follow-up wishes)
- Advisory-lock concurrency for multi-host simultaneous installs
- Full event sink + audit log
- `doctor.ts` validation that the scoped role is in active use
- Migration of pre-cutover object ownership

## Validated
- `bun test packages/cli/src/__tests__/` — 459 pass / 0 fail
- `bun run typecheck` — clean
- `biome check` — clean

## After release
On Felipe's host, `omni install --non-interactive` will:
1. Auto-create `omni` DB (PR #643)
2. **Provision `pgserve_omni_<fp12>_role`** (this PR)
3. omni-api starts with `<scoped_role>:<password>` credentials, not superuser
4. `DROP DATABASE genie` from inside omni-api now fails with `permission denied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)