### PR TITLE
ci: run autopg v3 in quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,22 @@ jobs:
       - name: Download NATS
         run: ./scripts/ensure-nats.sh
 
+      - name: Install autopg v3
+        # Use the current canonical pgserve distribution. `bunx pgserve@...`
+        # installs the legacy npm wrapper; Omni's runtime resolver prefers
+        # `autopg` v3 and only falls back to `pgserve` for old hosts.
+        # The installer verifies release attestations via gh/cosign; gh needs
+        # GH_TOKEN in Actions to make the verification API call. It also runs
+        # `autopg install`, which currently expects pm2 to be present even
+        # though the CI job starts autopg directly afterward.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bun add -g pm2
+          curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash
+
       - name: Start pgserve
-        # Pin to ~2.4 (the singleton supervisor entry); pgserve 2.4 dropped
-        # the bare `pgserve --port ... --no-cluster` legacy form (which now
-        # only prints a help banner) in favour of `pgserve serve`.
-        run: bunx pgserve@~2.4.0 serve --port 8432 --data .pgserve-data &
+        run: ~/.local/bin/autopg serve --port 8432 --data .pgserve-data &
 
       - name: Start NATS
         run: ./bin/nats-server -js -p 4222 &
@@ -86,6 +97,13 @@ jobs:
               echo "Database ready" && exit 0 || sleep 1
           done
           echo "Database failed to start" && exit 1
+
+      - name: Create omni database
+        # autopg v3 is consumer-only: it starts postgres/template DBs, not
+        # per-app databases. Create the `omni` DB explicitly for tests.
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -p 8432 -U postgres -c "CREATE DATABASE omni"
 
       - name: Build
         run: bun run build
@@ -148,11 +166,22 @@ jobs:
       - name: Download NATS
         run: ./scripts/ensure-nats.sh
 
+      - name: Install autopg v3
+        # Use the current canonical pgserve distribution. `bunx pgserve@...`
+        # installs the legacy npm wrapper; Omni's runtime resolver prefers
+        # `autopg` v3 and only falls back to `pgserve` for old hosts.
+        # The installer verifies release attestations via gh/cosign; gh needs
+        # GH_TOKEN in Actions to make the verification API call. It also runs
+        # `autopg install`, which currently expects pm2 to be present even
+        # though the CI job starts autopg directly afterward.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bun add -g pm2
+          curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash
+
       - name: Start pgserve
-        # Pin to ~2.4 (the singleton supervisor entry); pgserve 2.4 dropped
-        # the bare `pgserve --port ... --no-cluster` legacy form (which now
-        # only prints a help banner) in favour of `pgserve serve`.
-        run: bunx pgserve@~2.4.0 serve --port 8432 --data .pgserve-data &
+        run: ~/.local/bin/autopg serve --port 8432 --data .pgserve-data &
 
       - name: Start NATS
         run: ./bin/nats-server -js -p 4222 &
@@ -166,12 +195,10 @@ jobs:
           echo "Database failed to start" && exit 1
 
       - name: Create omni database
-        # pgserve@~2.4 `serve` is the consumer-only singleton supervisor: it
-        # boots the postmaster with the default postgres/template DBs only —
-        # it does NOT auto-provision per-app databases the way the legacy 2.3
-        # multi-tenant router did. omni-api connects to `…/omni`, so create
-        # it explicitly here. In production this is owned by `pgserve install`
-        # / `omni doctor --fix` (see pgserve-singleton-no-proxy wish G2/G5).
+        # autopg v3 is consumer-only: it starts postgres/template DBs, not
+        # per-app databases. omni-api connects to `…/omni`, so create it
+        # explicitly here. In production this is owned by `autopg install`
+        # / `omni doctor --fix`.
         env:
           PGPASSWORD: postgres
         run: psql -h localhost -p 8432 -U postgres -c "CREATE DATABASE omni"

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -324,6 +324,11 @@ function mkDeps(state: HarnessState): DoctorDeps {
         : { status: 'skipped' as const };
     },
     getCanonicalPgserveDataDir: () => state.canonicalDataDir,
