### PR TITLE
[codex] Add Slack assistant thread status support

### DIFF
--- a/packages/api/src/__tests__/messages-presence.test.ts
+++ b/packages/api/src/__tests__/messages-presence.test.ts
@@ -19,6 +19,20 @@ function createMockPlugin(
   overrides: Partial<{
     canSendTyping: boolean;
     sendTyping: (instanceId: string, chatId: string, duration?: number) => Promise<void>;
+    sendPresenceStatus: (
+      instanceId: string,
+      chatId: string,
+      type: 'typing' | 'recording' | 'paused',
+      duration?: number,
+      options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+    ) => Promise<{
+      delivered: boolean;
+      method: string;
+      threadId?: string;
+      status?: string;
+      loadingMessages?: string[];
+      reason?: string;
+    }>;
   }> = {},
 ) {
   return {
@@ -43,6 +57,7 @@ function createMockPlugin(
       maxFileSize: 100 * 1024 * 1024,
     },
     sendTyping: overrides.sendTyping ?? mock(async () => {}),
+    ...(overrides.sendPresenceStatus ? { sendPresenceStatus: overrides.sendPresenceStatus } : {}),
   };
 }
 
@@ -58,6 +73,7 @@ function createMockChannelRegistry(plugin: ReturnType<typeof createMockPlugin> |
 describeWithDb('POST /messages/send/presence', () => {
   let db: Database;
   let testInstance: Instance;
+  let testSlackInstance: Instance;
   const insertedInstanceIds: string[] = [];
 
   beforeAll(async () => {
@@ -76,6 +92,19 @@ describeWithDb('POST /messages/send/presence', () => {
     }
     testInstance = instance;
     insertedInstanceIds.push(instance.id);
+
+    const [slackInstance] = await db
+      .insert(instances)
+      .values({
+        name: `test-slack-presence-${Date.now()}`,
+        channel: 'slack' as const,
+      })
+      .returning();
+    if (!slackInstance) {
+      throw new Error('Failed to create Slack test instance');
+    }
+    testSlackInstance = slackInstance;
+    insertedInstanceIds.push(slackInstance.id);
   });
 
   afterAll(async () => {
@@ -200,7 +229,64 @@ describeWithDb('POST /messages/send/presence', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { code: string; message: string } };
     expect(body.error.code).toBe('CAPABILITY_NOT_SUPPORTED');
-    expect(body.error.message).toContain('typing indicators');
+    expect(body.error.message).toContain('typing indicators or thread status');
+  });
+
+  test('uses Slack thread status sender when native typing capability is false', async () => {
+    const sendPresenceStatusMock = mock(
+      async (
+        _instanceId: string,
+        _chatId: string,
+        _type: 'typing' | 'recording' | 'paused',
+        _duration?: number,
+        options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+      ) => ({
+        delivered: true,
+        method: 'assistant.threads.setStatus',
+        threadId: options?.threadId,
+        status: options?.status ?? 'is typing...',
+        loadingMessages: options?.loadingMessages,
+      }),
+    );
+    const mockPlugin = createMockPlugin({ canSendTyping: false, sendPresenceStatus: sendPresenceStatusMock });
+    const { app } = createTestApp(mockPlugin);
+
+    const res = await app.request('/messages/send/presence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testSlackInstance.id,
+        to: 'C12345',
+        type: 'typing',
+        threadId: '1234567890.001',
+        status: 'analisando contexto...',
+        loadingMessages: ['Lendo contexto...', 'Chamando ferramentas...'],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { delivered: boolean; method: string; threadId?: string; status?: string; loadingMessages?: string[] };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.delivered).toBe(true);
+    expect(body.data.method).toBe('assistant.threads.setStatus');
+    expect(body.data.threadId).toBe('1234567890.001');
+    expect(body.data.status).toBe('analisando contexto...');
+    expect(body.data.loadingMessages).toEqual(['Lendo contexto...', 'Chamando ferramentas...']);
+    expect(sendPresenceStatusMock).toHaveBeenCalledTimes(1);
+    expect(sendPresenceStatusMock.mock.calls[0]).toEqual([
+      testSlackInstance.id,
+      'C12345',
+      'typing',
+      0,
+      {
+        threadId: '1234567890.001',
+        status: 'analisando contexto...',
+        loadingMessages: ['Lendo contexto...', 'Chamando ferramentas...'],
+      },
+    ]);
   });
 
   test('validates duration bounds (max 30000)', async () => {

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -2213,15 +2213,51 @@ const sendPresenceSchema = z.object({
   instanceId: z.string().uuid().describe('Instance ID to send from'),
   to: z.string().min(1).describe('Chat ID to show presence in'),
   type: z.enum(['typing', 'recording', 'paused']).describe('Presence type'),
+  threadId: z.string().min(1).optional().describe('Thread timestamp/id for thread-scoped presence surfaces'),
+  status: z.string().min(1).max(100).optional().describe('Custom status text for channels that support it'),
+  loadingMessages: z
+    .array(z.string().min(1).max(100))
+    .max(10)
+    .optional()
+    .describe('Rotating loading messages for channels that support them'),
   duration: z
     .number()
     .int()
     .min(0)
     .max(30000)
     .optional()
-    .default(5000)
-    .describe('Duration in ms before auto-pause (default 5000, 0 = until paused)'),
+    .describe('Duration in ms before auto-pause; omit for channel default, 0 = until paused'),
 });
+
+type SendPresenceInput = z.infer<typeof sendPresenceSchema>;
+
+type PresenceStatusResult = {
+  delivered?: boolean;
+  method?: string;
+  threadId?: string;
+  status?: string;
+  loadingMessages?: string[];
+  reason?: string;
+};
+
+type PresenceStatusSender = {
+  sendPresenceStatus: (
+    instanceId: string,
+    chatId: string,
+    type: SendPresenceInput['type'],
+    duration?: number,
+    options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+  ) => Promise<PresenceStatusResult | undefined>;
+};
+
+function hasPresenceStatusSender(plugin: unknown): plugin is PresenceStatusSender {
+  return (
+    typeof plugin === 'object' &&
+    plugin !== null &&
+    'sendPresenceStatus' in plugin &&
+    typeof (plugin as { sendPresenceStatus?: unknown }).sendPresenceStatus === 'function'
+  );
+}
 
 /**
  * POST /messages/send/presence - Send presence indicator (typing, recording)
@@ -2229,42 +2265,55 @@ const sendPresenceSchema = z.object({
  * Shows typing/recording indicator in a chat. Auto-pauses after duration.
  * - WhatsApp: supports typing, recording, paused
  * - Discord: supports typing only (recording/paused treated as typing)
+ * - Slack: supports AI Assistant thread status via assistant.threads.setStatus
  */
 messagesRoutes.post('/send/presence', zValidator('json', sendPresenceSchema), async (c) => {
-  const { instanceId, to, type, duration } = c.req.valid('json');
+  const { instanceId, to, type, duration, threadId, status, loadingMessages } = c.req.valid('json');
   const services = c.get('services');
   checkInstanceAccess(c.get('apiKey'), instanceId);
 
-  const { instance, plugin } = await getPluginForInstance(
-    services,
-    c.get('channelRegistry'),
-    instanceId,
-    'canSendTyping',
-  );
+  const { instance, plugin } = await getPluginForInstance(services, c.get('channelRegistry'), instanceId);
 
   // Resolve recipient (handles person ID to platform ID resolution)
   const resolvedTo = await resolveRecipient(to, instance.channel, services);
 
-  // Check if plugin has sendTyping method
-  if (!('sendTyping' in plugin) || typeof plugin.sendTyping !== 'function') {
+  const canSendNativeTyping = plugin.capabilities.canSendTyping === true;
+  const canSendThreadStatus = hasPresenceStatusSender(plugin);
+
+  if (!canSendNativeTyping && !canSendThreadStatus) {
     throw new OmniError({
       code: ERROR_CODES.CAPABILITY_NOT_SUPPORTED,
-      message: `Channel ${instance.channel} plugin does not implement sendTyping`,
+      message: `Channel ${instance.channel} does not support typing indicators or thread status`,
       context: { channelType: instance.channel },
       recoverable: false,
     });
   }
 
-  // For paused type, send with 0 duration to immediately stop
-  const effectiveDuration = type === 'paused' ? 0 : duration;
+  // Native typing indicators keep the historical short burst default.
+  // Slack thread status follows Slack's loading-state model: omit duration to
+  // persist until reply cleanup, explicit pause, or Slack's own timeout.
+  const effectiveDuration = type === 'paused' ? 0 : (duration ?? (canSendThreadStatus ? 0 : 5000));
 
   // If recording type and plugin is discord, still use sendTyping (Discord only supports typing)
   // WhatsApp plugin handles all three types internally
-  await (plugin as { sendTyping: (instanceId: string, chatId: string, duration?: number) => Promise<void> }).sendTyping(
-    instanceId,
-    resolvedTo,
-    effectiveDuration,
-  );
+  const presenceResult = canSendThreadStatus
+    ? await plugin.sendPresenceStatus(instanceId, resolvedTo, type, effectiveDuration, {
+        threadId,
+        status,
+        loadingMessages,
+      })
+    : await (async (): Promise<PresenceStatusResult> => {
+        if (!('sendTyping' in plugin) || typeof plugin.sendTyping !== 'function') {
+          throw new OmniError({
+            code: ERROR_CODES.CAPABILITY_NOT_SUPPORTED,
+            message: `Channel ${instance.channel} plugin does not implement sendTyping`,
+            context: { channelType: instance.channel },
+            recoverable: false,
+          });
+        }
+        await plugin.sendTyping(instanceId, resolvedTo, effectiveDuration);
+        return { delivered: true, method: 'typing_indicator' };
+      })();
 
   return c.json({
     success: true,
@@ -2273,6 +2322,12 @@ messagesRoutes.post('/send/presence', zValidator('json', sendPresenceSchema), as
       chatId: resolvedTo,
       type,
       duration: effectiveDuration,
+      threadId: presenceResult?.threadId ?? threadId,
+      delivered: presenceResult?.delivered ?? true,
+      method: presenceResult?.method ?? 'typing_indicator',
+      reason: presenceResult?.reason,
+      status: presenceResult?.status,
+      loadingMessages: presenceResult?.loadingMessages,
     },
   });
 });

--- a/packages/api/src/schemas/openapi/messages.ts
+++ b/packages/api/src/schemas/openapi/messages.ts
@@ -79,14 +79,28 @@ export const SendPresenceSchema = z.object({
   instanceId: z.string().uuid().openapi({ description: 'Instance ID to send from' }),
   to: z.string().min(1).openapi({ description: 'Chat ID to show presence in' }),
   type: z.enum(['typing', 'recording', 'paused']).openapi({ description: 'Presence type' }),
+  threadId: z
+    .string()
+    .optional()
+    .openapi({ description: 'Thread timestamp/id for thread-scoped presence surfaces such as Slack AI Assistant' }),
+  status: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .openapi({ description: 'Custom status text for channels that support text status, such as Slack AI Assistant' }),
+  loadingMessages: z
+    .array(z.string().min(1).max(100))
+    .max(10)
+    .optional()
+    .openapi({ description: 'Rotating loading messages for channels that support them, such as Slack AI Assistant' }),
   duration: z
     .number()
     .int()
     .min(0)
     .max(30000)
     .optional()
-    .default(5000)
-    .openapi({ description: 'Duration in ms before auto-pause (default 5000, 0 = until paused)' }),
+    .openapi({ description: 'Duration in ms before auto-pause; omit for channel default, 0 = until paused' }),
 });
 
 // Presence response
@@ -95,6 +109,15 @@ export const PresenceResponseSchema = z.object({
   chatId: z.string().openapi({ description: 'Chat ID where presence was sent' }),
   type: z.string().openapi({ description: 'Presence type sent' }),
   duration: z.number().openapi({ description: 'Duration in ms' }),
+  threadId: z.string().optional().openapi({ description: 'Thread timestamp/id used by the presence renderer' }),
+  delivered: z.boolean().optional().openapi({ description: 'Whether the channel reported the status as delivered' }),
+  method: z.string().optional().openapi({ description: 'Channel-specific presence method used' }),
+  reason: z.string().optional().openapi({ description: 'Reason when the channel no-opped or failed best-effort' }),
+  status: z.string().optional().openapi({ description: 'Channel-specific status text sent' }),
+  loadingMessages: z
+    .array(z.string())
+    .optional()
+    .openapi({ description: 'Channel-specific rotating loading messages sent' }),
 });
 
 // Mark message read request
@@ -293,7 +316,7 @@ export function registerMessageSchemas(registry: OpenAPIRegistry): void {
     tags: ['Messages', 'Presence'],
     summary: 'Send presence indicator',
     description:
-      'Send typing/recording indicator in a chat. Auto-pauses after duration. WhatsApp supports typing, recording, paused. Discord only supports typing.',
+      'Send typing/recording indicator in a chat. WhatsApp supports typing, recording, paused. Discord supports typing. Slack supports AI Assistant thread status via threadId or the active thread cache; omit duration to keep Slack status until reply cleanup or Slack timeout.',
     request: { body: { content: { 'application/json': { schema: SendPresenceSchema } } } },
     responses: {
       200: {

--- a/packages/channel-slack/src/handlers/typing.test.ts
+++ b/packages/channel-slack/src/handlers/typing.test.ts
@@ -21,13 +21,16 @@ function makeLogger(): Logger {
 }
 
 function makeClientWithAssistant() {
-  const setStatusCalls: Array<{ channel_id: string; thread_ts: string; status: string }> = [];
+  const setStatusCalls: Array<{ channel_id: string; thread_ts: string; status: string; loading_messages?: string[] }> =
+    [];
   const client = {
     assistant: {
       threads: {
-        setStatus: mock(async (args: { channel_id: string; thread_ts: string; status: string }) => {
-          setStatusCalls.push(args);
-        }),
+        setStatus: mock(
+          async (args: { channel_id: string; thread_ts: string; status: string; loading_messages?: string[] }) => {
+            setStatusCalls.push(args);
+          },
+        ),
       },
     },
   };
@@ -57,7 +60,7 @@ describe('setSlackThreadStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: undefined,
@@ -65,6 +68,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
+    expect(result).toBe(false);
     expect(setStatusCalls.length).toBe(0);
   });
 
@@ -72,19 +76,22 @@ describe('setSlackThreadStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
       status: 'is typing...',
+      loadingMessages: ['Checking context...', 'Calling tools...'],
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls.length).toBe(1);
     expect(setStatusCalls[0]).toEqual({
       channel_id: 'C12345',
       thread_ts: '1234567890.001',
       status: 'is typing...',
+      loading_messages: ['Checking context...', 'Calling tools...'],
     });
   });
 
@@ -92,7 +99,7 @@ describe('setSlackThreadStatus', () => {
     const { client, apiCalls } = makeClientWithApiCall();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
@@ -100,6 +107,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
+    expect(result).toBe(true);
     expect(apiCalls.length).toBe(1);
     expect(apiCalls[0]?.method).toBe('assistant.threads.setStatus');
     expect(apiCalls[0]?.args).toEqual({
@@ -113,15 +121,15 @@ describe('setSlackThreadStatus', () => {
     const { client } = makeClientWithoutAssistant();
     const logger = makeLogger();
 
-    await expect(
-      setSlackThreadStatus({
-        client: client as never,
-        channelId: 'C12345',
-        threadTs: '1234567890.001',
-        status: 'is typing...',
-        logger,
-      }),
-    ).resolves.toBeUndefined();
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+
+    expect(result).toBe(false);
   });
 
   it('does not throw when API call fails', async () => {
@@ -131,25 +139,28 @@ describe('setSlackThreadStatus', () => {
     });
     const logger = makeLogger();
 
-    await expect(
-      setSlackThreadStatus({
-        client: client as never,
-        channelId: 'C12345',
-        threadTs: '1234567890.001',
-        status: 'is typing...',
-        logger,
-      }),
-    ).resolves.toBeUndefined();
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+
+    expect(result).toBe(false);
 
     // Should have logged the failure
-    expect((logger.warn as ReturnType<typeof mock>).mock.calls.length).toBeGreaterThan(0);
+    const warnCalls = (logger.warn as ReturnType<typeof mock>).mock.calls;
+    expect(warnCalls.length).toBeGreaterThan(0);
+    expect(warnCalls[0]?.[1]).toMatchObject({ clearing: false, statusLength: 'is typing...'.length });
+    expect(warnCalls[0]?.[1]).not.toHaveProperty('status');
   });
 
   it('can clear typing status with empty string', async () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
@@ -157,6 +168,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls[0]?.status).toBe('');
   });
 });
@@ -170,13 +182,14 @@ describe('setTypingStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setTypingStatus({
+    const result = await setTypingStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls[0]?.status).toBe('is typing...');
   });
 
@@ -184,12 +197,13 @@ describe('setTypingStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setTypingStatus({
+    const result = await setTypingStatus({
       client: client as never,
       channelId: 'C12345',
       logger,
     });
 
+    expect(result).toBe(false);
     expect(setStatusCalls.length).toBe(0);
   });
 });
@@ -199,13 +213,14 @@ describe('clearTypingStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await clearTypingStatus({
+    const result = await clearTypingStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls[0]?.status).toBe('');
   });
 });

