### PR TITLE
promote: agent timeout 600 default to homolog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/src/components/instances/AgentConfigForm.tsx
+++ b/apps/ui/src/components/instances/AgentConfigForm.tsx
@@ -20,7 +20,7 @@ interface AgentConfigFormProps {
 export function AgentConfigForm({ instance }: AgentConfigFormProps) {
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(instance.agentProviderId ?? null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(instance.agentId ?? null);
-  const [agentTimeout, setAgentTimeout] = useState(instance.agentTimeout ?? 60);
+  const [agentTimeout, setAgentTimeout] = useState(instance.agentTimeout ?? 600);
   const [streamMode, setStreamMode] = useState(instance.agentStreamMode ?? false);
   const [isDirty, setIsDirty] = useState(false);
 
@@ -34,7 +34,7 @@ export function AgentConfigForm({ instance }: AgentConfigFormProps) {
     const hasChanges =
       selectedProviderId !== (instance.agentProviderId ?? null) ||
       selectedAgentId !== (instance.agentId ?? null) ||
-      agentTimeout !== (instance.agentTimeout ?? 60) ||
+      agentTimeout !== (instance.agentTimeout ?? 600) ||
       streamMode !== (instance.agentStreamMode ?? false);
     setIsDirty(hasChanges);
   }, [selectedProviderId, selectedAgentId, agentTimeout, streamMode, instance]);
@@ -231,12 +231,12 @@ export function AgentConfigForm({ instance }: AgentConfigFormProps) {
                 id="agent-timeout"
                 type="number"
                 min={10}
-                max={300}
+                max={600}
                 value={agentTimeout}
                 onChange={(e) => setAgentTimeout(Number(e.target.value))}
                 className="max-w-[120px]"
               />
-              <p className="text-xs text-muted-foreground">Maximum time to wait for agent response (10-300 seconds)</p>
+              <p className="text-xs text-muted-foreground">Maximum time to wait for agent response (10-600 seconds)</p>
             </div>
 
             <div className="flex items-center justify-between rounded-lg border p-3">

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260602.2",
+      "version": "2.260603.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260531.2",
+      "version": "2.260531.5",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260531.5",
+      "version": "2.260531.6",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260602.1",
+      "version": "2.260602.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260603.2",
+      "version": "2.260603.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260531.6",
+      "version": "2.260601.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260530.5",
+      "version": "2.260531.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260531.1",
+      "version": "2.260531.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260601.1",
+      "version": "2.260602.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/docs/architecture/provider-system.md
+++ b/docs/architecture/provider-system.md
@@ -284,7 +284,7 @@ export const agentProviders = pgTable('agent_providers', {
 
   // Default settings
   defaultStream: boolean('default_stream').notNull().default(true),
-  defaultTimeout: integer('default_timeout').notNull().default(60),
+  defaultTimeout: integer('default_timeout').notNull().default(600),
 
   // Capabilities (auto-detected or manually set)
   supportsStreaming: boolean('supports_streaming').notNull().default(true),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -324,6 +324,45 @@ function createReactionEvent(overrides: Record<string, unknown> = {}) {
 // ============================================================================
 
 describe('agent-dispatcher', () => {
+  describe('human lifecycle observability helpers', () => {
+    it('builds redacted-readable lifecycle attributes without raw PII or secrets', () => {
+      const attributes = __test__.buildLifecycleSpanAttributes({
+        stage: 'provider_inbound',
+        eventType: 'user_message_turn',
+        channel: 'whatsapp-baileys',
+        provider: 'gupshup',
+        instanceId: 'inst-1',
+        chatId: '5511999887766@s.whatsapp.net',
+        sessionId: 'p0r-hml-20260531T204449Z',
+        traceId: 'trc-test-123',
+        messageId: 'wamid.123',
+        agentId: 'eugenia-seller',
+        inputText: 'Olá, meu telefone é 5511999887766 e email felipe@example.com. Quero cotar plano.',
+        outputText: 'Claro, posso ajudar com a cotação.',
+        extra: {
+          authorization: 'Bearer super-secret-token',
+          token: 'abc123',
+        },
+      });
+
+      expect(attributes['khal.lifecycle.stage']).toBe('provider_inbound');
+      expect(attributes['khal.event_type']).toBe('user_message_turn');
+      expect(attributes['khal.channel']).toBe('whatsapp-baileys');
+      expect(attributes['khal.provider']).toBe('gupshup');
+      expect(attributes['langfuse.session.id']).toBe('p0r-hml-20260531T204449Z');
+      expect(attributes['session.id']).toBe('p0r-hml-20260531T204449Z');
+      expect(attributes['khal.input_chars']).toBeGreaterThan(0);
+      expect(String(attributes['khal.input_sha256'])).toStartWith('sha256:');
+      expect(String(attributes['khal.output_sha256'])).toStartWith('sha256:');
+      expect(String(attributes['khal.input_preview_redacted'])).toContain('[PHONE]');
+      expect(String(attributes['khal.input_preview_redacted'])).toContain('[EMAIL]');
+      expect(JSON.stringify(attributes)).not.toContain('felipe@example.com');
+      expect(JSON.stringify(attributes)).not.toContain('5511999887766');
+      expect(JSON.stringify(attributes)).not.toContain('super-secret-token');
+      expect(JSON.stringify(attributes)).not.toContain('abc123');
+    });
+  });
+
   // ======================================================================
   // setupAgentDispatcher — subscribes to correct NATS subjects
   // ======================================================================

--- a/packages/api/src/plugins/__tests__/session-cleaner.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cleaner.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+import { clearAgentSession } from '../session-cleaner';
+
+function makeDbWithAgentProvider(providerId: string) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ agentProviderId: providerId }],
+        }),
+      }),
+    }),
+  } as never;
+}
+
+describe('session-cleaner canonical KHAL reset guard', () => {
+  it('fails closed for Agno/KHAL resets when canonical person identity cannot be resolved', async () => {
+    const services = {
+      agentRunner: {
+        getInstanceWithProvider: async () => ({
+          id: 'inst-1',
+          agentId: 'agent-1',
+          channel: 'whatsapp-gupshup',
+          agentSessionStrategy: 'per_chat',
+        }),
+      },
+      providers: {
+        getById: async () => ({
+          id: 'provider-1',
+          schema: 'agno',
+          baseUrl: 'http://agno.invalid',
+          apiKey: '',
+          defaultTimeout: 1,
+        }),
+      },
+      chats: {
+        findByExternalIdSmart: async () => null,
+      },
+    } as never;
+
+    await expect(
+      clearAgentSession(services, makeDbWithAgentProvider('provider-1'), 'inst-1', '5547996094523', '5547996094523', {
+        rawPayload: { headers: { 'x-khal-env': 'hml' } },
+      }),
+    ).rejects.toThrow('Canonical KHAL session resolution failed');
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3427,7 +3427,7 @@ function createAgnoProvider(provider: AgentProvider, instance: DispatchInstance)
     schema: provider.schema,
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
@@ -3435,7 +3435,7 @@ function createAgnoProvider(provider: AgentProvider, instance: DispatchInstance)
   return new AgnoAgentProvider(provider.id, provider.name, client, {
     agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
     agentType: (instance.agentType ?? 'agent') as 'agent' | 'team' | 'workflow',
-    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
+    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 600) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   });
@@ -3518,12 +3518,12 @@ function createAgUiProviderInstance(provider: AgentProvider, instance: DispatchI
     schema: provider.schema,
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   return new AgUiAgentProvider(provider.id, provider.name, client, {
     agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
-    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
+    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 600) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   });
@@ -3541,12 +3541,12 @@ function createA2AProviderInstance(provider: AgentProvider, instance: DispatchIn
     schema: provider.schema,
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   return new A2AAgentProvider(provider.id, provider.name, client, {
     agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
-    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
+    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 600) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   });

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -82,6 +82,7 @@ import {
   getSplitDelayConfig,
   shouldAgentReply,
 } from '../services/agent-runner';
+import { resolveKhalSessionId } from '../services/agent-session-identity';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
@@ -1776,11 +1777,20 @@ async function dispatchViaStreamingProvider(
   if (!messageTexts.length && mediaFiles.length) messageTexts.push('[Media message]');
 
   const rawThreadId = extractThreadId(messages);
-  const explicitKhalSessionId = extractKhalSessionId(messages);
-  const sessionId =
-    explicitKhalSessionId ??
-    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
   const rawPl = (messages[0]?.payload.rawPayload ?? {}) as Record<string, unknown>;
+  const sessionIdentity = resolveKhalSessionId({
+    providerSchema: resolved.provider.schema,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    from: senderId,
+    chatId,
+    channel,
+    instanceId: instance.id,
+    personId,
+    rawPayload: rawPl,
+    threadId: rawThreadId,
+  });
+  const sessionId = sessionIdentity.sessionId;
+  const explicitKhalSessionId = sessionIdentity.canonicalSessionId;
   const replyToId = messages[0]?.payload.replyToId ?? messages[0]?.payload.externalId;
 
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
@@ -2205,10 +2215,20 @@ async function dispatchViaProvider(
   }
 
   const rawThreadId = extractThreadId(messages);
-  const explicitKhalSessionId = extractKhalSessionId(messages);
-  const sessionId =
-    explicitKhalSessionId ??
-    computeSessionId(instance.agentSessionStrategy ?? 'per_chat', senderId, chatId, rawThreadId);
+  const rawPl = (messages[0]?.payload.rawPayload ?? {}) as Record<string, unknown>;
+  const sessionIdentity = resolveKhalSessionId({
+    providerSchema: provider.schema,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    from: senderId,
+    chatId,
+    channel,
+    instanceId: instance.id,
+    personId,
+    rawPayload: rawPl,
+    threadId: rawThreadId,
+  });
+  const sessionId = sessionIdentity.sessionId;
+  const explicitKhalSessionId = sessionIdentity.canonicalSessionId;
 
   // Build context messages for group and DM conversations (messages since last bot response)
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
@@ -3917,7 +3937,16 @@ async function processReactionTrigger(
       // Build AgentTrigger for the provider
       const effectivePersonId = reactionPersonId ?? metadata.personId;
       const senderName = await services.agentRunner.getSenderName(effectivePersonId, undefined);
-      const sessionId = computeSessionId(instance.agentSessionStrategy ?? 'per_chat', payload.from, externalChatId);
+      const sessionId = resolveKhalSessionId({
+        providerSchema: provider.schema,
+        sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+        from: payload.from,
+        chatId: externalChatId,
+        channel,
+        instanceId: instance.id,
+        personId: effectivePersonId,
+        rawPayload: payload.rawPayload as Record<string, unknown> | undefined,
+      }).sessionId;
       const customerContext = await resolveCustomerContext(services, effectivePersonId);
 
       const trigger: AgentTrigger = {

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -265,6 +265,19 @@ function emitLifecycleSpan(name: string, attributes: Record<string, LifecycleAtt
   });
 }
 
+function activeProviderTraceContext(): AgentTrigger['traceContext'] {
+  const activeSpan = trace.getActiveSpan();
+  const spanContext = activeSpan?.spanContext();
+  if (!spanContext?.traceId || !spanContext?.spanId) return undefined;
+
+  return {
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+    traceFlags: spanContext.traceFlags,
+    traceState: spanContext.traceState?.serialize(),
+  };
+}
+
 // ============================================================================
 // Plugin → AckProvider adapter
 // ============================================================================
@@ -2253,104 +2266,122 @@ async function dispatchViaProvider(
     inputText: messageTexts.join('\n'),
   };
 
-  emitLifecycleSpan(
-    'omni.provider_inbound',
+  return withLifecycleSpan(
+    'omni.turn',
     buildLifecycleSpanAttributes({
       ...lifecycleBase,
-      stage: 'provider_inbound',
-      extra: { trigger_type: triggerType, message_count: messages.length },
+      stage: 'turn',
+      extra: {
+        trigger_type: triggerType,
+        message_count: messages.length,
+        provider_id: provider.id,
+        provider_schema: provider.schema,
+      },
     }),
-  );
+    async () => {
+      await withLifecycleSpan(
+        'omni.provider_inbound',
+        buildLifecycleSpanAttributes({
+          ...lifecycleBase,
+          stage: 'provider_inbound',
+          extra: { trigger_type: triggerType, message_count: messages.length },
+        }),
+        async () => undefined,
+      );
 
-  // ── Turn-based mode: delegate to extracted helper ──
-  if (provider.mode === 'turn-based') {
-    return dispatchViaTurnBasedProvider(services, instance, provider, trigger, messages, chatId, traceId, db);
-  }
+      // ── Turn-based mode: delegate to extracted helper ──
+      if (provider.mode === 'turn-based') {
+        return dispatchViaTurnBasedProvider(services, instance, provider, trigger, messages, chatId, traceId, db);
+      }
 
-  // ── Standard (round-trip / fire-and-forget) dispatch ──
-  const correlationId = messages[0]?.metadata.correlationId;
-  const dispatchStart = Date.now();
-  const result = await withLifecycleSpan(
-    'omni.dispatch_to_agno',
-    buildLifecycleSpanAttributes({
-      ...lifecycleBase,
-      stage: 'dispatch_to_agno',
-      extra: { trigger_type: triggerType, provider_id: provider.id, provider_schema: provider.schema },
-    }),
-    () => provider.trigger(trigger),
-  );
-  const dispatchDurationMs = Date.now() - dispatchStart;
+      // ── Standard (round-trip / fire-and-forget) dispatch ──
+      const correlationId = messages[0]?.metadata.correlationId;
+      const dispatchStart = Date.now();
+      const result = await withLifecycleSpan(
+        'omni.dispatch_to_agno',
+        buildLifecycleSpanAttributes({
+          ...lifecycleBase,
+          stage: 'dispatch_to_agno',
+          extra: { trigger_type: triggerType, provider_id: provider.id, provider_schema: provider.schema },
+        }),
+        () => provider.trigger({ ...trigger, traceContext: activeProviderTraceContext() ?? trigger.traceContext }),
+      );
+      const dispatchDurationMs = Date.now() - dispatchStart;
 
-  // Sentry metrics: agent dispatch count and latency
-  if (sentryEnabled()) {
-    Sentry.metrics.count('agent.dispatch', 1, { attributes: { provider_type: provider.schema } });
-    Sentry.metrics.distribution('agent.dispatch.latency', dispatchDurationMs, {
-      unit: 'millisecond',
-      attributes: { provider_type: provider.schema },
-    });
-  }
+      // Sentry metrics: agent dispatch count and latency
+      if (sentryEnabled()) {
+        Sentry.metrics.count('agent.dispatch', 1, { attributes: { provider_type: provider.schema } });
+        Sentry.metrics.distribution('agent.dispatch.latency', dispatchDurationMs, {
+          unit: 'millisecond',
+          attributes: { provider_type: provider.schema },
+        });
+      }
 
-  // If the agent triggered a handoff during this run (agentPaused: true),
-  // suppress the response — the handoff message already notified the user.
-  const chatAfterRun = await services.chats.findByExternalIdSmart(instance.id, chatId);
-  const handoffTriggered = (chatAfterRun?.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
+      // If the agent triggered a handoff during this run (agentPaused: true),
+      // suppress the response — the handoff message already notified the user.
+      const chatAfterRun = await services.chats.findByExternalIdSmart(instance.id, chatId);
+      const handoffTriggered = (chatAfterRun?.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
 
-  if (result && result.parts.length > 0 && !handoffTriggered) {
-    const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
-    const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
-    // Apply before_message_write hooks to each response part before sending
-    const parts = await Promise.all(rawParts.map((part) => executeBeforeMessageWriteHooks(instance.id, chatId, part)));
-    const _fmtMode = (instance.messageFormatMode as 'convert' | 'passthrough') ?? 'convert';
-    const replyTo = messages[0]?.payload.replyToId ?? messages[0]?.payload.externalId;
+      if (result && result.parts.length > 0 && !handoffTriggered) {
+        const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
+        const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
+        // Apply before_message_write hooks to each response part before sending
+        const parts = await Promise.all(
+          rawParts.map((part) => executeBeforeMessageWriteHooks(instance.id, chatId, part)),
+        );
+        const _fmtMode = (instance.messageFormatMode as 'convert' | 'passthrough') ?? 'convert';
+        const replyTo = messages[0]?.payload.replyToId ?? messages[0]?.payload.externalId;
 
-    // T8: Processing send request
-    recordJourneyCheckpoint(correlationId, 'T8', JOURNEY_STAGES.T8);
+        // T8: Processing send request
+        recordJourneyCheckpoint(correlationId, 'T8', JOURNEY_STAGES.T8);
 
-    await withLifecycleSpan(
-      'omni.provider_outbound',
-      buildLifecycleSpanAttributes({
-        ...lifecycleBase,
-        stage: 'provider_outbound',
-        outputText: parts.join('\n'),
-        extra: { parts_count: parts.length, provider_id: provider.id, provider_schema: provider.schema },
-      }),
-      () =>
-        sendResponseParts(
-          channel,
-          instance.id,
+        await withLifecycleSpan(
+          'omni.provider_outbound',
+          buildLifecycleSpanAttributes({
+            ...lifecycleBase,
+            stage: 'provider_outbound',
+            outputText: parts.join('\n'),
+            extra: { parts_count: parts.length, provider_id: provider.id, provider_schema: provider.schema },
+          }),
+          () =>
+            sendResponseParts(
+              channel,
+              instance.id,
+              chatId,
+              parts,
+              getSplitDelayConfig(instance),
+              _fmtMode,
+              replyTo,
+              correlationId,
+              senderAgentId,
+            ),
+        );
+
+        // T9: Outbound sent via plugin
+        recordJourneyCheckpoint(correlationId, 'T9', JOURNEY_STAGES.T9);
+
+        // T10: Agent chaining — forward response to chained instance if configured
+        await forwardToChainedInstance(instance, parts, correlationId, messages);
+      } else if (handoffTriggered) {
+        log.info('Agent response suppressed — handoff triggered during run', {
+          instanceId: instance.id,
           chatId,
-          parts,
-          getSplitDelayConfig(instance),
-          _fmtMode,
-          replyTo,
-          correlationId,
-          senderAgentId,
-        ),
-    );
+        });
+      }
 
-    // T9: Outbound sent via plugin
-    recordJourneyCheckpoint(correlationId, 'T9', JOURNEY_STAGES.T9);
+      log.info('Agent response via IAgentProvider', {
+        instanceId: instance.id,
+        chatId,
+        parts: result?.parts.length ?? 0,
+        providerId: result?.metadata.providerId,
+        durationMs: result?.metadata.durationMs,
+        triggerType,
+        traceId,
+      });
 
-    // T10: Agent chaining — forward response to chained instance if configured
-    await forwardToChainedInstance(instance, parts, correlationId, messages);
-  } else if (handoffTriggered) {
-    log.info('Agent response suppressed — handoff triggered during run', {
-      instanceId: instance.id,
-      chatId,
-    });
-  }
-
-  log.info('Agent response via IAgentProvider', {
-    instanceId: instance.id,
-    chatId,
-    parts: result?.parts.length ?? 0,
-    providerId: result?.metadata.providerId,
-    durationMs: result?.metadata.durationMs,
-    triggerType,
-    traceId,
-  });
-
-  return true;
+      return true;
+    },
+  );
 }
 
 /**

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -17,6 +17,7 @@
  * - Preserves existing debouncing for message events
  */
 
+import { createHash } from 'node:crypto';
 import { unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -67,6 +68,7 @@ import type { AgentProvider, Database } from '@omni/db';
 import { agentSessions, agents, instances } from '@omni/db';
 import type { ChannelType, Instance } from '@omni/db';
 import { createMediaProcessingService } from '@omni/media-processing';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/bun';
 import { and, eq } from 'drizzle-orm';
 import { withIdempotency } from '../lib/idempotency';
@@ -108,6 +110,160 @@ const QUOTED_MESSAGE_MAX_CHARS = 4000;
 
 /** Hard cap on history messages fetched for DM conversations. */
 const DM_HISTORY_LIMIT = 20;
+
+const LIFECYCLE_PREVIEW_MAX_CHARS = 160;
+const LIFECYCLE_SENSITIVE_KEY_PARTS = ['authorization', 'bearer', 'password', 'secret', 'token', 'api_key', 'apikey'];
+
+type LifecycleAttributeValue = string | number | boolean;
+
+interface LifecycleSpanAttributeInput {
+  stage: 'provider_inbound' | 'dispatch_to_agno' | 'provider_outbound' | 'turn';
+  eventType: string;
+  channel: string;
+  provider?: string;
+  instanceId?: string;
+  chatId?: string;
+  sessionId?: string;
+  traceId?: string;
+  messageId?: string;
+  agentId?: string;
+  inputText?: string;
+  outputText?: string;
+  extra?: Record<string, unknown>;
+}
+
+function sha256Digest(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function redactLifecycleText(value: string): string {
+  return value
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[EMAIL]')
+    .replace(/\b\+?\d[\d\s().-]{5,}\d\b/g, '[PHONE]')
+    .replace(/\b\d{6,}\b/g, '[NUMBER]')
+    .replace(/\b[^\s@]+@(s\.whatsapp\.net|g\.us|lid|newsletter)\b/gi, '[JID]');
+}
+
+function previewLifecycleText(value: string): string {
+  const redacted = redactLifecycleText(value).replace(/\s+/g, ' ').trim();
+  if (redacted.length <= LIFECYCLE_PREVIEW_MAX_CHARS) return redacted;
+  return `${redacted.slice(0, LIFECYCLE_PREVIEW_MAX_CHARS - 1)}…`;
+}
+
+function isLifecycleSafeExtraKey(key: string): boolean {
+  const lowered = key.toLowerCase();
+  return !LIFECYCLE_SENSITIVE_KEY_PARTS.some((part) => lowered.includes(part));
+}
+
+function setTextLifecycleAttributes(
+  attributes: Record<string, LifecycleAttributeValue>,
+  prefix: 'input' | 'output',
+  value: string | undefined,
+): void {
+  if (value === undefined) return;
+  attributes[`khal.${prefix}_chars`] = value.length;
+  attributes[`khal.${prefix}_sha256`] = sha256Digest(value);
+  attributes[`khal.${prefix}_preview_redacted`] = previewLifecycleText(value);
+}
+
+function setOptionalLifecycleAttributes(
+  attributes: Record<string, LifecycleAttributeValue>,
+  pairs: Array<[string, string | undefined]>,
+): void {
+  for (const [key, value] of pairs) {
+    if (value) attributes[key] = value;
+  }
+}
+
+function setChatLifecycleAttributes(
+  attributes: Record<string, LifecycleAttributeValue>,
+  chatId: string | undefined,
+): void {
+  if (!chatId) return;
+  attributes['omni.chat_id_sha256'] = sha256Digest(chatId);
+  attributes['omni.chat_id_preview_redacted'] = previewLifecycleText(chatId);
+}
+
+function setSessionLifecycleAttributes(
+  attributes: Record<string, LifecycleAttributeValue>,
+  sessionId: string | undefined,
+): void {
+  if (!sessionId) return;
+  attributes['khal.session_id'] = sessionId;
+  attributes['langfuse.session.id'] = sessionId;
+  attributes['session.id'] = sessionId;
+}
+
+function setExtraLifecycleAttributes(
+  attributes: Record<string, LifecycleAttributeValue>,
+  extra: Record<string, unknown> | undefined,
+): void {
+  if (!extra) return;
+  for (const [key, value] of Object.entries(extra)) {
+    if (!isLifecycleSafeExtraKey(key) || value === undefined || value === null) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      attributes[`khal.${key}`] = typeof value === 'string' ? previewLifecycleText(value) : value;
+    }
+  }
+}
+
+function buildLifecycleSpanAttributes(input: LifecycleSpanAttributeInput): Record<string, LifecycleAttributeValue> {
+  const attributes: Record<string, LifecycleAttributeValue> = {
+    'khal.lifecycle.stage': input.stage,
+    'khal.event_type': input.eventType,
+    'khal.channel': input.channel,
+  };
+
+  setOptionalLifecycleAttributes(attributes, [
+    ['khal.provider', input.provider],
+    ['omni.instance_id', input.instanceId],
+    ['khal.trace_id', input.traceId],
+    ['khal.turn.message_id', input.messageId],
+    ['khal.agent_id', input.agentId],
+  ]);
+  setChatLifecycleAttributes(attributes, input.chatId);
+  setSessionLifecycleAttributes(attributes, input.sessionId);
+  setTextLifecycleAttributes(attributes, 'input', input.inputText);
+  setTextLifecycleAttributes(attributes, 'output', input.outputText);
+  setExtraLifecycleAttributes(attributes, input.extra);
+
+  return attributes;
+}
+
+async function withLifecycleSpan<T>(
+  name: string,
+  attributes: Record<string, LifecycleAttributeValue>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  let callbackStarted = false;
+  try {
+    const tracer = trace.getTracer('omni.agent-dispatcher');
+    return await tracer.startActiveSpan(name, { attributes }, async (span) => {
+      callbackStarted = true;
+      try {
+        const result = await fn();
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      } catch (error) {
+        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : String(error) });
+        throw error;
+      } finally {
+        span.end();
+      }
+    });
+  } catch (error) {
+    if (callbackStarted) throw error;
+    log.warn('Lifecycle span wrapper failed before dispatch; continuing without span', { spanName: name });
+    return fn();
+  }
+}
+
+function emitLifecycleSpan(name: string, attributes: Record<string, LifecycleAttributeValue>): void {
+  withLifecycleSpan(name, attributes, async () => undefined).catch(() => {
+    // best-effort — never throw from instrumentation path
+  });
+}
 
 // ============================================================================
 // Plugin → AckProvider adapter
@@ -1960,7 +2116,24 @@ async function dispatchViaTurnBasedProvider(
 
   // Dispatch (fire-and-forget — agent uses verb commands + omni done)
   const dispatchStart = Date.now();
-  await provider.trigger(trigger);
+  await withLifecycleSpan(
+    'omni.dispatch_to_agno',
+    buildLifecycleSpanAttributes({
+      stage: 'dispatch_to_agno',
+      eventType: 'user_message_turn',
+      channel: instance.channel,
+      provider: provider.schema,
+      instanceId: instance.id,
+      chatId,
+      sessionId: trigger.sessionId,
+      traceId,
+      messageId,
+      agentId: agentRecord.id,
+      inputText: trigger.content.text,
+      extra: { mode: 'turn-based', provider_id: provider.id, provider_schema: provider.schema },
+    }),
+    () => provider.trigger(trigger),
+  );
   const dispatchDurationMs = Date.now() - dispatchStart;
 
   if (sentryEnabled()) {
@@ -2067,6 +2240,28 @@ async function dispatchViaProvider(
     explicitKhalSessionId,
   );
 
+  const lifecycleBase = {
+    eventType: 'user_message_turn',
+    channel,
+    provider: provider.schema,
+    instanceId: instance.id,
+    chatId,
+    sessionId,
+    traceId,
+    messageId: messages[0]?.payload.externalId,
+    agentId: instance.agentInternalId ?? instance.agentId ?? undefined,
+    inputText: messageTexts.join('\n'),
+  };
+
+  emitLifecycleSpan(
+    'omni.provider_inbound',
+    buildLifecycleSpanAttributes({
+      ...lifecycleBase,
+      stage: 'provider_inbound',
+      extra: { trigger_type: triggerType, message_count: messages.length },
+    }),
+  );
+
   // ── Turn-based mode: delegate to extracted helper ──
   if (provider.mode === 'turn-based') {
     return dispatchViaTurnBasedProvider(services, instance, provider, trigger, messages, chatId, traceId, db);
@@ -2075,7 +2270,15 @@ async function dispatchViaProvider(
   // ── Standard (round-trip / fire-and-forget) dispatch ──
   const correlationId = messages[0]?.metadata.correlationId;
   const dispatchStart = Date.now();
-  const result = await provider.trigger(trigger);
+  const result = await withLifecycleSpan(
+    'omni.dispatch_to_agno',
+    buildLifecycleSpanAttributes({
+      ...lifecycleBase,
+      stage: 'dispatch_to_agno',
+      extra: { trigger_type: triggerType, provider_id: provider.id, provider_schema: provider.schema },
+    }),
+    () => provider.trigger(trigger),
+  );
   const dispatchDurationMs = Date.now() - dispatchStart;
 
   // Sentry metrics: agent dispatch count and latency
@@ -2103,16 +2306,26 @@ async function dispatchViaProvider(
     // T8: Processing send request
     recordJourneyCheckpoint(correlationId, 'T8', JOURNEY_STAGES.T8);
 
-    await sendResponseParts(
-      channel,
-      instance.id,
-      chatId,
-      parts,
-      getSplitDelayConfig(instance),
-      _fmtMode,
-      replyTo,
-      correlationId,
-      senderAgentId,
+    await withLifecycleSpan(
+      'omni.provider_outbound',
+      buildLifecycleSpanAttributes({
+        ...lifecycleBase,
+        stage: 'provider_outbound',
+        outputText: parts.join('\n'),
+        extra: { parts_count: parts.length, provider_id: provider.id, provider_schema: provider.schema },
+      }),
+      () =>
+        sendResponseParts(
+          channel,
+          instance.id,
+          chatId,
+          parts,
+          getSplitDelayConfig(instance),
+          _fmtMode,
+          replyTo,
+          correlationId,
+          senderAgentId,
+        ),
     );
 
     // T9: Outbound sent via plugin
@@ -2200,20 +2413,57 @@ async function dispatchViaLegacy(
     mediaFiles.length > 0 ? (mediaFiles as unknown as ProviderFile[]) : undefined,
   );
 
-  const result = await services.agentRunner.run({
-    instance,
-    chatId,
-    personId,
+  const lifecycleSessionId = computeSessionId(
+    instance.agentSessionStrategy ?? 'per_chat',
     senderId,
-    senderName,
-    senderAvatarUrl,
-    senderPlatformUsername,
-    chatType,
-    chatName,
-    participantCount,
-    messages: messageTexts,
-    files: mediaFiles.length > 0 ? mediaFiles : undefined,
-  });
+    chatId,
+    (rawPl as Record<string, unknown>).threadId as string | undefined,
+  );
+  const lifecycleBase = {
+    eventType: 'user_message_turn',
+    channel,
+    provider: 'legacy-agent-runner',
+    instanceId: instance.id,
+    chatId,
+    sessionId: lifecycleSessionId,
+    traceId,
+    messageId: messages[0]?.payload.externalId,
+    agentId: instance.agentInternalId ?? instance.agentId ?? undefined,
+    inputText: messageTexts.join('\n'),
+  };
+
+  emitLifecycleSpan(
+    'omni.provider_inbound',
+    buildLifecycleSpanAttributes({
+      ...lifecycleBase,
+      stage: 'provider_inbound',
+      extra: { trigger_type: triggerType, message_count: messages.length },
+    }),
+  );
+
+  const result = await withLifecycleSpan(
+    'omni.dispatch_to_agno',
+    buildLifecycleSpanAttributes({
+      ...lifecycleBase,
+      stage: 'dispatch_to_agno',
+      extra: { trigger_type: triggerType, provider_schema: 'legacy-agent-runner' },
+    }),
+    () =>
+      services.agentRunner.run({
+        instance,
+        chatId,
+        personId,
+        senderId,
+        senderName,
+        senderAvatarUrl,
+        senderPlatformUsername,
+        chatType,
+        chatName,
+        participantCount,
+        messages: messageTexts,
+        files: mediaFiles.length > 0 ? mediaFiles : undefined,
+      }),
+  );
 
   const correlationId = messages[0]?.metadata.correlationId;
   const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
@@ -2228,16 +2478,26 @@ async function dispatchViaLegacy(
   // T8: Processing send request
   recordJourneyCheckpoint(correlationId, 'T8', JOURNEY_STAGES.T8);
 
-  await sendResponseParts(
-    channel,
-    instance.id,
-    chatId,
-    parts,
-    getSplitDelayConfig(instance),
-    _fmtMode,
-    replyTo,
-    correlationId,
-    senderAgentId,
+  await withLifecycleSpan(
+    'omni.provider_outbound',
+    buildLifecycleSpanAttributes({
+      ...lifecycleBase,
+      stage: 'provider_outbound',
+      outputText: parts.join('\n'),
+      extra: { parts_count: parts.length, provider_schema: 'legacy-agent-runner' },
+    }),
+    () =>
+      sendResponseParts(
+        channel,
+        instance.id,
+        chatId,
+        parts,
+        getSplitDelayConfig(instance),
+        _fmtMode,
+        replyTo,
+        correlationId,
+        senderAgentId,
+      ),
   );
 
   // T9: Outbound sent via plugin
@@ -4874,6 +5134,7 @@ export const __test__ = {
   getDebounceConfig,
   extractKhalSessionId,
   buildTriggerHeaders,
+  buildLifecycleSpanAttributes,
   createNatsGenieProviderInstance,
   /** Override the NatsGenieProvider constructor for tests (avoids barrel mock contamination). */
   set NatsGenieProviderClass(cls: typeof NatsGenieProvider) {

--- a/packages/api/src/plugins/session-cleaner.ts
+++ b/packages/api/src/plugins/session-cleaner.ts
@@ -10,11 +10,11 @@
 import type { EventBus, TypedOmniEvent } from '@omni/core';
 import { createAgnoClient, createLogger } from '@omni/core';
 import type { ChannelType, Database } from '@omni/db';
-import { agents } from '@omni/db';
-import { eq } from 'drizzle-orm';
+import { agents, chatParticipants } from '@omni/db';
+import { and, eq } from 'drizzle-orm';
 import { withIdempotency } from '../lib/idempotency';
 import type { Services } from '../services';
-import { computeSessionId } from '../services/agent-runner';
+import { type ResolvedAgentSessionIdentity, resolveKhalSessionId } from '../services/agent-session-identity';
 import { applyAgentFkOverrides, resolveProvider } from './agent-dispatcher';
 import { getPlugin } from './loader';
 
@@ -55,13 +55,36 @@ async function sendMessage(services: Services, instanceId: string, chatId: strin
  * Tries IAgentProvider.resetSession() first (supports OpenClaw, Webhook, etc.),
  * falls back to direct AgnoOS client for legacy.
  */
+async function resolveCleanupPersonId(
+  services: Services,
+  db: Database,
+  instanceId: string,
+  chatId: string,
+  from: string,
+  metadataPersonId?: string,
+): Promise<string | undefined> {
+  if (metadataPersonId?.trim()) return metadataPersonId.trim();
+
+  const dbChat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+  if (!dbChat?.id) return undefined;
+
+  const [participant] = await db
+    .select({ personId: chatParticipants.personId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, dbChat.id), eq(chatParticipants.platformUserId, from)))
+    .limit(1);
+
+  return participant?.personId ?? undefined;
+}
+
 export async function clearAgentSession(
   services: Services,
   db: Database,
   instanceId: string,
   from: string,
   chatId: string,
-): Promise<{ sessionId: string; sessionStrategy: string }> {
+  options: { personId?: string; rawPayload?: Record<string, unknown> } = {},
+): Promise<ResolvedAgentSessionIdentity> {
   // Get instance with provider
   const instance = await services.agentRunner.getInstanceWithProvider(instanceId);
 
@@ -83,9 +106,22 @@ export async function clearAgentSession(
   // Get provider record from DB
   const providerRecord = await services.providers.getById(agentRow.agentProviderId);
 
-  // Compute session ID using the same strategy as agent-runner
-  const sessionStrategy = instance.agentSessionStrategy ?? 'per_chat';
-  const sessionId = computeSessionId(sessionStrategy, from, chatId);
+  const personId = await resolveCleanupPersonId(services, db, instanceId, chatId, from, options.personId);
+  const identity = resolveKhalSessionId({
+    providerSchema: providerRecord.schema,
+    sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
+    from,
+    chatId,
+    channel: instance.channel,
+    instanceId,
+    personId,
+    rawPayload: options.rawPayload,
+  });
+  const { sessionId, legacySessionId } = identity;
+  const hasKhalContext = !!identity.canonicalSessionId || !!identity.environment || !!options.rawPayload?.khalSessionId;
+  if (providerRecord.schema === 'agno' && hasKhalContext && identity.source === 'legacy') {
+    throw new Error('Canonical KHAL session resolution failed; refusing blind legacy Agno reset');
+  }
 
   // Try IAgentProvider.resetSession() first (covers OpenClaw, Agno, Claude, etc.)
   // Pass chatId so providers that build their own key format (e.g. OpenClaw)
@@ -100,7 +136,10 @@ export async function clearAgentSession(
   const agentProvider = resolveProvider(providerRecord, dispatchInstance, db);
   if (agentProvider?.resetSession) {
     await agentProvider.resetSession(sessionId, chatId, instanceId);
-    return { sessionId, sessionStrategy };
+    if (legacySessionId !== sessionId) {
+      await agentProvider.resetSession(legacySessionId, chatId, instanceId);
+    }
+    return identity;
   }
 
   // Fallback: direct AgnoOS client
@@ -114,9 +153,19 @@ export async function clearAgentSession(
     defaultTimeoutMs: (providerRecord.defaultTimeout ?? 60) * 1000,
   });
 
-  await client.deleteSession?.(sessionId);
+  const primaryDelete = await client.deleteSession?.(sessionId);
+  const legacyDelete = legacySessionId !== sessionId ? await client.deleteSession?.(legacySessionId) : undefined;
+  log.info('Agno session delete verified', {
+    instanceId,
+    sessionId,
+    legacySessionId,
+    primaryStatus: primaryDelete?.status,
+    primaryExisted: primaryDelete?.existed,
+    legacyStatus: legacyDelete?.status,
+    legacyExisted: legacyDelete?.existed,
+  });
 
-  return { sessionId, sessionStrategy };
+  return identity;
 }
 
 /**
@@ -135,14 +184,14 @@ async function handleTrashEmojiMessage(
   db: Database,
   event: TypedOmniEvent<'message.received'>,
 ): Promise<void> {
-  const { content, chatId, from } = event.payload;
+  const { content, chatId } = event.payload;
   const { instanceId } = event.metadata;
 
   if (!instanceId || !content?.text) return;
   if (!isTrashEmojiOnly(content.text)) return;
 
   const result = await withIdempotency(db, event.id, 'session-cleaner', async () => {
-    await runTrashEmojiCleanup(services, db, instanceId, chatId, from);
+    await runTrashEmojiCleanup(services, db, event);
   });
 
   if (!result.executed) {
@@ -157,16 +206,30 @@ async function handleTrashEmojiMessage(
 async function runTrashEmojiCleanup(
   services: Services,
   db: Database,
-  instanceId: string,
-  chatId: string,
-  from: string,
+  event: TypedOmniEvent<'message.received'>,
 ): Promise<void> {
-  log.info('Trash emoji detected, clearing session', { instanceId, chatId, from });
+  const { chatId, from, rawPayload } = event.payload;
+  const { instanceId, personId } = event.metadata;
+  if (!instanceId) return;
+
+  log.info('Trash emoji detected, clearing session', { instanceId, chatId, from, personId });
 
   try {
-    const { sessionId, sessionStrategy } = await clearAgentSession(services, db, instanceId, from, chatId);
+    const identity = await clearAgentSession(services, db, instanceId, from, chatId, { personId, rawPayload });
+    const { sessionId, legacySessionId, sessionStrategy, source, canonicalSessionId, environment, channelSegment } =
+      identity;
 
-    log.info('Session cleared successfully', { instanceId, sessionId, sessionStrategy });
+    log.info('Session cleared successfully', {
+      instanceId,
+      sessionId,
+      legacySessionId,
+      sessionStrategy,
+      source,
+      canonicalSessionId,
+      personId: identity.personId,
+      environment,
+      channelSegment,
+    });
 
     // Disarm any active follow-up sequence — clearing the session means the
     // user has explicitly reset the conversation; queued follow-ups referencing

--- a/packages/api/src/providers/gemini/videogen.test.ts
+++ b/packages/api/src/providers/gemini/videogen.test.ts
@@ -73,7 +73,7 @@ describe('GeminiVideoGenProvider', () => {
     expect(request.prompt).toContain('1. hero frame');
   });
 
-  it('preserves generateAudio for text-to-video requests', async () => {
+  it('omits generateAudio for text-to-video requests because current Veo 3.1 API rejects it', async () => {
     generateVideoCalls.length = 0;
     const provider = new GeminiVideoGenProvider({
       getSecret: async () => 'test-gemini-key',
@@ -84,10 +84,10 @@ describe('GeminiVideoGenProvider', () => {
 
     expect(generateVideoCalls).toHaveLength(1);
     const request = generateVideoCalls[0] as { config?: Record<string, unknown> };
-    expect(request.config?.generateAudio).toBe(true);
+    expect(request.config?.generateAudio).toBeUndefined();
   });
 
-  it('can disable generated audio for text-to-video requests', async () => {
+  it('treats --no-audio as a compatibility no-op while generateAudio is unsupported', async () => {
     generateVideoCalls.length = 0;
     const provider = new GeminiVideoGenProvider({
       getSecret: async () => 'test-gemini-key',
@@ -98,6 +98,6 @@ describe('GeminiVideoGenProvider', () => {
 
     expect(generateVideoCalls).toHaveLength(1);
     const request = generateVideoCalls[0] as { config?: Record<string, unknown> };
-    expect(request.config?.generateAudio).toBe(false);
+    expect(request.config?.generateAudio).toBeUndefined();
   });
 });

--- a/packages/api/src/providers/gemini/videogen.ts
+++ b/packages/api/src/providers/gemini/videogen.ts
@@ -70,7 +70,9 @@ export class GeminiVideoGenProvider implements IVideoGenProvider {
         ...(options?.durationSec !== undefined ? { durationSeconds: options.durationSec } : {}),
         ...(options?.seed !== undefined ? { seed: options.seed } : {}),
         ...(options?.resolution !== undefined ? { resolution: options.resolution } : {}),
-        ...(!options?.imageBase64 ? { generateAudio: options?.audio !== false } : {}),
+        // The current Gemini Veo 3.1 API rejects generateAudio in this SDK path.
+        // Keep --no-audio as a no-op compatibility flag until the provider exposes
+        // a supported audio toggle again.
       },
     };
     if (options?.imageBase64) {

--- a/packages/api/src/routes/v2/__tests__/messages-send-media.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-send-media.test.ts
@@ -67,4 +67,44 @@ describe('POST /messages/send/media', () => {
       },
     });
   });
+
+  test('forwards WhatsApp voice-note audio as audioBuffer instead of base64', async () => {
+    const sendMessage = mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'VOICE-MSG-ID',
+      timestamp: 123,
+    }));
+    const app = mountMessagesRoutes(sendMessage);
+    const audio = Buffer.from('ogg-opus-bytes');
+
+    const res = await app.request('/messages/send/media', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: '11111111-1111-4111-8111-111111111111',
+        to: '5511999999999@s.whatsapp.net',
+        type: 'audio',
+        base64: audio.toString('base64'),
+        filename: 'voice.ogg',
+        voiceNote: true,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const message = sendMessage.mock.calls[0]?.[1] as { metadata?: Record<string, unknown> };
+    expect(message).toMatchObject({
+      content: {
+        type: 'audio',
+        filename: 'voice.ogg',
+        mimeType: 'audio/ogg; codecs=opus',
+      },
+      metadata: {
+        ptt: true,
+      },
+    });
+    expect(message.metadata?.base64).toBeUndefined();
+    expect(Buffer.isBuffer(message.metadata?.audioBuffer)).toBe(true);
+    expect((message.metadata?.audioBuffer as Buffer).equals(audio)).toBe(true);
+  });
 });

--- a/packages/api/src/routes/v2/__tests__/messages-send-reaction.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-send-reaction.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { NotFoundError } from '@omni/core';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { messagesRoutes } from '../messages';
+
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const CHAT_ID = '22222222-2222-4222-8222-222222222222';
+const OTHER_CHAT_ID = '44444444-4444-4444-8444-444444444444';
+const OMNI_MESSAGE_ID = '33333333-3333-4333-8333-333333333333';
+const CHAT_EXTERNAL_ID = '51961151926407@lid';
+const MESSAGE_EXTERNAL_ID = '2A0726AEA0EE1EB26093';
+
+type MountOptions = {
+  sendMessage?: ReturnType<typeof mock>;
+  chatFound?: boolean;
+  messageChatId?: string;
+  getByIdThrows?: boolean;
+  getByIdError?: Error;
+};
+
+function mountMessagesRoutes(options: MountOptions = {}): Hono<{ Variables: AppVariables }> {
+  const sendMessage =
+    options.sendMessage ??
+    mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'REACTION-MSG-ID',
+      timestamp: 123,
+    }));
+
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async (id: string) => ({ id, channel: 'whatsapp-baileys' })),
+      },
+      persons: {
+        getIdentityForChannel: mock(async () => null),
+      },
+      chats: {
+        getById: mock(async (id: string) => ({ id, externalId: CHAT_EXTERNAL_ID })),
+        findByExternalIdSmart: mock(async () =>
+          options.chatFound === false
+            ? null
+            : {
+                id: CHAT_ID,
+                externalId: CHAT_EXTERNAL_ID,
+              },
+        ),
+      },
+      messages: {
+        getById: mock(async (id: string) => {
+          if (options.getByIdError) throw options.getByIdError;
+          if (options.getByIdThrows) throw new NotFoundError('Message', id);
+          return {
+            id,
+            chatId: options.messageChatId ?? CHAT_ID,
+            externalId: MESSAGE_EXTERNAL_ID,
+            isFromMe: false,
+            rawPayload: {
+              key: {
+                id: MESSAGE_EXTERNAL_ID,
+                remoteJid: CHAT_EXTERNAL_ID,
+                fromMe: false,
+              },
+            },
+          };
+        }),
+        getByExternalId: mock(async (_chatId: string, externalId: string) =>
+          externalId === MESSAGE_EXTERNAL_ID
+            ? {
+                id: OMNI_MESSAGE_ID,
+                chatId: CHAT_ID,
+                externalId: MESSAGE_EXTERNAL_ID,
+                isFromMe: false,
+                rawPayload: {
+                  key: {
+                    id: MESSAGE_EXTERNAL_ID,
+                    remoteJid: CHAT_EXTERNAL_ID,
+                    fromMe: false,
+                  },
+                },
+              }
+            : null,
+        ),
+      },
+    } as never);
+    c.set('channelRegistry', {
+      get: mock(() => ({
+        capabilities: { canSendReaction: true },
+        sendMessage,
+      })),
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/messages', messagesRoutes);
+  return app;
+}
+
+async function postReaction(app: Hono<{ Variables: AppVariables }>, messageId: string) {
+  return app.request('/messages/send/reaction', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      instanceId: INSTANCE_ID,
+      to: CHAT_ID,
+      messageId,
+      emoji: '👍',
+    }),
+  });
+}
+
+describe('POST /messages/send/reaction', () => {
+  test('resolves an Omni message UUID to the channel-native external ID before sending', async () => {
+    const sendMessage = mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'REACTION-MSG-ID',
+      timestamp: 123,
+    }));
+    const app = mountMessagesRoutes({ sendMessage });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBe(200);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      to: CHAT_EXTERNAL_ID,
+      content: {
+        type: 'reaction',
+        emoji: '👍',
+        targetMessageId: MESSAGE_EXTERNAL_ID,
+      },
+      metadata: {
+        fromMe: false,
+      },
+    });
+  });
+
+  test('fails closed for an Omni message UUID when the chat cannot be resolved', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, chatFound: false });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('fails closed for an Omni message UUID that belongs to another chat', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, messageChatId: OTHER_CHAT_ID });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('fails closed for an unknown Omni message UUID', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, getByIdThrows: true });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('does not mask unexpected message lookup errors as not found', async () => {
+    const sendMessage = mock(async () => ({ success: true }));
+    const app = mountMessagesRoutes({ sendMessage, getByIdError: new Error('database unavailable') });
+
+    const res = await postReaction(app, OMNI_MESSAGE_ID);
+
+    expect(res.status).toBe(500);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('preserves external message IDs for plugin fallback when DB lookup misses', async () => {
+    const sendMessage = mock(async (_instanceId: string, _message: unknown) => ({
+      success: true,
+      messageId: 'REACTION-MSG-ID',
+      timestamp: 123,
+    }));
+    const app = mountMessagesRoutes({ sendMessage });
+    const externalMessageId = 'EXTERNAL-NOT-IN-DB';
+
+    const res = await postReaction(app, externalMessageId);
+
+    expect(res.status).toBe(200);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      content: {
+        type: 'reaction',
+        emoji: '👍',
+        targetMessageId: externalMessageId,
+      },
+      metadata: {},
+    });
+  });
+});

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -57,7 +57,7 @@ const createInstanceSchema = z.object({
   name: z.string().min(1).max(255).describe('Unique name for the instance'),
   channel: ChannelTypeSchema.describe('Channel type (e.g., whatsapp-baileys, discord)'),
   agentId: z.string().uuid().nullable().optional().describe('Agent UUID referencing agents table'),
-  agentTimeout: z.number().int().positive().default(60).describe('Agent timeout in seconds'),
+  agentTimeout: z.number().int().positive().default(600).describe('Agent timeout in seconds'),
   agentStreamMode: z.boolean().default(false).describe('Enable streaming responses'),
   agentReplyFilter: agentReplyFilterSchema.optional().nullable().describe('When agent should reply'),
   agentSessionStrategy: z

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -39,7 +39,7 @@ import { extname, join } from 'node:path';
 import { zValidator } from '@hono/zod-validator';
 import { sanitizeOutboundText } from '@omni/channel-sdk';
 import type { ChannelRegistry, OutgoingContent, OutgoingMessage } from '@omni/channel-sdk';
-import { ERROR_CODES, JOURNEY_STAGES, OmniError, createLogger, getJourneyTracker } from '@omni/core';
+import { ERROR_CODES, JOURNEY_STAGES, NotFoundError, OmniError, createLogger, getJourneyTracker } from '@omni/core';
 import type { ChatClosedPayload, CloseContactOutcome } from '@omni/core/events';
 import type { ChannelType } from '@omni/core/types';
 import type { Database } from '@omni/db';
@@ -114,6 +114,92 @@ function extractReactionTargetParticipant(rawPayload: Record<string, unknown> | 
   const key = rawPayload?.key as Record<string, unknown> | undefined;
   const participant = key?.participant;
   return typeof participant === 'string' && participant.length > 0 ? participant : undefined;
+}
+
+async function resolveReactionTarget(
+  services: Services,
+  instanceId: string,
+  resolvedTo: string,
+  messageId: string,
+): Promise<{ targetMessageId: string; metadata: Record<string, unknown> }> {
+  const metadata: Record<string, unknown> = {};
+  const chat = await services.chats.findByExternalIdSmart(instanceId, resolvedTo);
+
+  if (!chat) {
+    if (isUUID(messageId)) {
+      throw new OmniError({
+        code: ERROR_CODES.NOT_FOUND,
+        message: `Reaction target message not found: ${messageId}`,
+        context: { instanceId, resolvedTo, messageId },
+        recoverable: false,
+      });
+    }
+
+    log.warn('Reaction target chat not found in DB; deferring fromMe to channel plugin fallback (#386)', {
+      instanceId,
+      resolvedTo,
+      messageId,
+      fallback: 'plugin-heuristic',
+    });
+    return { targetMessageId: messageId, metadata };
+  }
+
+  const target = isUUID(messageId)
+    ? await getReactionTargetByOmniId(services, instanceId, chat.id, messageId)
+    : await services.messages.getByExternalId(chat.id, messageId);
+
+  if (!target) {
+    log.warn('Reaction target message not found in DB; deferring fromMe to channel plugin fallback (#386)', {
+      instanceId,
+      chatId: chat.id,
+      messageId,
+      fallback: 'plugin-heuristic',
+    });
+    return { targetMessageId: messageId, metadata };
+  }
+
+  metadata.fromMe = target.isFromMe === true;
+  if (target.isFromMe !== true) {
+    const participant = extractReactionTargetParticipant(
+      target.rawPayload as Record<string, unknown> | null | undefined,
+    );
+    if (participant) metadata.targetParticipant = participant;
+  }
+
+  return { targetMessageId: target.externalId, metadata };
+}
+
+async function getReactionTargetByOmniId(
+  services: Services,
+  instanceId: string,
+  chatId: string,
+  messageId: string,
+): Promise<Awaited<ReturnType<Services['messages']['getByExternalId']>>> {
+  let target: Awaited<ReturnType<Services['messages']['getById']>>;
+
+  try {
+    target = await services.messages.getById(messageId);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      throw reactionTargetNotFound(instanceId, chatId, messageId);
+    }
+    throw error;
+  }
+
+  if (target.chatId !== chatId) {
+    throw reactionTargetNotFound(instanceId, chatId, messageId);
+  }
+
+  return target;
+}
+
+function reactionTargetNotFound(instanceId: string, chatId: string, messageId: string): OmniError {
+  return new OmniError({
+    code: ERROR_CODES.NOT_FOUND,
+    message: `Reaction target message not found: ${messageId}`,
+    context: { instanceId, chatId, messageId },
+    recoverable: false,
+  });
 }
 
 /**
@@ -1175,39 +1261,16 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
   // Note: For reactions, 'to' is typically a chat ID, but we support person ID resolution too
   const resolvedTo = await resolveRecipient(to, instance.channel, services);
 
-  // Look up the target message to determine fromMe (critical for WhatsApp reactions).
-  // Baileys needs key.fromMe to locate the correct message — if wrong, the reaction
-  // is silently dropped by WhatsApp. When the target isn't in our DB (history gap
-  // or unsynced chat), we leave fromMe undefined and let the channel plugin's
-  // heuristic decide — forcing false here breaks bot-to-own-message reactions (#386).
-  const reactionMetadata: Record<string, unknown> = {};
-  const chat = await services.chats.findByExternalIdSmart(instanceId, resolvedTo);
-  if (chat) {
-    const target = await services.messages.getByExternalId(chat.id, messageId);
-    if (target) {
-      reactionMetadata.fromMe = target.isFromMe === true;
-      if (target.isFromMe !== true) {
-        const participant = extractReactionTargetParticipant(
-          target.rawPayload as Record<string, unknown> | null | undefined,
-        );
-        if (participant) reactionMetadata.targetParticipant = participant;
-      }
-    } else {
-      log.warn('Reaction target message not found in DB; deferring fromMe to channel plugin fallback (#386)', {
-        instanceId,
-        chatId: chat.id,
-        messageId,
-        fallback: 'plugin-heuristic',
-      });
-    }
-  } else {
-    log.warn('Reaction target chat not found in DB; deferring fromMe to channel plugin fallback (#386)', {
-      instanceId,
-      resolvedTo,
-      messageId,
-      fallback: 'plugin-heuristic',
-    });
-  }
+  // Look up the target message to determine the provider-native ID and fromMe
+  // (critical for WhatsApp reactions). CLI/history surfaces Omni message UUIDs,
+  // but Baileys needs the WhatsApp externalId in key.id; sending an Omni UUID can
+  // return command-level success while WhatsApp silently ignores the reaction.
+  const { targetMessageId, metadata: reactionMetadata } = await resolveReactionTarget(
+    services,
+    instanceId,
+    resolvedTo,
+    messageId,
+  );
 
   // Build outgoing message for reaction. When the target is unknown, omit
   // metadata so the plugin applies its own fallback (defaults to true for Baileys).
@@ -1216,7 +1279,7 @@ messagesRoutes.post('/send/reaction', zValidator('json', sendReactionSchema), as
     content: {
       type: 'reaction',
       emoji,
-      targetMessageId: messageId,
+      targetMessageId,
     } as OutgoingContent,
     metadata: reactionMetadata,
   };

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -533,6 +533,21 @@ const sendMediaSchema = z.object({
   threadId: z.string().optional().describe('Thread/topic ID (e.g. Telegram forum topic)'),
 });
 
+function normalizeSendMediaMimeType(data: z.infer<typeof sendMediaSchema>): string {
+  const inferred = data.mimeType ?? inferMediaMimeType(data.type, data.filename);
+  if (data.type === 'audio' && data.voiceNote === true && inferred === 'audio/ogg') {
+    return 'audio/ogg; codecs=opus';
+  }
+  return inferred;
+}
+
+function buildSendMediaMetadata(data: z.infer<typeof sendMediaSchema>): Record<string, unknown> {
+  if (data.type === 'audio' && data.voiceNote === true && data.base64) {
+    return { audioBuffer: Buffer.from(data.base64, 'base64'), ptt: true };
+  }
+  return { base64: data.base64, ptt: data.voiceNote };
+}
+
 // Send reaction schema
 const sendReactionSchema = z.object({
   instanceId: z.string().uuid().describe('Instance ID'),
@@ -1147,7 +1162,7 @@ messagesRoutes.post('/send/media', zValidator('json', sendMediaSchema), async (c
   // Resolve recipient (handles person ID to platform ID resolution)
   const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
 
-  const mediaMimeType = data.mimeType ?? inferMediaMimeType(data.type, data.filename);
+  const mediaMimeType = normalizeSendMediaMimeType(data);
 
   // Build outgoing message
   const outgoingMessage: OutgoingMessage = {
@@ -1160,11 +1175,7 @@ messagesRoutes.post('/send/media', zValidator('json', sendMediaSchema), async (c
       filename: data.filename,
       mimeType: mediaMimeType,
     } as OutgoingContent,
-    metadata: {
-      base64: data.base64,
-      // WhatsApp uses 'ptt' (push-to-talk) flag for voice notes
-      ptt: data.voiceNote,
-    },
+    metadata: buildSendMediaMetadata(data),
   };
 
   // T8: API processed the send request

--- a/packages/api/src/routes/v2/providers.ts
+++ b/packages/api/src/routes/v2/providers.ts
@@ -48,7 +48,7 @@ const providerBaseSchema = z.object({
         'Note: apiKey in schemaConfig overrides the provider-level apiKey.',
     ),
   defaultStream: z.boolean().default(true).describe('Default streaming setting'),
-  defaultTimeout: z.number().int().positive().default(60).describe('Default timeout in seconds'),
+  defaultTimeout: z.number().int().positive().default(600).describe('Default timeout in seconds'),
   supportsStreaming: z.boolean().default(true).describe('Provider supports streaming'),
   supportsImages: z
     .boolean()
@@ -211,7 +211,7 @@ providersRoutes.get('/:id/agents', async (c) => {
   const client = createAgnoClient({
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const allEntries = (await client.discover?.()) ?? [];
@@ -240,7 +240,7 @@ providersRoutes.get('/:id/teams', async (c) => {
   const client = createAgnoClient({
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const allEntries = (await client.discover?.()) ?? [];
@@ -269,7 +269,7 @@ providersRoutes.get('/:id/workflows', async (c) => {
   const client = createAgnoClient({
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const allEntries = (await client.discover?.()) ?? [];

--- a/packages/api/src/schemas/openapi/instances.ts
+++ b/packages/api/src/schemas/openapi/instances.ts
@@ -34,7 +34,7 @@ export const CreateInstanceSchema = z.object({
   name: z.string().min(1).max(255).openapi({ description: 'Unique name for the instance' }),
   channel: ChannelTypeSchema.openapi({ description: 'Channel type' }),
   agentId: z.string().uuid().nullable().optional().openapi({ description: 'Agent UUID (agents table)' }),
-  agentTimeout: z.number().int().positive().default(60).openapi({ description: 'Agent timeout in seconds' }),
+  agentTimeout: z.number().int().positive().default(600).openapi({ description: 'Agent timeout in seconds' }),
   agentStreamMode: z.boolean().default(false).openapi({ description: 'Enable streaming responses' }),
   isDefault: z.boolean().default(false).openapi({ description: 'Set as default instance for channel' }),
   token: z.string().optional().openapi({ description: 'Bot token for Discord instances' }),

--- a/packages/api/src/schemas/openapi/providers.ts
+++ b/packages/api/src/schemas/openapi/providers.ts
@@ -79,7 +79,7 @@ export const CreateProviderSchema = z.object({
       example: { projectPath: '/home/user/my-project', model: 'claude-haiku-4-5-20251001', maxTurns: 5 },
     }),
   defaultStream: z.boolean().default(true).openapi({ description: 'Default streaming' }),
-  defaultTimeout: z.number().int().positive().default(60).openapi({ description: 'Default timeout' }),
+  defaultTimeout: z.number().int().positive().default(600).openapi({ description: 'Default timeout' }),
   supportsStreaming: z.boolean().default(true).openapi({ description: 'Supports streaming' }),
   supportsImages: z
     .boolean()

--- a/packages/api/src/services/__tests__/agent-session-identity.test.ts
+++ b/packages/api/src/services/__tests__/agent-session-identity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildCanonicalKhalSessionId,
+  extractKhalSessionIdFromRawPayload,
+  resolveKhalSessionId,
+} from '../agent-session-identity';
+
+describe('agent session identity', () => {
+  it('extracts explicit KHAL session ids from rawPayload and headers', () => {
+    expect(extractKhalSessionIdFromRawPayload({ khalSessionId: ' khal-session-123 ' })).toBe('khal-session-123');
+    expect(extractKhalSessionIdFromRawPayload({ headers: { 'x-khal-session-id': ' khal-session-456 ' } })).toBe(
+      'khal-session-456',
+    );
+  });
+
+  it('builds canonical HML Gupshup session ids for Agno/KHAL dispatch and cleanup', () => {
+    const resolved = resolveKhalSessionId({
+      providerSchema: 'agno',
+      sessionStrategy: 'per_chat',
+      from: '5547996094523',
+      chatId: '5547996094523',
+      channel: 'whatsapp-gupshup',
+      instanceId: 'c88f18fd-3e0a-49ed-9835-efd2c2be3988',
+      personId: '8e0b8253-7221-4756-af64-dece4f25a71d',
+      rawPayload: { headers: { 'x-khal-env': 'hml' } },
+    });
+
+    expect(resolved.source).toBe('canonical-khal');
+    expect(resolved.sessionId).toBe(
+      'khal:hml:omni:c88f18fd-3e0a-49ed-9835-efd2c2be3988:gupshup:8e0b8253-7221-4756-af64-dece4f25a71d',
+    );
+    expect(resolved.legacySessionId).toBe('5547996094523');
+  });
+
+  it('builds prod namespace canonical session ids from the same resolver', () => {
+    expect(
+      buildCanonicalKhalSessionId({
+        environment: 'prod',
+        instanceId: 'prod-instance',
+        channelSegment: 'gupshup',
+        personId: 'person-123',
+      }),
+    ).toBe('khal:prod:omni:prod-instance:gupshup:person-123');
+  });
+
+  it('preserves legacy computed ids for non-KHAL/non-Agno providers', () => {
+    const resolved = resolveKhalSessionId({
+      providerSchema: 'openclaw',
+      sessionStrategy: 'per_chat',
+      from: '5511999999999',
+      chatId: '5511999999999',
+      channel: 'whatsapp-gupshup',
+      instanceId: 'inst-1',
+      personId: 'person-1',
+      rawPayload: { headers: { 'x-khal-env': 'hml' } },
+    });
+
+    expect(resolved.source).toBe('legacy');
+    expect(resolved.sessionId).toBe('5511999999999');
+  });
+});

--- a/packages/api/src/services/__tests__/persons.test.ts
+++ b/packages/api/src/services/__tests__/persons.test.ts
@@ -88,6 +88,28 @@ describe('PersonService', () => {
     service = new PersonService(mockDb as unknown as Database, mockEventBus);
   });
 
+  describe('search()', () => {
+    test('returns people whose WhatsApp name only exists on chat participants', async () => {
+      const participantBackedPerson = {
+        id: 'person-cadu',
+        displayName: 'Cadu Cassau',
+        primaryPhone: null,
+        primaryEmail: null,
+        avatarUrl: null,
+        metadata: null,
+        createdAt: new Date('2026-04-10T06:36:32Z'),
+        updatedAt: new Date('2026-06-02T09:36:18Z'),
+      };
+
+      (mockDb as unknown as { execute: ReturnType<typeof mock> }).execute = mock(async () => [participantBackedPerson]);
+
+      const result = await service.search('Cadu Cassau', 5);
+
+      expect((mockDb as unknown as { execute: ReturnType<typeof mock> }).execute).toHaveBeenCalled();
+      expect(result).toEqual([participantBackedPerson]);
+    });
+  });
+
   describe('getIdentityForChannel()', () => {
     test('returns identity when person has single identity on channel', async () => {
       const identity = createMockIdentity({

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -348,7 +348,7 @@ export class AgentRunnerService {
       schema: provider.schema,
       baseUrl: provider.baseUrl,
       apiKey: provider.apiKey,
-      defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+      defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
     });
 
     // Cache it
@@ -465,7 +465,7 @@ export class AgentRunnerService {
         name: chatName,
         participantCount,
       },
-      timeoutMs: (instance.agentTimeout ?? 60) * 1000,
+      timeoutMs: (instance.agentTimeout ?? 600) * 1000,
       files,
     };
 
@@ -589,7 +589,7 @@ export class AgentRunnerService {
         name: chatName,
         participantCount,
       },
-      timeoutMs: (instance.agentTimeout ?? 60) * 1000,
+      timeoutMs: (instance.agentTimeout ?? 600) * 1000,
     };
 
     // Client routes by agentType internally

--- a/packages/api/src/services/agent-session-identity.ts
+++ b/packages/api/src/services/agent-session-identity.ts
@@ -71,7 +71,7 @@ export function extractKhalSessionIdFromRawPayload(rawPayload?: Record<string, u
   return readHeader(rawPayload?.headers, 'x-khal-session-id');
 }
 
-export function resolveKhalEnvironment(
+function resolveKhalEnvironment(
   rawPayload?: Record<string, unknown> | null,
   explicitEnvironment?: string | null,
 ): string | undefined {
@@ -90,7 +90,7 @@ export function resolveKhalEnvironment(
   );
 }
 
-export function channelToKhalSessionSegment(channel?: ChannelType | string): string | undefined {
+function channelToKhalSessionSegment(channel?: ChannelType | string): string | undefined {
   if (!channel) return undefined;
   if (channel === 'whatsapp-gupshup') return 'gupshup';
   if (channel === 'whatsapp-cloud') return 'whatsapp';

--- a/packages/api/src/services/agent-session-identity.ts
+++ b/packages/api/src/services/agent-session-identity.ts
@@ -1,0 +1,159 @@
+import type { ChannelType, ProviderSchema } from '@omni/db';
+
+declare const process: { env: Record<string, string | undefined> };
+
+type AgentSessionStrategyLike = 'per_user' | 'per_chat' | 'per_thread' | string;
+
+function computeLegacySessionId(
+  strategy: AgentSessionStrategyLike,
+  userId: string,
+  chatId: string,
+  threadId?: string,
+): string {
+  switch (strategy) {
+    case 'per_user':
+      return userId;
+    case 'per_chat':
+      return chatId;
+    case 'per_thread':
+      return `thread:${chatId}:${threadId ?? chatId}`;
+    default:
+      return `${userId}:${chatId}`;
+  }
+}
+
+export interface KhalSessionIdentityInput {
+  providerSchema?: ProviderSchema | string;
+  sessionStrategy?: string;
+  from: string;
+  chatId: string;
+  channel?: ChannelType | string;
+  instanceId: string;
+  personId?: string | null;
+  rawPayload?: Record<string, unknown> | null;
+  environment?: string | null;
+  threadId?: string;
+}
+
+export interface ResolvedAgentSessionIdentity {
+  sessionId: string;
+  legacySessionId: string;
+  sessionStrategy: string;
+  canonicalSessionId?: string;
+  personId?: string;
+  environment?: string;
+  channelSegment?: string;
+  source: 'explicit-khal' | 'canonical-khal' | 'legacy';
+}
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== 'object') return undefined;
+  const headerMap = headers as Record<string, unknown>;
+  const lowerName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headerMap)) {
+    if (key.toLowerCase() === lowerName && typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function readStringField(source: Record<string, unknown> | null | undefined, names: string[]): string | undefined {
+  if (!source) return undefined;
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export function extractKhalSessionIdFromRawPayload(rawPayload?: Record<string, unknown> | null): string | undefined {
+  const direct = readStringField(rawPayload, ['khalSessionId', 'khal_session_id', 'session_id']);
+  if (direct) return direct;
+  return readHeader(rawPayload?.headers, 'x-khal-session-id');
+}
+
+export function resolveKhalEnvironment(
+  rawPayload?: Record<string, unknown> | null,
+  explicitEnvironment?: string | null,
+): string | undefined {
+  const explicit = explicitEnvironment?.trim();
+  if (explicit) return explicit;
+
+  const fromPayload = readStringField(rawPayload, ['khalEnv', 'khalEnvironment', 'environment', 'env']);
+  if (fromPayload) return fromPayload;
+
+  return (
+    readHeader(rawPayload?.headers, 'x-khal-env') ??
+    readHeader(rawPayload?.headers, 'x-khal-environment') ??
+    process.env.KHAL_SESSION_ENV?.trim() ??
+    process.env.KHAL_ENV?.trim() ??
+    process.env.OMNI_ENV?.trim()
+  );
+}
+
+export function channelToKhalSessionSegment(channel?: ChannelType | string): string | undefined {
+  if (!channel) return undefined;
+  if (channel === 'whatsapp-gupshup') return 'gupshup';
+  if (channel === 'whatsapp-cloud') return 'whatsapp';
+  if (channel === 'whatsapp-baileys') return 'whatsapp';
+  return String(channel).replace(/^channel-/, '');
+}
+
+export function buildCanonicalKhalSessionId(input: {
+  environment: string;
+  instanceId: string;
+  channelSegment: string;
+  personId: string;
+}): string {
+  return `khal:${input.environment}:omni:${input.instanceId}:${input.channelSegment}:${input.personId}`;
+}
+
+export function resolveKhalSessionId(input: KhalSessionIdentityInput): ResolvedAgentSessionIdentity {
+  const sessionStrategy = input.sessionStrategy ?? 'per_chat';
+  const legacySessionId = computeLegacySessionId(sessionStrategy, input.from, input.chatId, input.threadId);
+  const explicitKhalSessionId = extractKhalSessionIdFromRawPayload(input.rawPayload);
+  if (explicitKhalSessionId) {
+    return {
+      sessionId: explicitKhalSessionId,
+      legacySessionId,
+      sessionStrategy,
+      canonicalSessionId: explicitKhalSessionId,
+      personId: input.personId ?? undefined,
+      environment: resolveKhalEnvironment(input.rawPayload, input.environment),
+      channelSegment: channelToKhalSessionSegment(input.channel),
+      source: 'explicit-khal',
+    };
+  }
+
+  const environment = resolveKhalEnvironment(input.rawPayload, input.environment);
+  const channelSegment = channelToKhalSessionSegment(input.channel);
+  const personId = input.personId?.trim();
+
+  if (input.providerSchema === 'agno' && environment && channelSegment && personId) {
+    const canonicalSessionId = buildCanonicalKhalSessionId({
+      environment,
+      instanceId: input.instanceId,
+      channelSegment,
+      personId,
+    });
+    return {
+      sessionId: canonicalSessionId,
+      legacySessionId,
+      sessionStrategy,
+      canonicalSessionId,
+      personId,
+      environment,
+      channelSegment,
+      source: 'canonical-khal',
+    };
+  }
+
+  return {
+    sessionId: legacySessionId,
+    legacySessionId,
+    sessionStrategy,
+    personId: personId ?? undefined,
+    environment,
+    channelSegment,
+    source: 'legacy',
+  };
+}

--- a/packages/api/src/services/persons.ts
+++ b/packages/api/src/services/persons.ts
@@ -15,7 +15,7 @@ import {
   persons,
   platformIdentities,
 } from '@omni/db';
-import { and, desc, eq, ilike, isNotNull, ne, or, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, ne, or, sql } from 'drizzle-orm';
 
 export interface PersonWithIdentities extends Person {
   identities: PlatformIdentity[];
@@ -76,22 +76,76 @@ export class PersonService {
   }
 
   /**
-   * Search persons by name, email, or phone
+   * Search persons by name, email, phone, platform identity, or chat participant display name.
+   *
+   * WhatsApp LID DMs frequently have the useful contact name only on chat_participants,
+   * while the canonical person row is intentionally sparse. Searching persons alone makes
+   * the identity graph useless for the main operational task: "find my chat with X".
    */
   async search(query: string, limit = 20): Promise<Person[]> {
     const searchPattern = `%${query}%`;
 
-    return this.db
-      .select()
-      .from(persons)
-      .where(
-        or(
-          ilike(persons.displayName, searchPattern),
-          ilike(persons.primaryEmail, searchPattern),
-          ilike(persons.primaryPhone, searchPattern),
-        ),
+    const result = await this.db.execute(sql`
+      WITH candidates AS (
+        SELECT
+          p.id,
+          CASE
+            WHEN p.display_name ILIKE ${searchPattern} ESCAPE '' THEN p.display_name
+            WHEN pi.platform_username ILIKE ${searchPattern} ESCAPE '' THEN pi.platform_username
+            WHEN cp.display_name ILIKE ${searchPattern} ESCAPE '' THEN cp.display_name
+            ELSE COALESCE(NULLIF(p.display_name, ''), NULLIF(pi.platform_username, ''), NULLIF(cp.display_name, ''))
+          END AS "displayName",
+          p.primary_phone AS "primaryPhone",
+          p.primary_email AS "primaryEmail",
+          p.avatar_url AS "avatarUrl",
+          p.metadata,
+          p.created_at AS "createdAt",
+          p.updated_at AS "updatedAt",
+          GREATEST(
+            COALESCE(pi.last_seen_at, 'epoch'::timestamptz),
+            COALESCE(cp.last_seen_at, 'epoch'::timestamptz),
+            COALESCE(p.updated_at, 'epoch'::timestamptz)
+          ) AS rank_ts
+        FROM persons p
+        LEFT JOIN platform_identities pi ON pi.person_id = p.id
+        LEFT JOIN chat_participants cp ON cp.person_id = p.id OR cp.platform_identity_id = pi.id
+        WHERE
+          p.display_name ILIKE ${searchPattern} ESCAPE ''
+          OR p.primary_email ILIKE ${searchPattern} ESCAPE ''
+          OR p.primary_phone ILIKE ${searchPattern} ESCAPE ''
+          OR pi.platform_username ILIKE ${searchPattern} ESCAPE ''
+          OR pi.platform_user_id ILIKE ${searchPattern} ESCAPE ''
+          OR cp.display_name ILIKE ${searchPattern} ESCAPE ''
+          OR cp.platform_user_id ILIKE ${searchPattern} ESCAPE ''
+      ), distinct_candidates AS (
+        SELECT DISTINCT ON (id)
+          id,
+          "displayName",
+          "primaryPhone",
+          "primaryEmail",
+          "avatarUrl",
+          metadata,
+          "createdAt",
+          "updatedAt",
+          rank_ts
+        FROM candidates
+        ORDER BY id, rank_ts DESC
       )
-      .limit(limit);
+      SELECT
+        id,
+        "displayName",
+        "primaryPhone",
+        "primaryEmail",
+        "avatarUrl",
+        metadata,
+        "createdAt",
+        "updatedAt"
+      FROM distinct_candidates
+      ORDER BY rank_ts DESC
+      LIMIT ${limit}
+    `);
+
+    return result as unknown as Person[];
   }
 
   /**

--- a/packages/api/src/trpc/router.ts
+++ b/packages/api/src/trpc/router.ts
@@ -69,7 +69,7 @@ export const appRouter = t.router({
           channel: ChannelTypeSchema,
           agentProviderId: z.string().uuid().optional(),
           agentId: z.string().max(255).default('default'),
-          agentTimeout: z.number().int().positive().default(60),
+          agentTimeout: z.number().int().positive().default(600),
           agentStreamMode: z.boolean().default(false),
           isDefault: z.boolean().default(false),
         }),
@@ -336,7 +336,7 @@ export const appRouter = t.router({
           apiKey: z.string().optional(),
           schemaConfig: z.record(z.string(), z.unknown()).optional(),
           defaultStream: z.boolean().default(true),
-          defaultTimeout: z.number().int().positive().default(60),
+          defaultTimeout: z.number().int().positive().default(600),
         }),
       )
       .mutation(async ({ ctx, input }) => {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/persons.ts
+++ b/packages/cli/src/commands/persons.ts
@@ -36,14 +36,16 @@ export function createPersonsCommand(): Command {
         const persons = results as Array<{
           id: string;
           displayName: string | null;
-          email: string | null;
-          phone: string | null;
+          primaryEmail?: string | null;
+          primaryPhone?: string | null;
+          email?: string | null;
+          phone?: string | null;
         }>;
         const items = persons.map((p) => ({
           id: p.id,
           displayName: p.displayName ?? '-',
-          email: p.email ?? '-',
-          phone: p.phone ?? '-',
+          email: p.primaryEmail ?? p.email ?? '-',
+          phone: p.primaryPhone ?? p.phone ?? '-',
         }));
 
         output.list(items, { emptyMessage: 'No persons found.' });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -364,6 +364,53 @@ describe('AgnoClient', () => {
       expect(chunks[3]).toMatchObject({ event: 'RunCompleted', isComplete: true, fullContent: 'Hello World!' });
     });
 
+    it('propagates W3C trace context and Khal session headers for streaming runs', async () => {
+      const sseData = 'event: RunCompleted\ndata: {"run_id": "run-1", "content": "done"}\n\n';
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseData));
+          controller.close();
+        },
+      });
+
+      mockImpl.mockResolvedValueOnce(
+        new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+      );
+
+      const client = new AgnoClient(config);
+      for await (const _chunk of client.stream({
+        message: 'Hi!',
+        agentId: 'agent-1',
+        userId: 'user-456',
+        khalSessionId: 'khal-session-stream',
+        traceContext: {
+          traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          spanId: 'bbbbbbbbbbbbbbbb',
+          traceFlags: 1,
+        },
+        omni: {
+          instanceId: 'inst-1',
+          chatId: 'chat-123',
+          messageId: 'msg-stream-1',
+          channel: 'gupshup',
+        },
+      })) {
+        // exhaust stream so the request is issued
+      }
+
+      const init = mockImpl.mock.calls[0]?.[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      const formData = init.body as FormData;
+      expect(headers.traceparent).toBe('00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01');
+      expect(headers['x-khal-session-id']).toBe('khal-session-stream');
+      expect(headers['x-khal-message-id']).toBe('msg-stream-1');
+      expect(headers['x-omni-instance-id']).toBe('inst-1');
+      expect(headers['x-omni-chat-id']).toBe('chat-123');
+      expect(headers['x-omni-channel']).toBe('gupshup');
+      expect(formData.get('session_id')).toBe('khal-session-stream');
+    });
+
     it('handles stream errors', async () => {
       const sseData = 'event: RunFailed\ndata: {"error": "Agent crashed"}\n\n';
 

--- a/packages/core/src/providers/__tests__/agno-client.test.ts
+++ b/packages/core/src/providers/__tests__/agno-client.test.ts
@@ -637,6 +637,33 @@ describe('AgnoClient', () => {
     });
   });
 
+  // --- IAgentClient interface: deleteSession() ---
+
+  describe('deleteSession', () => {
+    it('returns a verified delete result on success', async () => {
+      mockImpl.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const client = new AgnoClient(config);
+      const result = await client.deleteSession('khal:hml:omni:inst:gupshup:person');
+
+      expect(result).toEqual({
+        ok: true,
+        status: 204,
+        sessionId: 'khal:hml:omni:inst:gupshup:person',
+        existed: true,
+      });
+    });
+
+    it('treats a missing session as a verified no-op instead of throwing', async () => {
+      mockImpl.mockResolvedValueOnce(new Response('missing', { status: 404 }));
+
+      const client = new AgnoClient(config);
+      const result = await client.deleteSession('legacy-phone-session');
+
+      expect(result).toEqual({ ok: true, status: 404, sessionId: 'legacy-phone-session', existed: false });
+    });
+  });
+
   // --- Authentication ---
 
   describe('authentication', () => {

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -17,6 +17,7 @@ import {
   ProviderError,
   type ProviderRequest,
   type ProviderResponse,
+  type SessionDeleteResult,
   type StreamChunk,
 } from './types';
 
@@ -519,7 +520,7 @@ export class AgnoClient implements IAgentClient {
 
   // --- Session Management ---
 
-  async deleteSession(sessionId: string): Promise<void> {
+  async deleteSession(sessionId: string): Promise<SessionDeleteResult> {
     const url = `${this.baseUrl}/sessions/${encodeURIComponent(sessionId)}`;
     const response = await this.fetchWithTimeout(
       url,
@@ -527,9 +528,15 @@ export class AgnoClient implements IAgentClient {
       this.defaultTimeoutMs,
     );
 
+    if (response.status === 404) {
+      return { ok: true, status: response.status, sessionId, existed: false };
+    }
+
     if (!response.ok) {
       this.handleErrorResponse(response, `deleting session ${sessionId}`);
     }
+
+    return { ok: true, status: response.status, sessionId, existed: true };
   }
 }
 

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -210,6 +210,13 @@ export interface AgnoWorkflow {
   description?: string;
 }
 
+export interface SessionDeleteResult {
+  ok: boolean;
+  status: number;
+  sessionId: string;
+  existed: boolean | undefined;
+}
+
 /**
  * Generic agent client interface
  *
@@ -230,7 +237,7 @@ export interface IAgentClient {
   checkHealth(): Promise<AgentHealthResult>;
 
   /** Optional: delete a session (clear conversation history) */
-  deleteSession?(sessionId: string): Promise<void>;
+  deleteSession?(sessionId: string): Promise<SessionDeleteResult>;
 }
 
 /**

--- a/packages/core/src/schemas/instance.ts
+++ b/packages/core/src/schemas/instance.ts
@@ -58,7 +58,7 @@ export const CreateAgentProviderSchema = z.object({
   apiKey: z.string().optional(),
   schemaConfig: MetadataSchema.optional(),
   defaultStream: z.boolean().default(true),
-  defaultTimeout: z.number().int().positive().default(60),
+  defaultTimeout: z.number().int().positive().default(600),
   supportsStreaming: z.boolean().default(true),
   supportsImages: z.boolean().default(false),
   supportsAudio: z.boolean().default(false),
@@ -151,7 +151,7 @@ export const CreateInstanceSchema = z.object({
   name: z.string().max(255),
   channel: ChannelTypeSchema,
   agentId: z.string().uuid().nullable().optional(),
-  agentTimeout: z.number().int().positive().default(60),
+  agentTimeout: z.number().int().positive().default(600),
   agentStreamMode: z.boolean().default(false),
   isDefault: z.boolean().default(false),
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -288,7 +288,7 @@ export const agentProviders = pgTable(
 
     // Default settings
     defaultStream: boolean('default_stream').notNull().default(true),
-    defaultTimeout: integer('default_timeout').notNull().default(60),
+    defaultTimeout: integer('default_timeout').notNull().default(600),
 
     // Capabilities (auto-detected or manually set)
     supportsStreaming: boolean('supports_streaming').notNull().default(true),
@@ -690,7 +690,7 @@ export const instances = pgTable(
     agentId: uuid('agent_id').references(() => agents.id, { onDelete: 'set null' }),
 
     // ---- Agent Configuration (Instance Override) ----
-    agentTimeout: integer('agent_timeout').notNull().default(60),
+    agentTimeout: integer('agent_timeout').notNull().default(600),
     agentStreamMode: boolean('agent_stream_mode').notNull().default(false),
     /** When agent should reply to messages */
     agentReplyFilter: jsonb('agent_reply_filter').$type<AgentReplyFilter>(),

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2072,6 +2072,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/voice/join": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Join a voice channel
+         * @description Join a voice channel via a voice-capable channel plugin. Returns the created session.
+         */
+        post: operations["voiceJoin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice/leave": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Leave a voice session
+         * @description Leave an active voice session.
+         */
+        post: operations["voiceLeave"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List active voice sessions
+         * @description List all active voice sessions across voice-capable plugins.
+         */
+        get: operations["listVoiceSessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice/sessions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get voice session details
+         * @description Get details of a specific voice session by ID.
+         */
+        get: operations["getVoiceSession"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2116,6 +2196,10 @@ export interface components {
             isActive: boolean;
             /** @description Arbitrary metadata */
             metadata: {
+                [key: string]: unknown;
+            } | null;
+            /** @description A2A Agent Card overrides */
+            agentCard: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -2174,6 +2258,10 @@ export interface components {
             isActive: boolean;
             /** @description Arbitrary metadata */
             metadata?: {
+                [key: string]: unknown;
+            };
+            /** @description A2A Agent Card overrides */
+            agentCard?: {
                 [key: string]: unknown;
             };
         };
@@ -2341,7 +2429,7 @@ export interface components {
              * @description Channel type
              * @enum {string}
              */
-            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
             /** @description Whether instance is active */
             isActive: boolean;
             /** @description Whether this is the default instance for channel */
@@ -2384,7 +2472,7 @@ export interface components {
              * @description Channel type
              * @enum {string}
              */
-            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
             /**
              * Format: uuid
              * @description Agent UUID (agents table)
@@ -2392,7 +2480,7 @@ export interface components {
             agentId?: string | null;
             /**
              * @description Agent timeout in seconds
-             * @default 60
+             * @default 600
              */
             agentTimeout: number;
             /**
@@ -2479,7 +2567,7 @@ export interface components {
              * @description Channel type ID
              * @enum {string}
              */
-            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
             /** @description Human-readable channel name */
             name: string;
             /** @description Plugin version */
@@ -3578,7 +3666,7 @@ export interface components {
             defaultStream: boolean;
             /**
              * @description Default timeout
-             * @default 60
+             * @default 600
              */
             defaultTimeout: number;
             /**
@@ -4762,6 +4850,35 @@ export interface components {
             /** @description Emit a 2–3s typing/presence indicator before firing on supported channels. */
             showTypingIndicator: boolean;
         };
+        VoiceSession: {
+            /** @description Voice session ID */
+            sessionId: string;
+            /** @description Channel instance ID */
+            instanceId: string;
+            /** @description Voice channel ID */
+            channelId: string;
+            /** @description Session state (e.g. connecting, ready, disconnected) */
+            state: string;
+            /** @description User IDs of current participants */
+            participants: string[];
+            /**
+             * Format: date-time
+             * @description Session creation timestamp
+             */
+            createdAt?: string;
+        };
+        VoiceJoinRequest: {
+            /** @description Channel instance ID */
+            instanceId: string;
+            /** @description Voice channel ID to join */
+            channelId: string;
+            /** @description Guild/server ID (required for Discord) */
+            guildId?: string;
+        };
+        VoiceLeaveRequest: {
+            /** @description Voice session ID to leave */
+            sessionId: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -4832,6 +4949,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -4906,6 +5027,10 @@ export interface operations {
                     metadata?: {
                         [key: string]: unknown;
                     };
+                    /** @description A2A Agent Card overrides */
+                    agentCard?: {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };
@@ -4957,6 +5082,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -5054,6 +5183,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -5199,6 +5332,10 @@ export interface operations {
                     metadata?: {
                         [key: string]: unknown;
                     };
+                    /** @description A2A Agent Card overrides */
+                    agentCard?: {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };
@@ -5250,6 +5387,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -5590,7 +5731,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -5653,7 +5794,7 @@ export interface operations {
                      * @description Channel type
                      * @enum {string}
                      */
-                    channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                    channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                     /**
                      * Format: uuid
                      * @description Agent UUID (agents table)
@@ -5661,7 +5802,7 @@ export interface operations {
                     agentId?: string | null;
                     /**
                      * @description Agent timeout in seconds
-                     * @default 60
+                     * @default 600
                      */
                     agentTimeout?: number;
                     /**
@@ -5699,7 +5840,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -5782,7 +5923,7 @@ export interface operations {
                              * @description Channel type ID
                              * @enum {string}
                              */
-                            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Human-readable channel name */
                             name: string;
                             /** @description Plugin version */
@@ -5831,7 +5972,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -5959,7 +6100,7 @@ export interface operations {
                      * @description Channel type
                      * @enum {string}
                      */
-                    channel?: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                    channel?: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                     /**
                      * Format: uuid
                      * @description Agent UUID (agents table)
@@ -5967,7 +6108,7 @@ export interface operations {
                     agentId?: string | null;
                     /**
                      * @description Agent timeout in seconds
-                     * @default 60
+                     * @default 600
                      */
                     agentTimeout?: number;
                     /**
@@ -6005,7 +6146,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -10720,7 +10861,7 @@ export interface operations {
                     defaultStream?: boolean;
                     /**
                      * @description Default timeout
-                     * @default 60
+                     * @default 600
                      */
                     defaultTimeout?: number;
                     /**
@@ -11075,7 +11216,7 @@ export interface operations {
                     defaultStream?: boolean;
                     /**
                      * @description Default timeout
-                     * @default 60
+                     * @default 600
                      */
                     defaultTimeout?: number;
                     /**
@@ -16656,6 +16797,259 @@ export interface operations {
                             message: string;
                             /** @description Additional error details */
                             details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    voiceJoin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Channel instance ID */
+                    instanceId: string;
+                    /** @description Voice channel ID to join */
+                    channelId: string;
+                    /** @description Guild/server ID (required for Discord) */
+                    guildId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully joined voice channel */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Voice session ID */
+                            sessionId: string;
+                            /** @description Channel instance ID */
+                            instanceId: string;
+                            /** @description Voice channel ID */
+                            channelId: string;
+                            /** @description Session state (e.g. connecting, ready, disconnected) */
+                            state: string;
+                            /** @description User IDs of current participants */
+                            participants: string[];
+                            /**
+                             * Format: date-time
+                             * @description Session creation timestamp
+                             */
+                            createdAt?: string;
+                        };
+                    };
+                };
+            };
+            /** @description No voice-capable channel plugin available */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Failed to join voice channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    voiceLeave: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Voice session ID to leave */
+                    sessionId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully left voice session */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                    };
+                };
+            };
+            /** @description No voice-capable channel plugin available */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Failed to leave voice session */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    listVoiceSessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of active voice sessions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: {
+                            /** @description Voice session ID */
+                            sessionId: string;
+                            /** @description Channel instance ID */
+                            instanceId: string;
+                            /** @description Voice channel ID */
+                            channelId: string;
+                            /** @description Session state (e.g. connecting, ready, disconnected) */
+                            state: string;
+                            /** @description User IDs of current participants */
+                            participants: string[];
+                            /**
+                             * Format: date-time
+                             * @description Session creation timestamp
+                             */
+                            createdAt?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    getVoiceSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Voice session ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Voice session details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Voice session ID */
+                            sessionId: string;
+                            /** @description Channel instance ID */
+                            instanceId: string;
+                            /** @description Voice channel ID */
+                            channelId: string;
+                            /** @description Session state (e.g. connecting, ready, disconnected) */
+                            state: string;
+                            /** @description User IDs of current participants */
+                            participants: string[];
+                            /**
+                             * Format: date-time
+                             * @description Session creation timestamp
+                             */
+                            createdAt?: string;
+                        };
+                    };
+                };
+            };
+            /** @description No voice-capable channel plugin available */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Voice session not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
                         };
                     };
                 };

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260602.2",
+  "version": "2.260603.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260531.2",
+  "version": "2.260531.5",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260531.1",
+  "version": "2.260531.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260602.1",
+  "version": "2.260602.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260531.5",
+  "version": "2.260531.6",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260530.5",
+  "version": "2.260531.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260601.1",
+  "version": "2.260602.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260531.6",
+  "version": "2.260601.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260603.2",
+  "version": "2.260603.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Why
Carry the Agent Timeout 600s default/UI contract from dev into homolog so future HML images and UI config match the live HML instance value.

## Includes
- PR #703 merge commit ec55de6: agent timeout defaults/runtime fallbacks/UI max/help text set to 600 seconds.

## Verification from source PR
- #703 CI green before merge.
- Pre-push full typecheck: 21/21 successful.
- Full bun test: 3979 pass, 292 skip, 0 fail.

## Live HML already applied
- Existing HML instance c88f18fd-3e0a-49ed-9835-efd2c2be3988 has agentTimeout=600 via Omni v2 instance API.