### PR TITLE
fix(api): add agent dispatch backpressure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ API_MANAGED=true
 # A2A_SEND_WAIT_MS=30000
 
 # -----------------------------------------------------------------------------
+# Agent dispatch backpressure
+# -----------------------------------------------------------------------------
+# Bounds concurrent Omni -> agent/provider dispatches per instance. This keeps
+# traffic spikes or maintenance reloads from stampeding a downstream agent API.
+# OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT=8
+# OMNI_AGENT_DISPATCH_QUEUE_MAX_DEPTH=100
+# OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS=60000
+# OMNI_AGENT_DISPATCH_PER_CHAT_CONCURRENCY=1
+
+# -----------------------------------------------------------------------------
 # Sentry (Error Tracking & Performance Monitoring)
 # DSN is hardcoded to the Omni project — override to redirect, set empty to disable
 # -----------------------------------------------------------------------------

--- a/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, mock } from 'bun:test';
+import {
+  AgentDispatchLimiter,
+  AgentDispatchQueueFullError,
+  AgentDispatchQueueTimeoutError,
+  loadAgentDispatchLimiterConfig,
+} from '../agent-dispatch-limiter';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function logger() {
+  return {
+    debug: mock((_message: string, _fields?: Record<string, unknown>) => {}),
+    info: mock((_message: string, _fields?: Record<string, unknown>) => {}),
+    warn: mock((_message: string, _fields?: Record<string, unknown>) => {}),
+  };
+}
+
+async function flushStartedRuns() {
+  await Promise.resolve();
+}
+
+const CTX = { instanceId: 'inst-1', chatId: 'chat-1', traceId: 'trace-1' };
+
+describe('loadAgentDispatchLimiterConfig', () => {
+  it('uses safe defaults when env is empty', () => {
+    expect(loadAgentDispatchLimiterConfig({})).toEqual({
+      defaultConcurrency: 8,
+      maxQueueDepth: 100,
+      maxQueueWaitMs: 60_000,
+      perChatConcurrency: 1,
+    });
+  });
+
+  it('parses positive integer env overrides', () => {
+    expect(
+      loadAgentDispatchLimiterConfig({
+        OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT: '12',
+        OMNI_AGENT_DISPATCH_QUEUE_MAX_DEPTH: '50',
+        OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS: '30000',
+        OMNI_AGENT_DISPATCH_PER_CHAT_CONCURRENCY: '2',
+      }),
+    ).toEqual({
+      defaultConcurrency: 12,
+      maxQueueDepth: 50,
+      maxQueueWaitMs: 30_000,
+      perChatConcurrency: 2,
+    });
+  });
+
+  it('falls back and warns on invalid env values', () => {
+    const log = logger();
+    const cfg = loadAgentDispatchLimiterConfig({ OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT: '0' }, log);
+    expect(cfg.defaultConcurrency).toBe(8);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AgentDispatchLimiter', () => {
+  it('runs immediately under capacity', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const run = mock(async () => 'ok');
+
+    await expect(limiter.run(CTX, run)).resolves.toBe('ok');
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 0, queueDepth: 0 });
+  });
+
+  it('enqueues when global capacity is full and starts after completion', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const secondRun = mock(async () => 'second');
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const secondPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, secondRun);
+
+    expect(secondRun).toHaveBeenCalledTimes(0);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 1, queueDepth: 1 });
+
+    first.resolve();
+    await firstPromise;
+    await expect(secondPromise).resolves.toBe('second');
+    expect(secondRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes dispatches for the same chat by default', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 2, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const secondRun = mock(async () => 'second');
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const secondPromise = limiter.run(CTX, secondRun);
+
+    expect(secondRun).toHaveBeenCalledTimes(0);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 1, queueDepth: 1 });
+
+    first.resolve();
+    await firstPromise;
+    await expect(secondPromise).resolves.toBe('second');
+    expect(secondRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows different chats to run concurrently up to global capacity', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 2, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const second = deferred();
+    const firstRun = mock(async () => first.promise);
+    const secondRun = mock(async () => second.promise);
+
+    const firstPromise = limiter.run(CTX, firstRun);
+    const secondPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, secondRun);
+    await flushStartedRuns();
+
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondRun).toHaveBeenCalledTimes(1);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 2, queueDepth: 0 });
+
+    first.resolve();
+    second.resolve();
+    await firstPromise;
+    await secondPromise;
+  });
+
+  it('throws AgentDispatchQueueFullError when pending depth exceeds max', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 1, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const queuedPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, async () => 'queued');
+
+    await expect(limiter.run({ ...CTX, chatId: 'chat-3' }, async () => 'full')).rejects.toBeInstanceOf(
+      AgentDispatchQueueFullError,
+    );
+
+    first.resolve();
+    await firstPromise;
+    await queuedPromise;
+  });
+
+  it('throws AgentDispatchQueueTimeoutError when queued longer than max wait', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 5, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const timedOut = limiter.run({ ...CTX, chatId: 'chat-2' }, async () => 'too-late');
+
+    await expect(timedOut).rejects.toBeInstanceOf(AgentDispatchQueueTimeoutError);
+    first.resolve();
+    await firstPromise;
+  });
+
+  it('releases counters when callback throws', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+
+    await expect(
+      limiter.run(CTX, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 0, queueDepth: 0 });
+  });
+
+  it('does not deadlock behind a busy chat at the front of the queue', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 2, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const blocker = deferred();
+    const sameChatRun = mock(async () => 'same-chat');
+    const otherChatRun = mock(async () => blocker.promise);
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const sameChatPromise = limiter.run(CTX, sameChatRun);
+    const otherChatPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, otherChatRun);
+    await flushStartedRuns();
+
+    expect(sameChatRun).toHaveBeenCalledTimes(0);
+    expect(otherChatRun).toHaveBeenCalledTimes(1);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 2, queueDepth: 1 });
+
+    blocker.resolve();
+    await otherChatPromise;
+    expect(sameChatRun).toHaveBeenCalledTimes(0);
+
+    first.resolve();
+    await firstPromise;
+    await expect(sameChatPromise).resolves.toBe('same-chat');
+  });
+});

