### PR TITLE
fix(api): filter messages by exact externalId

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -169,7 +169,7 @@ Source: `packages/api/src/routes/v2/messages.ts`
 ```yaml
 GET    /api/v2/messages                       # List messages
   Query: chatId?, source?, messageType?, status?, hasMedia?,
-         senderPersonId?, since?, until?, search?, limit (1-100), cursor?
+         senderPersonId?, externalId?, since?, until?, search?, limit (1-100), cursor?
 
 GET    /api/v2/messages/by-external           # Find by external ID
   Query: chatId, externalId

--- a/packages/api/src/__tests__/unified-messages.test.ts
+++ b/packages/api/src/__tests__/unified-messages.test.ts
@@ -316,6 +316,39 @@ describeWithDb('Unified Messages', () => {
       expect(messages.length).toBe(5);
     });
 
+    test('should filter list by exact externalId only', async () => {
+      const externalId = `BAE5EXACT${Date.now()}`;
+      const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-external-${Date.now()}@g.us`, {
+        chatType: 'group',
+        channel: 'whatsapp-baileys',
+      });
+
+      await messageService.create({
+        chatId: chat.id,
+        externalId,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Target message',
+        platformTimestamp: new Date(),
+      });
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `${externalId}-other`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: `Debug log mentions ${externalId}`,
+        platformTimestamp: new Date(Date.now() + 1000),
+      });
+
+      const result = await messageService.list({ externalId });
+      const total = await messageService.count({ externalId });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.externalId).toBe(externalId);
+      expect(result.items[0]?.textContent).toBe('Target message');
+      expect(total).toBe(1);
+    });
+
     test('should mark message as deleted', async () => {
       const { chat } = await chatService.findOrCreate(testInstanceId, 'test-msg-delete@g.us', {
         chatType: 'group',

--- a/packages/api/src/routes/v2/__tests__/messages-date-validation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-date-validation.test.ts
@@ -74,4 +74,17 @@ describe('GET /messages — date parameter validation (#494)', () => {
     expect(calls[0]?.query.since).toBeInstanceOf(Date);
     expect(calls[0]?.query.until).toBeInstanceOf(Date);
   });
+
+  test('passes externalId as an exact-match filter instead of search text', async () => {
+    const calls: ListCall[] = [];
+    const app = mountMessagesRoutes(calls);
+
+    const res = await app.request('/messages?externalId=3EB029FAF90BE7AB265311&limit=5');
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.query.externalId).toBe('3EB029FAF90BE7AB265311');
+    expect(calls[0]?.query.search).toBeUndefined();
+    expect(calls[0]?.query.limit).toBe(5);
+  });
 });

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -290,6 +290,7 @@ const listQuerySchema = z.object({
     .transform((v) => v?.split(',') as z.infer<typeof MessageStatusSchema>[] | undefined),
   hasMedia: z.coerce.boolean().optional(),
   senderPersonId: z.string().uuid().optional(),
+  externalId: z.string().min(1).optional(),
   since: optionalDateParam('since'),
   until: optionalDateParam('until'),
   search: z.string().optional(),

--- a/packages/api/src/services/__tests__/messages-list.test.ts
+++ b/packages/api/src/services/__tests__/messages-list.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import type { Database, Message } from '@omni/db';
+import { isSQLWrapper } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { MessageService } from '../messages';
+
+interface QueryCapture {
+  whereSql?: string;
+  whereParams?: unknown[];
+  limitArg?: number;
+}
+
+function toWhereQuery(condition: unknown): { sql: string; params: unknown[] } {
+  if (!isSQLWrapper(condition)) {
+    throw new Error('Expected a Drizzle SQLWrapper in where()');
+  }
+
+  const query = new PgDialect().sqlToQuery(condition.getSQL());
+  return {
+    sql: query.sql.replace(/\s+/g, ' ').trim().toLowerCase(),
+    params: query.params,
+  };
+}
+
+function createListDbMock(capture: QueryCapture): Database {
+  const where = (condition: unknown) => {
+    const query = toWhereQuery(condition);
+    capture.whereSql = query.sql;
+    capture.whereParams = query.params;
+
+    return {
+      orderBy: () => ({
+        limit: (limitValue: number) => {
+          capture.limitArg = limitValue;
+          return Promise.resolve([] as Array<{ messages: Message }>);
+        },
+      }),
+    };
+  };
+
+  const from = () => ({ where });
+  const select = () => ({ from });
+  return { select } as unknown as Database;
+}
+
+describe('MessageService.list', () => {
+  test('filters externalId as an exact column match, not text search', async () => {
+    const capture: QueryCapture = {};
+    const service = new MessageService(createListDbMock(capture), null);
+
+    await service.list({ externalId: '3EB029FAF90BE7AB265311', includeHidden: true });
+
+    expect(capture.limitArg).toBe(51);
+    expect(capture.whereParams).toContain('3EB029FAF90BE7AB265311');
+    expect(capture.whereSql).toContain('"messages"."external_id" =');
+    expect(capture.whereSql).not.toContain('"messages"."text_content"');
+    expect(capture.whereSql).not.toContain('"messages"."transcription"');
+    expect(capture.whereSql).not.toContain('"messages"."image_description"');
+    expect(capture.whereSql).not.toContain('"messages"."document_extraction"');
+  });
+});

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -32,6 +32,7 @@ export interface ListMessagesOptions {
   status?: MessageStatus[];
   hasMedia?: boolean;
   senderPersonId?: string;
+  externalId?: string;
   since?: Date;
   until?: Date;
   search?: string;
@@ -134,6 +135,7 @@ export class MessageService {
       status,
       hasMedia,
       senderPersonId,
+      externalId,
       since,
       until,
       search,
@@ -153,6 +155,7 @@ export class MessageService {
     if (status?.length) conditions.push(inArray(messages.status, status));
     if (hasMedia !== undefined) conditions.push(eq(messages.hasMedia, hasMedia));
     if (senderPersonId) conditions.push(eq(messages.senderPersonId, senderPersonId));
+    if (externalId) conditions.push(eq(messages.externalId, externalId));
     if (since) conditions.push(gte(messages.platformTimestamp, since));
     if (until) conditions.push(lte(messages.platformTimestamp, until));
     if (search) {


### PR DESCRIPTION
Summary
- adds externalId to GET /api/v2/messages query validation
- filters MessageService list/count with exact messages.external_id match
- documents the query param and adds route/service regression coverage

Validation
- bun test packages/api/src/routes/v2/__tests__/messages-date-validation.test.ts packages/api/src/services/__tests__/messages-list.test.ts packages/api/src/__tests__/unified-messages.test.ts
- bun run build
- pre-push: bun run typecheck and full bun test

Upstream Ravi issue: filipexyz/ravi#50