### PR TITLE
fix(doctor): detect partial embedded→canonical migration by row-count compare

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -542,30 +542,43 @@ async function checkEmbeddedDataOrphaned(deps: DoctorDeps): Promise<CheckResult>
       detail: 'canonical not reachable yet — embedded check deferred',
     };
   }
-  // Read instance count via the API health endpoint already deployed at
-  // omni-api. If canonical has zero instances and embedded dir exists →
-  // FAIL with the actionable migration hint.
+  // Detect partial migration: instances may be reconciled by Baileys session
+  // re-attach (auto-recreates instance rows on startup) but the bulk
+  // historical tables (`omni_events`, `messages`, `chats`, etc.) stay empty
+  // until the migration ETL runs. So we compare event-row counts between
+  // embedded and canonical — if embedded has materially more rows than
+  // canonical for ANY of these history tables, the migration is needed.
+  //
+  // Comparison uses a temp spawn against the embedded dir (same primitive
+  // the fix uses), but bounded to ~5s — boot the postmaster, run two count
+  // queries, shut it down. The cost only fires on hosts where the embedded
+  // dir still exists alongside canonical mode, i.e. mid-migration users.
   try {
-    const resp = await fetch(`http://127.0.0.1:${serverConfig.port}/api/v2/health`, {
-      signal: AbortSignal.timeout(2000),
-    });
-    const body = (await resp.json()) as { instances?: { total?: number } };
-    const total = body?.instances?.total ?? 0;
-    if (total === 0) {
+    const { existsSync: fsExists } = await import('node:fs');
+    if (!fsExists(EMBEDDED_PGSERVE_DATA_DIR)) {
+      return { id: 'embedded-data-orphaned', level: 'OK', detail: 'no embedded data to compare' };
+    }
+    const { compareEmbeddedVsCanonicalCounts } = await import('../lib/embedded-canonical-migration.js');
+    const cmp = await compareEmbeddedVsCanonicalCounts({ canonicalPort: 5432 });
+    if (cmp.kind === 'embedded-has-more') {
       return {
         id: 'embedded-data-orphaned',
         level: 'FAIL',
-        detail: `embedded dir at ${EMBEDDED_PGSERVE_DATA_DIR} holds data but canonical omni is empty — run \`omni doctor --fix\` to migrate`,
+        detail: `embedded has ${cmp.embeddedRows} rows in ${cmp.divergentTables.length} tables canonical lacks (${cmp.divergentTables.slice(0, 3).join(', ')}${cmp.divergentTables.length > 3 ? '…' : ''}) — run \`omni doctor --fix\` to migrate`,
       };
     }
     return {
       id: 'embedded-data-orphaned',
       level: 'OK',
-      detail: `canonical omni already has ${total} instance(s)`,
+      detail: cmp.kind === 'in-sync' ? 'embedded ↔ canonical row counts match' : `compare unavailable: ${cmp.reason}`,
     };
-  } catch {
-    // Health unreachable — be silent rather than red-cross.
-    return { id: 'embedded-data-orphaned', level: 'OK', detail: 'health endpoint unreachable — defer' };
+  } catch (err) {
+    // Comparison itself failed — be silent rather than red-cross.
+    return {
+      id: 'embedded-data-orphaned',
+      level: 'OK',
+      detail: `compare unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 }
 

--- a/packages/cli/src/lib/embedded-canonical-migration.ts
+++ b/packages/cli/src/lib/embedded-canonical-migration.ts
@@ -277,6 +277,79 @@ WHERE pg_get_serial_sequence(c.table_schema || '.' || c.table_name, c.column_nam
  * so callers can present an actionable diagnostic without aborting the
  * larger --fix run.
  */
+/**
+ * Result of comparing embedded vs canonical row counts. Used by the
+ * doctor `embedded-data-orphaned` check to detect partial migrations
+ * (e.g. Baileys re-attach copies instance rows but the bulk historical
+ * tables stay empty until the ETL runs).
+ */
+export type CompareResult =
+  | { kind: 'in-sync' }
+  | { kind: 'embedded-has-more'; divergentTables: string[]; embeddedRows: number }
+  | { kind: 'skipped'; reason: string };
+
+export interface CompareOptions {
+  canonicalPort?: number;
+}
+
+/**
+ * Count rows in every public table on both the embedded data dir and the
+ * canonical postmaster, return which tables have MORE rows on embedded.
+ * Boots a temp postmaster against the embedded dir (5s ready window),
+ * runs two count queries, shuts it down. Best-effort: any spawn / query
+ * failure returns `{ kind: 'skipped' }`.
+ */
+export async function compareEmbeddedVsCanonicalCounts(opts: CompareOptions = {}): Promise<CompareResult> {
+  const canonicalPort = opts.canonicalPort ?? 5432;
+  if (!existsSync(EMBEDDED_DIR) || !existsSync(join(EMBEDDED_DIR, 'PG_VERSION'))) {
+    return { kind: 'skipped', reason: 'embedded dir absent' };
+  }
+  const binary = findAutopgPostgresBinary();
+  if (!binary) return { kind: 'skipped', reason: 'autopg postgres binary not found' };
+  const tempPort = await findFreePort();
+  let temp: { stop: () => Promise<void> } | null = null;
+  try {
+    temp = await spawnTempPostmaster(binary, EMBEDDED_DIR, tempPort, () => {});
+    const srcArgs = ['-h', '127.0.0.1', '-p', String(tempPort), '-U', 'postgres', '-d', 'omni'];
+    const dstArgs = ['-h', '127.0.0.1', '-p', String(canonicalPort), '-U', 'postgres', '-d', 'omni'];
+    // Enumerate then count per-table in a loop (simpler + portable across
+    // schema variations than a one-shot aggregate).
+    const tablesRaw = psqlCapture([
+      ...srcArgs,
+      '-tAc',
+      `SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename`,
+    ]);
+    const tables = tablesRaw
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (tables.length === 0) return { kind: 'skipped', reason: 'embedded has no public tables' };
+    const divergent: string[] = [];
+    let totalExtra = 0;
+    for (const t of tables) {
+      try {
+        const em = Number.parseInt(psqlCapture([...srcArgs, '-tAc', `SELECT count(*) FROM public.${t}`]).trim(), 10);
+        const ca = Number.parseInt(psqlCapture([...dstArgs, '-tAc', `SELECT count(*) FROM public.${t}`]).trim(), 10);
+        if (Number.isFinite(em) && Number.isFinite(ca) && em > ca) {
+          divergent.push(t);
+          totalExtra += em - ca;
+        }
+      } catch {
+        // Schema mismatch — table on embedded missing on canonical or vice
+        // versa. Treat as "needs migration" by adding to divergent if it
+        // came from embedded enumeration.
+        divergent.push(t);
+      }
+    }
+    if (divergent.length === 0) return { kind: 'in-sync' };
+    return { kind: 'embedded-has-more', divergentTables: divergent, embeddedRows: totalExtra };
+  } catch (err) {
+    return { kind: 'skipped', reason: err instanceof Error ? err.message : String(err) };
+  } finally {
+    if (temp) await temp.stop();
+  }
+}
+
 export async function migrateUnmountedEmbeddedToCanonical(opts: MigrateOptions = {}): Promise<MigrationResult> {
   const log = opts.log ?? defaultLog;
   const canonicalPort = opts.canonicalPort ?? 5432;


### PR DESCRIPTION
PR #650's check fired on instances=0 only. But Baileys session reattach auto-recreates the instances table on omni-api boot, masking the fact that the bulk history tables (omni_events, messages, chats) are still empty.

Felipe's host: 2 instances on canonical (from reattach) + 0 omni_events (160K on embedded) → check passed → fix never fired.

Fix: new compareEmbeddedVsCanonicalCounts() boots a temp postmaster, counts each public table on both sides, returns divergent tables. Check FAILs when any tables have more rows on embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)