### PR TITLE
fix(nats): register first-party custom event schemas

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -654,6 +654,33 @@ async function waitForRecord<T>(
   return null;
 }
 
+const MEDIA_WAIT_TIMEOUT_MS = 30_000;
+
+function awaitMediaCompletion(msgId: string): Promise<{ content: string; error?: string }> {
+  return new Promise<{ content: string; error?: string }>((resolvePromise, rejectPromise) => {
+    mediaCompletions.set(msgId, { resolve: resolvePromise, reject: rejectPromise, createdAt: Date.now() });
+    setTimeout(() => {
+      if (mediaCompletions.has(msgId)) {
+        mediaCompletions.delete(msgId);
+        rejectPromise(new Error(`media wait timeout (${MEDIA_WAIT_TIMEOUT_MS}ms)`));
+      }
+    }, MEDIA_WAIT_TIMEOUT_MS);
+  });
+}
+
+async function recoverProcessedMediaAfterTimeout(
+  services: Services,
+  chatRecordId: string,
+  externalId: string,
+  column: string,
+): Promise<{ content: string; localPath: string | null } | null> {
+  const refreshed = await services.messages.getByExternalId(chatRecordId, externalId);
+  if (!refreshed) return null;
+  const recovered = checkProcessedColumn(refreshed, column);
+  if (recovered === 'pending' || recovered === 'error') return null;
+  return recovered;
+}
+
 /**
  * Await media processing via NATS event instead of DB polling.
  * Checks: DB first (already done) → event cache (arrived early) → await promise (NATS delivery).
@@ -700,10 +727,24 @@ async function awaitMediaProcessing(
     return { content: cached.content, localPath };
   }
 
-  // 3. Await NATS event — guaranteed delivery via durable consumer
-  const result = await new Promise<{ content: string; error?: string }>((resolvePromise, rejectPromise) => {
-    mediaCompletions.set(msg.id, { resolve: resolvePromise, reject: rejectPromise, createdAt: Date.now() });
-  });
+  // 3. Await NATS event — guaranteed delivery via durable consumer (with 30s timeout fallback).
+  // If the event is delayed/lost (e.g. host overload), we re-read the DB before giving up so a
+  // successful processing whose event was dropped is still recovered.
+  let result: { content: string; error?: string };
+  try {
+    result = await awaitMediaCompletion(msg.id);
+  } catch (error) {
+    log.warn('Media wait timed out, retrying DB read', {
+      instanceId,
+      chatId,
+      externalId,
+      msgId: msg.id,
+      error: String(error),
+    });
+    const recovered = await recoverProcessedMediaAfterTimeout(services, chat.id, externalId, column);
+    if (recovered) return recovered;
+    return MEDIA_WAIT_NULL;
+  }
 
   if (!result.content || result.error) return MEDIA_WAIT_NULL;
 

--- a/packages/core/src/events/nats/__tests__/registry.test.ts
+++ b/packages/core/src/events/nats/__tests__/registry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { z } from 'zod';
-import { EventRegistry, SystemEventSchemas, createEventSchema } from '../registry';
+import { CustomEventSchemas, EventRegistry, SystemEventSchemas, createEventSchema, eventRegistry } from '../registry';
 
 describe('EventRegistry', () => {
   let registry: EventRegistry;
@@ -211,5 +211,38 @@ describe('SystemEventSchemas', () => {
 
     const result = SystemEventSchemas.healthDegraded.schema.safeParse(validPayload);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('CustomEventSchemas', () => {
+  test('chat unread schema validates first-party payloads', () => {
+    const result = CustomEventSchemas.chatUnreadUpdated.schema.safeParse({
+      chatId: '5511999999999@s.whatsapp.net',
+      unreadCount: 3,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('contact names schema validates first-party payloads', () => {
+    const result = CustomEventSchemas.contactsNames.schema.safeParse({
+      names: [{ jid: '5511999999999@s.whatsapp.net', name: 'Felipe' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('LID mapping schema validates first-party payloads', () => {
+    const result = CustomEventSchemas.lidMappingBatch.schema.safeParse({
+      mappings: [{ lidJid: '123@lid', phoneJid: '5511999999999@s.whatsapp.net' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('built-in custom schemas are registered in singleton registry', () => {
+    expect(eventRegistry.has('custom.chat.unread-updated')).toBe(true);
+    expect(eventRegistry.has('custom.contacts.names')).toBe(true);
+    expect(eventRegistry.has('custom.lid-mapping.batch')).toBe(true);
   });
 });

--- a/packages/core/src/events/nats/index.ts
+++ b/packages/core/src/events/nats/index.ts
@@ -63,5 +63,6 @@ export {
   createEventSchema,
   registerSchemas,
   SystemEventSchemas,
+  CustomEventSchemas,
 } from './registry';
 export type { EventSchemaEntry, ValidationResult } from './registry';

--- a/packages/core/src/events/nats/registry.ts
+++ b/packages/core/src/events/nats/registry.ts
@@ -262,3 +262,46 @@ export const SystemEventSchemas = {
     { description: 'System health degradation detected' },
   ),
 };
+
+/**
+ * Built-in custom event schemas emitted by first-party channels/plugins.
+ * Registering these keeps runtime validation useful without warning on normal traffic.
+ */
+export const CustomEventSchemas = {
+  chatUnreadUpdated: createEventSchema(
+    'custom.chat.unread-updated',
+    z.object({
+      chatId: z.string(),
+      unreadCount: z.number(),
+    }),
+    { description: 'Platform-native chat unread count update' },
+  ),
+
+  contactsNames: createEventSchema(
+    'custom.contacts.names',
+    z.object({
+      names: z.array(
+        z.object({
+          jid: z.string(),
+          name: z.string(),
+        }),
+      ),
+    }),
+    { description: 'Contact display names discovered by a channel' },
+  ),
+
+  lidMappingBatch: createEventSchema(
+    'custom.lid-mapping.batch',
+    z.object({
+      mappings: z.array(
+        z.object({
+          lidJid: z.string(),
+          phoneJid: z.string(),
+        }),
+      ),
+    }),
+    { description: 'Batch of WhatsApp LID to phone JID mappings' },
+  ),
+};
+
+registerSchemas([...Object.values(SystemEventSchemas), ...Object.values(CustomEventSchemas)]);


### PR DESCRIPTION
## Summary
- merge `origin/dev` into the dogfood fix branch so Felipe runtime includes the dispatcher media-timeout recovery
- register first-party `custom.*` NATS event schemas for WhatsApp unread/contact/LID events
- add registry coverage so these normal runtime events stop logging as unregistered schemas

## Validation
- `bun test packages/core/src/events/nats/__tests__/registry.test.ts`
- `bun run --filter @omni/core typecheck`
- `bun run --filter @automagik/omni build:server`
- full `bun run typecheck` via pre-push hook passed
- full `bun test` via pre-push hook is not clean: unrelated `packages/cli/src/__tests__/doctor.test.ts` timeouts/failures in pgserve/pm2 doctor checks; hook also mutates local PM2, runtime was restarted after
- `pm2 restart omni-api --update-env`
- `omni status` healthy
- post-restart logs since 03:00 show no `API_KEY_INVALID`, `Circuit breaker is open`, `No vision API configured`, or `No schema registered for event type`
