### PR TITLE
promote: agent timeout 600 default to homolog

### DIFF
--- a/apps/ui/src/components/instances/AgentConfigForm.tsx
+++ b/apps/ui/src/components/instances/AgentConfigForm.tsx
@@ -20,7 +20,7 @@ interface AgentConfigFormProps {
 export function AgentConfigForm({ instance }: AgentConfigFormProps) {
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(instance.agentProviderId ?? null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(instance.agentId ?? null);
-  const [agentTimeout, setAgentTimeout] = useState(instance.agentTimeout ?? 60);
+  const [agentTimeout, setAgentTimeout] = useState(instance.agentTimeout ?? 600);
   const [streamMode, setStreamMode] = useState(instance.agentStreamMode ?? false);
   const [isDirty, setIsDirty] = useState(false);
 
@@ -34,7 +34,7 @@ export function AgentConfigForm({ instance }: AgentConfigFormProps) {
     const hasChanges =
       selectedProviderId !== (instance.agentProviderId ?? null) ||
       selectedAgentId !== (instance.agentId ?? null) ||
-      agentTimeout !== (instance.agentTimeout ?? 60) ||
+      agentTimeout !== (instance.agentTimeout ?? 600) ||
       streamMode !== (instance.agentStreamMode ?? false);
     setIsDirty(hasChanges);
   }, [selectedProviderId, selectedAgentId, agentTimeout, streamMode, instance]);
@@ -231,12 +231,12 @@ export function AgentConfigForm({ instance }: AgentConfigFormProps) {
                 id="agent-timeout"
                 type="number"
                 min={10}
-                max={300}
+                max={600}
                 value={agentTimeout}
                 onChange={(e) => setAgentTimeout(Number(e.target.value))}
                 className="max-w-[120px]"
               />
-              <p className="text-xs text-muted-foreground">Maximum time to wait for agent response (10-300 seconds)</p>
+              <p className="text-xs text-muted-foreground">Maximum time to wait for agent response (10-600 seconds)</p>
             </div>
 
             <div className="flex items-center justify-between rounded-lg border p-3">

--- a/docs/architecture/provider-system.md
+++ b/docs/architecture/provider-system.md
@@ -284,7 +284,7 @@ export const agentProviders = pgTable('agent_providers', {
 
   // Default settings
   defaultStream: boolean('default_stream').notNull().default(true),
-  defaultTimeout: integer('default_timeout').notNull().default(60),
+  defaultTimeout: integer('default_timeout').notNull().default(600),
 
   // Capabilities (auto-detected or manually set)
   supportsStreaming: boolean('supports_streaming').notNull().default(true),

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3427,7 +3427,7 @@ function createAgnoProvider(provider: AgentProvider, instance: DispatchInstance)
     schema: provider.schema,
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
@@ -3435,7 +3435,7 @@ function createAgnoProvider(provider: AgentProvider, instance: DispatchInstance)
   return new AgnoAgentProvider(provider.id, provider.name, client, {
     agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
     agentType: (instance.agentType ?? 'agent') as 'agent' | 'team' | 'workflow',
-    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
+    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 600) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   });
@@ -3518,12 +3518,12 @@ function createAgUiProviderInstance(provider: AgentProvider, instance: DispatchI
     schema: provider.schema,
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   return new AgUiAgentProvider(provider.id, provider.name, client, {
     agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
-    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
+    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 600) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   });
@@ -3541,12 +3541,12 @@ function createA2AProviderInstance(provider: AgentProvider, instance: DispatchIn
     schema: provider.schema,
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   return new A2AAgentProvider(provider.id, provider.name, client, {
     agentId: resolveRequiredAgentId(instance, schemaConfig, provider.id),
-    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 60) * 1000,
+    timeoutMs: (instance.agentTimeout ?? provider.defaultTimeout ?? 600) * 1000,
     enableAutoSplit: instance.enableAutoSplit ?? true,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   });

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -57,7 +57,7 @@ const createInstanceSchema = z.object({
   name: z.string().min(1).max(255).describe('Unique name for the instance'),
   channel: ChannelTypeSchema.describe('Channel type (e.g., whatsapp-baileys, discord)'),
   agentId: z.string().uuid().nullable().optional().describe('Agent UUID referencing agents table'),
-  agentTimeout: z.number().int().positive().default(60).describe('Agent timeout in seconds'),
+  agentTimeout: z.number().int().positive().default(600).describe('Agent timeout in seconds'),
   agentStreamMode: z.boolean().default(false).describe('Enable streaming responses'),
   agentReplyFilter: agentReplyFilterSchema.optional().nullable().describe('When agent should reply'),
   agentSessionStrategy: z

--- a/packages/api/src/routes/v2/providers.ts
+++ b/packages/api/src/routes/v2/providers.ts
@@ -48,7 +48,7 @@ const providerBaseSchema = z.object({
         'Note: apiKey in schemaConfig overrides the provider-level apiKey.',
     ),
   defaultStream: z.boolean().default(true).describe('Default streaming setting'),
-  defaultTimeout: z.number().int().positive().default(60).describe('Default timeout in seconds'),
+  defaultTimeout: z.number().int().positive().default(600).describe('Default timeout in seconds'),
   supportsStreaming: z.boolean().default(true).describe('Provider supports streaming'),
   supportsImages: z
     .boolean()
@@ -211,7 +211,7 @@ providersRoutes.get('/:id/agents', async (c) => {
   const client = createAgnoClient({
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const allEntries = (await client.discover?.()) ?? [];
@@ -240,7 +240,7 @@ providersRoutes.get('/:id/teams', async (c) => {
   const client = createAgnoClient({
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const allEntries = (await client.discover?.()) ?? [];
@@ -269,7 +269,7 @@ providersRoutes.get('/:id/workflows', async (c) => {
   const client = createAgnoClient({
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+    defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
   });
 
   const allEntries = (await client.discover?.()) ?? [];

--- a/packages/api/src/schemas/openapi/instances.ts
+++ b/packages/api/src/schemas/openapi/instances.ts
@@ -34,7 +34,7 @@ export const CreateInstanceSchema = z.object({
   name: z.string().min(1).max(255).openapi({ description: 'Unique name for the instance' }),
   channel: ChannelTypeSchema.openapi({ description: 'Channel type' }),
   agentId: z.string().uuid().nullable().optional().openapi({ description: 'Agent UUID (agents table)' }),
-  agentTimeout: z.number().int().positive().default(60).openapi({ description: 'Agent timeout in seconds' }),
+  agentTimeout: z.number().int().positive().default(600).openapi({ description: 'Agent timeout in seconds' }),
   agentStreamMode: z.boolean().default(false).openapi({ description: 'Enable streaming responses' }),
   isDefault: z.boolean().default(false).openapi({ description: 'Set as default instance for channel' }),
   token: z.string().optional().openapi({ description: 'Bot token for Discord instances' }),

--- a/packages/api/src/schemas/openapi/providers.ts
+++ b/packages/api/src/schemas/openapi/providers.ts
@@ -79,7 +79,7 @@ export const CreateProviderSchema = z.object({
       example: { projectPath: '/home/user/my-project', model: 'claude-haiku-4-5-20251001', maxTurns: 5 },
     }),
   defaultStream: z.boolean().default(true).openapi({ description: 'Default streaming' }),
-  defaultTimeout: z.number().int().positive().default(60).openapi({ description: 'Default timeout' }),
+  defaultTimeout: z.number().int().positive().default(600).openapi({ description: 'Default timeout' }),
   supportsStreaming: z.boolean().default(true).openapi({ description: 'Supports streaming' }),
   supportsImages: z
     .boolean()

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -348,7 +348,7 @@ export class AgentRunnerService {
       schema: provider.schema,
       baseUrl: provider.baseUrl,
       apiKey: provider.apiKey,
-      defaultTimeoutMs: (provider.defaultTimeout ?? 60) * 1000,
+      defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
     });
 
     // Cache it
@@ -465,7 +465,7 @@ export class AgentRunnerService {
         name: chatName,
         participantCount,
       },
-      timeoutMs: (instance.agentTimeout ?? 60) * 1000,
+      timeoutMs: (instance.agentTimeout ?? 600) * 1000,
       files,
     };
 
@@ -589,7 +589,7 @@ export class AgentRunnerService {
         name: chatName,
         participantCount,
       },
-      timeoutMs: (instance.agentTimeout ?? 60) * 1000,
+      timeoutMs: (instance.agentTimeout ?? 600) * 1000,
     };
 
     // Client routes by agentType internally

--- a/packages/api/src/trpc/router.ts
+++ b/packages/api/src/trpc/router.ts
@@ -69,7 +69,7 @@ export const appRouter = t.router({
           channel: ChannelTypeSchema,
           agentProviderId: z.string().uuid().optional(),
           agentId: z.string().max(255).default('default'),
-          agentTimeout: z.number().int().positive().default(60),
+          agentTimeout: z.number().int().positive().default(600),
           agentStreamMode: z.boolean().default(false),
           isDefault: z.boolean().default(false),
         }),
@@ -336,7 +336,7 @@ export const appRouter = t.router({
           apiKey: z.string().optional(),
           schemaConfig: z.record(z.string(), z.unknown()).optional(),
           defaultStream: z.boolean().default(true),
-          defaultTimeout: z.number().int().positive().default(60),
+          defaultTimeout: z.number().int().positive().default(600),
         }),
       )
       .mutation(async ({ ctx, input }) => {

--- a/packages/core/src/schemas/instance.ts
+++ b/packages/core/src/schemas/instance.ts
@@ -58,7 +58,7 @@ export const CreateAgentProviderSchema = z.object({
   apiKey: z.string().optional(),
   schemaConfig: MetadataSchema.optional(),
   defaultStream: z.boolean().default(true),
-  defaultTimeout: z.number().int().positive().default(60),
+  defaultTimeout: z.number().int().positive().default(600),
   supportsStreaming: z.boolean().default(true),
   supportsImages: z.boolean().default(false),
   supportsAudio: z.boolean().default(false),
@@ -151,7 +151,7 @@ export const CreateInstanceSchema = z.object({
   name: z.string().max(255),
   channel: ChannelTypeSchema,
   agentId: z.string().uuid().nullable().optional(),
-  agentTimeout: z.number().int().positive().default(60),
+  agentTimeout: z.number().int().positive().default(600),
   agentStreamMode: z.boolean().default(false),
   isDefault: z.boolean().default(false),
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -288,7 +288,7 @@ export const agentProviders = pgTable(
 
     // Default settings
     defaultStream: boolean('default_stream').notNull().default(true),
-    defaultTimeout: integer('default_timeout').notNull().default(60),
+    defaultTimeout: integer('default_timeout').notNull().default(600),
 
     // Capabilities (auto-detected or manually set)
     supportsStreaming: boolean('supports_streaming').notNull().default(true),
@@ -690,7 +690,7 @@ export const instances = pgTable(
     agentId: uuid('agent_id').references(() => agents.id, { onDelete: 'set null' }),
 
     // ---- Agent Configuration (Instance Override) ----
-    agentTimeout: integer('agent_timeout').notNull().default(60),
+    agentTimeout: integer('agent_timeout').notNull().default(600),
     agentStreamMode: boolean('agent_stream_mode').notNull().default(false),
     /** When agent should reply to messages */
     agentReplyFilter: jsonb('agent_reply_filter').$type<AgentReplyFilter>(),

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2072,6 +2072,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/voice/join": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Join a voice channel
+         * @description Join a voice channel via a voice-capable channel plugin. Returns the created session.
+         */
+        post: operations["voiceJoin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice/leave": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Leave a voice session
+         * @description Leave an active voice session.
+         */
+        post: operations["voiceLeave"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List active voice sessions
+         * @description List all active voice sessions across voice-capable plugins.
+         */
+        get: operations["listVoiceSessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice/sessions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get voice session details
+         * @description Get details of a specific voice session by ID.
+         */
+        get: operations["getVoiceSession"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2116,6 +2196,10 @@ export interface components {
             isActive: boolean;
             /** @description Arbitrary metadata */
             metadata: {
+                [key: string]: unknown;
+            } | null;
+            /** @description A2A Agent Card overrides */
+            agentCard: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -2174,6 +2258,10 @@ export interface components {
             isActive: boolean;
             /** @description Arbitrary metadata */
             metadata?: {
+                [key: string]: unknown;
+            };
+            /** @description A2A Agent Card overrides */
+            agentCard?: {
                 [key: string]: unknown;
             };
         };
@@ -2341,7 +2429,7 @@ export interface components {
              * @description Channel type
              * @enum {string}
              */
-            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
             /** @description Whether instance is active */
             isActive: boolean;
             /** @description Whether this is the default instance for channel */
@@ -2384,7 +2472,7 @@ export interface components {
              * @description Channel type
              * @enum {string}
              */
-            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
             /**
              * Format: uuid
              * @description Agent UUID (agents table)
@@ -2392,7 +2480,7 @@ export interface components {
             agentId?: string | null;
             /**
              * @description Agent timeout in seconds
-             * @default 60
+             * @default 600
              */
             agentTimeout: number;
             /**
@@ -2479,7 +2567,7 @@ export interface components {
              * @description Channel type ID
              * @enum {string}
              */
-            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
             /** @description Human-readable channel name */
             name: string;
             /** @description Plugin version */
@@ -3578,7 +3666,7 @@ export interface components {
             defaultStream: boolean;
             /**
              * @description Default timeout
-             * @default 60
+             * @default 600
              */
             defaultTimeout: number;
             /**
@@ -4762,6 +4850,35 @@ export interface components {
             /** @description Emit a 2–3s typing/presence indicator before firing on supported channels. */
             showTypingIndicator: boolean;
         };
+        VoiceSession: {
+            /** @description Voice session ID */
+            sessionId: string;
+            /** @description Channel instance ID */
+            instanceId: string;
+            /** @description Voice channel ID */
+            channelId: string;
+            /** @description Session state (e.g. connecting, ready, disconnected) */
+            state: string;
+            /** @description User IDs of current participants */
+            participants: string[];
+            /**
+             * Format: date-time
+             * @description Session creation timestamp
+             */
+            createdAt?: string;
+        };
+        VoiceJoinRequest: {
+            /** @description Channel instance ID */
+            instanceId: string;
+            /** @description Voice channel ID to join */
+            channelId: string;
+            /** @description Guild/server ID (required for Discord) */
+            guildId?: string;
+        };
+        VoiceLeaveRequest: {
+            /** @description Voice session ID to leave */
+            sessionId: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -4832,6 +4949,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -4906,6 +5027,10 @@ export interface operations {
                     metadata?: {
                         [key: string]: unknown;
                     };
+                    /** @description A2A Agent Card overrides */
+                    agentCard?: {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };
@@ -4957,6 +5082,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -5054,6 +5183,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -5199,6 +5332,10 @@ export interface operations {
                     metadata?: {
                         [key: string]: unknown;
                     };
+                    /** @description A2A Agent Card overrides */
+                    agentCard?: {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };
@@ -5250,6 +5387,10 @@ export interface operations {
                             isActive: boolean;
                             /** @description Arbitrary metadata */
                             metadata: {
+                                [key: string]: unknown;
+                            } | null;
+                            /** @description A2A Agent Card overrides */
+                            agentCard: {
                                 [key: string]: unknown;
                             } | null;
                             /**
@@ -5590,7 +5731,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -5653,7 +5794,7 @@ export interface operations {
                      * @description Channel type
                      * @enum {string}
                      */
-                    channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                    channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                     /**
                      * Format: uuid
                      * @description Agent UUID (agents table)
@@ -5661,7 +5802,7 @@ export interface operations {
                     agentId?: string | null;
                     /**
                      * @description Agent timeout in seconds
-                     * @default 60
+                     * @default 600
                      */
                     agentTimeout?: number;
                     /**
@@ -5699,7 +5840,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -5782,7 +5923,7 @@ export interface operations {
                              * @description Channel type ID
                              * @enum {string}
                              */
-                            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Human-readable channel name */
                             name: string;
                             /** @description Plugin version */
@@ -5831,7 +5972,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -5959,7 +6100,7 @@ export interface operations {
                      * @description Channel type
                      * @enum {string}
                      */
-                    channel?: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                    channel?: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                     /**
                      * Format: uuid
                      * @description Agent UUID (agents table)
@@ -5967,7 +6108,7 @@ export interface operations {
                     agentId?: string | null;
                     /**
                      * @description Agent timeout in seconds
-                     * @default 60
+                     * @default 600
                      */
                     agentTimeout?: number;
                     /**
@@ -6005,7 +6146,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "gupshup";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -10720,7 +10861,7 @@ export interface operations {
                     defaultStream?: boolean;
                     /**
                      * @description Default timeout
-                     * @default 60
+                     * @default 600
                      */
                     defaultTimeout?: number;
                     /**
@@ -11075,7 +11216,7 @@ export interface operations {
                     defaultStream?: boolean;
                     /**
                      * @description Default timeout
-                     * @default 60
+                     * @default 600
                      */
                     defaultTimeout?: number;
                     /**
@@ -16656,6 +16797,259 @@ export interface operations {
                             message: string;
                             /** @description Additional error details */
                             details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    voiceJoin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Channel instance ID */
+                    instanceId: string;
+                    /** @description Voice channel ID to join */
+                    channelId: string;
+                    /** @description Guild/server ID (required for Discord) */
+                    guildId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully joined voice channel */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Voice session ID */
+                            sessionId: string;
+                            /** @description Channel instance ID */
+                            instanceId: string;
+                            /** @description Voice channel ID */
+                            channelId: string;
+                            /** @description Session state (e.g. connecting, ready, disconnected) */
+                            state: string;
+                            /** @description User IDs of current participants */
+                            participants: string[];
+                            /**
+                             * Format: date-time
+                             * @description Session creation timestamp
+                             */
+                            createdAt?: string;
+                        };
+                    };
+                };
+            };
+            /** @description No voice-capable channel plugin available */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Failed to join voice channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    voiceLeave: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Voice session ID to leave */
+                    sessionId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully left voice session */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                    };
+                };
+            };
+            /** @description No voice-capable channel plugin available */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Failed to leave voice session */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    listVoiceSessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of active voice sessions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: {
+                            /** @description Voice session ID */
+                            sessionId: string;
+                            /** @description Channel instance ID */
+                            instanceId: string;
+                            /** @description Voice channel ID */
+                            channelId: string;
+                            /** @description Session state (e.g. connecting, ready, disconnected) */
+                            state: string;
+                            /** @description User IDs of current participants */
+                            participants: string[];
+                            /**
+                             * Format: date-time
+                             * @description Session creation timestamp
+                             */
+                            createdAt?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    getVoiceSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Voice session ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Voice session details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Voice session ID */
+                            sessionId: string;
+                            /** @description Channel instance ID */
+                            instanceId: string;
+                            /** @description Voice channel ID */
+                            channelId: string;
+                            /** @description Session state (e.g. connecting, ready, disconnected) */
+                            state: string;
+                            /** @description User IDs of current participants */
+                            participants: string[];
+                            /**
+                             * Format: date-time
+                             * @description Session creation timestamp
+                             */
+                            createdAt?: string;
+                        };
+                    };
+                };
+            };
+            /** @description No voice-capable channel plugin available */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Voice session not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /** @description Error code */
+                            code: string;
+                            /** @description Error message */
+                            message: string;
                         };
                     };
                 };


### PR DESCRIPTION
## Why
Promote the merged dev Agent Timeout 600s default/UI contract into homolog without carrying unrelated dev/version drift.

## Includes
- Cherry-pick of dev PR #703 as homolog commit e60e3b3.
- Agent timeout defaults/runtime fallbacks/UI max/help text set to 600 seconds.

## Live HML already applied
- HML instance c88f18fd-3e0a-49ed-9835-efd2c2be3988 has agentTimeout=600 via Omni v2 instance API and Omni was restarted.

## Verification
- #703 CI green before dev merge.
- Local/pre-push full typecheck: 21/21 successful.
- Full bun test: 3979 pass, 292 skip, 0 fail.