### PR TITLE
fix(cutover): GRANT CREATE ON DATABASE + pre-create pgcrypto for migrations

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -629,6 +629,13 @@ Module: pm2-logrotate
 });
 
 describe('runDoctor — --fix mode', () => {
+  beforeEach(() => {
+    // Force legacy `postgres:postgres` URL — the scoped-role sentinel
+    // on Felipe's dogfood host would otherwise rewrite DATABASE_URL
+    // and break the legacy-shape assertion below.
+    process.env.OMNI_ROLE_CUTOVER = '0';
+  });
+
   test('healthy state is a no-op under --fix (no fixes recorded)', async () => {
     const { VERSION } = await import('../version.js');
     const state = mkHarness({ serverVersion: VERSION });
@@ -659,7 +666,11 @@ describe('runDoctor — --fix mode', () => {
     expect(startCall).toBeDefined();
     // The env passed to pm2 must NOT contain the polluted garbage URL.
     expect(startCall?.env?.DATABASE_URL).not.toContain('garbage');
-    expect(startCall?.env?.DATABASE_URL).toMatch(/postgres@(\/omni\?host=|[^/]+:8432\/omni)/);
+    // Accept three valid shapes:
+    //   - Plain UDS form: postgres@localhost/omni  (PR #645+ post-postgres.js fix)
+    //   - Legacy UDS w/ libpq: postgres@localhost/omni?host=… (pre-#645)
+    //   - TCP fallback: postgres@<host>:8432/omni
+    expect(startCall?.env?.DATABASE_URL).toMatch(/postgres@(localhost\/omni|[^/]+:8432\/omni)/);
     // Recheck sees the drift as fixed.
     const drift = report.checks.find((c) => c.id === 'pm2-env-drift');
     expect(drift?.level).toBe('OK');

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -779,6 +779,10 @@ describe('runDoctor — mutation safety', () => {
   }
 
   beforeEach(() => {
+    // Disable role-cutover sentinel reads so buildRuntimeEnv assertions
+    // see the legacy postgres:postgres URL on hosts where the sentinel
+    // file exists (Felipe's dogfood host).
+    process.env.OMNI_ROLE_CUTOVER = '0';
     // Populate a fake pgserve data directory with known files.
     rmSync(FIXTURE_DIR, { recursive: true, force: true });
     mkdirSync(FIXTURE_DIR, { recursive: true });

--- a/packages/cli/src/__tests__/runtime-env.test.ts
+++ b/packages/cli/src/__tests__/runtime-env.test.ts
@@ -40,9 +40,15 @@ function clearShellDbUrl(): void {
  * the assertions that target the embedded URL would flake on those hosts.
  */
 let prevXdg: string | undefined;
+let prevCutover: string | undefined;
 beforeEach(() => {
   prevXdg = process.env.XDG_RUNTIME_DIR;
   process.env.XDG_RUNTIME_DIR = '/var/empty';
+  // Disable role-cutover sentinel reads for the legacy hermetic-env
+  // assertions. Tests that need to verify the cutover credential
+  // override can opt back in by setting OMNI_ROLE_CUTOVER unset.
+  prevCutover = process.env.OMNI_ROLE_CUTOVER;
+  process.env.OMNI_ROLE_CUTOVER = '0';
 });
 afterEach(() => {
   if (prevXdg === undefined) {
@@ -54,6 +60,12 @@ afterEach(() => {
     delete process.env[key];
   } else {
     process.env.XDG_RUNTIME_DIR = prevXdg;
+  }
+  if (prevCutover === undefined) {
+    const key = 'OMNI_ROLE_CUTOVER';
+    delete process.env[key];
+  } else {
+    process.env.OMNI_ROLE_CUTOVER = prevCutover;
   }
 });
 

--- a/packages/cli/src/lib/role-cutover.ts
+++ b/packages/cli/src/lib/role-cutover.ts
@@ -233,8 +233,14 @@ BEGIN
   END IF;
 END
 $$;`,
-    // Database-level grants.
-    `GRANT CONNECT, TEMPORARY ON DATABASE "${database}" TO "${roleName}";`,
+    // Database-level grants. CREATE on the database is required so Drizzle
+    // migrations can `CREATE SCHEMA "drizzle"` (the migration-tracker schema)
+    // and `CREATE EXTENSION IF NOT EXISTS pgcrypto` from non-superuser. Without
+    // this, omni-api boots, passes waitForDatabaseReady (SELECT 1 succeeds),
+    // and then crashes with `PostgresError: permission denied for database
+    // omni` on the first Drizzle migrate call. Mirror of genie's
+    // `ensurePrivilegedBootstrapObjects` pattern.
+    `GRANT CONNECT, TEMPORARY, CREATE ON DATABASE "${database}" TO "${roleName}";`,
   ];
   // Run the role + database-grants script on the postgres database.
   const dbCreateOk = await runPsql(sqlScript.join('\n'), { socketDir: opts.socketDir, port, database: 'postgres' });
@@ -242,7 +248,14 @@ $$;`,
     return { status: 'skipped', reason: 'psql role provisioning failed' };
   }
   // Schema/object grants must be applied inside the target database.
+  // ALTER SCHEMA public OWNER mirrors genie's pattern: the scoped role
+  // owns the public schema so it can do schema DDL (ALTER TABLE, CREATE
+  // INDEX, etc.) in Drizzle migrations. pgcrypto pre-create lets a
+  // non-superuser migration that calls CREATE EXTENSION IF NOT EXISTS
+  // pgcrypto succeed as a no-op (untrusted extensions = superuser-only).
   const grantsScript = [
+    'CREATE EXTENSION IF NOT EXISTS pgcrypto;',
+    `ALTER SCHEMA public OWNER TO "${roleName}";`,
     `GRANT USAGE, CREATE ON SCHEMA public TO "${roleName}";`,
     `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${roleName}";`,
     `GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO "${roleName}";`,


### PR DESCRIPTION
Found during dogfood of v2.260520.11.

`waitForDatabaseReady` (SELECT 1) passes with the scoped role, but the first Drizzle migrate call fails with `PostgresError: permission denied for database omni`. Drizzle's migrate runs `CREATE SCHEMA "drizzle"` which needs CREATE on the database — not just CONNECT.

Fix:
- `GRANT CONNECT, TEMPORARY, **CREATE** ON DATABASE` (was just CONNECT, TEMPORARY)
- `ALTER SCHEMA public OWNER TO scoped_role` (genie pattern)
- Pre-create pgcrypto extension as superuser (untrusted ext = superuser-only; `CREATE EXTENSION IF NOT EXISTS pgcrypto` in migrations short-circuits)

Tests:
- Tests now set `OMNI_ROLE_CUTOVER=0` so they read legacy postgres:postgres URLs (the live sentinel on Felipe's dogfood host was rewriting URLs and breaking 5 existing buildRuntimeEnv assertions).
- pm2-env-drift regex updated to accept post-#645 plain `@localhost/omni` URL shape.

Validated: bun test → 459 pass / 0 fail; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)