### PR TITLE
fix(api): merge chat.settings on writes + publish real escalated flag

### DIFF
--- a/packages/api/src/routes/v2/chats.ts
+++ b/packages/api/src/routes/v2/chats.ts
@@ -1050,8 +1050,13 @@ chatsRoutes.post('/clear-session', async (c) => {
 
       const isAgentPaused = (dbChat.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
       if (isAgentPaused) {
+        // Merge — a bare replace would drop unrelated settings keys.
         await services.chats.update(dbChat.id, {
-          settings: { agentPaused: false, agentResumedAt: new Date().toISOString() },
+          settings: {
+            ...((dbChat.settings as Record<string, unknown>) ?? {}),
+            agentPaused: false,
+            agentResumedAt: new Date().toISOString(),
+          },
         });
       }
     }

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -1650,9 +1650,12 @@ messagesRoutes.post('/send/handoff', zValidator('json', sendHandoffSchema), asyn
     });
   }
 
-  // Set agentPaused — chains: chat.handoff_activated → follow-up disarm + agent stop
+  // Set agentPaused — chains: chat.handoff_activated → follow-up disarm + agent stop.
+  // Merge into existing settings so unrelated keys (followUpConfig, close*, …)
+  // survive — a bare `{ agentPaused: true }` replaces the whole JSONB column.
+  const handoffChat = await services.chats.getById(data.chatId);
   await services.chats.update(data.chatId, {
-    settings: { agentPaused: true },
+    settings: { ...((handoffChat?.settings as Record<string, unknown>) ?? {}), agentPaused: true },
   });
 
   // Close the race between chat.handoff_activated (two NATS hops away) and the
@@ -1884,8 +1887,12 @@ messagesRoutes.post('/send/close-contact', zValidator('json', sendCloseContactSc
   // terminal) for skip and treats a pure soft cooldown as pass.
   const shouldPauseAgent = outcome === 'lost';
   const closedAt = new Date();
+  // Merge into existing settings — replacing the whole JSONB column here would
+  // drop unrelated keys such as followUpConfig.
+  const closeChat = await services.chats.getById(data.chatId);
   await services.chats.update(data.chatId, {
     settings: {
+      ...((closeChat?.settings as Record<string, unknown>) ?? {}),
       ...(shouldPauseAgent ? { agentPaused: true } : {}),
       closed: terminal,
       closeUntil: closeUntil?.toISOString() ?? null,
@@ -1913,7 +1920,7 @@ messagesRoutes.post('/send/close-contact', zValidator('json', sendCloseContactSc
       agentId: instance.agentId ?? null,
       outcome,
       reason: data.reason ?? null,
-      escalated: terminal,
+      escalated,
       closedFields: data.closeFields ?? null,
       closedAt: closedAt.toISOString(),
     };


### PR DESCRIPTION
Resolves #589 review findings **#5, #6, #7** (verified still-present on current `dev`).

## Settings clobber (#5, #6, + a third matching site)
Several writes set `chats.settings` to a freshly-built object, which **replaces the entire JSONB column** and drops unrelated keys (`followUpConfig`, `close*`, `agentResumedAt`, …). Fixed to **merge over existing settings**, matching the codebase's own established pattern (`reopen-contact`, `PUT /follow-up/chats/:id`):
- `POST` handoff — `{ agentPaused: true }` → merged (#5)
- `POST` close-contact — `agentPaused`/`closed`/`closeUntil`/`closeOutcome` → merged (#6)
- clear-session **resume** — `{ agentPaused: false, agentResumedAt }` → merged (same bug, not in the original review but identical shape)

A service-layer merge was rejected on purpose: `DELETE /follow-up/chats/:id` relies on a wholesale replace to drop a key, so merging must stay at the call sites.

## chat.closed escalated flag (#7)
The event published `escalated: terminal`, so hard-terminal closes (`won`/`lost` — `terminal:true` but `escalated:false`) were always reported as escalations, corrupting BI/audit and any automation distinguishing hard closes from threshold escalations. Now publishes the computed `escalated` (the HTTP response already returned the correct value).

## Validation
Typecheck + biome clean; full gate green (4299 pass / 0 fail). No dedicated route-level tests added — these routes have no existing isolation harness, and the fixes mirror an already-shipped, already-tested pattern; the `escalated`≠`terminal` divergence is covered by the close-contact-state suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)