### PR TITLE
fix: propagate KHAL session ids through Gupshup dispatch

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1692,6 +1692,46 @@ describe('agent-dispatcher', () => {
   });
 
   // ======================================================================
+  // KHAL session correlation
+  // ======================================================================
+  describe('KHAL session correlation', () => {
+    it('extracts an explicit KHAL session id from rawPayload and mirrors it into trigger headers', () => {
+      const messages = [
+        {
+          payload: {
+            rawPayload: {
+              khalSessionId: ' khal-session-123 ',
+            },
+          },
+        },
+      ] as any;
+
+      const sessionId = __test__.extractKhalSessionId(messages);
+
+      expect(sessionId).toBe('khal-session-123');
+      expect(__test__.buildTriggerHeaders(sessionId!)).toEqual({ 'x-khal-session-id': 'khal-session-123' });
+    });
+
+    it('extracts KHAL session id from inbound rawPayload headers', () => {
+      const messages = [
+        {
+          payload: {
+            rawPayload: {
+              headers: { 'x-khal-session-id': 'khal-header-session' },
+            },
+          },
+        },
+      ] as any;
+
+      expect(__test__.extractKhalSessionId(messages)).toBe('khal-header-session');
+    });
+
+    it('does not build a KHAL header for computed fallback sessions', () => {
+      expect(__test__.buildTriggerHeaders(undefined)).toBeUndefined();
+    });
+  });
+
+  // ======================================================================
   // buildContextMessages — DM context behavior
   // ======================================================================
   describe('buildContextMessages (DM context)', () => {

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -1418,6 +1418,26 @@ function extractThreadId(messages: BufferedMessage[]): string | undefined {
   return ((messages[0]?.payload.rawPayload ?? {}) as Record<string, unknown>).threadId as string | undefined;
 }
 
+function extractKhalSessionId(messages: BufferedMessage[]): string | undefined {
+  for (const message of messages) {
+    const rawPayload = (message.payload.rawPayload ?? {}) as Record<string, unknown>;
+    const direct = rawPayload.khalSessionId;
+    if (typeof direct === 'string' && direct.trim()) return direct.trim();
+
+    const headers = rawPayload.headers;
+    if (headers && typeof headers === 'object') {
+      const headerMap = headers as Record<string, unknown>;
+      const value = headerMap['x-khal-session-id'] ?? headerMap['X-Khal-Session-Id'] ?? headerMap['X-KHAL-SESSION-ID'];
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function buildTriggerHeaders(khalSessionId: string | undefined): Record<string, string> | undefined {
+  return khalSessionId ? { 'x-khal-session-id': khalSessionId } : undefined;
+}
+
 /** Merge per-thread history context with DB-fetched context messages (extra comes first) */
 function mergeContextMessages(extra: string[] | undefined, db: string[]): string[] {
   return extra?.length ? [...extra, ...db] : db;
@@ -1519,6 +1539,7 @@ function buildMessageTrigger(
   sessionId: string,
   customerContext: OmniCustomerContext | undefined,
   allContextMessages: string[],
+  khalSessionId?: string,
 ): AgentTrigger {
   const threadId = extractThreadId(messages);
   // Instance-scoped env that any provider/bridge path should see, regardless
@@ -1551,6 +1572,7 @@ function buildMessageTrigger(
       referencedMessageId: messages[0]?.payload.replyToId || undefined,
     },
     sessionId,
+    headers: buildTriggerHeaders(khalSessionId),
     sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
     customer: customerContext,
     contextMessages: allContextMessages.length > 0 ? allContextMessages : undefined,
@@ -1585,7 +1607,10 @@ async function dispatchViaStreamingProvider(
   if (!messageTexts.length && mediaFiles.length) messageTexts.push('[Media message]');
 
   const rawThreadId = extractThreadId(messages);
-  const sessionId = computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
+  const explicitKhalSessionId = extractKhalSessionId(messages);
+  const sessionId =
+    explicitKhalSessionId ??
+    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
   const rawPl = (messages[0]?.payload.rawPayload ?? {}) as Record<string, unknown>;
   const replyToId = messages[0]?.payload.replyToId ?? messages[0]?.payload.externalId;
 
@@ -1631,6 +1656,7 @@ async function dispatchViaStreamingProvider(
     sessionId,
     customerContext,
     allContextMessages,
+    explicitKhalSessionId,
   );
 
   const chatType = determineChatType(chatId, channel, rawPl);
@@ -1993,7 +2019,10 @@ async function dispatchViaProvider(
   }
 
   const rawThreadId = extractThreadId(messages);
-  const sessionId = computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
+  const explicitKhalSessionId = extractKhalSessionId(messages);
+  const sessionId =
+    explicitKhalSessionId ??
+    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
 
   // Build context messages for group and DM conversations (messages since last bot response)
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
@@ -2035,6 +2064,7 @@ async function dispatchViaProvider(
     sessionId,
     customerContext,
     allContextMessages,
+    explicitKhalSessionId,
   );
 
   // ── Turn-based mode: delegate to extracted helper ──
@@ -2315,12 +2345,9 @@ async function handleSessionReset(
       : resolvedChatType;
 
   const rawThreadIdForReset = (msgRawPayload as Record<string, unknown>).threadId as string | undefined;
-  const sessionId = computeSessionId(
-    instance.agentSessionStrategy ?? 'per_chat',
-    senderId,
-    chatId,
-    rawThreadIdForReset,
-  );
+  const sessionId =
+    extractKhalSessionId([firstMessage]) ??
+    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadIdForReset);
   const sessionResetConfig = inst.sessionReset as SessionResetConfig | null;
   const activity = sessionActivityStore.getActivity(instance.id, sessionId);
   const resetResult = checkSessionReset(sessionResetConfig, resetChatType, activity);
@@ -4845,6 +4872,8 @@ export const __test__ = {
   resolveCustomerContext,
   mergeRouteOverrides,
   getDebounceConfig,
+  extractKhalSessionId,
+  buildTriggerHeaders,
   createNatsGenieProviderInstance,
   /** Override the NatsGenieProvider constructor for tests (avoids barrel mock contamination). */
   set NatsGenieProviderClass(cls: typeof NatsGenieProvider) {

--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -360,6 +360,7 @@ function makeHandlerHarness() {
     externalId: string;
     from: string;
     content: { type: string; text?: string };
+    rawPayload?: Record<string, unknown>;
   }> = [];
 
   const logger = {
@@ -385,12 +386,14 @@ function makeHandlerHarness() {
       externalId: string;
       from: string;
       content: { type: string; text?: string };
+      rawPayload?: Record<string, unknown>;
     }) => {
       received.push({
         instanceId: params.instanceId,
         externalId: params.externalId,
         from: params.from,
         content: params.content,
+        rawPayload: params.rawPayload,
       });
     },
   } as unknown as GupshupPlugin;
@@ -398,11 +401,11 @@ function makeHandlerHarness() {
   return { plugin, logs, received };
 }
 
-function makeWebhookRequest(payload: Record<string, unknown> | string): Request {
+function makeWebhookRequest(payload: Record<string, unknown> | string, headers: Record<string, string> = {}): Request {
   const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
   return new Request('https://example.com/api/v2/channels/gupshup/inst-gs-handler/webhook', {
     method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
     body,
   });
 }
@@ -429,6 +432,27 @@ describe('handleGupshupWebhook — event_type routing against real fixtures (#50
     expect(received[0]?.externalId).toBe('wamid.TEST_ASYNC_RESPONSE_TEXT_001');
     expect(received[0]?.content.text).toBe('Boa noite, gostaria de contratar um plano');
     expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unknown event_type'))).toHaveLength(0);
+  });
+
+  it('maps inbound KHAL session headers and Gupshup context into rawPayload', async () => {
+    const { plugin, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    const response = await handleGupshupWebhook(
+      makeWebhookRequest(loadFixtureText('async_response-text.json'), { 'x-khal-session-id': 'khal-session-abc' }),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.rawPayload?.khalSessionId).toBe('khal-session-abc');
+    expect((received[0]?.rawPayload?.headers as Record<string, string> | undefined)?.['x-khal-session-id']).toBe(
+      'khal-session-abc',
+    );
+    expect(received[0]?.rawPayload?.threadId).toBe('5521900000002');
   });
 
   it('processes user_input text message (legacy format regression guard)', async () => {

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -319,7 +319,9 @@ export async function handleGupshupWebhook(
     });
   }
 
-  const processed = await processInboundMessage(plugin, instanceId, webhook, dedupeCache);
+  const processed = await processInboundMessage(plugin, instanceId, webhook, dedupeCache, {
+    khalSessionId: request.headers.get('x-khal-session-id')?.trim() || undefined,
+  });
 
   // Unknown event_type wins the label — the alerting signal is format drift
   // detection, independent of whether the downstream extraction succeeded.
@@ -350,6 +352,7 @@ async function processInboundMessage(
   instanceId: string,
   webhook: GupshupNativeInboundWebhook,
   dedupeCache: DedupeCache,
+  options: { khalSessionId?: string } = {},
 ): Promise<boolean> {
   const msg = webhook.messageobj;
   const from = webhook.sender;
@@ -382,6 +385,8 @@ async function processInboundMessage(
     webhook.senderobj?.display ??
     webhook.contextobj?.senderName ??
     (webhook.messageobj?.raw?.sender as { name?: string } | undefined)?.name;
+  const threadId = webhook.contextobj?.contextid;
+  const khalSessionHeaders = options.khalSessionId ? { 'x-khal-session-id': options.khalSessionId } : undefined;
 
   await plugin.handleMessageReceived({
     instanceId,
@@ -389,7 +394,13 @@ async function processInboundMessage(
     chatId: from,
     from,
     content,
-    rawPayload: { ...webhook, pushName: senderName } as unknown as Record<string, unknown>,
+    rawPayload: {
+      ...webhook,
+      pushName: senderName,
+      ...(threadId ? { threadId } : {}),
+      ...(options.khalSessionId ? { khalSessionId: options.khalSessionId } : {}),
+      ...(khalSessionHeaders ? { headers: khalSessionHeaders } : {}),
+    } as unknown as Record<string, unknown>,
     platformTimestamp,
     replyTo,
   });

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -495,6 +495,8 @@ export interface AgentTrigger {
    * Includes OMNI_INSTANCE, OMNI_CHAT, OMNI_MESSAGE, OMNI_TURN_ID.
    */
   env?: Record<string, string>;
+  /** Headers providers should propagate on outbound trigger requests. */
+  headers?: Record<string, string>;
   /** Distributed trace context to propagate on outbound provider calls. */
   traceContext?: TraceContext;
 }
@@ -558,6 +560,8 @@ export interface WebhookPayload {
     emoji?: string;
   };
   traceId: string;
+  /** Headers propagated from the AgentTrigger; webhook providers also send these as HTTP headers. */
+  headers?: Record<string, string>;
   executionContext?: OmniExecutionContext;
   /** The endpoint to call back for sending responses */
   replyEndpoint: string;

--- a/packages/core/src/providers/webhook-provider.ts
+++ b/packages/core/src/providers/webhook-provider.ts
@@ -64,6 +64,7 @@ export class WebhookAgentProvider implements IAgentProvider {
         emoji: context.content.emoji,
       },
       traceId: context.traceId,
+      headers: context.headers,
       executionContext: buildOmniExecutionContext(context),
       replyEndpoint: 'POST /api/v2/messages/send',
     };
@@ -136,10 +137,11 @@ export class WebhookAgentProvider implements IAgentProvider {
     }
   }
 
-  private buildHeaders(): Record<string, string> {
+  private buildHeaders(extraHeaders?: Record<string, string>): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'X-Omni-Provider': 'webhook',
+      ...extraHeaders,
     };
     if (this.config.apiKey) {
       headers.Authorization = `Bearer ${this.config.apiKey}`;
@@ -152,7 +154,7 @@ export class WebhookAgentProvider implements IAgentProvider {
 
     const response = await fetch(this.config.webhookUrl, {
       method: 'POST',
-      headers: this.buildHeaders(),
+      headers: this.buildHeaders(payload.headers),
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(timeoutMs),
     });


### PR DESCRIPTION
## Summary
- propagate explicit `x-khal-session-id` from Gupshup inbound webhooks into Omni raw payload
- prefer explicit KHAL session ids over computed per_chat/per_thread ids for agent dispatch
- forward explicit KHAL session headers through AgentTrigger/webhook provider calls without labeling computed fallback sessions as KHAL ids

## Verification
- `bun install --frozen-lockfile`
- `bun test packages/channel-gupshup/src/__tests__/webhooks.test.ts packages/api/src/plugins/__tests__/agent-dispatcher.test.ts` — 89 pass, 0 fail
- `bun --filter @omni/channel-gupshup typecheck`
- `bun --filter @omni/api typecheck`
- `bun --filter @omni/core typecheck`
- `bunx biome check packages/channel-gupshup/src/handlers/webhooks.ts packages/channel-gupshup/src/__tests__/webhooks.test.ts packages/api/src/plugins/agent-dispatcher.ts packages/api/src/plugins/__tests__/agent-dispatcher.test.ts packages/core/src/providers/types.ts packages/core/src/providers/webhook-provider.ts`

## KHAL/HML context
P7i remediation for strict Omni → Agno → Langfuse session identity: explicit `x-khal-session-id` must survive Gupshup ingress and become the dispatch/provider session identity for HML proof.