### PR TITLE
fix(core): block provider errors from customer replies

### DIFF
--- a/packages/core/src/providers/__tests__/agno-provider.test.ts
+++ b/packages/core/src/providers/__tests__/agno-provider.test.ts
@@ -10,6 +10,8 @@ import type { AgentTrigger, IAgentClient, ProviderRequest, ProviderResponse, Str
 // provider test when the entire monorepo suite runs in one process.
 // @ts-expect-error Bun test supports query-suffixed imports; TypeScript does not resolve them.
 const { AgnoAgentProvider } = await import('../agno-provider.ts?real-agno-provider-test');
+// @ts-expect-error Bun test supports query-suffixed imports; TypeScript does not resolve them.
+const { SAFE_PROVIDER_ERROR_MESSAGE } = await import('../customer-safe-errors.ts?real-agno-provider-test');
 
 function createTrigger(overrides: Partial<AgentTrigger> = {}): AgentTrigger {
   return {
@@ -60,6 +62,30 @@ function createClient(chunks: StreamChunk[] = []): IAgentClient & { lastRequest?
       client.lastRequest = request;
       for (const chunk of chunks) {
         yield chunk;
+      }
+    }),
+    discover: mock(async () => []),
+    checkHealth: mock(async () => ({ healthy: true, latencyMs: 1 })),
+  };
+
+  return client;
+}
+
+function createClientReturning(content: string): IAgentClient & { lastRequest?: ProviderRequest } {
+  const client: IAgentClient & { lastRequest?: ProviderRequest } = {
+    run: mock(async (request: ProviderRequest): Promise<ProviderResponse> => {
+      client.lastRequest = request;
+      return {
+        content,
+        runId: 'run-1',
+        sessionId: 'session-1',
+        status: 'completed',
+      };
+    }),
+    stream: mock(async function* (request: ProviderRequest): AsyncGenerator<StreamChunk> {
+      client.lastRequest = request;
+      if (request.agentId === '__never__') {
+        yield { event: 'noop', isComplete: true };
       }
     }),
     discover: mock(async () => []),
@@ -179,6 +205,37 @@ describe('AgnoAgentProvider', () => {
     });
   });
 
