### PR TITLE
chore: promote felipe dogfood fixes

### DIFF
--- a/packages/api/src/__tests__/delete-channel-resolve.test.ts
+++ b/packages/api/src/__tests__/delete-channel-resolve.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for delete-channel endpoint messageId resolution.
+ *
+ * WhatsApp/Baileys delete-for-everyone needs the platform-native message key id,
+ * not Omni's internal UUID. The route must resolve an internal UUID to externalId
+ * before calling channel plugin deleteMessage().
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveChannelMessageId } from '../routes/v2/messages';
+
+const MESSAGE_UUID = '11111111-1111-4111-8111-111111111111';
+const INSTANCE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const INSTANCE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function servicesFor(chatInstanceId = INSTANCE_A) {
+  return {
+    messages: {
+      async getById(id: string) {
+        if (id !== MESSAGE_UUID) throw new Error('not found');
+        return {
+          id,
+          chatId: 'chat-a',
+          externalId: '3EB0DELETE_FOR_EVERYONE',
+        };
+      },
+    },
+    chats: {
+      async getById(id: string) {
+        if (id !== 'chat-a') throw new Error('chat not found');
+        return {
+          id,
+          instanceId: chatInstanceId,
+        };
+      },
+    },
+  };
+}
+
+describe('delete-channel messageId resolution', () => {
+  test('resolves internal UUID to externalId for channel delete calls', async () => {
+    const resolved = await resolveChannelMessageId(servicesFor() as never, MESSAGE_UUID, INSTANCE_A);
+
+    expect(resolved).toBe('3EB0DELETE_FOR_EVERYONE');
+  });
+
+  test('passes platform-native non-UUID message ids through unchanged', async () => {
+    await expect(resolveChannelMessageId(servicesFor() as never, '3EB0A1B2C3D4E5F6', INSTANCE_A)).resolves.toBe(
+      '3EB0A1B2C3D4E5F6',
+    );
+  });
+
+  test('rejects cross-instance internal UUID resolution', async () => {
+    await expect(resolveChannelMessageId(servicesFor(INSTANCE_A) as never, MESSAGE_UUID, INSTANCE_B)).rejects.toThrow(
+      /Message does not belong to this instance/,
+    );
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -654,6 +654,33 @@ async function waitForRecord<T>(
   return null;
 }
 
+const MEDIA_WAIT_TIMEOUT_MS = 30_000;
+
+function awaitMediaCompletion(msgId: string): Promise<{ content: string; error?: string }> {
+  return new Promise<{ content: string; error?: string }>((resolvePromise, rejectPromise) => {
+    mediaCompletions.set(msgId, { resolve: resolvePromise, reject: rejectPromise, createdAt: Date.now() });
+    setTimeout(() => {
+      if (mediaCompletions.has(msgId)) {
+        mediaCompletions.delete(msgId);
+        rejectPromise(new Error(`media wait timeout (${MEDIA_WAIT_TIMEOUT_MS}ms)`));
+      }
+    }, MEDIA_WAIT_TIMEOUT_MS);
+  });
+}
+
+async function recoverProcessedMediaAfterTimeout(
+  services: Services,
+  chatRecordId: string,
+  externalId: string,
+  column: string,
+): Promise<{ content: string; localPath: string | null } | null> {
+  const refreshed = await services.messages.getByExternalId(chatRecordId, externalId);
+  if (!refreshed) return null;
+  const recovered = checkProcessedColumn(refreshed, column);
+  if (recovered === 'pending' || recovered === 'error') return null;
+  return recovered;
+}
+
 /**
  * Await media processing via NATS event instead of DB polling.
  * Checks: DB first (already done) → event cache (arrived early) → await promise (NATS delivery).
@@ -700,10 +727,24 @@ async function awaitMediaProcessing(
     return { content: cached.content, localPath };
   }
 
-  // 3. Await NATS event — guaranteed delivery via durable consumer
-  const result = await new Promise<{ content: string; error?: string }>((resolvePromise, rejectPromise) => {
-    mediaCompletions.set(msg.id, { resolve: resolvePromise, reject: rejectPromise, createdAt: Date.now() });
-  });
+  // 3. Await NATS event — guaranteed delivery via durable consumer (with 30s timeout fallback).
+  // If the event is delayed/lost (e.g. host overload), we re-read the DB before giving up so a
+  // successful processing whose event was dropped is still recovered.
+  let result: { content: string; error?: string };
+  try {
+    result = await awaitMediaCompletion(msg.id);
+  } catch (error) {
+    log.warn('Media wait timed out, retrying DB read', {
+      instanceId,
+      chatId,
+      externalId,
+      msgId: msg.id,
+      error: String(error),
+    });
+    const recovered = await recoverProcessedMediaAfterTimeout(services, chat.id, externalId, column);
+    if (recovered) return recovered;
+    return MEDIA_WAIT_NULL;
+  }
 
   if (!result.content || result.error) return MEDIA_WAIT_NULL;
 

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -2605,7 +2605,7 @@ messagesRoutes.post('/send/embed', zValidator('json', sendEmbedSchema), async (c
  * Throws FORBIDDEN if the message's chat is owned by a different instance.
  */
 async function verifyMessageInstanceOwnership(
-  services: Services,
+  services: Pick<Services, 'chats'>,
   message: { chatId: string; externalId: string },
   instanceId: string,
 ): Promise<void> {
@@ -2619,6 +2619,27 @@ async function verifyMessageInstanceOwnership(
       recoverable: false,
     });
   }
+}
+
+/**
+ * Resolve a message ID for channel plugin calls.
+ *
+ * Channel plugins need platform-native IDs (e.g. Baileys message key IDs), not
+ * Omni internal UUIDs. If the caller passes an internal UUID, resolve it to the
+ * stored externalId and enforce instance ownership before returning it.
+ */
+export async function resolveChannelMessageId(
+  services: Pick<Services, 'messages' | 'chats'>,
+  messageId: string,
+  instanceId: string,
+): Promise<string> {
+  if (!isUUID(messageId)) return messageId;
+
+  const message = await services.messages.getById(messageId);
+  await verifyMessageInstanceOwnership(services, message, instanceId);
+
+  log.debug('Resolved internal UUID to external ID', { messageId, externalId: message.externalId });
+  return message.externalId;
 }
 
 /**
@@ -2672,15 +2693,7 @@ messagesRoutes.post('/edit-channel', zValidator('json', editMessageChannelSchema
     });
   }
 
-  // Resolve messageId: if it's an internal UUID, look up the external ID from the database.
-  // Channel plugins (e.g. Baileys) need the platform-native message ID, not the Omni UUID.
-  let resolvedMessageId = messageId;
-  if (isUUID(messageId)) {
-    const message = await services.messages.getById(messageId);
-    await verifyMessageInstanceOwnership(services, message, instanceId);
-    resolvedMessageId = message.externalId;
-    log.debug('Resolved internal UUID to external ID', { messageId, externalId: resolvedMessageId });
-  }
+  const resolvedMessageId = await resolveChannelMessageId(services, messageId, instanceId);
 
   // Edit via channel plugin — catch and surface plugin errors
   try {
@@ -2758,16 +2771,18 @@ messagesRoutes.post('/delete-channel', zValidator('json', deleteMessageChannelSc
     });
   }
 
+  const resolvedMessageId = await resolveChannelMessageId(services, messageId, instanceId);
+
   // Delete via channel plugin
   await (
     plugin as {
       deleteMessage: (instanceId: string, channelId: string, messageId: string, fromMe?: boolean) => Promise<void>;
     }
-  ).deleteMessage(instanceId, channelId, messageId, fromMe);
+  ).deleteMessage(instanceId, channelId, resolvedMessageId, fromMe);
 
   return c.json({
     success: true,
-    data: { messageId, deleted: true },
+    data: { messageId, externalId: resolvedMessageId, deleted: true },
   });
 });
 

--- a/packages/channel-whatsapp/src/__tests__/all-events-missing.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/all-events-missing.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import type { WASocket } from 'baileys';
+import { setupAllEventHandlers } from '../handlers/all-events';
+import { WhatsAppPlugin } from '../plugin';
+
+function createMockSocket() {
+  const ev = new EventEmitter();
+  return { ev } as unknown as WASocket & { ev: EventEmitter };
+}
+
+function createMockPlugin() {
+  return {
+    id: 'whatsapp-baileys',
+    handleCallReceived: mock(() => undefined),
+    handlePresenceUpdate: mock(() => undefined),
+    handleChatsUpsert: mock(() => undefined),
+    handleChatsUpdate: mock(() => undefined),
+    handleChatsDelete: mock(() => undefined),
+    handleContactsUpsert: mock(() => undefined),
+    handleContactsUpdate: mock(() => undefined),
+    handleGroupsUpsert: mock(() => undefined),
+    handleGroupsUpdate: mock(() => undefined),
+    handleGroupParticipantsUpdate: mock(() => undefined),
+    handleGroupJoinRequest: mock(() => undefined),
+    handleMessageReceiptUpdate: mock(() => undefined),
+    handleMediaUpdate: mock(() => undefined),
+    handleHistorySync: mock(() => undefined),
+    handleBlocklistSet: mock(() => undefined),
+    handleBlocklistUpdate: mock(() => undefined),
+    handleLabelEdit: mock(() => undefined),
+    handleLabelAssociation: mock(() => undefined),
+    storeLidMapping: mock(() => undefined),
+    handleMessagingHistoryStatus: mock(() => undefined),
+    handleMessageCappingUpdate: mock(() => undefined),
+    handleSettingsUpdate: mock(() => undefined),
+    handleChatLockUpdate: mock(() => undefined),
+    handleGroupMemberTagUpdate: mock(() => undefined),
+  };
+}
+
+function createPluginWithEventBus() {
+  const publishGeneric = mock(async (_event: string, _payload: unknown, _meta: unknown) => undefined);
+  const plugin = new WhatsAppPlugin();
+  (plugin as unknown as { eventBus: unknown }).eventBus = { publishGeneric };
+  (plugin as unknown as { logger: unknown }).logger = { info: mock(), debug: mock(), warn: mock(), error: mock() };
+  return { plugin, publishGeneric };
+}
+
+describe('setupAllEventHandlers missing Baileys events', () => {
+  const instanceId = 'test-instance';
+
+  test('delegates messaging-history.status', () => {
+    const sock = createMockSocket();
+    const plugin = createMockPlugin();
+    setupAllEventHandlers(sock as WASocket, plugin as never, instanceId);
+
+    const payload = { syncType: 1, status: 'complete', explicit: true };
+    sock.ev.emit('messaging-history.status', payload);
+
+    expect(plugin.handleMessagingHistoryStatus).toHaveBeenCalledTimes(1);
+    expect(plugin.handleMessagingHistoryStatus).toHaveBeenCalledWith(instanceId, payload);
+  });
+
+  test('delegates message-capping.update', () => {
+    const sock = createMockSocket();
+    const plugin = createMockPlugin();
+    setupAllEventHandlers(sock as WASocket, plugin as never, instanceId);
+
+    const payload = { reason: 'cap', limit: 100 };
+    sock.ev.emit('message-capping.update', payload);
+
+    expect(plugin.handleMessageCappingUpdate).toHaveBeenCalledTimes(1);
+    expect(plugin.handleMessageCappingUpdate).toHaveBeenCalledWith(instanceId, payload);
+  });
+
+  test('delegates settings.update', () => {
+    const sock = createMockSocket();
+    const plugin = createMockPlugin();
+    setupAllEventHandlers(sock as WASocket, plugin as never, instanceId);
+
+    const payload = { setting: 'locale', value: 'pt-BR' };
+    sock.ev.emit('settings.update', payload);
+
+    expect(plugin.handleSettingsUpdate).toHaveBeenCalledTimes(1);
+    expect(plugin.handleSettingsUpdate).toHaveBeenCalledWith(instanceId, payload);
+  });
+
+  test('delegates chats.lock', () => {
+    const sock = createMockSocket();
+    const plugin = createMockPlugin();
+    setupAllEventHandlers(sock as WASocket, plugin as never, instanceId);
+
+    const payload = { id: '5511999999999@s.whatsapp.net', locked: true };
+    sock.ev.emit('chats.lock', payload);
+
+    expect(plugin.handleChatLockUpdate).toHaveBeenCalledTimes(1);
+    expect(plugin.handleChatLockUpdate).toHaveBeenCalledWith(instanceId, payload);
+  });
+
+  test('delegates group.member-tag.update', () => {
+    const sock = createMockSocket();
+    const plugin = createMockPlugin();
+    setupAllEventHandlers(sock as WASocket, plugin as never, instanceId);
+
+    const payload = {
+      groupId: '120363000000000000@g.us',
+      participant: '5511999999999@s.whatsapp.net',
+      participantAlt: '123@lid',
+      label: 'admin',
+      messageTimestamp: 1710000000,
+    };
+    sock.ev.emit('group.member-tag.update', payload);
+
+    expect(plugin.handleGroupMemberTagUpdate).toHaveBeenCalledTimes(1);
+    expect(plugin.handleGroupMemberTagUpdate).toHaveBeenCalledWith(instanceId, payload);
+  });
+
+  test('registers every read-only Baileys event selected for coverage', () => {
+    const sock = createMockSocket();
+    const plugin = createMockPlugin();
+    setupAllEventHandlers(sock as WASocket, plugin as never, instanceId);
+
+    const expectedEvents = [
+      'messaging-history.status',
+      'message-capping.update',
+      'settings.update',
+      'chats.lock',
+      'group.member-tag.update',
+    ];
+
+    for (const event of expectedEvents) {
+      expect(sock.ev.listenerCount(event)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('WhatsAppPlugin read-only Baileys event publishing', () => {
+  const instanceId = 'test-instance';
+
+  test('publishes messaging-history.status as custom event', () => {
+    const { plugin, publishGeneric } = createPluginWithEventBus();
+
+    plugin.handleMessagingHistoryStatus(instanceId, { syncType: 1, status: 'complete', explicit: true });
+
+    expect(publishGeneric).toHaveBeenCalledTimes(1);
+    expect(publishGeneric.mock.calls[0]?.[0]).toBe('custom.whatsapp.messaging-history-status');
+    expect(publishGeneric.mock.calls[0]?.[1]).toMatchObject({
+      instanceId,
+      syncType: 1,
+      status: 'complete',
+      explicit: true,
+    });
+    expect(publishGeneric.mock.calls[0]?.[1]).toHaveProperty('timestamp');
+    expect(publishGeneric.mock.calls[0]?.[2]).toMatchObject({
+      instanceId,
+      channelType: plugin.id,
+      source: `channel:${plugin.id}`,
+    });
+  });
+
+  test('publishes message-capping.update as custom event', () => {
+    const { plugin, publishGeneric } = createPluginWithEventBus();
+    const info = { reason: 'cap', limit: 100 };
+
+    plugin.handleMessageCappingUpdate(instanceId, info);
+
+    expect(publishGeneric).toHaveBeenCalledTimes(1);
+    expect(publishGeneric.mock.calls[0]?.[0]).toBe('custom.whatsapp.message-capping-updated');
+    expect(publishGeneric.mock.calls[0]?.[1]).toMatchObject({ instanceId, info });
+    expect(publishGeneric.mock.calls[0]?.[2]).toMatchObject({
+      instanceId,
+      channelType: plugin.id,
+      source: `channel:${plugin.id}`,
+    });
+  });
+
+  test('publishes settings.update as custom event', () => {
+    const { plugin, publishGeneric } = createPluginWithEventBus();
+
+    plugin.handleSettingsUpdate(instanceId, { setting: 'locale', value: 'pt-BR' });
+
+    expect(publishGeneric).toHaveBeenCalledTimes(1);
+    expect(publishGeneric.mock.calls[0]?.[0]).toBe('custom.whatsapp.settings-updated');
+    expect(publishGeneric.mock.calls[0]?.[1]).toMatchObject({ instanceId, setting: 'locale', value: 'pt-BR' });
+    expect(publishGeneric.mock.calls[0]?.[2]).toMatchObject({
+      instanceId,
+      channelType: plugin.id,
+      source: `channel:${plugin.id}`,
+    });
+  });
+
+  test('publishes chats.lock as custom event', () => {
+    const { plugin, publishGeneric } = createPluginWithEventBus();
+
+    plugin.handleChatLockUpdate(instanceId, { id: '5511999999999@s.whatsapp.net', locked: true });
+
+    expect(publishGeneric).toHaveBeenCalledTimes(1);
+    expect(publishGeneric.mock.calls[0]?.[0]).toBe('custom.whatsapp.chat-lock-updated');
+    expect(publishGeneric.mock.calls[0]?.[1]).toMatchObject({
+      instanceId,
+      chatId: '5511999999999@s.whatsapp.net',
+      locked: true,
+    });
+    expect(publishGeneric.mock.calls[0]?.[2]).toMatchObject({
+      instanceId,
+      channelType: plugin.id,
+      source: `channel:${plugin.id}`,
+    });
+  });
+
+  test('publishes group.member-tag.update as custom event', () => {
+    const { plugin, publishGeneric } = createPluginWithEventBus();
+
+    plugin.handleGroupMemberTagUpdate(instanceId, {
+      groupId: '120363000000000000@g.us',
+      participant: '5511999999999@s.whatsapp.net',
+      participantAlt: '123@lid',
+      label: 'admin',
+      messageTimestamp: 1710000000,
+    });
+
+    expect(publishGeneric).toHaveBeenCalledTimes(1);
+    expect(publishGeneric.mock.calls[0]?.[0]).toBe('custom.whatsapp.group-member-tag-updated');
+    expect(publishGeneric.mock.calls[0]?.[1]).toMatchObject({
+      instanceId,
+      groupId: '120363000000000000@g.us',
+      participant: '5511999999999@s.whatsapp.net',
+      participantAlt: '123@lid',
+      label: 'admin',
+      messageTimestamp: 1710000000,
+    });
+    expect(publishGeneric.mock.calls[0]?.[2]).toMatchObject({
+      instanceId,
+      channelType: plugin.id,
+      source: `channel:${plugin.id}`,
+    });
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/all-events.ts
+++ b/packages/channel-whatsapp/src/handlers/all-events.ts
@@ -13,6 +13,8 @@ import type { WhatsAppPlugin } from '../plugin';
 const waLog = createLogger('whatsapp:events');
 const DEBUG = process.env.DEBUG_PAYLOADS === 'true';
 
+type BaileysEventListener = (event: string, listener: (payload: never) => void) => void;
+
 function logEvent(event: string, data: unknown): void {
   waLog.debug('Event received', { event });
   if (DEBUG) {
@@ -50,6 +52,11 @@ function processLidMappings(data: unknown, plugin: WhatsAppPlugin, instanceId: s
  * This captures everything for debugging and future feature development
  */
 export function setupAllEventHandlers(sock: WASocket, plugin: WhatsAppPlugin, instanceId: string): void {
+  // Some read-only events are available at runtime in newer Baileys RCs before
+  // the local vendored typings catch up. Keep those listeners string-based and
+  // isolated so this file remains type-safe without blocking observability.
+  const onReadOnlyEvent = sock.ev.on.bind(sock.ev) as BaileysEventListener;
+
   // ============================================================================
   // CALLS - Voice/Video calls
   // ============================================================================
@@ -105,6 +112,12 @@ export function setupAllEventHandlers(sock: WASocket, plugin: WhatsAppPlugin, in
     plugin.handleChatsDelete(instanceId, chatIds);
   });
 
+  onReadOnlyEvent('chats.lock', (update: { id?: string; locked?: boolean }) => {
+    waLog.info('Chat lock update', { chatId: update.id, locked: update.locked });
+    if (DEBUG) logEvent('chats.lock', update);
+    plugin.handleChatLockUpdate(instanceId, update);
+  });
+
   // ============================================================================
   // CONTACTS - Contact list updates
   // ============================================================================
@@ -147,6 +160,25 @@ export function setupAllEventHandlers(sock: WASocket, plugin: WhatsAppPlugin, in
     plugin.handleGroupJoinRequest(instanceId, request);
   });
 
+  onReadOnlyEvent(
+    'group.member-tag.update',
+    (update: {
+      groupId?: string;
+      participant?: string;
+      participantAlt?: string;
+      label?: string;
+      messageTimestamp?: number;
+    }) => {
+      waLog.info('Group member tag update', {
+        groupId: update.groupId,
+        participant: update.participant,
+        label: update.label,
+      });
+      if (DEBUG) logEvent('group.member-tag.update', update);
+      plugin.handleGroupMemberTagUpdate(instanceId, update);
+    },
+  );
+
   // ============================================================================
   // MESSAGE RECEIPTS - Delivery/read confirmations
   // ============================================================================
@@ -173,6 +205,15 @@ export function setupAllEventHandlers(sock: WASocket, plugin: WhatsAppPlugin, in
     }
   });
 
