### PR TITLE
fix(core): propagate Langfuse trace context on homolog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Start pgserve
-        run: bunx pgserve --port 8432 --data .pgserve-data --no-cluster &
+        run: bunx pgserve@1.1.8 --port 8432 --data .pgserve-data --no-cluster &
 
       - name: Start NATS
         run: ./bin/nats-server -js -p 4222 &
@@ -146,7 +146,7 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Start pgserve
-        run: bunx pgserve --port 8432 --data .pgserve-data --no-cluster &
+        run: bunx pgserve@1.1.8 --port 8432 --data .pgserve-data --no-cluster &
 
       - name: Start NATS
         run: ./bin/nats-server -js -p 4222 &

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -86,7 +86,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -161,7 +161,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -195,7 +195,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -243,7 +243,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "croner": "^9.1.0",
@@ -258,7 +258,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -272,7 +272,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -290,7 +290,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -298,7 +298,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -312,7 +312,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260410.1",
+      "version": "2.260418.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",
@@ -1044,7 +1044,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -2174,13 +2174,15 @@
 
     "@nuxtjs/opencollective/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "@omni/api/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@omni/api/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@omni/channel-discord/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@omni/channel-gupshup/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@omni/channel-internal/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@omni/channel-sdk/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@omni/channel-sdk/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@omni/channel-slack/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -2188,17 +2190,17 @@
 
     "@omni/channel-whatsapp/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
-    "@omni/core/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@omni/core/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "@omni/db/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@omni/db/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "@omni/media-processing/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@omni/media-processing/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@omni/plugin-openclaw/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@omni/ui/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@omni/voice-client/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@omni/voice-client/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@openapitools/openapi-generator-cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2236,7 +2238,7 @@
 
     "@types/body-parser/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@types/connect/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
@@ -2401,6 +2403,8 @@
     "@nuxtjs/opencollective/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "@omni/api/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "@omni/channel-discord/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@omni/channel-gupshup/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
@@ -2588,6 +2592,8 @@
 
     "@omni/api/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "@omni/channel-discord/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
     "@omni/channel-gupshup/@types/bun/bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@omni/channel-sdk/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -2623,6 +2629,8 @@
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
+
+    "@omni/channel-discord/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@omni/channel-gupshup/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -109,6 +109,144 @@ describe('AgnoClient', () => {
       expect(mockImpl).toHaveBeenCalledTimes(1);
     });
 