+  it('replaces raw LiteLLM balance errors before building outbound message parts', async () => {
+    const raw =
+      'litellm.BadRequestError: AnthropicException - Your credit balance is too low to access the Anthropic API. Available Model Group Fallbacks=None';
+    const client = createClientReturning(raw);
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const result = await provider.trigger(createTrigger());
+
+    expect(result.parts).toEqual([SAFE_PROVIDER_ERROR_MESSAGE]);
+    expect(result.parts.join(' ')).not.toContain('Anthropic');
+    expect(result.parts.join(' ')).not.toContain('credit balance');
+  });
+
+  it('replaces raw API key errors before building outbound message parts', async () => {
+    const raw = 'Authentication Error, Invalid proxy server token passed. Received API Key = ***';
+    const client = createClientReturning(raw);
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const result = await provider.trigger(createTrigger());
+
+    expect(result.parts).toEqual([SAFE_PROVIDER_ERROR_MESSAGE]);
+    expect(result.parts.join(' ')).not.toContain('API Key');
+    expect(result.parts.join(' ')).not.toContain('sk-');
+  });
+
   it('derives a W3C trace context from Omni traceId when dispatcher did not provide one', async () => {
     const client = createClient();
     const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
@@ -198,7 +255,7 @@ describe('AgnoAgentProvider', () => {
     expect(client.lastRequest?.traceContext?.traceFlags).toBe(1);
   });
 
-  it('converts Agno stream exceptions into error deltas instead of throwing', async () => {
+  it('converts Agno stream exceptions into safe error deltas instead of throwing raw errors', async () => {
     const client = createThrowingStreamClient();
     const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
       agentId: 'agent-1',
@@ -207,8 +264,27 @@ describe('AgnoAgentProvider', () => {
 
     const deltas = await collect(provider.triggerStream(createTrigger()));
 
-    expect(deltas).toEqual([{ phase: 'error', error: 'stream exploded' }]);
+    expect(deltas).toEqual([{ phase: 'error', error: SAFE_PROVIDER_ERROR_MESSAGE }]);
     expect(client.stream).toHaveBeenCalledTimes(1);
     expect(client.run).not.toHaveBeenCalled();
+  });
+
+  it('replaces raw provider errors in stream chunks and final content', async () => {
+    const raw = 'Authentication Error, Invalid proxy server token passed. Received API Key = ***';
+    const client = createClient([
+      { event: 'delta', content: raw, isComplete: false },
+      { event: 'complete', fullContent: raw, isComplete: true },
+    ]);
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const deltas = await collect(provider.triggerStream(createTrigger()));
+
+    expect(deltas).toEqual([
+      { phase: 'content', content: SAFE_PROVIDER_ERROR_MESSAGE },
+      { phase: 'final', content: SAFE_PROVIDER_ERROR_MESSAGE },
+    ]);
   });
 });

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '../logger';
+import { SAFE_PROVIDER_ERROR_MESSAGE, toSafeCustomerFallback } from './customer-safe-errors';
 import { buildProviderRequestContext } from './execution-context';
 import { createTraceContextFromTraceId } from './trace-context';
 import type {
@@ -70,14 +71,24 @@ export class AgnoAgentProvider implements IAgentProvider {
     // Call the provider — client routes internally by agentType
     const response = await this.client.run(request);
 
+    const customerContent = toSafeCustomerFallback(response.content);
+
+    if (customerContent !== response.content) {
+      log.error('Blocked provider error from customer-facing Agno response', {
+        agentId: this.config.agentId,
+        runId: response.runId,
+        traceId: context.traceId,
+      });
+    }
+
     // Split response if enabled
     const parts =
       this.config.enableAutoSplit !== false
-        ? response.content
+        ? customerContent
             .split('\n\n')
             .map((p) => p.trim())
             .filter(Boolean)
-        : [response.content.trim()].filter(Boolean);
+        : [customerContent.trim()].filter(Boolean);
 
     const durationMs = Date.now() - startTime;
 
@@ -125,11 +136,21 @@ export class AgnoAgentProvider implements IAgentProvider {
     try {
       for await (const chunk of this.client.stream(request)) {
         if (chunk.content) {
-          yield { phase: 'content', content: chunk.content };
+          const safeContent = toSafeCustomerFallback(chunk.content);
+          if (safeContent !== chunk.content) {
+            log.error('Blocked provider error from customer-facing Agno stream chunk', {
+              agentId: this.config.agentId,
+              traceId: context.traceId,
+            });
+            yield { phase: 'content', content: safeContent };
+            continue;
+          }
+          yield { phase: 'content', content: safeContent };
         }
 
         if (chunk.isComplete) {
-          yield { phase: 'final', content: chunk.fullContent ?? chunk.content ?? '' };
+          const finalContent = chunk.fullContent ?? chunk.content ?? '';
+          yield { phase: 'final', content: toSafeCustomerFallback(finalContent) };
         }
       }
     } catch (error) {
@@ -139,7 +160,7 @@ export class AgnoAgentProvider implements IAgentProvider {
         traceId: context.traceId,
         error: message,
       });
-      yield { phase: 'error', error: message };
+      yield { phase: 'error', error: SAFE_PROVIDER_ERROR_MESSAGE };
     }
   }
 

--- a/packages/core/src/providers/customer-safe-errors.ts
+++ b/packages/core/src/providers/customer-safe-errors.ts
@@ -4,7 +4,7 @@ const SAFE_PROVIDER_ERROR_MESSAGE =
 const PROVIDER_ERROR_PATTERN =
   /(litellm\.(BadRequestError|AuthenticationError|RateLimitError|APIError)|ModelProviderError|AnthropicException|Authentication Error|Invalid proxy server token|Received API Key|Available Model Group Fallbacks|credit balance is too low|Plans\s*&\s*Billing|\bsk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]+|api[_ -]?key\s*[=:])/i;
 
-export function isUnsafeCustomerFacingProviderText(text: string | undefined | null): boolean {
+function isUnsafeCustomerFacingProviderText(text: string | undefined | null): boolean {
   return Boolean(text && PROVIDER_ERROR_PATTERN.test(text));
 }
 

--- a/packages/core/src/providers/customer-safe-errors.ts
+++ b/packages/core/src/providers/customer-safe-errors.ts
@@ -1,0 +1,18 @@
+const SAFE_PROVIDER_ERROR_MESSAGE =
+  'Tô com um probleminha técnico aqui agora. Já estou avisando o time. Pode tentar de novo em alguns minutos? 🙏';
+
+const PROVIDER_ERROR_PATTERN =
+  /(litellm\.(BadRequestError|AuthenticationError|RateLimitError|APIError)|ModelProviderError|AnthropicException|Authentication Error|Invalid proxy server token|Received API Key|Available Model Group Fallbacks|credit balance is too low|Plans\s*&\s*Billing|\bsk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]+|api[_ -]?key\s*[=:])/i;
+
+export function isUnsafeCustomerFacingProviderText(text: string | undefined | null): boolean {
+  return Boolean(text && PROVIDER_ERROR_PATTERN.test(text));
+}
+
+export function toSafeCustomerFallback(text: string | undefined | null): string {
+  if (isUnsafeCustomerFacingProviderText(text)) {
+    return SAFE_PROVIDER_ERROR_MESSAGE;
+  }
+  return text ?? '';
+}
+
+export { SAFE_PROVIDER_ERROR_MESSAGE };


### PR DESCRIPTION
## Summary
- add a core provider safety gate for customer-facing provider/API-key/billing errors
- sanitize Agno round-trip parts, stream chunks, final stream content, and stream exceptions
- add regression coverage for raw LiteLLM balance and API-key errors

## Test Plan
- `bun test packages/core/src/providers/__tests__/agno-provider.test.ts`
- `bunx biome check packages/core/src/providers/agno-provider.ts packages/core/src/providers/customer-safe-errors.ts packages/core/src/providers/__tests__/agno-provider.test.ts`
- `bun run typecheck`
- pre-push full test suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider error messages are now automatically sanitized to exclude sensitive information including API keys, authentication credentials, account balance details, and provider-specific error identifiers. This protection applies consistently across both standard and streaming response flows, ensuring sensitive data is not inadvertently exposed through error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->