### PR TITLE
fix(pgserve): canonical default port (5432) + match PG major when reading legacy embedded data

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -670,8 +670,10 @@ describe('runDoctor — --fix mode', () => {
     // Accept three valid shapes:
     //   - Plain UDS form: postgres@localhost/omni  (PR #645+ post-postgres.js fix)
     //   - Legacy UDS w/ libpq: postgres@localhost/omni?host=… (pre-#645)
-    //   - TCP fallback: postgres@<host>:8432/omni
-    expect(startCall?.env?.DATABASE_URL).toMatch(/postgres@(localhost\/omni|[^/]+:8432\/omni)/);
+    //   - TCP fallback: postgres@<host>:<DEFAULT_PGSERVE_PORT>/omni (now canonical 5432)
+    expect(startCall?.env?.DATABASE_URL).toMatch(
+      new RegExp(`postgres@(localhost/omni|[^/]+:${DEFAULT_PGSERVE_PORT}/omni)`),
+    );
     // Recheck sees the drift as fixed.
     const drift = report.checks.find((c) => c.id === 'pm2-env-drift');
     expect(drift?.level).toBe('OK');

--- a/packages/cli/src/__tests__/runtime-env.test.ts
+++ b/packages/cli/src/__tests__/runtime-env.test.ts
@@ -20,6 +20,7 @@ import {
   buildEmbeddedDatabaseUrl,
   buildRuntimeEnv,
   resolveDatabaseUrl,
+  resolvePgservePort,
 } from '../runtime-env.js';
 
 const LEGACY_DEFAULT = 'postgresql://postgres:postgres@localhost:5432/omni';
@@ -76,6 +77,30 @@ describe('buildEmbeddedDatabaseUrl', () => {
 
   test('honors a custom port', () => {
     expect(buildEmbeddedDatabaseUrl(9999)).toBe('postgresql://postgres:postgres@localhost:9999/omni');
+  });
+});
+
+describe('resolvePgservePort', () => {
+  test('falls back to the CANONICAL port (5432), NOT the legacy 8432', () => {
+    // Regression guard: the fallback feeds the PGSERVE_PORT env that
+    // `omni doctor` probes. Defaulting to 8432 false-FAILed pgserve-reachable
+    // on every healthy canonical host.
+    expect(resolvePgservePort(DEFAULT_SERVER_CONFIG)).toBe(CANONICAL_PG_PORT);
+    expect(resolvePgservePort(DEFAULT_SERVER_CONFIG)).toBe(5432);
+  });
+
+  test('honors an explicit server.pgservePort override', () => {
+    const config = { ...DEFAULT_SERVER_CONFIG, pgservePort: 6543 } as typeof DEFAULT_SERVER_CONFIG & {
+      pgservePort: number;
+    };
+    expect(resolvePgservePort(config)).toBe(6543);
+  });
+
+  test('ignores a non-positive / non-finite override and uses canonical', () => {
+    const bad = { ...DEFAULT_SERVER_CONFIG, pgservePort: 0 } as typeof DEFAULT_SERVER_CONFIG & {
+      pgservePort: number;
+    };
+    expect(resolvePgservePort(bad)).toBe(CANONICAL_PG_PORT);
   });
 });
 

--- a/packages/cli/src/lib/__tests__/embedded-canonical-migration.test.ts
+++ b/packages/cli/src/lib/__tests__/embedded-canonical-migration.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { readDataDirMajor } from '../embedded-canonical-migration.js';
+import { compareVersionDesc, readDataDirMajor } from '../embedded-canonical-migration.js';
 
 // readDataDirMajor underpins the matching-major reader selection: the temp
 // postmaster MUST be the same PG major as the data dir's catalog, or it
@@ -43,4 +43,11 @@ test('returns null on a non-numeric PG_VERSION', () => {
     writeFileSync(join(dir, 'PG_VERSION'), 'not-a-version');
     expect(readDataDirMajor(dir)).toBeNull();
   });
+});
+
+test('compareVersionDesc sorts autopg version dirs newest-first, deterministically', () => {
+  const dirs = ['v2.6.1', 'v3.0.7', 'v2.6.10', 'v3.0.6'];
+  expect([...dirs].sort(compareVersionDesc)).toEqual(['v3.0.7', 'v3.0.6', 'v2.6.10', 'v2.6.1']);
+  // numeric (not lexicographic): 2.6.10 must sort above 2.6.1
+  expect(compareVersionDesc('v2.6.10', 'v2.6.1')).toBeLessThan(0);
 });