+    checkEmbeddedDataOrphaned: async () => ({
+      id: 'embedded-data-orphaned',
+      level: 'OK',
+      detail: 'test harness: no host-local embedded data comparison',
+    }),
     saveServerConfig: (partial) => {
       state.serverConfig = { ...state.serverConfig, ...partial };
       state.savedServerConfigs.push({ ...partial });

--- a/packages/cli/src/__tests__/update-maintenance.test.ts
+++ b/packages/cli/src/__tests__/update-maintenance.test.ts
@@ -258,9 +258,14 @@ describe('runDoctor dryRun contract', () => {
       listLockedInstances: async () => [],
       cliHasSigningKey: () => true,
       setupCanonicalPgserve: async () => 'postgres://localhost/omni',
-      dumpEmbeddedDb: async () => ({ status: 'no-embedded-data' }),
+      dumpEmbeddedDb: async () => ({ status: 'no-embedded-data', embeddedDir: '/tmp/embedded' }),
       restoreSnapshotToCanonical: async () => ({ status: 'skipped' }),
       getCanonicalPgserveDataDir: () => '/tmp/canonical',
+      checkEmbeddedDataOrphaned: async () => ({
+        id: 'embedded-data-orphaned',
+        level: 'OK',
+        detail: 'test harness: no host-local embedded data comparison',
+      }),
       saveServerConfig: () => {
         throw new Error('saveServerConfig must NOT be called in dry-run');
       },

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -254,6 +254,11 @@ export interface DoctorDeps {
   /** Resolve canonical pgserve's on-disk data dir for operator-facing logs. */
   getCanonicalPgserveDataDir: () => string;
   /**
+   * Optional test seam for the expensive host-local orphaned embedded data
+   * comparison. Production leaves this undefined and uses the real disk.
+   */
+  checkEmbeddedDataOrphaned?: () => Promise<CheckResult | null>;
+  /**
    * Persist a partial server config (merges with existing). Stubbed in
    * tests so the canonical-pgserve fix can be validated without writing
    * to ~/.omni/config.json.
@@ -526,6 +531,9 @@ async function checkOmniDbExists(deps: DoctorDeps): Promise<CheckResult> {
  * against the embedded dir, copies tables to canonical, shuts down).
  */
 async function checkEmbeddedDataOrphaned(deps: DoctorDeps): Promise<CheckResult> {
+  const injected = await deps.checkEmbeddedDataOrphaned?.();
+  if (injected) return injected;
+
   const { serverConfig } = deps.loadState();
   if (serverConfig.useCanonicalPgserve !== true) {
     return { id: 'embedded-data-orphaned', level: 'OK', detail: 'embedded mode — no orphan check needed' };


### PR DESCRIPTION
## Summary
- switch CI pgserve boot from legacy `bunx pgserve@~2.4.0` to canonical `autopg` v3
- explicitly create the `omni` database for quality-gate tests, matching autopg v3 consumer-only behavior
- keep doctor/update-maintenance tests hermetic by stubbing the host-local embedded-data comparison seam

## Systematic debug notes
- CI workflow was still starting DB with the old npm `pgserve` wrapper, while runtime resolver prefers `autopg` and only falls back to `pgserve` for legacy hosts.
- Local doctor test reproduced a separate hermeticity leak: `embedded-data-orphaned` read Felipe's real `~/.omni/data/pgserve`, making unit tests spawn real migration postmasters and timeout.
- Current observed upstream CI failure before this patch is GitGuardian quota exhaustion, unrelated to pgserve.

## Validation
- pre-push `bun run typecheck` ✅
- pre-push full `bun test`: 3902 pass / 292 skip / 0 fail ✅
- `bun test packages/cli/src/__tests__/doctor.test.ts --timeout 20000` ✅
- `bun test packages/cli/src/__tests__/update-maintenance.test.ts --timeout 10000` ✅
- `bunx biome check ...` ✅
- local autopg v3 smoke: `autopg serve --port 18432 --data /tmp/...` + `CREATE DATABASE omni` ✅
- `git diff --check` ✅