### PR TITLE
fix(whatsapp): resolve reaction UUID targets

### DIFF
--- a/packages/api/src/routes/v2/__tests__/messages-send-reaction.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-send-reaction.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { NotFoundError } from '@omni/core';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { messagesRoutes } from '../messages';
+
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const CHAT_ID = '22222222-2222-4222-8222-222222222222';
+const OTHER_CHAT_ID = '44444444-4444-4444-8444-444444444444';
+const OMNI_MESSAGE_ID = '33333333-3333-4333-8333-333333333333';
+const CHAT_EXTERNAL_ID = '51961151926407@lid';
+const MESSAGE_EXTERNAL_ID = '2A0726AEA0EE1EB26093';
+
+type MountOptions = {
+  sendMessage?: ReturnType<typeof mock>;
+  chatFound?: boolean;
+  messageChatId?: string;
+  getByIdThrows?: boolean;
+  getByIdError?: Error;
+};
+
+function mountMessagesRoutes(options: MountOptions = {}): Hono<{ Variables: AppVariables }> {
+  const sendMessage =
+    options.sendMessage ??
+    mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'REACTION-MSG-ID',
+      timestamp: 123,
+    }));
+
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async (id: string) => ({ id, channel: 'whatsapp-baileys' })),
+      },
+      persons: {
+        getIdentityForChannel: mock(async () => null),
+      },
+      chats: {
+        getById: mock(async (id: string) => ({ id, externalId: CHAT_EXTERNAL_ID })),
+        findByExternalIdSmart: mock(async () =>
+          options.chatFound === false
+            ? null
+            : {
+                id: CHAT_ID,
+                externalId: CHAT_EXTERNAL_ID,
+              },
+        ),
+      },
+      messages: {
+        getById: mock(async (id: string) => {
+          if (options.getByIdError) throw options.getByIdError;
+          if (options.getByIdThrows) throw new NotFoundError('Message', id);
+          return {
+            id,
+            chatId: options.messageChatId ?? CHAT_ID,
+            externalId: MESSAGE_EXTERNAL_ID,
+            isFromMe: false,
+            rawPayload: {
+              key: {
+                id: MESSAGE_EXTERNAL_ID,
+                remoteJid: CHAT_EXTERNAL_ID,
+                fromMe: false,
+              },
+            },
+          };
+        }),
+        getByExternalId: mock(async (_chatId: string, externalId: string) =>
+          externalId === MESSAGE_EXTERNAL_ID
+            ? {
+                id: OMNI_MESSAGE_ID,
+                chatId: CHAT_ID,
+                externalId: MESSAGE_EXTERNAL_ID,
+                isFromMe: false,
+                rawPayload: {
+                  key: {
+                    id: MESSAGE_EXTERNAL_ID,
+                    remoteJid: CHAT_EXTERNAL_ID,
+                    fromMe: false,
+                  },
+                },
+              }
+            : null,
+        ),
+      },
+    } as never);
+    c.set('channelRegistry', {
+      get: mock(() => ({
+        capabilities: { canSendReaction: true },
+        sendMessage,
+      })),
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/messages', messagesRoutes);
+  return app;
+}
+
+async function postReaction(app: Hono<{ Variables: AppVariables }>, messageId: string) {
+  return app.request('/messages/send/reaction', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      instanceId: INSTANCE_ID,
+      to: CHAT_ID,
+      messageId,
+      emoji: '👍',
+    }),
+  });
+}
+
+describe('POST /messages/send/reaction', () => {
+  test('resolves an Omni message UUID to the channel-native external ID before sending', async () => {
+    const sendMessage = mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'REACTION-MSG-ID',
+      timestamp: 123,
+    }));
+    const app = mountMessagesRoutes({ sendMessage });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBe(200);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      to: CHAT_EXTERNAL_ID,
+      content: {
+        type: 'reaction',
+        emoji: '👍',
+        targetMessageId: MESSAGE_EXTERNAL_ID,
+      },
+      metadata: {
+        fromMe: false,
+      },
+    });
+  });
+
+  test('fails closed for an Omni message UUID when the chat cannot be resolved', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, chatFound: false });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('fails closed for an Omni message UUID that belongs to another chat', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, messageChatId: OTHER_CHAT_ID });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('fails closed for an unknown Omni message UUID', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, getByIdThrows: true });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('does not mask unexpected message lookup errors as not found', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, getByIdError: new Error('database unavailable') });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBe(500);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('preserves external message IDs for plugin fallback when DB lookup misses', async () => {
+    const sendMessage = mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'REACTION-MSG-ID',
+      timestamp: 123,
+    }));
+    const app = mountMessagesRoutes({ sendMessage });
+    const externalMessageId = 'EXTERNAL-NOT-IN-DB';
+
+    const res = await postReaction(app, externalMessageId);
+
+    expect(res.status).toBe(200);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      content: {
+        type: 'reaction',
+        emoji: '👍',
+        targetMessageId: externalMessageId,
+      },
+      metadata: {},
+    });
+  });
+});

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -39,7 +39,7 @@ import { extname, join } from 'node:path';
 import { zValidator } from '@hono/zod-validator';
 import { sanitizeOutboundText } from '@omni/channel-sdk';
 import type { ChannelRegistry, OutgoingContent, OutgoingMessage } from '@omni/channel-sdk';