+  onReadOnlyEvent('message-capping.update', (info: unknown) => {
+    waLog.info('Message capping update', {
+      type: info && typeof info === 'object' ? (info as { type?: unknown }).type : undefined,
+      reason: info && typeof info === 'object' ? (info as { reason?: unknown }).reason : undefined,
+    });
+    if (DEBUG) logEvent('message-capping.update', info);
+    plugin.handleMessageCappingUpdate(instanceId, info);
+  });
+
   // ============================================================================
   // HISTORY SYNC - Initial chat/message sync
   // ============================================================================
@@ -196,6 +237,16 @@ export function setupAllEventHandlers(sock: WASocket, plugin: WhatsAppPlugin, in
     await plugin.handleHistorySync(instanceId, history);
   });
 
+  onReadOnlyEvent('messaging-history.status', (status: { syncType?: unknown; status?: string; explicit?: boolean }) => {
+    waLog.info('History sync status', {
+      syncType: status.syncType,
+      status: status.status,
+      explicit: status.explicit,
+    });
+    if (DEBUG) logEvent('messaging-history.status', status);
+    plugin.handleMessagingHistoryStatus(instanceId, status);
+  });
+
   // ============================================================================
   // BLOCKLIST - Blocked contacts
   // ============================================================================
@@ -209,6 +260,12 @@ export function setupAllEventHandlers(sock: WASocket, plugin: WhatsAppPlugin, in
     waLog.info('Blocklist update', { type: data.type, count: data.blocklist.length });
     if (DEBUG) logEvent('blocklist.update', data);
     plugin.handleBlocklistUpdate(instanceId, data.blocklist, data.type);
+  });
+
+  onReadOnlyEvent('settings.update', (update: { setting?: string; value?: unknown }) => {
+    waLog.info('Settings update', { setting: update.setting });
+    if (DEBUG) logEvent('settings.update', update);
+    plugin.handleSettingsUpdate(instanceId, update);
   });
 
   // ============================================================================

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3068,6 +3068,126 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   // ALL EVENT HANDLERS (for comprehensive Baileys coverage)
   // ─────────────────────────────────────────────────────────────
 
