### PR TITLE
fix(media): harden media size cleanup

### DIFF
--- a/packages/channel-whatsapp/src/__tests__/media.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/media.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import { readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import {
   buildAudioContent,
   buildDocumentContent,
@@ -11,7 +15,12 @@ import {
   buildStickerContent,
   buildVideoContent,
 } from '../senders/media';
-import { generateFilename, getExtension, getWhatsAppMediaDownloadMaxBytes } from '../utils/download';
+import {
+  generateFilename,
+  getExtension,
+  getWhatsAppMediaDownloadMaxBytes,
+  writeMediaStreamToFile,
+} from '../utils/download';
 
 describe('Media Utilities', () => {
   describe('getExtension', () => {
@@ -83,11 +92,32 @@ describe('Media Utilities', () => {
   });
 
   describe('downloadMediaToFile cleanup', () => {
-    it('removes partial files when stream download fails or writes zero bytes', () => {
-      const source = readFileSync(new URL('../utils/download.ts', import.meta.url), 'utf8');
-      expect(source).toContain('await rm(outputPath, { force: true });');
-      expect(source).toContain('catch (error)');
-      expect(source).toContain('if (size === 0)');
+    it('removes partial files when stream download fails', async () => {
+      const outputPath = join(tmpdir(), `omni-download-partial-${Date.now()}.bin`);
+      const failingStream = Readable.from(
+        (async function* () {
+          yield Buffer.from('partial');
+          throw new Error('stream failed');
+        })(),
+      );
+
+      try {
+        await expect(writeMediaStreamToFile(failingStream, outputPath)).rejects.toThrow('stream failed');
+        expect(existsSync(outputPath)).toBe(false);
+      } finally {
+        await rm(outputPath, { force: true });
+      }
+    });
+
+    it('removes zero-byte files and returns size 0', async () => {
+      const outputPath = join(tmpdir(), `omni-download-empty-${Date.now()}.bin`);
+      try {
+        const size = await writeMediaStreamToFile(Readable.from([]), outputPath);
+        expect(size).toBe(0);
+        expect(existsSync(outputPath)).toBe(false);
+      } finally {
+        await rm(outputPath, { force: true });
+      }
     });
   });
 });

--- a/packages/channel-whatsapp/src/__tests__/media.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/media.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import {
   buildAudioContent,
   buildDocumentContent,
@@ -78,6 +79,15 @@ describe('Media Utilities', () => {
         if (original === undefined) process.env.OMNI_WHATSAPP_MEDIA_MAX_DOWNLOAD_MB = undefined;
         else process.env.OMNI_WHATSAPP_MEDIA_MAX_DOWNLOAD_MB = original;
       }
+    });
+  });
+
+  describe('downloadMediaToFile cleanup', () => {
+    it('removes partial files when stream download fails or writes zero bytes', () => {
+      const source = readFileSync(new URL('../utils/download.ts', import.meta.url), 'utf8');
+      expect(source).toContain('await rm(outputPath, { force: true });');
+      expect(source).toContain('catch (error)');
+      expect(source).toContain('if (size === 0)');
     });
   });
 });

--- a/packages/channel-whatsapp/src/utils/download.ts
+++ b/packages/channel-whatsapp/src/utils/download.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -283,8 +283,16 @@ export async function downloadMediaToFile(
 
   const stream = await downloadMediaMessage(msg, 'stream', {});
   await mkdir(dirname(outputPath), { recursive: true });
-  await pipeline(stream, sizeGuard, createWriteStream(outputPath));
+  try {
+    await pipeline(stream, sizeGuard, createWriteStream(outputPath));
+  } catch (error) {
+    await rm(outputPath, { force: true });
+    throw error;
+  }
 
-  if (size === 0) return null;
+  if (size === 0) {
+    await rm(outputPath, { force: true });
+    return null;
+  }
   return { mimeType: mediaInfo.mimeType, size };
 }

--- a/packages/channel-whatsapp/src/utils/download.ts
+++ b/packages/channel-whatsapp/src/utils/download.ts
@@ -269,6 +269,17 @@ export async function downloadMediaToFile(
   const mediaInfo = detectMediaType(msg);
   if (!mediaInfo) return null;
 
+  const stream = await downloadMediaMessage(msg, 'stream', {});
+  const size = await writeMediaStreamToFile(stream, outputPath, maxSizeBytes);
+  if (size === 0) return null;
+  return { mimeType: mediaInfo.mimeType, size };
+}
+
+export async function writeMediaStreamToFile(
+  stream: NodeJS.ReadableStream,
+  outputPath: string,
+  maxSizeBytes = getWhatsAppMediaDownloadMaxBytes(),
+): Promise<number> {
   let size = 0;
   const sizeGuard = new Transform({
     transform(chunk: Buffer, _encoding, callback) {
@@ -281,7 +292,6 @@ export async function downloadMediaToFile(
     },
   });
 
-  const stream = await downloadMediaMessage(msg, 'stream', {});
   await mkdir(dirname(outputPath), { recursive: true });
   try {
     await pipeline(stream, sizeGuard, createWriteStream(outputPath));
@@ -292,7 +302,6 @@ export async function downloadMediaToFile(
 
   if (size === 0) {
     await rm(outputPath, { force: true });
-    return null;
   }
-  return { mimeType: mediaInfo.mimeType, size };
+  return size;
 }

--- a/packages/media-processing/__tests__/processors.test.ts
+++ b/packages/media-processing/__tests__/processors.test.ts
@@ -4,7 +4,7 @@
 
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AudioProcessor, DocumentProcessor, ImageProcessor, VideoProcessor } from '../src/processors';
@@ -19,9 +19,11 @@ const mockConfig: ProcessorConfig = {
 };
 
 const originalFetch = globalThis.fetch;
+const originalPath = process.env.PATH;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  process.env.PATH = originalPath;
 });
 
 describe('processors', () => {
@@ -101,19 +103,41 @@ describe('processors', () => {
       }
     });
 
-    it('does not use synchronous ffmpeg/file normalization in the event loop', () => {
-      const source = readFileSync(new URL('../src/processors/audio.ts', import.meta.url), 'utf8');
-      expect(source).not.toContain('execFileSync');
-      expect(source).not.toContain('readFileSync');
-      expect(source).not.toContain('mkdtempSync');
-      expect(source).not.toContain('rmSync');
-    });
+    it('normalizes once across fallback attempts and rejects oversized normalized audio', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'omni-audio-normalize-'));
+      const audioPath = join(dir, 'input.ogg');
+      const ffmpegPath = join(dir, 'ffmpeg');
+      const counterPath = join(dir, 'ffmpeg-count');
+      await writeFile(audioPath, Buffer.from('fake ogg input'));
+      await writeFile(
+        ffmpegPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+counter=${counterPath}
+count=0
+if [ -f "$counter" ]; then count=$(cat "$counter"); fi
+echo $((count + 1)) > "$counter"
+out="${'${@: -1}'}"
+python3 - "$out" <<'PY'
+from pathlib import Path
+import sys
+Path(sys.argv[1]).write_bytes(b'x' * (25 * 1024 * 1024))
+PY
+`,
+      );
+      await chmod(ffmpegPath, 0o755);
+      process.env.PATH = `${dir}:${originalPath ?? ''}`;
 
-    it('checks provider upload limit after ffmpeg normalization', () => {
-      const source = readFileSync(new URL('../src/processors/audio.ts', import.meta.url), 'utf8');
-      expect(source).toContain('const normalizedStats = await fs.stat(output);');
-      expect(source).toContain('normalizedStats.size > PROVIDER_AUDIO_TARGET_BYTES');
-      expect(source).toContain('Normalized audio still exceeds provider upload limit');
+      try {
+        const processorWithOpenAi = new AudioProcessor({ ...mockConfig, openaiApiKey: 'test-openai-key' });
+        const result = await processorWithOpenAi.process(audioPath, 'audio/ogg', { language: 'pt-BR' });
+
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toContain('Normalized audio still exceeds provider upload limit');
+        expect(readFileSync(counterPath, 'utf8').trim()).toBe('1');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/media-processing/__tests__/processors.test.ts
+++ b/packages/media-processing/__tests__/processors.test.ts
@@ -108,6 +108,13 @@ describe('processors', () => {
       expect(source).not.toContain('mkdtempSync');
       expect(source).not.toContain('rmSync');
     });
+
+    it('checks provider upload limit after ffmpeg normalization', () => {
+      const source = readFileSync(new URL('../src/processors/audio.ts', import.meta.url), 'utf8');
+      expect(source).toContain('const normalizedStats = await fs.stat(output);');
+      expect(source).toContain('normalizedStats.size > PROVIDER_AUDIO_TARGET_BYTES');
+      expect(source).toContain('Normalized audio still exceeds provider upload limit');
+    });
   });
 
   describe('ImageProcessor', () => {

--- a/packages/media-processing/src/processors/audio.ts
+++ b/packages/media-processing/src/processors/audio.ts
@@ -63,83 +63,107 @@ export class AudioProcessor extends BaseProcessor {
     const provider = options?.provider ?? this.config.audioProvider ?? 'openai';
     const preferredModel = options?.model ?? this.config.audioModel;
 
-    const attempts: Array<() => Promise<ProcessingResult>> = [];
-    if (provider === 'openai') {
-      attempts.push(
-        () =>
-          this.transcribeWithOpenAiAudioChat(
-            filePath,
-            language,
-            mimeType,
-            options,
-            preferredModel ?? OPENAI_AUDIO_CHAT_MODEL,
-          ),
-        () => this.transcribeWithOpenAiTranscriptions(filePath, language, mimeType, options, OPENAI_TRANSCRIBE_MODEL),
-        () => this.transcribeWithGemini(filePath, language, mimeType, options, GEMINI_AUDIO_MODEL),
-        () => this.transcribeWithGroq(filePath, language, mimeType),
-      );
-    } else if (provider === 'gemini') {
-      attempts.push(
-        () => this.transcribeWithGemini(filePath, language, mimeType, options, preferredModel ?? GEMINI_AUDIO_MODEL),
-        () => this.transcribeWithOpenAiAudioChat(filePath, language, mimeType, options, OPENAI_AUDIO_CHAT_MODEL),
-        () => this.transcribeWithGroq(filePath, language, mimeType),
-      );
-    } else {
-      attempts.push(
-        () => this.transcribeWithGroq(filePath, language, mimeType),
-        () =>
-          this.transcribeWithOpenAiTranscriptions(
-            filePath,
-            language,
-            mimeType,
-            options,
-            preferredModel ?? OPENAI_TRANSCRIBE_MODEL,
-          ),
-      );
-    }
+    let normalizedAudioPromise: Promise<NormalizedAudioFile> | undefined;
+    const getNormalizedAudio = () => {
+      normalizedAudioPromise ??= normalizeAudioFileForProvider(filePath, mimeType);
+      return normalizedAudioPromise;
+    };
+
+    const attempts = this.buildTranscriptionAttempts(provider, language, options, preferredModel, getNormalizedAudio);
 
     let result: ProcessingResult = this.createFailedResult(
       'No transcription attempts configured',
       provider,
       preferredModel ?? 'unknown',
     );
-    for (const attempt of attempts) {
-      result = await attempt();
-      if (result.success) break;
-      this.log.warn('Audio transcription attempt failed; trying next fallback', {
-        provider: result.provider,
-        model: result.model,
-        error: result.errorMessage,
-      });
+    try {
+      for (const attempt of attempts) {
+        result = await attempt();
+        if (shouldStopAudioFallback(result)) break;
+        this.log.warn('Audio transcription attempt failed; trying next fallback', {
+          provider: result.provider,
+          model: result.model,
+          error: result.errorMessage,
+        });
+      }
+    } finally {
+      await cleanupNormalizedAudio(normalizedAudioPromise);
     }
 
     result.processingTimeMs = Math.round(performance.now() - startTime);
-    if (result.success && durationSeconds) {
-      result.duration = durationSeconds;
-      const pricingKey = result.provider === 'groq' ? 'groq_whisper' : 'openai_whisper';
-      result.costCents = calculateCost(pricingKey, result.model, { durationSeconds });
-    }
-
-    if (result.success) {
-      this.log.info('Audio transcription successful', {
-        provider: result.provider,
-        model: result.model,
-        processingTimeMs: result.processingTimeMs,
-        costCents: result.costCents,
-      });
-    } else {
-      this.log.error('Audio transcription failed', { error: result.errorMessage });
-    }
+    this.applyDurationAndCost(result, durationSeconds);
+    this.logProcessingResult(result);
 
     return result;
   }
 
-  private async transcribeWithOpenAiAudioChat(
-    filePath: string,
+  private applyDurationAndCost(result: ProcessingResult, durationSeconds: number | undefined): void {
+    if (!result.success || !durationSeconds) return;
+    result.duration = durationSeconds;
+    const pricingKey = result.provider === 'groq' ? 'groq_whisper' : 'openai_whisper';
+    result.costCents = calculateCost(pricingKey, result.model, { durationSeconds });
+  }
+
+  private logProcessingResult(result: ProcessingResult): void {
+    if (!result.success) {
+      this.log.error('Audio transcription failed', { error: result.errorMessage });
+      return;
+    }
+    this.log.info('Audio transcription successful', {
+      provider: result.provider,
+      model: result.model,
+      processingTimeMs: result.processingTimeMs,
+      costCents: result.costCents,
+    });
+  }
+
+  private buildTranscriptionAttempts(
+    provider: string,
     language: string,
-    mimeType: string,
+    options: ProcessOptions | undefined,
+    preferredModel: string | undefined,
+    getNormalizedAudio: () => Promise<NormalizedAudioFile>,
+  ): Array<() => Promise<ProcessingResult>> {
+    if (provider === 'openai') {
+      return [
+        () =>
+          this.transcribeWithOpenAiAudioChat(
+            language,
+            options,
+            preferredModel ?? OPENAI_AUDIO_CHAT_MODEL,
+            getNormalizedAudio,
+          ),
+        () => this.transcribeWithOpenAiTranscriptions(language, options, OPENAI_TRANSCRIBE_MODEL, getNormalizedAudio),
+        () => this.transcribeWithGemini(language, options, GEMINI_AUDIO_MODEL, getNormalizedAudio),
+        () => this.transcribeWithGroq(language, getNormalizedAudio),
+      ];
+    }
+
+    if (provider === 'gemini') {
+      return [
+        () => this.transcribeWithGemini(language, options, preferredModel ?? GEMINI_AUDIO_MODEL, getNormalizedAudio),
+        () => this.transcribeWithOpenAiAudioChat(language, options, OPENAI_AUDIO_CHAT_MODEL, getNormalizedAudio),
+        () => this.transcribeWithGroq(language, getNormalizedAudio),
+      ];
+    }
+
+    return [
+      () => this.transcribeWithGroq(language, getNormalizedAudio),
+      () =>
+        this.transcribeWithOpenAiTranscriptions(
+          language,
+          options,
+          preferredModel ?? OPENAI_TRANSCRIBE_MODEL,
+          getNormalizedAudio,
+        ),
+    ];
+  }
+
+  private async transcribeWithOpenAiAudioChat(
+    language: string,
     options: ProcessOptions | undefined,
     model: string,
+    getNormalizedAudio: () => Promise<NormalizedAudioFile>,
   ): Promise<ProcessingResult> {
     if (!this.config.openaiApiKey) {
       return this.createFailedResult('OpenAI client not configured (missing API key)', 'openai', model);
@@ -149,7 +173,8 @@ export class AudioProcessor extends BaseProcessor {
       const text = await this.executeWithResilience(
         'openai',
         async () => {
-          const normalized = await normalizeFileForOpenAiAudioChat(filePath, mimeType);
+          const normalized = await getNormalizedAudio();
+          const audio = await fs.readFile(normalized.filePath);
           const response = await fetch(OPENAI_CHAT_COMPLETIONS_URL, {
             method: 'POST',
             headers: {
@@ -169,8 +194,8 @@ export class AudioProcessor extends BaseProcessor {
                     {
                       type: 'input_audio',
                       input_audio: {
-                        data: normalized.audio.toString('base64'),
-                        format: normalized.format,
+                        data: audio.toString('base64'),
+                        format: normalized.format === 'wav' ? 'wav' : 'mp3',
                       },
                     },
                   ],
@@ -193,11 +218,10 @@ export class AudioProcessor extends BaseProcessor {
   }
 
   private async transcribeWithOpenAiTranscriptions(
-    filePath: string,
     language: string,
-    mimeType: string,
     options: ProcessOptions | undefined,
     model: string,
+    getNormalizedAudio: () => Promise<NormalizedAudioFile>,
   ): Promise<ProcessingResult> {
     if (!this.config.openaiApiKey) {
       return this.createFailedResult('OpenAI client not configured (missing API key)', 'openai', model);
@@ -207,30 +231,26 @@ export class AudioProcessor extends BaseProcessor {
       const text = await this.executeWithResilience(
         'openai',
         async () => {
-          const normalized = await normalizeAudioFileForProvider(filePath, mimeType);
-          try {
-            const fileBuffer = await Bun.file(normalized.filePath).arrayBuffer();
-            const form = new FormData();
-            form.append(
-              'file',
-              new File([fileBuffer], `audio.${normalized.format}`, { type: normalized.mimeType }) as unknown as Blob,
-            );
-            form.append('model', model);
-            form.append('response_format', 'json');
-            if (language) form.append('language', language.toLowerCase() === 'pt-br' ? 'pt' : language);
-            form.append('prompt', buildPrompt(language, options, this.config.audioPrompt, this.config.audioGlossary));
-            const response = await fetch(OPENAI_TRANSCRIPTIONS_URL, {
-              method: 'POST',
-              headers: { Authorization: `Bearer ${this.config.openaiApiKey}` },
-              body: form,
-            });
-            if (!response.ok)
-              throw new Error(`OpenAI transcription error (${response.status}): ${await response.text()}`);
-            const data = (await response.json()) as { text?: string };
-            return data.text ?? '';
-          } finally {
-            if (normalized.cleanupPath) await fs.rm(normalized.cleanupPath, { recursive: true, force: true });
-          }
+          const normalized = await getNormalizedAudio();
+          const fileBuffer = await Bun.file(normalized.filePath).arrayBuffer();
+          const form = new FormData();
+          form.append(
+            'file',
+            new File([fileBuffer], `audio.${normalized.format}`, { type: normalized.mimeType }) as unknown as Blob,
+          );
+          form.append('model', model);
+          form.append('response_format', 'json');
+          if (language) form.append('language', language.toLowerCase() === 'pt-br' ? 'pt' : language);
+          form.append('prompt', buildPrompt(language, options, this.config.audioPrompt, this.config.audioGlossary));
+          const response = await fetch(OPENAI_TRANSCRIPTIONS_URL, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${this.config.openaiApiKey}` },
+            body: form,
+          });
+          if (!response.ok)
+            throw new Error(`OpenAI transcription error (${response.status}): ${await response.text()}`);
+          const data = (await response.json()) as { text?: string };
+          return data.text ?? '';
         },
         { timeoutMs: timeouts.audioTimeoutMs },
       );
