### PR TITLE
feat(whatsapp): expose group mutation REST endpoints

### DIFF
--- a/packages/api/src/routes/v2/__tests__/instances-group-mutations.test.ts
+++ b/packages/api/src/routes/v2/__tests__/instances-group-mutations.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { instancesRoutes } from '../instances';
+
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const GROUP_JID = '120000000000000000@g.us';
+const ENCODED_GROUP_JID = encodeURIComponent(GROUP_JID);
+const PARTICIPANTS = ['5511000000000'];
+
+function mountInstancesRoutes(plugin: Record<string, unknown>): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async (id: string) => ({ id, channel: 'whatsapp-baileys' })),
+      },
+    } as never);
+    c.set('channelRegistry', {
+      get: mock(() => plugin),
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+
+  app.route('/instances', instancesRoutes);
+  return app;
+}
+
+function jsonRequest(method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+  };
+}
+
+describe('instance group mutation routes', () => {
+  test('POST /participants adds participants', async () => {
+    const updateGroupParticipants = mock(async (_id, groupJid, participants, action) => ({
+      groupJid,
+      action,
+      participants: participants.map((jid: string) => ({ jid, status: '200' })),
+    }));
+    const app = mountInstancesRoutes({ updateGroupParticipants });
+
+    const res = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/participants`,
+      jsonRequest('POST', { participants: PARTICIPANTS }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateGroupParticipants).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, PARTICIPANTS, 'add');
+    const body = (await res.json()) as { data: { action: string; changedCount: number } };
+    expect(body.data.action).toBe('add');
+    expect(body.data.changedCount).toBe(1);
+  });
+
+  test('POST /participants/:action uses the action-specific route for remove/promote/demote', async () => {
+    const updateGroupParticipants = mock(async (_id, groupJid, participants, action) => ({
+      groupJid,
+      action,
+      participants: participants.map((jid: string) => ({ jid, status: '200' })),
+    }));
+    const app = mountInstancesRoutes({ updateGroupParticipants });
+
+    const res = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/participants/remove`,
+      jsonRequest('POST', { participants: PARTICIPANTS }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateGroupParticipants).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, PARTICIPANTS, 'remove');
+  });
+
+  test('PATCH /participants supports body.action fallback', async () => {
+    const updateGroupParticipants = mock(async (_id, groupJid, participants, action) => ({
+      groupJid,
+      action,
+      participants: participants.map((jid: string) => ({ jid, status: '200' })),
+    }));
+    const app = mountInstancesRoutes({ updateGroupParticipants });
+
+    const res = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/participants`,
+      jsonRequest('PATCH', { action: 'promote', participants: PARTICIPANTS }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateGroupParticipants).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, PARTICIPANTS, 'promote');
+  });
+
+  test('PATCH /groups/:groupJid updates subject, description, and settings', async () => {
+    const updateGroupSubject = mock(async () => {});
+    const updateGroupDescription = mock(async () => {});
+    const updateGroupSettings = mock(async () => {});
+    const app = mountInstancesRoutes({ updateGroupSubject, updateGroupDescription, updateGroupSettings });
+
+    const res = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}`,
+      jsonRequest('PATCH', {
+        subject: 'novo nome',
+        description: 'nova descricao',
+        setting: 'announcement',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateGroupSubject).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, 'novo nome');
+    expect(updateGroupDescription).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, 'nova descricao');
+    expect(updateGroupSettings).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, 'announcement');
+  });
+
+  test('subject, description, settings, and leave action routes delegate to plugin methods', async () => {
+    const updateGroupSubject = mock(async () => {});
+    const updateGroupDescription = mock(async () => {});
+    const updateGroupSettings = mock(async () => {});
+    const leaveGroup = mock(async () => {});
+    const app = mountInstancesRoutes({ updateGroupSubject, updateGroupDescription, updateGroupSettings, leaveGroup });
+
+    const subject = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/subject`,
+      jsonRequest('POST', { subject: 'renomeado' }),
+    );
+    const description = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/description`,
+      jsonRequest('POST', { description: 'descrita' }),
+    );
+    const settings = await app.request(
+      `/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/settings`,
+      jsonRequest('POST', { setting: 'locked' }),
+    );
+    const leave = await app.request(`/instances/${INSTANCE_ID}/groups/${ENCODED_GROUP_JID}/leave`, jsonRequest('POST'));
+
+    expect(subject.status).toBe(200);
+    expect(description.status).toBe(200);
+    expect(settings.status).toBe(200);
+    expect(leave.status).toBe(200);
+    expect(updateGroupSubject).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, 'renomeado');
+    expect(updateGroupDescription).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, 'descrita');
+    expect(updateGroupSettings).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID, 'locked');
+    expect(leaveGroup).toHaveBeenCalledWith(INSTANCE_ID, GROUP_JID);
+  });
+});

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -3,7 +3,7 @@
  */
 
 import { zValidator } from '@hono/zod-validator';
