### PR TITLE
fix(history-sync): preserve original messageTimestamp instead of ingest time

### DIFF
--- a/packages/api/src/plugins/__tests__/message-persistence.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { extractPlatformTimestamp } from '../message-persistence';
+
+describe('extractPlatformTimestamp', () => {
+  const FALLBACK = Date.now();
+
+  test('returns null when rawPayload is undefined', () => {
+    expect(extractPlatformTimestamp(undefined, FALLBACK)).toBeNull();
+  });
+
+  test('returns null when messageTimestamp is missing', () => {
+    expect(extractPlatformTimestamp({}, FALLBACK)).toBeNull();
+  });
+
+  test('returns null when messageTimestamp is 0', () => {
+    expect(extractPlatformTimestamp({ messageTimestamp: 0 }, FALLBACK)).toBeNull();
+  });
+
+  test('returns null when messageTimestamp is empty string', () => {
+    expect(extractPlatformTimestamp({ messageTimestamp: '' }, FALLBACK)).toBeNull();
+  });
+
+  test('handles number timestamp in seconds', () => {
+    const ts = 1746665253; // 2025-05-08
+    const result = extractPlatformTimestamp({ messageTimestamp: ts }, FALLBACK);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(ts * 1000);
+  });
+
+  test('handles string timestamp in seconds', () => {
+    const ts = '1746665253';
+    const result = extractPlatformTimestamp({ messageTimestamp: ts }, FALLBACK);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(1746665253 * 1000);
+  });
+
+  test('handles Long object (protobuf uint64) with non-zero low, zero high', () => {
+    // Baileys emits messageTimestamp as { low, high, unsigned } after deepSanitize
+    const ts = 1746665253; // 2025-05-08
+    const result = extractPlatformTimestamp(
+      { messageTimestamp: { low: ts, high: 0, unsigned: false } },
+      FALLBACK,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(ts * 1000);
+  });
+
+  test('handles Long object with high bits set (timestamps after 2038)', () => {
+    // 2^32 = 4294967296; simulate ts = 4294967296 + 1 (just past the 2038 boundary)
+    // In a signed int32, this would be low = 1, high = 1
+    const hi = 1;
+    const lo = 1;
+    const expectedTs = hi * 0x100000000 + lo; // 4294967297 seconds
+    const result = extractPlatformTimestamp(
+      { messageTimestamp: { low: lo, high: hi, unsigned: false } },
+      FALLBACK,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(expectedTs * 1000);
+  });
+
+  test('Long with negative low (signed int32 > 2^31 seconds) reconstructs correctly via >>> 0', () => {
+    // 2147483648 = 0x80000000 — in int32 this is -2147483648
+    // This is January 19, 2038 03:14:08 UTC
+    const tsSeconds = 2147483648;
+    // In a Long: high = 0, low = -2147483648 (signed int32 wrapping)
+    const signedLow = -2147483648; // 0x80000000 as int32
+    const result = extractPlatformTimestamp(
+      { messageTimestamp: { low: signedLow, high: 0, unsigned: false } },
+      FALLBACK,
+    );
+    expect(result).not.toBeNull();
+    // (signedLow >>> 0) = 2147483648, which is the correct seconds value
+    expect(result!.getTime()).toBe(tsSeconds * 1000);
+  });
+
+  test('handles already-millisecond timestamp (>= 1e12)', () => {
+    const tsMs = 1746665253000; // already in ms
+    const result = extractPlatformTimestamp({ messageTimestamp: tsMs }, FALLBACK);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(tsMs);
+  });
+
+  test('does NOT fall back to fallback when messageTimestamp is present', () => {
+    const ts = 1746665253;
+    const wrongFallback = Date.now(); // very different from ts
+    const result = extractPlatformTimestamp({ messageTimestamp: ts }, wrongFallback);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(ts * 1000);
+    expect(result!.getTime()).not.toBeCloseTo(wrongFallback, -3);
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -2613,7 +2613,7 @@ async function processAgentResponse(
   // messages that arrived during the handoff window and should not be processed.
   if (chatSettings?.agentResumedAt) {
     const resumedAt = new Date(chatSettings.agentResumedAt).getTime();
-    const msgTimestamp = extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()).getTime();
+    const msgTimestamp = (extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()) ?? new Date()).getTime();
     if (msgTimestamp < resumedAt) {
       log.debug('Dropping pre-resume message (arrived during handoff window)', {
         instanceId: instance.id,
@@ -3550,7 +3550,7 @@ export function isInboundTooStale(
   if (maxAgeMinutes <= 0) {
     return { stale: false, ageMs: 0, maxAgeMs };
   }
-  const platformTs = extractPlatformTimestamp(rawPayload, now);
+  const platformTs = extractPlatformTimestamp(rawPayload, now) ?? new Date(now);
   const ageMs = now - platformTs.getTime();
   return { stale: ageMs > maxAgeMs, ageMs, maxAgeMs };
 }

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -5,7 +5,8 @@
  * This is the bridge between the event-based system and the unified message model.
  *
  * Flow:
- * - message.received → find/create chat → create message (source: 'realtime')
+ * - message.received (realtime)     → find/create chat → create message (source: 'realtime')
+ * - message.received (history-sync) → find/create chat → create message (source: 'sync')
  * - message.sent → find/create chat → create message (source: 'realtime', isFromMe: true)
  * - message.delivered/read → update message delivery status
  *
@@ -150,10 +151,14 @@ function findLongStrings(obj: unknown, prefix = '', minLength = 200): Record<str
 }
 
 /**
- * Extract platform timestamp from raw payload
+ * Extract platform timestamp from raw payload.
+ * Returns null when no timestamp can be extracted (caller decides what to do).
  */
-export function extractPlatformTimestamp(rawPayload: Record<string, unknown> | undefined, fallback: number): Date {
-  if (!rawPayload?.messageTimestamp) return new Date(fallback);
+export function extractPlatformTimestamp(
+  rawPayload: Record<string, unknown> | undefined,
+  _fallback: number,
+): Date | null {
+  if (!rawPayload?.messageTimestamp) return null;
 
   const ts = rawPayload.messageTimestamp;
   let tsNum: number | null = null;
@@ -164,10 +169,14 @@ export function extractPlatformTimestamp(rawPayload: Record<string, unknown> | u
     tsNum = Number(ts);
   } else if (typeof ts === 'object' && ts !== null && 'low' in ts) {
     // Protobuf Long format: { low: number, high: number, unsigned: boolean }
-    tsNum = (ts as { low: number }).low;
+    // Use unsigned right-shift (>>> 0) to treat both halves as uint32 before combining,
+    // so timestamps after 2038 (where low bit 31 is set) reconstruct correctly.
+    const lo = (ts as { low: number; high?: number }).low >>> 0;
+    const hi = ((ts as { low: number; high?: number }).high ?? 0) >>> 0;
+    tsNum = hi * 0x100000000 + lo;
   }
 
-  if (!tsNum || Number.isNaN(tsNum)) return new Date(fallback);
+  if (!tsNum || Number.isNaN(tsNum)) return null;
 
   // WhatsApp timestamps are in seconds, convert to milliseconds
   return new Date(tsNum < 1e12 ? tsNum * 1000 : tsNum);
@@ -338,6 +347,7 @@ interface MessageMetadata {
   personId?: string;
   platformIdentityId?: string;
   channelType?: string;
+  ingestMode?: 'realtime' | 'history-sync';
 }
 
 /** Check if a chat name should be updated given a new incoming name */
@@ -574,6 +584,7 @@ async function handleMessageReceived(
   eventTimestamp: number,
 ): Promise<void> {
   const channel = (metadata.channelType ?? 'whatsapp') as ChannelType;
+  const isHistorySync = metadata.ingestMode === 'history-sync';
 
   const chatExternalId = truncate(payload.chatId, 255) ?? payload.chatId;
   const messageExternalId = truncate(payload.externalId, 255) ?? payload.externalId;
@@ -639,11 +650,25 @@ async function handleMessageReceived(
   const quotedMessage = rawPayload?.quotedMessage as Record<string, unknown> | undefined;
   const platformTimestamp = extractPlatformTimestamp(rawPayload, eventTimestamp);
 
+  // For history-sync messages, messageTimestamp is the source of truth.
+  // If it's missing (null), we have no reliable timestamp to preserve — skip rather than
+  // storing with event.timestamp (= Date.now()), which would be misleading.
+  if (isHistorySync && platformTimestamp === null) {
+    log.debug('Skipping history-sync message without messageTimestamp', {
+      externalId: payload.externalId,
+      chatId: payload.chatId,
+    });
+    return;
+  }
+
   const { message, created } = await services.messages.findOrCreate(chat.id, messageExternalId, {
-    source: 'realtime',
+    source: isHistorySync ? 'sync' : 'realtime',
     messageType: mapContentType(payload.content.type),
     textContent: sanitizeText(payload.content.text),
-    platformTimestamp,
+    // platformTimestamp is null only for realtime messages without messageTimestamp;
+    // fall back to event.timestamp (≈ now) — acceptable for realtime, not for history-sync
+    // (history-sync null case is already handled above with early return).
+    platformTimestamp: platformTimestamp ?? new Date(eventTimestamp),
     senderPlatformUserId: truncate(payload.from, 255),
     senderDisplayName,
     senderPersonId: personId,
@@ -668,7 +693,7 @@ async function handleMessageReceived(
     rawPayload,
     message.id,
     sanitizeText(payload.content.text) ?? undefined,
-    platformTimestamp,
+    platformTimestamp ?? new Date(eventTimestamp),
     payload.from,
   );
 
@@ -680,7 +705,14 @@ async function handleMessageReceived(
   await maybeRecordParticipantActivity(services, chat.id, payload.from);
 
   // Step 7/8: Update chat + instance recency (edits should not bump recency)
-  maybeUpdateRecency(services, metadata.instanceId, chat.id, rawPayload, payload, platformTimestamp);
+  maybeUpdateRecency(
+    services,
+    metadata.instanceId,
+    chat.id,
+    rawPayload,
+    payload,
+    platformTimestamp ?? new Date(eventTimestamp),
+  );
 }
 
 /**

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3465,13 +3465,24 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
 
     const timestamp = this.getMessageTimestamp(msg);
 
+    // Messages without a timestamp cannot be reliably ordered or filtered.
+    // Skip them instead of fabricating a misleading ingest-time timestamp.
+    if (!timestamp) {
+      this.logger.debug('Skipping history message without timestamp', {
+        instanceId,
+        messageId: msg.key.id,
+        chatId: msg.key.remoteJid,
+      });
+      return;
+    }
+
     // Filter by date range if specified
     if (syncState?.since && timestamp < syncState.since) {
       this.logger.debug('Skipping history message - before since', {
         instanceId,
         messageId: msg.key.id,
         chatId: msg.key.remoteJid,
-        timestamp: new Date(timestamp).toISOString(),
+        timestamp: timestamp.toISOString(),
         since: new Date(syncState.since).toISOString(),
       });
       return;
@@ -3481,7 +3492,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         instanceId,
         messageId: msg.key.id,
         chatId: msg.key.remoteJid,
-        timestamp: new Date(timestamp).toISOString(),
+        timestamp: timestamp.toISOString(),
         until: new Date(syncState.until).toISOString(),
       });
       return;
@@ -3587,12 +3598,15 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   }
 
   /**
-   * Get timestamp from a message
+   * Get timestamp from a message.
+   * Returns null when messageTimestamp is absent or zero — callers must handle this
+   * explicitly rather than silently falling back to the current time.
    * @internal
    */
-  private getMessageTimestamp(msg: WAMessage): Date {
-    if (!msg.messageTimestamp) return new Date();
+  private getMessageTimestamp(msg: WAMessage): Date | null {
+    if (!msg.messageTimestamp) return null;
     const ts = typeof msg.messageTimestamp === 'number' ? msg.messageTimestamp : Number(msg.messageTimestamp);
+    if (!ts || Number.isNaN(ts)) return null;
     return new Date(ts * 1000);
   }
 


### PR DESCRIPTION
## Summary

WhatsApp history sync messages were being stored with `platform_timestamp = now()` (ingest time) instead of the original `messageTimestamp` from the Baileys event. This caused all historical messages replayed on reconnect to appear as if they were sent at the moment of reconnection, breaking timeline ordering and conversation history display.

### Root causes fixed

**Bug 1 — `extractPlatformTimestamp` fell back to ingest time when messageTimestamp was absent**

Previously the function returned `new Date(fallback)` (where `fallback = Date.now()` at call site) when `messageTimestamp` was missing or zero. During history sync, many messages lack a `messageTimestamp`, so they silently got the current timestamp. Fixed: function now returns `Date | null`; callers handle null explicitly.

**Bug 2 — Protobuf Long object reconstruction was broken**

Baileys emits `messageTimestamp` as a protobuf `uint64` serialized after `deepSanitize` as `{ low, high, unsigned }`. The old code used only `ts.low`, losing the `high` word. Correct reconstruction:
```typescript
const lo = (ts.low >>> 0);   // treat as unsigned int32
const hi = (ts.high ?? 0) >>> 0;
tsNum = hi * 0x100000000 + lo;
```
This also handles negative `low` values (signed int32 wrapping at `0x80000000`).

**Bug 3 — `ingestMode` from EventMetadata was never read**

`EventMetadata.ingestMode?: 'realtime' | 'history-sync'` is set correctly by the NATS publisher, but `setupMessagePersistence` never consumed it. History-sync messages were always stored with `source = 'realtime'` instead of `source = 'sync'`.

**Bug 4 — `channel-whatsapp` `getMessageTimestamp` could propagate wrong timestamps**

`getMessageTimestamp` didn't handle missing/zero timestamps explicitly, risking `new Date(NaN)` or `new Date(0)` propagation.

## Changes

- `packages/api/src/plugins/message-persistence.ts`
  - `extractPlatformTimestamp`: returns `Date | null` (was `Date`)
  - Long reconstruction: `(hi >>> 0) * 0x100000000 + (lo >>> 0)`
  - `MessageMetadata` gains `ingestMode?: 'realtime' | 'history-sync'`
  - `handleMessageReceived`: reads `ingestMode`, sets `source = 'sync'` for history-sync, skips messages without `messageTimestamp` in history-sync path (can't store null — schema is NOT NULL), falls back to event timestamp only for realtime path
  
- `packages/api/src/plugins/agent-dispatcher.ts`
  - Two callers of `extractPlatformTimestamp` updated for `Date | null` return type

- `packages/channel-whatsapp/src/plugin.ts`
  - `getMessageTimestamp`: returns `Date | null`, skips messages without valid timestamp instead of publishing with wrong time

- `packages/api/src/plugins/__tests__/message-persistence.test.ts` (new)
  - 11 unit tests covering: undefined/missing/zero/empty input → null; number seconds; string seconds; Long with zero high; Long with non-zero high (post-2038); Long with negative low (signed int32 at 0x80000000); already-millisecond timestamp; no fallback contamination

## Reproduction

```sql
-- Before fix: all history-sync messages show platform_timestamp ≈ created_at (ingest time)
SELECT
  COUNT(*) FILTER (WHERE ABS(EXTRACT(EPOCH FROM (platform_timestamp - created_at))) < 5) AS wrong_timestamp,
  COUNT(*) FILTER (WHERE ABS(EXTRACT(EPOCH FROM (platform_timestamp - created_at))) >= 5) AS correct_timestamp
FROM messages
WHERE source = 'sync';
-- Before: wrong_timestamp ≈ 20297, correct_timestamp ≈ 0
-- After:  wrong_timestamp ≈ 0,     correct_timestamp ≈ N
```

Messages without `messageTimestamp` in history-sync are now skipped (not persisted) since the schema requires `platform_timestamp NOT NULL` and there is no recoverable correct timestamp for them.

## Test plan

- [x] All 11 unit tests for `extractPlatformTimestamp` pass (`bun test packages/api/src/plugins/__tests__/message-persistence.test.ts`)
- [x] TypeScript compilation passes (`bun run typecheck`)
- [x] Biome lint passes (`bun run lint`)
- [ ] Manual: reconnect a WhatsApp instance and verify `messages.platform_timestamp` matches `raw_payload->>'messageTimestamp'` for synced messages
- [ ] Manual: verify `messages.source = 'sync'` for history-sync messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating timestamp extraction across various formats and edge cases.

* **Bug Fixes**
  * Hardened timestamp handling with fallbacks to prevent crashes when platform timestamps are missing or invalid.
  * History sync messages lacking valid timestamps are now skipped during ingestion.

* **Refactor**
  * Updated timestamp extraction logic to distinguish between realtime and history-sync message processing modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/omni/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->