@@ -242,11 +262,10 @@ export class AudioProcessor extends BaseProcessor {
   }
 
   private async transcribeWithGemini(
-    filePath: string,
     language: string,
-    mimeType: string,
     options: ProcessOptions | undefined,
     model: string,
+    getNormalizedAudio: () => Promise<NormalizedAudioFile>,
   ): Promise<ProcessingResult> {
     if (!this.config.geminiApiKey) {
       return this.createFailedResult('Gemini client not configured (missing API key)', 'gemini', model);
@@ -256,39 +275,35 @@ export class AudioProcessor extends BaseProcessor {
       const text = await this.executeWithResilience(
         'gemini',
         async () => {
-          const normalized = await normalizeAudioFileForProvider(filePath, mimeType);
-          try {
-            const fileBuffer = await Bun.file(normalized.filePath).arrayBuffer();
-            const url = `${GEMINI_GENERATE_URL}/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(this.config.geminiApiKey ?? '')}`;
-            const response = await fetch(url, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                contents: [
-                  {
-                    role: 'user',
-                    parts: [
-                      { text: buildPrompt(language, options, this.config.audioPrompt, this.config.audioGlossary) },
-                      {
-                        inlineData: {
-                          data: Buffer.from(fileBuffer).toString('base64'),
-                          mimeType: normalizeGeminiAudioMimeType(normalized.mimeType),
-                        },
+          const normalized = await getNormalizedAudio();
+          const fileBuffer = await Bun.file(normalized.filePath).arrayBuffer();
+          const url = `${GEMINI_GENERATE_URL}/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(this.config.geminiApiKey ?? '')}`;
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              contents: [
+                {
+                  role: 'user',
+                  parts: [
+                    { text: buildPrompt(language, options, this.config.audioPrompt, this.config.audioGlossary) },
+                    {
+                      inlineData: {
+                        data: Buffer.from(fileBuffer).toString('base64'),
+                        mimeType: normalizeGeminiAudioMimeType(normalized.mimeType),
                       },
-                    ],
-                  },
-                ],
-              }),
-            });
-            if (!response.ok)
-              throw new Error(`Gemini transcription error (${response.status}): ${await response.text()}`);
-            const data = (await response.json()) as {
-              candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
-            };
-            return data.candidates?.[0]?.content?.parts?.map((p) => p.text ?? '').join('\n') ?? '';
-          } finally {
-            if (normalized.cleanupPath) await fs.rm(normalized.cleanupPath, { recursive: true, force: true });
-          }
+                    },
+                  ],
+                },
+              ],
+            }),
+          });
+          if (!response.ok)
+            throw new Error(`Gemini transcription error (${response.status}): ${await response.text()}`);
+          const data = (await response.json()) as {
+            candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+          };
+          return data.candidates?.[0]?.content?.parts?.map((p) => p.text ?? '').join('\n') ?? '';
         },
         { timeoutMs: timeouts.audioTimeoutMs },
       );
