### PR TITLE
chore(sync): bring homolog into dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -272,7 +272,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -288,7 +288,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -302,7 +302,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -321,7 +321,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -329,7 +329,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -343,7 +343,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260609.2",
+      "version": "2.260609.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/__tests__/unified-messages.test.ts
+++ b/packages/api/src/__tests__/unified-messages.test.ts
@@ -316,6 +316,38 @@ describeWithDb('Unified Messages', () => {
       expect(messages.length).toBe(5);
     });
 
+    test('findRecentOutboundBefore allows Gupshup second-precision reply timestamp grace', async () => {
+      const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-gupshup-grace-${Date.now()}@g.us`, {
+        chatType: 'dm',
+        channel: 'gupshup',
+      });
+      const inboundSecond = new Date('2026-06-09T17:51:55.000Z');
+
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `old-plan-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Opção antiga Nosso Médico SP Leste R$ 160,00/mês',
+        platformTimestamp: new Date('2026-06-08T22:16:45.000Z'),
+        isFromMe: true,
+      });
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `new-plan-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'QUOTE-CANARY — Opção 2 Nosso Plano Completo Enfermaria R$ 182,47/mês',
+        platformTimestamp: new Date('2026-06-09T17:51:55.211Z'),
+        isFromMe: true,
+      });
+
+      const result = await messageService.findRecentOutboundBefore(chat.id, inboundSecond, 'quero esse');
+
+      expect(result?.textContent).toContain('QUOTE-CANARY');
+      expect(result?.textContent).toContain('R$ 182,47');
+    });
+
     test('should filter list by exact externalId only', async () => {
       const externalId = `BAE5EXACT${Date.now()}`;
       const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-external-${Date.now()}@g.us`, {

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1632,6 +1632,51 @@ describe('agent-dispatcher', () => {
       ]);
     });
 