-import type { ChannelPlugin, ChannelRegistry } from '@omni/channel-sdk';
+import type { ChannelPlugin, ChannelRegistry, GroupParticipantUpdateResult } from '@omni/channel-sdk';
 import { AccessModeSchema, ChannelTypeSchema, NotFoundError, createLogger } from '@omni/core';
 import type { SyncJobType } from '@omni/db';
 import { Hono } from 'hono';
@@ -2357,6 +2357,71 @@ instancesRoutes.delete('/:id/profile/picture', instanceAccess, async (c) => {
   }
 });
 
+const groupParticipantActionSchema = z.enum(['add', 'remove', 'promote', 'demote']);
+const groupSettingSchema = z.enum(['announcement', 'not_announcement', 'locked', 'unlocked']);
+
+const groupParticipantsSchema = z.object({
+  participants: z.array(z.string().min(1)).min(1).describe('Phone numbers or JIDs to mutate'),
+});
+
+const groupParticipantsPatchSchema = groupParticipantsSchema.extend({
+  action: groupParticipantActionSchema.describe('Participant mutation action'),
+});
+
+const updateGroupSubjectSchema = z.object({
+  subject: z.string().min(1).max(100).describe('New group name/subject'),
+});
+
+const updateGroupDescriptionSchema = z.object({
+  description: z.string().max(2048).describe('New group description. Empty string clears the description.'),
+});
+
+const updateGroupSettingsSchema = z.object({
+  setting: groupSettingSchema.describe('Group setting to apply'),
+});
+
+const patchGroupSchema = z
+  .object({
+    subject: z.string().min(1).max(100).optional(),
+    description: z.string().max(2048).optional(),
+    setting: groupSettingSchema.optional(),
+  })
+  .refine((value) => value.subject !== undefined || value.description !== undefined || value.setting !== undefined, {
+    message: 'At least one of subject, description, or setting is required',
+  });
+
+async function resolveInstancePlugin(
+  services: Services,
+  channelRegistry: ChannelRegistry | null | undefined,
+  instanceId: string,
+): Promise<
+  { ok: true; plugin: ChannelPlugin } | { ok: false; status: 400 | 503; error: { code: string; message: string } }
+> {
+  const instance = await services.instances.getById(instanceId);
+
+  if (!channelRegistry) {
+    return { ok: false, status: 503, error: { code: 'NO_REGISTRY', message: 'Channel registry not available' } };
+  }
+
+  const plugin = channelRegistry.get(instance.channel as Parameters<typeof channelRegistry.get>[0]);
+  if (!plugin) {
+    return {
+      ok: false,
+      status: 400,
+      error: { code: 'PLUGIN_NOT_FOUND', message: `No plugin for channel: ${instance.channel}` },
+    };
+  }
+
+  return { ok: true, plugin };
+}
+
+function participantUpdateResponse(result: GroupParticipantUpdateResult) {
+  return {
+    ...result,
+    changedCount: result.participants.length,
+  };
+}
+
 // ============================================================================
 // Group Create
 // ============================================================================
@@ -2410,6 +2475,342 @@ instancesRoutes.post(
     return c.json({ data: result }, 201);
   },
 );
