### PR TITLE
ci: tolerate git-cliff output wrapper failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,13 @@ jobs:
           echo "Previous release tag: ${PREV:-none}"
 
       - name: Generate changelog
+        # git-cliff-action can fail after writing the requested file when the
+        # generated multi-line changelog trips GitHub output delimiter parsing
+        # ("Invalid value. Matching delimiter not found 'EOF'"). The release
+        # artifact should not go red for that wrapper-output bug; the next step
+        # uses /tmp/release-notes.md if it exists and otherwise leaves the
+        # generated release body in place.
+        continue-on-error: true
         uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772 # v4.7.0
         with:
           config: cliff.toml


### PR DESCRIPTION
## Why

The homolog version-bump repair correctly advanced `homolog` to `v2.260531.3`, but the downstream `Release` workflow failed in the release-notes job after `git-cliff` generated notes:

```text
Invalid value. Matching delimiter not found 'EOF'
```

This is a wrapper/output-file-command failure from `orhun/git-cliff-action`, not a release-content or source failure.

## Fix

Make the changelog generation step `continue-on-error: true` and let the following step use `/tmp/release-notes.md` when present; otherwise it leaves the generated GitHub release body in place.

That keeps the signed/published release path from going red because a release-note wrapper failed after producing the file.

## Verification

```text
bun scripts/verify-versions.ts
=> OK: 21/21 files match

git diff --check
=> passed
```

This PR changes only `.github/workflows/release.yml`.