+    it('falls back to the latest outbound bot message before the inbound native reply when Gupshup returns no provider aliases', async () => {
+      const chatRow = { id: 'chat-db-1', externalId: 'chat-ext-1', chatType: 'dm' };
+      const quotedRow = {
+        externalId: 'omni-outbound-uuid',
+        senderDisplayName: 'Eugenia',
+        senderPlatformUserId: 'bot-123',
+        isFromMe: true,
+        platformTimestamp: new Date('2026-06-09T13:13:22Z').getTime(),
+        messageType: 'text',
+        textContent: '**Opção 2, Nosso Plano Completo Enfermaria** R$ 182,47/mês',
+        transcription: null,
+        imageDescription: null,
+        videoDescription: null,
+        documentExtraction: null,
+      };
+      const findRecentOutboundBefore = mock(async (_chatId: string, before: Date, _hint?: string) =>
+        before.toISOString() === '2026-06-09T13:13:55.000Z' ? quotedRow : null,
+      );
+      const services = {
+        chats: { findByExternalIdSmart: mock(async () => chatRow) },
+        messages: {
+          getByExternalId: mock(async () => null),
+          findByProviderAlias: mock(async () => null),
+          findRecentOutboundBefore,
+        },
+      } as unknown as import('../../services').Services;
+
+      const result = await resolveQuotedMessage(
+        services,
+        'inst-1',
+        'chat-ext-1',
+        '033voYFyV6Txceb45MFW7k',
+        ['ddbf1157-be24-4176-a1f8-9f679a26a39c'],
+        { inboundAt: new Date('2026-06-09T13:13:55Z'), inboundText: 'quero esse' },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('Opção 2');
+      expect(findRecentOutboundBefore).toHaveBeenCalledWith(
+        'chat-db-1',
+        new Date('2026-06-09T13:13:55Z'),
+        'quero esse',
+      );
+    });
+
     it('returns full text when content is under 4000 chars', async () => {
       const content = 'A'.repeat(3999);
       const services = createQuotedMessageServices(content);

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -983,7 +983,17 @@ function getMessageContentText(msg: {
  */
 type MessageAliasLookup = Services['messages'] & {
   findByProviderAlias?: (chatId: string, aliases: string[]) => ReturnType<Services['messages']['getByExternalId']>;
+  findRecentOutboundBefore?: (
+    chatId: string,
+    before: Date,
+    inboundText?: string,
+  ) => ReturnType<Services['messages']['getByExternalId']>;
 };
+
+interface QuotedLookupOptions {
+  inboundAt?: Date;
+  inboundText?: string;
+}
 
 function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
   return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
@@ -994,6 +1004,7 @@ async function lookupQuotedMessage(
   chatDbId: string,
   replyToId: string,
   aliases: string[],
+  options: QuotedLookupOptions = {},
 ): ReturnType<Services['messages']['getByExternalId']> {
   const quoted = await messages.getByExternalId(chatDbId, replyToId);
   if (quoted) return quoted;
@@ -1011,6 +1022,11 @@ async function lookupQuotedMessage(
     if (byExternalId) return byExternalId;
   }
 
+  if (options.inboundAt && aliasLookup.findRecentOutboundBefore) {
+    const fallback = await aliasLookup.findRecentOutboundBefore(chatDbId, options.inboundAt, options.inboundText);
+    if (fallback) return fallback;
+  }
+
   return null;
 }
 
@@ -1020,12 +1036,13 @@ export async function resolveQuotedMessage(
   chatId: string,
   replyToId: string,
   providerAliases: string[] = [],
+  options: QuotedLookupOptions = {},
 ): Promise<string | null> {
   try {
     const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
     if (!chat) return null;
 
-    const quoted = await lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases);
+    const quoted = await lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases, options);
     if (!quoted) return null;
 
     const sender = quoted.senderDisplayName ?? quoted.senderPlatformUserId ?? (quoted.isFromMe ? 'You' : 'unknown');
@@ -1181,6 +1198,16 @@ function extractQuotedProviderAliases(rawPayload: Record<string, unknown> | unde
   ]);
 }
 
+function extractInboundPlatformDate(rawPayload: Record<string, unknown> | undefined): Date | undefined {
+  if (!rawPayload) return undefined;
+  const messageObj = isRecord(rawPayload.messageobj) ? rawPayload.messageobj : undefined;
+  const timestamp = messageObj?.timestamp;
+  if (typeof timestamp === 'number' && Number.isFinite(timestamp) && timestamp > 0) {
+    return new Date(timestamp * 1000);
+  }
+  return undefined;
+}
+
 async function prependQuotedContext(
   services: Services,
   instanceId: string,
@@ -1193,8 +1220,12 @@ async function prependQuotedContext(
     const replyToId = m.payload.replyToId;
     if (!replyToId) continue;
 
-    const providerAliases = extractQuotedProviderAliases(m.payload.rawPayload as Record<string, unknown> | undefined);
-    const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId, providerAliases);
+    const rawPayload = m.payload.rawPayload as Record<string, unknown> | undefined;
+    const providerAliases = extractQuotedProviderAliases(rawPayload);
+    const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId, providerAliases, {
+      inboundAt: extractInboundPlatformDate(rawPayload),
+      inboundText: m.payload.content?.text,
+    });
     if (!quotedText) continue;
 
     const messageKey = messageKeyByIndex.get(index);

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -333,6 +333,57 @@ export class MessageService {
     return result ?? null;
   }
 
+  /**
+   * Best-effort fallback for providers that expose native reply ids on inbound
+   * replies but do not return those ids on outbound sends. This is deliberately
+   * scoped to recent outbound bot messages in the same chat and is used only
+   * after exact external-id and provider-alias lookup fail.
+   */
+  async findRecentOutboundBefore(chatId: string, before: Date, inboundText?: string): Promise<Message | null> {
+    // Gupshup's native reply payload timestamp is second-precision while our
+    // outbound rows retain millisecond precision. A customer can reply in the
+    // same second as the outbound send; allow a tiny future grace window so the
+    // just-quoted outbound is not accidentally excluded in favor of older plans.
+    const upperBound = new Date(before.getTime() + 2000);
+
+    const rows = await this.db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.chatId, chatId),
+          eq(messages.isFromMe, true),
+          lte(messages.platformTimestamp, upperBound),
+          sql`${messages.deletedAt} IS NULL`,
+        ),
+      )
+      .orderBy(desc(messages.platformTimestamp))
+      .limit(8);
+
+    if (rows.length === 0) return null;
+
+    const hint = (inboundText ?? '').toLocaleLowerCase('pt-BR');
+    const wantsPlanLikeTarget = /\b(esse|essa|este|esta|op[cç][aã]o|plano|quero|gostei)\b/i.test(hint);
+    if (!wantsPlanLikeTarget) return rows[0] ?? null;
+
+    const score = (message: Message): number => {
+      const text = (message.textContent ?? '').toLocaleLowerCase('pt-BR');
+      let value = 0;
+      if (/op[cç][aã]o|plano/.test(text)) value += 4;
+      if (/r\$|mensal|coparticipa|enfermaria|apartamento|ambulatorial|notrelife|hapvida/.test(text)) value += 3;
+      if (/\?\s*$/.test(text) && !/r\$/.test(text)) value -= 2;
+      return value;
+    };
+
+    return (
+      rows
+        .map((message) => ({ message, score: score(message) }))
+        .sort(
+          (a, b) => b.score - a.score || b.message.platformTimestamp.getTime() - a.message.platformTimestamp.getTime(),
+        )[0]?.message ?? null
+    );
+  }
+
   /** Get multiple messages by external IDs in a single query */
   async getByExternalIds(chatId: string, externalIds: string[]): Promise<Message[]> {
     if (externalIds.length === 0) return [];

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260609.2",
+  "version": "2.260609.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Summary
- Sync current `homolog`/HML content into `dev` as one compliant sync commit.
- Brings the PR #710 Gupshup native quote fallback and 2s timestamp grace tests to `dev`.
- Replaces closed PR #711, which used a shared bidirectional merge head; GitHub attached the opposite-base commitlint failure to the same head status.

## Proof
- Source base `origin/dev`: 646065842ca2965ad1148a1872637f2468a91c5b
- Homolog source `origin/homolog`: cf018bb51254ba3310c48b764cd9499f4e99af94
- Replacement head: e40927fbc766bc657aa9cb6e8caf1b8300a3d921
- Final tree matches the composed bidirectional sync tree: `7f104d255ba7721b0c2858491a66f90c41cc1c3b`

## Verification
- Commit hook Biome: pass, 1131 files checked
- pre-push `bun run typecheck`: 21 successful / 21 total
- pre-push full `bun test`: 3988 pass / 293 skip / 0 fail