+
+// ============================================================================
+// Group Participant Mutations
+// ============================================================================
+
+/**
+ * POST /instances/:id/groups/:groupJid/participants - Add participants to a group
+ */
+instancesRoutes.post(
+  '/:id/groups/:groupJid/participants',
+  instanceAccess,
+  zValidator('json', groupParticipantsSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { participants } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupParticipants !== 'function') {
+      return c.json(
+        { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group participant updates' } },
+        400,
+      );
+    }
+
+    try {
+      const result = await resolved.plugin.updateGroupParticipants(id, groupJid, participants, 'add');
+      return c.json({ success: true, data: participantUpdateResponse(result) });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_PARTICIPANTS_UPDATE_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * POST /instances/:id/groups/:groupJid/participants/:action - Remove/promote/demote participants
+ */
+instancesRoutes.post(
+  '/:id/groups/:groupJid/participants/:action',
+  instanceAccess,
+  zValidator('json', groupParticipantsSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const parsedAction = groupParticipantActionSchema.safeParse(c.req.param('action'));
+    const { participants } = c.req.valid('json');
+
+    if (!parsedAction.success) {
+      return c.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid group participant action. Expected add, remove, promote, or demote.',
+          },
+        },
+        400,
+      );
+    }
+
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupParticipants !== 'function') {
+      return c.json(
+        { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group participant updates' } },
+        400,
+      );
+    }
+
+    try {
+      const result = await resolved.plugin.updateGroupParticipants(id, groupJid, participants, parsedAction.data);
+      return c.json({ success: true, data: participantUpdateResponse(result) });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_PARTICIPANTS_UPDATE_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * PATCH /instances/:id/groups/:groupJid/participants - Mutate participants with body.action
+ */
+instancesRoutes.patch(
+  '/:id/groups/:groupJid/participants',
+  instanceAccess,
+  zValidator('json', groupParticipantsPatchSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { action, participants } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupParticipants !== 'function') {
+      return c.json(
+        { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group participant updates' } },
+        400,
+      );
+    }
+
+    try {
+      const result = await resolved.plugin.updateGroupParticipants(id, groupJid, participants, action);
+      return c.json({ success: true, data: participantUpdateResponse(result) });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_PARTICIPANTS_UPDATE_FAILED', message } }, 500);
+    }
+  },
+);
+
+// ============================================================================
+// Group Metadata Mutations
+// ============================================================================
+
+/**
+ * PATCH /instances/:id/groups/:groupJid - Update group subject, description, or settings
+ */
+instancesRoutes.patch('/:id/groups/:groupJid', instanceAccess, zValidator('json', patchGroupSchema), async (c) => {
+  const id = c.req.param('id');
+  const groupJid = c.req.param('groupJid');
+  const body = c.req.valid('json');
+  const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+  if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+  if (body.subject !== undefined && typeof resolved.plugin.updateGroupSubject !== 'function') {
+    return c.json({ error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group rename' } }, 400);
+  }
+  if (body.description !== undefined && typeof resolved.plugin.updateGroupDescription !== 'function') {
+    return c.json(
+      { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group description updates' } },
+      400,
+    );
+  }
+  if (body.setting !== undefined && typeof resolved.plugin.updateGroupSettings !== 'function') {
+    return c.json({ error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group settings updates' } }, 400);
+  }
+
+  try {
+    const updated: string[] = [];
+    if (body.subject !== undefined) {
+      await resolved.plugin.updateGroupSubject?.(id, groupJid, body.subject);
+      updated.push('subject');
+    }
+    if (body.description !== undefined) {
+      await resolved.plugin.updateGroupDescription?.(id, groupJid, body.description);
+      updated.push('description');
+    }
+    if (body.setting !== undefined) {
+      await resolved.plugin.updateGroupSettings?.(id, groupJid, body.setting);
+      updated.push('settings');
+    }
+
+    return c.json({ success: true, data: { instanceId: id, groupJid, updated, ...body } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return c.json({ error: { code: 'GROUP_UPDATE_FAILED', message } }, 500);
+  }
+});
+
+/**
+ * PUT /instances/:id/groups/:groupJid/subject - Rename a group
+ */
+instancesRoutes.put(
+  '/:id/groups/:groupJid/subject',
+  instanceAccess,
+  zValidator('json', updateGroupSubjectSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { subject } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupSubject !== 'function') {
+      return c.json({ error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group rename' } }, 400);
+    }
+
+    try {
+      await resolved.plugin.updateGroupSubject(id, groupJid, subject);
+      return c.json({ success: true, data: { instanceId: id, groupJid, subject, action: 'group_subject_updated' } });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_RENAME_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * POST /instances/:id/groups/:groupJid/subject - Rename a group
+ */
+instancesRoutes.post(
+  '/:id/groups/:groupJid/subject',
+  instanceAccess,
+  zValidator('json', updateGroupSubjectSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { subject } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupSubject !== 'function') {
+      return c.json({ error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group rename' } }, 400);
+    }
+
+    try {
+      await resolved.plugin.updateGroupSubject(id, groupJid, subject);
+      return c.json({ success: true, data: { instanceId: id, groupJid, subject, action: 'group_subject_updated' } });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_RENAME_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * PUT /instances/:id/groups/:groupJid/description - Set or clear group description
+ */
+instancesRoutes.put(
+  '/:id/groups/:groupJid/description',
+  instanceAccess,
+  zValidator('json', updateGroupDescriptionSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { description } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupDescription !== 'function') {
+      return c.json(
+        { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group description updates' } },
+        400,
+      );
+    }
+
+    try {
+      await resolved.plugin.updateGroupDescription(id, groupJid, description);
+      return c.json({
+        success: true,
+        data: { instanceId: id, groupJid, description, action: 'group_description_updated' },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_DESCRIPTION_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * POST /instances/:id/groups/:groupJid/description - Set or clear group description
+ */
+instancesRoutes.post(
+  '/:id/groups/:groupJid/description',
+  instanceAccess,
+  zValidator('json', updateGroupDescriptionSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { description } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupDescription !== 'function') {
+      return c.json(
+        { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group description updates' } },
+        400,
+      );
+    }
+
+    try {
+      await resolved.plugin.updateGroupDescription(id, groupJid, description);
+      return c.json({
+        success: true,
+        data: { instanceId: id, groupJid, description, action: 'group_description_updated' },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_DESCRIPTION_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * POST /instances/:id/groups/:groupJid/settings - Update group settings
+ */
+instancesRoutes.post(
+  '/:id/groups/:groupJid/settings',
+  instanceAccess,
+  zValidator('json', updateGroupSettingsSchema),
+  async (c) => {
+    const id = c.req.param('id');
+    const groupJid = c.req.param('groupJid');
+    const { setting } = c.req.valid('json');
+    const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+    if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+    if (typeof resolved.plugin.updateGroupSettings !== 'function') {
+      return c.json(
+        { error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support group settings updates' } },
+        400,
+      );
+    }
+
+    try {
+      await resolved.plugin.updateGroupSettings(id, groupJid, setting);
+      return c.json({ success: true, data: { instanceId: id, groupJid, setting, action: 'group_settings_updated' } });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: { code: 'GROUP_SETTINGS_FAILED', message } }, 500);
+    }
+  },
+);
+
+/**
+ * POST /instances/:id/groups/:groupJid/leave - Leave a group
+ */
+instancesRoutes.post('/:id/groups/:groupJid/leave', instanceAccess, async (c) => {
+  const id = c.req.param('id');
+  const groupJid = c.req.param('groupJid');
+  const resolved = await resolveInstancePlugin(c.get('services'), c.get('channelRegistry'), id);
+
+  if (!resolved.ok) return c.json({ error: resolved.error }, resolved.status);
+  if (typeof resolved.plugin.leaveGroup !== 'function') {
+    return c.json({ error: { code: 'NOT_SUPPORTED', message: 'Plugin does not support leaving groups' } }, 400);
+  }
+
+  try {
+    await resolved.plugin.leaveGroup(id, groupJid);
+    return c.json({ success: true, data: { instanceId: id, groupJid, left: true } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return c.json({ error: { code: 'GROUP_LEAVE_FAILED', message } }, 500);
+  }
+});
 
 // ============================================================================
 // C3: Group Invite Links

--- a/packages/channel-sdk/src/types/plugin.ts
+++ b/packages/channel-sdk/src/types/plugin.ts
@@ -13,6 +13,18 @@ import type { ConnectionStatus, InstanceConfig } from './instance';
 import type { OutgoingMessage, SendResult } from './messaging';
 import type { StreamSender } from './streaming';
 
+export type GroupParticipantAction = 'add' | 'remove' | 'promote' | 'demote';
+export type GroupSetting = 'announcement' | 'not_announcement' | 'locked' | 'unlocked';
+
+export interface GroupParticipantUpdateResult {
+  groupJid: string;
+  action: GroupParticipantAction;
+  participants: Array<{
+    jid?: string;
+    status: string;
+  }>;
+}
+
 /**
  * Health status for the plugin
  */
@@ -329,6 +341,51 @@ export interface ChannelPlugin {
       role?: 'admin' | 'superadmin' | 'member';
     }>;
   }>;
+
+  /**
+   * Add, remove, promote, or demote group participants.
+   *
+   * Optional - implement to support group participant mutations.
+   *
+   * @param instanceId - Instance to mutate group participants for
+   * @param groupJid - Group JID to mutate
+   * @param participants - User phone numbers or JIDs
+   * @param action - Mutation action
+   */
+  updateGroupParticipants?(
+    instanceId: string,
+    groupJid: string,
+    participants: string[],
+    action: GroupParticipantAction,
+  ): Promise<GroupParticipantUpdateResult>;
+
+  /**
+   * Rename a group.
+   *
+   * Optional - implement to support group subject updates.
+   */
+  updateGroupSubject?(instanceId: string, groupJid: string, subject: string): Promise<void>;
+
+  /**
+   * Set or clear a group description.
+   *
+   * Optional - implement to support group description updates.
+   */
+  updateGroupDescription?(instanceId: string, groupJid: string, description?: string): Promise<void>;
+
+  /**
+   * Update WhatsApp-style group settings.
+   *
+   * Optional - implement to support group settings updates.
+   */
+  updateGroupSettings?(instanceId: string, groupJid: string, setting: GroupSetting): Promise<void>;
+
+  /**
+   * Leave a group.
+   *
+   * Optional - implement to support leaving groups.
+   */
+  leaveGroup?(instanceId: string, groupJid: string): Promise<void>;
 
   // ─────────────────────────────────────────────────────────────
   // Health

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -11,6 +11,9 @@ import type {
   DedupeCache,
   FetchHistoryOptions,
   FetchHistoryResult,
+  GroupParticipantAction,
+  GroupParticipantUpdateResult,
+  GroupSetting,
   HistorySyncMessage,
   InstanceConfig,
   OutgoingMessage,
@@ -32,7 +35,7 @@ import {
   setupConnectionHandlers,
 } from './handlers/connection';
 import { setupMessageHandlers, tryDownloadMedia } from './handlers/messages';
-import { fromJid, isGroupJid, isLidJid, isUserJid, toJid } from './jid';
+import { fromJid, isGroupJid, isLidJid, isUserJid, toGroupJid, toJid } from './jid';
 import { buildMessageContent } from './senders/builders';
 import { computeWaid } from './senders/contact';
 import { removeReaction, sendReaction } from './senders/reaction';
@@ -2450,6 +2453,116 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       });
 
       return { members };
+    } catch (error) {
+      const waError = mapBaileysError(error);
+      throw waError;
+    }
+  }
+
+  /**
+   * Add, remove, promote, or demote group participants.
+   */
+  async updateGroupParticipants(
+    instanceId: string,
+    groupJid: string,
+    participants: string[],
+    action: GroupParticipantAction,
+  ): Promise<GroupParticipantUpdateResult> {
+    await this.humanDelay(instanceId);
+    const sock = this.getSocket(instanceId);
+    const jid = toGroupJid(groupJid);
+    const participantJids = participants.map((participant) => toJid(participant));
+
+    try {
+      const result = await sock.groupParticipantsUpdate(jid, participantJids, action);
+      this.invalidateGroupMetadataCache(instanceId, jid);
+      this.logger.info('Group participants updated', {
+        instanceId,
+        groupJid: jid,
+        action,
+        participantCount: participantJids.length,
+      });
+
+      return {
+        groupJid: jid,
+        action,
+        participants: result.map((participant) => ({
+          jid: participant.jid,
+          status: participant.status,
+        })),
+      };
+    } catch (error) {
+      const waError = mapBaileysError(error);
+      throw waError;
+    }
+  }
+
+  /**
+   * Rename a group.
+   */
+  async updateGroupSubject(instanceId: string, groupJid: string, subject: string): Promise<void> {
+    await this.humanDelay(instanceId);
+    const sock = this.getSocket(instanceId);
+    const jid = toGroupJid(groupJid);
+
+    try {
+      await sock.groupUpdateSubject(jid, subject);
+      this.invalidateGroupMetadataCache(instanceId, jid);
+      this.logger.info('Group subject updated', { instanceId, groupJid: jid });
+    } catch (error) {
+      const waError = mapBaileysError(error);
+      throw waError;
+    }
+  }
+
+  /**
+   * Set or clear a group description.
+   */
+  async updateGroupDescription(instanceId: string, groupJid: string, description?: string): Promise<void> {
+    await this.humanDelay(instanceId);
+    const sock = this.getSocket(instanceId);
+    const jid = toGroupJid(groupJid);
+
+    try {
+      await sock.groupUpdateDescription(jid, description);
+      this.invalidateGroupMetadataCache(instanceId, jid);
+      this.logger.info('Group description updated', { instanceId, groupJid: jid, cleared: !description });
+    } catch (error) {
+      const waError = mapBaileysError(error);
+      throw waError;
+    }
+  }
+
+  /**
+   * Update group settings.
+   */
+  async updateGroupSettings(instanceId: string, groupJid: string, setting: GroupSetting): Promise<void> {
+    await this.humanDelay(instanceId);
+    const sock = this.getSocket(instanceId);
+    const jid = toGroupJid(groupJid);
+
+    try {
+      await sock.groupSettingUpdate(jid, setting);
+      this.invalidateGroupMetadataCache(instanceId, jid);
+      this.logger.info('Group settings updated', { instanceId, groupJid: jid, setting });
+    } catch (error) {
+      const waError = mapBaileysError(error);
+      throw waError;
+    }
+  }
+
+  /**
+   * Leave a group.
+   */
+  async leaveGroup(instanceId: string, groupJid: string): Promise<void> {
+    await this.humanDelay(instanceId);
+    const sock = this.getSocket(instanceId);
+    const jid = toGroupJid(groupJid);
+
+    try {
+      await sock.groupLeave(jid);
+      this.invalidateGroupMetadataCache(instanceId, jid);
+      this.logger.info('Left group', { instanceId, groupJid: jid });
     } catch (error) {
       const waError = mapBaileysError(error);
       throw waError;


### PR DESCRIPTION
## Summary

- add the channel SDK contract for group participant and metadata mutations
- implement WhatsApp-backed participant add/remove/promote/demote, subject, description, settings, and leave operations
- expose instance-scoped REST endpoints for those group mutations

## Validation

- `bun test packages/api/src/routes/v2/__tests__/instances-group-mutations.test.ts`
- `bunx biome check packages/api/src/routes/v2/instances.ts packages/api/src/routes/v2/__tests__/instances-group-mutations.test.ts packages/channel-sdk/src/types/plugin.ts packages/channel-whatsapp/src/plugin.ts`
- `bun run typecheck`
- `bun run build`
- pre-push hook: `bun run typecheck` and full `bun test` suite

## Local Deploy

- restarted the local PM2 API/NATS processes
- confirmed local API health on `http://localhost:8882/api/v2/health`
