### PR TITLE
feat(follow-up): pre-fire human-active probe + 'human_active' disarm reason

### DIFF
--- a/packages/api/src/services/follow-up-sweeper.ts
+++ b/packages/api/src/services/follow-up-sweeper.ts
@@ -19,8 +19,10 @@ import {
   type EventBus,
   type FollowUpStateRepo,
   type FollowUpStateRow,
+  type HumanActiveProbe,
   type Logger,
   type MessagingWindowProbe,
+  createDbHumanActiveProbe,
   createLogger,
   createMessagingWindowProbe,
   sweepFollowUps,
@@ -34,6 +36,7 @@ const log = createLogger('follow-up-sweeper');
 export class FollowUpSweeperService {
   private readonly repo: FollowUpStateRepo;
   private readonly messagingWindowProbe: MessagingWindowProbe;
+  private readonly humanActiveProbe: HumanActiveProbe;
 
   constructor(
     private db: Database,
@@ -56,6 +59,13 @@ export class FollowUpSweeperService {
       },
     };
     this.messagingWindowProbe = createMessagingWindowProbe();
+    // DB-only probe: relies on `chats.lastMessageAt` / `lastMessageFromMe`
+    // already loaded by `findAndLockDue`. Cheap, no network. Disarms with
+    // `human_active` when the chat's most recent message is outbound and
+    // post-dates the last agent reply by more than the grace window —
+    // strong signal that a human operator took over directly in the
+    // channel inbox without going through `human_handoff`.
+    this.humanActiveProbe = createDbHumanActiveProbe();
   }
 
   /**
@@ -71,6 +81,7 @@ export class FollowUpSweeperService {
       eventBus: this.eventBus,
       logger: this.logger,
       messagingWindowProbe: this.messagingWindowProbe,
+      humanActiveProbe: this.humanActiveProbe,
     });
   }
 
@@ -110,6 +121,8 @@ export class FollowUpSweeperService {
           lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
           chatName: chats.name,
           channelType: instances.channel,
+          chatLastMessageAt: chats.lastMessageAt,
+          chatLastMessageFromMe: chats.lastMessageFromMe,
         })
         .from(chatFollowUpState)
         .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
@@ -135,6 +148,8 @@ export class FollowUpSweeperService {
         lastAgentMessageAt: r.lastAgentMessageAt,
         lastInboundCustomerMessageAt: r.lastInboundCustomerMessageAt ?? null,
         channelType: (r.channelType ?? null) as ChannelType | null,
+        chatLastMessageAt: r.chatLastMessageAt ?? null,
+        chatLastMessageFromMe: r.chatLastMessageFromMe ?? null,
       }),
     );
   }

--- a/packages/core/src/automations/follow-up/__tests__/capabilities.test.ts
+++ b/packages/core/src/automations/follow-up/__tests__/capabilities.test.ts
@@ -18,6 +18,7 @@ import {
   MESSAGING_WINDOW_MS,
   channelHasMessagingWindow,
   channelSupportsTypingIndicator,
+  createDbHumanActiveProbe,
   createMessagingWindowProbe,
   playTypingIndicator,
 } from '../capabilities';
@@ -262,5 +263,58 @@ describe('playTypingIndicator', () => {
     expect(logger.debug).toHaveBeenCalled();
     // No wait when the indicator failed to start.
     expect(waitCalls).toEqual([]);
+  });
+});
+
+describe('createDbHumanActiveProbe', () => {
+  const lastAgentReply = new Date('2026-04-14T12:00:00.000Z');
+  const probeNow = new Date('2026-04-14T12:10:00.000Z');
+
+  test("returns 'active' when last message is outbound AND past grace window", async () => {
+    const probe = createDbHumanActiveProbe({ graceMs: 2 * 60 * 1000 });
+    const r = row({
+      lastAgentMessageAt: lastAgentReply,
+      chatLastMessageAt: new Date(lastAgentReply.getTime() + 5 * 60 * 1000),
+      chatLastMessageFromMe: true,
+    });
+    expect(await probe(r, probeNow)).toBe('active');
+  });
+
+  test("returns 'inactive' when last message is outbound but within grace window", async () => {
+    const probe = createDbHumanActiveProbe({ graceMs: 2 * 60 * 1000 });
+    const r = row({
+      lastAgentMessageAt: lastAgentReply,
+      chatLastMessageAt: new Date(lastAgentReply.getTime() + 30 * 1000),
+      chatLastMessageFromMe: true,
+    });
+    expect(await probe(r, probeNow)).toBe('inactive');
+  });
+
+  test("returns 'inactive' when last message is inbound (customer_replied path covers it)", async () => {
+    const probe = createDbHumanActiveProbe({ graceMs: 2 * 60 * 1000 });
+    const r = row({
+      lastAgentMessageAt: lastAgentReply,
+      chatLastMessageAt: new Date(lastAgentReply.getTime() + 5 * 60 * 1000),
+      chatLastMessageFromMe: false,
+    });
+    expect(await probe(r, probeNow)).toBe('inactive');
+  });
+
+  test("returns 'unknown' when chat metadata is missing", async () => {
+    const probe = createDbHumanActiveProbe();
+    expect(await probe(row({ chatLastMessageAt: null, chatLastMessageFromMe: null }), probeNow)).toBe('unknown');
+    expect(await probe(row({ chatLastMessageAt: new Date(), chatLastMessageFromMe: null }), probeNow)).toBe('unknown');
+    expect(await probe(row({ chatLastMessageAt: null, chatLastMessageFromMe: true }), probeNow)).toBe('unknown');
+  });
+
+  test('grace window is configurable', async () => {
+    const probe = createDbHumanActiveProbe({ graceMs: 10 * 60 * 1000 });
+    const r = row({
+      lastAgentMessageAt: lastAgentReply,
+      chatLastMessageAt: new Date(lastAgentReply.getTime() + 5 * 60 * 1000),
+      chatLastMessageFromMe: true,
+    });
+    // 5min < 10min grace ⇒ inactive
+    expect(await probe(r, probeNow)).toBe('inactive');
   });
 });

--- a/packages/core/src/automations/follow-up/__tests__/sweeper.test.ts
+++ b/packages/core/src/automations/follow-up/__tests__/sweeper.test.ts
@@ -11,7 +11,13 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { EventBus } from '../../../events/bus';
 import type { Logger } from '../../../logger/types';
 import type { FollowUpSequenceConfig } from '../../../schemas/follow-up';
-import type { AdvanceInput, FollowUpStateRepo, FollowUpStateRow, MessagingWindowProbe } from '../sweeper';
+import type {
+  AdvanceInput,
+  FollowUpStateRepo,
+  FollowUpStateRow,
+  HumanActiveProbe,
+  MessagingWindowProbe,
+} from '../sweeper';
 import { renderSyntheticPrompt, sweepFollowUps } from '../sweeper';
 
 type PublishFn = EventBus['publish'];
@@ -285,6 +291,82 @@ describe('sweepFollowUps', () => {
     });
 
     expect(probe).not.toHaveBeenCalled();
+  });
+
+  test('humanActiveProbe=active disarms with human_active, does NOT fire idle_timeout', async () => {
+    const r = row();
+    const { repo, disarmed, fired } = makeRepo([r]);
+    const { bus, calls } = makeEventBus();
+    const probe: HumanActiveProbe = async () => 'active';
+
+    const stats = await sweepFollowUps({
+      repo,
+      eventBus: bus,
+      logger: silentLogger,
+      humanActiveProbe: probe,
+      now: () => fixedNow,
+    });
+
+    expect(stats).toEqual({ scanned: 1, fired: 0, disarmed: 1, skipped: 0 });
+    expect(calls.map((c) => c.type)).toEqual(['follow_up.disarmed']);
+    expect(fired).toHaveLength(0);
+    expect(disarmed).toHaveLength(1);
+    expect(disarmed[0]?.reason).toBe('human_active');
+  });
+
+  test('humanActiveProbe=inactive allows fire', async () => {
+    const r = row();
+    const { repo } = makeRepo([r]);
+    const { bus, calls } = makeEventBus();
+    const probe: HumanActiveProbe = async () => 'inactive';
+
+    await sweepFollowUps({
+      repo,
+      eventBus: bus,
+      logger: silentLogger,
+      humanActiveProbe: probe,
+      now: () => fixedNow,
+    });
+
+    expect(calls.map((c) => c.type)).toContain('chat.idle_timeout');
+  });
+
+  test('humanActiveProbe=unknown allows fire (graceful degrade)', async () => {
+    const r = row();
+    const { repo } = makeRepo([r]);
+    const { bus, calls } = makeEventBus();
+    const probe: HumanActiveProbe = async () => 'unknown';
+
+    await sweepFollowUps({
+      repo,
+      eventBus: bus,
+      logger: silentLogger,
+      humanActiveProbe: probe,
+      now: () => fixedNow,
+    });
+
+    expect(calls.map((c) => c.type)).toContain('chat.idle_timeout');
+  });
+
+  test('humanActiveProbe consulted AFTER messagingWindowProbe (window guard wins on expired)', async () => {
+    const r = row();
+    const { repo, disarmed } = makeRepo([r]);
+    const { bus } = makeEventBus();
+    const winProbe = mock<MessagingWindowProbe>(() => 'expired');
+    const humProbe = mock<HumanActiveProbe>(async () => 'active');
+
+    await sweepFollowUps({
+      repo,
+      eventBus: bus,
+      logger: silentLogger,
+      messagingWindowProbe: winProbe,
+      humanActiveProbe: humProbe,
+      now: () => fixedNow,
+    });
+
+    expect(disarmed).toHaveLength(1);
+    expect(disarmed[0]?.reason).toBe('window_expired');
+    expect(humProbe).not.toHaveBeenCalled();
   });
 
   test('per-row exception is isolated, emits follow_up.skipped, continues processing', async () => {

--- a/packages/core/src/automations/follow-up/capabilities.ts
+++ b/packages/core/src/automations/follow-up/capabilities.ts
@@ -29,7 +29,7 @@
  */
 
 import type { ChannelType } from '../../types/channel';
-import type { FollowUpStateRow, MessagingWindowProbe } from './sweeper';
+import type { FollowUpStateRow, HumanActiveProbe, MessagingWindowProbe } from './sweeper';
 
 /**
  * WhatsApp BSP / Cloud API enforces a 24-hour window after the customer's
@@ -124,6 +124,68 @@ export function createMessagingWindowProbe(options: CreateMessagingWindowProbeOp
     }
     const elapsedMs = now.getTime() - lastInbound.getTime();
     return elapsedMs > windowMs ? 'expired' : 'within';
+  };
+}
+
+/**
+ * Probe options for {@link createDbHumanActiveProbe}.
+ */
+export interface CreateDbHumanActiveProbeOptions {
+  /**
+   * Minimum gap between `chatLastMessageAt` and `lastAgentMessageAt` to
+   * consider the chat as having out-of-band human activity. Buffers race
+   * conditions where the agent's own message takes a tick to propagate
+   * into `chats.lastMessageAt`. Defaults to 2 minutes.
+   */
+  graceMs?: number;
+}
+
+const DEFAULT_HUMAN_ACTIVE_GRACE_MS = 2 * 60 * 1000;
+
+/**
+ * Build a {@link HumanActiveProbe} backed only by columns already loaded
+ * into {@link FollowUpStateRow} (no I/O, no channel HTTP calls).
+ *
+ * Detection rule: if the chat's most recent message is **outbound**
+ * (`chatLastMessageFromMe = true`) AND its timestamp is more than `graceMs`
+ * after `lastAgentMessageAt`, conclude that someone outside the bot pipeline
+ * (typically a human operator who took over the chat in the channel inbox)
+ * sent the message. The sweeper then disarms with `human_active`.
+ *
+ * Inbound messages (`chatLastMessageFromMe = false`) are NOT treated as
+ * human-active: they are the customer replying, which the existing
+ * `customer_replied` disarm path covers.
+ *
+ * Return values:
+ * - `'active'` — out-of-band outbound activity detected.
+ * - `'inactive'` — no signal.
+ * - `'unknown'` — required columns missing on the row (probe gracefully
+ *   degrades to no-op rather than guessing).
+ *
+ * This probe is intentionally cheap (no network) and conservative (only
+ * outbound messages count). Channels can add an HTTP-backed probe on top
+ * if they want stronger guarantees (e.g. ask Gupshup Agent Assist directly
+ * whether a chat is currently assigned to a human agent) — see
+ * brain/snapshots/cego-historico-gupshup-2026-05-28 (Caso B) for the
+ * production incident this addresses.
+ */
+export function createDbHumanActiveProbe(options: CreateDbHumanActiveProbeOptions = {}): HumanActiveProbe {
+  const graceMs = options.graceMs ?? DEFAULT_HUMAN_ACTIVE_GRACE_MS;
+
+  return async (row: FollowUpStateRow, _now: Date) => {
+    const lastMessageAt = row.chatLastMessageAt ?? null;
+    const fromMe = row.chatLastMessageFromMe ?? null;
+
+    if (lastMessageAt === null || fromMe === null) {
+      return 'unknown';
+    }
+    if (!fromMe) {
+      // Inbound — customer_replied will (or already did) cover this path.
+      return 'inactive';
+    }
+
+    const gapMs = lastMessageAt.getTime() - row.lastAgentMessageAt.getTime();
+    return gapMs > graceMs ? 'active' : 'inactive';
   };
 }
 

--- a/packages/core/src/automations/follow-up/sweeper.ts
+++ b/packages/core/src/automations/follow-up/sweeper.ts
@@ -50,6 +50,20 @@ export interface FollowUpStateRow {
   channelType?: ChannelType | null;
   /** Timestamp of the most recent inbound customer message — consumed by the 24h BSP window guard. */
   lastInboundCustomerMessageAt?: Date | null;
+  /**
+   * Most recent message timestamp on the chat (any direction). Consumed
+   * by `HumanActiveProbe` implementations to detect out-of-band activity
+   * — when this is more recent than `lastAgentMessageAt` AND
+   * `chatLastMessageFromMe` is `true`, it strongly suggests a human
+   * operator replied directly in the channel inbox without going through
+   * the bot pipeline.
+   */
+  chatLastMessageAt?: Date | null;
+  /**
+   * Direction of the most recent message on the chat. Companion to
+   * `chatLastMessageAt` — see field doc above for usage.
+   */
+  chatLastMessageFromMe?: boolean | null;
 }
 
 /**
@@ -96,6 +110,31 @@ export interface FollowUpStateRepo {
 export type MessagingWindowProbe = (row: FollowUpStateRow, now: Date) => 'within' | 'expired' | 'unknown';
 
 /**
+ * Out-of-band human-agent probe. Lets the sweeper detect that a human agent
+ * is actively handling the chat outside the bot pipeline (e.g. an operator
+ * took over the conversation directly in the channel's agent inbox without
+ * going through our `human_handoff` tool).
+ *
+ * - `'active'`  — a human agent is currently handling the chat; the sweeper
+ *                 disarms with reason `human_active` and does NOT emit
+ *                 `chat.idle_timeout`. Re-arm happens normally on the next
+ *                 genuine `message.sent` from the configured agent.
+ * - `'inactive'` — no human-agent activity detected; the fire proceeds.
+ * - `'unknown'` — probe is unable to decide (channel doesn't expose the
+ *                 signal, transient error). Treated as `'inactive'` —
+ *                 fire-on-uncertainty preserves the existing behaviour for
+ *                 channels/configurations without the probe wired in.
+ *
+ * Implementations are expected to be cheap (read DB columns the sweeper
+ * already has access to) OR to apply their own pre-filter before doing any
+ * expensive lookup (HTTP to a channel API). The sweeper does not pre-filter.
+ *
+ * See: brain/snapshots/cego-historico-gupshup-2026-05-28 (Caso B) for the
+ * production incident this probe addresses.
+ */
+export type HumanActiveProbe = (row: FollowUpStateRow, now: Date) => Promise<'active' | 'inactive' | 'unknown'>;
+
+/**
  * Dependencies for a single sweep invocation.
  */
 export interface SweeperDeps {
@@ -104,6 +143,13 @@ export interface SweeperDeps {
   logger: Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
   /** Optional window probe — if omitted, the window guard is skipped. */
   messagingWindowProbe?: MessagingWindowProbe;
+  /**
+   * Optional human-active probe — if omitted, the human-active guard is
+   * skipped (current behaviour preserved). When provided, the sweeper
+   * disarms candidate rows where the probe returns `'active'` instead of
+   * firing `chat.idle_timeout`.
+   */
+  humanActiveProbe?: HumanActiveProbe;
   /**
    * Max rows processed per tick. Defaults to 100 — enough to keep 6k/min of
    * throughput on a single worker while bounding DB load per query.
@@ -207,6 +253,19 @@ async function processRow(row: FollowUpStateRow, now: Date, deps: SweeperDeps, s
     const verdict = deps.messagingWindowProbe(row, now);
     if (verdict === 'expired') {
       await disarm(deps, row, 'window_expired', now);
+      stats.disarmed += 1;
+      return;
+    }
+  }
+
+  // Out-of-band human-agent guard. If a human is actively handling the
+  // chat outside the bot pipeline, disarm instead of firing — otherwise
+  // the proactive nudge would step on the live human conversation. See
+  // brain/snapshots/cego-historico-gupshup-2026-05-28 (Caso B).
+  if (deps.humanActiveProbe) {
+    const verdict = await deps.humanActiveProbe(row, now);
+    if (verdict === 'active') {
+      await disarm(deps, row, 'human_active', now);
       stats.disarmed += 1;
       return;
     }

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -675,7 +675,15 @@ export type FollowUpDisarmReason =
   | 'sequence_complete'
   | 'agent_error'
   | 'send_failed'
-  | 'session_cleared';
+  | 'session_cleared'
+  /**
+   * Pre-fire probe detected a human agent active on the chat (out-of-band
+   * activity that didn't pass through our agent pipeline). The sweeper
+   * disarms instead of firing to avoid stepping on a live human handoff
+   * that wasn't initiated via the `human_handoff` tool. Re-arm happens
+   * normally on the next genuine `message.sent` from the agent.
+   */
+  | 'human_active';
 
 /**
  * Fired when a chat is flagged for human takeover. Any armed follow-up

--- a/packages/core/src/schemas/follow-up.ts
+++ b/packages/core/src/schemas/follow-up.ts
@@ -21,6 +21,9 @@ import { z } from 'zod';
  * - `agent_error` — agent failed while generating a follow-up.
  * - `send_failed` — outbound send failed after render.
  * - `session_cleared` — user cleared the agent session (e.g. trash emoji).
+ * - `human_active` — pre-fire probe detected a human agent handling the
+ *   chat out-of-band (operator took over in the channel inbox without
+ *   `human_handoff`). Re-arm is allowed on the next genuine agent reply.
  */
 export const DisarmReasonSchema = z.enum([
   'customer_replied',
@@ -31,6 +34,7 @@ export const DisarmReasonSchema = z.enum([
   'agent_error',
   'send_failed',
   'session_cleared',
+  'human_active',
 ]);
 
 export type DisarmReason = z.infer<typeof DisarmReasonSchema>;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2658,6 +2658,10 @@ export const followUpDisarmReasons = [
   'agent_error',
   'send_failed',
   'session_cleared',
+  // Pre-fire human-active probe detected a human agent handling the chat
+  // out-of-band (operator took over directly in the channel inbox without
+  // going through `human_handoff`). See sweeper.ts `HumanActiveProbe`.
+  'human_active',
 ] as const;
 export type FollowUpDisarmReasonDb = (typeof followUpDisarmReasons)[number];
 

--- a/scripts/test-human-active-disarm.sh
+++ b/scripts/test-human-active-disarm.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Smoke test: out-of-band human takeover → follow-up sweeper should disarm
+# with reason 'human_active' (after PR #667 merges).
+#
+# Before PR #667: shows the bug — sweeper fires `chat.idle_timeout` despite
+# the human reply, no disarm happens.
+# After PR #667: shows the fix — within ~15s the row is disarmed with reason
+# `human_active` and no `chat.idle_timeout` is published.
+#
+# Usage:
+#   PGURL=postgresql://postgres:postgres@localhost:18432/omni \
+#   OMNI_URL=http://localhost:8882 \
+#   ./scripts/test-human-active-disarm.sh
+#
+# Optional:
+#   CHAT_ID=<uuid>          Use this chat instead of auto-picking one.
+#   SWEEP_WAIT_SECONDS=25   Override the wait (default 25s = sweeper tick + margin).
+
+set -euo pipefail
+
+PGURL="${PGURL:?PGURL must be set, e.g. postgresql://postgres:postgres@localhost:18432/omni}"
+OMNI_URL="${OMNI_URL:-http://localhost:8882}"
+SWEEP_WAIT_SECONDS="${SWEEP_WAIT_SECONDS:-25}"
+
+step() { printf '\n\033[1m== %s ==\033[0m\n' "$1"; }
+sql()  { psql "$PGURL" -At -F'|' -c "$1"; }
+
+step '1. Pick a chat to test'
+if [[ -z "${CHAT_ID:-}" ]]; then
+  CHAT_ID=$(sql "SELECT id FROM chats WHERE channel = 'gupshup' ORDER BY last_message_at DESC NULLS LAST LIMIT 1")
+  if [[ -z "$CHAT_ID" ]]; then
+    echo "ERR: No gupshup chats found in DB. Set CHAT_ID=<uuid> explicitly." >&2
+    exit 1
+  fi
+fi
+echo "chatId = $CHAT_ID"
+sql "SELECT id, name, last_message_at, last_message_from_me FROM chats WHERE id = '$CHAT_ID'"
+
+step '2. Ensure a follow-up row exists and is armed'
+EXISTING_ROW=$(sql "SELECT id, disarm_reason, next_fire_at, last_agent_message_at FROM chat_follow_up_state WHERE chat_id = '$CHAT_ID' LIMIT 1")
+if [[ -n "$EXISTING_ROW" ]]; then
+  echo "Existing follow-up row: $EXISTING_ROW"
+  # Reset the row to armed, set lastAgentMessageAt to 5min ago, nextFireAt to now
+  # so the sweeper will pick it up on the next tick.
+  sql "UPDATE chat_follow_up_state
+       SET disarm_reason = NULL,
+           disarmed_at = NULL,
+           next_fire_at = NOW(),
+           last_agent_message_at = NOW() - INTERVAL '5 minutes',
+           updated_at = NOW()
+       WHERE chat_id = '$CHAT_ID'"
+  echo "Re-armed existing row, nextFireAt=NOW, lastAgentMessageAt=5min ago"
+else
+  echo "No follow-up row exists for this chat. The sweeper has nothing to act on."
+  echo "Pick a chat that has had agent activity (use omni chats list to find one)."
+  exit 2
+fi
+
+step '3. Inject out-of-band human takeover'
+# Simulates an operator replying to the chat directly in the channel inbox.
+# The probe needs: lastMessageAt > lastAgentMessageAt + graceMs AND lastMessageFromMe = true.
+sql "UPDATE chats
+     SET last_message_at = NOW(),
+         last_message_from_me = true,
+         last_message_preview = '[SMOKE TEST] simulated operator reply',
+         updated_at = NOW()
+     WHERE id = '$CHAT_ID'"
+echo "Set chats.lastMessageAt = NOW, lastMessageFromMe = true"
+
+step "4. Wait $SWEEP_WAIT_SECONDS s for the sweeper tick"
+for i in $(seq 1 "$SWEEP_WAIT_SECONDS"); do
+  printf '.'
+  sleep 1
+done
+echo
+
+step '5. Observe the result'
+AFTER=$(sql "SELECT disarm_reason, disarmed_at, next_fire_at FROM chat_follow_up_state WHERE chat_id = '$CHAT_ID' LIMIT 1")
+echo "After sweep tick: $AFTER"
+
+DISARM_REASON=$(echo "$AFTER" | cut -d'|' -f1)
+if [[ "$DISARM_REASON" == "human_active" ]]; then
+  echo
+  echo "✅ PASS — sweeper detected the out-of-band takeover and disarmed with 'human_active'."
+  echo "   This means PR #667 (or equivalent) is live."
+elif [[ -z "$DISARM_REASON" ]]; then
+  echo
+  echo "❌ FAIL — row is still armed (disarm_reason IS NULL). The sweeper either"
+  echo "   didn't run yet, or this build doesn't include PR #667. Expected behaviour"
+  echo "   on origin/main BEFORE the merge."
+elif [[ "$DISARM_REASON" == "sequence_complete" || "$DISARM_REASON" == "window_expired" ]]; then
+  echo
+  echo "⚠️  Row disarmed but with a different reason: $DISARM_REASON"
+  echo "   Probably the sweeper fired and advanced normally before the probe could see"
+  echo "   the takeover. Re-run with SWEEP_WAIT_SECONDS=10 or after another tick."
+else
+  echo
+  echo "⚠️  Unexpected disarm reason: $DISARM_REASON"
+fi
+
+step '6. Optional: verify re-arm semantics'
+echo "To verify that a future agent reply re-arms the sequence, run:"
+echo
+echo "  omni say --chat $CHAT_ID --text 'follow-up re-arm probe' --agent eugenia"
+echo
+echo "Then check chat_follow_up_state.disarmReason returns to NULL with a fresh nextFireAt."


### PR DESCRIPTION
## Problem

When a human operator takes over a chat directly in the channel inbox (e.g. Gupshup Agent Assist) **without** going through the `human_handoff` tool, none of the existing disarm paths fire:

- `chat.handoff_activated` is only emitted on the `agentPaused` `false → true` transition (set by `/api/v2/messages/send/handoff`). Manual takeover never flips it.
- `customer_replied` only disarms when the customer sends a new inbound message. The customer is happily talking to the human in between sweeper ticks.

Result: the follow-up sweeper nudges the customer with a generic "are you still interested?" right on top of the human-led conversation.

Production incident: `chat 616959139` on 2026-05-26 — operator started replying at 10:23 BRT, follow-up fired at **10:33:44 BRT**, 22 seconds after the human's `"Tá legal 😊"`. Full incident snapshot at [`brain/snapshots/cego-historico-gupshup-2026-05-28`](https://github.com/namastexlabs/genie-hapvida/blob/docs/eugenia-cards-1-2-3-2026-05-28/brain/snapshots/cego-historico-gupshup-2026-05-28/INVESTIGATION.md) (Caso B).

## Solution

Add a **pre-fire human-active probe** to the sweeper. Mirrors the existing `MessagingWindowProbe` pattern: optional, no-op when omitted, runs before `chat.idle_timeout` is published. Returning `'active'` disarms the row with a new `human_active` reason.

The probe is **DB-only**: it reads `chats.lastMessageAt` + `chats.lastMessageFromMe` that the sweep query already joins. Detection rule: outbound message strictly past `lastAgentMessageAt + graceMs` (default 2 min) ⇒ human took over. Inbound messages return `'inactive'` (the existing `customer_replied` path covers them). Missing columns return `'unknown'` (graceful degrade, preserves current behaviour).

No HTTP roundtrips, no new channel-plugin contract, no schema migration beyond a single enum value addition.

## Changes

### Core (`packages/core/`)

- `events/types.ts`, `schemas/follow-up.ts`, `db/schema.ts` (`followUpDisarmReasons`): new `'human_active'` value on `FollowUpDisarmReason`. **Non-terminal** — re-arm is allowed on the next genuine agent reply, same semantics as `customer_replied`.
- `automations/follow-up/sweeper.ts`:
  - New `HumanActiveProbe` interface (async, mirrors `MessagingWindowProbe`).
  - `FollowUpStateRow` gains two optional fields: `chatLastMessageAt`, `chatLastMessageFromMe`.
  - `processRow` consults the probe between the window guard and the `chat.idle_timeout` emission; `'active'` → `disarm('human_active')`.
- `automations/follow-up/capabilities.ts`: new `createDbHumanActiveProbe({ graceMs })` factory.

### API service (`packages/api/`)

- `services/follow-up-sweeper.ts`:
  - `findAndLockDue` selects `chats.lastMessageAt` and `chats.lastMessageFromMe` and propagates them into the row.
  - Constructor instantiates `createDbHumanActiveProbe()` and passes it to `sweepFollowUps()`.

### Tests

- `packages/core/src/automations/follow-up/__tests__/sweeper.test.ts`: 4 new cases (`active` disarms with `human_active`; `inactive` fires; `unknown` fires; window guard runs first when both probes would disarm).
- `packages/core/src/automations/follow-up/__tests__/capabilities.test.ts`: 5 new cases covering the DB probe (active past grace; inactive within grace; inactive on inbound; unknown on missing columns; configurable graceMs).

```
Follow-up suite : 75 → 84 pass (9 new)
API services    : 192 pass
Core typecheck  : clean
Lint            : clean (warnings only — pre-existing)
```

## Out of scope (and why)

- **Channel-specific HTTP probe (e.g. Gupshup Partner API `GET /chats/:id`)** — `chats.lastMessageAt` is updated by the channel webhook pipeline for every message regardless of direction, so by the time the sweeper picks a candidate row, the human operator's outbound message is already visible. No side trip needed. A channel that wants stronger guarantees can layer an HTTP probe on top later.
- **Per-instance opt-in flag** — the DB probe is cheap enough (no extra query) and the detection rule is conservative (only outbound, only after a grace window) that defaulting it on for all instances is safe. Flag can be added later if any instance reports false positives.
- **`agentPaused: true` write** — out of scope here. The disarm alone stops the follow-up; the wider question of "should we also pause the agent dispatcher for this chat?" is a separate decision that belongs in a follow-up PR if needed.

## Re-arm semantics

`'human_active'` is intentionally **NOT** in `TERMINAL_DISARM_REASONS` (`packages/api/src/services/follow-up-lifecycle.ts`). When the bot eventually replies again on the same chat (human hands back, chat returns to the bot via normal `message.received` → agent dispatcher), `armForOutbound` re-arms the sequence as usual. Same semantics as `customer_replied` re-arm.

## Test plan

- [x] `bun test packages/core/src/automations/follow-up/` — 84/84 pass
- [x] `bun test packages/api/src/services/__tests__/` — 192/192 pass
- [x] Core typecheck (`bunx tsc --noEmit -p packages/core`) — clean
- [x] **Smoke test against origin/main (omni v2.260430.12) — bug reproduced**. See `scripts/test-human-active-disarm.sh`. Pre-merge run: row stayed armed (`disarm_reason = NULL`) and `nextFireAt` advanced — sweeper fired despite the simulated human takeover. Post-merge expected: same script flips to `disarm_reason = 'human_active'`.
- [ ] After merge, run the same smoke against a HML/PROD Omni build that includes this PR to confirm the fix end-to-end.
- [ ] Confirm next-agent-reply re-arms (i.e. `disarmReason` returns to NULL on subsequent armed sequence).

### Smoke script (`scripts/test-human-active-disarm.sh`)

```bash
PGURL='postgresql://user:pwd@127.0.0.1:9432/omni' \
  SWEEP_WAIT_SECONDS=25 \
  ./scripts/test-human-active-disarm.sh
```

The script (a) picks a gupshup chat, (b) re-arms its follow-up row, (c) injects `chats.lastMessageAt = NOW, lastMessageFromMe = true` (exactly what `createDbHumanActiveProbe` looks for), (d) waits one sweeper tick, (e) checks `chat_follow_up_state.disarm_reason`. Optional `CHAT_ID=<uuid>` override.

## Notes for reviewers

- The `'human_active'` enum value is added to **three** places (`events/types.ts`, `schemas/follow-up.ts`, `db/schema.ts`) intentionally — the codebase keeps these in sync by hand for type/runtime/zod parity. Followed the existing pattern.
- Pre-existing typecheck errors in `packages/api/src/app.ts:151`, `routes/v2/agent-routes.ts:14`, `routes/v2/instances.ts:25` are unrelated to this PR — they fail on `origin/main` too (verified via `git stash` round-trip).
- The 2 NATS test failures (`consumer.test.ts`, `streams.test.ts` — `RetentionPolicy not found`) are pre-existing import errors against the local `nats@2.29.3` install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Follow-up automation now detects when a human agent is actively handling a chat and intelligently prevents idle timeout messages, eliminating duplicate automated messages during live agent assistance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/omni/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