@@ -299,7 +314,10 @@ export class AudioProcessor extends BaseProcessor {
     }
   }
 
-  private async transcribeWithGroq(filePath: string, language: string, mimeType?: string): Promise<ProcessingResult> {
+  private async transcribeWithGroq(
+    language: string,
+    getNormalizedAudio: () => Promise<NormalizedAudioFile>,
+  ): Promise<ProcessingResult> {
     const client = this.getGroqClient();
     if (!client)
       return this.createFailedResult('Groq client not configured (missing API key)', 'groq', GROQ_WHISPER_MODEL);
@@ -309,23 +327,17 @@ export class AudioProcessor extends BaseProcessor {
       const text = await this.executeWithResilience(
         'groq',
         async () => {
-          const normalized = await normalizeAudioFileForProvider(filePath, mimeType ?? '');
-          try {
-            const filename = `audio.${normalized.format}`;
-            const fileBuffer = await Bun.file(normalized.filePath).arrayBuffer();
-            const file = new File([fileBuffer], filename, { type: normalized.mimeType });
-            const transcription = await client.audio.transcriptions.create({
-              file: file as unknown as Uploadable,
-              model: GROQ_WHISPER_MODEL,
-              language: language.toLowerCase() === 'pt-br' ? 'pt' : language,
-              response_format: 'text',
-            });
-            return typeof transcription === 'string'
-              ? transcription
-              : ((transcription as { text?: string }).text ?? '');
-          } finally {
-            if (normalized.cleanupPath) await fs.rm(normalized.cleanupPath, { recursive: true, force: true });
-          }
+          const normalized = await getNormalizedAudio();
+          const filename = `audio.${normalized.format}`;
+          const fileBuffer = await Bun.file(normalized.filePath).arrayBuffer();
+          const file = new File([fileBuffer], filename, { type: normalized.mimeType });
+          const transcription = await client.audio.transcriptions.create({
+            file: file as unknown as Uploadable,
+            model: GROQ_WHISPER_MODEL,
+            language: language.toLowerCase() === 'pt-br' ? 'pt' : language,
+            response_format: 'text',
+          });
+          return typeof transcription === 'string' ? transcription : ((transcription as { text?: string }).text ?? '');
         },
         { timeoutMs: timeouts.audioTimeoutMs },
       );
@@ -360,6 +372,22 @@ export class AudioProcessor extends BaseProcessor {
     } catch {
       return undefined;
     }
+  }
+}
+
+function shouldStopAudioFallback(result: ProcessingResult): boolean {
+  return (
+    result.success || Boolean(result.errorMessage?.includes('Normalized audio still exceeds provider upload limit'))
+  );
+}
+
+async function cleanupNormalizedAudio(normalizedAudioPromise: Promise<NormalizedAudioFile> | undefined): Promise<void> {
+  if (!normalizedAudioPromise) return;
+  try {
+    const normalized = await normalizedAudioPromise;
+    if (normalized.cleanupPath) await fs.rm(normalized.cleanupPath, { recursive: true, force: true });
+  } catch {
+    // normalizeAudioFileForProvider already cleans up failed temp dirs.
   }
 }
 
@@ -405,18 +433,6 @@ function extractText(content: unknown): string {
     return (parsed.text ?? parsed.transcription ?? parsed.transcript ?? raw).trim();
   } catch {
     return raw;
-  }
-}
-
-async function normalizeFileForOpenAiAudioChat(
-  filePath: string,
-  mimeType: string,
-): Promise<{ audio: Buffer; format: 'mp3' | 'wav' }> {
-  const normalized = await normalizeAudioFileForProvider(filePath, mimeType);
-  try {
-    return { audio: await fs.readFile(normalized.filePath), format: normalized.format === 'wav' ? 'wav' : 'mp3' };
-  } finally {
-    if (normalized.cleanupPath) await fs.rm(normalized.cleanupPath, { recursive: true, force: true });
   }
 }
 