+  private whatsappEventMeta(instanceId: string, suffix: string): Record<string, unknown> {
+    return {
+      instanceId,
+      channelType: this.id,
+      source: `channel:${this.id}`,
+      correlationId: `${suffix}-${instanceId}`,
+    };
+  }
+
+  /**
+   * Handle Baileys messaging-history.status events.
+   * Read-only observability event: no WhatsApp side effects.
+   * @internal
+   */
+  handleMessagingHistoryStatus(
+    instanceId: string,
+    status: { syncType?: unknown; status?: string; explicit?: boolean },
+  ): void {
+    this.eventBus
+      .publishGeneric(
+        'custom.whatsapp.messaging-history-status',
+        {
+          instanceId,
+          syncType: status.syncType,
+          status: status.status ?? 'unknown',
+          explicit: status.explicit,
+          timestamp: Date.now(),
+        },
+        this.whatsappEventMeta(instanceId, 'history-status'),
+      )
+      .catch((err) => this.logger.warn('Failed to publish messaging history status', { error: String(err) }));
+  }
+
+  /**
+   * Handle Baileys message-capping.update events.
+   * Read-only observability event: no WhatsApp side effects.
+   * @internal
+   */
+  handleMessageCappingUpdate(instanceId: string, info: unknown): void {
+    this.eventBus
+      .publishGeneric(
+        'custom.whatsapp.message-capping-updated',
+        { instanceId, info, timestamp: Date.now() },
+        this.whatsappEventMeta(instanceId, 'message-capping'),
+      )
+      .catch((err) => this.logger.warn('Failed to publish message capping update', { error: String(err) }));
+  }
+
+  /**
+   * Handle Baileys settings.update events.
+   * Read-only observability event: no WhatsApp side effects.
+   * @internal
+   */
+  handleSettingsUpdate(instanceId: string, update: { setting?: string; value?: unknown }): void {
+    this.eventBus
+      .publishGeneric(
+        'custom.whatsapp.settings-updated',
+        {
+          instanceId,
+          setting: update.setting ?? 'unknown',
+          value: update.value,
+          timestamp: Date.now(),
+        },
+        this.whatsappEventMeta(instanceId, `settings-${update.setting ?? 'unknown'}`),
+      )
+      .catch((err) => this.logger.warn('Failed to publish settings update', { error: String(err) }));
+  }
+
+  /**
+   * Handle Baileys chats.lock events.
+   * Read-only observability event: no WhatsApp side effects.
+   * @internal
+   */
+  handleChatLockUpdate(instanceId: string, update: { id?: string; locked?: boolean }): void {
+    this.eventBus
+      .publishGeneric(
+        'custom.whatsapp.chat-lock-updated',
+        {
+          instanceId,
+          chatId: update.id ?? '',
+          locked: update.locked ?? false,
+          timestamp: Date.now(),
+        },
+        this.whatsappEventMeta(instanceId, `chat-lock-${update.id ?? 'unknown'}`),
+      )
+      .catch((err) => this.logger.warn('Failed to publish chat lock update', { error: String(err) }));
+  }
+
+  /**
+   * Handle Baileys group.member-tag.update events.
+   * Read-only observability event: no WhatsApp side effects.
+   * @internal
+   */
+  handleGroupMemberTagUpdate(
+    instanceId: string,
+    update: {
+      groupId?: string;
+      participant?: string;
+      participantAlt?: string;
+      label?: string;
+      messageTimestamp?: number;
+    },
+  ): void {
+    this.eventBus
+      .publishGeneric(
+        'custom.whatsapp.group-member-tag-updated',
+        {
+          instanceId,
+          groupId: update.groupId ?? '',
+          participant: update.participant ?? '',
+          participantAlt: update.participantAlt,
+          label: update.label ?? '',
+          messageTimestamp: update.messageTimestamp,
+          timestamp: Date.now(),
+        },
+        this.whatsappEventMeta(instanceId, `group-member-tag-${update.groupId ?? 'unknown'}`),
+      )
+      .catch((err) => this.logger.warn('Failed to publish group member tag update', { error: String(err) }));
+  }
+
   /**
    * Handle incoming call (voice/video)
    * @internal

--- a/packages/cli/src/commands/messages.ts
+++ b/packages/cli/src/commands/messages.ts
@@ -331,7 +331,7 @@ export function createMessagesCommand(): Command {
           output.error('--chat is required');
           return;
         }
-        const resolvedMessageId = await resolveMessageId(messageId);
+        const resolvedMessageId = await resolveMessageId(messageId, channelId);
         const instanceId = await resolveInstanceId(options.instance);
         const config = (await import('../config.js')).loadConfig();
         const baseUrl = config.apiUrl ?? 'http://localhost:8882';

--- a/packages/core/src/events/nats/__tests__/registry.test.ts
+++ b/packages/core/src/events/nats/__tests__/registry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { z } from 'zod';
-import { EventRegistry, SystemEventSchemas, createEventSchema } from '../registry';
+import { CustomEventSchemas, EventRegistry, SystemEventSchemas, createEventSchema, eventRegistry } from '../registry';
 
 describe('EventRegistry', () => {
   let registry: EventRegistry;
@@ -211,5 +211,38 @@ describe('SystemEventSchemas', () => {
 
     const result = SystemEventSchemas.healthDegraded.schema.safeParse(validPayload);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('CustomEventSchemas', () => {
+  test('chat unread schema validates first-party payloads', () => {
+    const result = CustomEventSchemas.chatUnreadUpdated.schema.safeParse({
+      chatId: '5511999999999@s.whatsapp.net',
+      unreadCount: 3,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('contact names schema validates first-party payloads', () => {
+    const result = CustomEventSchemas.contactsNames.schema.safeParse({
+      names: [{ jid: '5511999999999@s.whatsapp.net', name: 'Felipe' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('LID mapping schema validates first-party payloads', () => {
+    const result = CustomEventSchemas.lidMappingBatch.schema.safeParse({
+      mappings: [{ lidJid: '123@lid', phoneJid: '5511999999999@s.whatsapp.net' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('built-in custom schemas are registered in singleton registry', () => {
+    expect(eventRegistry.has('custom.chat.unread-updated')).toBe(true);
+    expect(eventRegistry.has('custom.contacts.names')).toBe(true);
+    expect(eventRegistry.has('custom.lid-mapping.batch')).toBe(true);
   });
 });

--- a/packages/core/src/events/nats/index.ts
+++ b/packages/core/src/events/nats/index.ts
@@ -63,5 +63,6 @@ export {
   createEventSchema,
   registerSchemas,
   SystemEventSchemas,
+  CustomEventSchemas,
 } from './registry';
 export type { EventSchemaEntry, ValidationResult } from './registry';

--- a/packages/core/src/events/nats/registry.ts
+++ b/packages/core/src/events/nats/registry.ts
@@ -262,3 +262,46 @@ export const SystemEventSchemas = {
     { description: 'System health degradation detected' },
   ),
 };
+
+/**
+ * Built-in custom event schemas emitted by first-party channels/plugins.
+ * Registering these keeps runtime validation useful without warning on normal traffic.
+ */
+export const CustomEventSchemas = {
+  chatUnreadUpdated: createEventSchema(
+    'custom.chat.unread-updated',
+    z.object({
+      chatId: z.string(),
+      unreadCount: z.number(),
+    }),
+    { description: 'Platform-native chat unread count update' },
+  ),
+
+  contactsNames: createEventSchema(
+    'custom.contacts.names',
+    z.object({
+      names: z.array(
+        z.object({
+          jid: z.string(),
+          name: z.string(),
+        }),
+      ),
+    }),
+    { description: 'Contact display names discovered by a channel' },
+  ),
+
+  lidMappingBatch: createEventSchema(
+    'custom.lid-mapping.batch',
+    z.object({
+      mappings: z.array(
+        z.object({
+          lidJid: z.string(),
+          phoneJid: z.string(),
+        }),
+      ),
+    }),
+    { description: 'Batch of WhatsApp LID to phone JID mappings' },
+  ),
+};
+
+registerSchemas([...Object.values(SystemEventSchemas), ...Object.values(CustomEventSchemas)]);


### PR DESCRIPTION
## Summary
- promote Felipe dogfood branch back to `dev`
- includes WhatsApp dogfood delete/read-only event coverage from `felipe`
- includes first-party custom NATS schemas for WhatsApp unread/contact/LID events
- records `origin/dev` ancestry in `felipe` before promotion, so the dispatcher media-timeout recovery is already accounted for

## Dogfood / validation
- `bun test packages/core/src/events/nats/__tests__/registry.test.ts`
- `bun run --filter @omni/core typecheck`
- full `bun run typecheck` passed in pre-push hook
- `bun run --filter @automagik/omni build:server`
- `pm2 restart omni-api --update-env`
- `omni status` healthy on local Felipe runtime
- post-restart logs show no `API_KEY_INVALID`, `Circuit breaker is open`, `No vision API configured`, or `No schema registered for event type`

## Known unrelated validation noise
- full `bun test` via pre-push is not clean locally because `packages/cli/src/__tests__/doctor.test.ts` times out/fails in pgserve/pm2 doctor checks and mutates PM2 state; runtime was restarted and verified healthy after that.
