### PR TITLE
chore: rolling promotion dev → main (publishes @latest; includes CI secrets-scan fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "author": {
         "name": "Automagik"
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
     # action for push-time coverage only; running both on PRs can exhaust the
     # action API quota and produce false red CI despite the app passing.
     if: ${{ github.event_name == 'push' }}
+    # NON-BLOCKING: a GitGuardian failure/cancellation (e.g. a missing/invalid
+    # GITGUARDIAN_API_KEY or quota exhaustion) must NOT poison the overall CI
+    # run conclusion. The `version.yml` auto-release gates on the main-push CI
+    # run concluding `success`; before this guard, a cancelled secrets-scan job
+    # flipped the whole run to `cancelled`, so `version.yml` skipped and the
+    # dev→main promotion never published `@latest` (stuck since ~2026-05-31).
+    # The PR-time GitGuardian App check remains the enforcing gate.
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +34,7 @@ jobs:
           fetch-depth: 0
 
       - uses: GitGuardian/ggshield-action@v1
+        continue-on-error: true
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260619.1",
+      "version": "2.260619.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260619.1",
+  "version": "2.260619.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
Rolling `dev → main` promotion. **Merging this re-enables and performs the `@latest` npm publish.**

Includes **#728** — `ci: make GitGuardian secrets-scan non-blocking`. Once that ci.yml change is on `main`, the main-push CI concludes `success` (instead of `cancelled`), so `version.yml`'s auto-release fires and publishes the promoted build to npm **`@latest`** (currently stuck on the April `2.260410.1`).

Also carries everything from the prior promotion batch (#719 security, #721 data-correctness, #722 embedded→canonical migration arc, gupshup #707/#718/#726, test de-flakes) — see prior promotion notes.

> Human approval required for merge to production. Merging publishes `@latest`.