### PR TITLE
fix(cli): fully automatic, host-tooling-free omni doctor --fix migration (#722)

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -24,6 +24,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { type DoctorDeps, runDoctor } from '../commands/doctor.js';
 import type { Config, ServerConfig } from '../config.js';
+import type { MigrationResult } from '../lib/embedded-canonical-migration.js';
 import { DEFAULT_PGSERVE_PORT, buildRuntimeEnv } from '../runtime-env.js';
 
 // Neutralize host XDG_RUNTIME_DIR so the synchronous canonical-pgserve socket
@@ -115,13 +116,25 @@ interface HarnessState {
   restoreCalled: boolean;
   /** Canonical data dir reported by the stubbed `getCanonicalPgserveDataDir()`. */
   canonicalDataDir: string;
+  /** Result the stubbed `migrateEmbeddedData()` returns (host-tooling-free copy). */
+  migrateResult: MigrationResult;
+  /** When set, the stubbed `migrateEmbeddedData()` throws this error. */
+  migrateError: Error | null;
+  /** Set to true the first time `migrateEmbeddedData()` is called. */
+  migrateCalled: boolean;
   /**
-   * Records the order in which fix-handler dependencies were invoked, so
-   * tests can assert the correct dump → stop → install → restore → delete
-   * → start sequence.
+   * Records the order in which fix-handler dependencies were invoked, so tests
+   * can assert the canonical-migration sequence: stop → install → delete →
+   * start → migrate.
    */
   callOrder: Array<
-    'pm2-stop-api' | 'dump-embedded' | 'setup-canonical' | 'restore-snapshot' | 'pm2-start-api' | 'pm2-delete-api'
+    | 'pm2-stop-api'
+    | 'dump-embedded'
+    | 'setup-canonical'
+    | 'restore-snapshot'
+    | 'migrate-embedded'
+    | 'pm2-start-api'
+    | 'pm2-delete-api'
   >;
 }
 
@@ -184,6 +197,9 @@ function mkHarness(overrides?: Partial<HarnessState>): HarnessState {
     restoreError: null,
     restoreCalled: false,
     canonicalDataDir: '/tmp/omni-test/canonical',
+    migrateResult: { status: 'migrated', tables: 12, durationMs: 5 },
+    migrateError: null,
+    migrateCalled: false,
     callOrder: [],
     ...overrides,
   };
@@ -324,6 +340,12 @@ function mkDeps(state: HarnessState): DoctorDeps {
         : { status: 'skipped' as const };
     },
     getCanonicalPgserveDataDir: () => state.canonicalDataDir,
+    migrateEmbeddedData: async (_canonicalPort: number) => {
+      state.migrateCalled = true;
+      state.callOrder.push('migrate-embedded');
+      if (state.migrateError) throw state.migrateError;
+      return state.migrateResult;
+    },
     checkEmbeddedDataOrphaned: async () => ({
       id: 'embedded-data-orphaned',
       level: 'OK',
@@ -1033,137 +1055,104 @@ describe('runDoctor — pgserve-canonical check', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Embedded → canonical data migration via pg_dump + psql (issue #584)
+  // Embedded → canonical data migration — host-tooling-free (issue #722)
   //
-  // Before the data-migration step landed, `omni doctor --fix` flipped
-  // `databaseUrl` to canonical without moving the existing PG cluster.
-  // Operators with non-trivial data ended up on an empty canonical DB even
-  // though their messages/chats/etc. were still on disk under
-  // `~/.omni/data/pgserve/`. These tests pin the new ordering — mirroring
-  // genie's `db backup` / `db restore` pattern (pg_dump → gzip → psql):
-  //   dump (while embedded live) → stop omni-api → install canonical →
-  //   restore snapshot → persist → relaunch.
+  // The copy no longer shells to pg_dump/psql: omni-api boots on canonical to
+  // create the schema (drizzle migrations), then data is streamed over the
+  // wire (postgres.js COPY) by migrateEmbeddedData. New ordering:
+  //   stop omni-api → install canonical → persist → delete+start (schema) →
+  //   wait healthy → copy data.
   // -------------------------------------------------------------------------
 
-  test('--fix runs dump → stop → install → restore → delete → start in that order', async () => {
+  test('--fix runs stop → install → delete → start → migrate in that order', async () => {
     const { VERSION } = await import('../version.js');
     const state = mkHarness({ serverVersion: VERSION });
     state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
-    state.dumpResult = {
-      status: 'dumped',
-      embeddedDir: '/home/operator/.omni/data/pgserve',
-      snapshotPath: '/home/operator/.omni/backups/embedded-migration-2026-04-30T23-30-00-000Z.sql.gz',
-      bytes: 42_000_000,
-    };
     state.canonicalDataDir = '/home/operator/.pgserve/data';
+    state.migrateResult = { status: 'migrated', tables: 23, durationMs: 1200 };
 
     const report = await runDoctor({ fix: true }, mkDeps(state));
 
-    // All four side-effects ran
-    expect(state.dumpCalled).toBe(true);
     expect(state.canonicalPgserveSetupCalled).toBe(true);
-    expect(state.restoreCalled).toBe(true);
+    expect(state.migrateCalled).toBe(true);
+    // No host-tooling path — dump/restore are never invoked.
+    expect(state.dumpCalled).toBe(false);
+    expect(state.restoreCalled).toBe(false);
 
-    // Required ordering: dump must come BEFORE stop (embedded must be live
-    // for pg_dump). install must come BEFORE restore (canonical must exist
-    // for psql to write into).
-    const dumpIdx = state.callOrder.indexOf('dump-embedded');
+    // Ordering: stop (free embedded lock) → install canonical → delete+start
+    // omni-api on canonical (creates schema) → copy data last (after schema +
+    // health). The data copy MUST come after the relaunch (delete).
     const stopIdx = state.callOrder.indexOf('pm2-stop-api');
     const setupIdx = state.callOrder.indexOf('setup-canonical');
-    const restoreIdx = state.callOrder.indexOf('restore-snapshot');
-    expect(dumpIdx).toBeGreaterThanOrEqual(0);
-    expect(stopIdx).toBeGreaterThan(dumpIdx);
+    const deleteIdx = state.callOrder.indexOf('pm2-delete-api');
+    const migrateIdx = state.callOrder.indexOf('migrate-embedded');
+    expect(stopIdx).toBeGreaterThanOrEqual(0);
     expect(setupIdx).toBeGreaterThan(stopIdx);
-    expect(restoreIdx).toBeGreaterThan(setupIdx);
+    expect(deleteIdx).toBeGreaterThan(setupIdx);
+    expect(migrateIdx).toBeGreaterThan(deleteIdx);
+    // omni-api was relaunched on canonical (delete + start) before the copy.
+    expect(state.pm2Calls.map((c) => c.args[0])).toContain('start');
 
-    // Final result message surfaces the snapshot path AND the canonical data
-    // dir so the operator can verify the destination without grepping logs.
+    // Config persisted with the canonical flag + url, before the data copy.
+    expect(state.savedServerConfigs).toHaveLength(1);
+    expect(state.savedServerConfigs[0]).toMatchObject({ useCanonicalPgserve: true });
+
     const fix = report.fixesApplied.find((f) => f.includes('canonical pgserve'));
     expect(fix).toBeDefined();
-    expect(fix).toContain('embedded-migration-2026-04-30T23-30-00-000Z.sql.gz');
+    expect(fix).toContain('copied 23 table(s)');
     expect(fix).toContain('/home/operator/.pgserve/data');
-    expect(fix).toContain('postgresql://postgres:postgres@localhost:8432/omni');
   });
 
-  test('--fix on a fresh install (no embedded data) skips dump+restore and proceeds', async () => {
+  test('--fix on a fresh install (no embedded data) proceeds; copy reports skipped', async () => {
     const { VERSION } = await import('../version.js');
     const state = mkHarness({ serverVersion: VERSION });
     state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
     state.canonicalDataDir = '/home/operator/.pgserve/data';
-    // Default dumpResult is already 'no-embedded-data'; explicit for readability.
-    state.dumpResult = { status: 'no-embedded-data', embeddedDir: '/home/operator/.omni/data/pgserve' };
+    state.migrateResult = { status: 'skipped', reason: 'no embedded data dir' };
 
     const report = await runDoctor({ fix: true }, mkDeps(state));
 
-    // Dump probe ran (so we don't second-guess) but returned no-op.
-    expect(state.dumpCalled).toBe(true);
     expect(state.canonicalPgserveSetupCalled).toBe(true);
-    // Restore was still called but skipped internally (status === 'skipped')
-    // because dump status was no-embedded-data.
-    expect(state.restoreCalled).toBe(true);
+    expect(state.migrateCalled).toBe(true);
     expect(state.savedServerConfigs).toHaveLength(1);
     const fix = report.fixesApplied.find((f) => f.includes('canonical pgserve'));
-    expect(fix).toContain('no embedded data to migrate; canonical started empty');
+    expect(fix).toContain('no data copied (no embedded data dir)');
     expect(fix).toContain('/home/operator/.pgserve/data');
   });
 
-  test('--fix rolls back omni-api to embedded when pg_dump throws (omni-api never stopped)', async () => {
+  test('--fix records FAILED when omni-api never becomes healthy on canonical', async () => {
     const { VERSION } = await import('../version.js');
     const state = mkHarness({ serverVersion: VERSION });
     state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
-    state.dumpError = new Error('pg_dump not found in PATH — install postgresql-client');
+    // omni-api never reports a version → health wait times out → schema unknown.
+    state.serverVersion = null;
 
     const report = await runDoctor({ fix: true }, mkDeps(state));
 
-    expect(state.dumpCalled).toBe(true);
-    // We never proceeded past dump — no stop, no setup, no restore.
-    expect(state.callOrder).not.toContain('pm2-stop-api');
-    expect(state.canonicalPgserveSetupCalled).toBe(false);
-    expect(state.restoreCalled).toBe(false);
-    expect(state.savedServerConfigs).toHaveLength(0);
-
+    // Got far enough to flip config + relaunch, but bailed before the copy.
+    expect(state.canonicalPgserveSetupCalled).toBe(true);
+    expect(state.migrateCalled).toBe(false);
     const failedFix = report.fixesApplied.find((f) => f.startsWith('FAILED pgserve-canonical'));
     expect(failedFix).toBeDefined();
-    expect(failedFix).toContain('pg_dump of embedded omni DB failed');
-    expect(failedFix).toContain('postgresql-client');
+    expect(failedFix).toContain('did not become healthy');
   });
 
-  test('--fix rolls back to embedded + preserves snapshot when restore fails', async () => {
+  test('--fix surfaces FAILED when the data copy throws (embedded data is intact)', async () => {
     const { VERSION } = await import('../version.js');
     const state = mkHarness({ serverVersion: VERSION });
     state.serverConfig = { ...state.serverConfig, useCanonicalPgserve: false };
-    state.dumpResult = {
-      status: 'dumped',
-      embeddedDir: '/home/op/.omni/data/pgserve',
-      snapshotPath: '/home/op/.omni/backups/embedded-migration-2026-04-30T23-31-00-000Z.sql.gz',
-      bytes: 12_345_678,
-    };
-    state.restoreError = new Error('ERROR: relation "messages" already exists');
+    state.migrateError = new Error('temp postmaster failed to become ready within 20s');
 
     const report = await runDoctor({ fix: true }, mkDeps(state));
 
-    // Sequence reached restore but failed there
-    expect(state.dumpCalled).toBe(true);
-    expect(state.canonicalPgserveSetupCalled).toBe(true);
-    expect(state.restoreCalled).toBe(true);
-
-    // omni-api must have been brought back up so operator isn't dead.
-    expect(state.callOrder).toContain('pm2-stop-api');
-    expect(state.callOrder).toContain('pm2-start-api');
-    const stopIdx = state.callOrder.indexOf('pm2-stop-api');
-    const startIdx = state.callOrder.indexOf('pm2-start-api');
-    expect(startIdx).toBeGreaterThan(stopIdx);
-
-    // No config write — embedded mode preserved.
-    expect(state.savedServerConfigs).toHaveLength(0);
-
-    // Failure message includes the snapshot path so operators can replay
-    // manually with `gunzip -c <path> | psql <canonical-url>`.
+    expect(state.migrateCalled).toBe(true);
+    // Config was already flipped to canonical (the only runnable state for this
+    // build); the embedded data dir is untouched and the idempotent
+    // embedded-data-orphaned check re-runs the copy next time.
+    expect(state.savedServerConfigs).toHaveLength(1);
     const failedFix = report.fixesApplied.find((f) => f.startsWith('FAILED pgserve-canonical'));
     expect(failedFix).toBeDefined();
-    expect(failedFix).toContain('psql restore into canonical pgserve failed');
-    expect(failedFix).toContain('snapshot preserved at /home/op/.omni/backups/embedded-migration-');
-    expect(failedFix).toContain('relation "messages" already exists');
+    expect(failedFix).toContain('temp postmaster failed to become ready');
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -66,7 +66,11 @@ import {
   restoreSnapshotToCanonical,
   setupCanonicalPgserve,
 } from '../lib/canonical-pgserve.js';
-import { EMBEDDED_PGSERVE_DATA_DIR, migrateUnmountedEmbeddedToCanonical } from '../lib/embedded-canonical-migration.js';
+import {
+  EMBEDDED_PGSERVE_DATA_DIR,
+  type MigrationResult,
+  migrateUnmountedEmbeddedToCanonical,
+} from '../lib/embedded-canonical-migration.js';
 import * as output from '../output.js';
 import { PM2_HARDENED_DEFAULTS, PM2_PROCESSES, buildPm2StartArgs, capturePm2, isPm2Available, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv, resolvePgservePort } from '../runtime-env.js';
@@ -254,6 +258,13 @@ export interface DoctorDeps {
   /** Resolve canonical pgserve's on-disk data dir for operator-facing logs. */
   getCanonicalPgserveDataDir: () => string;
   /**
+   * Copy data embedded → canonical over the wire (postgres.js COPY; no host
+   * psql/pg_dump). Called AFTER omni-api has booted on canonical so the schema
+   * exists. Mounts the embedded data dir in a temp postmaster, copies, and
+   * restarts omni-api on canonical. Stubbed in tests.
+   */
+  migrateEmbeddedData: (canonicalPort: number) => Promise<MigrationResult>;
+  /**
    * Optional test seam for the expensive host-local orphaned embedded data
    * comparison. Production leaves this undefined and uses the real disk.
    */
@@ -392,6 +403,7 @@ function productionDeps(): DoctorDeps {
     dumpEmbeddedDb,
     restoreSnapshotToCanonical,
     getCanonicalPgserveDataDir,
+    migrateEmbeddedData: (canonicalPort: number) => migrateUnmountedEmbeddedToCanonical({ canonicalPort }),
     saveServerConfig,
     findPortOwner: async (port: number): Promise<number | null> => {
       // `ss -tlnpH "sport = :PORT"` always present on modern Linux; lsof
@@ -924,90 +936,66 @@ async function fixCliKeyValid(deps: DoctorDeps): Promise<string> {
   return 'rotated CLI key and re-validated';
 }
 
+/** Poll omni-api /health until it reports a version (schema migrations done). */
+async function waitForApiHealthy(deps: DoctorDeps, apiPort: number, attempts = 30): Promise<boolean> {
+  for (let i = 0; i < attempts; i++) {
+    if (await deps.fetchHealthVersion(apiPort)) return true;
+    await deps.sleepMs(1000);
+  }
+  return false;
+}
+
 /**
- * Migrate an embedded install onto canonical pgserve via `pg_dump` + `psql`,
- * mirroring genie's `db backup` / `db restore` pattern.
+ * Migrate an embedded install onto canonical pgserve — host-tooling-free.
+ *
+ * No `pg_dump`/`psql`: the data copy streams `COPY` over the wire via
+ * postgres.js (see migrateUnmountedEmbeddedToCanonical). The canonical schema
+ * is created by omni-api's own startup migrations, so we only copy row data.
  *
  * Sequence:
- *   1. Pre-flight: dump the embedded `omni` DB to a gzipped snapshot at
- *      `~/.omni/backups/embedded-migration-<ISO>.sql.gz`. omni-api MUST be
- *      running here so pg_dump can connect — that's why dump is step 1, not
- *      step 3.
- *   2. Stop omni-api → frees :8432 + releases the embedded data dir's locks.
- *   3. `pgserve install` → canonical pgserve at canonical data dir
- *      (`~/.pgserve/data` by default; surfaced explicitly to the operator).
- *   4. Restore the snapshot into canonical via `psql ON_ERROR_STOP=1`.
- *   5. Persist `useCanonicalPgserve: true` + canonical `databaseUrl`.
- *   6. Relaunch omni-api with the new env so `PGSERVE_EMBEDDED=false` takes
- *      effect.
+ *   1. Stop omni-api → frees :8432 + the embedded data dir's postmaster lock
+ *      (the migrator mounts that dir in a temp postmaster later).
+ *   2. `pgserve install` → canonical pgserve (creates the omni db + role).
+ *   3. Persist `useCanonicalPgserve: true` + canonical `databaseUrl`.
+ *   4. Relaunch omni-api on canonical → its startup runs the drizzle
+ *      migrations, so the (empty) canonical DB gets the schema.
+ *   5. Wait for omni-api health → schema is ready.
+ *   6. Copy data embedded → canonical (postgres.js COPY). The migrator stops
+ *      omni-api during the copy and restarts it on the populated canonical DB.
  *
  * SAFETY:
- *   - Embedded data dir at `~/.omni/data/pgserve` is never modified. On
- *     any failure the operator can roll back by removing
- *     `useCanonicalPgserve` from `~/.omni/config.json` and restarting
- *     omni-api — embedded mode picks the data right back up.
- *   - The snapshot is preserved at the path printed at step 1. If restore
- *     fails, operators can replay it manually with
- *     `gunzip -c <snapshot> | psql <canonical-url>` once they've fixed
- *     whatever blocked psql.
- *
- * On any failure (dump error, pgserve install failed, restore failed,
- * omni-api relaunch failed) we restart omni-api on embedded so operators
- * are not left with a dead API. Config is only persisted after the
- * complete dump → install → restore → relaunch chain succeeds.
+ *   - The embedded data dir is never mutated. If setup (step 2) fails before
+ *     the config flip, omni-api is restarted on embedded — operator not left
+ *     dead. After the flip, canonical is the target (this build can't run
+ *     embedded); a failed copy leaves canonical empty-but-healthy with the
+ *     embedded data intact, and the idempotent `embedded-data-orphaned` check
+ *     re-runs the copy on the next `omni doctor --fix`.
  */
 async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
   const { serverConfig, cliConfig } = deps.loadState();
 
-  // Step 1: dump embedded DB FIRST while omni-api (and its embedded pgserve)
-  // is still running. pg_dump needs a live target. The snapshot is written
-  // outside any pgserve data dir so it survives the migration regardless of
-  // outcome.
-  let dumpResult: EmbeddedDumpResult;
-  try {
-    dumpResult = await deps.dumpEmbeddedDb(serverConfig.databaseUrl);
-  } catch (err) {
-    throw new Error(
-      `pg_dump of embedded omni DB failed (${err instanceof Error ? err.message : String(err)}); omni-api still running on embedded — the dump hint above names the exact client major to install (the distro-default postgresql-client is often older than the embedded server and will fail), then re-run \`omni doctor --fix\``,
-    );
-  }
-
-  // Step 2: stop omni-api so the embedded pgserve releases port 8432 AND
-  // the data dir's postmaster lock. After this point the embedded DB is no
-  // longer reachable; we rely on the snapshot from step 1.
+  // Step 1: stop omni-api so the embedded postmaster releases :8432 + its
+  // data-dir lock (the migrator mounts that dir in a temp postmaster later).
   await deps.runPm2(['stop', PM2_PROCESSES.api]);
 
-  // Step 3: provision canonical pgserve.
+  // Step 2: provision canonical pgserve (creates the omni db + role).
   const url = await deps.setupCanonicalPgserve();
   if (!url) {
-    // Bring omni-api back up on embedded — operator isn't left dead.
+    // Config not flipped yet — bring omni-api back up on embedded.
     await deps.runPm2(['start', PM2_PROCESSES.api]);
     throw new Error(
       'canonical pgserve setup failed (autopg v3 / pgserve v2 binary unavailable or install failed) — install autopg:\n  curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash\nthen re-run: omni doctor --fix',
     );
   }
 
-  // Step 4: restore the snapshot. No-op when nothing was dumped (fresh
-  // install). On failure: rollback omni-api to embedded, preserve the
-  // snapshot path so operators can investigate / replay manually.
-  let restoreOutcome: { status: 'restored' | 'skipped'; snapshotPath?: string };
-  try {
-    restoreOutcome = await deps.restoreSnapshotToCanonical(dumpResult, url);
-  } catch (err) {
-    await deps.runPm2(['start', PM2_PROCESSES.api]);
-    const snapshotHint = dumpResult.status === 'dumped' ? ` snapshot preserved at ${dumpResult.snapshotPath}` : '';
-    throw new Error(
-      `psql restore into canonical pgserve failed (${err instanceof Error ? err.message : String(err)}); omni-api restarted on embedded —${snapshotHint} retry by replaying the dump manually or re-running \`omni doctor --fix\``,
-    );
-  }
-
-  // Step 5: persist config first so a relaunch failure leaves the operator
-  // on canonical (the new recommended state) rather than half-migrated.
+  // Step 3: point config at canonical BEFORE bringing omni-api up there, so a
+  // relaunch hiccup leaves the operator on canonical (the only runnable state
+  // for this build) rather than half-migrated.
   deps.saveServerConfig({ databaseUrl: url, useCanonicalPgserve: true });
 
-  // Step 6: relaunch omni-api with the new env so PGSERVE_EMBEDDED=false
-  // takes effect. delete + start (instead of restart) so the new env is
-  // picked up — pm2's restart preserves stored env in some configurations.
+  // Step 4: relaunch omni-api on canonical — startup runs the drizzle
+  // migrations, creating the schema the data copy needs. delete + start (not
+  // restart) so the new env is picked up.
   const env = buildRuntimeEnv({ ...serverConfig, databaseUrl: url, useCanonicalPgserve: true }, cliConfig);
   await deps.runPm2(['delete', PM2_PROCESSES.api], env);
   const startArgs = buildPm2StartArgs({
@@ -1018,21 +1006,28 @@ async function fixPgserveCanonical(deps: DoctorDeps): Promise<string> {
   });
   const startCode = await deps.runPm2(startArgs, env);
   if (startCode !== 0) {
-    throw new Error(`pm2 start ${PM2_PROCESSES.api} exited ${startCode} after canonical migration`);
+    throw new Error(`pm2 start ${PM2_PROCESSES.api} exited ${startCode} after pointing config at canonical`);
   }
 
-  // Compose a result message that surfaces every concrete path so the
-  // operator can verify the migration without grepping logs:
-  //   - canonical data dir (where the cluster lives on disk)
-  //   - canonical URL (where omni-api connects)
-  //   - snapshot path (rollback artifact)
+  // Step 5: wait for omni-api to report healthy → schema migrations applied.
+  if (!(await waitForApiHealthy(deps, serverConfig.port))) {
+    throw new Error(
+      'omni-api did not become healthy on canonical within the timeout; schema migrations may not have applied — check `omni logs --process api`, then re-run `omni doctor --fix`',
+    );
+  }
+
+  // Step 6: copy data embedded → canonical (postgres.js COPY; no host tools).
+  // migrateEmbeddedData stops omni-api during the copy and restarts it on the
+  // populated canonical DB. On failure the embedded data is intact and the
+  // idempotent embedded-data-orphaned check re-runs the copy next time.
+  const canonicalPort = Number.parseInt(new URL(url).port || '5432', 10);
+  const result = await deps.migrateEmbeddedData(canonicalPort);
+
   const canonicalDir = deps.getCanonicalPgserveDataDir();
   const dataNote =
-    dumpResult.status === 'dumped' && restoreOutcome.status === 'restored'
-      ? `restored ${dumpResult.snapshotPath} into ${canonicalDir} (omni-api → ${url})`
-      : dumpResult.status === 'no-embedded-data'
-        ? `no embedded data to migrate; canonical started empty at ${canonicalDir} (omni-api → ${url})`
-        : `embedded data dir invalid; canonical started empty at ${canonicalDir} (omni-api → ${url})`;
+    result.status === 'migrated'
+      ? `copied ${result.tables} table(s) into ${canonicalDir} (omni-api → ${url})`
+      : `no data copied (${result.reason}); canonical at ${canonicalDir} (omni-api → ${url})`;
   return `migrated to canonical pgserve@^2.1.0; ${dataNote}`;
 }
 

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -28,6 +28,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSyn
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { gunzipSync, gzipSync } from 'node:zlib';
+import postgres from 'postgres';
 
 import { loadServerConfig } from '../config.js';
 import * as output from '../output.js';
@@ -218,45 +219,42 @@ function buildOmniDatabaseUrl(port: number): string {
  * attempts` because omni-api can connect to the postmaster but the
  * `omni` DB simply doesn't exist there yet. This helper closes the gap.
  *
- * Idempotent via Postgres's "IF NOT EXISTS"-equivalent: catch the
- * `42P04` (duplicate_database) error code and treat as success. Uses
- * `psql` because the CLI already has it on PATH whenever autopg / pgserve
- * is installed (it's bundled with the postmaster).
+ * Idempotent: a `42P04` (duplicate_database) error means it already exists →
+ * success. Uses postgres.js over the wire (NOT `psql`) — the autopg/pgserve
+ * postmaster ships only the server trio (initdb/pg_ctl/postgres), so `psql`
+ * is frequently absent on a fresh host; shelling to it aborted the migration.
  *
- * Best-effort: any non-fatal failure (binary missing, transient timeout)
- * returns false so the caller can warn without aborting the install.
+ * Best-effort: any non-fatal failure returns false so the caller can warn
+ * without aborting the install.
  */
 async function ensureOmniDatabaseExists(port: number): Promise<boolean> {
-  const psqlArgs = [
-    '-h',
-    '127.0.0.1',
-    '-p',
-    String(port),
-    '-U',
-    'postgres',
-    '-d',
-    'postgres',
-    '-tAc',
-    `CREATE DATABASE ${OMNI_DATABASE_NAME}`,
-  ];
-  const proc = Bun.spawn({
-    cmd: ['psql', ...psqlArgs],
-    stdout: 'pipe',
-    stderr: 'pipe',
-    env: { ...process.env, PGPASSWORD: 'postgres' },
+  const sql = postgres({
+    host: '127.0.0.1',
+    port,
+    user: 'postgres',
+    password: 'postgres',
+    database: 'postgres',
+    max: 1,
+    idle_timeout: 5,
+    connect_timeout: 30,
+    onnotice: () => {},
+    prepare: false,
   });
-  const stderr = await new Response(proc.stderr).text();
-  const code = await proc.exited;
-  if (code === 0) {
+  try {
+    // CREATE DATABASE cannot run inside a transaction; .unsafe() simple-queries it.
+    await sql.unsafe(`CREATE DATABASE ${OMNI_DATABASE_NAME}`);
     output.raw(`  Created \`${OMNI_DATABASE_NAME}\` database on canonical postmaster.`);
     return true;
+  } catch (err) {
+    // 42P04 duplicate_database → already exists → success (idempotent).
+    const code = (err as { code?: string })?.code;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (code === '42P04' || msg.includes('already exists')) return true;
+    output.warn(`Could not ensure \`${OMNI_DATABASE_NAME}\` database exists: ${msg}`);
+    return false;
+  } finally {
+    await sql.end({ timeout: 5 });
   }
-  // Already-exists is success. Postgres surfaces 42P04 in the error text.
-  if (stderr.includes('42P04') || stderr.includes('already exists')) {
-    return true;
-  }
-  output.warn(`Could not ensure \`${OMNI_DATABASE_NAME}\` database exists (psql exit ${code}): ${stderr.trim()}`);
-  return false;
 }
 
 /**

--- a/packages/cli/src/lib/role-cutover.ts
+++ b/packages/cli/src/lib/role-cutover.ts
@@ -33,6 +33,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import postgres from 'postgres';
 
 // ============================================================================
 // Naming
@@ -245,7 +246,11 @@ $$;`,
     `GRANT CONNECT, TEMPORARY, CREATE ON DATABASE "${database}" TO "${roleName}";`,
   ];
   // Run the role + database-grants script on the postgres database.
-  const dbCreateOk = await runPsql(sqlScript.join('\n'), { socketDir: opts.socketDir, port, database: 'postgres' });
+  const dbCreateOk = await runProvisioningSql(sqlScript.join('\n'), {
+    socketDir: opts.socketDir,
+    port,
+    database: 'postgres',
+  });
   if (!dbCreateOk) {
     return { status: 'skipped', reason: 'psql role provisioning failed' };
   }
@@ -286,7 +291,7 @@ $$;`,
     `ALTER DEFAULT PRIVILEGES IN SCHEMA drizzle GRANT ALL ON TABLES TO "${roleName}";`,
     `ALTER DEFAULT PRIVILEGES IN SCHEMA drizzle GRANT ALL ON SEQUENCES TO "${roleName}";`,
   ].join('\n');
-  const grantsOk = await runPsql(grantsScript, { socketDir: opts.socketDir, port, database });
+  const grantsOk = await runProvisioningSql(grantsScript, { socketDir: opts.socketDir, port, database });
   if (!grantsOk) {
     return { status: 'skipped', reason: 'psql grant step failed' };
   }
@@ -301,40 +306,45 @@ $$;`,
     : { status: 'provisioned', roleName };
 }
 
-interface PsqlOptions {
+interface ProvisioningSqlOptions {
   socketDir: string;
   port: number;
   database: string;
 }
 
-async function runPsql(sql: string, opts: PsqlOptions): Promise<boolean> {
-  const proc = Bun.spawn({
-    cmd: [
-      'psql',
-      '-h',
-      opts.socketDir,
-      '-p',
-      String(opts.port),
-      '-U',
-      'postgres',
-      '-d',
-      opts.database,
-      '-v',
-      'ON_ERROR_STOP=1',
-      '-c',
-      sql,
-    ],
-    stdout: 'pipe',
-    stderr: 'pipe',
-    env: { ...process.env, PGPASSWORD: 'postgres' },
+/**
+ * Run a (possibly multi-statement) provisioning script over the wire via
+ * postgres.js — NOT `psql`. The autopg/pgserve postmaster ships only the
+ * server trio (no client tools), so `psql` is frequently absent on a fresh
+ * host; shelling to it aborted role/grant provisioning. postgres.js runs the
+ * script as a simple query, which fails-fast on the first error (the
+ * `ON_ERROR_STOP=1` equivalent). Connects on the local unix socket as the
+ * `postgres` superuser. Best-effort: returns false on any failure.
+ */
+async function runProvisioningSql(script: string, opts: ProvisioningSqlOptions): Promise<boolean> {
+  const sql = postgres({
+    host: opts.socketDir, // absolute path → unix socket
+    port: opts.port,
+    user: 'postgres',
+    password: 'postgres',
+    database: opts.database,
+    max: 1,
+    idle_timeout: 5,
+    connect_timeout: 30,
+    onnotice: () => {},
+    prepare: false,
   });
-  const stderr = await new Response(proc.stderr).text();
-  const code = await proc.exited;
-  if (code !== 0) {
-    process.stderr.write(`role-cutover: psql exited ${code}: ${stderr.trim()}\n`);
+  try {
+    await sql.unsafe(script);
+    return true;
+  } catch (err) {
+    process.stderr.write(
+      `role-cutover: provisioning SQL failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
     return false;
+  } finally {
+    await sql.end({ timeout: 5 });
   }
-  return true;
 }
 
 // ============================================================================


### PR DESCRIPTION
Completes #722: a fresh `omni doctor --fix` now migrates an embedded install to canonical pgserve **fully automatically, with zero host Postgres client tools** (`psql`/`pg_dump`).

## What changed
1. **Rewired `fixPgserveCanonical`** off the `pg_dump`/`psql` snapshot path onto the postgres.js copier (#724):
   `stop omni-api → pgserve install → persist canonical config → delete+start omni-api on canonical (startup runs drizzle migrations → schema) → wait /health → copy data via migrateEmbeddedData (postgres.js COPY)`.
   The schema comes from omni-api's own migrations, so the copy is data-only. Added `DoctorDeps.migrateEmbeddedData` (stubbable) + `waitForApiHealthy`.
2. **Converted two remaining `psql` shell-outs** in canonical *provisioning* (surfaced by the clean-room e2e — `Bun.spawn` throws on a missing executable, aborting the fix):
   - `ensureOmniDatabaseExists` — `CREATE DATABASE` over the wire (42P04 → idempotent success).
   - `role-cutover` `runProvisioningSql` (was `runPsql`) — role-create + grants as a simple query over the local socket; fails-fast like `ON_ERROR_STOP=1`.

## Failure semantics (new architecture — this build can't run embedded)
- setup fails (pre-flip) → restart omni-api on embedded, FAIL.
- after the config flip, canonical is the target; a health-timeout or copy failure leaves canonical healthy/empty with the **embedded data intact**, and the idempotent `embedded-data-orphaned` check re-runs the copy next time.

## Validation
- **49 doctor unit tests** rewritten for the new ordering + failure modes (copy-skip, health-timeout, copy-throw); dump/restore are no longer invoked by the fix.
- **Clean-room e2e** (fresh container): `@automagik/omni@latest` embedded install + seeded canary → upgrade to this build → `omni doctor --fix` → **13 OK / 0 FAIL**, omni-api healthy on canonical, **30 tables copied (855ms)**, canary instance preserved with an **identical UUID**, `embedded ↔ canonical row counts match`. No `psql`/`pg_dump` present.

## Notes
- `dumpEmbeddedDb`/`restoreSnapshotToCanonical` remain in canonical-pgserve.ts (still referenced by update-maintenance tests) but are no longer used by the fix path.
- The reader resolver (`findAutopgPostgresBinary`) looks under `~/.local/share/autopg`, while autopg ≥2.6 installs to `~/.autopg`; on a host with only autopg installed and no `npm` for the embedded-postgres fallback, the copy gracefully reports *skipped* (no reader) rather than crashing, and the orphaned-data check recovers once a reader is available. Worth a follow-up to teach the resolver autopg's real path.

Closes #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)