### PR TITLE
feat(agent-dispatcher): configurable failure message + 600s timeout defaults (#737, #738)

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for resolveDispatchErrorMessage — issue #737.
+ *
+ * Precedence: per-instance `agentErrorMessage` → `OMNI_AGENT_DISPATCH_ERROR_MESSAGE`
+ * env → built-in default. Blank/whitespace values fall through to the next tier.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+// Mock the plugin loader to avoid real FS/channel-sdk imports — same pattern
+// as agent-dispatcher-retry.test.ts. Without this the module init crashes
+// loading the parent agent-dispatcher.ts.
+mock.module('../loader', () => ({
+  getPlugin: mock(() => Promise.resolve(undefined)),
+}));
+
+import { DEFAULT_DISPATCH_ERROR_MESSAGE, resolveDispatchErrorMessage } from '../agent-dispatcher';
+
+describe('resolveDispatchErrorMessage', () => {
+  it('falls back to the built-in default when nothing is configured', () => {
+    expect(resolveDispatchErrorMessage(null, {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+    expect(resolveDispatchErrorMessage(undefined, {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+  });
+
+  it('uses the env override when no per-instance value is set', () => {
+    const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'Estamos com um problema, tente novamente.' };
+    expect(resolveDispatchErrorMessage(null, env)).toBe('Estamos com um problema, tente novamente.');
+  });
+
+  it('prefers the per-instance value over env and default', () => {
+    const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env message' };
+    expect(resolveDispatchErrorMessage('instance message', env)).toBe('instance message');
+  });
+
+  it('ignores blank/whitespace-only values and falls through', () => {
+    const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: '  ' };
+    // Blank instance + blank env → default.
+    expect(resolveDispatchErrorMessage('   ', env)).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+    // Blank instance + valid env → env.
+    expect(resolveDispatchErrorMessage('  ', { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env msg' })).toBe('env msg');
+  });
+
+  it('trims surrounding whitespace from the resolved value', () => {
+    expect(resolveDispatchErrorMessage('  hi there  ', {})).toBe('hi there');
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
@@ -35,7 +35,7 @@ describe('loadAgentDispatchLimiterConfig', () => {
     expect(loadAgentDispatchLimiterConfig({})).toEqual({
       defaultConcurrency: 8,
       maxQueueDepth: 100,
-      maxQueueWaitMs: 60_000,
+      maxQueueWaitMs: 600_000,
       perChatConcurrency: 1,
     });
   });

--- a/packages/api/src/plugins/__tests__/message-persistence.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence.test.ts
@@ -37,10 +37,7 @@ describe('extractPlatformTimestamp', () => {
   test('handles Long object (protobuf uint64) with non-zero low, zero high', () => {
     // Baileys emits messageTimestamp as { low, high, unsigned } after deepSanitize
     const ts = 1746665253; // 2025-05-08
-    const result = extractPlatformTimestamp(
-      { messageTimestamp: { low: ts, high: 0, unsigned: false } },
-      FALLBACK,
-    );
+    const result = extractPlatformTimestamp({ messageTimestamp: { low: ts, high: 0, unsigned: false } }, FALLBACK);
     expect(result).not.toBeNull();
     expect(result!.getTime()).toBe(ts * 1000);
   });
@@ -51,10 +48,7 @@ describe('extractPlatformTimestamp', () => {
     const hi = 1;
     const lo = 1;
     const expectedTs = hi * 0x100000000 + lo; // 4294967297 seconds
-    const result = extractPlatformTimestamp(
-      { messageTimestamp: { low: lo, high: hi, unsigned: false } },
-      FALLBACK,
-    );
+    const result = extractPlatformTimestamp({ messageTimestamp: { low: lo, high: hi, unsigned: false } }, FALLBACK);
     expect(result).not.toBeNull();
     expect(result!.getTime()).toBe(expectedTs * 1000);
   });

--- a/packages/api/src/plugins/agent-dispatch-limiter.ts
+++ b/packages/api/src/plugins/agent-dispatch-limiter.ts
@@ -1,6 +1,9 @@
 const DEFAULT_AGENT_DISPATCH_CONCURRENCY = 8;
 const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_DEPTH = 100;
-const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS = 60_000;
+// #738 — raised 60s → 600s so legitimately long agent runs (multi-tool loops,
+// slow upstream LLM/gateway) are not failed at the queue-wait gate. Override
+// via OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS.
+const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS = 600_000;
 const DEFAULT_AGENT_DISPATCH_PER_CHAT_CONCURRENCY = 1;
 
 interface LoggerLike {

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -527,19 +527,54 @@ async function sendTextMessage(
 }
 
 /**
+ * Built-in dispatch-failure message (#737). Kept in English for backwards
+ * compatibility — non-English deployments override it globally via the
+ * `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env var (a per-instance override tier is
+ * a planned follow-up; see {@link resolveDispatchErrorMessage}).
+ */
+export const DEFAULT_DISPATCH_ERROR_MESSAGE = '⚠️ Sorry, I ran into an issue processing your message. Please try again.';
+
+/**
+ * Resolve the customer-facing dispatch-failure message (#737). Precedence:
+ *   1. per-instance override (localized per deployment),
+ *   2. `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env (global override),
+ *   3. {@link DEFAULT_DISPATCH_ERROR_MESSAGE}.
+ * Blank/whitespace-only values are ignored so they fall through to the next tier.
+ *
+ * NOTE: the per-instance tier is wired through the first argument but no
+ * `instances` column exists yet — callers pass `null` today and rely on the
+ * env override. The column is a follow-up, deferred until the Drizzle snapshot
+ * drift in `packages/db` is reconciled (re-adding it now would re-propose
+ * already-migrated columns and crash auto-migrate). The tier is kept here +
+ * tested so dropping the column in is a one-line call-site change.
+ */
+export function resolveDispatchErrorMessage(
+  instanceErrorMessage: string | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const instanceMsg = instanceErrorMessage?.trim();
+  if (instanceMsg) return instanceMsg;
+  const envMsg = env.OMNI_AGENT_DISPATCH_ERROR_MESSAGE?.trim();
+  if (envMsg) return envMsg;
+  return DEFAULT_DISPATCH_ERROR_MESSAGE;
+}
+
+/**
  * Send error feedback to user when agent dispatch fails.
  * Fire-and-forget — errors during feedback delivery are silently swallowed.
+ * `message` is the already-resolved customer-facing text (see
+ * {@link resolveDispatchErrorMessage}).
  */
 async function sendErrorFeedback(
   channel: ChannelType,
   instanceId: string,
   chatId: string,
   error: unknown,
+  message: string,
 ): Promise<void> {
   const errorMsg = error instanceof Error ? error.message : String(error);
   log.error('agent_dispatch_error', { channel, instanceId, chatId, error: errorMsg });
-  const text = '⚠️ Sorry, I ran into an issue processing your message. Please try again.';
-  await sendTextMessage(channel, instanceId, chatId, text);
+  await sendTextMessage(channel, instanceId, chatId, message);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -3336,7 +3371,9 @@ async function processAgentResponse(
   // messages that arrived during the handoff window and should not be processed.
   if (chatSettings?.agentResumedAt) {
     const resumedAt = new Date(chatSettings.agentResumedAt).getTime();
-    const msgTimestamp = (extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()) ?? new Date()).getTime();
+    const msgTimestamp = (
+      extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()) ?? new Date()
+    ).getTime();
     if (msgTimestamp < resumedAt) {
       log.debug('Dropping pre-resume message (arrived during handoff window)', {
         instanceId: instance.id,
@@ -3426,7 +3463,15 @@ async function processAgentResponse(
       error: String(error),
       traceId,
     });
-    sendErrorFeedback(channel, instance.id, chatId, error).catch(() => {});
+    sendErrorFeedback(
+      channel,
+      instance.id,
+      chatId,
+      error,
+      // Per-instance override tier is null until the `agentErrorMessage` column
+      // lands (see resolveDispatchErrorMessage note) — env + default for now.
+      resolveDispatchErrorMessage(null),
+    ).catch(() => {});
   } finally {
     ackHandle.remove();
   }
@@ -3499,7 +3544,7 @@ function createOpenClawProviderInstance(provider: AgentProvider, instance: Dispa
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
   const providerConfig: OpenClawProviderConfig = {
     defaultAgentId: resolveRequiredAgentId(instance, schemaConfig, provider.id, 'defaultAgentId'),
-    agentTimeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 120) as number) * 1000,
+    agentTimeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 600) as number) * 1000,
     sendAckTimeoutMs: 10_000,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   };
@@ -3569,7 +3614,7 @@ function createClaudeCodeProviderInstance(
     },
     createSessionStorage(db, provider.id),
     {
-      timeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 120) as number) * 1000,
+      timeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 600) as number) * 1000,
       enableAutoSplit: instance.enableAutoSplit ?? true,
       prefixSenderName: instance.agentPrefixSenderName ?? true,
       streamConfig: schemaConfig.streamConfig as
@@ -3592,7 +3637,9 @@ function createWebhookProvider(provider: AgentProvider): IAgentProvider {
     webhookUrl: provider.baseUrl,
     apiKey: provider.apiKey ?? undefined,
     mode: (schemaConfig.mode as 'round-trip' | 'fire-and-forget') ?? 'round-trip',
-    timeoutMs: (provider.defaultTimeout ?? 30) * 1000,
+    // #738 — aligned to the 600s provider default (was 30s) so webhook agents
+    // get the same budget as every other provider when no explicit timeout set.
+    timeoutMs: (provider.defaultTimeout ?? 600) * 1000,
     retries: (schemaConfig.retries as number) ?? 1,
   });
 }

--- a/packages/channel-gupshup/src/__tests__/identity.test.ts
+++ b/packages/channel-gupshup/src/__tests__/identity.test.ts
@@ -61,9 +61,7 @@ describe('toGupshupPhone', () => {
   });
 
   it('returns empty string for non-string input (contract violation, no crash)', () => {
-    // biome-ignore lint/suspicious/noExplicitAny: simulating a runtime contract violation
-    expect(toGupshupPhone(undefined as any)).toBe('');
-    // biome-ignore lint/suspicious/noExplicitAny: simulating a runtime contract violation
-    expect(toGupshupPhone(null as any)).toBe('');
+    expect(toGupshupPhone(undefined as unknown as string)).toBe('');
+    expect(toGupshupPhone(null as unknown as string)).toBe('');
   });
 });

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3830,6 +3830,41 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    *
    * @internal
    */
+  /**
+   * Date-range gate for a history message. Returns false (and logs the reason)
+   * when the message falls outside the active sync window. Extracted from
+   * {@link processHistoryMessage} to keep that method within the biome
+   * cognitive-complexity budget.
+   */
+  private isHistoryMessageWithinSyncRange(
+    msg: WAMessage,
+    timestamp: Date,
+    syncState: { since?: Date; until?: Date } | undefined,
+    instanceId: string,
+  ): boolean {
+    if (syncState?.since && timestamp < syncState.since) {
+      this.logger.debug('Skipping history message - before since', {
+        instanceId,
+        messageId: msg.key?.id,
+        chatId: msg.key?.remoteJid,
+        timestamp: timestamp.toISOString(),
+        since: new Date(syncState.since).toISOString(),
+      });
+      return false;
+    }
+    if (syncState?.until && timestamp > syncState.until) {
+      this.logger.debug('Skipping history message - after until', {
+        instanceId,
+        messageId: msg.key?.id,
+        chatId: msg.key?.remoteJid,
+        timestamp: timestamp.toISOString(),
+        until: new Date(syncState.until).toISOString(),
+      });
+      return false;
+    }
+    return true;
+  }
+
   private async processHistoryMessage(
     instanceId: string,
     msg: WAMessage,
@@ -3854,24 +3889,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     }
 
     // Filter by date range if specified
-    if (syncState?.since && timestamp < syncState.since) {
-      this.logger.debug('Skipping history message - before since', {
-        instanceId,
-        messageId: msg.key.id,
-        chatId: msg.key.remoteJid,
-        timestamp: timestamp.toISOString(),
-        since: new Date(syncState.since).toISOString(),
-      });
-      return;
-    }
-    if (syncState?.until && timestamp > syncState.until) {
-      this.logger.debug('Skipping history message - after until', {
-        instanceId,
-        messageId: msg.key.id,
-        chatId: msg.key.remoteJid,
-        timestamp: timestamp.toISOString(),
-        until: new Date(syncState.until).toISOString(),
-      });
+    if (!this.isHistoryMessageWithinSyncRange(msg, timestamp, syncState, instanceId)) {
       return;
     }
 

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -21,7 +21,9 @@ import {
   type StreamChunk,
 } from './types';
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+// #738 — aligned to the 600s agent-dispatch default so a caller that omits an
+// explicit timeout gets the same generous budget as the rest of the pipeline.
+const DEFAULT_TIMEOUT_MS = 600_000;
 
 export class AgnoClient implements IAgentClient {
   private readonly baseUrl: string;


### PR DESCRIPTION
Fixes #737 and #738 in one dispatcher pass.

## #737 — configurable dispatch-failure message
The dispatch-failure fallback was a hardcoded English string in `sendErrorFeedback()` (`⚠️ Sorry, I ran into an issue…`), which reached Portuguese-deployment customers during a prod incident.

- Adds `DEFAULT_DISPATCH_ERROR_MESSAGE` + `resolveDispatchErrorMessage()` with precedence: **per-instance override → `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env → built-in default**.
- `sendErrorFeedback()` now takes the resolved text, so operators localize via env without code changes.
- Blank/whitespace values fall through tiers; values are trimmed.

**Scope note:** the per-instance column tier is wired through `resolveDispatchErrorMessage(instanceErrorMessage, env)` and unit-tested, but the call site passes `null` for now. I intentionally **deferred adding an `instances.agentErrorMessage` column** — `drizzle-kit generate` surfaced pre-existing snapshot drift in `packages/db` (it re-proposes already-migrated columns like `gupshup_callback_url`). Adding a column through that drift risks a migration that crashes the API's auto-migrate. The env override fully satisfies the issue's "and/or env var" ask; dropping the column in later is a one-line call-site change once the snapshot drift is reconciled.

## #738 — raise low/inconsistent agent timeout defaults to 600s
Verified in source — the earlier 600s work (#703/#705) left these behind:
- `DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS`: **60s → 600s** (the queue-wait gate that throws `AgentDispatchQueueTimeoutError`)
- `AgnoClient.DEFAULT_TIMEOUT_MS`: **60s → 600s**
- inconsistent `provider.defaultTimeout` fallbacks aligned to **600s**: OpenClaw `?? 120`, Claude-Code `?? 120`, **and** Webhook provider `?? 30` (flagged for review — biggest behavioral delta)
- `OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS` env override unchanged.

## Tests
- New `agent-dispatch-error-message.test.ts` — resolution precedence (default / env / instance / blank-fallthrough / trim).
- `agent-dispatch-limiter.test.ts` default-config assertion updated to 600s.
- Full suite green locally via pre-push: **4039 pass, 0 fail**.

## Note: separate `fix(lint)` commit
The first commit (`fix(lint)`) clears **pre-existing** biome debt unrelated to this feature — three files merged to `dev` via server-side squash-merges (which skip local hooks) had left `make lint` red and blocked all local commits:
- `message-persistence.test.ts` formatter wrap (from #663)
- gupshup `identity.test.ts` 2 unused `noExplicitAny` suppressions
- `channel-whatsapp/plugin.ts` `processHistoryMessage` complexity 21>20 (pushed over by #663) — extracted `isHistoryMessageWithinSyncRange()`, behavior-preserving (360 WA tests pass)