### PR TITLE
fix(api): resolve KHAL trash reset session ids

### DIFF
--- a/packages/api/src/plugins/__tests__/session-cleaner.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cleaner.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+import { clearAgentSession } from '../session-cleaner';
+
+function makeDbWithAgentProvider(providerId: string) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ agentProviderId: providerId }],
+        }),
+      }),
+    }),
+  } as never;
+}
+
+describe('session-cleaner canonical KHAL reset guard', () => {
+  it('fails closed for Agno/KHAL resets when canonical person identity cannot be resolved', async () => {
+    const services = {
+      agentRunner: {
+        getInstanceWithProvider: async () => ({
+          id: 'inst-1',
+          agentId: 'agent-1',
+          channel: 'whatsapp-gupshup',
+          agentSessionStrategy: 'per_chat',
+        }),
+      },
+      providers: {
+        getById: async () => ({
+          id: 'provider-1',
+          schema: 'agno',
+          baseUrl: 'http://agno.invalid',
+          apiKey: '',
+          defaultTimeout: 1,
+        }),
+      },
+      chats: {
+        findByExternalIdSmart: async () => null,
+      },
+    } as never;
+
+    await expect(
+      clearAgentSession(services, makeDbWithAgentProvider('provider-1'), 'inst-1', '5547996094523', '5547996094523', {
+        rawPayload: { headers: { 'x-khal-env': 'hml' } },
+      }),
+    ).rejects.toThrow('Canonical KHAL session resolution failed');
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -82,6 +82,7 @@ import {
   getSplitDelayConfig,
   shouldAgentReply,
 } from '../services/agent-runner';
+import { resolveKhalSessionId } from '../services/agent-session-identity';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
@@ -1776,11 +1777,20 @@ async function dispatchViaStreamingProvider(
   if (!messageTexts.length && mediaFiles.length) messageTexts.push('[Media message]');
 
   const rawThreadId = extractThreadId(messages);
-  const explicitKhalSessionId = extractKhalSessionId(messages);
-  const sessionId =
-    explicitKhalSessionId ??
-    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
   const rawPl = (messages[0]?.payload.rawPayload ?? {}) as Record<string, unknown>;
+  const sessionIdentity = resolveKhalSessionId({
+    providerSchema: resolved.provider.schema,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    from: senderId,
+    chatId,
+    channel,
+    instanceId: instance.id,
+    personId,
+    rawPayload: rawPl,
+    threadId: rawThreadId,
+  });
+  const sessionId = sessionIdentity.sessionId;
+  const explicitKhalSessionId = sessionIdentity.canonicalSessionId;
   const replyToId = messages[0]?.payload.replyToId ?? messages[0]?.payload.externalId;
 
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
@@ -2205,10 +2215,20 @@ async function dispatchViaProvider(
   }
 
   const rawThreadId = extractThreadId(messages);
-  const explicitKhalSessionId = extractKhalSessionId(messages);
-  const sessionId =
-    explicitKhalSessionId ??
-    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
+  const rawPl = (messages[0]?.payload.rawPayload ?? {}) as Record<string, unknown>;
+  const sessionIdentity = resolveKhalSessionId({
+    providerSchema: provider.schema,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    from: senderId,
+    chatId,
+    channel,
+    instanceId: instance.id,
+    personId,
+    rawPayload: rawPl,
+    threadId: rawThreadId,
+  });
+  const sessionId = sessionIdentity.sessionId;
+  const explicitKhalSessionId = sessionIdentity.canonicalSessionId;
 
   // Build context messages for group and DM conversations (messages since last bot response)
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
@@ -3917,7 +3937,16 @@ async function processReactionTrigger(
       // Build AgentTrigger for the provider
       const effectivePersonId = reactionPersonId ?? metadata.personId;
       const senderName = await services.agentRunner.getSenderName(effectivePersonId, undefined);
-      const sessionId = computeSessionId(instance.agentSessionStrategy ?? 'per_chat', payload.from, externalChatId);
+      const sessionId = resolveKhalSessionId({
+        providerSchema: provider.schema,
+        sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+        from: payload.from,
+        chatId: externalChatId,
+        channel,
+        instanceId: instance.id,
+        personId: effectivePersonId,
+        rawPayload: payload.rawPayload as Record<string, unknown> | undefined,
+      }).sessionId;
       const customerContext = await resolveCustomerContext(services, effectivePersonId);
 
       const trigger: AgentTrigger = {

--- a/packages/api/src/plugins/session-cleaner.ts
+++ b/packages/api/src/plugins/session-cleaner.ts
@@ -10,11 +10,11 @@
 import type { EventBus, TypedOmniEvent } from '@omni/core';
 import { createAgnoClient, createLogger } from '@omni/core';
 import type { ChannelType, Database } from '@omni/db';
-import { agents } from '@omni/db';
-import { eq } from 'drizzle-orm';
+import { agents, chatParticipants } from '@omni/db';
+import { and, eq } from 'drizzle-orm';
 import { withIdempotency } from '../lib/idempotency';
 import type { Services } from '../services';
-import { computeSessionId } from '../services/agent-runner';
+import { type ResolvedAgentSessionIdentity, resolveKhalSessionId } from '../services/agent-session-identity';
 import { applyAgentFkOverrides, resolveProvider } from './agent-dispatcher';
 import { getPlugin } from './loader';
 
@@ -55,13 +55,36 @@ async function sendMessage(services: Services, instanceId: string, chatId: strin
  * Tries IAgentProvider.resetSession() first (supports OpenClaw, Webhook, etc.),
  * falls back to direct AgnoOS client for legacy.
  */
+async function resolveCleanupPersonId(
+  services: Services,
+  db: Database,
+  instanceId: string,
+  chatId: string,
+  from: string,
+  metadataPersonId?: string,
+): Promise<string | undefined> {
+  if (metadataPersonId?.trim()) return metadataPersonId.trim();
+
+  const dbChat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+  if (!dbChat?.id) return undefined;
+
+  const [participant] = await db
+    .select({ personId: chatParticipants.personId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, dbChat.id), eq(chatParticipants.platformUserId, from)))
+    .limit(1);
+
+  return participant?.personId ?? undefined;
+}
+
 export async function clearAgentSession(
   services: Services,
   db: Database,
   instanceId: string,
   from: string,
   chatId: string,
-): Promise<{ sessionId: string; sessionStrategy: string }> {
+  options: { personId?: string; rawPayload?: Record<string, unknown> } = {},
+): Promise<ResolvedAgentSessionIdentity> {
   // Get instance with provider
   const instance = await services.agentRunner.getInstanceWithProvider(instanceId);
 
@@ -83,9 +106,22 @@ export async function clearAgentSession(
   // Get provider record from DB
   const providerRecord = await services.providers.getById(agentRow.agentProviderId);
 
-  // Compute session ID using the same strategy as agent-runner
-  const sessionStrategy = instance.agentSessionStrategy ?? 'per_chat';
-  const sessionId = computeSessionId(sessionStrategy, from, chatId);
+  const personId = await resolveCleanupPersonId(services, db, instanceId, chatId, from, options.personId);
+  const identity = resolveKhalSessionId({
+    providerSchema: providerRecord.schema,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    from,
+    chatId,
+    channel: instance.channel,
+    instanceId,
+    personId,
+    rawPayload: options.rawPayload,
+  });
+  const { sessionId, legacySessionId } = identity;
+  const hasKhalContext = !!identity.canonicalSessionId || !!identity.environment || !!options.rawPayload?.khalSessionId;
+  if (providerRecord.schema === 'agno' && hasKhalContext && identity.source === 'legacy') {
+    throw new Error('Canonical KHAL session resolution failed; refusing blind legacy Agno reset');
+  }
 
   // Try IAgentProvider.resetSession() first (covers OpenClaw, Agno, Claude, etc.)
   // Pass chatId so providers that build their own key format (e.g. OpenClaw)
@@ -100,7 +136,10 @@ export async function clearAgentSession(
   const agentProvider = resolveProvider(providerRecord, dispatchInstance, db);
   if (agentProvider?.resetSession) {
     await agentProvider.resetSession(sessionId, chatId, instanceId);
-    return { sessionId, sessionStrategy };
+    if (legacySessionId !== sessionId) {
+      await agentProvider.resetSession(legacySessionId, chatId, instanceId);
+    }
+    return identity;
   }
 
   // Fallback: direct AgnoOS client
@@ -114,9 +153,19 @@ export async function clearAgentSession(
     defaultTimeoutMs: (providerRecord.defaultTimeout ?? 60) * 1000,
   });
 
-  await client.deleteSession?.(sessionId);
+  const primaryDelete = await client.deleteSession?.(sessionId);
+  const legacyDelete = legacySessionId !== sessionId ? await client.deleteSession?.(legacySessionId) : undefined;
+  log.info('Agno session delete verified', {
+    instanceId,
+    sessionId,
+    legacySessionId,
+    primaryStatus: primaryDelete?.status,
+    primaryExisted: primaryDelete?.existed,
+    legacyStatus: legacyDelete?.status,
+    legacyExisted: legacyDelete?.existed,
+  });
 
-  return { sessionId, sessionStrategy };
+  return identity;
 }
 
 /**
@@ -135,14 +184,14 @@ async function handleTrashEmojiMessage(
   db: Database,
   event: TypedOmniEvent<'message.received'>,
 ): Promise<void> {
-  const { content, chatId, from } = event.payload;
+  const { content, chatId } = event.payload;
   const { instanceId } = event.metadata;
 
   if (!instanceId || !content?.text) return;
   if (!isTrashEmojiOnly(content.text)) return;
 
   const result = await withIdempotency(db, event.id, 'session-cleaner', async () => {
-    await runTrashEmojiCleanup(services, db, instanceId, chatId, from);
+    await runTrashEmojiCleanup(services, db, event);
   });
 
   if (!result.executed) {
@@ -157,16 +206,30 @@ async function handleTrashEmojiMessage(
 async function runTrashEmojiCleanup(
   services: Services,
   db: Database,
-  instanceId: string,
-  chatId: string,
-  from: string,
+  event: TypedOmniEvent<'message.received'>,
 ): Promise<void> {
-  log.info('Trash emoji detected, clearing session', { instanceId, chatId, from });
+  const { chatId, from, rawPayload } = event.payload;
+  const { instanceId, personId } = event.metadata;
+  if (!instanceId) return;
+
+  log.info('Trash emoji detected, clearing session', { instanceId, chatId, from, personId });
 
   try {
-    const { sessionId, sessionStrategy } = await clearAgentSession(services, db, instanceId, from, chatId);
+    const identity = await clearAgentSession(services, db, instanceId, from, chatId, { personId, rawPayload });
+    const { sessionId, legacySessionId, sessionStrategy, source, canonicalSessionId, environment, channelSegment } =
+      identity;
 
-    log.info('Session cleared successfully', { instanceId, sessionId, sessionStrategy });
+    log.info('Session cleared successfully', {
+      instanceId,
+      sessionId,
+      legacySessionId,
+      sessionStrategy,
+      source,
+      canonicalSessionId,
+      personId: identity.personId,
+      environment,
+      channelSegment,
+    });
 
     // Disarm any active follow-up sequence — clearing the session means the
     // user has explicitly reset the conversation; queued follow-ups referencing

--- a/packages/api/src/services/__tests__/agent-session-identity.test.ts
+++ b/packages/api/src/services/__tests__/agent-session-identity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildCanonicalKhalSessionId,
+  extractKhalSessionIdFromRawPayload,
+  resolveKhalSessionId,
+} from '../agent-session-identity';
+
+describe('agent session identity', () => {
+  it('extracts explicit KHAL session ids from rawPayload and headers', () => {
+    expect(extractKhalSessionIdFromRawPayload({ khalSessionId: ' khal-session-123 ' })).toBe('khal-session-123');
+    expect(extractKhalSessionIdFromRawPayload({ headers: { 'x-khal-session-id': ' khal-session-456 ' } })).toBe(
+      'khal-session-456',
+    );
+  });
+
+  it('builds canonical HML Gupshup session ids for Agno/KHAL dispatch and cleanup', () => {
+    const resolved = resolveKhalSessionId({
+      providerSchema: 'agno',
+      sessionStrategy: 'per_chat',
+      from: '5547996094523',
+      chatId: '5547996094523',
+      channel: 'whatsapp-gupshup',
+      instanceId: 'c88f18fd-3e0a-49ed-9835-efd2c2be3988',
+      personId: '8e0b8253-7221-4756-af64-dece4f25a71d',
+      rawPayload: { headers: { 'x-khal-env': 'hml' } },
+    });
+
+    expect(resolved.source).toBe('canonical-khal');
+    expect(resolved.sessionId).toBe(
+      'khal:hml:omni:c88f18fd-3e0a-49ed-9835-efd2c2be3988:gupshup:8e0b8253-7221-4756-af64-dece4f25a71d',
+    );
+    expect(resolved.legacySessionId).toBe('5547996094523');
+  });
+
+  it('builds prod namespace canonical session ids from the same resolver', () => {
+    expect(
+      buildCanonicalKhalSessionId({
+        environment: 'prod',
+        instanceId: 'prod-instance',
+        channelSegment: 'gupshup',
+        personId: 'person-123',
+      }),
+    ).toBe('khal:prod:omni:prod-instance:gupshup:person-123');
+  });
+
+  it('preserves legacy computed ids for non-KHAL/non-Agno providers', () => {
+    const resolved = resolveKhalSessionId({
+      providerSchema: 'openclaw',
+      sessionStrategy: 'per_chat',
+      from: '5511999999999',
+      chatId: '5511999999999',
+      channel: 'whatsapp-gupshup',
+      instanceId: 'inst-1',
+      personId: 'person-1',
+      rawPayload: { headers: { 'x-khal-env': 'hml' } },
+    });
+
+    expect(resolved.source).toBe('legacy');
+    expect(resolved.sessionId).toBe('5511999999999');
+  });
+});

--- a/packages/api/src/services/agent-session-identity.ts
+++ b/packages/api/src/services/agent-session-identity.ts
@@ -1,0 +1,159 @@
+import type { ChannelType, ProviderSchema } from '@omni/db';
+
+declare const process: { env: Record<string, string | undefined> };
+
+type AgentSessionStrategyLike = 'per_user' | 'per_chat' | 'per_thread' | string;
+
+function computeLegacySessionId(
+  strategy: AgentSessionStrategyLike,
+  userId: string,
+  chatId: string,
+  threadId?: string,
+): string {
+  switch (strategy) {
+    case 'per_user':
+      return userId;
+    case 'per_chat':
+      return chatId;
+    case 'per_thread':
+      return `thread:${chatId}:${threadId ?? chatId}`;
+    default:
+      return `${userId}:${chatId}`;
+  }
+}
+
+export interface KhalSessionIdentityInput {
+  providerSchema?: ProviderSchema | string;
+  sessionStrategy?: string;
+  from: string;
+  chatId: string;
+  channel?: ChannelType | string;
+  instanceId: string;
+  personId?: string | null;
+  rawPayload?: Record<string, unknown> | null;
+  environment?: string | null;
+  threadId?: string;
+}
+
+export interface ResolvedAgentSessionIdentity {
+  sessionId: string;
+  legacySessionId: string;
+  sessionStrategy: string;
+  canonicalSessionId?: string;
+  personId?: string;
+  environment?: string;
+  channelSegment?: string;
+  source: 'explicit-khal' | 'canonical-khal' | 'legacy';
+}
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== 'object') return undefined;
+  const headerMap = headers as Record<string, unknown>;
+  const lowerName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headerMap)) {
+    if (key.toLowerCase() === lowerName && typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function readStringField(source: Record<string, unknown> | null | undefined, names: string[]): string | undefined {
+  if (!source) return undefined;
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export function extractKhalSessionIdFromRawPayload(rawPayload?: Record<string, unknown> | null): string | undefined {
+  const direct = readStringField(rawPayload, ['khalSessionId', 'khal_session_id', 'session_id']);
+  if (direct) return direct;
+  return readHeader(rawPayload?.headers, 'x-khal-session-id');
+}
+
+export function resolveKhalEnvironment(
+  rawPayload?: Record<string, unknown> | null,
+  explicitEnvironment?: string | null,
+): string | undefined {
+  const explicit = explicitEnvironment?.trim();
+  if (explicit) return explicit;
+
+  const fromPayload = readStringField(rawPayload, ['khalEnv', 'khalEnvironment', 'environment', 'env']);
+  if (fromPayload) return fromPayload;
+
+  return (
+    readHeader(rawPayload?.headers, 'x-khal-env') ??
+    readHeader(rawPayload?.headers, 'x-khal-environment') ??
+    process.env.KHAL_SESSION_ENV?.trim() ??
+    process.env.KHAL_ENV?.trim() ??
+    process.env.OMNI_ENV?.trim()
+  );
+}
+
+export function channelToKhalSessionSegment(channel?: ChannelType | string): string | undefined {
+  if (!channel) return undefined;
+  if (channel === 'whatsapp-gupshup') return 'gupshup';
+  if (channel === 'whatsapp-cloud') return 'whatsapp';
+  if (channel === 'whatsapp-baileys') return 'whatsapp';
+  return String(channel).replace(/^channel-/, '');
+}
+
+export function buildCanonicalKhalSessionId(input: {
+  environment: string;
+  instanceId: string;
+  channelSegment: string;
+  personId: string;
+}): string {
+  return `khal:${input.environment}:omni:${input.instanceId}:${input.channelSegment}:${input.personId}`;
+}
+
+export function resolveKhalSessionId(input: KhalSessionIdentityInput): ResolvedAgentSessionIdentity {
+  const sessionStrategy = input.sessionStrategy ?? 'per_chat';
+  const legacySessionId = computeLegacySessionId(sessionStrategy, input.from, input.chatId, input.threadId);
+  const explicitKhalSessionId = extractKhalSessionIdFromRawPayload(input.rawPayload);
+  if (explicitKhalSessionId) {
+    return {
+      sessionId: explicitKhalSessionId,
+      legacySessionId,
+      sessionStrategy,
+      canonicalSessionId: explicitKhalSessionId,
+      personId: input.personId ?? undefined,
+      environment: resolveKhalEnvironment(input.rawPayload, input.environment),
+      channelSegment: channelToKhalSessionSegment(input.channel),
+      source: 'explicit-khal',
+    };
+  }
+
+  const environment = resolveKhalEnvironment(input.rawPayload, input.environment);
+  const channelSegment = channelToKhalSessionSegment(input.channel);
+  const personId = input.personId?.trim();
+
+  if (input.providerSchema === 'agno' && environment && channelSegment && personId) {
+    const canonicalSessionId = buildCanonicalKhalSessionId({
+      environment,
+      instanceId: input.instanceId,
+      channelSegment,
+      personId,
+    });
+    return {
+      sessionId: canonicalSessionId,
+      legacySessionId,
+      sessionStrategy,
+      canonicalSessionId,
+      personId,
+      environment,
+      channelSegment,
+      source: 'canonical-khal',
+    };
+  }
+
+  return {
+    sessionId: legacySessionId,
+    legacySessionId,
+    sessionStrategy,
+    personId: personId ?? undefined,
+    environment,
+    channelSegment,
+    source: 'legacy',
+  };
+}

--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -637,6 +637,33 @@ describe('AgnoClient', () => {
     });
   });
 
+  // --- IAgentClient interface: deleteSession() ---
+
+  describe('deleteSession', () => {
+    it('returns a verified delete result on success', async () => {
+      mockImpl.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const client = new AgnoClient(config);
+      const result = await client.deleteSession('khal:hml:omni:inst:gupshup:person');
+
+      expect(result).toEqual({
+        ok: true,
+        status: 204,
+        sessionId: 'khal:hml:omni:inst:gupshup:person',
+        existed: true,
+      });
+    });
+
+    it('treats a missing session as a verified no-op instead of throwing', async () => {
+      mockImpl.mockResolvedValueOnce(new Response('missing', { status: 404 }));
+
+      const client = new AgnoClient(config);
+      const result = await client.deleteSession('legacy-phone-session');
+
+      expect(result).toEqual({ ok: true, status: 404, sessionId: 'legacy-phone-session', existed: false });
+    });
+  });
+
   // --- Authentication ---
 
   describe('authentication', () => {

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -17,6 +17,7 @@ import {
   ProviderError,
   type ProviderRequest,
   type ProviderResponse,
+  type SessionDeleteResult,
   type StreamChunk,
 } from './types';
 
@@ -519,7 +520,7 @@ export class AgnoClient implements IAgentClient {
 
   // --- Session Management ---
 
-  async deleteSession(sessionId: string): Promise<void> {
+  async deleteSession(sessionId: string): Promise<SessionDeleteResult> {
     const url = `${this.baseUrl}/sessions/${encodeURIComponent(sessionId)}`;
     const response = await this.fetchWithTimeout(
       url,
@@ -527,9 +528,15 @@ export class AgnoClient implements IAgentClient {
       this.defaultTimeoutMs,
     );
 
+    if (response.status === 404) {
+      return { ok: true, status: response.status, sessionId, existed: false };
+    }
+
     if (!response.ok) {
       this.handleErrorResponse(response, `deleting session ${sessionId}`);
     }
+
+    return { ok: true, status: response.status, sessionId, existed: true };
   }
 }
 

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -210,6 +210,13 @@ export interface AgnoWorkflow {
   description?: string;
 }
 
+export interface SessionDeleteResult {
+  ok: boolean;
+  status: number;
+  sessionId: string;
+  existed: boolean | undefined;
+}
+
 /**
  * Generic agent client interface
  *
@@ -230,7 +237,7 @@ export interface IAgentClient {
   checkHealth(): Promise<AgentHealthResult>;
 
   /** Optional: delete a session (clear conversation history) */
-  deleteSession?(sessionId: string): Promise<void>;
+  deleteSession?(sessionId: string): Promise<SessionDeleteResult>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a shared `resolveKhalSessionId` identity resolver so Agno/KHAL dispatch and trash reset target the same canonical `khal:<env>:omni:<instance>:<channel>:<person>` session key instead of the stale phone/chat id.
- Update trash reset to resolve `personId`, fail closed for KHAL/Agno when canonical identity cannot be derived, delete both canonical and legacy keys, and log delete verification details.
- Make Agno `deleteSession` return a structured result (`status`, `existed`) so reset logs can prove what happened instead of silently trusting HTTP-level success.

## Why
HML reset was reporting "Conversa limpa" while the live active Agno session/memories survived because cleanup targeted the stale legacy id (for example phone/chat id) while dispatch used/needed the canonical KHAL session id. This PR aligns dispatch + cleanup and prevents silent success on mismatched targets.

## Test Plan
- [x] `bunx biome check packages/api/src/services/agent-session-identity.ts packages/api/src/services/__tests__/agent-session-identity.test.ts packages/api/src/plugins/session-cleaner.ts packages/api/src/plugins/__tests__/session-cleaner.test.ts packages/api/src/plugins/agent-dispatcher.ts packages/core/src/providers/types.ts packages/core/src/providers/agno-client.ts packages/core/src/providers/__tests__/agno-client.test.ts`
- [x] `(cd packages/api && bun test src/services/__tests__/agent-session-identity.test.ts src/plugins/__tests__/session-cleaner.test.ts src/plugins/__tests__/agent-dispatcher.test.ts)` — 64 pass, 0 fail
- [x] `(cd packages/core && bun test src/providers/__tests__/agno-client.test.ts)` — 29 pass, 0 fail
- [x] `(cd packages/api && bun run typecheck)`
- [x] `(cd packages/core && bun run typecheck)`
- [x] pre-push hook: `turbo typecheck` across 19 packages + full `bun test` suite — 3979 pass, 292 skip, 0 fail

## Follow-up after merge
- Promote dev to homolog via PR.
- Deploy HML.
- Verify a real trash reset removes the canonical HML Agno session/memories and produces `Agno session delete verified` / `Session cleared successfully` logs with the canonical session id.