--- a/packages/api/src/plugins/agent-dispatch-limiter.ts
+++ b/packages/api/src/plugins/agent-dispatch-limiter.ts
@@ -1,0 +1,268 @@
+const DEFAULT_AGENT_DISPATCH_CONCURRENCY = 8;
+const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_DEPTH = 100;
+const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS = 60_000;
+const DEFAULT_AGENT_DISPATCH_PER_CHAT_CONCURRENCY = 1;
+
+interface LoggerLike {
+  debug: (message: string, fields?: Record<string, unknown>) => void;
+  info: (message: string, fields?: Record<string, unknown>) => void;
+  warn: (message: string, fields?: Record<string, unknown>) => void;
+}
+
+export interface AgentDispatchLimiterConfig {
+  defaultConcurrency: number;
+  maxQueueDepth: number;
+  maxQueueWaitMs: number;
+  perChatConcurrency: number;
+}
+
+export interface AgentDispatchContext {
+  instanceId: string;
+  chatId: string;
+  traceId?: string;
+}
+
+export interface AgentDispatchQueueSnapshot {
+  [key: string]: unknown;
+  instanceId: string;
+  chatId: string;
+  traceId?: string;
+  activeCount: number;
+  queueDepth: number;
+  maxConcurrency: number;
+  maxQueueDepth: number;
+  waitMs?: number;
+}
+
+interface InstanceQueue {
+  instanceId: string;
+  activeCount: number;
+  pending: QueueItem<unknown>[];
+}
+
+interface QueueItem<T> {
+  context: AgentDispatchContext;
+  enqueuedAt: number;
+  run: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+  timeout: ReturnType<typeof setTimeout> | null;
+}
+
+export class AgentDispatchQueueFullError extends Error {
+  constructor(public readonly snapshot: AgentDispatchQueueSnapshot) {
+    super(
+      `Agent dispatch queue full for instance ${snapshot.instanceId}: ${snapshot.queueDepth}/${snapshot.maxQueueDepth} pending`,
+    );
+    this.name = 'AgentDispatchQueueFullError';
+  }
+}
+
+export class AgentDispatchQueueTimeoutError extends Error {
+  constructor(public readonly snapshot: AgentDispatchQueueSnapshot) {
+    super(
+      `Agent dispatch queue timed out for instance ${snapshot.instanceId} chat ${snapshot.chatId} after ${snapshot.waitMs ?? 0}ms`,
+    );
+    this.name = 'AgentDispatchQueueTimeoutError';
+  }
+}
+
+function parsePositiveInt(
+  env: Record<string, string | undefined>,
+  key: string,
+  fallback: number,
+  logger?: Pick<LoggerLike, 'warn'>,
+): number {
+  const raw = env[key];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger?.warn('Invalid agent dispatch limiter env value, using default', { key, value: raw, fallback });
+    return fallback;
+  }
+  return parsed;
+}
+
+export function loadAgentDispatchLimiterConfig(
+  env: Record<string, string | undefined> = process.env,
+  logger?: Pick<LoggerLike, 'warn'>,
+): AgentDispatchLimiterConfig {
+  return {
+    defaultConcurrency: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT',
+      DEFAULT_AGENT_DISPATCH_CONCURRENCY,
+      logger,
+    ),
+    maxQueueDepth: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_QUEUE_MAX_DEPTH',
+      DEFAULT_AGENT_DISPATCH_QUEUE_MAX_DEPTH,
+      logger,
+    ),
+    maxQueueWaitMs: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS',
+      DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS,
+      logger,
+    ),
+    perChatConcurrency: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_PER_CHAT_CONCURRENCY',
+      DEFAULT_AGENT_DISPATCH_PER_CHAT_CONCURRENCY,
+      logger,
+    ),
+  };
+}
+
+export class AgentDispatchLimiter {
+  private readonly queues = new Map<string, InstanceQueue>();
+  private readonly chatActiveCounts = new Map<string, number>();
+
+  constructor(
+    private readonly config: AgentDispatchLimiterConfig,
+    private readonly logger?: LoggerLike,
+  ) {}
+
+  run<T>(context: AgentDispatchContext, run: () => Promise<T>): Promise<T> {
+    const queue = this.getQueue(context.instanceId);
+    if (this.canStart(queue, context)) {
+      return new Promise<T>((resolve, reject) => {
+        this.startItem(queue, {
+          context,
+          enqueuedAt: Date.now(),
+          run,
+          resolve,
+          reject,
+          timeout: null,
+        });
+      });
+    }
+
+    if (queue.pending.length >= this.config.maxQueueDepth) {
+      const snapshot = this.snapshot(queue, context);
+      this.logger?.warn('agent_dispatch_queue_full', snapshot);
+      return Promise.reject(new AgentDispatchQueueFullError(snapshot));
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const item: QueueItem<T> = {
+        context,
+        enqueuedAt: Date.now(),
+        run,
+        resolve,
+        reject,
+        timeout: null,
+      };
+      item.timeout = setTimeout(() => {
+        const idx = queue.pending.indexOf(item as QueueItem<unknown>);
+        if (idx < 0) return;
+        queue.pending.splice(idx, 1);
+        const snapshot = this.snapshot(queue, context, Date.now() - item.enqueuedAt);
+        this.logger?.warn('agent_dispatch_queue_timeout', snapshot);
+        reject(new AgentDispatchQueueTimeoutError(snapshot));
+        this.drain(queue);
+      }, this.config.maxQueueWaitMs);
+      if (typeof item.timeout === 'object' && item.timeout && 'unref' in item.timeout) {
+        item.timeout.unref();
+      }
+
+      queue.pending.push(item as QueueItem<unknown>);
+      this.logger?.info('agent_dispatch_queue_enqueued', this.snapshot(queue, context));
+      this.drain(queue);
+    });
+  }
+
+  getSnapshot(instanceId: string): {
+    activeCount: number;
+    queueDepth: number;
+    maxConcurrency: number;
+    maxQueueDepth: number;
+  } {
+    const queue = this.getQueue(instanceId);
+    return {
+      activeCount: queue.activeCount,
+      queueDepth: queue.pending.length,
+      maxConcurrency: this.config.defaultConcurrency,
+      maxQueueDepth: this.config.maxQueueDepth,
+    };
+  }
+
+  private getQueue(instanceId: string): InstanceQueue {
+    let queue = this.queues.get(instanceId);
+    if (!queue) {
+      queue = { instanceId, activeCount: 0, pending: [] };
+      this.queues.set(instanceId, queue);
+    }
+    return queue;
+  }
+
+  private canStart(queue: InstanceQueue, context: AgentDispatchContext): boolean {
+    return (
+      queue.activeCount < this.config.defaultConcurrency &&
+      (this.chatActiveCounts.get(this.chatKey(context)) ?? 0) < this.config.perChatConcurrency
+    );
+  }
+
+  private startItem<T>(queue: InstanceQueue, item: QueueItem<T>): void {
+    if (item.timeout) {
+      clearTimeout(item.timeout);
+      item.timeout = null;
+    }
+    const chatKey = this.chatKey(item.context);
+    queue.activeCount += 1;
+    this.chatActiveCounts.set(chatKey, (this.chatActiveCounts.get(chatKey) ?? 0) + 1);
+    const queueWaitMs = Date.now() - item.enqueuedAt;
+    this.logger?.info('agent_dispatch_queue_started', this.snapshot(queue, item.context, queueWaitMs));
+
+    Promise.resolve()
+      .then(item.run)
+      .then(item.resolve, item.reject)
+      .finally(() => {
+        queue.activeCount = Math.max(0, queue.activeCount - 1);
+        const chatActive = (this.chatActiveCounts.get(chatKey) ?? 1) - 1;
+        if (chatActive > 0) {
+          this.chatActiveCounts.set(chatKey, chatActive);
+        } else {
+          this.chatActiveCounts.delete(chatKey);
+        }
+        this.logger?.info(
+          'agent_dispatch_queue_finished',
+          this.snapshot(queue, item.context, Date.now() - item.enqueuedAt),
+        );
+        this.drain(queue);
+      });
+  }
+
+  private drain(queue: InstanceQueue): void {
+    let started = true;
+    while (started && queue.activeCount < this.config.defaultConcurrency) {
+      started = false;
+      for (let i = 0; i < queue.pending.length; i += 1) {
+        const item = queue.pending[i];
+        if (!item || !this.canStart(queue, item.context)) continue;
+        queue.pending.splice(i, 1);
+        this.startItem(queue, item);
+        started = true;
+        break;
+      }
+    }
+  }
+
+  private snapshot(queue: InstanceQueue, context: AgentDispatchContext, waitMs?: number): AgentDispatchQueueSnapshot {
+    return {
+      instanceId: context.instanceId,
+      chatId: context.chatId,
+      traceId: context.traceId,
+      activeCount: queue.activeCount,
+      queueDepth: queue.pending.length,
+      maxConcurrency: this.config.defaultConcurrency,
+      maxQueueDepth: this.config.maxQueueDepth,
+      waitMs,
+    };
+  }
+
+  private chatKey(context: AgentDispatchContext): string {
+    return `${context.instanceId}:${context.chatId}`;
+  }
+}

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -86,6 +86,7 @@ import { resolveKhalSessionId } from '../services/agent-session-identity';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
+import { AgentDispatchLimiter, loadAgentDispatchLimiterConfig } from './agent-dispatch-limiter';
 import { getPlugin } from './loader';
 import {
   type BufferedMessage,
@@ -97,6 +98,7 @@ import { extractPlatformTimestamp } from './message-persistence';
 import { createSessionStorage } from './session-storage';
 
 const log = createLogger('agent-dispatcher');
+const agentDispatchLimiter = new AgentDispatchLimiter(loadAgentDispatchLimiterConfig(process.env, log), log);
 
 /**
  * Test-only DI hook for NatsGenieProvider constructor. In production this is
@@ -3369,48 +3371,54 @@ async function processAgentResponse(
     senderAgentId,
   });
 
-  await sendTypingPresence(channel, instance.id, chatId, 'composing');
-
   // ── Auto-ack text message (pre-dispatch, fire-and-forget) ──
   const inst = instance as unknown as Record<string, unknown>;
   const agentAckMessage = (inst.agentAckMessage as string) ?? null;
-  if (agentAckMessage) {
-    sendTextMessage(channel, instance.id, chatId, agentAckMessage).catch((err) => {
-      log.warn('Failed to send agent ack message', { instanceId: instance.id, chatId, error: String(err) });
-    });
-  }
-
-  // ── Per-thread lazy init ──
-  const perThreadExtraContext = await resolvePerThreadExtraContext(
-    db,
-    services,
-    instance,
-    channel,
-    chatId,
-    senderId,
-    firstMessage,
-  );
 
   try {
-    await runWithTransientDispatchRetry(
-      () =>
-        dispatchToAgent(
+    await agentDispatchLimiter.run({ instanceId: instance.id, chatId, traceId }, async () => {
+      await sendTypingPresence(channel, instance.id, chatId, 'composing');
+      try {
+        if (agentAckMessage) {
+          sendTextMessage(channel, instance.id, chatId, agentAckMessage).catch((err) => {
+            log.warn('Failed to send agent ack message', { instanceId: instance.id, chatId, error: String(err) });
+          });
+        }
+
+        // ── Per-thread lazy init ──
+        const perThreadExtraContext = await resolvePerThreadExtraContext(
+          db,
           services,
           instance,
-          messages,
-          triggerType,
           channel,
           chatId,
           senderId,
-          personId,
-          senderName,
-          traceId,
-          senderAgentId,
-          perThreadExtraContext,
-          db,
-        ),
-      { instanceId: instance.id, chatId, traceId },
-    );
+          firstMessage,
+        );
+
+        await runWithTransientDispatchRetry(
+          () =>
+            dispatchToAgent(
+              services,
+              instance,
+              messages,
+              triggerType,
+              channel,
+              chatId,
+              senderId,
+              personId,
+              senderName,
+              traceId,
+              senderAgentId,
+              perThreadExtraContext,
+              db,
+            ),
+          { instanceId: instance.id, chatId, traceId },
+        );
+      } finally {
+        await sendTypingPresence(channel, instance.id, chatId, 'paused');
+      }
+    });
   } catch (error) {
     log.error('agent_dispatch_failed_after_retries', {
       instanceId: instance.id,
@@ -3421,7 +3429,6 @@ async function processAgentResponse(
     sendErrorFeedback(channel, instance.id, chatId, error).catch(() => {});
   } finally {
     ackHandle.remove();
-    await sendTypingPresence(channel, instance.id, chatId, 'paused');
   }
 }
 


### PR DESCRIPTION
## Summary
- add an env-configurable in-process limiter for Omni agent dispatches
- bound concurrent dispatches per instance and serialize dispatches per chat by default
- queue excess dispatches with timeout/full errors and structured logs before calling providers
- document the new backpressure env vars

## Test Plan
- `bun test packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts packages/api/src/plugins/__tests__/agent-dispatcher-retry.test.ts` → 39 passed
- `bunx biome check .env.example packages/api/src/plugins/agent-dispatcher.ts packages/api/src/plugins/agent-dispatch-limiter.ts packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts` → pass
- `cd packages/api && bun run typecheck` → blocked by existing TTS ChildProcessWithEvents errors outside this change (`src/providers/*/tts.ts`, `src/services/tts.ts`)
- pre-push `turbo typecheck` also blocked by existing `@omni/channel-whatsapp` ChildProcessWithEvents error outside this change

## Notes
- Production deploy is separate from this PR.
- Defaults are conservative for CT208/Eugenia: concurrency 8, queue depth 100, max wait 60s, per-chat concurrency 1.
