### PR TITLE
fix(api): resolve Gupshup native quote fallback

### DIFF
--- a/packages/api/src/__tests__/unified-messages.test.ts
+++ b/packages/api/src/__tests__/unified-messages.test.ts
@@ -316,6 +316,38 @@ describeWithDb('Unified Messages', () => {
       expect(messages.length).toBe(5);
     });
 
+    test('findRecentOutboundBefore allows Gupshup second-precision reply timestamp grace', async () => {
+      const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-gupshup-grace-${Date.now()}@g.us`, {
+        chatType: 'dm',
+        channel: 'gupshup',
+      });
+      const inboundSecond = new Date('2026-06-09T17:51:55.000Z');
+
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `old-plan-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Opção antiga Nosso Médico SP Leste R$ 160,00/mês',
+        platformTimestamp: new Date('2026-06-08T22:16:45.000Z'),
+        isFromMe: true,
+      });
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `new-plan-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'QUOTE-CANARY — Opção 2 Nosso Plano Completo Enfermaria R$ 182,47/mês',
+        platformTimestamp: new Date('2026-06-09T17:51:55.211Z'),
+        isFromMe: true,
+      });
+
+      const result = await messageService.findRecentOutboundBefore(chat.id, inboundSecond, 'quero esse');
+
+      expect(result?.textContent).toContain('QUOTE-CANARY');
+      expect(result?.textContent).toContain('R$ 182,47');
+    });
+
     test('should filter list by exact externalId only', async () => {
       const externalId = `BAE5EXACT${Date.now()}`;
       const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-external-${Date.now()}@g.us`, {

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1632,6 +1632,51 @@ describe('agent-dispatcher', () => {
       ]);
     });
 
