### PR TITLE
fix(api): keep session resolver helpers internal

### DIFF
--- a/packages/api/src/services/agent-session-identity.ts
+++ b/packages/api/src/services/agent-session-identity.ts
@@ -71,7 +71,7 @@ export function extractKhalSessionIdFromRawPayload(rawPayload?: Record<string, u
   return readHeader(rawPayload?.headers, 'x-khal-session-id');
 }
 
-export function resolveKhalEnvironment(
+function resolveKhalEnvironment(
   rawPayload?: Record<string, unknown> | null,
   explicitEnvironment?: string | null,
 ): string | undefined {
@@ -90,7 +90,7 @@ export function resolveKhalEnvironment(
   );
 }
 
-export function channelToKhalSessionSegment(channel?: ChannelType | string): string | undefined {
+function channelToKhalSessionSegment(channel?: ChannelType | string): string | undefined {
   if (!channel) return undefined;
   if (channel === 'whatsapp-gupshup') return 'gupshup';
   if (channel === 'whatsapp-cloud') return 'whatsapp';


### PR DESCRIPTION
## Summary
- Fix red dev CI from `bunx knip` by keeping internal `agent-session-identity` helper functions non-exported.
- No behavior change: `resolveKhalSessionId`, explicit session extraction, and canonical KHAL session builder remain exported and tested.

## Test Plan
- [x] `bunx knip`
- [x] `bunx biome check packages/api/src/services/agent-session-identity.ts packages/api/src/services/__tests__/agent-session-identity.test.ts`
- [x] `(cd packages/api && bun test src/services/__tests__/agent-session-identity.test.ts src/plugins/__tests__/session-cleaner.test.ts)` — 5 pass, 0 fail
- [x] `(cd packages/api && bun run typecheck)`
