### PR TITLE
fix(core): port homolog Langfuse trace context onto dev

### DIFF
--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -109,6 +109,144 @@ describe('AgnoClient', () => {
       expect(mockImpl).toHaveBeenCalledTimes(1);
     });
 
+    it('propagates W3C trace context in headers for Langfuse session stitching', async () => {
+      const response = {
+        run_id: 'run-123',
+        agent_id: 'agent-1',
+        session_id: 'session-456',
+        content: 'Hello from agent!',
+        status: 'COMPLETED',
+      };
+
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(response), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      await client.run({
+        message: 'Hello!',
+        agentId: 'agent-1',
+        agentType: 'agent',
+        sessionId: 'chat-123',
+        userId: 'user-456',
+        traceContext: {
+          traceId: '0123456789ABCDEF0123456789ABCDEF',
+          spanId: 'FEDCBA9876543210',
+          parentSpanId: '0011223344556677',
+          traceFlags: 1,
+          tracestate: 'vendor=value',
+        },
+        khalSessionId: 'khal-session-123',
+        omni: {
+          instanceId: 'inst-1',
+          chatId: 'chat-123',
+          messageId: 'msg-789',
+          channel: 'whatsapp-cloud',
+        },
+      });
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      const formData = init.body as FormData;
+      expect(headers.traceparent).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
+      expect(headers.tracestate).toBe('vendor=value');
+      expect(headers['x-trace-id']).toBe('0123456789abcdef0123456789abcdef');
+      expect(headers['x-span-id']).toBe('fedcba9876543210');
+      expect(headers['x-parent-span-id']).toBe('0011223344556677');
+      expect(headers['x-khal-session-id']).toBe('khal-session-123');
+      expect(headers['x-khal-user-id']).toBe('user-456');
+      expect(headers['x-khal-message-id']).toBe('msg-789');
+      expect(headers['x-omni-instance-id']).toBe('inst-1');
+      expect(headers['x-omni-chat-id']).toBe('chat-123');
+      expect(headers['x-omni-channel']).toBe('whatsapp-cloud');
+      expect(formData.get('session_id')).toBe('khal-session-123');
+    });
+
+    it('includes structured Omni metadata in Agno run form payloads', async () => {
+      const response = {
+        run_id: 'run-123',
+        agent_id: 'agent-1',
+        session_id: 'session-456',
+        content: 'Hello from agent!',
+        status: 'COMPLETED',
+      };
+
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(response), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      await client.run({
+        message: 'Hello!',
+        agentId: 'agent-1',
+        agentType: 'agent',
+        sessionId: 'chat-123',
+        khalSessionId: 'khal-session-123',
+        userId: 'person-uuid',
+        platform: {
+          id: '5511999999999',
+          channel: 'whatsapp-cloud',
+          instanceId: 'inst-1',
+        },
+        sender: { displayName: 'Felipe' },
+        chat: { type: 'group', id: 'group-1', threadId: 'topic-1' },
+        messageId: 'msg-789',
+        replyToMessageId: 'msg-456',
+        mcpUrlParams: { chat_id: 'group-1' },
+        env: { OMNI_CHAT: 'group-1' },
+        omni: {
+          instanceId: 'inst-1',
+          chatId: 'group-1',
+          messageId: 'msg-789',
+          channel: 'whatsapp-cloud',
+        },
+      });
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const formData = init.body as FormData;
+      expect(formData.get('user_id')).toBe('person-uuid');
+      expect(formData.get('khal_session_id')).toBe('khal-session-123');
+      expect(formData.get('message_id')).toBe('msg-789');
+      expect(formData.get('reply_to_message_id')).toBe('msg-456');
+      expect(JSON.parse(String(formData.get('platform')))).toEqual({
+        id: '5511999999999',
+        channel: 'whatsapp-cloud',
+        instanceId: 'inst-1',
+      });
+      expect(JSON.parse(String(formData.get('sender')))).toEqual({ displayName: 'Felipe' });
+      expect(JSON.parse(String(formData.get('chat')))).toEqual({ type: 'group', id: 'group-1', threadId: 'topic-1' });
+      expect(JSON.parse(String(formData.get('mcp_url_params')))).toEqual({ chat_id: 'group-1' });
+      expect(JSON.parse(String(formData.get('env')))).toEqual({ OMNI_CHAT: 'group-1' });
+      expect(JSON.parse(String(formData.get('omni')))).toEqual({
+        instanceId: 'inst-1',
+        chatId: 'group-1',
+        messageId: 'msg-789',
+        channel: 'whatsapp-cloud',
+      });
+    });
+
+    it('uses sessionId as x-khal-session-id when khalSessionId is omitted', async () => {
+      const response = {
+        run_id: 'run-123',
+        agent_id: 'agent-1',
+        session_id: 'session-456',
+        content: 'Hello response',
+        status: 'COMPLETED',
+      };
+
+      mockImpl.mockResolvedValueOnce(new Response(JSON.stringify(response), { status: 200 }));
+
+      const client = new AgnoClient(config);
+      await client.run({
+        message: 'Hello!',
+        agentId: 'agent-1',
+        userId: 'test-user-id',
+        sessionId: 'legacy-session-123',
+      });
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      const formData = init.body as FormData;
+      expect(headers['x-khal-session-id']).toBe('legacy-session-123');
+      expect(formData.get('session_id')).toBe('legacy-session-123');
+    });
+
     it('routes to teams endpoint for team agentType', async () => {
       const response = {
         run_id: 'run-123',

--- a/packages/core/src/providers/__tests__/agno-provider.test.ts
+++ b/packages/core/src/providers/__tests__/agno-provider.test.ts
@@ -1,0 +1,214 @@
+/**
+ * AgnoAgentProvider Tests
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import type { AgentTrigger, IAgentClient, ProviderRequest, ProviderResponse, StreamChunk } from '../types';
+
+// Import the provider through a query-suffixed module id so Bun's process-wide
+// mock.module('@omni/core') in API dispatcher tests cannot poison this source-level
+// provider test when the entire monorepo suite runs in one process.
+// @ts-expect-error Bun test supports query-suffixed imports; TypeScript does not resolve them.
+const { AgnoAgentProvider } = await import('../agno-provider.ts?real-agno-provider-test');
+
+function createTrigger(overrides: Partial<AgentTrigger> = {}): AgentTrigger {
+  return {
+    traceId: 'trace-1',
+    type: 'mention',
+    event: {} as AgentTrigger['event'],
+    source: {
+      channelType: 'whatsapp-cloud',
+      instanceId: 'inst-1',
+      chatId: 'group-1',
+      messageId: 'msg-1',
+      threadId: 'thread-1',
+    },
+    sender: {
+      platformUserId: '5511999999999',
+      personId: 'person-uuid',
+      displayName: 'Felipe',
+    },
+    content: {
+      text: 'hello agno',
+      referencedMessageId: 'msg-0',
+    },
+    sessionId: 'session-1',
+    traceContext: {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: 'fedcba9876543210',
+      parentSpanId: '0011223344556677',
+      traceFlags: 1,
+      tracestate: 'vendor=value',
+    },
+    env: { OMNI_CHAT: 'group-1' },
+    ...overrides,
+  };
+}
+
+function createClient(chunks: StreamChunk[] = []): IAgentClient & { lastRequest?: ProviderRequest } {
+  const client: IAgentClient & { lastRequest?: ProviderRequest } = {
+    run: mock(async (request: ProviderRequest): Promise<ProviderResponse> => {
+      client.lastRequest = request;
+      return {
+        content: 'done',
+        runId: 'run-1',
+        sessionId: 'session-1',
+        status: 'completed',
+      };
+    }),
+    stream: mock(async function* (request: ProviderRequest): AsyncGenerator<StreamChunk> {
+      client.lastRequest = request;
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    }),
+    discover: mock(async () => []),
+    checkHealth: mock(async () => ({ healthy: true, latencyMs: 1 })),
+  };
+
+  return client;
+}
+
+function createThrowingStreamClient(): IAgentClient & { lastRequest?: ProviderRequest } {
+  const client: IAgentClient & { lastRequest?: ProviderRequest } = {
+    run: mock(async (request: ProviderRequest): Promise<ProviderResponse> => {
+      client.lastRequest = request;
+      return { content: 'done', runId: 'run-1', sessionId: 'session-1', status: 'completed' };
+    }),
+    stream: mock(async function* (request: ProviderRequest): AsyncGenerator<StreamChunk> {
+      client.lastRequest = request;
+      if (request.agentId === 'unreachable') {
+        yield { event: 'unreachable', isComplete: false };
+      }
+      throw new Error('stream exploded');
+    }),
+    discover: mock(async () => []),
+    checkHealth: mock(async () => ({ healthy: true, latencyMs: 1 })),
+  };
+
+  return client;
+}
+
+async function collect<T>(stream: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const item of stream) {
+    results.push(item);
+  }
+  return results;
+}
+
+describe('AgnoAgentProvider', () => {
+  it('streams Agno client chunks as provider deltas instead of falling back to trigger()', async () => {
+    const client = createClient([
+      { event: 'delta', content: 'hel', isComplete: false },
+      { event: 'delta', content: 'lo', isComplete: false },
+      { event: 'complete', fullContent: 'hello', isComplete: true },
+    ]);
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+      timeoutMs: 1234,
+    });
+
+    const deltas = await collect(provider.triggerStream(createTrigger()));
+
+    expect(deltas).toEqual([
+      { phase: 'content', content: 'hel' },
+      { phase: 'content', content: 'lo' },
+      { phase: 'final', content: 'hello' },
+    ]);
+    expect(client.stream).toHaveBeenCalledTimes(1);
+    expect(client.run).not.toHaveBeenCalled();
+    expect(client.lastRequest).toMatchObject({
+      agentId: 'agent-1',
+      agentType: 'agent',
+      stream: true,
+      sessionId: 'session-1',
+      userId: 'person-uuid',
+      khalSessionId: 'session-1',
+      messageId: 'msg-1',
+      replyToMessageId: 'msg-0',
+      mcpUrlParams: { chat_id: 'group-1' },
+      omni: {
+        instanceId: 'inst-1',
+        chatId: 'group-1',
+        messageId: 'msg-1',
+        channel: 'whatsapp-cloud',
+      },
+      platform: {
+        id: '5511999999999',
+        channel: 'whatsapp-cloud',
+        instanceId: 'inst-1',
+      },
+      sender: { displayName: 'Felipe' },
+      chat: { type: 'channel', id: 'group-1', threadId: 'thread-1' },
+      traceContext: {
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: 'fedcba9876543210',
+        parentSpanId: '0011223344556677',
+        traceFlags: 1,
+        tracestate: 'vendor=value',
+      },
+    });
+  });
+
+  it('passes internal person UUID as userId for non-streaming Agno runs', async () => {
+    const client = createClient();
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'team',
+      prefixSenderName: false,
+    });
+
+    const result = await provider.trigger(createTrigger());
+
+    expect(result.parts).toEqual(['done']);
+    expect(client.lastRequest).toMatchObject({
+      message: 'hello agno',
+      agentType: 'team',
+      stream: false,
+      userId: 'person-uuid',
+      traceContext: {
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: 'fedcba9876543210',
+        parentSpanId: '0011223344556677',
+        traceFlags: 1,
+        tracestate: 'vendor=value',
+      },
+      platform: { id: '5511999999999' },
+    });
+  });
+
+  it('derives a W3C trace context from Omni traceId when dispatcher did not provide one', async () => {
+    const client = createClient();
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    await provider.trigger(
+      createTrigger({
+        traceId: 'trc-homolog-dispatch-1',
+        traceContext: undefined,
+      }),
+    );
+
+    expect(client.lastRequest?.traceContext?.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(client.lastRequest?.traceContext?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(client.lastRequest?.traceContext?.traceFlags).toBe(1);
+  });
+
+  it('converts Agno stream exceptions into error deltas instead of throwing', async () => {
+    const client = createThrowingStreamClient();
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const deltas = await collect(provider.triggerStream(createTrigger()));
+
+    expect(deltas).toEqual([{ phase: 'error', error: 'stream exploded' }]);
+    expect(client.stream).toHaveBeenCalledTimes(1);
+    expect(client.run).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
+++ b/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
@@ -16,14 +16,14 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 // Mock the nats module before importing the provider
 // ---------------------------------------------------------------------------
 
-type CapturedPublish = { subject: string; data: string };
+type CapturedPublish = { subject: string; data: string; options?: { headers?: Map<string, string> } };
 
 const publishCalls: CapturedPublish[] = [];
 let lastSubscribedSubject: string | null = null;
 const pendingReplies: Array<{ subject: string; data: string }> = [];
 
-const publishSpy = mock((subject: string, data: Uint8Array) => {
-  publishCalls.push({ subject, data: new TextDecoder().decode(data) });
+const publishSpy = mock((subject: string, data: Uint8Array, options?: { headers?: Map<string, string> }) => {
+  publishCalls.push({ subject, data: new TextDecoder().decode(data), options });
 });
 
 // A minimal async iterable subscription that yields any pending replies
@@ -74,6 +74,14 @@ mock.module('nats', () => ({
     decode: (b: Uint8Array) => new TextDecoder().decode(b),
   }),
   StorageType: { File: 'file' },
+  headers: () => {
+    const values = new Map<string, string>();
+    return {
+      set: (key: string, value: string) => values.set(key, value),
+      get: (key: string) => values.get(key),
+      values,
+    };
+  },
   connect: mock(async () => ({
     publish: publishSpy,
     subscribe: (subject: string) => createSubscription(subject),
@@ -342,5 +350,61 @@ describe('NatsGenieProvider.trigger() — env pass-through', () => {
       OMNI_USER_ID: '5511999999999',
       OMNI_PLATFORM_USER_ID: '5511999999999',
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Langfuse/HML trace propagation
+// ---------------------------------------------------------------------------
+
+describe('NatsGenieProvider.trigger() — trace context propagation', () => {
+  it('publishes W3C and khal-os trace headers and mirrors trace context in the payload', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.sessionId = 'session-abc';
+    trigger.traceContext = {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: 'fedcba9876543210',
+      parentSpanId: '0011223344556677',
+      traceFlags: 1,
+      tracestate: 'vendor=value',
+    };
+
+    await provider.trigger(trigger);
+
+    const call = publishCalls[publishCalls.length - 1]!;
+    const headers = call.options?.headers;
+    expect(headers?.get('traceparent')).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
+    expect(headers?.get('tracestate')).toBe('vendor=value');
+    expect(headers?.get('x-khal-session-id')).toBe('session-abc');
+    expect(headers?.get('x-trace-id')).toBe('0123456789abcdef0123456789abcdef');
+    expect(headers?.get('x-span-id')).toBe('fedcba9876543210');
+    expect(headers?.get('x-parent-span-id')).toBe('0011223344556677');
+
+    const payload = JSON.parse(call.data);
+    expect(payload.traceContext).toEqual(trigger.traceContext);
+    expect(payload.metadata.traceparent).toBe('00-0123456789abcdef0123456789abcdef-fedcba9876543210-01');
+    expect(payload.metadata['x-khal-session-id']).toBe('session-abc');
+  });
+
+  it('keeps raw user and chat identifiers out of mirrored payload metadata', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.sessionId = 'session-abc';
+    trigger.traceContext = {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: 'fedcba9876543210',
+      traceFlags: 1,
+    };
+
+    await provider.trigger(trigger);
+
+    const payload = JSON.parse(publishCalls[publishCalls.length - 1]!.data);
+    expect(payload.metadata['x-khal-user-id']).toBeUndefined();
+    expect(payload.metadata['x-omni-chat-id']).toBeUndefined();
+    expect(JSON.stringify(payload.metadata)).not.toContain('5511999999999');
+    expect(JSON.stringify(payload.metadata)).not.toContain('s.whatsapp.net');
+    expect(payload.metadata['x-khal-user-hash']).toMatch(/^[a-f0-9]{12}$/);
+    expect(payload.metadata['x-omni-chat-hash']).toMatch(/^[a-f0-9]{12}$/);
   });
 });

--- a/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
+++ b/packages/core/src/providers/__tests__/nats-genie-provider.test.ts
@@ -407,4 +407,27 @@ describe('NatsGenieProvider.trigger() — trace context propagation', () => {
     expect(payload.metadata['x-khal-user-hash']).toMatch(/^[a-f0-9]{12}$/);
     expect(payload.metadata['x-omni-chat-hash']).toMatch(/^[a-f0-9]{12}$/);
   });
+
+  it('derives W3C trace headers and payload trace context from dispatcher traceId when traceContext is omitted', async () => {
+    const provider = makeProvider();
+    const trigger = makeTrigger();
+    trigger.traceId = 'LEGACY-TRACE-ID';
+    trigger.traceContext = undefined;
+
+    await provider.trigger(trigger);
+
+    const call = publishCalls[publishCalls.length - 1]!;
+    const headers = call.options?.headers;
+    expect(headers?.get('traceparent')).toMatch(/^00-[a-f0-9]{32}-[a-f0-9]{16}-01$/);
+    expect(headers?.get('x-trace-id')).toMatch(/^[a-f0-9]{32}$/);
+    expect(headers?.get('x-span-id')).toMatch(/^[a-f0-9]{16}$/);
+
+    const payload = JSON.parse(call.data);
+    expect(payload.traceContext).toEqual({
+      traceId: headers?.get('x-trace-id'),
+      spanId: headers?.get('x-span-id'),
+      traceFlags: 1,
+    });
+    expect(payload.metadata.traceparent).toBe(headers?.get('traceparent'));
+  });
 });

--- a/packages/core/src/providers/__tests__/trace-context.test.ts
+++ b/packages/core/src/providers/__tests__/trace-context.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { createTraceContextFromTraceId } from '../trace-context';
+
+describe('trace-context normalization', () => {
+  it('hashes legacy trace ids deterministically regardless of casing', () => {
+    const upper = createTraceContextFromTraceId('Legacy-Trace-ID', 'SPAN-SEED');
+    const lower = createTraceContextFromTraceId('legacy-trace-id', 'span-seed');
+
+    expect(upper).toEqual(lower);
+    expect(upper?.traceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(upper?.spanId).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it('normalizes empty and all-zero values to non-zero W3C ids', () => {
+    const context = createTraceContextFromTraceId('00000000000000000000000000000000', '0000000000000000');
+
+    expect(context?.traceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(context?.traceId).not.toBe('00000000000000000000000000000000');
+    expect(context?.spanId).toMatch(/^[a-f0-9]{16}$/);
+    expect(context?.spanId).not.toBe('0000000000000000');
+  });
+});

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -5,6 +5,7 @@
  * with both sync and streaming support.
  */
 
+import { buildTraceHeaders } from './trace-context';
 import {
   type AgentDiscoveryEntry,
   type AgentHealthResult,
@@ -191,12 +192,15 @@ export class AgnoClient implements IAgentClient {
     formData.append('message', request.message);
     formData.append('stream', String(stream));
 
-    if (request.sessionId) {
-      formData.append('session_id', request.sessionId);
+    const sessionId = request.khalSessionId ?? request.sessionId;
+    if (sessionId) {
+      formData.append('session_id', sessionId);
     }
     if (request.userId) {
       formData.append('user_id', request.userId);
     }
+
+    this.appendStructuredMetadata(formData, request);
 
     if (request.files?.length) {
       for (const file of request.files) {
@@ -217,6 +221,31 @@ export class AgnoClient implements IAgentClient {
     }
 
     return formData;
+  }
+
+  private appendStructuredMetadata(formData: FormData, request: ProviderRequest): void {
+    const appendJson = (key: string, value: unknown) => {
+      if (value !== undefined) {
+        formData.append(key, JSON.stringify(value));
+      }
+    };
+
+    if (request.khalSessionId) {
+      formData.append('khal_session_id', request.khalSessionId);
+    }
+    if (request.messageId) {
+      formData.append('message_id', request.messageId);
+    }
+    if (request.replyToMessageId) {
+      formData.append('reply_to_message_id', request.replyToMessageId);
+    }
+
+    appendJson('platform', request.platform);
+    appendJson('sender', request.sender);
+    appendJson('chat', request.chat);
+    appendJson('mcp_url_params', request.mcpUrlParams);
+    appendJson('env', request.env);
+    appendJson('omni', request.omni);
   }
 
   async runAgent(agentId: string, request: ProviderRequest): Promise<ProviderResponse> {
@@ -244,7 +273,15 @@ export class AgnoClient implements IAgentClient {
       url,
       {
         method: 'POST',
-        headers: this.getHeaders(),
+        headers: {
+          ...this.getHeaders(),
+          ...buildTraceHeaders(request.traceContext, {
+            khalSessionId: request.khalSessionId ?? request.sessionId,
+            userId: request.userId,
+            messageId: request.omni?.messageId,
+            omni: request.omni,
+          }),
+        },
         body: formData,
       },
       timeoutMs,
@@ -311,7 +348,15 @@ export class AgnoClient implements IAgentClient {
       url,
       {
         method: 'POST',
-        headers: this.getHeaders(),
+        headers: {
+          ...this.getHeaders(),
+          ...buildTraceHeaders(request.traceContext, {
+            khalSessionId: request.khalSessionId ?? request.sessionId,
+            userId: request.userId,
+            messageId: request.omni?.messageId,
+            omni: request.omni,
+          }),
+        },
         body: formData,
       },
       timeoutMs,

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -7,7 +7,15 @@
 
 import { createLogger } from '../logger';
 import { buildProviderRequestContext } from './execution-context';
-import type { AgentTrigger, AgentTriggerResult, IAgentClient, IAgentProvider, ProviderRequest } from './types';
+import { createTraceContextFromTraceId } from './trace-context';
+import type {
+  AgentTrigger,
+  AgentTriggerResult,
+  IAgentClient,
+  IAgentProvider,
+  ProviderRequest,
+  StreamDelta,
+} from './types';
 
 const log = createLogger('provider:agno');
 
@@ -36,14 +44,7 @@ export class AgnoAgentProvider implements IAgentProvider {
   async trigger(context: AgentTrigger): Promise<AgentTriggerResult> {
     const startTime = Date.now();
 
-    // Build the message from trigger content
-    let message = '';
-    if (context.content.text) {
-      message = context.content.text;
-    } else if (context.content.emoji) {
-      // For reaction triggers, format as a reaction notification
-      message = `[Reaction: ${context.content.emoji} on message ${context.content.referencedMessageId ?? context.source.messageId}]`;
-    }
+    const message = this.buildMessage(context);
 
     if (!message) {
       log.debug('No content to send to agent', { traceId: context.traceId });
@@ -57,19 +58,7 @@ export class AgnoAgentProvider implements IAgentProvider {
       };
     }
 
-    // Prefix sender name if configured
-    if (this.config.prefixSenderName !== false && context.sender.displayName) {
-      message = `[${context.sender.displayName}]: ${message}`;
-    }
-
-    const request: ProviderRequest = {
-      ...buildProviderRequestContext(context),
-      message,
-      agentId: this.config.agentId,
-      agentType: this.config.agentType,
-      stream: false,
-      timeoutMs: this.config.timeoutMs ?? 60000,
-    };
+    const request = this.buildRequest(context, message, false);
 
     log.info('Triggering Agno agent', {
       agentId: this.config.agentId,
@@ -116,7 +105,90 @@ export class AgnoAgentProvider implements IAgentProvider {
     };
   }
 
+  async *triggerStream(context: AgentTrigger): AsyncGenerator<StreamDelta> {
+    const message = this.buildMessage(context);
+
+    if (!message) {
+      log.debug('No content to send to Agno agent (stream)', { traceId: context.traceId });
+      return;
+    }
+
+    const request = this.buildRequest(context, message, true);
+
+    log.info('Streaming Agno agent', {
+      agentId: this.config.agentId,
+      agentType: this.config.agentType,
+      triggerType: context.type,
+      traceId: context.traceId,
+    });
+
+    try {
+      for await (const chunk of this.client.stream(request)) {
+        if (chunk.content) {
+          yield { phase: 'content', content: chunk.content };
+        }
+
+        if (chunk.isComplete) {
+          yield { phase: 'final', content: chunk.fullContent ?? chunk.content ?? '' };
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error('Error in Agno agent stream', {
+        agentId: this.config.agentId,
+        traceId: context.traceId,
+        error: message,
+      });
+      yield { phase: 'error', error: message };
+    }
+  }
+
   async checkHealth(): Promise<{ healthy: boolean; latencyMs: number; error?: string }> {
     return this.client.checkHealth();
+  }
+
+  private buildMessage(context: AgentTrigger): string {
+    let message = '';
+    if (context.content.text) {
+      message = context.content.text;
+    } else if (context.content.emoji) {
+      // For reaction triggers, format as a reaction notification
+      message = `[Reaction: ${context.content.emoji} on message ${context.content.referencedMessageId ?? context.source.messageId}]`;
+    }
+
+    // Prefix sender name if configured
+    if (message && this.config.prefixSenderName !== false && context.sender.displayName) {
+      message = `[${context.sender.displayName}]: ${message}`;
+    }
+
+    return message;
+  }
+
+  private buildRequest(context: AgentTrigger, message: string, stream: boolean): ProviderRequest {
+    const traceContext =
+      context.traceContext ??
+      createTraceContextFromTraceId(
+        context.traceId,
+        `${context.source.instanceId}:${context.source.chatId}:${context.source.messageId}:agno`,
+      );
+
+    return {
+      ...buildProviderRequestContext(context),
+      message,
+      agentId: this.config.agentId,
+      agentType: this.config.agentType,
+      stream,
+      timeoutMs: this.config.timeoutMs ?? 60000,
+      files: context.content.files,
+      traceContext,
+      khalSessionId: context.sessionId,
+      omni: {
+        instanceId: context.source.instanceId,
+        chatId: context.source.chatId,
+        messageId: context.source.messageId,
+        channel: context.source.channelType,
+      },
+      ...(context.source.chatId ? { mcpUrlParams: { chat_id: context.source.chatId } } : {}),
+    };
   }
 }

--- a/packages/core/src/providers/nats-genie-provider.ts
+++ b/packages/core/src/providers/nats-genie-provider.ts
@@ -15,13 +15,22 @@
  * Agent replies come back via NATS subscription.
  */
 
+import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { type NatsConnection, StringCodec, connect } from 'nats';
+import { type NatsConnection, StringCodec, connect, headers as createNatsHeaders } from 'nats';
 import { createLogger } from '../logger';
 import { buildOmniEnv, buildOmniExecutionContext } from './execution-context';
-import type { AgentTrigger, AgentTriggerResult, IAgentProvider, OmniExecutionContext, ProviderFile } from './types';
+import { buildTraceHeaders } from './trace-context';
+import type {
+  AgentTrigger,
+  AgentTriggerResult,
+  IAgentProvider,
+  OmniExecutionContext,
+  ProviderFile,
+  TraceContext,
+} from './types';
 
 const log = createLogger('provider:nats-genie');
 
@@ -54,7 +63,10 @@ interface NatsOutboundMessage {
   timestamp: string;
   traceId: string;
   messageId?: string;
+  contextMessages?: string[];
   files?: ProviderFile[];
+  traceContext?: TraceContext;
+  metadata?: Record<string, string>;
   /** Environment variables for turn-based agents (OMNI_INSTANCE, OMNI_CHAT, etc.) */
   env?: Record<string, string>;
   executionContext?: OmniExecutionContext;
@@ -121,6 +133,7 @@ export class NatsGenieProvider implements IAgentProvider {
     }
 
     const topic = `omni.message.${this.config.instanceId}.${context.source.chatId}`;
+    const propagationHeaders = this.buildPropagationHeaders(context);
     const payload: NatsOutboundMessage = {
       content: message,
       sender: context.sender.displayName ?? context.sender.platformUserId,
@@ -130,24 +143,30 @@ export class NatsGenieProvider implements IAgentProvider {
       timestamp: new Date().toISOString(),
       traceId: context.traceId,
       messageId: context.source.messageId,
+      contextMessages: context.contextMessages,
       files: context.content.files,
+      traceContext: context.traceContext,
+      metadata: this.buildSafePayloadMetadata(propagationHeaders),
       env: buildOmniEnv(context),
       executionContext: buildOmniExecutionContext(context),
     };
 
     try {
       await this.ensureConnected();
-      this.nc?.publish(topic, this.sc.encode(JSON.stringify(payload)));
+      this.nc?.publish(topic, this.sc.encode(JSON.stringify(payload)), this.buildPublishOptions(propagationHeaders));
 
       log.info('Published to NATS', {
-        topic,
+        subject: 'omni.message.<instance>.<chat_hash>',
         agent: this.config.agentName,
-        chatId: context.source.chatId,
+        instanceId: this.config.instanceId,
+        chatHash: this.safeHash(context.source.chatId),
         traceId: context.traceId,
       });
     } catch (error) {
       log.error('Failed to publish to NATS, writing to dead-letter queue', {
-        topic,
+        subject: 'omni.message.<instance>.<chat_hash>',
+        instanceId: this.config.instanceId,
+        chatHash: this.safeHash(context.source.chatId),
         error: error instanceof Error ? error.message : String(error),
         traceId: context.traceId,
       });
@@ -214,7 +233,8 @@ export class NatsGenieProvider implements IAgentProvider {
           }
         } catch (error) {
           log.error('Error processing reply', {
-            subject: msg.subject,
+            subject: 'omni.reply.<instance>.<chat_hash>',
+            subjectHash: this.safeHash(msg.subject),
             error: error instanceof Error ? error.message : String(error),
           });
         }
@@ -253,7 +273,7 @@ export class NatsGenieProvider implements IAgentProvider {
     if (!chatId) {
       log.warn('NATS session reset skipped: missing chatId', {
         providerId: this.id,
-        sessionKey,
+        sessionKeyHash: this.safeHash(sessionKey),
       });
       throw new Error('chatId is required to reset NATS Genie session');
     }
@@ -272,14 +292,17 @@ export class NatsGenieProvider implements IAgentProvider {
       await this.ensureConnected();
       this.nc?.publish(topic, this.sc.encode(JSON.stringify(payload)));
       log.info('Published session reset to NATS', {
-        topic,
+        subject: 'omni.session.reset.<instance>.<chat_hash>',
         providerId: this.id,
-        sessionKey,
-        chatId,
+        instanceId: resolvedInstanceId,
+        sessionKeyHash: this.safeHash(sessionKey),
+        chatHash: this.safeHash(chatId),
       });
     } catch (error) {
       log.error('Failed to publish NATS session reset', {
-        topic,
+        subject: 'omni.session.reset.<instance>.<chat_hash>',
+        instanceId: resolvedInstanceId,
+        chatHash: this.safeHash(chatId),
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;
@@ -317,6 +340,54 @@ export class NatsGenieProvider implements IAgentProvider {
     });
 
     log.info('Connected to NATS', { url: this.config.natsUrl });
+  }
+
+  private buildPropagationHeaders(context: AgentTrigger): Record<string, string> {
+    return buildTraceHeaders(context.traceContext, {
+      khalSessionId: context.sessionId,
+      userId: context.sender.personId ?? context.sender.platformUserId,
+      messageId: context.source.messageId,
+      omni: {
+        instanceId: context.source.instanceId,
+        chatId: context.source.chatId,
+        channel: context.source.channelType,
+      },
+    });
+  }
+
+  private buildPublishOptions(
+    traceHeaders: Record<string, string>,
+  ): { headers?: ReturnType<typeof createNatsHeaders> } | undefined {
+    if (Object.keys(traceHeaders).length === 0) return undefined;
+
+    const natsHeaders = createNatsHeaders();
+    for (const [key, value] of Object.entries(traceHeaders)) {
+      natsHeaders.set(key, value);
+    }
+
+    return { headers: natsHeaders };
+  }
+
+  private buildSafePayloadMetadata(traceHeaders: Record<string, string>): Record<string, string> {
+    const metadata: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(traceHeaders)) {
+      if (key === 'x-khal-user-id') {
+        metadata['x-khal-user-hash'] = this.safeHash(value);
+        continue;
+      }
+      if (key === 'x-omni-chat-id') {
+        metadata['x-omni-chat-hash'] = this.safeHash(value);
+        continue;
+      }
+      metadata[key] = value;
+    }
+
+    return metadata;
+  }
+
+  private safeHash(value: string): string {
+    return createHash('sha256').update(value).digest('hex').slice(0, 12);
   }
 
   private buildMessage(context: AgentTrigger): string {

--- a/packages/core/src/providers/nats-genie-provider.ts
+++ b/packages/core/src/providers/nats-genie-provider.ts
@@ -22,7 +22,7 @@ import { join } from 'node:path';
 import { type NatsConnection, StringCodec, connect, headers as createNatsHeaders } from 'nats';
 import { createLogger } from '../logger';
 import { buildOmniEnv, buildOmniExecutionContext } from './execution-context';
-import { buildTraceHeaders } from './trace-context';
+import { buildTraceHeaders, createTraceContextFromTraceId } from './trace-context';
 import type {
   AgentTrigger,
   AgentTriggerResult,
@@ -133,7 +133,8 @@ export class NatsGenieProvider implements IAgentProvider {
     }
 
     const topic = `omni.message.${this.config.instanceId}.${context.source.chatId}`;
-    const propagationHeaders = this.buildPropagationHeaders(context);
+    const traceContext = this.resolveTraceContext(context);
+    const propagationHeaders = this.buildPropagationHeaders(context, traceContext);
     const payload: NatsOutboundMessage = {
       content: message,
       sender: context.sender.displayName ?? context.sender.platformUserId,
@@ -145,7 +146,7 @@ export class NatsGenieProvider implements IAgentProvider {
       messageId: context.source.messageId,
       contextMessages: context.contextMessages,
       files: context.content.files,
-      traceContext: context.traceContext,
+      traceContext,
       metadata: this.buildSafePayloadMetadata(propagationHeaders),
       env: buildOmniEnv(context),
       executionContext: buildOmniExecutionContext(context),
@@ -342,8 +343,18 @@ export class NatsGenieProvider implements IAgentProvider {
     log.info('Connected to NATS', { url: this.config.natsUrl });
   }
 
-  private buildPropagationHeaders(context: AgentTrigger): Record<string, string> {
-    return buildTraceHeaders(context.traceContext, {
+  private resolveTraceContext(context: AgentTrigger): TraceContext | undefined {
+    return (
+      context.traceContext ??
+      createTraceContextFromTraceId(
+        context.traceId,
+        `${context.source.instanceId}:${context.source.chatId}:${context.source.messageId}:nats-genie`,
+      )
+    );
+  }
+
+  private buildPropagationHeaders(context: AgentTrigger, traceContext?: TraceContext): Record<string, string> {
+    return buildTraceHeaders(traceContext, {
       khalSessionId: context.sessionId,
       userId: context.sender.personId ?? context.sender.platformUserId,
       messageId: context.source.messageId,

--- a/packages/core/src/providers/trace-context.ts
+++ b/packages/core/src/providers/trace-context.ts
@@ -16,7 +16,7 @@ const W3C_TRACE_ID = /^[0-9a-f]{32}$/i;
 const W3C_SPAN_ID = /^[0-9a-f]{16}$/i;
 
 function isNonZeroHex(value: string): boolean {
-  return !/^0+$/.test(value);
+  return value.length > 0 && !/^0+$/.test(value);
 }
 
 function hashHex(value: string, length: 16 | 32): string {
@@ -28,7 +28,7 @@ function normalizeTraceId(value: string): string {
   if (W3C_TRACE_ID.test(lower) && isNonZeroHex(lower)) {
     return lower;
   }
-  return hashHex(value, 32);
+  return hashHex(lower, 32);
 }
 
 function normalizeSpanId(value: string): string {
@@ -36,7 +36,7 @@ function normalizeSpanId(value: string): string {
   if (W3C_SPAN_ID.test(lower) && isNonZeroHex(lower)) {
     return lower;
   }
-  return hashHex(value, 16);
+  return hashHex(lower, 16);
 }
 
 /** Build a W3C trace context from Omni's legacy trace id when no span context is available. */

--- a/packages/core/src/providers/trace-context.ts
+++ b/packages/core/src/providers/trace-context.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'node:crypto';
+import type { TraceContext } from './types';
+
+interface KhalHeaderContext {
+  khalSessionId?: string;
+  userId?: string;
+  messageId?: string;
+  omni?: {
+    instanceId?: string;
+    chatId?: string;
+    channel?: string;
+  };
+}
+
+const W3C_TRACE_ID = /^[0-9a-f]{32}$/i;
+const W3C_SPAN_ID = /^[0-9a-f]{16}$/i;
+
+function isNonZeroHex(value: string): boolean {
+  return !/^0+$/.test(value);
+}
+
+function hashHex(value: string, length: 16 | 32): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, length);
+}
+
+function normalizeTraceId(value: string): string {
+  const lower = value.toLowerCase();
+  if (W3C_TRACE_ID.test(lower) && isNonZeroHex(lower)) {
+    return lower;
+  }
+  return hashHex(value, 32);
+}
+
+function normalizeSpanId(value: string): string {
+  const lower = value.toLowerCase();
+  if (W3C_SPAN_ID.test(lower) && isNonZeroHex(lower)) {
+    return lower;
+  }
+  return hashHex(value, 16);
+}
+
+/** Build a W3C trace context from Omni's legacy trace id when no span context is available. */
+export function createTraceContextFromTraceId(traceId?: string, spanSeed = 'provider'): TraceContext | undefined {
+  if (!traceId) return undefined;
+
+  return {
+    traceId: normalizeTraceId(traceId),
+    spanId: normalizeSpanId(`${traceId}:${spanSeed}`),
+    traceFlags: 1,
+  };
+}
+
+/** Format a W3C traceparent value from a backend-agnostic trace context. */
+function formatTraceparent(ctx: TraceContext): string {
+  const traceFlags = (ctx.traceFlags ?? 1) & 0xff;
+  const paddedFlagsHex = traceFlags.toString(16).padStart(2, '0');
+  return `00-${normalizeTraceId(ctx.traceId)}-${normalizeSpanId(ctx.spanId)}-${paddedFlagsHex}`;
+}
+
+/** Headers expected by HTTP/NATS providers for cross-process trace stitching. */
+export function buildTraceHeaders(ctx?: TraceContext, khal?: KhalHeaderContext): Record<string, string> {
+  const traceHeaders: Record<string, string> = {};
+
+  if (ctx) {
+    traceHeaders.traceparent = formatTraceparent(ctx);
+    traceHeaders['x-trace-id'] = normalizeTraceId(ctx.traceId);
+    traceHeaders['x-span-id'] = normalizeSpanId(ctx.spanId);
+
+    const tracestate = ctx.tracestate ?? ctx.traceState;
+    if (tracestate) {
+      traceHeaders.tracestate = tracestate;
+    }
+
+    if (ctx.parentSpanId) {
+      traceHeaders['x-parent-span-id'] = normalizeSpanId(ctx.parentSpanId);
+    }
+  }
+
+  if (khal?.khalSessionId) {
+    traceHeaders['x-khal-session-id'] = khal.khalSessionId;
+  }
+  if (khal?.userId) {
+    traceHeaders['x-khal-user-id'] = khal.userId;
+  }
+  if (khal?.messageId) {
+    traceHeaders['x-khal-message-id'] = khal.messageId;
+  }
+  if (khal?.omni?.instanceId) {
+    traceHeaders['x-omni-instance-id'] = khal.omni.instanceId;
+  }
+  if (khal?.omni?.chatId) {
+    traceHeaders['x-omni-chat-id'] = khal.omni.chatId;
+  }
+  if (khal?.omni?.channel) {
+    traceHeaders['x-omni-channel'] = khal.omni.channel;
+  }
+
+  return traceHeaders;
+}

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -86,6 +86,17 @@ export interface ProviderRequest {
 
   /** Canonical Omni execution context propagated across local CLIs and remote protocols. */
   executionContext?: OmniExecutionContext;
+  /** Distributed trace context to propagate on outbound provider calls. */
+  traceContext?: TraceContext;
+  /** Khal session id for cross-service session stitching. Falls back to sessionId when unset. */
+  khalSessionId?: string;
+  /** Omni source metadata propagated to provider transports. */
+  omni?: {
+    instanceId?: string;
+    chatId?: string;
+    messageId?: string;
+    channel?: ChannelType;
+  };
 }
 
 export interface ProviderFile {
@@ -308,6 +319,10 @@ export interface TraceContext {
   parentSpanId?: string;
   /** W3C trace flags (1 = sampled, 0 = not). Default 1 when unset. */
   traceFlags?: number;
+  /** W3C tracestate header value. */
+  tracestate?: string;
+  /** Backward-compatible camelCase alias for tracestate. */
+  traceState?: string;
 }
 
 /**
@@ -393,6 +408,15 @@ export interface IAgentProvider {
   readonly name: string;
   readonly schema: ProviderSchema;
   readonly mode: 'round-trip' | 'fire-and-forget' | 'turn-based';
+  /**
+   * Optional observability hooks. See {@link ProviderObservability}.
+   *
+   * Providers that don't implement this fall back to no-op tracing — the
+   * dispatcher checks for the field's presence and skips propagation calls
+   * when absent. Backend-neutral: emitted spans use whatever OTel SDK the
+   * host configured via OTEL_* env vars; no vendor coupling here.
+   */
+  readonly observability?: ProviderObservability;
 
   /** Check if this provider can handle a given trigger */
   canHandle(trigger: AgentTrigger): boolean;
@@ -414,16 +438,6 @@ export interface IAgentProvider {
    *  can reconstruct the correct session key.
    *  instanceId is provided for providers that scope persistence by instance. */
   resetSession?(sessionKey: string, chatId?: string, instanceId?: string): Promise<void>;
-
-  /**
-   * Optional observability hooks. See {@link ProviderObservability}.
-   *
-   * Providers that don't implement this fall back to no-op tracing — the
-   * dispatcher checks for the field's presence and skips propagation calls
-   * when absent. Backend-neutral: emitted spans use whatever OTel SDK the
-   * host configured via OTEL_* env vars; no vendor coupling here.
-   */
-  observability?: ProviderObservability;
 }
 
 /**
@@ -481,6 +495,8 @@ export interface AgentTrigger {
    * Includes OMNI_INSTANCE, OMNI_CHAT, OMNI_MESSAGE, OMNI_TURN_ID.
    */
   env?: Record<string, string>;
+  /** Distributed trace context to propagate on outbound provider calls. */
+  traceContext?: TraceContext;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Ports the homolog/PR #666 Langfuse trace-context repair onto current `dev` as a single repair commit.
- Keeps the repair branch intentionally minimal: `origin/dev...repair/homolog-from-dev-plus-pr666 = 0 / 1`.
- Avoids reviving the stale CT208/c97 lineage, which is ~170 commits behind `dev`.

## Why
HML evidence showed the live c97/CT208 path has the Langfuse trace-context behavior that must be preserved, but the safe production path is to apply that minimal fix on top of current `dev`, then promote `dev -> homolog`.

## Validation
Local/pre-push gates passed:
- Focused provider tests: `45 pass / 0 fail`
- `bun run --cwd packages/core typecheck`
- `bunx biome check .`
- Repository pre-push hook:
  - SDK/CLI build completed
  - `turbo typecheck`: `21 successful / 21 total`
  - full `bun test`: `3911 pass / 292 skip / 0 fail / 9900 expect() calls`

## Operational note
This is source-only. No production/HML runtime, OCI, Kubernetes, DNS, or secrets were changed.