--- a/packages/cli/src/lib/__tests__/embedded-canonical-migration.test.ts
+++ b/packages/cli/src/lib/__tests__/embedded-canonical-migration.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readDataDirMajor } from '../embedded-canonical-migration.js';
+
+// readDataDirMajor underpins the matching-major reader selection: the temp
+// postmaster MUST be the same PG major as the data dir's catalog, or it
+// refuses to start ("database files are incompatible with server").
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), 'omni-pgver-'));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('reads the PG_VERSION catalog major (17)', () => {
+  withTempDir((dir) => {
+    writeFileSync(join(dir, 'PG_VERSION'), '17\n');
+    expect(readDataDirMajor(dir)).toBe(17);
+  });
+});
+
+test('reads PG_VERSION major 18', () => {
+  withTempDir((dir) => {
+    writeFileSync(join(dir, 'PG_VERSION'), '18');
+    expect(readDataDirMajor(dir)).toBe(18);
+  });
+});
+
+test('returns null when PG_VERSION is absent', () => {
+  withTempDir((dir) => {
+    expect(readDataDirMajor(dir)).toBeNull();
+  });
+});
+
+test('returns null on a non-numeric PG_VERSION', () => {
+  withTempDir((dir) => {
+    writeFileSync(join(dir, 'PG_VERSION'), 'not-a-version');
+    expect(readDataDirMajor(dir)).toBeNull();
+  });
+});

--- a/packages/cli/src/lib/embedded-canonical-migration.ts
+++ b/packages/cli/src/lib/embedded-canonical-migration.ts
@@ -48,8 +48,8 @@
  *     (postgres self-heals stale pidfiles on startup)
  */
 
-import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -72,23 +72,60 @@ function defaultLog(line: string): void {
   process.stdout.write(`${line}\n`);
 }
 
