### PR TITLE
fix(api): return JSON from root health endpoint

### DIFF
--- a/packages/api/src/__tests__/health-redirect.test.ts
+++ b/packages/api/src/__tests__/health-redirect.test.ts
@@ -1,32 +1,37 @@
 /**
- * Tests for root-level /health redirect (#335)
+ * Tests for root-level /health
  *
  * External health checkers (k8s probes, genie providers) hit GET /health
- * which should redirect to /api/v2/health.
+ * and should receive the same JSON health payload as /api/v2/health.
  */
 
 import { describe, expect, test } from 'bun:test';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
 
-describe('GET /health redirect', () => {
+describe('GET /health', () => {
   function createTestApp() {
     const app = new Hono();
+    const healthPayload = { status: 'healthy' };
 
-    // Root-level health redirect (mirrors app.ts)
-    app.get('/health', (c) => c.redirect('/api/v2/health', 307));
+    // Root-level health response (mirrors app.ts)
+    app.get('/health', (c: Context) => c.json(healthPayload));
 
     // Stub /api/v2/health so we can verify it still works
-    app.get('/api/v2/health', (c) => c.json({ status: 'healthy' }));
+    app.get('/api/v2/health', (c: Context) => c.json(healthPayload));
 
     return app;
   }
 
-  test('GET /health returns 307 redirect to /api/v2/health', async () => {
+  test('GET /health returns 200 JSON directly', async () => {
     const app = createTestApp();
     const res = await app.request('/health', { redirect: 'manual' });
 
-    expect(res.status).toBe(307);
-    expect(res.headers.get('Location')).toBe('/api/v2/health');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Location')).toBeNull();
+    expect(res.headers.get('content-type')).toContain('application/json');
+
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('healthy');
   });
 
   test('GET /api/v2/health still returns 200', async () => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -76,7 +76,7 @@ import { rateLimitMiddleware } from './middleware/rate-limit';
 import { defaultTimeoutMiddleware } from './middleware/timeout';
 import { versionHeadersMiddleware } from './middleware/version-headers';
 import { createWebhookAuthMiddleware } from './middleware/webhook-auth';
-import { healthRoutes } from './routes/health';
+import { getHealth, healthRoutes } from './routes/health';
 import { openapiRoutes } from './routes/openapi';
 import { v2Routes } from './routes/v2';
 import type { Services } from './services';
@@ -149,7 +149,7 @@ export function createApp(
   app.onError(errorHandler);
 
   // Root-level health redirect for external checkers (k8s probes, genie providers)
-  app.get('/health', (c) => c.redirect('/api/v2/health', 307));
+  app.get('/health', getHealth);
 
   // Health routes (no auth required)
   app.route('/api/v2', healthRoutes);

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -4,7 +4,7 @@
 
 import { consumerOffsets, instances } from '@omni/db';
 import { sql } from 'drizzle-orm';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
 import packageJson from '../../package.json';
 import { arePluginsDegraded, getPluginsDegradedReason } from '../plugin-state';
 import type { AppVariables, HealthCheck, HealthResponse } from '../types';
@@ -17,7 +17,7 @@ export const healthRoutes = new Hono<{ Variables: AppVariables }>();
 /**
  * GET /health - Basic health check (no auth required)
  */
-healthRoutes.get('/health', async (c) => {
+export const getHealth = async (c: Context<{ Variables: AppVariables }>) => {
   const db = c.get('db');
   const eventBus = c.get('eventBus');
   const channelRegistry = c.get('channelRegistry');
@@ -106,7 +106,9 @@ healthRoutes.get('/health', async (c) => {
   };
 
   return c.json(response, status === 'healthy' ? 200 : 503);
-});
+};
+
+healthRoutes.get('/health', getHealth);
 
 /**
  * GET /info - System info (no auth required)


### PR DESCRIPTION
## Summary
- route GET /health to the existing JSON health handler
- keep /api/v2/health behavior unchanged
- unblock direct health proof for KHAL/Eugenia promotion

## Verification
- bun test packages/api/src/__tests__/health-redirect.test.ts
- bunx tsc --noEmit -p packages/api/tsconfig.json
- bunx biome check packages/api/src/app.ts packages/api/src/routes/health.ts packages/api/src/__tests__/health-redirect.test.ts
- pre-push full suite: 3934 pass / 292 skip / 0 fail

## Release gate
Source only. Deploy remains gated on immutable digest, OCI labels,
WorkOS/AuthKit callback proof, and Langfuse trace proof.
