### PR TITLE
fix(gupshup): resolve native reply quoted aliases

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1585,6 +1585,53 @@ describe('agent-dispatcher', () => {
       } as unknown as import('../../services').Services;
     }
 
+    it('resolves gupshup native reply aliases when replyContext.id is not the outbound external id', async () => {
+      const chatRow = { id: 'chat-db-1', externalId: 'chat-ext-1', chatType: 'dm' };
+      const quotedRow = {
+        externalId: 'omni-outbound-uuid',
+        senderDisplayName: 'You',
+        senderPlatformUserId: 'bot-123',
+        isFromMe: true,
+        platformTimestamp: new Date('2026-06-09T05:49:16Z').getTime(),
+        messageType: 'text',
+        textContent: '*Notrelife SP* com coparticipação parcial',
+        transcription: null,
+        imageDescription: null,
+        videoDescription: null,
+        documentExtraction: null,
+        rawPayload: {
+          gupshupResponse: {
+            messageId: '033ve4XFB8ikDjlsH9KcOI',
+            gsId: 'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+          },
+        },
+      };
+      const getByExternalId = mock(async (_chatId: string, externalId: string) =>
+        externalId === 'omni-outbound-uuid' ? quotedRow : null,
+      );
+      const findByProviderAlias = mock(async (_chatId: string, aliases: string[]) =>
+        aliases.includes('033ve4XFB8ikDjlsH9KcOI') || aliases.includes('f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b')
+          ? quotedRow
+          : null,
+      );
+      const services = {
+        chats: { findByExternalIdSmart: mock(async () => chatRow) },
+        messages: { getByExternalId, findByProviderAlias },
+      } as unknown as import('../../services').Services;
+
+      const result = await resolveQuotedMessage(services, 'inst-1', 'chat-ext-1', '033ve4XFB8ikDjlsH9KcOI', [
+        'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+      ]);
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('*Notrelife SP*');
+      expect(getByExternalId).toHaveBeenCalledWith('chat-db-1', '033ve4XFB8ikDjlsH9KcOI');
+      expect(findByProviderAlias).toHaveBeenCalledWith('chat-db-1', [
+        '033ve4XFB8ikDjlsH9KcOI',
+        'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+      ]);
+    });
+
     it('returns full text when content is under 4000 chars', async () => {
       const content = 'A'.repeat(3999);
       const services = createQuotedMessageServices(content);

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -981,17 +981,51 @@ function getMessageContentText(msg: {
  * Resolve a quoted message into formatted text for the agent.
  * Looks up the referenced message and formats its content.
  */
+type MessageAliasLookup = Services['messages'] & {
+  findByProviderAlias?: (chatId: string, aliases: string[]) => ReturnType<Services['messages']['getByExternalId']>;
+};
+
+function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}
+
+async function lookupQuotedMessage(
+  messages: Services['messages'],
+  chatDbId: string,
+  replyToId: string,
+  aliases: string[],
+): ReturnType<Services['messages']['getByExternalId']> {
+  const quoted = await messages.getByExternalId(chatDbId, replyToId);
+  if (quoted) return quoted;
+
+  const candidates = uniqueNonEmpty([replyToId, ...aliases]);
+  const aliasLookup = messages as MessageAliasLookup;
+  if (aliasLookup.findByProviderAlias && candidates.length > 0) {
+    const byAlias = await aliasLookup.findByProviderAlias(chatDbId, candidates);
+    if (byAlias) return byAlias;
+  }
+
+  for (const candidate of candidates) {
+    if (candidate === replyToId) continue;
+    const byExternalId = await messages.getByExternalId(chatDbId, candidate);
+    if (byExternalId) return byExternalId;
+  }
+
+  return null;
+}
+
 export async function resolveQuotedMessage(
   services: Services,
   instanceId: string,
   chatId: string,
   replyToId: string,
+  providerAliases: string[] = [],
 ): Promise<string | null> {
   try {
     const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
     if (!chat) return null;
 
-    const quoted = await services.messages.getByExternalId(chat.id, replyToId);
+    const quoted = await lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases);
     if (!quoted) return null;
 
     const sender = quoted.senderDisplayName ?? quoted.senderPlatformUserId ?? (quoted.isFromMe ? 'You' : 'unknown');
@@ -1129,6 +1163,24 @@ async function collectProcessedMedia(
 /**
  * Resolve quoted messages and prepend context to message texts.
  */
+function extractQuotedProviderAliases(rawPayload: Record<string, unknown> | undefined): string[] {
+  if (!rawPayload) return [];
+
+  const messageObj = isRecord(rawPayload.messageobj) ? rawPayload.messageobj : undefined;
+  const replyContext = isRecord(messageObj?.replyContext) ? messageObj.replyContext : undefined;
+  const rawMessage = isRecord(messageObj?.raw) ? messageObj.raw : undefined;
+  const rawContext = isRecord(rawMessage?.context) ? rawMessage.context : undefined;
+  const topContext = isRecord(rawPayload.context) ? rawPayload.context : undefined;
+
+  return uniqueNonEmpty([
+    replyContext?.internalId as string | undefined,
+    rawContext?.gsId as string | undefined,
+    rawContext?.id as string | undefined,
+    topContext?.gsId as string | undefined,
+    topContext?.id as string | undefined,
+  ]);
+}
+
 async function prependQuotedContext(
   services: Services,
   instanceId: string,
@@ -1141,7 +1193,8 @@ async function prependQuotedContext(
     const replyToId = m.payload.replyToId;
     if (!replyToId) continue;
 
-    const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId);
+    const providerAliases = extractQuotedProviderAliases(m.payload.rawPayload as Record<string, unknown> | undefined);
+    const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId, providerAliases);
     if (!quotedText) continue;
 
     const messageKey = messageKeyByIndex.get(index);

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -298,6 +298,41 @@ export class MessageService {
     return result ?? null;
   }
 
+  /**
+   * Get an outbound message by provider alias captured in raw_payload.
+   *
+   * Gupshup native replies may reference provider-generated ids
+   * (replyContext.id / gsId / internalId) instead of Omni's external_id. When
+   * the send path preserved the provider response, search those aliases before
+   * giving up on quoted-message context.
+   */
+  async findByProviderAlias(chatId: string, aliases: string[]): Promise<Message | null> {
+    const candidates = [
+      ...new Set(
+        aliases.filter((alias) => typeof alias === 'string' && alias.length > 0).map((alias) => alias.slice(0, 255)),
+      ),
+    ].slice(0, 8);
+    if (candidates.length === 0) return null;
+
+    const aliasConditions = candidates.flatMap((alias) => [
+      eq(messages.externalId, alias),
+      sql`${messages.rawPayload}->'gupshupResponse'->>'messageId' = ${alias}`,
+      sql`${messages.rawPayload}->'gupshupResponse'->>'gsId' = ${alias}`,
+      sql`${messages.rawPayload}->'gupshupResponse'->>'id' = ${alias}`,
+      sql`${messages.rawPayload}->'gupshupResponse'->'messageIds' @> ${JSON.stringify([alias])}::jsonb`,
+      sql`${messages.rawPayload}->'gupshupProviderAliases' @> ${JSON.stringify([alias])}::jsonb`,
+    ]);
+
+    const [result] = await this.db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.chatId, chatId), eq(messages.isFromMe, true), or(...aliasConditions)))
+      .orderBy(desc(messages.platformTimestamp))
+      .limit(1);
+
+    return result ?? null;
+  }
+
   /** Get multiple messages by external IDs in a single query */
   async getByExternalIds(chatId: string, externalIds: string[]): Promise<Message[]> {
     if (externalIds.length === 0) return [];

--- a/packages/channel-gupshup/src/__tests__/plugin.test.ts
+++ b/packages/channel-gupshup/src/__tests__/plugin.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, mock, spyOn } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import { GupshupPlugin } from '../plugin';
+
+function makeOkResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeLogger() {
+  const logger = {
+    child: mock(() => logger),
+    info: mock(() => undefined),
+    debug: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  };
+  return logger;
+}
+
+describe('GupshupPlugin — outbound provider aliases', () => {
+  it('emits message.sent with gupshup response aliases in rawPayload', async () => {
+    const published: Array<[string, Record<string, unknown>, Record<string, unknown>]> = [];
+    const publish = mock(async (type: string, payload: unknown, metadata: unknown) => {
+      published.push([type, payload as Record<string, unknown>, metadata as Record<string, unknown>]);
+    });
+    const fetchSpy = spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(makeOkResponse({ status: 'ok' }))
+      .mockResolvedValueOnce(
+        makeOkResponse({
+          status: 'ok',
+          messageId: '033ve4XFB8ikDjlsH9KcOI',
+          gsId: 'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+          messageIds: ['033ve4XFB8ikDjlsH9KcOI'],
+          echoedSecret: 'must-not-persist',
+        }),
+      );
+
+    const plugin = new GupshupPlugin();
+    await plugin.initialize({
+      eventBus: { publish } as unknown as EventBus,
+      logger: makeLogger(),
+      storage: {} as never,
+      config: {} as never,
+      db: {} as never,
+    });
+    await plugin.connect('inst-1', {
+      instanceId: 'inst-1',
+      credentials: {
+        gupshupCallbackUrl: 'https://callbacks.gupshup.io/custom/abc123',
+        gupshupAuthToken: 'Bearer test-auth-token',
+      },
+    });
+
+    const result = await plugin.sendMessage('inst-1', {
+      to: '+55 11 98888-0000',
+      content: { type: 'text', text: 'Plano Notrelife' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe('033ve4XFB8ikDjlsH9KcOI');
+
+    const sentEvent = published.find(([type]) => type === 'message.sent');
+    expect(sentEvent).toBeDefined();
+    const [, payload] = sentEvent!;
+    expect(payload.externalId).toBe('033ve4XFB8ikDjlsH9KcOI');
+    expect(payload.rawPayload).toEqual({
+      gupshupResponse: {
+        status: 'ok',
+        messageId: '033ve4XFB8ikDjlsH9KcOI',
+        gsId: 'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+        messageIds: ['033ve4XFB8ikDjlsH9KcOI'],
+      },
+      gupshupProviderAliases: ['033ve4XFB8ikDjlsH9KcOI', 'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b'],
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it('keeps UUID externalId fallback when Gupshup response has aliases but no messageId', async () => {
+    const published: Array<[string, Record<string, unknown>, Record<string, unknown>]> = [];
+    const publish = mock(async (type: string, payload: unknown, metadata: unknown) => {
+      published.push([type, payload as Record<string, unknown>, metadata as Record<string, unknown>]);
+    });
+    const fetchSpy = spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(makeOkResponse({ status: 'ok' }))
+      .mockResolvedValueOnce(
+        makeOkResponse({
+          status: 'ok',
+          gsId: 'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+          id: 'provider-short-id',
+        }),
+      );
+
+    const plugin = new GupshupPlugin();
+    await plugin.initialize({
+      eventBus: { publish } as unknown as EventBus,
+      logger: makeLogger(),
+      storage: {} as never,
+      config: {} as never,
+      db: {} as never,
+    });
+    await plugin.connect('inst-1', {
+      instanceId: 'inst-1',
+      credentials: {
+        gupshupCallbackUrl: 'https://callbacks.gupshup.io/custom/abc123',
+        gupshupAuthToken: 'Bearer test-auth-token',
+      },
+    });
+
+    const result = await plugin.sendMessage('inst-1', {
+      to: '+55 11 98888-0000',
+      content: { type: 'text', text: 'Sem messageId' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).not.toBe('f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b');
+    expect(result.messageId).not.toBe('provider-short-id');
+    expect(typeof result.messageId).toBe('string');
+
+    const sentEvent = published.find(([type]) => type === 'message.sent');
+    expect(sentEvent).toBeDefined();
+    const [, payload] = sentEvent!;
+    expect(payload.externalId).toBe(result.messageId);
+    expect(payload.rawPayload).toEqual({
+      gupshupResponse: {
+        status: 'ok',
+        messageId: undefined,
+        gsId: 'f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b',
+        id: 'provider-short-id',
+        messageIds: [],
+      },
+      gupshupProviderAliases: ['f5d6cdc1-3b1d-4c8d-a1fa-089b43c7105b', 'provider-short-id'],
+    });
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/channel-gupshup/src/plugin.ts
+++ b/packages/channel-gupshup/src/plugin.ts
@@ -75,6 +75,38 @@ interface GupshupInstanceState {
   dedupeCache: DedupeCache;
 }
 
+function extractResponseString(response: GupshupSendResponse, key: string): string | undefined {
+  const value = response[key];
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value.slice(0, 255);
+}
+
+function extractGupshupMessageIds(response: GupshupSendResponse): string[] {
+  if (!Array.isArray(response.messageIds)) return [];
+  return response.messageIds
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .map((value) => value.slice(0, 255));
+}
+
+function extractGupshupProviderAliases(response: GupshupSendResponse): string[] {
+  return [
+    extractResponseString(response, 'messageId'),
+    extractResponseString(response, 'gsId'),
+    extractResponseString(response, 'id'),
+    ...extractGupshupMessageIds(response),
+  ].filter((value, index, values): value is string => typeof value === 'string' && values.indexOf(value) === index);
+}
+
+function buildGupshupResponseMetadata(response: GupshupSendResponse): Record<string, unknown> {
+  return {
+    status: extractResponseString(response, 'status'),
+    messageId: extractResponseString(response, 'messageId'),
+    gsId: extractResponseString(response, 'gsId'),
+    id: extractResponseString(response, 'id'),
+    messageIds: extractGupshupMessageIds(response),
+  };
+}
+
 export class GupshupPlugin extends BaseChannelPlugin {
   readonly id = 'gupshup' as ChannelType;
   readonly name = 'Gupshup WhatsApp';
@@ -190,9 +222,11 @@ export class GupshupPlugin extends BaseChannelPlugin {
 
     try {
       const response = await dispatchContent(client, dest, message);
-      // Gupshup doesn't reliably return a messageId — fall back to a UUID so each
-      // sent message gets a unique externalId and is stored as its own DB row.
-      const messageId = typeof response.messageId === 'string' ? response.messageId : crypto.randomUUID();
+      const providerAliases = extractGupshupProviderAliases(response);
+      // Preserve existing externalId semantics: use Gupshup's canonical
+      // messageId when present, otherwise keep Omni's UUID fallback. Other
+      // provider ids remain searchable through rawPayload aliases.
+      const messageId = extractResponseString(response, 'messageId') ?? crypto.randomUUID();
 
       // Journey timing: T11 (platformDeliveredAt) after API responds
       if (correlationId) this.captureT11(correlationId);
@@ -208,6 +242,10 @@ export class GupshupPlugin extends BaseChannelPlugin {
           mediaUrl: content.mediaUrl,
         },
         replyToId: message.replyTo,
+        rawPayload: {
+          gupshupResponse: buildGupshupResponseMetadata(response),
+          gupshupProviderAliases: providerAliases,
+        },
         senderAgentId: message.metadata?.senderAgentId as string | undefined,
       });
 


### PR DESCRIPTION
## Summary
- Preserve Gupshup native reply identifiers from inbound payloads as response aliases.
- Resolve quoted-message lookups through those aliases when `replyContext.id` is not the outbound external id.
- Add regression coverage at the Gupshup plugin boundary and agent dispatcher resolver.

## Test plan
- `bun test packages/api/src/plugins/__tests__/agent-dispatcher.test.ts -t "resolves gupshup native reply aliases when replyContext.id is not the outbound external id"`
- `bun test packages/channel-gupshup/src/__tests__/plugin.test.ts`
- `bunx biome check --write packages/api/src/plugins/agent-dispatcher.ts packages/api/src/plugins/__tests__/agent-dispatcher.test.ts packages/api/src/services/messages.ts packages/channel-gupshup/src/plugin.ts packages/channel-gupshup/src/__tests__/plugin.test.ts`
- pre-push hook: `turbo typecheck` + full `bun test` suite passed