+    it('falls back to the latest outbound bot message before the inbound native reply when Gupshup returns no provider aliases', async () => {
+      const chatRow = { id: 'chat-db-1', externalId: 'chat-ext-1', chatType: 'dm' };
+      const quotedRow = {
+        externalId: 'omni-outbound-uuid',
+        senderDisplayName: 'Eugenia',
+        senderPlatformUserId: 'bot-123',
+        isFromMe: true,
+        platformTimestamp: new Date('2026-06-09T13:13:22Z').getTime(),
+        messageType: 'text',
+        textContent: '**Opção 2, Nosso Plano Completo Enfermaria** R$ 182,47/mês',
+        transcription: null,
+        imageDescription: null,
+        videoDescription: null,
+        documentExtraction: null,
+      };
+      const findRecentOutboundBefore = mock(async (_chatId: string, before: Date, _hint?: string) =>
+        before.toISOString() === '2026-06-09T13:13:55.000Z' ? quotedRow : null,
+      );
+      const services = {
+        chats: { findByExternalIdSmart: mock(async () => chatRow) },
+        messages: {
+          getByExternalId: mock(async () => null),
+          findByProviderAlias: mock(async () => null),
+          findRecentOutboundBefore,
+        },
+      } as unknown as import('../../services').Services;
+
+      const result = await resolveQuotedMessage(
+        services,
+        'inst-1',
+        'chat-ext-1',
+        '033voYFyV6Txceb45MFW7k',
+        ['ddbf1157-be24-4176-a1f8-9f679a26a39c'],
+        { inboundAt: new Date('2026-06-09T13:13:55Z'), inboundText: 'quero esse' },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('Opção 2');
+      expect(findRecentOutboundBefore).toHaveBeenCalledWith(
+        'chat-db-1',
+        new Date('2026-06-09T13:13:55Z'),
+        'quero esse',
+      );
+    });
+
     it('returns full text when content is under 4000 chars', async () => {
       const content = 'A'.repeat(3999);
       const services = createQuotedMessageServices(content);

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -983,7 +983,17 @@ function getMessageContentText(msg: {
  */
 type MessageAliasLookup = Services['messages'] & {
   findByProviderAlias?: (chatId: string, aliases: string[]) => ReturnType<Services['messages']['getByExternalId']>;
+  findRecentOutboundBefore?: (
+    chatId: string,
+    before: Date,
+    inboundText?: string,
+  ) => ReturnType<Services['messages']['getByExternalId']>;
 };
+
+interface QuotedLookupOptions {
+  inboundAt?: Date;
+  inboundText?: string;
+}
 
 function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
   return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
@@ -994,6 +1004,7 @@ async function lookupQuotedMessage(
   chatDbId: string,
   replyToId: string,
   aliases: string[],
+  options: QuotedLookupOptions = {},
 ): ReturnType<Services['messages']['getByExternalId']> {
   const quoted = await messages.getByExternalId(chatDbId, replyToId);
   if (quoted) return quoted;
@@ -1011,6 +1022,11 @@ async function lookupQuotedMessage(
     if (byExternalId) return byExternalId;
   }
 
+  if (options.inboundAt && aliasLookup.findRecentOutboundBefore) {
+    const fallback = await aliasLookup.findRecentOutboundBefore(chatDbId, options.inboundAt, options.inboundText);
+    if (fallback) return fallback;
+  }
+
   return null;
 }
 
@@ -1020,12 +1036,13 @@ export async function resolveQuotedMessage(
   chatId: string,
   replyToId: string,
   providerAliases: string[] = [],
+  options: QuotedLookupOptions = {},
 ): Promise<string | null> {
   try {
     const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
     if (!chat) return null;
 
-    const quoted = await lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases);
+    const quoted = await lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases, options);
     if (!quoted) return null;
 
     const sender = quoted.senderDisplayName ?? quoted.senderPlatformUserId ?? (quoted.isFromMe ? 'You' : 'unknown');
@@ -1181,6 +1198,16 @@ function extractQuotedProviderAliases(rawPayload: Record<string, unknown> | unde
   ]);
 }
 
+function extractInboundPlatformDate(rawPayload: Record<string, unknown> | undefined): Date | undefined {
+  if (!rawPayload) return undefined;
+  const messageObj = isRecord(rawPayload.messageobj) ? rawPayload.messageobj : undefined;
+  const timestamp = messageObj?.timestamp;
+  if (typeof timestamp === 'number' && Number.isFinite(timestamp) && timestamp > 0) {
+    return new Date(timestamp * 1000);
+  }
+  return undefined;
+}
+
 async function prependQuotedContext(
   services: Services,
   instanceId: string,
@@ -1193,8 +1220,12 @@ async function prependQuotedContext(
     const replyToId = m.payload.replyToId;
     if (!replyToId) continue;
 
-    const providerAliases = extractQuotedProviderAliases(m.payload.rawPayload as Record<string, unknown> | undefined);
-    const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId, providerAliases);
+    const rawPayload = m.payload.rawPayload as Record<string, unknown> | undefined;
+    const providerAliases = extractQuotedProviderAliases(rawPayload);
+    const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId, providerAliases, {
+      inboundAt: extractInboundPlatformDate(rawPayload),
+      inboundText: m.payload.content?.text,
+    });
     if (!quotedText) continue;
 
     const messageKey = messageKeyByIndex.get(index);

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -340,6 +340,12 @@ export class MessageService {
    * after exact external-id and provider-alias lookup fail.
    */
   async findRecentOutboundBefore(chatId: string, before: Date, inboundText?: string): Promise<Message | null> {
+    // Gupshup's native reply payload timestamp is second-precision while our
+    // outbound rows retain millisecond precision. A customer can reply in the
+    // same second as the outbound send; allow a tiny future grace window so the
+    // just-quoted outbound is not accidentally excluded in favor of older plans.
+    const upperBound = new Date(before.getTime() + 2000);
+
     const rows = await this.db
       .select()
       .from(messages)
@@ -347,7 +353,7 @@ export class MessageService {
         and(
           eq(messages.chatId, chatId),
           eq(messages.isFromMe, true),
-          lte(messages.platformTimestamp, before),
+          lte(messages.platformTimestamp, upperBound),
           sql`${messages.deletedAt} IS NULL`,
         ),
       )

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -333,6 +333,51 @@ export class MessageService {
     return result ?? null;
   }
 
+  /**
+   * Best-effort fallback for providers that expose native reply ids on inbound
+   * replies but do not return those ids on outbound sends. This is deliberately
+   * scoped to recent outbound bot messages in the same chat and is used only
+   * after exact external-id and provider-alias lookup fail.
+   */
+  async findRecentOutboundBefore(chatId: string, before: Date, inboundText?: string): Promise<Message | null> {
+    const rows = await this.db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.chatId, chatId),
+          eq(messages.isFromMe, true),
+          lte(messages.platformTimestamp, before),
+          sql`${messages.deletedAt} IS NULL`,
+        ),
+      )
+      .orderBy(desc(messages.platformTimestamp))
+      .limit(8);
+
+    if (rows.length === 0) return null;
+
+    const hint = (inboundText ?? '').toLocaleLowerCase('pt-BR');
+    const wantsPlanLikeTarget = /\b(esse|essa|este|esta|op[cç][aã]o|plano|quero|gostei)\b/i.test(hint);
+    if (!wantsPlanLikeTarget) return rows[0] ?? null;
+
+    const score = (message: Message): number => {
+      const text = (message.textContent ?? '').toLocaleLowerCase('pt-BR');
+      let value = 0;
+      if (/op[cç][aã]o|plano/.test(text)) value += 4;
+      if (/r\$|mensal|coparticipa|enfermaria|apartamento|ambulatorial|notrelife|hapvida/.test(text)) value += 3;
+      if (/\?\s*$/.test(text) && !/r\$/.test(text)) value -= 2;
+      return value;
+    };
+
+    return (
+      rows
+        .map((message) => ({ message, score: score(message) }))
+        .sort(
+          (a, b) => b.score - a.score || b.message.platformTimestamp.getTime() - a.message.platformTimestamp.getTime(),
+        )[0]?.message ?? null
+    );
+  }
+
   /** Get multiple messages by external IDs in a single query */
   async getByExternalIds(chatId: string, externalIds: string[]): Promise<Message[]> {
     if (externalIds.length === 0) return [];


### PR DESCRIPTION
## Summary
- Resolves Gupshup native WhatsApp reply short IDs (`replyContext.id=033...`) to the bounded prior outbound bot message when provider aliases/external IDs do not match outbound records.
- Adds recent outbound fallback scoring for plan-like replies (`quero esse`, `opção`, `plano`) after exact `externalId` and provider-alias lookup fail.
- Adds a 2s upper-bound grace for Gupshup second-precision inbound timestamps so a reply in the same second does not exclude the just-quoted outbound message stored with millisecond precision.

## HML runtime proof
- Source commit: `e31f17efd97e35f1474eac4a464c701cf67f2b32`
- Image digest deployed to HML: `sha256:c3c9b07795de7de6568185330610ef611dbbf35c0a533efda9e4d9e464133282`
- Runtime image: `gru.ocir.io/grkjlq07pmjv/omni-api@sha256:c3c9b07795de7de6568185330610ef611dbbf35c0a533efda9e4d9e464133282`
- K8s deploy revision: `43`, ready `1/1`
- Rollback image annotation: `gru.ocir.io/grkjlq07pmjv/omni-api@sha256:b351292944f2593897758a1dd4e149dc4010ca201cd1d26950118130978937b9`
- Health: `healthy` with DB OK, NATS OK, plugins OK, `gupshup: 1 connected`

## Canary proof
Real HML canary against `HML Closer Canary`:
- Marker: `QUOTE-CANARY-REAL-20260609180304`
- Native reply short id: `033real20260609180304`
- Inbound text: `quero esse`
- Bounded quote delivered to Eugenia/Agno contained the just-sent outbound quote:
  - `Opção 2, Nosso Plano Completo Enfermaria ... R$ 182,47/mês`
- Agent response selected the intended quoted plan:
  - `Nosso Plano Completo Enfermaria`, `R$ 182,47/mês`

## Tests
- `bun test packages/api/src/plugins/__tests__/agent-dispatcher.test.ts -t "resolveQuotedMessage"` → 8 pass / 0 fail
- `bun run --filter @omni/api typecheck` → pass
- pre-push full suite → 3983 pass / 293 skip / 0 fail

## Rollback
HML-only rollback handle:
```bash
kubectl -n khal-hml set image deploy/omni-api omni-api=gru.ocir.io/grkjlq07pmjv/omni-api@sha256:b351292944f2593897758a1dd4e149dc4010ca201cd1d26950118130978937b9
kubectl -n khal-hml rollout status deploy/omni-api --timeout=300s
```
