### PR TITLE
fix(channel-gupshup): preserve Brazilian extra-9 in outbound identity

### DIFF
--- a/packages/channel-gupshup/src/__tests__/identity.test.ts
+++ b/packages/channel-gupshup/src/__tests__/identity.test.ts
@@ -59,4 +59,11 @@ describe('toGupshupPhone', () => {
   it('leaves an already-clean 12-digit number unchanged', () => {
     expect(toGupshupPhone('555197285829')).toBe('555197285829');
   });
+
+  it('returns empty string for non-string input (contract violation, no crash)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: simulating a runtime contract violation
+    expect(toGupshupPhone(undefined as any)).toBe('');
+    // biome-ignore lint/suspicious/noExplicitAny: simulating a runtime contract violation
+    expect(toGupshupPhone(null as any)).toBe('');
+  });
 });

--- a/packages/channel-gupshup/src/__tests__/identity.test.ts
+++ b/packages/channel-gupshup/src/__tests__/identity.test.ts
@@ -1,68 +1,62 @@
 /**
  * Gupshup identity utilities — unit tests
  *
- * Covers phone normalization edge cases and user ID extraction.
- * New behavior: normalizePhone strips + and handles BR extra-9.
+ * Identity is round-tripped: only transport formatting (+, @suffix, :device)
+ * is stripped. The Brazilian extra-9 is always preserved — stripping it would
+ * point the outbound callback at a different (non-existent) contact and break
+ * Journey/Goals matching.
  */
 
 import { describe, expect, it } from 'bun:test';
 import { extractUserId, normalizePhone, toGupshupPhone } from '../utils/identity';
 
 describe('normalizePhone', () => {
-  it('strips leading + and BR extra-9 from E.164 mobile', () => {
-    // +55 11 9 99999999 → 551199999999
-    expect(normalizePhone('+5511999999999')).toBe('551199999999');
+  it('strips a leading + but preserves all digits, including the BR extra-9', () => {
+    expect(normalizePhone('+5511999999999')).toBe('5511999999999');
   });
 
-  it('strips BR extra-9 digit for 13-digit mobile', () => {
-    // 5551997285829 (13 digits with 9) → 555197285829 (12 digits without 9)
-    expect(normalizePhone('5551997285829')).toBe('555197285829');
+  it('preserves the BR extra-9 on a 13-digit mobile', () => {
+    expect(normalizePhone('5511959946920')).toBe('5511959946920');
   });
 
-  it('strips + and then BR extra-9', () => {
-    expect(normalizePhone('+5551997285829')).toBe('555197285829');
-  });
-
-  it('does not strip 9 from non-BR numbers', () => {
-    expect(normalizePhone('+12125551234')).toBe('12125551234');
-  });
-
-  it('does not strip 9 from BR landline (12 digits, no extra-9)', () => {
-    // 55 + 11 + 33334444 = 12 digits — regex requires 13, so no match
+  it('leaves a 12-digit number (no extra-9) unchanged', () => {
     expect(normalizePhone('551133334444')).toBe('551133334444');
   });
 
-  it('strips extra-9 from SP mobile (5511 prefix)', () => {
-    // 5511999999999 = 55 + 11 + 9 + 99999999 → matches BR mobile pattern
-    expect(normalizePhone('5511999999999')).toBe('551199999999');
+  it('strips a JID @suffix', () => {
+    expect(normalizePhone('5511959946920@s.whatsapp.net')).toBe('5511959946920');
+  });
+
+  it('strips a :device suffix', () => {
+    expect(normalizePhone('5511959946920:12')).toBe('5511959946920');
+  });
+
+  it('does not touch non-BR numbers', () => {
+    expect(normalizePhone('+12125551234')).toBe('12125551234');
   });
 });
 
 describe('extractUserId', () => {
-  it('normalizes source phone (strips + and BR extra-9)', () => {
-    expect(extractUserId('5551997285829')).toBe('555197285829');
+  it('preserves the real number (incl. BR extra-9)', () => {
+    expect(extractUserId('+5511959946920')).toBe('5511959946920');
   });
 
-  it('strips + prefix and BR extra-9', () => {
-    expect(extractUserId('+5511999999999')).toBe('551199999999');
-  });
-
-  it('handles already-clean phone', () => {
-    expect(extractUserId('5511888880000')).toBe('5511888880000');
+  it('strips a JID @suffix', () => {
+    expect(extractUserId('5585999726413@s.whatsapp.net')).toBe('5585999726413');
   });
 });
 
 describe('toGupshupPhone', () => {
-  it('strips leading + and BR extra-9', () => {
-    expect(toGupshupPhone('+5511999999999')).toBe('551199999999');
+  it('round-trips the contact number with the BR extra-9 (regression: customer_id must keep the 9)', () => {
+    // The exact case behind the Journey mismatch: must NOT become 551159946920.
+    expect(toGupshupPhone('5511959946920')).toBe('5511959946920');
   });
 
-  it('strips BR extra-9', () => {
-    expect(toGupshupPhone('5551997285829')).toBe('555197285829');
+  it('strips a leading + but keeps the 9', () => {
+    expect(toGupshupPhone('+5511911349383')).toBe('5511911349383');
   });
 
-  it('leaves already-clean 12-digit number unchanged', () => {
-    // 12-digit BR number (no extra-9 to strip)
+  it('leaves an already-clean 12-digit number unchanged', () => {
     expect(toGupshupPhone('555197285829')).toBe('555197285829');
   });
 });

--- a/packages/channel-gupshup/src/utils/identity.ts
+++ b/packages/channel-gupshup/src/utils/identity.ts
@@ -16,6 +16,10 @@
 
 /** Strip transport formatting (leading +, JID @suffix, :device suffix). Digits kept verbatim. */
 function stripFormatting(phone: string): string {
+  // Defensive: these values originate from external webhooks/storage, so a
+  // non-string is a contract violation rather than a usable recipient.
+  // Mirrors agent-dispatcher's normalizePhoneIdentity guard.
+  if (typeof phone !== 'string') return '';
   return phone.trim().replace(/^\+/, '').replace(/@.*$/, '').replace(/:\d+$/, '');
 }
 

--- a/packages/channel-gupshup/src/utils/identity.ts
+++ b/packages/channel-gupshup/src/utils/identity.ts
@@ -1,33 +1,35 @@
 /**
  * Gupshup identity utilities
  *
- * Phone normalization and user ID extraction for Gupshup Custom Integration.
- * Strips BR extra-9 for outbound to match what Gupshup expects.
+ * Identity is round-tripped, never reshaped: the number Omni receives on
+ * inbound (and stores as the chat id) is exactly what goes back out on the
+ * Custom Integration callback (customer_id / user.phone), so Journey/Goals
+ * can match the contact.
+ *
+ * We only strip transport formatting (leading +, a JID @suffix, a :device
+ * suffix). We deliberately do NOT touch the Brazilian extra-9: it is present
+ * on some numbers and absent on others, so any add/strip heuristic corrupts
+ * identity. This mirrors the platform-wide convention — AccessService
+ * .normalizePhone and agent-dispatcher's normalizePhoneIdentity also preserve
+ * the digits and only drop formatting.
  */
 
-/**
- * Normalize a phone number for use in Gupshup API requests.
- * - Remove leading + if present
- * - Strip extra 9 from Brazilian mobile: 5551997285829 → 555197285829
- */
+/** Strip transport formatting (leading +, JID @suffix, :device suffix). Digits kept verbatim. */
+function stripFormatting(phone: string): string {
+  return phone.trim().replace(/^\+/, '').replace(/@.*$/, '').replace(/:\d+$/, '');
+}
+
+/** Normalize a phone number for identity use (formatting stripped, digits — incl. BR 9 — preserved). */
 export function normalizePhone(phone: string): string {
-  // Remove leading + if present
-  const clean = phone.startsWith('+') ? phone.slice(1) : phone;
-  // Strip extra 9 from Brazilian mobile: 5551997285829 → 555197285829
-  return clean.replace(/^(55\d{2})9(\d{8})$/, '$1$2');
+  return stripFormatting(phone);
 }
 
-/**
- * Convert a phone number to Gupshup format (no leading +, BR extra-9 stripped).
- */
+/** Convert a phone number to Gupshup outbound format. Identity is preserved verbatim. */
 export function toGupshupPhone(phone: string): string {
-  return normalizePhone(phone);
+  return stripFormatting(phone);
 }
 
-/**
- * Extract the user ID from a webhook source field.
- * Returns normalized phone (no leading +, BR extra-9 stripped).
- */
+/** Extract the user ID from a webhook source field (formatting stripped, digits preserved). */
 export function extractUserId(phone: string): string {
-  return normalizePhone(phone);
+  return stripFormatting(phone);
 }


### PR DESCRIPTION
## Summary

Outbound messages to the Gupshup Custom Integration callback were mutating the recipient's phone identity by stripping the Brazilian mobile "extra-9" digit. `customer_id` / `user.phone` in the callback payload therefore no longer matched the identity the contact was created with, so downstream identity-keyed systems (e.g. Journey/Goals) could not resolve the contact.

## Background

Brazilian mobile numbers in E.164 are `55` + 2-digit area code + a leading `9` + 8 digits (13 digits total). The "extra-9" is present on some numbers and absent on others, and providers are not always consistent about it. Treating it as a deterministic, strippable digit is unsafe.

## Root cause

`toGupshupPhone()` applied a normalization regex on the outbound path:

```ts
return clean.replace(/^(55\d{2})9(\d{8})$/, '$1$2'); // 5511 9 XXXXXXXX -> 5511 XXXXXXXX
```

Inbound webhooks store the sender verbatim (with the 9), so the chat identity keeps it. The outbound path then stripped it, producing a different number than the one the contact is keyed on:

```
5511999999999  ->  551199999999   (identity changed)
```

The callback client uses that value directly (`customer_id: phone`, `user: { phone }`), so the mismatch propagates to any consumer that correlates by phone.

## Fix

Identity should be **round-tripped, not reshaped**. The number received on inbound is exactly what should go back out; an add/strip heuristic on a digit that varies per number corrupts identity.

This aligns `channel-gupshup` with the identity convention already used elsewhere in the codebase, which strips only transport formatting and preserves the digits:

- `AccessService.normalizePhone` — strips a leading `+` only.
- `agent-dispatcher`'s `normalizePhoneIdentity` — strips JID `@suffix` / `:device` suffix / non-digits, keeps the digits.

`identity.ts` now exposes a single `stripFormatting()` (leading `+`, JID `@suffix`, `:device` suffix) and never touches the extra-9. `normalizePhone`, `toGupshupPhone`, and `extractUserId` are now consistent.

## Compatibility

Behavior change: outbound `customer_id` / `user.phone` now preserve the extra-9 (i.e. they echo the inbound identity). No public API surface changes — same exported function signatures.

## Testing

- `identity.test.ts` rewritten to assert the extra-9 is round-tripped and only formatting is stripped; includes a regression case for a 13-digit mobile.
- `bun test packages/channel-gupshup/` → 105 pass / 0 fail.
- `tsc --noEmit`, `biome check .`, and `knip` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)