### PR TITLE
fix(channel-gupshup): accept simplified HV-Entry-Flow payload

### DIFF
--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -14,7 +14,7 @@
 import { describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { handleGupshupWebhook } from '../handlers/webhooks';
+import { GupshupSimplifiedWebhookSchema, handleGupshupWebhook, parseSimplifiedWebhook } from '../handlers/webhooks';
 import { GUPSHUP_WEBHOOK_METRIC } from '../observability';
 import type { GupshupPlugin } from '../plugin';
 
@@ -683,5 +683,139 @@ describe('handleGupshupWebhook — observability signals (#504)', () => {
     expect(firstSeenWarns).toHaveLength(1);
     expect(firstSeenWarns[0]?.data?.knownMessage).toBe(false);
     expect(firstSeenWarns[0]?.data?.knownNonMessage).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Simplified HV-Entry-Flow payload (2026-06 "Payload Data Clean-up")
+// ─────────────────────────────────────────────────────────────
+
+describe('Gupshup simplified Entry-Flow payload', () => {
+  const SIMPLIFIED = {
+    sender: { id: '5535984370828', name: 'Henrique GupShup' },
+    message: { text: 'Mensagem', timestamp: '1776273477' },
+    event: { project_id: '15646' },
+  };
+
+  it('schema accepts the simplified shape', () => {
+    expect(GupshupSimplifiedWebhookSchema.safeParse(SIMPLIFIED).success).toBe(true);
+  });
+
+  it('normalizes onto the native inbound shape', () => {
+    const w = parseSimplifiedWebhook(SIMPLIFIED);
+    expect(w).not.toBeNull();
+    expect(w?.sender).toBe('5535984370828');
+    expect(w?.event_type).toBe('user_input');
+    expect(w?.channel).toBe('whatsapp');
+    expect(w?.messageobj.type).toBe('text');
+    expect(w?.messageobj.text).toBe('Mensagem');
+    expect(w?.messageobj.from).toBe('5535984370828');
+    expect(w?.messageobj.timestamp).toBe(1776273477);
+    expect(w?.senderobj.display).toBe('Henrique GupShup');
+    expect(w?.messageHeader?.project_id).toBe('15646');
+  });
+
+  it('synthesizes a dedupe-stable id when none is provided (retries dedupe)', () => {
+    const a = parseSimplifiedWebhook(SIMPLIFIED);
+    const b = parseSimplifiedWebhook(SIMPLIFIED);
+    expect(a?.messageobj.id).toBe(b?.messageobj.id);
+    expect(a?.messageobj.id).toContain('5535984370828');
+  });
+
+  it('prefers an explicit message.id when present', () => {
+    const w = parseSimplifiedWebhook({ ...SIMPLIFIED, message: { ...SIMPLIFIED.message, id: 'wamid.X1' } });
+    expect(w?.messageobj.id).toBe('wamid.X1');
+  });
+
+  it('accepts millisecond timestamps and returns an integer unix-seconds value', () => {
+    const w = parseSimplifiedWebhook({ ...SIMPLIFIED, message: { text: 'oi', timestamp: 1776273477000 } });
+    expect(w?.messageobj.timestamp).toBe(1776273477);
+    expect(Number.isInteger(w?.messageobj.timestamp)).toBe(true);
+  });
+
+  it('floors a fractional timestamp to an integer (native schema requires int)', () => {
+    const w = parseSimplifiedWebhook({ ...SIMPLIFIED, message: { text: 'oi', timestamp: 1776273477.9 } });
+    expect(w?.messageobj.timestamp).toBe(1776273477);
+  });
+
+  it('returns null for the native (old) format — not its job', () => {
+    const native = { sender: '5511960008976', messageobj: { type: 'text', text: 'Oi' } };
+    expect(parseSimplifiedWebhook(native)).toBeNull();
+  });
+
+  it('returns null for the routing envelope (mensagem.tipo=route, conteudo null)', () => {
+    const route = {
+      event: 'message',
+      mensagem: { tipo: 'route', conteudo: null },
+      destino_previsto: 'eugenia-2',
+      context: { 'contact.phone': '5511984420290' },
+    };
+    expect(parseSimplifiedWebhook(route)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// End-to-end: simplified payload dispatches identically to native
+// ─────────────────────────────────────────────────────────────
+
+describe('handleGupshupWebhook — simplified payload dispatches like native', () => {
+  it('native and simplified payloads reach the agent with the same phone + text', async () => {
+    // Native (legacy) payload
+    const nativeH = makeHandlerHarness();
+    const nativeRes = await handleGupshupWebhook(
+      makeWebhookRequest(
+        makePayload({ type: 'text', text: 'Oi', from: '5511960008976', timestamp: 1776273477, id: 'wamid.NATIVE1' }),
+      ),
+      nativeH.plugin,
+      'inst-gs-handler',
+      undefined,
+      createInboundDedupeCache(),
+    );
+
+    // Simplified (HV-Entry-Flow) payload — same lead, same text
+    const simpleH = makeHandlerHarness();
+    const simpleRes = await handleGupshupWebhook(
+      makeWebhookRequest({
+        sender: { id: '5511960008976', name: 'Tuane' },
+        message: { text: 'Oi', timestamp: 1776273477 },
+        event: { project_id: '31569198' },
+      }),
+      simpleH.plugin,
+      'inst-gs-handler',
+      undefined,
+      createInboundDedupeCache(),
+    );
+
+    // Both ack and both dispatch exactly one inbound message…
+    expect(nativeRes.status).toBe(200);
+    expect(simpleRes.status).toBe(200);
+    expect(nativeH.received).toHaveLength(1);
+    expect(simpleH.received).toHaveLength(1);
+
+    // …with the same phone + text, so the rest of the pipeline behaves identically.
+    expect(nativeH.received[0]?.from).toBe('5511960008976');
+    expect(nativeH.received[0]?.content.text).toBe('Oi');
+    expect(simpleH.received[0]?.from).toBe(nativeH.received[0]?.from);
+    expect(simpleH.received[0]?.content.text).toBe(nativeH.received[0]?.content.text);
+  });
+
+  it('simplified payload is processed, not dropped (no unrecognized-shape warn)', async () => {
+    const { plugin, logs, received } = makeHandlerHarness();
+    const res = await handleGupshupWebhook(
+      makeWebhookRequest({
+        sender: { id: '5535984370828', name: 'Henrique' },
+        message: { text: 'oi quero plano' },
+        event: { project_id: '15646' },
+      }),
+      plugin,
+      'inst-gs-handler',
+      undefined,
+      createInboundDedupeCache(),
+    );
+
+    expect(res.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.content.text).toBe('oi quero plano');
+    expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unrecognized shape'))).toHaveLength(0);
   });
 });

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -102,6 +102,119 @@ const GupshupNativeWebhookSchema = z
   })
   .passthrough();
 
+// ─────────────────────────────────────────────────────────────
+// Simplified payload (HV-Entry-Flow "Payload Data Clean-up", 2026-06)
+// The Entry-Flow may send a slimmed-down shape instead of the native one:
+//   { sender: { id, name }, message: { text, timestamp }, event: { project_id } }
+// We accept it and normalize to the native shape so the rest of the handler —
+// and every downstream consumer — stays unchanged. Old + new both work.
+// ─────────────────────────────────────────────────────────────
+
+export const GupshupSimplifiedWebhookSchema = z
+  .object({
+    sender: z.object({
+      id: z.string().min(1).max(32),
+      name: z.string().max(256).optional(),
+    }),
+    message: z.object({
+      id: z.string().max(512).optional(),
+      text: z.string().max(65536).optional(),
+      timestamp: z.union([z.string(), z.number()]).optional(),
+    }),
+    event: z
+      .object({ project_id: z.string().max(64).optional() })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+/** messageobj.timestamp is unix *seconds* (int); accept seconds or millis from the source. */
+function toUnixSeconds(ts: string | number | undefined): number {
+  const n = typeof ts === 'number' ? ts : Number.parseInt(String(ts ?? ''), 10);
+  if (!Number.isFinite(n) || n <= 0) return Math.floor(Date.now() / 1000);
+  // Math.floor guarantees an integer even when a float timestamp is passed in.
+  return Math.floor(n > 1e12 ? n / 1000 : n);
+}
+
+/** Map the simplified Entry-Flow payload onto the native inbound webhook shape. */
+export function normalizeSimplifiedWebhook(
+  p: z.infer<typeof GupshupSimplifiedWebhookSchema>,
+): GupshupNativeInboundWebhook {
+  const phone = p.sender.id;
+  const text = p.message?.text;
+  const tsSeconds = toUnixSeconds(p.message?.timestamp);
+  // No native message id in the simplified payload — prefer one if present, else
+  // synthesize a stable id (phone+ts+len) so retries of the same message still
+  // dedupe. Distinct messages within the same second would collide (rare).
+  const id = p.message?.id ?? `gs-simplified-${phone}-${tsSeconds}-${text ? text.length : 0}`;
+  return {
+    source: 'gupshup-hv-entry-flow-simplified',
+    sender: phone,
+    channel: 'whatsapp',
+    destination: '',
+    botname: '',
+    event_type: 'user_input',
+    message: text,
+    postbackText: null,
+    senderobj: { channelid: phone, display: p.sender.name, channeltype: 'whatsapp' },
+    messageobj: {
+      id,
+      type: 'text',
+      from: phone,
+      timestamp: tsSeconds,
+      text,
+      raw: { sender: { name: p.sender.name } },
+    },
+    messageHeader: { event_type: 'user_input', project_id: p.event?.project_id },
+  };
+}
+
+/** Try the simplified schema; return a normalized native webhook, or null if it doesn't match. */
+export function parseSimplifiedWebhook(parsed: unknown): GupshupNativeInboundWebhook | null {
+  const r = GupshupSimplifiedWebhookSchema.safeParse(parsed);
+  return r.success ? normalizeSimplifiedWebhook(r.data) : null;
+}
+
+/**
+ * Resolve the parsed body into a native inbound webhook: native schema first,
+ * then the simplified HV-Entry-Flow fallback. Returns null when neither matches
+ * (already logged + drop metric recorded — the caller just acks with 200).
+ */
+function resolveInboundWebhook(
+  parsed: unknown,
+  instanceId: string,
+  logger: import('@omni/core').Logger,
+): GupshupNativeInboundWebhook | null {
+  const result = GupshupNativeWebhookSchema.safeParse(parsed);
+  if (result.success) {
+    return result.data as unknown as GupshupNativeInboundWebhook;
+  }
+  const simplified = parseSimplifiedWebhook(parsed);
+  if (simplified) {
+    logger.info('[gupshup] simplified Entry-Flow payload normalized', {
+      instanceId,
+      sender: simplified.sender,
+    });
+    return simplified;
+  }
+  logger.warn('[gupshup] webhook payload unrecognized shape (acking anyway)', {
+    instanceId,
+    errors: result.error.issues,
+    parsed,
+  });
+  // Fail-open: always ack so Gupshup doesn't retry.
+  const parsedEventType =
+    parsed !== null && typeof parsed === 'object' && 'event_type' in parsed
+      ? String((parsed as { event_type: unknown }).event_type ?? 'unparsed')
+      : 'unparsed';
+  recordGupshupWebhookReceived(logger, {
+    instanceId,
+    event_type: parsedEventType,
+    handled: 'dropped_unrecognized_shape',
+  });
+  return null;
+}
+
 // Download guard for media (100MB limit)
 const _downloadGuard = createInboundDedupeCache;
 
@@ -260,27 +373,12 @@ export async function handleGupshupWebhook(
     return new Response('OK', { status: 200 });
   }
 
-  const result = GupshupNativeWebhookSchema.safeParse(parsed);
-  if (!result.success) {
-    logger.warn('[gupshup] webhook payload unrecognized shape (acking anyway)', {
-      instanceId,
-      errors: result.error.issues,
-      parsed,
-    });
-    // Fail-open: always ack so Gupshup doesn't retry
-    const parsedEventType =
-      parsed !== null && typeof parsed === 'object' && 'event_type' in parsed
-        ? String((parsed as { event_type: unknown }).event_type ?? 'unparsed')
-        : 'unparsed';
-    recordGupshupWebhookReceived(logger, {
-      instanceId,
-      event_type: parsedEventType,
-      handled: 'dropped_unrecognized_shape',
-    });
+  // Native schema first, then the simplified HV-Entry-Flow fallback.
+  // resolveInboundWebhook logs + records the drop metric when neither matches.
+  const webhook = resolveInboundWebhook(parsed, instanceId, logger);
+  if (!webhook) {
     return new Response('OK', { status: 200 });
   }
-
-  const webhook = result.data as unknown as GupshupNativeInboundWebhook;
 
   // First-seen WARN — fires once per process per event_type value. Would have
   // caught the 2026-04-22 async_response cutover at webhook #1.

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -137,7 +137,7 @@ function toUnixSeconds(ts: string | number | undefined): number {
 }
 
 /** Map the simplified Entry-Flow payload onto the native inbound webhook shape. */
-export function normalizeSimplifiedWebhook(
+function normalizeSimplifiedWebhook(
   p: z.infer<typeof GupshupSimplifiedWebhookSchema>,
 ): GupshupNativeInboundWebhook {
   const phone = p.sender.id;

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -137,9 +137,7 @@ function toUnixSeconds(ts: string | number | undefined): number {
 }
 
 /** Map the simplified Entry-Flow payload onto the native inbound webhook shape. */
-function normalizeSimplifiedWebhook(
-  p: z.infer<typeof GupshupSimplifiedWebhookSchema>,
-): GupshupNativeInboundWebhook {
+function normalizeSimplifiedWebhook(p: z.infer<typeof GupshupSimplifiedWebhookSchema>): GupshupNativeInboundWebhook {
   const phone = p.sender.id;
   const text = p.message?.text;
   const tsSeconds = toUnixSeconds(p.message?.timestamp);


### PR DESCRIPTION
## Problem

A Gupshup integration can send a **simplified inbound webhook payload** (a "payload clean-up" variant) instead of the native shape:

```json
{ "sender": { "id": "...", "name": "..." },
  "message": { "text": "...", "timestamp": "..." },
  "event": { "project_id": "..." } }
```

This shape fails `GupshupNativeWebhookSchema` — which requires `sender` as a string plus `messageobj` / `senderobj` / `botname` / `channel` / `destination` / `event_type` — so the webhook is acked (200) but **dropped as `dropped_unrecognized_shape`**. The inbound message never reaches the agent dispatcher.

## Fix

- `GupshupSimplifiedWebhookSchema` for the simplified shape
- `normalizeSimplifiedWebhook()` maps it onto the native inbound shape (synthesizes a dedupe-stable message id when none is provided; `Math.floor` keeps the unix-seconds timestamp an integer; accepts seconds or milliseconds)
- The webhook handler falls back **native → simplified** before dropping (extracted `resolveInboundWebhook` to keep `handleGupshupWebhook` within the cognitive-complexity limit)
- Downstream consumers unchanged; the native payload keeps working

## Tests

- Unit tests for the schema + normalizer (fractional/ms timestamps, explicit `message.id`, and that it rejects both the native shape and unrelated routing envelopes)
- **End-to-end handler tests** proving the simplified payload dispatches an **identical** inbound message (same phone + text) as the native one, and is not dropped
- All `channel-gupshup` tests pass · biome + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
