### PR TITLE
fix(core): customer-safe guard no longer black-holes valid replies (gemini #739)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/src/providers/__tests__/customer-safe-errors.test.ts
+++ b/packages/core/src/providers/__tests__/customer-safe-errors.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for customer-safe-errors — the guard that stops raw provider/billing
+ * errors (and leaked secrets) from reaching customers.
+ *
+ * Focus:
+ * - the tightened `Bearer` branch no longer false-positives on benign English
+ *   (gemini review on #739), while still catching real leaked tokens;
+ * - the existing provider/secret patterns still trip;
+ * - the message is overridable via OMNI_SAFE_PROVIDER_ERROR_MESSAGE.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  SAFE_PROVIDER_ERROR_MESSAGE,
+  resolveSafeProviderErrorMessage,
+  toSafeCustomerFallback,
+} from '../customer-safe-errors';
+
+describe('toSafeCustomerFallback — Bearer false positives', () => {
+  it.each([
+    'Bearer of bad news: your appointment was cancelled.',
+    'She was the bearer of glad tidings today.',
+    'Bearer token required.',
+    'Please become a Bearer of good will.',
+  ])('does NOT block benign English after "bearer": %s', (text) => {
+    expect(toSafeCustomerFallback(text)).toBe(text);
+  });
+
+  it.each([
+    // Low-entropy placeholders (not real secrets) that still satisfy the 20+ char rule.
+    'Authorization failed: Bearer EXAMPLE0EXAMPLE0EXAMPLE0EXAMPLE0',
+    'Bearer PLACEHOLDERTOKENPLACEHOLDERTOKEN',
+  ])('still blocks a real leaked bearer token: %s', (text) => {
+    expect(toSafeCustomerFallback(text)).toBe(SAFE_PROVIDER_ERROR_MESSAGE);
+  });
+});
+
+describe('toSafeCustomerFallback — existing leak patterns still trip', () => {
+  it.each([
+    'litellm.AuthenticationError: invalid key',
+    'ModelProviderError: upstream 500',
+    'your credit balance is too low to run this',
+    'sk-EXAMPLEKEYPLACEHOLDER',
+    'api_key=EXAMPLE_PLACEHOLDER',
+    'Received API Key for the wrong org',
+  ])('blocks: %s', (text) => {
+    expect(toSafeCustomerFallback(text)).toBe(SAFE_PROVIDER_ERROR_MESSAGE);
+  });
+
+  it('passes through ordinary agent replies untouched', () => {
+    const ok = 'Sure! Your order #1234 ships tomorrow.';
+    expect(toSafeCustomerFallback(ok)).toBe(ok);
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(toSafeCustomerFallback(null)).toBe('');
+    expect(toSafeCustomerFallback(undefined)).toBe('');
+  });
+});
+
+describe('resolveSafeProviderErrorMessage', () => {
+  it('defaults to the pt-BR message when no env override', () => {
+    expect(resolveSafeProviderErrorMessage({})).toBe(SAFE_PROVIDER_ERROR_MESSAGE);
+  });
+
+  it('honors OMNI_SAFE_PROVIDER_ERROR_MESSAGE', () => {
+    const env = { OMNI_SAFE_PROVIDER_ERROR_MESSAGE: 'We hit a snag, please try again shortly.' };
+    expect(resolveSafeProviderErrorMessage(env)).toBe('We hit a snag, please try again shortly.');
+    // ...and the override flows through the blocking path too.
+    expect(toSafeCustomerFallback('litellm.APIError: boom', env)).toBe('We hit a snag, please try again shortly.');
+  });
+
+  it('ignores a blank override and falls back to default', () => {
+    expect(resolveSafeProviderErrorMessage({ OMNI_SAFE_PROVIDER_ERROR_MESSAGE: '   ' })).toBe(
+      SAFE_PROVIDER_ERROR_MESSAGE,
+    );
+  });
+});

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from '../logger';
-import { SAFE_PROVIDER_ERROR_MESSAGE, toSafeCustomerFallback } from './customer-safe-errors';
+import { resolveSafeProviderErrorMessage, toSafeCustomerFallback } from './customer-safe-errors';
 import { buildProviderRequestContext } from './execution-context';
 import { createTraceContextFromTraceId } from './trace-context';
 import type {
@@ -160,7 +160,7 @@ export class AgnoAgentProvider implements IAgentProvider {
         traceId: context.traceId,
         error: message,
       });
-      yield { phase: 'error', error: SAFE_PROVIDER_ERROR_MESSAGE };
+      yield { phase: 'error', error: resolveSafeProviderErrorMessage() };
     }
   }
 