--- a/packages/channel-slack/src/handlers/typing.ts
+++ b/packages/channel-slack/src/handlers/typing.ts
@@ -2,12 +2,14 @@
  * Slack thread typing indicator helper
  *
  * Uses assistant.threads.setStatus to show/clear typing status in Slack threads.
- * Only works for thread messages — channel-level messages are a no-op.
+ * Requires a Slack thread timestamp; for top-level channel messages, use the
+ * source message timestamp as the thread timestamp.
  *
- * Requires the "Agents & AI Apps" feature flag on the Slack App.
+ * Requires Slack Web API scope `chat:write`. The legacy `assistant:write` scope
+ * is also accepted by Slack during their transition period.
  * Failures are swallowed gracefully — typing never blocks message processing.
  *
- * @see https://api.slack.com/methods/assistant.threads.setStatus
+ * @see https://docs.slack.dev/reference/methods/assistant.threads.setStatus/
  */
 
 import type { Logger } from '@omni/channel-sdk';
@@ -26,18 +28,20 @@ export async function setSlackThreadStatus(params: {
   channelId: string;
   threadTs?: string;
   status: string;
+  loadingMessages?: string[];
   logger: Logger;
   instanceId?: string;
-}): Promise<void> {
-  const { client, channelId, threadTs, status, logger, instanceId } = params;
+}): Promise<boolean> {
+  const { client, channelId, threadTs, status, loadingMessages, logger, instanceId } = params;
 
   // Thread-only guard
-  if (!threadTs) return;
+  if (!threadTs) return false;
 
   const payload = {
     channel_id: channelId,
     thread_ts: threadTs,
     status,
+    ...(loadingMessages?.length ? { loading_messages: loadingMessages } : {}),
   };
 
   try {
@@ -52,21 +56,26 @@ export async function setSlackThreadStatus(params: {
 
     if (typeof clientAny.assistant?.threads?.setStatus === 'function') {
       await clientAny.assistant.threads.setStatus(payload);
-      return;
+      return true;
     }
 
     if (typeof clientAny.apiCall === 'function') {
       await clientAny.apiCall('assistant.threads.setStatus', payload);
+      return true;
     }
   } catch (err) {
     logger.warn('setSlackThreadStatus: failed', {
       instanceId,
       channelId,
       threadTs,
-      status,
+      clearing: status.length === 0,
+      statusLength: status.length,
+      loadingMessageCount: loadingMessages?.length ?? 0,
       error: String(err),
     });
   }
+
+  return false;
 }
 
 /**
@@ -78,7 +87,7 @@ export async function setTypingStatus(params: {
   threadTs?: string;
   logger: Logger;
   instanceId?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   return setSlackThreadStatus({ ...params, status: TYPING_STATUS });
 }
 
@@ -91,6 +100,6 @@ export async function clearTypingStatus(params: {
   threadTs?: string;
   logger: Logger;
   instanceId?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   return setSlackThreadStatus({ ...params, status: CLEAR_STATUS });
 }

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -40,7 +40,7 @@ import { downloadSlackFile, extractFileInfo, getContentTypeFromMime } from './ha
 import { setupInteractionHandlers } from './handlers/interactions';
 import { type SlackDebouncedArgs, setupMessageHandlers } from './handlers/messages';
 import { setupReactionHandlers } from './handlers/reactions';
-import { clearTypingStatus, setTypingStatus } from './handlers/typing';
+import { clearTypingStatus, setSlackThreadStatus } from './handlers/typing';
 import { uploadFile, uploadFileFromUrl } from './senders/media';
 import { createNativeStreamSender } from './senders/native-stream';
 import { createSlackStreamSender } from './senders/stream';
@@ -50,6 +50,17 @@ import { SlackError, SlackErrorCode } from './types';
 
 /** Download size guard — 50MB default; applied to inbound file metadata before dispatching */
 const downloadGuard = createDownloadGuard();
+
+type SlackPresenceType = 'typing' | 'recording' | 'paused';
+
+type SlackPresenceStatusResult = {
+  delivered: boolean;
+  method: 'assistant.threads.setStatus';
+  threadId?: string;
+  status?: string;
+  loadingMessages?: string[];
+  reason?: 'not_connected' | 'no_active_thread' | 'slack_status_failed';
+};
 
 /**
  * Resolve Slack credentials from config, options, and credentials sources.
@@ -130,6 +141,12 @@ export class SlackPlugin extends BaseChannelPlugin {
   private activeThreads = new Map<string, string>();
 
   /**
+   * Pending auto-clear timers per active status thread.
+   * Key: `${instanceId}:${channelId}:${threadTs}`
+   */
+  private presenceStatusTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /**
    * Pending ack reactions awaiting removal after reply.
    * Key: `${instanceId}:${channelId}:${messageTs}`, Value: emoji name
    */
@@ -168,6 +185,10 @@ export class SlackPlugin extends BaseChannelPlugin {
       cache.dispose();
     }
     this.threadCaches.clear();
+    for (const timer of this.presenceStatusTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.presenceStatusTimers.clear();
     this.activeThreads.clear();
     this.pendingAckReactions.clear();
   }
@@ -303,6 +324,11 @@ export class SlackPlugin extends BaseChannelPlugin {
     }
     for (const key of this.activeThreads.keys()) {
       if (key.startsWith(`${instanceId}:`)) this.activeThreads.delete(key);
+    }
+    for (const [key, timer] of this.presenceStatusTimers) {
+      if (!key.startsWith(`${instanceId}:`)) continue;
+      clearTimeout(timer);
+      this.presenceStatusTimers.delete(key);
     }
     for (const key of this.pendingAckReactions.keys()) {
       if (key.startsWith(`${instanceId}:`)) this.pendingAckReactions.delete(key);
@@ -456,31 +482,103 @@ export class SlackPlugin extends BaseChannelPlugin {
    * hence `canSendTyping: false` in capabilities. This method exists for the
    * thread context but silently no-ops when no active thread is tracked.
    *
-   * No auto-refresh needed: the status persists until explicitly cleared
-   * (duration === 0) or the assistant replies.
+   * Slack clears status when the assistant replies, when status is set to an
+   * empty string, or after Slack's own timeout. Omni can also clear earlier
+   * when callers pass an explicit duration.
    */
   async sendTyping(instanceId: string, chatId: string, duration?: number): Promise<void> {
+    await this.sendPresenceStatus(instanceId, chatId, duration === 0 ? 'paused' : 'typing', duration);
+  }
+
+  /**
+   * Send Slack's official AI Assistant thread status.
+   *
+   * This is intentionally separate from `canSendTyping`: Slack does not expose
+   * generic channel typing for bots, but `assistant.threads.setStatus` is the
+   * official status surface for AI assistant threads.
+   */
+  async sendPresenceStatus(
+    instanceId: string,
+    chatId: string,
+    type: SlackPresenceType,
+    duration?: number,
+    options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+  ): Promise<SlackPresenceStatusResult> {
+    const method = 'assistant.threads.setStatus' as const;
     const connection = this.connections.get(instanceId);
-    if (!connection) return;
+    if (!connection) return { delivered: false, method, reason: 'not_connected' };
 
-    const threadTs = this.activeThreads.get(`${instanceId}:${chatId}`);
-    if (!threadTs) return; // Thread-only guard
+    const threadTs = options?.threadId ?? this.activeThreads.get(`${instanceId}:${chatId}`);
+    if (!threadTs) return { delivered: false, method, reason: 'no_active_thread' };
 
-    if (duration === 0) {
-      await clearTypingStatus({
-        client: connection.client,
-        channelId: chatId,
-        threadTs,
-        logger: this.logger,
-      });
-    } else {
-      await setTypingStatus({
-        client: connection.client,
-        channelId: chatId,
-        threadTs,
-        logger: this.logger,
-      });
+    const shouldClear = type === 'paused';
+    const status = shouldClear ? '' : (options?.status ?? (type === 'recording' ? 'is recording...' : 'is typing...'));
+    const timerKey = this.presenceStatusTimerKey(instanceId, chatId, threadTs);
+
+    const delivered =
+      status === ''
+        ? await clearTypingStatus({
+            client: connection.client,
+            channelId: chatId,
+            threadTs,
+            logger: this.logger,
+          })
+        : await setSlackThreadStatus({
+            client: connection.client,
+            channelId: chatId,
+            threadTs,
+            status,
+            loadingMessages: options?.loadingMessages,
+            logger: this.logger,
+          });
+
+    if (delivered) {
+      this.clearPresenceStatusTimer(timerKey);
     }
+
+    if (delivered && status !== '' && duration && duration > 0) {
+      const timer = setTimeout(() => {
+        if (this.presenceStatusTimers.get(timerKey) !== timer) return;
+        this.presenceStatusTimers.delete(timerKey);
+        clearTypingStatus({
+          client: connection.client,
+          channelId: chatId,
+          threadTs,
+          logger: this.logger,
+        }).catch((err) => {
+          this.logger.warn('Slack presence status auto-clear failed', {
+            instanceId,
+            channelId: chatId,
+            threadTs,
+            error: String(err),
+          });
+        });
+      }, duration);
+      this.presenceStatusTimers.set(timerKey, timer);
+      timer.unref?.();
+    }
+
+    return delivered
+      ? { delivered: true, method, threadId: threadTs, status, loadingMessages: options?.loadingMessages }
+      : {
+          delivered: false,
+          method,
+          threadId: threadTs,
+          status,
+          loadingMessages: options?.loadingMessages,
+          reason: 'slack_status_failed',
+        };
+  }
+
+  private presenceStatusTimerKey(instanceId: string, channelId: string, threadTs: string): string {
+    return `${instanceId}:${channelId}:${threadTs}`;
+  }
+
+  private clearPresenceStatusTimer(timerKey: string): void {
+    const timer = this.presenceStatusTimers.get(timerKey);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.presenceStatusTimers.delete(timerKey);
   }
 
   /**
@@ -891,6 +989,7 @@ export class SlackPlugin extends BaseChannelPlugin {
       threadTs: resolvedThread,
       logger: this.logger,
     });
+    this.clearPresenceStatusTimer(this.presenceStatusTimerKey(instanceId, channelId, resolvedThread));
   }
 
   /**

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -40,6 +40,14 @@ function readFileAsBase64(path: string): string {
   return buffer.toString('base64');
 }
 
+function parseLoadingMessages(value?: string): string[] | undefined {
+  const messages = value
+    ?.split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return messages?.length ? messages : undefined;
+}
+
 /** Send options type */
 interface SendOptions {
   instance?: string;
@@ -71,6 +79,8 @@ interface SendOptions {
   color?: number;
   url?: string;
   presence?: string;
+  status?: string;
+  loadingMessages?: string;
   tts?: string;
   voiceId?: string;
   presenceDelay?: number;
@@ -225,6 +235,9 @@ const messageSenders = {
       instanceId,
       to,
       type: presence as 'typing' | 'recording' | 'paused',
+      threadId: options.threadId,
+      status: options.status,
+      loadingMessages: parseLoadingMessages(options.loadingMessages),
     });
     output.success('Presence sent', result);
   },
@@ -389,6 +402,8 @@ function buildGroupedSendHelp(): string {
 
   const presenceOptions: OptionDef[] = [
     { flags: '--presence <type>', description: 'Send typing/recording/paused indicator' },
+    { flags: '--status <text>', description: 'Custom status text for channels that support it' },
+    { flags: '--loading-messages <items>', description: 'Comma-separated rotating loading messages' },
   ];
 
   const ttsOptions: OptionDef[] = [
@@ -493,6 +508,8 @@ export function createSendCommand(): Command {
     .option('--url <url>', 'Embed URL')
     // Presence
     .option('--presence <type>', 'Send presence indicator (typing, recording, paused)')
+    .option('--status <text>', 'Custom status text for channels that support it')
+    .option('--loading-messages <items>', 'Comma-separated rotating loading messages')
     // TTS
     .option('--tts <text>', 'Send TTS voice note (text-to-speech)')
     .option('--voice-id <id>', 'ElevenLabs voice ID for TTS')

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1062,6 +1062,9 @@ export interface SendPresenceBody {
   instanceId: string;
   to: string;
   type: 'typing' | 'recording' | 'paused';
+  threadId?: string;
+  status?: string;
+  loadingMessages?: string[];
   duration?: number;
 }
 
@@ -1073,6 +1076,12 @@ export interface SendPresenceResult {
   chatId: string;
   type: string;
   duration: number;
+  threadId?: string;
+  delivered?: boolean;
+  method?: string;
+  reason?: string;
+  status?: string;
+  loadingMessages?: string[];
 }
 
 /**
@@ -1937,12 +1946,17 @@ export function createOmniClient(config: OmniClientConfig) {
         });
         const json = (await resp.json()) as { data?: SendPresenceResult };
         if (!resp.ok) throw OmniApiError.from(json, resp.status);
+        const inferredDuration =
+          body.duration ?? (body.threadId || body.status || body.loadingMessages?.length ? 0 : 5000);
         return (
           json?.data ?? {
             instanceId: body.instanceId,
             chatId: body.to,
             type: body.type,
-            duration: body.duration ?? 5000,
+            duration: inferredDuration,
+            threadId: body.threadId,
+            status: body.status,
+            loadingMessages: body.loadingMessages,
           }
         );
       },

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -539,7 +539,7 @@ export interface paths {
         put?: never;
         /**
          * Send presence indicator
-         * @description Send typing/recording indicator in a chat. Auto-pauses after duration. WhatsApp supports typing, recording, paused. Discord only supports typing.
+         * @description Send typing/recording indicator in a chat. WhatsApp supports typing, recording, paused. Discord supports typing. Slack supports AI Assistant thread status via threadId or the active thread cache; omit duration to keep Slack status until reply cleanup or Slack timeout.
          */
         post: operations["sendPresence"];
         delete?: never;
@@ -2832,11 +2832,14 @@ export interface components {
              * @enum {string}
              */
             type: "typing" | "recording" | "paused";
-            /**
-             * @description Duration in ms before auto-pause (default 5000, 0 = until paused)
-             * @default 5000
-             */
-            duration: number;
+            /** @description Thread timestamp/id for thread-scoped presence surfaces such as Slack AI Assistant */
+            threadId?: string;
+            /** @description Custom status text for channels that support text status, such as Slack AI Assistant */
+            status?: string;
+            /** @description Rotating loading messages for channels that support them, such as Slack AI Assistant */
+            loadingMessages?: string[];
+            /** @description Duration in ms before auto-pause; omit for channel default, 0 = until paused */
+            duration?: number;
         };
         PresenceResponse: {
             /**
@@ -2850,6 +2853,18 @@ export interface components {
             type: string;
             /** @description Duration in ms */
             duration: number;
+            /** @description Thread timestamp/id used by the presence renderer */
+            threadId?: string;
+            /** @description Whether the channel reported the status as delivered */
+            delivered?: boolean;
+            /** @description Channel-specific presence method used */
+            method?: string;
+            /** @description Reason when the channel no-opped or failed best-effort */
+            reason?: string;
+            /** @description Channel-specific status text sent */
+            status?: string;
+            /** @description Channel-specific rotating loading messages sent */
+            loadingMessages?: string[];
         };
         MarkMessageReadRequest: {
             /**
@@ -7643,10 +7658,13 @@ export interface operations {
                      * @enum {string}
                      */
                     type: "typing" | "recording" | "paused";
-                    /**
-                     * @description Duration in ms before auto-pause (default 5000, 0 = until paused)
-                     * @default 5000
-                     */
+                    /** @description Thread timestamp/id for thread-scoped presence surfaces such as Slack AI Assistant */
+                    threadId?: string;
+                    /** @description Custom status text for channels that support text status, such as Slack AI Assistant */
+                    status?: string;
+                    /** @description Rotating loading messages for channels that support them, such as Slack AI Assistant */
+                    loadingMessages?: string[];
+                    /** @description Duration in ms before auto-pause; omit for channel default, 0 = until paused */
                     duration?: number;
                 };
             };
@@ -7672,6 +7690,18 @@ export interface operations {
                             type: string;
                             /** @description Duration in ms */
                             duration: number;
+                            /** @description Thread timestamp/id used by the presence renderer */
+                            threadId?: string;
+                            /** @description Whether the channel reported the status as delivered */
+                            delivered?: boolean;
+                            /** @description Channel-specific presence method used */
+                            method?: string;
+                            /** @description Reason when the channel no-opped or failed best-effort */
+                            reason?: string;
+                            /** @description Channel-specific status text sent */
+                            status?: string;
+                            /** @description Channel-specific rotating loading messages sent */
+                            loadingMessages?: string[];
                         };
                     };
                 };


### PR DESCRIPTION
## Summary

Adds Slack AI Assistant thread status support using `assistant.threads.setStatus` while keeping generic typing capability semantics unchanged.

## Changes

- Adds Slack thread status delivery for `typing`, `recording`, and `paused` presence updates.
- Supports caller-provided `threadId`, custom `status`, and `loadingMessages` through the presence endpoint, CLI, and TypeScript SDK.
- Clears Slack thread status on explicit pause, assistant reply cleanup, disconnect/dispose, or optional duration-based auto-clear.
- Updates OpenAPI and generated TypeScript SDK types.
- Avoids logging raw status/loading message content on Slack API failures.

## Impact

Slack bots can now expose the official assistant-thread progress/status UI without claiming support for generic channel typing indicators. Existing non-Slack presence behavior remains unchanged.

## Validation

- `bunx biome check ...` for changed files
- `bun test packages/channel-slack/src/handlers/typing.test.ts packages/api/src/__tests__/messages-presence.test.ts`
- `bun run typecheck`
- `git diff --check`
- Pre-push hook: full typecheck and full test suite, `3988 pass`, `294 skip`, `0 fail`
- Local smoke against Slack thread status returned `delivered: true` for set and clear flows