### PR TITLE
[codex] A2A execution context propagation

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1621,6 +1621,77 @@ describe('agent-dispatcher', () => {
   });
 
   // ======================================================================
+  // A2A customer context — remote identity is external-only
+  // ======================================================================
+  describe('A2A customer context', () => {
+    const { extractA2ACustomerContext, resolveCustomerContext } = __test__;
+
+    it('extracts external customer context from A2A raw payload without internal IDs', () => {
+      const messages = [
+        {
+          payload: {
+            externalId: 'a2a-msg-1',
+            chatId: 'a2a-task-1',
+            from: 'workos-user-1',
+            content: { type: 'text', text: 'hello' },
+            rawPayload: {
+              omniExecutionContext: {
+                identity: {
+                  userId: 'remote-person-should-not-be-trusted',
+                  personId: 'remote-internal-person',
+                  platformUserId: 'workos-user-1',
+                },
+                customer: {
+                  customerId: 'cust-1',
+                  organizationId: 'org-1',
+                  tenantId: 'tenant-1',
+                },
+              },
+            },
+          },
+          metadata: {
+            instanceId: 'inst-1',
+            traceId: 'trace-1',
+          },
+          timestamp: Date.now(),
+        },
+      ] as Parameters<typeof extractA2ACustomerContext>[0];
+
+      expect(extractA2ACustomerContext(messages, 'a2a')).toEqual({
+        externalUserId: 'workos-user-1',
+        customerId: 'cust-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+      });
+    });
+
+    it('merges remote customer context with stored person metadata, preferring stored values', async () => {
+      const services = {
+        persons: {
+          getById: mock(async () => ({
+            metadata: {
+              externalUserId: 'stored-user-1',
+              customerId: 'stored-cust-1',
+            },
+          })),
+        },
+      } as unknown as import('../../services').Services;
+
+      const context = await resolveCustomerContext(services, 'person-1', {
+        externalUserId: 'remote-user-1',
+        customerId: 'remote-cust-1',
+        organizationId: 'remote-org-1',
+      });
+
+      expect(context).toEqual({
+        externalUserId: 'stored-user-1',
+        customerId: 'stored-cust-1',
+        organizationId: 'remote-org-1',
+      });
+    });
+  });
+
+  // ======================================================================
   // buildContextMessages — DM context behavior
   // ======================================================================
   describe('buildContextMessages (DM context)', () => {

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -45,6 +45,7 @@ import {
   type MediaProcessedPayload,
   type MessageReceivedPayload,
   NatsGenieProvider,
+  type OmniCustomerContext,
   OpenClawAgentProvider,
   OpenClawClient,
   type OpenClawClientConfig,
@@ -1131,6 +1132,75 @@ async function resolvePersonId(
   return undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pickString(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function compactCustomerContext(context: OmniCustomerContext): OmniCustomerContext | undefined {
+  const compacted = Object.fromEntries(Object.entries(context).filter(([, value]) => value !== undefined));
+  return Object.keys(compacted).length > 0 ? compacted : undefined;
+}
+
+function customerContextFromRecord(record: Record<string, unknown>): OmniCustomerContext | undefined {
+  return compactCustomerContext({
+    externalUserId: pickString(record, 'externalUserId', 'external_user_id'),
+    customerId: pickString(record, 'customerId', 'customer_id'),
+    organizationId: pickString(record, 'organizationId', 'organization_id', 'orgId', 'org_id'),
+    tenantId: pickString(record, 'tenantId', 'tenant_id'),
+  });
+}
+
+function extractA2ACustomerContext(messages: BufferedMessage[], channel: ChannelType): OmniCustomerContext | undefined {
+  if (channel !== 'a2a') return undefined;
+
+  const rawPayload = messages[0]?.payload.rawPayload;
+  if (!isRecord(rawPayload)) return undefined;
+
+  const executionContext = rawPayload.omniExecutionContext;
+  if (!isRecord(executionContext)) return undefined;
+
+  const customer = isRecord(executionContext.customer) ? executionContext.customer : {};
+  const identity = isRecord(executionContext.identity) ? executionContext.identity : {};
+
+  return compactCustomerContext({
+    ...customerContextFromRecord(customer),
+    externalUserId:
+      pickString(customer, 'externalUserId', 'external_user_id') ?? pickString(identity, 'platformUserId', 'userId'),
+  });
+}
+
+async function resolveCustomerContext(
+  services: Services,
+  personId: string | undefined,
+  externalContext?: OmniCustomerContext,
+): Promise<OmniCustomerContext | undefined> {
+  let storedContext: OmniCustomerContext | undefined;
+
+  if (personId) {
+    try {
+      const person = await services.persons.getById(personId);
+      if (isRecord(person.metadata)) {
+        storedContext = customerContextFromRecord(person.metadata);
+      }
+    } catch (error) {
+      log.debug('Failed to resolve customer context', { personId, error: String(error) });
+    }
+  }
+
+  return compactCustomerContext({
+    ...(externalContext ?? {}),
+    ...(storedContext ?? {}),
+  });
+}
+
 /**
  * Fetch sender identity metadata (avatar URL, username)
  */
@@ -1406,6 +1476,7 @@ function buildMessageTrigger(
   messageTexts: string[],
   triggerFiles: ProviderFile[] | undefined,
   sessionId: string,
+  customerContext: OmniCustomerContext | undefined,
   allContextMessages: string[],
 ): AgentTrigger {
   const threadId = extractThreadId(messages);
@@ -1439,6 +1510,8 @@ function buildMessageTrigger(
       referencedMessageId: messages[0]?.payload.replyToId || undefined,
     },
     sessionId,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    customer: customerContext,
     contextMessages: allContextMessages.length > 0 ? allContextMessages : undefined,
     env: Object.keys(env).length > 0 ? env : undefined,
   };
@@ -1496,6 +1569,11 @@ async function dispatchViaStreamingProvider(
   // TODO: before_message_write for streaming — batch after stream completes
   // (per-segment hooks would add latency; batch transform is the right approach)
 
+  const customerContext = await resolveCustomerContext(
+    services,
+    personId,
+    extractA2ACustomerContext(messages, channel),
+  );
   const trigger = buildMessageTrigger(
     traceId,
     triggerType,
@@ -1510,6 +1588,7 @@ async function dispatchViaStreamingProvider(
     messageTexts,
     triggerFiles,
     sessionId,
+    customerContext,
     allContextMessages,
   );
 
@@ -1894,6 +1973,11 @@ async function dispatchViaProvider(
     triggerFiles,
   );
 
+  const customerContext = await resolveCustomerContext(
+    services,
+    personId,
+    extractA2ACustomerContext(messages, channel),
+  );
   const trigger = buildMessageTrigger(
     traceId,
     triggerType,
@@ -1908,6 +1992,7 @@ async function dispatchViaProvider(
     messageTexts,
     triggerFiles,
     sessionId,
+    customerContext,
     allContextMessages,
   );
 
@@ -3474,6 +3559,7 @@ async function processReactionTrigger(
       const effectivePersonId = reactionPersonId ?? metadata.personId;
       const senderName = await services.agentRunner.getSenderName(effectivePersonId, undefined);
       const sessionId = computeSessionId(instance.agentSessionStrategy ?? 'per_chat', payload.from, externalChatId);
+      const customerContext = await resolveCustomerContext(services, effectivePersonId);
 
       const trigger: AgentTrigger = {
         traceId: metadata.traceId,
@@ -3495,6 +3581,8 @@ async function processReactionTrigger(
           referencedMessageId: payload.messageId,
         },
         sessionId,
+        sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+        customer: customerContext,
       };
 
       const result = await provider.trigger(trigger);
@@ -4628,6 +4716,8 @@ export const __test__ = {
   checkProcessedColumn,
   getProcessedColumn,
   MEDIA_WAIT_NULL,
+  extractA2ACustomerContext,
+  resolveCustomerContext,
   mergeRouteOverrides,
   getDebounceConfig,
   createNatsGenieProviderInstance,

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -1187,7 +1187,7 @@ async function resolveCustomerContext(
   if (personId) {
     try {
       const person = await services.persons.getById(personId);
-      if (isRecord(person.metadata)) {
+      if (person && isRecord(person.metadata)) {
         storedContext = customerContextFromRecord(person.metadata);
       }
     } catch (error) {

--- a/packages/api/src/services/__tests__/a2a-discovery.test.ts
+++ b/packages/api/src/services/__tests__/a2a-discovery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { OMNI_EXECUTION_CONTEXT_EXTENSION_URI } from '@omni/core';
 import type { Agent, Instance } from '@omni/db';
 import { resolveA2AAgentCard } from '../a2a-discovery';
 import type { Services } from '../index';
@@ -94,5 +95,25 @@ describe('resolveA2AAgentCard', () => {
     });
 
     expect(resolved?.card.metadata).toBeUndefined();
+  });
+
+  test('declares Omni execution context extension by default', async () => {
+    const agent = createAgent();
+    const instance = createInstance();
+
+    const resolved = await resolveA2AAgentCard({
+      services: createServices(agent, instance),
+      baseUrl: 'http://localhost:8882',
+      instanceId: instance.id,
+    });
+
+    expect(resolved?.card.extensions).toEqual([
+      {
+        uri: OMNI_EXECUTION_CONTEXT_EXTENSION_URI,
+        description: 'Omni execution context metadata for user, source, session, trace, and customer identity.',
+        version: '1.0',
+        required: false,
+      },
+    ]);
   });
 });

--- a/packages/api/src/services/a2a-discovery.ts
+++ b/packages/api/src/services/a2a-discovery.ts
@@ -1,3 +1,4 @@
+import { OMNI_EXECUTION_CONTEXT_EXTENSION_URI } from '@omni/core';
 import type { Agent, AgentProvider, Instance } from '@omni/db';
 import type { Services } from './index';
 
@@ -85,6 +86,16 @@ function buildA2AAgentCard(params: {
       extendedAgentCard: false,
       ...(isRecord(override.capabilities) ? override.capabilities : {}),
     },
+    extensions: Array.isArray(override.extensions)
+      ? override.extensions
+      : [
+          {
+            uri: OMNI_EXECUTION_CONTEXT_EXTENSION_URI,
+            description: 'Omni execution context metadata for user, source, session, trace, and customer identity.',
+            version: '1.0',
+            required: false,
+          },
+        ],
     defaultInputModes: stringArray(override.defaultInputModes) ?? ['text/plain'],
     defaultOutputModes: stringArray(override.defaultOutputModes) ?? ['text/plain'],
     skills: Array.isArray(override.skills) ? override.skills : buildDefaultSkills(capabilities),

--- a/packages/channel-a2a/src/__tests__/a2a-handler.test.ts
+++ b/packages/channel-a2a/src/__tests__/a2a-handler.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test';
-import type { EventBus } from '@omni/core';
+import { OMNI_EXECUTION_CONTEXT_EXTENSION_URI } from '@omni/core';
+import type { EventBus, OmniExecutionContext } from '@omni/core';
 import { handleA2ARequest } from '../a2a-handler';
 import { A2AStreamStore } from '../stream-store';
 import type { A2ATaskStore } from '../task-store';
@@ -194,6 +195,63 @@ describe('handleA2ARequest', () => {
 
       const published = bus.calls.find((c) => c.type === 'message.received');
       expect((published?.metadata as Record<string, unknown>).instanceId).toBe('inst-1');
+    });
+
+    it('maps Omni execution context metadata onto message.received', async () => {
+      const bus = createMockEventBus();
+      const executionContext: OmniExecutionContext = {
+        identity: {
+          userId: 'customer-user-1',
+          personId: 'person-1',
+          platformUserId: 'workos-user-1',
+          displayName: 'Luis',
+        },
+        source: {
+          channel: 'a2a',
+          instanceId: 'a2a-inst',
+          chatId: 'agent-chat',
+          threadId: 'thread-1',
+          messageId: 'source-msg-1',
+        },
+        session: { id: 'session-1', strategy: 'per_user' },
+        trace: { id: 'trace-1' },
+        customer: {
+          externalUserId: 'workos-user-1',
+          customerId: 'cust-1',
+          organizationId: 'org-1',
+          tenantId: 'tenant-1',
+        },
+      };
+      const reqWithContext = {
+        ...validSend,
+        params: {
+          ...validSend.params,
+          message: {
+            ...validSend.params.message,
+            extensions: [OMNI_EXECUTION_CONTEXT_EXTENSION_URI],
+            metadata: { omniExecutionContext: executionContext },
+          },
+        },
+      };
+
+      await handleA2ARequest(makeRequest(reqWithContext), makeCtx(bus));
+
+      const published = bus.calls.find((c) => c.type === 'message.received');
+      const payload = published?.payload as Record<string, unknown>;
+      const metadata = published?.metadata as Record<string, unknown>;
+
+      expect(payload.from).toBe('workos-user-1');
+      expect(payload.senderName).toBe('Luis');
+      expect(payload.threadId).toBe('thread-1');
+      expect(payload.rawPayload).toMatchObject({
+        omniExecutionContext: executionContext,
+        omniExecutionContextExtension: true,
+      });
+      expect(metadata).toMatchObject({
+        traceId: 'trace-1',
+      });
+      expect(metadata).not.toHaveProperty('personId');
+      expect(metadata).not.toHaveProperty('platformIdentityId');
     });
 
     it('returns 400 when params.message is missing', async () => {

--- a/packages/channel-a2a/src/a2a-handler.ts
+++ b/packages/channel-a2a/src/a2a-handler.ts
@@ -5,7 +5,8 @@
  * v0.3-style Omni method names as compatibility aliases.
  */
 
-import { generateCorrelationId } from '@omni/core';
+import { OMNI_EXECUTION_CONTEXT_EXTENSION_URI, generateCorrelationId } from '@omni/core';
+import type { OmniExecutionContext } from '@omni/core';
 import type { EventBus } from '@omni/core/events';
 import { z } from 'zod';
 import type { A2AChannelPlugin } from './plugin';
@@ -44,6 +45,7 @@ const MessageSendParamsSchema = z.object({
     messageId: z.string().optional(),
     taskId: z.string().optional(),
     contextId: z.string().optional(),
+    extensions: z.array(z.string()).optional(),
     metadata: z.record(z.unknown()).optional(),
   }),
   configuration: z
@@ -161,6 +163,7 @@ function normalizeMessage(message: z.infer<typeof MessageSendParamsSchema>['mess
     messageId: message.messageId,
     taskId: message.taskId,
     contextId: message.contextId,
+    extensions: message.extensions,
     metadata: message.metadata,
   };
 }
@@ -170,6 +173,52 @@ function extractText(message: A2AMessage): string {
     .filter((p): p is { text: string } => typeof (p as { text?: unknown }).text === 'string')
     .map((p) => p.text)
     .join('\n');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asOmniExecutionContext(value: unknown): OmniExecutionContext | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const identity = value.identity;
+  const source = value.source;
+  const session = value.session;
+  const trace = value.trace;
+
+  if (!isRecord(identity) || typeof identity.userId !== 'string') return undefined;
+  if (!isRecord(source) || typeof source.instanceId !== 'string') return undefined;
+  if (!isRecord(session) || typeof session.id !== 'string') return undefined;
+  if (!isRecord(trace) || typeof trace.id !== 'string') return undefined;
+
+  return value as unknown as OmniExecutionContext;
+}
+
+function extractOmniExecutionContext(
+  message: A2AMessage,
+  requestMetadata?: Record<string, unknown>,
+): OmniExecutionContext | undefined {
+  const messageContext = asOmniExecutionContext(message.metadata?.omniExecutionContext);
+  if (messageContext) return messageContext;
+
+  const requestContext = asOmniExecutionContext(requestMetadata?.omniExecutionContext);
+  if (requestContext) return requestContext;
+
+  return undefined;
+}
+
+function a2aEventFrom(contextId: string, executionContext?: OmniExecutionContext): string {
+  return (
+    executionContext?.customer?.externalUserId ??
+    executionContext?.identity.platformUserId ??
+    executionContext?.identity.userId ??
+    `a2a:${contextId}`
+  );
+}
+
+function hasOmniExecutionContextExtension(message: A2AMessage): boolean {
+  return message.extensions?.includes(OMNI_EXECUTION_CONTEXT_EXTENSION_URI) ?? false;
 }
 
 // ─── Helper: JSON-RPC response builders ──────────────────────
@@ -444,7 +493,15 @@ async function handleMessageSend(
   const timings = ctx.plugin.inboundTimings(t0);
 
   try {
-    const correlationId = await emitMessageReceived(normalizedMessage, text, taskId, contextId, ctx, timings);
+    const correlationId = await emitMessageReceived(
+      normalizedMessage,
+      text,
+      taskId,
+      contextId,
+      ctx,
+      timings,
+      sendParams.metadata,
+    );
     if (timings) ctx.plugin.recordT2(correlationId, timings);
   } catch {
     await taskStore.updateStatus(ctx.instanceId, taskId, 'TASK_STATE_FAILED');
@@ -490,7 +547,15 @@ async function handleMessageStream(
   const timings = ctx.plugin.inboundTimings(t0);
 
   try {
-    const correlationId = await emitMessageReceived(normalizedMessage, text, taskId, contextId, ctx, timings);
+    const correlationId = await emitMessageReceived(
+      normalizedMessage,
+      text,
+      taskId,
+      contextId,
+      ctx,
+      timings,
+      sendParams.metadata,
+    );
     if (timings) ctx.plugin.recordT2(correlationId, timings);
   } catch {
     await taskStore.updateStatus(ctx.instanceId, taskId, 'TASK_STATE_FAILED');
@@ -723,26 +788,39 @@ async function emitMessageReceived(
   contextId: string,
   ctx: A2AHandlerContext,
   timings?: Record<string, number>,
+  requestMetadata?: Record<string, unknown>,
 ): Promise<string> {
   const correlationId = generateCorrelationId('evt');
+  const executionContext = extractOmniExecutionContext(message, requestMetadata);
+  const rawPayload: Record<string, unknown> = {
+    a2aTaskId: taskId,
+    a2aContextId: contextId,
+    a2aMessage: message,
+  };
 
-  await ctx.eventBus.publish(
-    'message.received',
-    {
-      externalId: message.messageId ?? taskId,
-      chatId: taskId, // taskId as chatId -> dispatcher uses it for sendResponseParts routing
-      from: `a2a:${contextId}`,
-      content: { type: 'text', text },
-      rawPayload: { a2aTaskId: taskId, a2aContextId: contextId, a2aMessage: message },
-    },
-    {
-      correlationId,
-      instanceId: ctx.instanceId,
-      channelType: ctx.channelType,
-      source: 'channel:a2a',
-      timings,
-    },
-  );
+  if (executionContext) {
+    rawPayload.omniExecutionContext = executionContext;
+    rawPayload.omniExecutionContextExtension = hasOmniExecutionContextExtension(message);
+  }
+  const eventPayload = {
+    externalId: message.messageId ?? taskId,
+    chatId: taskId, // taskId as chatId -> dispatcher uses it for sendResponseParts routing
+    from: a2aEventFrom(contextId, executionContext),
+    ...(executionContext?.identity.displayName ? { senderName: executionContext.identity.displayName } : {}),
+    ...(executionContext?.source.threadId ? { threadId: executionContext.source.threadId } : {}),
+    content: { type: 'text' as const, text },
+    rawPayload,
+  };
+  const eventMetadata = {
+    correlationId,
+    instanceId: ctx.instanceId,
+    channelType: ctx.channelType,
+    ...(executionContext?.trace.id ? { traceId: executionContext.trace.id } : {}),
+    source: 'channel:a2a',
+    ...(timings ? { timings } : {}),
+  };
+
+  await ctx.eventBus.publish('message.received', eventPayload, eventMetadata);
 
   return correlationId;
 }

--- a/packages/channel-a2a/src/types.ts
+++ b/packages/channel-a2a/src/types.ts
@@ -50,6 +50,7 @@ export interface A2AMessage {
   messageId?: string;
   taskId?: string;
   contextId?: string;
+  extensions?: string[];
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/core/src/providers/__tests__/a2a-client.test.ts
+++ b/packages/core/src/providers/__tests__/a2a-client.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { A2AClient, createA2AClient } from '../a2a-client';
+import { OMNI_EXECUTION_CONTEXT_EXTENSION_URI } from '../execution-context';
 import { ProviderError, type StreamChunk } from '../types';
 
 // ─── Mock fetch helpers ───────────────────────────────────────
@@ -171,6 +172,43 @@ describe('A2AClient', () => {
 
       const body = JSON.parse((mockImpl.mock.calls[0]?.[1] as RequestInit).body as string);
       expect(body.params.contextId).toBe('my-session');
+    });
+
+    it('serializes Omni execution context as A2A message metadata', async () => {
+      const rpcResponse = {
+        jsonrpc: '2.0',
+        result: { task: { id: 't', contextId: 'ctx', status: { state: 'completed' }, artifacts: [] } },
+      };
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(rpcResponse), { status: 200 }));
+
+      const client = new A2AClient(CONFIG);
+      await client.run({
+        message: 'Hi',
+        userId: 'person-111',
+        agentId: 'test-agent',
+        sessionId: 'session-1',
+        executionContext: {
+          identity: {
+            userId: 'person-111',
+            personId: 'person-111',
+            platformUserId: 'sender-999',
+          },
+          source: {
+            channel: 'whatsapp-baileys',
+            instanceId: 'instance-123',
+            chatId: 'chat-456',
+            messageId: 'message-789',
+          },
+          session: { id: 'session-1', strategy: 'per_chat' },
+          trace: { id: 'trace-123' },
+          customer: { externalUserId: 'usr_123' },
+        },
+      });
+
+      const body = JSON.parse((mockImpl.mock.calls[0]?.[1] as RequestInit).body as string);
+      expect(body.params.message.extensions).toEqual([OMNI_EXECUTION_CONTEXT_EXTENSION_URI]);
+      expect(body.params.message.metadata.omniExecutionContext.identity.userId).toBe('person-111');
+      expect(body.params.message.metadata.omniExecutionContext.customer.externalUserId).toBe('usr_123');
     });
 
     it('throws ProviderError on non-ok HTTP response', async () => {

--- a/packages/core/src/providers/__tests__/claude-code-client.test.ts
+++ b/packages/core/src/providers/__tests__/claude-code-client.test.ts
@@ -460,7 +460,11 @@ describe('ClaudeCodeAgentProvider', () => {
     expect(capturedRequest?.env.OMNI_CHAT).toBe('chat-456');
     expect(capturedRequest?.env.OMNI_MESSAGE).toBe('message-789');
     expect(capturedRequest?.env.OMNI_SESSION).toBe('session-chat-456');
+    expect(capturedRequest?.env.OMNI_USER_ID).toBe('person-111');
+    expect(capturedRequest?.env.OMNI_PERSON_ID).toBe('person-111');
+    expect(capturedRequest?.env.OMNI_PLATFORM_USER_ID).toBe('sender-999');
     expect(capturedRequest?.env.OMNI_SENDER).toBe('sender-999');
+    expect(capturedRequest?.executionContext.identity.userId).toBe('person-111');
     expect(capturedRequest?.mcpUrlParams).toEqual({ chat_id: 'chat-456' });
   });
 

--- a/packages/core/src/providers/__tests__/execution-context.test.ts
+++ b/packages/core/src/providers/__tests__/execution-context.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import { buildOmniEnv, buildOmniExecutionContext, buildProviderRequestContext } from '../execution-context';
+import type { AgentTrigger } from '../types';
+
+const trigger: AgentTrigger = {
+  traceId: 'trace-123',
+  type: 'dm',
+  event: {} as AgentTrigger['event'],
+  source: {
+    channelType: 'whatsapp-baileys',
+    instanceId: 'instance-123',
+    chatId: 'chat-456',
+    messageId: 'message-789',
+    threadId: 'thread-001',
+  },
+  sender: {
+    platformUserId: '5511999999999@s.whatsapp.net',
+    personId: 'person-111',
+    displayName: 'Luis',
+  },
+  content: {
+    text: 'hello',
+    referencedMessageId: 'quoted-001',
+  },
+  sessionId: 'session-abc',
+  sessionStrategy: 'per_chat',
+  customer: {
+    externalUserId: 'usr_123',
+    customerId: 'cus_456',
+    organizationId: 'org_789',
+    tenantId: 'tenant_abc',
+  },
+  env: {
+    GENIE_TMUX_SESSION: 'omni',
+  },
+};
+
+describe('execution context', () => {
+  it('builds canonical Omni execution context', () => {
+    const context = buildOmniExecutionContext(trigger);
+
+    expect(context.identity.userId).toBe('person-111');
+    expect(context.identity.platformUserId).toBe('5511999999999@s.whatsapp.net');
+    expect(context.source.instanceId).toBe('instance-123');
+    expect(context.session.id).toBe('session-abc');
+    expect(context.customer?.externalUserId).toBe('usr_123');
+  });
+
+  it('falls back to platform user ID when personId is missing', () => {
+    const context = buildOmniExecutionContext({
+      ...trigger,
+      sender: { platformUserId: 'telegram-user-1' },
+      customer: undefined,
+    });
+
+    expect(context.identity.userId).toBe('telegram-user-1');
+    expect(context.identity.personId).toBeUndefined();
+  });
+
+  it('builds CLI env with legacy aliases and customer IDs', () => {
+    const env = buildOmniEnv(trigger);
+
+    expect(env.OMNI_USER_ID).toBe('person-111');
+    expect(env.OMNI_PERSON_ID).toBe('person-111');
+    expect(env.OMNI_PLATFORM_USER_ID).toBe('5511999999999@s.whatsapp.net');
+    expect(env.OMNI_SENDER).toBe('5511999999999@s.whatsapp.net');
+    expect(env.OMNI_EXTERNAL_USER_ID).toBe('usr_123');
+    expect(env.OMNI_CUSTOMER_ID).toBe('cus_456');
+    expect(env.GENIE_TMUX_SESSION).toBe('omni');
+  });
+
+  it('builds provider request context', () => {
+    const requestContext = buildProviderRequestContext(trigger);
+
+    expect(requestContext.userId).toBe('person-111');
+    expect(requestContext.sessionId).toBe('session-abc');
+    expect(requestContext.platform?.id).toBe('5511999999999@s.whatsapp.net');
+    expect(requestContext.messageId).toBe('message-789');
+    expect(requestContext.replyToMessageId).toBe('quoted-001');
+    expect(requestContext.executionContext?.customer?.tenantId).toBe('tenant_abc');
+  });
+});

--- a/packages/core/src/providers/__tests__/execution-context.test.ts
+++ b/packages/core/src/providers/__tests__/execution-context.test.ts
@@ -79,4 +79,22 @@ describe('execution context', () => {
     expect(requestContext.replyToMessageId).toBe('quoted-001');
     expect(requestContext.executionContext?.customer?.tenantId).toBe('tenant_abc');
   });
+
+  it('uses the trigger classification to identify direct messages', () => {
+    const requestContext = buildProviderRequestContext({
+      ...trigger,
+      type: 'dm',
+      source: {
+        ...trigger.source,
+        channelType: 'slack',
+        chatId: 'D123',
+        threadId: undefined,
+      },
+      sender: {
+        platformUserId: 'U123',
+      },
+    });
+
+    expect(requestContext.chat?.type).toBe('dm');
+  });
 });

--- a/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
+++ b/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
@@ -133,6 +133,7 @@ function makeTrigger(): AgentTrigger {
     content: {
       text: 'hello',
     },
+    sessionId: '5511999999999',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
@@ -298,13 +299,19 @@ describe('NatsGenieProvider.trigger() — env pass-through', () => {
     await provider.trigger(trigger);
     expect(publishCalls.length).toBeGreaterThan(0);
     const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
-    expect(payload.env).toEqual({
+    expect(payload.env).toMatchObject({
       OMNI_INSTANCE: 'inst-1',
-      OMNI_CHAT: 'chat-42',
+      OMNI_CHAT: '5511999999999@s.whatsapp.net',
       OMNI_MESSAGE: 'msg-1',
       OMNI_TURN_ID: 'turn-xyz',
       GENIE_TMUX_SESSION: 'whatsapp-scout-12',
+      OMNI_USER_ID: '5511999999999',
+      OMNI_PLATFORM_USER_ID: '5511999999999',
+      OMNI_SENDER: '5511999999999',
+      OMNI_SESSION: '5511999999999',
+      OMNI_TRACE_ID: 'trace-1',
     });
+    expect(payload.executionContext.identity.platformUserId).toBe('5511999999999');
   });
 
   it('omits GENIE_TMUX_SESSION from payload.env when the dispatcher did not set it', async () => {
@@ -320,14 +327,20 @@ describe('NatsGenieProvider.trigger() — env pass-through', () => {
     const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
     expect(payload.env).not.toHaveProperty('GENIE_TMUX_SESSION');
     expect(payload.env.OMNI_INSTANCE).toBe('inst-1');
+    expect(payload.env.OMNI_USER_ID).toBe('5511999999999');
   });
 
-  it('preserves trigger.env untouched when it has no GENIE_ prefixed keys (backward compat)', async () => {
+  it('merges trigger.env with canonical Omni execution env', async () => {
     const provider = makeProvider();
     const trigger = makeTrigger();
     trigger.env = { OMNI_INSTANCE: 'inst-1', OMNI_CHAT: 'chat-42' };
     await provider.trigger(trigger);
     const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
-    expect(payload.env).toEqual({ OMNI_INSTANCE: 'inst-1', OMNI_CHAT: 'chat-42' });
+    expect(payload.env).toMatchObject({
+      OMNI_INSTANCE: 'inst-1',
+      OMNI_CHAT: '5511999999999@s.whatsapp.net',
+      OMNI_USER_ID: '5511999999999',
+      OMNI_PLATFORM_USER_ID: '5511999999999',
+    });
   });
 });

--- a/packages/core/src/providers/a2a-client.ts
+++ b/packages/core/src/providers/a2a-client.ts
@@ -9,6 +9,7 @@
  */
 
 import { createLogger } from '../logger';
+import { OMNI_EXECUTION_CONTEXT_EXTENSION_URI } from './execution-context';
 import { ProviderError } from './types';
 import type { IAgentClient, ProviderRequest, ProviderResponse, StreamChunk } from './types';
 
@@ -157,16 +158,25 @@ export class A2AClient implements IAgentClient {
   }
 
   private buildJsonRpcRequest(method: string, request: ProviderRequest): unknown {
+    const message: Record<string, unknown> = {
+      role: 'ROLE_USER',
+      parts: [{ text: request.message, mediaType: 'text/plain' }],
+      messageId: `msg-${crypto.randomUUID()}`,
+    };
+
+    if (request.executionContext) {
+      message.extensions = [OMNI_EXECUTION_CONTEXT_EXTENSION_URI];
+      message.metadata = {
+        omniExecutionContext: request.executionContext,
+      };
+    }
+
     return {
       jsonrpc: '2.0',
       id: `omni-${crypto.randomUUID()}`,
       method,
       params: {
-        message: {
-          role: 'ROLE_USER',
-          parts: [{ text: request.message, mediaType: 'text/plain' }],
-          messageId: `msg-${crypto.randomUUID()}`,
-        },
+        message,
         configuration: {
           acceptedOutputModes: ['text/plain'],
           returnImmediately: true,

--- a/packages/core/src/providers/a2a-provider.ts
+++ b/packages/core/src/providers/a2a-provider.ts
@@ -9,6 +9,7 @@
 
 import { createLogger } from '../logger';
 import { createA2AClient } from './a2a-client';
+import { buildProviderRequestContext } from './execution-context';
 import type {
   AgentTrigger,
   AgentTriggerResult,
@@ -50,10 +51,9 @@ export class A2AAgentProvider implements IAgentProvider {
     }
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: this.config.agentId,
-      sessionId: context.sessionId,
-      userId: context.sender.platformUserId,
       timeoutMs: this.config.timeoutMs ?? 60_000,
     };
 
@@ -97,10 +97,9 @@ export class A2AAgentProvider implements IAgentProvider {
     }
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: this.config.agentId,
-      sessionId: context.sessionId,
-      userId: context.sender.platformUserId,
       timeoutMs: this.config.timeoutMs ?? 60_000,
     };
 

--- a/packages/core/src/providers/ag-ui-provider.ts
+++ b/packages/core/src/providers/ag-ui-provider.ts
@@ -8,6 +8,7 @@
 
 import { createLogger } from '../logger';
 import { createAgUiClient } from './ag-ui-client';
+import { buildProviderRequestContext } from './execution-context';
 import type {
   AgentTrigger,
   AgentTriggerResult,
@@ -49,10 +50,9 @@ export class AgUiAgentProvider implements IAgentProvider {
     }
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: this.config.agentId,
-      sessionId: context.sessionId,
-      userId: context.sender.platformUserId,
       timeoutMs: this.config.timeoutMs ?? 60_000,
     };
 
@@ -91,10 +91,9 @@ export class AgUiAgentProvider implements IAgentProvider {
     }
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: this.config.agentId,
-      sessionId: context.sessionId,
-      userId: context.sender.platformUserId,
       timeoutMs: this.config.timeoutMs ?? 60_000,
     };
 

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '../logger';
+import { buildProviderRequestContext } from './execution-context';
 import type { AgentTrigger, AgentTriggerResult, IAgentClient, IAgentProvider, ProviderRequest } from './types';
 
 const log = createLogger('provider:agno');
@@ -62,12 +63,11 @@ export class AgnoAgentProvider implements IAgentProvider {
     }
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: this.config.agentId,
       agentType: this.config.agentType,
       stream: false,
-      sessionId: context.sessionId,
-      userId: context.sender.platformUserId,
       timeoutMs: this.config.timeoutMs ?? 60000,
     };
 

--- a/packages/core/src/providers/claude-code-provider.ts
+++ b/packages/core/src/providers/claude-code-provider.ts
@@ -8,6 +8,7 @@
 import { createLogger } from '../logger';
 import type { ClaudeCodeClient, ClaudeCodeConfig, ClaudeCodeStreamConfig } from './claude-code-client';
 import { createClaudeCodeClient } from './claude-code-client';
+import { buildProviderRequestContext } from './execution-context';
 import type { AgentTrigger, AgentTriggerResult, IAgentProvider, ProviderRequest, StreamDelta } from './types';
 
 /**
@@ -56,21 +57,6 @@ interface PreparedRequest {
   message: string;
   resolvedSessionId: string | undefined;
   internalSessionKey: string;
-}
-
-function buildOmniEnv(context: AgentTrigger): Record<string, string> {
-  return {
-    ...(context.env ?? {}),
-    OMNI_INSTANCE: context.source.instanceId,
-    OMNI_CHAT: context.source.chatId,
-    OMNI_MESSAGE: context.source.messageId,
-    OMNI_CHANNEL: context.source.channelType,
-    OMNI_SESSION: context.sessionId,
-    OMNI_TRACE_ID: context.traceId,
-    OMNI_SENDER: context.sender.platformUserId,
-    ...(context.sender.personId ? { OMNI_PERSON_ID: context.sender.personId } : {}),
-    ...(context.source.threadId ? { OMNI_THREAD: context.source.threadId } : {}),
-  };
 }
 
 export class ClaudeCodeAgentProvider implements IAgentProvider {
@@ -237,13 +223,12 @@ export class ClaudeCodeAgentProvider implements IAgentProvider {
     const { message, resolvedSessionId, internalSessionKey } = prepared;
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: 'claude-code', // Claude Code IS the agent
       stream: false,
       sessionId: resolvedSessionId,
-      userId: context.sender.personId ?? context.sender.platformUserId,
       timeoutMs: this.options.timeoutMs ?? 120_000,
-      env: buildOmniEnv(context),
       // Use source.chatId (conversation identifier) — correct for both DMs and groups.
       // In DMs chatId == platformUserId; in groups chatId identifies the group, not the individual sender.
       ...(context.source.chatId ? { mcpUrlParams: { chat_id: context.source.chatId } } : {}),
@@ -306,13 +291,12 @@ export class ClaudeCodeAgentProvider implements IAgentProvider {
     const { message, resolvedSessionId, internalSessionKey } = prepared;
 
     const request: ProviderRequest = {
+      ...buildProviderRequestContext(context),
       message,
       agentId: 'claude-code',
       stream: true,
       sessionId: resolvedSessionId,
-      userId: context.sender.personId ?? context.sender.platformUserId,
       timeoutMs: this.options.timeoutMs ?? 120_000,
-      env: buildOmniEnv(context),
       // Use source.chatId (conversation identifier) — correct for both DMs and groups.
       ...(context.source.chatId ? { mcpUrlParams: { chat_id: context.source.chatId } } : {}),
     };

--- a/packages/core/src/providers/execution-context.ts
+++ b/packages/core/src/providers/execution-context.ts
@@ -10,6 +10,7 @@ function compactEnv(values: Record<string, string | undefined>): Record<string, 
 }
 
 function inferChatType(context: AgentTrigger): 'dm' | 'group' | 'channel' {
+  if (context.type === 'dm') return 'dm';
   if (context.source.chatId === context.sender.platformUserId) return 'dm';
   if (context.source.threadId) return 'channel';
   return 'group';

--- a/packages/core/src/providers/execution-context.ts
+++ b/packages/core/src/providers/execution-context.ts
@@ -1,0 +1,114 @@
+import type { AgentTrigger, OmniCustomerContext, OmniExecutionContext, ProviderRequest } from './types';
+
+export const OMNI_EXECUTION_CONTEXT_EXTENSION_URI = 'https://omni.dev/extensions/execution-context/v1';
+
+function compactEnv(values: Record<string, string | undefined>): Record<string, string> {
+  return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined)) as Record<
+    string,
+    string
+  >;
+}
+
+function inferChatType(context: AgentTrigger): 'dm' | 'group' | 'channel' {
+  if (context.source.chatId === context.sender.platformUserId) return 'dm';
+  if (context.source.threadId) return 'channel';
+  return 'group';
+}
+
+function compactCustomer(customer: OmniCustomerContext | undefined): OmniCustomerContext | undefined {
+  if (!customer) return undefined;
+  const compacted = Object.fromEntries(Object.entries(customer).filter(([, value]) => value !== undefined));
+  return Object.keys(compacted).length > 0 ? compacted : undefined;
+}
+
+export function buildOmniExecutionContext(context: AgentTrigger): OmniExecutionContext {
+  const userId = context.sender.personId ?? context.sender.platformUserId;
+  const sessionId = context.sessionId || context.source.threadId || context.source.chatId || userId;
+  const customer = compactCustomer(context.customer);
+  return {
+    identity: {
+      userId,
+      ...(context.sender.personId ? { personId: context.sender.personId } : {}),
+      platformUserId: context.sender.platformUserId,
+      ...(context.sender.displayName ? { displayName: context.sender.displayName } : {}),
+    },
+    source: {
+      channel: context.source.channelType,
+      instanceId: context.source.instanceId,
+      chatId: context.source.chatId,
+      ...(context.source.threadId ? { threadId: context.source.threadId } : {}),
+      messageId: context.source.messageId,
+    },
+    session: {
+      id: sessionId,
+      ...(context.sessionStrategy ? { strategy: context.sessionStrategy } : {}),
+    },
+    trace: {
+      id: context.traceId,
+    },
+    ...(customer ? { customer } : {}),
+  };
+}
+
+export function buildOmniEnv(
+  context: AgentTrigger,
+  executionContext: OmniExecutionContext = buildOmniExecutionContext(context),
+): Record<string, string> {
+  return compactEnv({
+    ...(context.env ?? {}),
+    OMNI_USER_ID: executionContext.identity.userId,
+    OMNI_PERSON_ID: executionContext.identity.personId,
+    OMNI_PLATFORM_USER_ID: executionContext.identity.platformUserId,
+    OMNI_SENDER: executionContext.identity.platformUserId,
+    OMNI_DISPLAY_NAME: executionContext.identity.displayName,
+    OMNI_INSTANCE: executionContext.source.instanceId,
+    OMNI_CHAT: executionContext.source.chatId,
+    OMNI_MESSAGE: executionContext.source.messageId,
+    OMNI_CHANNEL: executionContext.source.channel,
+    OMNI_SESSION: executionContext.session.id,
+    OMNI_TRACE_ID: executionContext.trace.id,
+    OMNI_THREAD: executionContext.source.threadId,
+    OMNI_EXTERNAL_USER_ID: executionContext.customer?.externalUserId,
+    OMNI_CUSTOMER_ID: executionContext.customer?.customerId,
+    OMNI_ORGANIZATION_ID: executionContext.customer?.organizationId,
+    OMNI_TENANT_ID: executionContext.customer?.tenantId,
+  });
+}
+
+export function buildProviderRequestContext(
+  context: AgentTrigger,
+): Pick<
+  ProviderRequest,
+  | 'chat'
+  | 'env'
+  | 'executionContext'
+  | 'messageId'
+  | 'platform'
+  | 'replyToMessageId'
+  | 'sender'
+  | 'sessionId'
+  | 'userId'
+> {
+  const executionContext = buildOmniExecutionContext(context);
+  return {
+    userId: executionContext.identity.userId,
+    sessionId: executionContext.session.id,
+    platform: {
+      id: executionContext.identity.platformUserId,
+      channel: executionContext.source.channel,
+      instanceId: executionContext.source.instanceId,
+    },
+    sender: {
+      ...(executionContext.identity.displayName ? { displayName: executionContext.identity.displayName } : {}),
+    },
+    chat: {
+      type: inferChatType(context),
+      id: executionContext.source.chatId,
+      ...(executionContext.source.threadId ? { threadId: executionContext.source.threadId } : {}),
+    },
+    messageId: executionContext.source.messageId,
+    ...(context.content.referencedMessageId ? { replyToMessageId: context.content.referencedMessageId } : {}),
+    env: buildOmniEnv(context, executionContext),
+    executionContext,
+  };
+}

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -12,6 +12,8 @@ export {
   type ProviderResponse,
   type ProviderMetrics,
   type StreamChunk,
+  type OmniCustomerContext,
+  type OmniExecutionContext,
   type AgnoAgent,
   type AgnoTeam,
   type AgnoWorkflow,
@@ -22,6 +24,13 @@ export {
   ProviderError,
   type ProviderErrorCode,
 } from './types';
+
+export {
+  OMNI_EXECUTION_CONTEXT_EXTENSION_URI,
+  buildOmniEnv,
+  buildOmniExecutionContext,
+  buildProviderRequestContext,
+} from './execution-context';
 
 // Types — unified AgentProvider abstraction
 export type {

--- a/packages/core/src/providers/nats-genie-provider.ts
+++ b/packages/core/src/providers/nats-genie-provider.ts
@@ -20,7 +20,8 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { type NatsConnection, StringCodec, connect } from 'nats';
 import { createLogger } from '../logger';
-import type { AgentTrigger, AgentTriggerResult, IAgentProvider, ProviderFile } from './types';
+import { buildOmniEnv, buildOmniExecutionContext } from './execution-context';
+import type { AgentTrigger, AgentTriggerResult, IAgentProvider, OmniExecutionContext, ProviderFile } from './types';
 
 const log = createLogger('provider:nats-genie');
 
@@ -56,6 +57,7 @@ interface NatsOutboundMessage {
   files?: ProviderFile[];
   /** Environment variables for turn-based agents (OMNI_INSTANCE, OMNI_CHAT, etc.) */
   env?: Record<string, string>;
+  executionContext?: OmniExecutionContext;
 }
 
 /** NATS reply payload received from omni.reply.{instance}.{chat_id} */
@@ -129,7 +131,8 @@ export class NatsGenieProvider implements IAgentProvider {
       traceId: context.traceId,
       messageId: context.source.messageId,
       files: context.content.files,
-      env: context.env,
+      env: buildOmniEnv(context),
+      executionContext: buildOmniExecutionContext(context),
     };
 
     try {

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -83,6 +83,9 @@ export interface ProviderRequest {
 
   /** Environment variables to expose to provider subprocesses/SDK runtimes. */
   env?: Record<string, string>;
+
+  /** Canonical Omni execution context propagated across local CLIs and remote protocols. */
+  executionContext?: OmniExecutionContext;
 }
 
 export interface ProviderFile {
@@ -345,6 +348,40 @@ export interface ProviderObservability {
   heartbeat(): Promise<{ healthy: boolean; lastProcessedAt?: Date; backlog?: number }>;
 }
 
+export interface OmniCustomerContext {
+  externalUserId?: string;
+  customerId?: string;
+  organizationId?: string;
+  tenantId?: string;
+}
+
+export interface OmniExecutionContext {
+  identity: {
+    /** Canonical requester ID: internal person UUID when available, otherwise platform user ID. */
+    userId: string;
+    /** Omni internal person UUID, when identity graph resolution succeeded. */
+    personId?: string;
+    /** Platform-specific sender ID, such as WhatsApp JID, Discord user ID, Telegram user ID. */
+    platformUserId: string;
+    displayName?: string;
+  };
+  source: {
+    channel: ChannelType;
+    instanceId: string;
+    chatId: string;
+    threadId?: string;
+    messageId: string;
+  };
+  session: {
+    id: string;
+    strategy?: 'per_user' | 'per_chat' | 'per_thread' | string;
+  };
+  trace: {
+    id: string;
+  };
+  customer?: OmniCustomerContext;
+}
+
 /**
  * Unified agent provider interface
  *
@@ -427,6 +464,10 @@ export interface AgentTrigger {
   };
   /** Session ID computed from instance's session strategy */
   sessionId: string;
+  /** Session strategy used to compute sessionId. */
+  sessionStrategy?: 'per_user' | 'per_chat' | 'per_thread' | string;
+  /** Optional customer/account identifiers resolved from person metadata. */
+  customer?: OmniCustomerContext;
   /** Recent message history for context (optional, formatted as "[Name - time] message") */
   contextMessages?: string[];
   /**
@@ -501,6 +542,7 @@ export interface WebhookPayload {
     emoji?: string;
   };
   traceId: string;
+  executionContext?: OmniExecutionContext;
   /** The endpoint to call back for sending responses */
   replyEndpoint: string;
 }

--- a/packages/core/src/providers/webhook-provider.ts
+++ b/packages/core/src/providers/webhook-provider.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger } from '../logger';
+import { buildOmniExecutionContext } from './execution-context';
 import {
   type AgentTrigger,
   type AgentTriggerResult,
@@ -63,6 +64,7 @@ export class WebhookAgentProvider implements IAgentProvider {
         emoji: context.content.emoji,
       },
       traceId: context.traceId,
+      executionContext: buildOmniExecutionContext(context),
       replyEndpoint: 'POST /api/v2/messages/send',
     };
 


### PR DESCRIPTION
## Summary
- add a canonical Omni execution context/env builder for agent providers
- propagate execution context through A2A, Claude Code, Agno, AG-UI, Webhook, and NATS Genie
- declare the Omni execution-context extension in A2A Agent Cards and safely ingest external customer context without trusting remote internal IDs

## Why
- enables a server-side dashboard/WorkOS integration to discover Omni agents and talk to them through A2A while preserving per-user/customer/session identity for downstream CLIs

## Safety
- A2A inbound does not trust remote `personId` or `platformIdentityId`; Omni resolves/creates internal identity from external sender IDs
- stored Omni person metadata wins over remote customer context when merging

## Validation
- `bun test packages/channel-a2a/src/__tests__/a2a-handler.test.ts packages/api/src/plugins/__tests__/agent-dispatcher.test.ts packages/core/src/providers/__tests__/execution-context.test.ts packages/core/src/providers/__tests__/a2a-client.test.ts packages/core/src/providers/__tests__/claude-code-client.test.ts packages/core/src/providers/__tests__/nats-genie-provider.test.ts packages/api/src/services/__tests__/a2a-discovery.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- pre-push hook: typecheck + full test suite