+/** Read the catalog major (e.g. 17, 18) recorded in a data dir's PG_VERSION. */
+export function readDataDirMajor(dataDir: string): number | null {
+  try {
+    const major = Number.parseInt(readFileSync(join(dataDir, 'PG_VERSION'), 'utf8').trim(), 10);
+    return Number.isFinite(major) ? major : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the server major of a `postgres` binary via `postgres --version`. */
+function binaryMajor(binary: string): number | null {
+  try {
+    // e.g. "postgres (PostgreSQL) 17.4" / "... 18.3.0-beta.17"
+    const out = execFileSync(binary, ['--version'], { encoding: 'utf8', timeout: 5000 });
+    const m = out.match(/(\d+)(?:[.\s]|$)/);
+    return m ? Number.parseInt(m[1], 10) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Locate autopg's bundled `postgres` binary. Required for the temp spawn
- * because the embedded data dir's catalog version must match the binary's
- * server version exactly. Returns null when not found — caller surfaces
- * the install-autopg-first hint.
+ * Locate an autopg-bundled `postgres` binary whose server major MATCHES the
+ * embedded data dir's catalog version. A PostgreSQL server refuses to open a
+ * data dir from a different major ("database files are incompatible with
+ * server"), so the temp-postmaster reader MUST match exactly.
+ *
+ * Previously this returned the *last* binary found under
+ * `~/.local/share/autopg/<version>/postgres/bin/postgres` regardless of major.
+ * On a v3-only host (PG 18) reading a legacy PG 17 dir, that handed back PG 18
+ * and the temp postmaster died — surfacing as
+ * "temp postmaster exited before ready" / orphaned data. Now we pick the
+ * matching-major binary and return null when none is installed, so the caller
+ * can tell the operator to install a PG<major> reader instead of silently
+ * failing.
+ *
+ * `wantMajor === null` (unknown data-dir version) falls back to the previous
+ * "last available" behavior.
  */
-function findAutopgPostgresBinary(): string | null {
+function findAutopgPostgresBinary(wantMajor: number | null): string | null {
   const autopgRoot = join(homedir(), '.local', 'share', 'autopg');
   if (!existsSync(autopgRoot)) return null;
-  // Walk to find the highest-version postgres binary at
-  // ~/.local/share/autopg/<version>/postgres/bin/postgres.
-  let bestPath: string | null = null;
+  const candidates: string[] = [];
   for (const entry of safeReaddir(autopgRoot)) {
     const candidate = join(autopgRoot, entry, 'postgres', 'bin', 'postgres');
-    if (existsSync(candidate)) bestPath = candidate;
+    if (existsSync(candidate)) candidates.push(candidate);
   }
-  return bestPath;
+  if (candidates.length === 0) return null;
+  if (wantMajor === null) return candidates[candidates.length - 1];
+  for (const candidate of candidates) {
+    if (binaryMajor(candidate) === wantMajor) return candidate;
+  }
+  return null;
 }
 
 function safeReaddir(path: string): string[] {
@@ -345,8 +382,16 @@ export async function compareEmbeddedVsCanonicalCounts(opts: CompareOptions = {}
   if (!existsSync(EMBEDDED_DIR) || !existsSync(join(EMBEDDED_DIR, 'PG_VERSION'))) {
     return { kind: 'skipped', reason: 'embedded dir absent' };
   }
-  const binary = findAutopgPostgresBinary();
-  if (!binary) return { kind: 'skipped', reason: 'autopg postgres binary not found' };
+  const wantMajor = readDataDirMajor(EMBEDDED_DIR);
+  const binary = findAutopgPostgresBinary(wantMajor);
+  if (!binary) {
+    return {
+      kind: 'skipped',
+      reason: wantMajor
+        ? `no PostgreSQL ${wantMajor} reader under ~/.local/share/autopg (embedded dir is PG ${wantMajor})`
+        : 'autopg postgres binary not found',
+    };
+  }
   const tempPort = await findFreePort();
   let temp: { stop: () => Promise<void> } | null = null;
   try {
@@ -402,11 +447,17 @@ export async function migrateUnmountedEmbeddedToCanonical(opts: MigrateOptions =
     return { status: 'skipped', reason: 'embedded dir missing PG_VERSION' };
   }
 
-  const binary = findAutopgPostgresBinary();
+  const wantMajor = readDataDirMajor(EMBEDDED_DIR);
+  const binary = findAutopgPostgresBinary(wantMajor);
   if (!binary) {
-    return { status: 'skipped', reason: 'autopg postgres binary not found — install autopg first' };
+    return {
+      status: 'skipped',
+      reason: wantMajor
+        ? `no PostgreSQL ${wantMajor} reader installed under ~/.local/share/autopg — your data is PG ${wantMajor}; install a matching autopg/reader so it can be dumped into the canonical cluster`
+        : 'autopg postgres binary not found — install autopg first',
+    };
   }
-  log(`  using postgres binary: ${binary}`);
+  log(`  using postgres binary: ${binary} (matched PG ${wantMajor ?? '?'})`);
 
   // Stop omni-api during the copy. Otherwise omni-api's bootstrap (default
   // global_settings, Baileys instance reattach, etc.) races our COPYs and

--- a/packages/cli/src/lib/embedded-canonical-migration.ts
+++ b/packages/cli/src/lib/embedded-canonical-migration.ts
@@ -109,23 +109,39 @@ function binaryMajor(binary: string): number | null {
  * can tell the operator to install a PG<major> reader instead of silently
  * failing.
  *
- * `wantMajor === null` (unknown data-dir version) falls back to the previous
- * "last available" behavior.
+ * `wantMajor === null` (unknown data-dir version) falls back to the
+ * newest installed binary.
+ *
+ * Candidates are sorted by their `~/.local/share/autopg/<version>` dir name
+ * (newest first, version-aware) so selection is deterministic regardless of
+ * the OS-dependent `readdirSync` order — picking the highest patch within the
+ * wanted major, and the newest overall when the major is unknown.
  */
 function findAutopgPostgresBinary(wantMajor: number | null): string | null {
   const autopgRoot = join(homedir(), '.local', 'share', 'autopg');
   if (!existsSync(autopgRoot)) return null;
-  const candidates: string[] = [];
-  for (const entry of safeReaddir(autopgRoot)) {
-    const candidate = join(autopgRoot, entry, 'postgres', 'bin', 'postgres');
-    if (existsSync(candidate)) candidates.push(candidate);
-  }
+  const candidates = safeReaddir(autopgRoot)
+    .sort((a, b) => compareVersionDesc(a, b))
+    .map((entry) => join(autopgRoot, entry, 'postgres', 'bin', 'postgres'))
+    .filter((candidate) => existsSync(candidate));
   if (candidates.length === 0) return null;
-  if (wantMajor === null) return candidates[candidates.length - 1];
+  if (wantMajor === null) return candidates[0];
   for (const candidate of candidates) {
     if (binaryMajor(candidate) === wantMajor) return candidate;
   }
   return null;
+}
+
+/** Compare two `vX.Y.Z`-ish dir names numerically, newest first. */
+export function compareVersionDesc(a: string, b: string): number {
+  const parse = (s: string): number[] => (s.match(/\d+/g) ?? []).map(Number);
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return b.localeCompare(a);
 }
 
 function safeReaddir(path: string): string[] {

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -70,20 +70,20 @@ const LEGACY_DEFAULT_DATABASE_URL = 'postgresql://postgres:postgres@localhost:54
 const LEGACY_PHASE2_DATABASE_URL = 'postgresql://postgres:postgres@localhost:8432/omni';
 
 /**
- * Default pgserve port when none is set explicitly.
+ * Default pgserve port when none is set explicitly — the CANONICAL port.
  *
  * Phase 2 of the canonical-pgserve cutover (omni#595/#596/#597) used the
  * bun-bridge port `8432`. Phase 3 (`pgserve-singleton-no-proxy`) lands the
- * postmaster directly on **5432** (canonical postgres port) and listens
- * on the canonical UDS at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`.
- *
- * Kept as the module-level default for backwards compatibility with the
- * stored `~/.omni/config.json` entries that still record `8432`. Use
- * {@link resolveDatabaseUrl} as the entry point — it prefers the canonical
- * UDS when available and falls back to the legacy port only when the
- * socket is missing AND the operator hasn't migrated their config.
+ * postmaster directly on **5432** (the canonical postgres port) and listens
+ * on the canonical UDS at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`. There is
+ * no embedded 8432 listener anymore, so the default MUST be canonical — a
+ * hardcoded 8432 here leaked into `resolvePgservePort` (→ the `PGSERVE_PORT`
+ * env that `omni doctor`'s `pgserve-reachable` check probes), making doctor
+ * false-FAIL "cannot connect to pgserve on :8432" on every healthy host.
+ * Stored `8432` entries in `~/.omni/config.json` are treated as a stale
+ * default and re-resolved by {@link resolveDatabaseUrl} (UDS-first).
  */
-export const DEFAULT_PGSERVE_PORT = 8432;
+export const DEFAULT_PGSERVE_PORT = CANONICAL_PG_PORT;
 
 /** Canonical postgres TCP port the postmaster binds in singleton mode. */
 export { CANONICAL_PG_PORT } from './lib/pgserve-transport.js';
@@ -112,9 +112,13 @@ export function buildCanonicalSocketDatabaseUrl(): string {
 
 /**
  * Extract the effective pgserve port. Honors an explicit override on the
- * server config first (`server.pgservePort`, if ever added), then the
- * hard-coded default. This function intentionally does NOT read
- * `process.env.PGSERVE_PORT` — env pollution is the bug we're fixing.
+ * server config first (`server.pgservePort`), then falls back to
+ * {@link DEFAULT_PGSERVE_PORT} — which is now the CANONICAL port (5432), not
+ * the legacy 8432. This value feeds the runtime `PGSERVE_PORT` env that
+ * `omni doctor`'s `pgserve-reachable` check probes.
+ *
+ * This function intentionally does NOT read `process.env.PGSERVE_PORT` —
+ * env pollution is the bug we're fixing.
  */
 export function resolvePgservePort(serverConfig: ServerConfig): number {
   const maybe = (serverConfig as ServerConfig & { pgservePort?: number }).pgservePort;


### PR DESCRIPTION
Two broadly-applicable bugs in the canonical-pgserve path (both reproduced on a real upgraded host).

## 1. `DEFAULT_PGSERVE_PORT` hardcoded 8432 → `omni doctor` false-FAIL
`DEFAULT_PGSERVE_PORT` was `8432` (legacy bun-bridge era). It feeds `resolvePgservePort()` → the `PGSERVE_PORT` runtime env that `omni doctor`'s `pgserve-reachable` check probes. After the phase-3 socket-singleton cutover the canonical backbone binds **5432** over the UDS, so doctor reported:

```
✗ pgserve-reachable    cannot connect to pgserve on :8432
```

on **every healthy canonical host**, even though omni-api connects fine over the socket. Default is now `CANONICAL_PG_PORT` (5432). Stored `8432` entries in `~/.omni/config.json` are still treated as a stale default and re-resolved UDS-first by `resolveDatabaseUrl`.

## 2. `findAutopgPostgresBinary()` ignored PG major → 17→18 migration silently dies
It returned the *last* autopg `postgres` binary under `~/.local/share/autopg/<ver>/...` regardless of server major. A PostgreSQL server refuses to open a data dir from a different major ("database files are incompatible with server"), so on a v3-only host (PG 18) reading a **legacy PG 17** embedded dir (`~/.omni/data/pgserve`) it handed back PG 18 and the temp postmaster died — the `embedded-data-orphaned: temp postmaster exited before ready` symptom, leaving data stranded.

Now selects the binary whose major **matches** the embedded dir's `PG_VERSION`, and returns a version-specific skip reason ("no PostgreSQL 17 reader … install a matching autopg/reader") instead of silently failing.

## Tests
- `runtime-env.test.ts`: `resolvePgservePort` falls back to canonical 5432 (not 8432); honors explicit `server.pgservePort`; ignores non-positive overrides.
- `embedded-canonical-migration.test.ts` (new): `readDataDirMajor` reads PG_VERSION (17/18), null on absent/non-numeric.
- `doctor.test.ts`: legacy TCP-fallback assertion updated to the canonical port.
- Full `packages/cli` suite: **492 pass / 0 fail**; `turbo typecheck` 21/21; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)