-import { ERROR_CODES, JOURNEY_STAGES, OmniError, createLogger, getJourneyTracker } from '@omni/core';
+import { ERROR_CODES, JOURNEY_STAGES, NotFoundError, OmniError, createLogger, getJourneyTracker } from '@omni/core';
 import type { ChatClosedPayload, CloseContactOutcome } from '@omni/core/events';
 import type { ChannelType } from '@omni/core/types';
 import type { Database } from '@omni/db';
@@ -114,6 +114,92 @@ function extractReactionTargetParticipant(rawPayload: Record<string, unknown> | 
   const key = rawPayload?.key as Record<string, unknown> | undefined;
   const participant = key?.participant;
   return typeof participant === 'string' && participant.length > 0 ? participant : undefined;
+}
+
+async function resolveReactionTarget(
+  services: Services,
+  instanceId: string,
+  resolvedTo: string,
+  messageId: string,
+): Promise<{ targetMessageId: string; metadata: Record<string, unknown> }> {
+  const metadata: Record<string, unknown> = {};
+  const chat = await services.chats.findByExternalIdSmart(instanceId, resolvedTo);
+
+  if (!chat) {
+    if (isUUID(messageId)) {
+      throw new OmniError({
+        code: ERROR_CODES.NOT_FOUND,
+        message: `Reaction target message not found: ${messageId}`,
+        context: { instanceId, resolvedTo, messageId },
+        recoverable: false,
+      });
+    }
+
+    log.warn('Reaction target chat not found in DB; deferring fromMe to channel plugin fallback (#386)', {
+      instanceId,
+      resolvedTo,
+      messageId,
+      fallback: 'plugin-heuristic',
+    });
+    return { targetMessageId: messageId, metadata };
+  }
+
+  const target = isUUID(messageId)
+    ? await getReactionTargetByOmniId(services, instanceId, chat.id, messageId)
+    : await services.messages.getByExternalId(chat.id, messageId);
+
+  if (!target) {
+    log.warn('Reaction target message not found in DB; deferring fromMe to channel plugin fallback (#386)', {
+      instanceId,
+      chatId: chat.id,
+      messageId,
+      fallback: 'plugin-heuristic',
+    });
+    return { targetMessageId: messageId, metadata };
+  }
+
+  metadata.fromMe = target.isFromMe === true;
+  if (target.isFromMe !== true) {
+    const participant = extractReactionTargetParticipant(
+      target.rawPayload as Record<string, unknown> | null | undefined,
+    );
+    if (participant) metadata.targetParticipant = participant;
+  }
+
+  return { targetMessageId: target.externalId, metadata };
+}
+
+async function getReactionTargetByOmniId(
+  services: Services,
+  instanceId: string,
+  chatId: string,
+  messageId: string,
+): Promise<Awaited<ReturnType<Services['messages']['getByExternalId']>>> {
+  let target: Awaited<ReturnType<Services['messages']['getById']>>;
+
+  try {
+    target = await services.messages.getById(messageId);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      throw reactionTargetNotFound(instanceId, chatId, messageId);
+    }
+    throw error;
+  }
+
+  if (target.chatId !== chatId) {
+    throw reactionTargetNotFound(instanceId, chatId, messageId);
+  }
+
+  return target;
+}
+
+function reactionTargetNotFound(instanceId: string, chatId: string, messageId: string): OmniError {
+  return new OmniError({
+    code: ERROR_CODES.NOT_FOUND,
+    message: `Reaction target message not found: ${messageId}`,
+    context: { instanceId, chatId, messageId },
+    recoverable: false,
+  });
 }
 
 /**
@@ -1175,39 +1261,16 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
   // Note: For reactions, 'to' is typically a chat ID, but we support person ID resolution too
   const resolvedTo = await resolveRecipient(to, instance.channel, services);
 
-  // Look up the target message to determine fromMe (critical for WhatsApp reactions).
-  // Baileys needs key.fromMe to locate the correct message — if wrong, the reaction
-  // is silently dropped by WhatsApp. When the target isn't in our DB (history gap
-  // or unsynced chat), we leave fromMe undefined and let the channel plugin's
-  // heuristic decide — forcing false here breaks bot-to-own-message reactions (#386).
-  const reactionMetadata: Record<string, unknown> = {};
-  const chat = await services.chats.findByExternalIdSmart(instanceId, resolvedTo);
-  if (chat) {
-    const target = await services.messages.getByExternalId(chat.id, messageId);
-    if (target) {
-      reactionMetadata.fromMe = target.isFromMe === true;
-      if (target.isFromMe !== true) {
-        const participant = extractReactionTargetParticipant(
-          target.rawPayload as Record<string, unknown> | null | undefined,
-        );
-        if (participant) reactionMetadata.targetParticipant = participant;
-      }
-    } else {
-      log.warn('Reaction target message not found in DB; deferring fromMe to channel plugin fallback (#386)', {
-        instanceId,
-        chatId: chat.id,
-        messageId,
-        fallback: 'plugin-heuristic',
-      });
-    }
-  } else {
-    log.warn('Reaction target chat not found in DB; deferring fromMe to channel plugin fallback (#386)', {
-      instanceId,
-      resolvedTo,
-      messageId,
-      fallback: 'plugin-heuristic',
-    });
-  }
+  // Look up the target message to determine the provider-native ID and fromMe
+  // (critical for WhatsApp reactions). CLI/history surfaces Omni message UUIDs,
+  // but Baileys needs the WhatsApp externalId in key.id; sending an Omni UUID can
+  // return command-level success while WhatsApp silently ignores the reaction.
+  const { targetMessageId, metadata: reactionMetadata } = await resolveReactionTarget(
+    services,
+    instanceId,
+    resolvedTo,
+    messageId,
+  );
 
   // Build outgoing message for reaction. When the target is unknown, omit
   // metadata so the plugin applies its own fallback (defaults to true for Baileys).
@@ -1216,7 +1279,7 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
     content: {
       type: 'reaction',
       emoji,
-      targetMessageId: messageId,
+      targetMessageId,
     } as OutgoingContent,
     metadata: reactionMetadata,
   };


### PR DESCRIPTION
## Summary
- Resolve Omni message UUID reaction targets to provider-native external IDs before sending to channel plugins
- Fail closed for UUID targets when chat/message scoping cannot be verified
- Add regression coverage for UUID happy path, missing chat/message, cross-chat mismatch, and external-ID fallback

## Test Plan
- `bunx biome check packages/api/src/routes/v2/messages.ts packages/api/src/routes/v2/__tests__/messages-send-reaction.test.ts`
- `bun test packages/api/src/routes/v2/__tests__/messages-send-reaction.test.ts packages/cli/src/__tests__/react-context.test.ts`
- `bun run --filter @omni/api typecheck`
- `bun run --filter @automagik/omni build:server`
- dogfood: reacted between Felipe's two WhatsApp instances using an Omni UUID; async reaction record indexed without fallback text duplication

## Notes
This fixes the WhatsApp reaction path where CLI/history surfaces an Omni UUID but Baileys needs the WhatsApp external message id (`3EB...`) in `key.id`.