+    it('propagates W3C trace context in headers for Langfuse session stitching', async () => {
+      const response = {
+        run_id: 'run-123',
+        agent_id: 'agent-1',
+        session_id: 'session-456',
+        content: 'Hello from agent!',
+        status: 'COMPLETED',
+      };
+
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(response), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      await client.run({
+        message: 'Hello!',
+        agentId: 'agent-1',
+        agentType: 'agent',
+        sessionId: 'chat-123',
+        userId: 'user-456',
+        traceContext: {
+          traceId: '0123456789abcdef0123456789abcdef',
+          spanId: 'fedcba9876543210',
+          parentSpanId: '0011223344556677',
+          traceFlags: 1,
+          tracestate: 'vendor=value',
+        },
+        khalSessionId: 'khal-session-123',
+        omni: {
+          instanceId: 'inst-1',
+          chatId: 'chat-123',
+          messageId: 'msg-789',
+          channel: 'whatsapp-cloud',
+        },
+      });
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      const formData = init.body as FormData;
+      expect(headers.traceparent).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
+      expect(headers.tracestate).toBe('vendor=value');
+      expect(headers['x-trace-id']).toBe('0123456789abcdef0123456789abcdef');
+      expect(headers['x-span-id']).toBe('fedcba9876543210');
+      expect(headers['x-parent-span-id']).toBe('0011223344556677');
+      expect(headers['x-khal-session-id']).toBe('khal-session-123');
+      expect(headers['x-khal-user-id']).toBe('user-456');
+      expect(headers['x-khal-message-id']).toBe('msg-789');
+      expect(headers['x-omni-instance-id']).toBe('inst-1');
+      expect(headers['x-omni-chat-id']).toBe('chat-123');
+      expect(headers['x-omni-channel']).toBe('whatsapp-cloud');
+      expect(formData.get('session_id')).toBe('khal-session-123');
+    });
+
+    it('includes structured Omni metadata in Agno run form payloads', async () => {
+      const response = {
+        run_id: 'run-123',
+        agent_id: 'agent-1',
+        session_id: 'session-456',
+        content: 'Hello from agent!',
+        status: 'COMPLETED',
+      };
+
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(response), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      await client.run({
+        message: 'Hello!',
+        agentId: 'agent-1',
+        agentType: 'agent',
+        sessionId: 'chat-123',
+        khalSessionId: 'khal-session-123',
+        userId: 'person-uuid',
+        platform: {
+          id: '5511999999999',
+          channel: 'whatsapp-cloud',
+          instanceId: 'inst-1',
+        },
+        sender: { displayName: 'Felipe' },
+        chat: { type: 'group', id: 'group-1', threadId: 'topic-1' },
+        messageId: 'msg-789',
+        replyToMessageId: 'msg-456',
+        mcpUrlParams: { chat_id: 'group-1' },
+        env: { OMNI_CHAT: 'group-1' },
+        omni: {
+          instanceId: 'inst-1',
+          chatId: 'group-1',
+          messageId: 'msg-789',
+          channel: 'whatsapp-cloud',
+        },
+      });
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const formData = init.body as FormData;
+      expect(formData.get('user_id')).toBe('person-uuid');
+      expect(formData.get('khal_session_id')).toBe('khal-session-123');
+      expect(formData.get('message_id')).toBe('msg-789');
+      expect(formData.get('reply_to_message_id')).toBe('msg-456');
+      expect(JSON.parse(String(formData.get('platform')))).toEqual({
+        id: '5511999999999',
+        channel: 'whatsapp-cloud',
+        instanceId: 'inst-1',
+      });
+      expect(JSON.parse(String(formData.get('sender')))).toEqual({ displayName: 'Felipe' });
+      expect(JSON.parse(String(formData.get('chat')))).toEqual({ type: 'group', id: 'group-1', threadId: 'topic-1' });
+      expect(JSON.parse(String(formData.get('mcp_url_params')))).toEqual({ chat_id: 'group-1' });
+      expect(JSON.parse(String(formData.get('env')))).toEqual({ OMNI_CHAT: 'group-1' });
+      expect(JSON.parse(String(formData.get('omni')))).toEqual({
+        instanceId: 'inst-1',
+        chatId: 'group-1',
+        messageId: 'msg-789',
+        channel: 'whatsapp-cloud',
+      });
+    });
+
+    it('uses sessionId as x-khal-session-id when khalSessionId is omitted', async () => {
+      const response = {
+        run_id: 'run-123',
+        agent_id: 'agent-1',
+        session_id: 'session-456',
+        content: 'Hello response',
+        status: 'COMPLETED',
+      };
+
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(response), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      await client.run({
+        message: 'Hello!',
+        agentId: 'agent-1',
+        userId: 'test-user-id',
+        sessionId: 'legacy-session-123',
+      });
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      const formData = init.body as FormData;
+      expect(headers['x-khal-session-id']).toBe('legacy-session-123');
+      expect(formData.get('session_id')).toBe('legacy-session-123');
+    });
+
     it('routes to teams endpoint for team agentType', async () => {
       const response = {
         run_id: 'run-123',

--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -128,8 +128,8 @@ describe('AgnoClient', () => {
         sessionId: 'chat-123',
         userId: 'user-456',
         traceContext: {
-          traceId: '0123456789abcdef0123456789abcdef',
-          spanId: 'fedcba9876543210',
+          traceId: '0123456789ABCDEF0123456789ABCDEF',
+          spanId: 'FEDCBA9876543210',
           parentSpanId: '0011223344556677',
           traceFlags: 1,
           tracestate: 'vendor=value',

--- a/packages/core/src/providers/__tests__/agno-provider.test.ts
+++ b/packages/core/src/providers/__tests__/agno-provider.test.ts
@@ -1,0 +1,161 @@
+/**
+ * AgnoAgentProvider Tests
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import type { AgentTrigger, IAgentClient, ProviderRequest, ProviderResponse, StreamChunk } from '../types';
+
+// Import the provider through a query-suffixed module id so Bun's process-wide
+// mock.module('@omni/core') in API dispatcher tests cannot poison this source-level
+// provider test when the entire monorepo suite runs in one process.
+// @ts-expect-error Bun test supports query-suffixed imports; TypeScript does not resolve them.
+const { AgnoAgentProvider } = await import('../agno-provider.ts?real-agno-provider-test');
+
+function createTrigger(overrides: Partial<AgentTrigger> = {}): AgentTrigger {
+  return {
+    traceId: 'trace-1',
+    type: 'mention',
+    event: {} as AgentTrigger['event'],
+    source: {
+      channelType: 'whatsapp-cloud',
+      instanceId: 'inst-1',
+      chatId: 'group-1',
+      messageId: 'msg-1',
+      threadId: 'thread-1',
+    },
+    sender: {
+      platformUserId: '5511999999999',
+      personId: 'person-uuid',
+      displayName: 'Felipe',
+    },
+    content: {
+      text: 'hello agno',
+      referencedMessageId: 'msg-0',
+    },
+    sessionId: 'session-1',
+    traceContext: {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: 'fedcba9876543210',
+      parentSpanId: '0011223344556677',
+      traceFlags: 1,
+      tracestate: 'vendor=value',
+    },
+    env: { OMNI_CHAT: 'group-1' },
+    ...overrides,
+  };
+}
+
+function createClient(chunks: StreamChunk[] = []): IAgentClient & { lastRequest?: ProviderRequest } {
+  const client: IAgentClient & { lastRequest?: ProviderRequest } = {
+    run: mock(async (request: ProviderRequest): Promise<ProviderResponse> => {
+      client.lastRequest = request;
+      return {
+        content: 'done',
+        runId: 'run-1',
+        sessionId: 'session-1',
+        status: 'completed',
+      };
+    }),
+    stream: mock(async function* (request: ProviderRequest): AsyncGenerator<StreamChunk> {
+      client.lastRequest = request;
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    }),
+    discover: mock(async () => []),
+    checkHealth: mock(async () => ({ healthy: true, latencyMs: 1 })),
+  };
+
+  return client;
+}
+
+async function collect<T>(stream: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const item of stream) {
+    results.push(item);
+  }
+  return results;
+}
+
+describe('AgnoAgentProvider', () => {
+  it('streams Agno client chunks as provider deltas instead of falling back to trigger()', async () => {
+    const client = createClient([
+      { event: 'delta', content: 'hel', isComplete: false },
+      { event: 'delta', content: 'lo', isComplete: false },
+      { event: 'complete', fullContent: 'hello', isComplete: true },
+    ]);
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+      timeoutMs: 1234,
+    });
+
+    const deltas = await collect(provider.triggerStream(createTrigger()));
+
+    expect(deltas).toEqual([
+      { phase: 'content', content: 'hel' },
+      { phase: 'content', content: 'lo' },
+      { phase: 'final', content: 'hello' },
+    ]);
+    expect(client.stream).toHaveBeenCalledTimes(1);
+    expect(client.run).not.toHaveBeenCalled();
+    expect(client.lastRequest).toMatchObject({
+      agentId: 'agent-1',
+      agentType: 'agent',
+      stream: true,
+      sessionId: 'session-1',
+      userId: 'person-uuid',
+      khalSessionId: 'session-1',
+      messageId: 'msg-1',
+      replyToMessageId: 'msg-0',
+      mcpUrlParams: { chat_id: 'group-1' },
+      omni: {
+        instanceId: 'inst-1',
+        chatId: 'group-1',
+        messageId: 'msg-1',
+        channel: 'whatsapp-cloud',
+      },
+      platform: {
+        id: '5511999999999',
+        channel: 'whatsapp-cloud',
+        instanceId: 'inst-1',
+      },
+      sender: { displayName: 'Felipe' },
+      chat: { type: 'group', id: 'group-1', threadId: 'thread-1' },
+      traceContext: {
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: 'fedcba9876543210',
+        parentSpanId: '0011223344556677',
+        traceFlags: 1,
+        tracestate: 'vendor=value',
+      },
+    });
+  });
+
+  it('passes internal person UUID as userId for non-streaming Agno runs', async () => {
+    const client = createClient();
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'team',
+      prefixSenderName: false,
+    });
+
+    const result = await provider.trigger(createTrigger());
+
+    expect(result.parts).toEqual(['done']);
+    expect(client.lastRequest).toMatchObject({
+      message: 'hello agno',
+      agentType: 'team',
+      stream: false,
+      userId: 'person-uuid',
+      traceContext: {
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: 'fedcba9876543210',
+        parentSpanId: '0011223344556677',
+        traceFlags: 1,
+        tracestate: 'vendor=value',
+      },
+      platform: { id: '5511999999999' },
+    });
+  });
+});

--- a/packages/core/src/providers/__tests__/agno-provider.test.ts
+++ b/packages/core/src/providers/__tests__/agno-provider.test.ts
@@ -69,6 +69,26 @@ function createClient(chunks: StreamChunk[] = []): IAgentClient & { lastRequest?
   return client;
 }
 
+function createThrowingStreamClient(): IAgentClient & { lastRequest?: ProviderRequest } {
+  const client: IAgentClient & { lastRequest?: ProviderRequest } = {
+    run: mock(async (request: ProviderRequest): Promise<ProviderResponse> => {
+      client.lastRequest = request;
+      return { content: 'done', runId: 'run-1', sessionId: 'session-1', status: 'completed' };
+    }),
+    stream: mock(async function* (request: ProviderRequest): AsyncGenerator<StreamChunk> {
+      client.lastRequest = request;
+      if (request.agentId === 'unreachable') {
+        yield { event: 'unreachable', isComplete: false };
+      }
+      throw new Error('stream exploded');
+    }),
+    discover: mock(async () => []),
+    checkHealth: mock(async () => ({ healthy: true, latencyMs: 1 })),
+  };
+
+  return client;
+}
+
 async function collect<T>(stream: AsyncGenerator<T>): Promise<T[]> {
   const results: T[] = [];
   for await (const item of stream) {
@@ -157,5 +177,38 @@ describe('AgnoAgentProvider', () => {
       },
       platform: { id: '5511999999999' },
     });
+  });
+
+  it('derives a W3C trace context from Omni traceId when dispatcher did not provide one', async () => {
+    const client = createClient();
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    await provider.trigger(
+      createTrigger({
+        traceId: 'trc-homolog-dispatch-1',
+        traceContext: undefined,
+      }),
+    );
+
+    expect(client.lastRequest?.traceContext?.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(client.lastRequest?.traceContext?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(client.lastRequest?.traceContext?.traceFlags).toBe(1);
+  });
+
+  it('converts Agno stream exceptions into error deltas instead of throwing', async () => {
+    const client = createThrowingStreamClient();
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const deltas = await collect(provider.triggerStream(createTrigger()));
+
+    expect(deltas).toEqual([{ phase: 'error', error: 'stream exploded' }]);
+    expect(client.stream).toHaveBeenCalledTimes(1);
+    expect(client.run).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
+++ b/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
@@ -16,14 +16,14 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 // Mock the nats module before importing the provider
 // ---------------------------------------------------------------------------
 
-type CapturedPublish = { subject: string; data: string };
+type CapturedPublish = { subject: string; data: string; options?: { headers?: Map<string, string> } };
 
 const publishCalls: CapturedPublish[] = [];
 let lastSubscribedSubject: string | null = null;
 const pendingReplies: Array<{ subject: string; data: string }> = [];
 
-const publishSpy = mock((subject: string, data: Uint8Array) => {
-  publishCalls.push({ subject, data: new TextDecoder().decode(data) });
+const publishSpy = mock((subject: string, data: Uint8Array, options?: { headers?: Map<string, string> }) => {
+  publishCalls.push({ subject, data: new TextDecoder().decode(data), options });
 });
 
 // A minimal async iterable subscription that yields any pending replies
@@ -70,6 +70,15 @@ mock.module('nats', () => ({
     encode: (s: string) => new TextEncoder().encode(s),
     decode: (b: Uint8Array) => new TextDecoder().decode(b),
   }),
+  StorageType: { File: 'file' },
+  headers: () => {
+    const values = new Map<string, string>();
+    return {
+      set: (key: string, value: string) => values.set(key, value),
+      get: (key: string) => values.get(key),
+      values,
+    };
+  },
   connect: mock(async () => ({
     publish: publishSpy,
     subscribe: (subject: string) => createSubscription(subject),
@@ -273,5 +282,92 @@ describe('NatsGenieProvider.trigger() — parts: [] regression guard', () => {
     (trigger as any).content = {};
     const result = await provider.trigger(trigger);
     expect(result.parts).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trigger.env → NATS payload.env pass-through (GENIE_TMUX_SESSION plumbing)
+// ---------------------------------------------------------------------------
+
+describe('NatsGenieProvider.trigger() — env pass-through', () => {
+  it('propagates GENIE_TMUX_SESSION from trigger.env into the published NATS payload', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.env = {
+      OMNI_INSTANCE: 'inst-1',
+      OMNI_CHAT: 'chat-42',
+      OMNI_MESSAGE: 'msg-1',
+      OMNI_TURN_ID: 'turn-xyz',
+      GENIE_TMUX_SESSION: 'whatsapp-scout-12',
+    };
+    await provider.trigger(trigger);
+    expect(publishCalls.length).toBeGreaterThan(0);
+    const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
+    expect(payload.env).toEqual({
+      OMNI_INSTANCE: 'inst-1',
+      OMNI_CHAT: 'chat-42',
+      OMNI_MESSAGE: 'msg-1',
+      OMNI_TURN_ID: 'turn-xyz',
+      GENIE_TMUX_SESSION: 'whatsapp-scout-12',
+    });
+  });
+
+  it('omits GENIE_TMUX_SESSION from payload.env when the dispatcher did not set it', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.env = {
+      OMNI_INSTANCE: 'inst-1',
+      OMNI_CHAT: 'chat-42',
+      OMNI_MESSAGE: 'msg-1',
+      OMNI_TURN_ID: 'turn-xyz',
+    };
+    await provider.trigger(trigger);
+    const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
+    expect(payload.env).not.toHaveProperty('GENIE_TMUX_SESSION');
+    expect(payload.env.OMNI_INSTANCE).toBe('inst-1');
+  });
+
+  it('preserves trigger.env untouched when it has no GENIE_ prefixed keys (backward compat)', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.env = { OMNI_INSTANCE: 'inst-1', OMNI_CHAT: 'chat-42' };
+    await provider.trigger(trigger);
+    const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
+    expect(payload.env).toEqual({ OMNI_INSTANCE: 'inst-1', OMNI_CHAT: 'chat-42' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Langfuse/HML trace propagation
+// ---------------------------------------------------------------------------
+
+describe('NatsGenieProvider.trigger() — trace context propagation', () => {
+  it('publishes W3C and khal-os trace headers and mirrors trace context in the payload', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.sessionId = 'session-abc';
+    trigger.traceContext = {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: 'fedcba9876543210',
+      parentSpanId: '0011223344556677',
+      traceFlags: 1,
+      tracestate: 'vendor=value',
+    };
+
+    await provider.trigger(trigger);
+
+    const call = publishCalls[publishCalls.length - 1]!;
+    const headers = call.options?.headers;
+    expect(headers?.get('traceparent')).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
+    expect(headers?.get('tracestate')).toBe('vendor=value');
+    expect(headers?.get('x-khal-session-id')).toBe('session-abc');
+    expect(headers?.get('x-trace-id')).toBe('0123456789abcdef0123456789abcdef');
+    expect(headers?.get('x-span-id')).toBe('fedcba9876543210');
+    expect(headers?.get('x-parent-span-id')).toBe('0011223344556677');
+
+    const payload = JSON.parse(call.data);
+    expect(payload.traceContext).toEqual(trigger.traceContext);
+    expect(payload.metadata.traceparent).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
+    expect(payload.metadata['x-khal-session-id']).toBe('session-abc');
   });
 });

--- a/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
+++ b/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
@@ -370,4 +370,25 @@ describe('NatsGenieProvider.trigger() — trace context propagation', () => {
     expect(payload.metadata.traceparent).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
     expect(payload.metadata['x-khal-session-id']).toBe('session-abc');
   });
+
+  it('keeps raw user and chat identifiers out of mirrored payload metadata', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.sessionId = 'session-abc';
+    trigger.traceContext = {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: 'fedcba9876543210',
+      traceFlags: 1,
+    };
+
+    await provider.trigger(trigger);
+
+    const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
+    expect(payload.metadata['x-khal-user-id']).toBeUndefined();
+    expect(payload.metadata['x-omni-chat-id']).toBeUndefined();
+    expect(JSON.stringify(payload.metadata)).not.toContain('5511999999999');
+    expect(JSON.stringify(payload.metadata)).not.toContain('s.whatsapp.net');
+    expect(payload.metadata['x-khal-user-hash']).toMatch(/^[a-f0-9]{12}$/);
+    expect(payload.metadata['x-omni-chat-hash']).toMatch(/^[a-f0-9]{12}$/);
+  });
 });

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -5,6 +5,7 @@
  * with both sync and streaming support.
  */
 
+import { buildTraceHeaders } from './trace-context';
 import {
   type AgentDiscoveryEntry,
   type AgentHealthResult,
@@ -191,12 +192,15 @@ export class AgnoClient implements IAgentClient {
     formData.append('message', request.message);
     formData.append('stream', String(stream));
 
-    if (request.sessionId) {
-      formData.append('session_id', request.sessionId);
+    const sessionId = request.khalSessionId ?? request.sessionId;
+    if (sessionId) {
+      formData.append('session_id', sessionId);
     }
     if (request.userId) {
       formData.append('user_id', request.userId);
     }
+
+    this.appendStructuredMetadata(formData, request);
 
     if (request.files?.length) {
       for (const file of request.files) {
@@ -217,6 +221,31 @@ export class AgnoClient implements IAgentClient {
     }
 
     return formData;
+  }
+
+  private appendStructuredMetadata(formData: FormData, request: ProviderRequest): void {
+    const appendJson = (key: string, value: unknown) => {
+      if (value !== undefined) {
+        formData.append(key, JSON.stringify(value));
+      }
+    };
+
+    if (request.khalSessionId) {
+      formData.append('khal_session_id', request.khalSessionId);
+    }
+    if (request.messageId) {
+      formData.append('message_id', request.messageId);
+    }
+    if (request.replyToMessageId) {
+      formData.append('reply_to_message_id', request.replyToMessageId);
+    }
+
+    appendJson('platform', request.platform);
+    appendJson('sender', request.sender);
+    appendJson('chat', request.chat);
+    appendJson('mcp_url_params', request.mcpUrlParams);
+    appendJson('env', request.env);
+    appendJson('omni', request.omni);
   }
 
   async runAgent(agentId: string, request: ProviderRequest): Promise<ProviderResponse> {
@@ -244,7 +273,15 @@ export class AgnoClient implements IAgentClient {
       url,
       {
         method: 'POST',
-        headers: this.getHeaders(),
+        headers: {
+          ...this.getHeaders(),
+          ...buildTraceHeaders(request.traceContext, {
+            khalSessionId: request.khalSessionId ?? request.sessionId,
+            userId: request.userId,
+            messageId: request.omni?.messageId,
+            omni: request.omni,
+          }),
+        },
         body: formData,
       },
       timeoutMs,
@@ -311,7 +348,15 @@ export class AgnoClient implements IAgentClient {
       url,
       {
         method: 'POST',
-        headers: this.getHeaders(),
+        headers: {
+          ...this.getHeaders(),
+          ...buildTraceHeaders(request.traceContext, {
+            khalSessionId: request.khalSessionId ?? request.sessionId,
+            userId: request.userId,
+            messageId: request.omni?.messageId,
+            omni: request.omni,
+          }),
+        },
         body: formData,
       },
       timeoutMs,

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '../logger';
+import { createTraceContextFromTraceId } from './trace-context';
 import type {
   AgentTrigger,
   AgentTriggerResult,
@@ -120,14 +121,24 @@ export class AgnoAgentProvider implements IAgentProvider {
       traceId: context.traceId,
     });
 
-    for await (const chunk of this.client.stream(request)) {
-      if (chunk.content) {
-        yield { phase: 'content', content: chunk.content };
-      }
+    try {
+      for await (const chunk of this.client.stream(request)) {
+        if (chunk.content) {
+          yield { phase: 'content', content: chunk.content };
+        }
 
-      if (chunk.isComplete) {
-        yield { phase: 'final', content: chunk.fullContent ?? chunk.content ?? '' };
+        if (chunk.isComplete) {
+          yield { phase: 'final', content: chunk.fullContent ?? chunk.content ?? '' };
+        }
       }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error('Error in Agno agent stream', {
+        agentId: this.config.agentId,
+        traceId: context.traceId,
+        error: message,
+      });
+      yield { phase: 'error', error: message };
     }
   }
 
@@ -154,6 +165,12 @@ export class AgnoAgentProvider implements IAgentProvider {
 
   private buildRequest(context: AgentTrigger, message: string, stream: boolean): ProviderRequest {
     const chatType = context.source.chatId === context.sender.platformUserId ? 'dm' : 'group';
+    const traceContext =
+      context.traceContext ??
+      createTraceContextFromTraceId(
+        context.traceId,
+        `${context.source.instanceId}:${context.source.chatId}:${context.source.messageId}:agno`,
+      );
 
     return {
       message,
@@ -165,7 +182,7 @@ export class AgnoAgentProvider implements IAgentProvider {
       timeoutMs: this.config.timeoutMs ?? 60000,
       files: context.content.files,
       env: context.env,
-      traceContext: context.traceContext,
+      traceContext,
       khalSessionId: context.sessionId,
       omni: {
         instanceId: context.source.instanceId,

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -6,7 +6,14 @@
  */
 
 import { createLogger } from '../logger';
-import type { AgentTrigger, AgentTriggerResult, IAgentClient, IAgentProvider, ProviderRequest } from './types';
+import type {
+  AgentTrigger,
+  AgentTriggerResult,
+  IAgentClient,
+  IAgentProvider,
+  ProviderRequest,
+  StreamDelta,
+} from './types';
 
 const log = createLogger('provider:agno');
 
@@ -35,14 +42,7 @@ export class AgnoAgentProvider implements IAgentProvider {
   async trigger(context: AgentTrigger): Promise<AgentTriggerResult> {
     const startTime = Date.now();
 
-    // Build the message from trigger content
-    let message = '';
-    if (context.content.text) {
-      message = context.content.text;
-    } else if (context.content.emoji) {
-      // For reaction triggers, format as a reaction notification
-      message = `[Reaction: ${context.content.emoji} on message ${context.content.referencedMessageId ?? context.source.messageId}]`;
-    }
+    const message = this.buildMessage(context);
 
     if (!message) {
       log.debug('No content to send to agent', { traceId: context.traceId });
@@ -56,20 +56,7 @@ export class AgnoAgentProvider implements IAgentProvider {
       };
     }
 
-    // Prefix sender name if configured
-    if (this.config.prefixSenderName !== false && context.sender.displayName) {
-      message = `[${context.sender.displayName}]: ${message}`;
-    }
-
-    const request: ProviderRequest = {
-      message,
-      agentId: this.config.agentId,
-      agentType: this.config.agentType,
-      stream: false,
-      sessionId: context.sessionId,
-      userId: context.sender.platformUserId,
-      timeoutMs: this.config.timeoutMs ?? 60000,
-    };
+    const request = this.buildRequest(context, message, false);
 
     log.info('Triggering Agno agent', {
       agentId: this.config.agentId,
@@ -116,7 +103,92 @@ export class AgnoAgentProvider implements IAgentProvider {
     };
   }
 
+  async *triggerStream(context: AgentTrigger): AsyncGenerator<StreamDelta> {
+    const message = this.buildMessage(context);
+
+    if (!message) {
+      log.debug('No content to send to Agno agent (stream)', { traceId: context.traceId });
+      return;
+    }
+
+    const request = this.buildRequest(context, message, true);
+
+    log.info('Streaming Agno agent', {
+      agentId: this.config.agentId,
+      agentType: this.config.agentType,
+      triggerType: context.type,
+      traceId: context.traceId,
+    });
+
+    for await (const chunk of this.client.stream(request)) {
+      if (chunk.content) {
+        yield { phase: 'content', content: chunk.content };
+      }
+
+      if (chunk.isComplete) {
+        yield { phase: 'final', content: chunk.fullContent ?? chunk.content ?? '' };
+      }
+    }
+  }
+
   async checkHealth(): Promise<{ healthy: boolean; latencyMs: number; error?: string }> {
     return this.client.checkHealth();
+  }
+
+  private buildMessage(context: AgentTrigger): string {
+    let message = '';
+    if (context.content.text) {
+      message = context.content.text;
+    } else if (context.content.emoji) {
+      // For reaction triggers, format as a reaction notification
+      message = `[Reaction: ${context.content.emoji} on message ${context.content.referencedMessageId ?? context.source.messageId}]`;
+    }
+
+    // Prefix sender name if configured
+    if (message && this.config.prefixSenderName !== false && context.sender.displayName) {
+      message = `[${context.sender.displayName}]: ${message}`;
+    }
+
+    return message;
+  }
+
+  private buildRequest(context: AgentTrigger, message: string, stream: boolean): ProviderRequest {
+    const chatType = context.source.chatId === context.sender.platformUserId ? 'dm' : 'group';
+
+    return {
+      message,
+      agentId: this.config.agentId,
+      agentType: this.config.agentType,
+      stream,
+      sessionId: context.sessionId,
+      userId: context.sender.personId ?? context.sender.platformUserId,
+      timeoutMs: this.config.timeoutMs ?? 60000,
+      files: context.content.files,
+      env: context.env,
+      traceContext: context.traceContext,
+      khalSessionId: context.sessionId,
+      omni: {
+        instanceId: context.source.instanceId,
+        chatId: context.source.chatId,
+        messageId: context.source.messageId,
+        channel: context.source.channelType,
+      },
+      platform: {
+        id: context.sender.platformUserId,
+        channel: context.source.channelType,
+        instanceId: context.source.instanceId,
+      },
+      sender: {
+        displayName: context.sender.displayName,
+      },
+      chat: {
+        type: chatType,
+        id: context.source.chatId,
+        threadId: context.source.threadId,
+      },
+      messageId: context.source.messageId,
+      replyToMessageId: context.content.referencedMessageId,
+      ...(context.source.chatId ? { mcpUrlParams: { chat_id: context.source.chatId } } : {}),
+    };
   }
 }

--- a/packages/core/src/providers/nats-genie-provider.ts
+++ b/packages/core/src/providers/nats-genie-provider.ts
@@ -137,7 +137,7 @@ export class NatsGenieProvider implements IAgentProvider {
       contextMessages: context.contextMessages,
       files: context.content.files,
       traceContext: context.traceContext,
-      metadata: propagationHeaders,
+      metadata: this.buildSafePayloadMetadata(propagationHeaders),
       env: context.env,
     };
 
@@ -356,6 +356,24 @@ export class NatsGenieProvider implements IAgentProvider {
     }
 
     return { headers: natsHeaders };
+  }
+
+  private buildSafePayloadMetadata(traceHeaders: Record<string, string>): Record<string, string> {
+    const metadata: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(traceHeaders)) {
+      if (key === 'x-khal-user-id') {
+        metadata['x-khal-user-hash'] = this.safeHash(value);
+        continue;
+      }
+      if (key === 'x-omni-chat-id') {
+        metadata['x-omni-chat-hash'] = this.safeHash(value);
+        continue;
+      }
+      metadata[key] = value;
+    }
+
+    return metadata;
   }
 
   private safeHash(value: string): string {

--- a/packages/core/src/providers/nats-genie-provider.ts
+++ b/packages/core/src/providers/nats-genie-provider.ts
@@ -15,12 +15,14 @@
  * Agent replies come back via NATS subscription.
  */
 
+import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { type NatsConnection, StringCodec, connect } from 'nats';
+import { type NatsConnection, StringCodec, connect, headers as createNatsHeaders } from 'nats';
 import { createLogger } from '../logger';
-import type { AgentTrigger, AgentTriggerResult, IAgentProvider, ProviderFile } from './types';
+import { buildTraceHeaders } from './trace-context';
+import type { AgentTrigger, AgentTriggerResult, IAgentProvider, ProviderFile, TraceContext } from './types';
 
 const log = createLogger('provider:nats-genie');
 
@@ -53,7 +55,10 @@ interface NatsOutboundMessage {
   timestamp: string;
   traceId: string;
   messageId?: string;
+  contextMessages?: string[];
   files?: ProviderFile[];
+  traceContext?: TraceContext;
+  metadata?: Record<string, string>;
   /** Environment variables for turn-based agents (OMNI_INSTANCE, OMNI_CHAT, etc.) */
   env?: Record<string, string>;
 }
@@ -119,6 +124,7 @@ export class NatsGenieProvider implements IAgentProvider {
     }
 
     const topic = `omni.message.${this.config.instanceId}.${context.source.chatId}`;
+    const propagationHeaders = this.buildPropagationHeaders(context);
     const payload: NatsOutboundMessage = {
       content: message,
       sender: context.sender.displayName ?? context.sender.platformUserId,
@@ -128,23 +134,29 @@ export class NatsGenieProvider implements IAgentProvider {
       timestamp: new Date().toISOString(),
       traceId: context.traceId,
       messageId: context.source.messageId,
+      contextMessages: context.contextMessages,
       files: context.content.files,
+      traceContext: context.traceContext,
+      metadata: propagationHeaders,
       env: context.env,
     };
 
     try {
       await this.ensureConnected();
-      this.nc?.publish(topic, this.sc.encode(JSON.stringify(payload)));
+      this.nc?.publish(topic, this.sc.encode(JSON.stringify(payload)), this.buildPublishOptions(propagationHeaders));
 
       log.info('Published to NATS', {
-        topic,
+        subject: 'omni.message.<instance>.<chat_hash>',
         agent: this.config.agentName,
-        chatId: context.source.chatId,
+        instanceId: this.config.instanceId,
+        chatHash: this.safeHash(context.source.chatId),
         traceId: context.traceId,
       });
     } catch (error) {
       log.error('Failed to publish to NATS, writing to dead-letter queue', {
-        topic,
+        subject: 'omni.message.<instance>.<chat_hash>',
+        instanceId: this.config.instanceId,
+        chatHash: this.safeHash(context.source.chatId),
         error: error instanceof Error ? error.message : String(error),
         traceId: context.traceId,
       });
@@ -211,7 +223,8 @@ export class NatsGenieProvider implements IAgentProvider {
           }
         } catch (error) {
           log.error('Error processing reply', {
-            subject: msg.subject,
+            subject: 'omni.reply.<instance>.<chat_hash>',
+            subjectHash: this.safeHash(msg.subject),
             error: error instanceof Error ? error.message : String(error),
           });
         }
@@ -250,7 +263,7 @@ export class NatsGenieProvider implements IAgentProvider {
     if (!chatId) {
       log.warn('NATS session reset skipped: missing chatId', {
         providerId: this.id,
-        sessionKey,
+        sessionKeyHash: this.safeHash(sessionKey),
       });
       throw new Error('chatId is required to reset NATS Genie session');
     }
@@ -269,14 +282,17 @@ export class NatsGenieProvider implements IAgentProvider {
       await this.ensureConnected();
       this.nc?.publish(topic, this.sc.encode(JSON.stringify(payload)));
       log.info('Published session reset to NATS', {
-        topic,
+        subject: 'omni.session.reset.<instance>.<chat_hash>',
         providerId: this.id,
-        sessionKey,
-        chatId,
+        instanceId: resolvedInstanceId,
+        sessionKeyHash: this.safeHash(sessionKey),
+        chatHash: this.safeHash(chatId),
       });
     } catch (error) {
       log.error('Failed to publish NATS session reset', {
-        topic,
+        subject: 'omni.session.reset.<instance>.<chat_hash>',
+        instanceId: resolvedInstanceId,
+        chatHash: this.safeHash(chatId),
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;
@@ -314,6 +330,36 @@ export class NatsGenieProvider implements IAgentProvider {
     });
 
     log.info('Connected to NATS', { url: this.config.natsUrl });
+  }
+
+  private buildPropagationHeaders(context: AgentTrigger): Record<string, string> {
+    return buildTraceHeaders(context.traceContext, {
+      khalSessionId: context.sessionId,
+      userId: context.sender.personId ?? context.sender.platformUserId,
+      messageId: context.source.messageId,
+      omni: {
+        instanceId: context.source.instanceId,
+        chatId: context.source.chatId,
+        channel: context.source.channelType,
+      },
+    });
+  }
+
+  private buildPublishOptions(
+    traceHeaders: Record<string, string>,
+  ): { headers?: ReturnType<typeof createNatsHeaders> } | undefined {
+    if (Object.keys(traceHeaders).length === 0) return undefined;
+
+    const natsHeaders = createNatsHeaders();
+    for (const [key, value] of Object.entries(traceHeaders)) {
+      natsHeaders.set(key, value);
+    }
+
+    return { headers: natsHeaders };
+  }
+
+  private safeHash(value: string): string {
+    return createHash('sha256').update(value).digest('hex').slice(0, 12);
   }
 
   private buildMessage(context: AgentTrigger): string {

--- a/packages/core/src/providers/trace-context.ts
+++ b/packages/core/src/providers/trace-context.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { TraceContext } from './types';
 
 interface KhalHeaderContext {
@@ -11,12 +12,49 @@ interface KhalHeaderContext {
   };
 }
 
+const W3C_TRACE_ID = /^[0-9a-f]{32}$/i;
+const W3C_SPAN_ID = /^[0-9a-f]{16}$/i;
+
+function isNonZeroHex(value: string): boolean {
+  return !/^0+$/.test(value);
+}
+
+function hashHex(value: string, length: 16 | 32): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, length);
+}
+
+function normalizeTraceId(value: string): string {
+  const lower = value.toLowerCase();
+  if (W3C_TRACE_ID.test(lower) && isNonZeroHex(lower)) {
+    return lower;
+  }
+  return hashHex(value, 32);
+}
+
+function normalizeSpanId(value: string): string {
+  const lower = value.toLowerCase();
+  if (W3C_SPAN_ID.test(lower) && isNonZeroHex(lower)) {
+    return lower;
+  }
+  return hashHex(value, 16);
+}
+
+/** Build a W3C trace context from Omni's legacy trace id when no span context is available. */
+export function createTraceContextFromTraceId(traceId?: string, spanSeed = 'provider'): TraceContext | undefined {
+  if (!traceId) return undefined;
+
+  return {
+    traceId: normalizeTraceId(traceId),
+    spanId: normalizeSpanId(`${traceId}:${spanSeed}`),
+    traceFlags: 1,
+  };
+}
+
 /** Format a W3C traceparent value from a backend-agnostic trace context. */
 function formatTraceparent(ctx: TraceContext): string {
   const traceFlags = (ctx.traceFlags ?? 1) & 0xff;
-  const flagsHex = traceFlags.toString(16);
-  const paddedFlagsHex = flagsHex.length === 1 ? `0${flagsHex}` : flagsHex;
-  return `00-${ctx.traceId}-${ctx.spanId}-${paddedFlagsHex}`;
+  const paddedFlagsHex = traceFlags.toString(16).padStart(2, '0');
+  return `00-${normalizeTraceId(ctx.traceId)}-${normalizeSpanId(ctx.spanId)}-${paddedFlagsHex}`;
 }
 
 /** Headers expected by HTTP/NATS providers for cross-process trace stitching. */
@@ -25,8 +63,8 @@ export function buildTraceHeaders(ctx?: TraceContext, khal?: KhalHeaderContext):
 
   if (ctx) {
     traceHeaders.traceparent = formatTraceparent(ctx);
-    traceHeaders['x-trace-id'] = ctx.traceId;
-    traceHeaders['x-span-id'] = ctx.spanId;
+    traceHeaders['x-trace-id'] = normalizeTraceId(ctx.traceId);
+    traceHeaders['x-span-id'] = normalizeSpanId(ctx.spanId);
 
     const tracestate = ctx.tracestate ?? ctx.traceState;
     if (tracestate) {
@@ -34,7 +72,7 @@ export function buildTraceHeaders(ctx?: TraceContext, khal?: KhalHeaderContext):
     }
 
     if (ctx.parentSpanId) {
-      traceHeaders['x-parent-span-id'] = ctx.parentSpanId;
+      traceHeaders['x-parent-span-id'] = normalizeSpanId(ctx.parentSpanId);
     }
   }
 

--- a/packages/core/src/providers/trace-context.ts
+++ b/packages/core/src/providers/trace-context.ts
@@ -12,7 +12,7 @@ interface KhalHeaderContext {
 }
 
 /** Format a W3C traceparent value from a backend-agnostic trace context. */
-export function formatTraceparent(ctx: TraceContext): string {
+function formatTraceparent(ctx: TraceContext): string {
   const traceFlags = (ctx.traceFlags ?? 1) & 0xff;
   const flagsHex = traceFlags.toString(16);
   const paddedFlagsHex = flagsHex.length === 1 ? `0${flagsHex}` : flagsHex;

--- a/packages/core/src/providers/trace-context.ts
+++ b/packages/core/src/providers/trace-context.ts
@@ -1,0 +1,61 @@
+import type { TraceContext } from './types';
+
+interface KhalHeaderContext {
+  khalSessionId?: string;
+  userId?: string;
+  messageId?: string;
+  omni?: {
+    instanceId?: string;
+    chatId?: string;
+    channel?: string;
+  };
+}
+
+/** Format a W3C traceparent value from a backend-agnostic trace context. */
+export function formatTraceparent(ctx: TraceContext): string {
+  const traceFlags = (ctx.traceFlags ?? 1) & 0xff;
+  const flagsHex = traceFlags.toString(16);
+  const paddedFlagsHex = flagsHex.length === 1 ? `0${flagsHex}` : flagsHex;
+  return `00-${ctx.traceId}-${ctx.spanId}-${paddedFlagsHex}`;
+}
+
+/** Headers expected by HTTP/NATS providers for cross-process trace stitching. */
+export function buildTraceHeaders(ctx?: TraceContext, khal?: KhalHeaderContext): Record<string, string> {
+  const traceHeaders: Record<string, string> = {};
+
+  if (ctx) {
+    traceHeaders.traceparent = formatTraceparent(ctx);
+    traceHeaders['x-trace-id'] = ctx.traceId;
+    traceHeaders['x-span-id'] = ctx.spanId;
+
+    const tracestate = ctx.tracestate ?? ctx.traceState;
+    if (tracestate) {
+      traceHeaders.tracestate = tracestate;
+    }
+
+    if (ctx.parentSpanId) {
+      traceHeaders['x-parent-span-id'] = ctx.parentSpanId;
+    }
+  }
+
+  if (khal?.khalSessionId) {
+    traceHeaders['x-khal-session-id'] = khal.khalSessionId;
+  }
+  if (khal?.userId) {
+    traceHeaders['x-khal-user-id'] = khal.userId;
+  }
+  if (khal?.messageId) {
+    traceHeaders['x-khal-message-id'] = khal.messageId;
+  }
+  if (khal?.omni?.instanceId) {
+    traceHeaders['x-omni-instance-id'] = khal.omni.instanceId;
+  }
+  if (khal?.omni?.chatId) {
+    traceHeaders['x-omni-chat-id'] = khal.omni.chatId;
+  }
+  if (khal?.omni?.channel) {
+    traceHeaders['x-omni-channel'] = khal.omni.channel;
+  }
+
+  return traceHeaders;
+}

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -355,6 +355,8 @@ export interface IAgentProvider {
   readonly name: string;
   readonly schema: ProviderSchema;
   readonly mode: 'round-trip' | 'fire-and-forget' | 'turn-based';
+  /** Optional observability hooks for trace propagation and silent-failure detection. */
+  readonly observability?: ProviderObservability;
 
   /** Check if this provider can handle a given trigger */
   canHandle(trigger: AgentTrigger): boolean;

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -83,6 +83,17 @@ export interface ProviderRequest {
 
   /** Environment variables to expose to provider subprocesses/SDK runtimes. */
   env?: Record<string, string>;
+  /** Distributed trace context to propagate on outbound provider calls. */
+  traceContext?: TraceContext;
+  /** Khal session id for cross-service session stitching. Falls back to sessionId when unset. */
+  khalSessionId?: string;
+  /** Omni source metadata propagated to provider transports. */
+  omni?: {
+    instanceId?: string;
+    chatId?: string;
+    messageId?: string;
+    channel?: ChannelType;
+  };
 }
 
 export interface ProviderFile {
@@ -269,6 +280,71 @@ export type ProviderErrorCode =
 export type AgentTriggerType = 'mention' | 'reaction' | 'dm' | 'reply' | 'name_match' | 'command';
 
 /**
+ * Distributed trace context for cross-process propagation.
+ *
+ * Aligns with W3C Trace Context (`traceparent` HTTP header) so providers can
+ * propagate trace identity across HTTP/NATS/gRPC boundaries without coupling
+ * to any specific OpenTelemetry SDK. Producers receive this from the dispatcher
+ * and inject it on outbound calls so cross-process traces stitch correctly.
+ *
+ * Backend-agnostic: the trace identifier itself is a 16-byte hex string per
+ * W3C; how it's exported (OTLP, Zipkin, vendor-native) is the host's concern,
+ * configured via standard `OTEL_*` env vars.
+ */
+export interface TraceContext {
+  /** W3C trace-id — 32 hex chars (16 bytes). */
+  traceId: string;
+  /** W3C span-id of the current span — 16 hex chars (8 bytes). */
+  spanId: string;
+  /** Optional parent span-id for nested propagation. */
+  parentSpanId?: string;
+  /** W3C trace flags (1 = sampled, 0 = not). Default 1 when unset. */
+  traceFlags?: number;
+  /** W3C tracestate header value. */
+  tracestate?: string;
+  /** Backward-compatible camelCase alias for tracestate. */
+  traceState?: string;
+}
+
+/**
+ * Optional observability hooks on a provider.
+ *
+ * Providers that want to participate in distributed tracing (propagate the
+ * W3C `traceparent` on outbound HTTP/NATS calls, emit OTel spans for internal
+ * operations, expose a health probe for silent-failure detection) implement
+ * this interface. Providers without an `observability` field fall back to
+ * default no-op behavior — no behavior change for legacy providers.
+ *
+ * **Backend-neutral by design.** Emitted spans flow through whatever OTel SDK
+ * the host configured via standard `OTEL_EXPORTER_OTLP_ENDPOINT` /
+ * `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES`. No vendor SDK is coupled
+ * here.
+ */
+export interface ProviderObservability {
+  /**
+   * Receive a trace context from the dispatcher when triggering this provider.
+   *
+   * The provider SHOULD propagate it on any outbound calls it makes:
+   * - HTTP requests: inject `traceparent` header
+   * - NATS publishes: inject `traceparent` AND custom
+   *   `x-trace-id`/`x-span-id`/`x-parent-span-id` headers (forward-compat
+   *   with khal-os o11y consumer)
+   * - Subprocess spawns: pass through env vars if the child reads them
+   */
+  propagateTrace(ctx: TraceContext): void;
+
+  /**
+   * Health probe — does the provider currently process inbound work?
+   *
+   * Used by silent-failure detection: e.g. a NATS bridge that has lost its
+   * consumer subscription should report `{ healthy: false }` even if the
+   * outer process is alive. Optional `lastProcessedAt` and `backlog` enrich
+   * alerting context.
+   */
+  heartbeat(): Promise<{ healthy: boolean; lastProcessedAt?: Date; backlog?: number }>;
+}
+
+/**
  * Unified agent provider interface
  *
  * All agent providers (Agno, OpenClaw webhook, Claude SDK, etc.)
@@ -353,6 +429,8 @@ export interface AgentTrigger {
    * Includes OMNI_INSTANCE, OMNI_CHAT, OMNI_MESSAGE, OMNI_TURN_ID.
    */
   env?: Record<string, string>;
+  /** Distributed trace context to propagate on outbound provider calls. */
+  traceContext?: TraceContext;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rebased the Omni Langfuse/session propagation work onto `homolog` instead of `dev`.
- Preserves the HML invariant: `x-khal-session-id == Omni dispatch session id == Agno session_id == Langfuse session.id`.
- Propagates W3C trace context and KHAL/Omni metadata through Agno HTTP + stream paths and NATS payload/headers.
- Redacts raw NATS chat/session/reply identifiers in logs using hashed/template fields.
- Adds source-level Agno provider coverage while avoiding Bun process-wide mock contamination from dispatcher tests.

## Verification
- `bun test packages/core/src/providers/__tests__/agno-client.test.ts packages/core/src/providers/__tests__/agno-provider.test.ts packages/core/src/providers/__tests__/nats-genie-provider.test.ts` → 41 pass / 0 fail
- `bun run --filter @omni/core typecheck` → pass
- `bunx biome check` on touched provider files/tests → pass
- `git diff --check` → pass
- full pre-push gate with `ANTHROPIC_API_KEY` unset for env-sensitive Claude Code test → typecheck 20/20, `bun test` 3159 pass / 264 skip / 0 fail

## Note
Supersedes PR #665, which was incorrectly based on `dev` and became dirty/conflict-heavy relative to the actual homolog deployment branch.