### PR TITLE
fix(channel-gupshup): harden simplified-payload id + drop empty text

### DIFF
--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -752,6 +752,17 @@ describe('Gupshup simplified Entry-Flow payload', () => {
     };
     expect(parseSimplifiedWebhook(route)).toBeNull();
   });
+
+  it('returns null when there is no text (does not dispatch an empty inbound)', () => {
+    expect(parseSimplifiedWebhook({ sender: { id: '5535984370828' }, event: { project_id: '1' } })).toBeNull();
+    expect(parseSimplifiedWebhook({ ...SIMPLIFIED, message: { timestamp: '1776273477' } })).toBeNull();
+  });
+
+  it('gives distinct ids to distinct same-second messages of equal length (no dedupe collision)', () => {
+    const a = parseSimplifiedWebhook({ ...SIMPLIFIED, message: { text: 'Oi', timestamp: '1776273477' } });
+    const b = parseSimplifiedWebhook({ ...SIMPLIFIED, message: { text: 'Ok', timestamp: '1776273477' } });
+    expect(a?.messageobj.id).not.toBe(b?.messageobj.id);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -136,15 +136,32 @@ function toUnixSeconds(ts: string | number | undefined): number {
   return Math.floor(n > 1e12 ? n / 1000 : n);
 }
 
-/** Map the simplified Entry-Flow payload onto the native inbound webhook shape. */
-function normalizeSimplifiedWebhook(p: z.infer<typeof GupshupSimplifiedWebhookSchema>): GupshupNativeInboundWebhook {
+/** Deterministic, dependency-free 32-bit FNV-1a digest of the text, as base36. */
+function textDigest(text: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Map the simplified Entry-Flow payload onto the native inbound webhook shape.
+ * Returns null when there's no text — the simplified shape only carries text
+ * messages, and dispatching an empty inbound is worse than dropping it.
+ */
+function normalizeSimplifiedWebhook(
+  p: z.infer<typeof GupshupSimplifiedWebhookSchema>,
+): GupshupNativeInboundWebhook | null {
   const phone = p.sender.id;
   const text = p.message?.text;
+  if (!text) return null;
   const tsSeconds = toUnixSeconds(p.message?.timestamp);
   // No native message id in the simplified payload — prefer one if present, else
-  // synthesize a stable id (phone+ts+len) so retries of the same message still
-  // dedupe. Distinct messages within the same second would collide (rare).
-  const id = p.message?.id ?? `gs-simplified-${phone}-${tsSeconds}-${text ? text.length : 0}`;
+  // synthesize a stable id (phone+ts+content-digest) so retries of the same
+  // message dedupe while distinct messages in the same second stay distinct.
+  const id = p.message?.id ?? `gs-simplified-${phone}-${tsSeconds}-${textDigest(text)}`;
   return {
     source: 'gupshup-hv-entry-flow-simplified',
     sender: phone,


### PR DESCRIPTION
## Problem
Follow-up to #707 (simplified HV-Entry-Flow payload support). Review surfaced two edge cases in `normalizeSimplifiedWebhook`:

1. **Dedupe collision.** The synthesized message id used `text.length` (`gs-simplified-{phone}-{ts}-{len}`). Two *distinct* messages from the same sender in the same unix-second with equal length (e.g. "Oi" then "Ok") produced the same id → dedupe key `{phone}:{id}` collided → the second message was silently dropped. Short, fast greeting bursts are exactly the entry-flow's traffic.
2. **Empty-text dispatch.** `message.text` is optional in the schema, but normalize unconditionally produced `{ type: 'text', text: undefined }`, dispatching an empty inbound instead of dropping it.

## Fix
- Synthesized id now uses a deterministic, dependency-free **FNV-1a content digest** of the text instead of its length — distinct content stays distinct, retries of the same message still dedupe.
- `normalizeSimplifiedWebhook` returns `null` when there's no text → falls through to the existing drop path (`dropped_unrecognized_shape`, acked 200) rather than dispatching an empty message.

## Tests
- distinct same-second equal-length messages get distinct ids (no collision)
- no-text simplified payloads normalize to `null`
- All existing #707 tests still pass · biome + typecheck + full suite (4000 pass / 0 fail) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)