--- a/packages/core/src/providers/customer-safe-errors.ts
+++ b/packages/core/src/providers/customer-safe-errors.ts
@@ -1,16 +1,46 @@
+/**
+ * Default customer-facing message shown when a raw provider/billing error is
+ * intercepted before it reaches the user. Defaults to pt-BR (the deployments
+ * this guard was built for); override globally with the
+ * `OMNI_SAFE_PROVIDER_ERROR_MESSAGE` env var for other locales.
+ */
 const SAFE_PROVIDER_ERROR_MESSAGE =
   'Tô com um probleminha técnico aqui agora. Já estou avisando o time. Pode tentar de novo em alguns minutos? 🙏';
 
+/**
+ * Patterns that mark text as a leaked provider/billing/secret error which must
+ * never reach a customer.
+ *
+ * NOTE on the `Bearer` branch: it requires a 20+ char token run so it matches
+ * a real leaked credential (`Bearer eyJhbGciOi...`) but NOT benign English
+ * that happens to follow the word "bearer" — e.g. "bearer of bad news". The
+ * previous `Bearer\s+[A-Za-z0-9._-]+` matched any word and black-holed valid
+ * agent replies (gemini review on #739).
+ */
 const PROVIDER_ERROR_PATTERN =
-  /(litellm\.(BadRequestError|AuthenticationError|RateLimitError|APIError)|ModelProviderError|AnthropicException|Authentication Error|Invalid proxy server token|Received API Key|Available Model Group Fallbacks|credit balance is too low|Plans\s*&\s*Billing|\bsk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]+|api[_ -]?key\s*[=:])/i;
+  /(litellm\.(BadRequestError|AuthenticationError|RateLimitError|APIError)|ModelProviderError|AnthropicException|Authentication Error|Invalid proxy server token|Received API Key|Available Model Group Fallbacks|credit balance is too low|Plans\s*&\s*Billing|\bsk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]{20,}|api[_ -]?key\s*[=:])/i;
 
 function isUnsafeCustomerFacingProviderText(text: string | undefined | null): boolean {
   return Boolean(text && PROVIDER_ERROR_PATTERN.test(text));
 }
 
-export function toSafeCustomerFallback(text: string | undefined | null): string {
+/**
+ * Resolve the customer-facing provider-error message. Precedence:
+ *   1. `OMNI_SAFE_PROVIDER_ERROR_MESSAGE` env (global locale override),
+ *   2. {@link SAFE_PROVIDER_ERROR_MESSAGE} (pt-BR default).
+ * Blank/whitespace-only overrides are ignored.
+ */
+export function resolveSafeProviderErrorMessage(env: Record<string, string | undefined> = process.env): string {
+  const override = env.OMNI_SAFE_PROVIDER_ERROR_MESSAGE?.trim();
+  return override || SAFE_PROVIDER_ERROR_MESSAGE;
+}
+
+export function toSafeCustomerFallback(
+  text: string | undefined | null,
+  env: Record<string, string | undefined> = process.env,
+): string {
   if (isUnsafeCustomerFacingProviderText(text)) {
-    return SAFE_PROVIDER_ERROR_MESSAGE;
+    return resolveSafeProviderErrorMessage(env);
   }
   return text ?? '';
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
Addresses the gemini-code-assist findings on the `customer-safe-errors` guard (raised during review of #739; the code itself shipped in #734).

## The bug (HIGH)
`PROVIDER_ERROR_PATTERN`'s Bearer branch was `Bearer\s+[A-Za-z0-9._-]+` — it matched **any** word following "bearer". So legitimate agent replies were intercepted and replaced with the generic provider-error message:

- ❌ "Bearer of bad news: your appointment was cancelled." → blocked
- ❌ "She was the bearer of glad tidings." → blocked

**Fix:** require a 20+ char token run — `Bearer\s+[A-Za-z0-9._-]{20,}`. Real leaked credentials (`Bearer eyJhbGci…`) are long; English prose after "bearer" is not. Benign text now passes; real tokens still trip.

## i18n (MEDIUM)
The intercept message `SAFE_PROVIDER_ERROR_MESSAGE` was hardcoded pt-BR, forcing it on every deployment. Added `resolveSafeProviderErrorMessage()` with an `OMNI_SAFE_PROVIDER_ERROR_MESSAGE` env override (default stays pt-BR, so current deployments are unaffected), and routed both `toSafeCustomerFallback` and the agno-provider error-phase `yield` through it. Mirrors the `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` pattern from #737.

## Tests
New `customer-safe-errors.test.ts`:
- Bearer false-positives (benign English) pass through untouched
- real leaked bearer tokens still blocked
- existing leak patterns (litellm / ModelProviderError / `sk-…` / `api_key=` / billing) still trip
- env override resolution + blank-override fallthrough

Existing `agno-provider.test.ts` still green (consumer change is backward-compatible). Local: 24 pass / 0 fail, typecheck + biome clean.

## Not addressed
Gemini's 3rd comment (dedupe the `yield`/`continue` in the agno stream loop) is a cosmetic style nit with no behavior change — left out to keep this fix tight.