--- a/packages/media-processing/src/processors/audio.ts
+++ b/packages/media-processing/src/processors/audio.ts
@@ -461,6 +461,12 @@ async function normalizeAudioFileForProvider(filePath: string, mimeType: string)
         timeout: 5 * 60_000,
       },
     );
+    const normalizedStats = await fs.stat(output);
+    if (normalizedStats.size > PROVIDER_AUDIO_TARGET_BYTES) {
+      throw new Error(
+        `Normalized audio still exceeds provider upload limit: ${normalizedStats.size} bytes > ${PROVIDER_AUDIO_TARGET_BYTES} bytes`,
+      );
+    }
     return { filePath: output, mimeType: 'audio/mpeg', format: 'mp3', cleanupPath: dir };
   } catch (error) {
     await fs.rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
Addresses automated review feedback from #675.\n\n- remove partial WhatsApp media files when streaming download fails or writes zero bytes\n- reject normalized audio that still exceeds provider upload limits before provider upload\n- add regression coverage for both guardrails\n\nLocal verification:\n- bun test packages/channel-whatsapp/src/__tests__/media.test.ts packages/media-processing/__tests__/processors.test.ts\n- bun run --filter @omni/channel-whatsapp typecheck\n- bun run --filter @omni/media-processing typecheck\n- bunx biome check packages/channel-whatsapp/src/utils/download.ts packages/channel-whatsapp/src/__tests__/media.test.ts packages/media-processing/src/processors/audio.ts packages/media-processing/__tests__/processors.test.ts\n- git diff --check\n- pre-push: bun run typecheck + bun test