### PR TITLE
fix(cli): fail-fast on legacy embedded pgserve + major-aware migration hint (#722)

### DIFF
--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Unit tests for the `omni start` legacy-embedded preflight guard (#722).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { legacyEmbeddedNeedsMigration } from '../start.js';
+
+describe('legacyEmbeddedNeedsMigration', () => {
+  test('canonical install is never blocked (short-circuits before fs check)', () => {
+    // useCanonicalPgserve === true wins regardless of on-disk embedded data.
+    expect(legacyEmbeddedNeedsMigration(true, true)).toBe(false);
+    expect(legacyEmbeddedNeedsMigration(true, false)).toBe(false);
+  });
+
+  test('legacy embedded (no canonical flag + embedded data present) → must migrate', () => {
+    expect(legacyEmbeddedNeedsMigration(undefined, true)).toBe(true);
+    expect(legacyEmbeddedNeedsMigration(false, true)).toBe(true);
+  });
+
+  test('fresh/no-embedded install (no embedded data dir) → not blocked', () => {
+    expect(legacyEmbeddedNeedsMigration(undefined, false)).toBe(false);
+    expect(legacyEmbeddedNeedsMigration(false, false)).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -968,7 +968,7 @@ async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
     dumpResult = await deps.dumpEmbeddedDb(serverConfig.databaseUrl);
   } catch (err) {
     throw new Error(
-      `pg_dump of embedded omni DB failed (${err instanceof Error ? err.message : String(err)}); omni-api still running on embedded — install postgresql-client (apt install postgresql-client) if pg_dump is missing, then retry`,
+      `pg_dump of embedded omni DB failed (${err instanceof Error ? err.message : String(err)}); omni-api still running on embedded — the dump hint above names the exact client major to install (the distro-default postgresql-client is often older than the embedded server and will fail), then re-run \`omni doctor --fix\``,
     );
   }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { Command } from 'commander';
 import { loadConfig, loadServerConfig } from '../config.js';
 import { getHealthCheckUrl, waitForHealth } from '../health.js';
+import { EMBEDDED_PGSERVE_DATA_DIR, readDataDirMajor } from '../lib/embedded-canonical-migration.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, isPm2Available, pm2NotFoundError, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv } from '../runtime-env.js';
@@ -26,6 +27,21 @@ const START_HEALTH_TIMEOUT_MS = 10_000;
 // ACTION
 // ============================================================================
 
+/**
+ * A legacy embedded-pgserve install (created before the canonical cutover)
+ * cannot be served by this build — omni-api never spawns the embedded
+ * postmaster, so it crash-loops on "Database not ready". Legacy installs
+ * predate the `useCanonicalPgserve` flag, so they don't trip the API's
+ * PGSERVE_EMBEDDED=true guard. The signal: not committed to canonical AND an
+ * embedded data dir is present on disk.
+ */
+export function legacyEmbeddedNeedsMigration(
+  useCanonicalPgserve: boolean | undefined,
+  embeddedDataPresent: boolean = existsSync(join(EMBEDDED_PGSERVE_DATA_DIR, 'PG_VERSION')),
+): boolean {
+  return useCanonicalPgserve !== true && embeddedDataPresent;
+}
+
 async function runStart(): Promise<void> {
   // 1. Check PM2 availability
   if (!(await isPm2Available())) {
@@ -40,6 +56,22 @@ async function runStart(): Promise<void> {
 
   const serverConfig = loadServerConfig();
   const apiPort = serverConfig.port;
+
+  // Preflight: a legacy embedded-pgserve install (created before the canonical
+  // cutover) cannot be served by this build — omni-api never spawns the
+  // embedded postmaster, so it would crash-loop on "Database not ready after
+  // 30 attempts". Legacy installs predate the `useCanonicalPgserve` flag, so
+  // they DON'T trip the API's PGSERVE_EMBEDDED=true guard. Detect the shape
+  // (no canonical flag + embedded data dir present) and fail fast with the
+  // migration hint instead of an opaque crash loop.
+  if (legacyEmbeddedNeedsMigration(serverConfig.useCanonicalPgserve)) {
+    const major = readDataDirMajor(EMBEDDED_PGSERVE_DATA_DIR);
+    output.error(
+      `Legacy embedded pgserve detected — this omni build does not run an embedded Postgres.\n  Embedded data dir: ${EMBEDDED_PGSERVE_DATA_DIR}${major ? ` (PostgreSQL ${major})` : ''}\n  Your data is intact. Migrate to canonical pgserve first:\n      omni doctor --fix\n  (idempotent — preserves data; do not \`omni start\` until it completes).`,
+      undefined,
+      1,
+    );
+  }
 
   // Ensure hardened log directory exists before pm2 spawns.
   mkdirSync(getPm2LogDir(), { recursive: true });

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -409,6 +409,28 @@ function getEmbeddedPgserveDataDir(): string {
   return OMNI_EMBEDDED_PGSERVE_DATA_DIR;
 }
 
+/** Read the embedded cluster's PG major from its PG_VERSION file (null if absent). */
+function embeddedServerMajor(): number | null {
+  try {
+    const v = Number.parseInt(readFileSync(join(getEmbeddedPgserveDataDir(), 'PG_VERSION'), 'utf8').trim(), 10);
+    return Number.isFinite(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a client-tool remediation hint that names the REQUIRED major.
+ * The distro default `postgresql-client` is frequently older than the embedded
+ * server (e.g. Ubuntu 24.04 ships PG16) and a `pg_dump`/`psql` older than the
+ * server refuses to run — so never suggest the bare package.
+ */
+function clientToolHint(tool: 'pg_dump' | 'psql'): string {
+  const major = embeddedServerMajor();
+  const v = major ?? '<server-major>';
+  return `${tool} not found in PATH (or older than the embedded server). The embedded cluster is PostgreSQL ${v}; you need a ${tool} of major >= ${v}. Debian/Ubuntu (PGDG): \`apt install postgresql-client-${v}\` — NOT the bare \`postgresql-client\`, which may be older and will fail with "server version is newer". macOS: \`brew install postgresql@${v}\`. Then re-run \`omni doctor --fix\`.`;
+}
+
 /**
  * Resolve the canonical pgserve data dir from `~/.pgserve/config.json`.
  * pgserve writes `{dataDir, port, registeredAt}` during `pgserve install`.
@@ -504,9 +526,7 @@ export async function dumpEmbeddedDb(currentDatabaseUrl: string): Promise<Embedd
   }
 
   if (!commandIsAvailable('pg_dump')) {
-    throw new Error(
-      'pg_dump not found in PATH — install postgresql-client (apt install postgresql-client / brew install postgresql) and retry',
-    );
+    throw new Error(clientToolHint('pg_dump'));
   }
 
   const snapshotPath = getSnapshotPath();
@@ -571,9 +591,7 @@ export async function restoreSnapshotToCanonical(
   }
 
   if (!commandIsAvailable('psql')) {
-    throw new Error(
-      'psql not found in PATH — install postgresql-client (apt install postgresql-client / brew install postgresql) and retry',
-    );
+    throw new Error(clientToolHint('psql'));
   }
 
   output.raw('  Restoring snapshot into canonical pgserve via psql...');


### PR DESCRIPTION
Partial fix for #722 (embedded→canonical pgserve upgrade break). Resolves the two **operator-facing** gaps; the host-tooling-free data copy is tracked as a separate follow-up (Bun.SQL has no COPY API, so it's a careful per-type rewrite — see below).

## #1 — Fail-fast instead of opaque crash loop
The dev API only fail-fasts on `PGSERVE_EMBEDDED=true`, which **legacy** embedded installs (created before the canonical cutover) never set — so they fell into the API's 30× `Database not ready` retry crash loop with no guidance. `omni start` now detects the legacy-embedded shape (no `useCanonicalPgserve` flag **and** an embedded data dir present) and exits with the `omni doctor --fix` hint **before** starting omni-api. Extracted `legacyEmbeddedNeedsMigration()` + unit tests.

## #3 — Major-aware remediation hint
`dumpEmbeddedDb`/`restoreSnapshotToCanonical` told operators to `apt install postgresql-client`, which on Ubuntu 24.04 is **PG16** and refuses to dump a **PG18** server. New `clientToolHint()` reads the embedded cluster's `PG_VERSION` and names the **required major** (`postgresql-client-18` / `brew postgresql@18`), warning that the bare package is often too old (`server version is newer`).

## Validation (isolated Podman sandbox, real upgrade)
- `omni start` on a legacy-embedded install → **exit 1** with the migration hint (no crash loop). ✔
- `omni doctor --fix` with `pg_dump` absent → surfaces the major-aware hint (`PostgreSQL 18` / `postgresql-client-18` / "server version is newer"). ✔
- Unit tests for `legacyEmbeddedNeedsMigration` (canonical never blocked; legacy detected; fresh install not blocked).

## Not in this PR (follow-up)
The actual data migration still shells to `pg_dump`/`psql` (host tools omni doesn't bundle). A host-tooling-free copy needs `Bun.SQL` — but Bun 1.3.14's `SQL` has **no COPY API**, so it requires a per-column-type `SELECT`→`INSERT` rewrite (risky on a customer data path). Filed for its own reviewed PR.

Refs #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)