### PR TITLE
fix(api): close scope-enforcer body-injection + header-target gaps (P1)

### DIFF
--- a/packages/api/src/middleware/__tests__/scope-enforcer.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer.test.ts
@@ -231,6 +231,49 @@ describe('extractLockTargets — route & body target extraction', () => {
     expect(t.instance).toBeNull();
     expect(t.recipient).toBeNull();
   });
+
+  // ── Precedence: route-derived targets win over the body (scope-bypass guard) ──
+
+  test('path instance wins over a conflicting body.instanceId (no body-injection bypass)', () => {
+    const t = extractLockTargets('PATCH', '/api/v2/instances/real-inst', { instanceId: 'allowlisted-inst' });
+    expect(t.instance).toBe('real-inst');
+  });
+
+  test('path chat wins over a conflicting body.chatId', () => {
+    const t = extractLockTargets('PATCH', '/api/v2/chats/real-chat', { chatId: 'allowlisted-chat' });
+    expect(t.chat).toBe('real-chat');
+  });
+
+  // ── Header-derived targets (x-omni-*) are extracted and rank above the body ──
+
+  test('x-omni-instance / x-omni-chat headers become targets (header-scoped routes)', () => {
+    const t = extractLockTargets('POST', '/api/v2/turns/close', null, {
+      instance: 'hdr-inst',
+      chat: 'hdr-chat',
+    });
+    expect(t.instance).toBe('hdr-inst');
+    expect(t.chat).toBe('hdr-chat');
+  });
+
+  test('header target wins over a conflicting body target', () => {
+    const t = extractLockTargets('POST', '/api/v2/turns/close', { instanceId: 'body-inst' }, { instance: 'hdr-inst' });
+    expect(t.instance).toBe('hdr-inst');
+  });
+
+  test('path target still wins over the header', () => {
+    const t = extractLockTargets('PATCH', '/api/v2/instances/path-inst', null, { instance: 'hdr-inst' });
+    expect(t.instance).toBe('path-inst');
+  });
+
+  test('body is still used when neither path nor header supplies the target', () => {
+    const t = extractLockTargets(
+      'POST',
+      '/api/v2/messages/send',
+      { instanceId: 'body-inst', to: 'jid', text: 'x' },
+      {},
+    );
+    expect(t.instance).toBe('body-inst');
+  });
 });
 
 describe('Integration scenarios from wish acceptance criteria', () => {

--- a/packages/api/src/middleware/require-signed-instance.ts
+++ b/packages/api/src/middleware/require-signed-instance.ts
@@ -33,7 +33,7 @@ import { createLogger } from '@omni/core';
 import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import type { AppVariables } from '../types';
-import { extractLockTargets } from './scope-enforcer';
+import { extractLockTargets, readHeaderTargets } from './scope-enforcer';
 
 const log = createLogger('api:require-signed-instance');
 
@@ -92,7 +92,7 @@ export const requireSignedInstanceMiddleware = createMiddleware<{ Variables: App
   const path = c.req.path;
   const body = await safeReadJsonBody(c);
 
-  const targets = extractLockTargets(method, path, body);
+  const targets = extractLockTargets(method, path, body, readHeaderTargets(c));
   if (!targets.instance) {
     // No instance target → nothing to enforce.
     return next();

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -238,19 +238,54 @@ function readBodyTargets(body: unknown): { instanceId: string | null; to: string
  * Merge path-param and body-derived target candidates into a single
  * `LockTargets`. Exported so tests can exercise extraction without HTTP.
  */
-export function extractLockTargets(method: string, rawPath: string, body: unknown): LockTargets {
+/**
+ * Route-derived targets carried in `x-omni-instance` / `x-omni-chat` headers.
+ * These are trusted like path params (set by the platform / API-key context),
+ * not like the caller-controllable JSON body.
+ */
+export interface HeaderLockTargets {
+  instance?: string | null;
+  chat?: string | null;
+}
+
+/** Read the `x-omni-*` target headers off a request context. */
+export function readHeaderTargets(c: Context<{ Variables: AppVariables }>): HeaderLockTargets {
+  const norm = (v: string | undefined): string | null => (v && v.length > 0 ? v : null);
+  return {
+    instance: norm(c.req.header('x-omni-instance')),
+    chat: norm(c.req.header('x-omni-chat')),
+  };
+}
+
+export function extractLockTargets(
+  method: string,
+  rawPath: string,
+  body: unknown,
+  headers?: HeaderLockTargets,
+): LockTargets {
   const cleanPath = normalizePath(rawPath);
   const { instanceId, to, chatId } = readBodyTargets(body);
-
-  let instance: string | null = instanceId;
-  let chat: string | null = chatId;
-  let recipient: string | null = null;
 
   // Path-param extraction: /instances/:id, /chats/:id
   const pathInstance = PATH_INSTANCE_PREFIXES.map((p) => firstPathSegment(cleanPath, p)).find((v) => v != null) ?? null;
   const pathChat = PATH_CHAT_PREFIXES.map((p) => firstPathSegment(cleanPath, p)).find((v) => v != null) ?? null;
-  if (!instance && pathInstance) instance = pathInstance;
-  if (!chat && pathChat) chat = pathChat;
+  const headerInstance = headers?.instance && headers.instance.length > 0 ? headers.instance : null;
+  const headerChat = headers?.chat && headers.chat.length > 0 ? headers.chat : null;
+
+  // Precedence: route-derived targets (path param first, then x-omni-* header)
+  // win over the request body. The body is caller-controllable, so:
+  //   • Letting it override a path/header target would let a caller authorize
+  //     against one instance/chat while the operation runs against another
+  //     (scope bypass — e.g. PATCH /instances/:realId with body.instanceId set
+  //     to an allowlisted id).
+  //   • Ignoring header targets entirely makes header-scoped routes (e.g.
+  //     POST /turns/close, which targets via x-omni-instance / x-omni-chat)
+  //     invisible to allowlist + signature enforcement.
+  // Body fields are used only when neither path nor header supplies the target
+  // (outbound sends, explicit-body turn close, etc.).
+  const instance = pathInstance ?? headerInstance ?? instanceId;
+  let chat = pathChat ?? headerChat ?? chatId;
+  let recipient: string | null = null;
 
   if (isOutboundSendRoute(cleanPath)) {
     // `to` is the outbound recipient. It is ALSO the chat target for DM sends
@@ -421,7 +456,7 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   // Admin (wildcard) keys still pass through locks because a profile key MAY
   // have been granted '*' via overrides; rely on the lock columns to decide.
   const body = await safeReadJsonBody(c);
-  const targets = extractLockTargets(method, path, body);
+  const targets = extractLockTargets(method, path, body, readHeaderTargets(c));
 
   const instanceResult = enforceInstanceAllowlist(apiKey, targets.instance);
   if (!instanceResult.allowed) {


### PR DESCRIPTION
Resolves the three **P1** authorization findings from the #589 (`dev → main`) bot review, verified still-present on current `dev`.

## Problem
`extractLockTargets()` — the helper feeding both the allowlist enforcer and `require-signed-instance` — resolved targets from **path params + JSON body only, body-first**. Two failure modes:

1. **Scope bypass (Codex P1, `scope-enforcer.ts`)** — `PATCH /instances/:realId` with `body.instanceId = <allowlisted-id>` made allowlist + `require_genie_signature` evaluate against the injected id, not the path target.
2. **Missed signature enforcement (Codex P1, `require-signed-instance.ts`)** — header-scoped routes (`POST /turns/close` targets via `x-omni-instance`/`x-omni-chat`) returned no instance target, so the signature gate was skipped on `requireGenieSignature` instances.
3. **False 403 (Codex P1, `scope-enforcer.ts`)** — same root cause: header targets were invisible, so allowlisted profile keys were wrongly denied on header-scoped routes.

## Fix
- `extractLockTargets` now also reads `x-omni-instance` / `x-omni-chat` (new `readHeaderTargets(c)` helper) and applies precedence **path > header > body**. Route-derived targets (path, header) are trusted; the caller-controllable body can no longer *override* them — it's used only when neither path nor header supplies the target (outbound sends, explicit-body turn close).
- Both `scope-enforcer` and `require-signed-instance` middleware pass header targets through.

## Tests
- path target beats a conflicting `body.instanceId`/`body.chatId` (bypass guard)
- `x-omni-*` headers populate targets for header-scoped routes
- header beats body; path beats header; body still used when no path/header target
- all existing extraction + enforcement + signature tests preserved · full gate green (4299 pass / 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)