### PR TITLE
feat(agent-dispatcher): human handoff on agent errors for Gupshup

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-handoff.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-handoff.test.ts
@@ -12,10 +12,10 @@ import { describe, expect, it, mock } from 'bun:test';
 // Configurable plugin mock for `getPlugin`. Tests mutate `pluginState` per case.
 const pluginState: {
   canHandoff: boolean;
-  sendMessage: (...args: unknown[]) => Promise<{ messageId: string }>;
+  sendMessage: (...args: unknown[]) => Promise<{ success: boolean; messageId?: string; error?: string }>;
 } = {
   canHandoff: true,
-  sendMessage: mock(() => Promise.resolve({ messageId: 'msg-1' })),
+  sendMessage: mock(() => Promise.resolve({ success: true, messageId: 'msg-1' })),
 };
 
 mock.module('../loader', () => ({
@@ -55,11 +55,20 @@ describe('triggerErrorHandoff', () => {
     pluginState.canHandoff = true;
   });
 
-  it('returns false when the HANDOFF message delivery fails (safe to fall back)', async () => {
+  it('returns false when the HANDOFF message delivery throws (safe to fall back)', async () => {
     pluginState.sendMessage = mock(() => Promise.reject(new Error('network down')));
     const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
     expect(ok).toBe(false);
-    pluginState.sendMessage = mock(() => Promise.resolve({ messageId: 'msg-1' }));
+    pluginState.sendMessage = mock(() => Promise.resolve({ success: true, messageId: 'msg-1' }));
+  });
+
+  it('returns false when sendMessage reports success:false (not connected / rejected)', async () => {
+    // Gupshup returns { success:false } without throwing — must still fall back,
+    // not pause the agent and swallow the message.
+    pluginState.sendMessage = mock(() => Promise.resolve({ success: false, error: 'not connected' }));
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(false);
+    pluginState.sendMessage = mock(() => Promise.resolve({ success: true, messageId: 'msg-1' }));
   });
 
   it('returns true even when a side-effect fails — no double message', async () => {

--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-handoff.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-handoff.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for triggerErrorHandoff — the system-initiated handoff on agent errors
+ * for native-handoff channels (Gupshup).
+ *
+ * The critical invariant (gemini review on #741): once the HANDOFF message is
+ * delivered, a failure in the persistence side-effects must STILL return true,
+ * so the caller does NOT send a second (plain error) message to the user.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+// Configurable plugin mock for `getPlugin`. Tests mutate `pluginState` per case.
+const pluginState: {
+  canHandoff: boolean;
+  sendMessage: (...args: unknown[]) => Promise<{ messageId: string }>;
+} = {
+  canHandoff: true,
+  sendMessage: mock(() => Promise.resolve({ messageId: 'msg-1' })),
+};
+
+mock.module('../loader', () => ({
+  getPlugin: mock(() =>
+    Promise.resolve({
+      capabilities: { canHandoff: pluginState.canHandoff },
+      sendMessage: pluginState.sendMessage,
+    }),
+  ),
+}));
+
+import { triggerErrorHandoff } from '../agent-dispatcher';
+
+// Minimal stand-ins; only the fields triggerErrorHandoff touches are present.
+function makeServices(overrides: Record<string, unknown> = {}) {
+  return {
+    chats: {
+      findByExternalIdSmart: mock(() => Promise.resolve({ id: 'chat-uuid', settings: {} })),
+      update: mock(() => Promise.resolve(undefined)),
+    },
+    followUpLifecycle: { disarm: mock(() => Promise.resolve(undefined)) },
+    ...overrides,
+  } as never;
+}
+
+function makeDb() {
+  return { insert: () => ({ values: mock(() => Promise.resolve(undefined)) }) } as never;
+}
+
+const instance = { id: 'inst-1', agentId: 'agent-1' } as never;
+
+describe('triggerErrorHandoff', () => {
+  it('returns false on a non-handoff channel (no message sent)', async () => {
+    pluginState.canHandoff = false;
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'whatsapp' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(false);
+    pluginState.canHandoff = true;
+  });
+
+  it('returns false when the HANDOFF message delivery fails (safe to fall back)', async () => {
+    pluginState.sendMessage = mock(() => Promise.reject(new Error('network down')));
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(false);
+    pluginState.sendMessage = mock(() => Promise.resolve({ messageId: 'msg-1' }));
+  });
+
+  it('returns true even when a side-effect fails — no double message', async () => {
+    // Message delivered, but chats.update throws. Must still return true.
+    const services = makeServices({
+      chats: {
+        findByExternalIdSmart: mock(() => Promise.resolve({ id: 'chat-uuid', settings: {} })),
+        update: mock(() => Promise.reject(new Error('db down'))),
+      },
+    });
+    const ok = await triggerErrorHandoff(services, makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(true);
+  });
+
+  it('returns true on the happy path (message + side-effects persisted)', async () => {
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
@@ -14,7 +14,12 @@ mock.module('../loader', () => ({
   getPlugin: mock(() => Promise.resolve(undefined)),
 }));
 
-import { DEFAULT_DISPATCH_ERROR_MESSAGE, resolveDispatchErrorMessage } from '../agent-dispatcher';
+import {
+  DEFAULT_DISPATCH_ERROR_MESSAGE,
+  DEFAULT_ERROR_HANDOFF_MESSAGE,
+  resolveDispatchErrorMessage,
+  resolveErrorHandoffMessage,
+} from '../agent-dispatcher';
 
 describe('resolveDispatchErrorMessage', () => {
   it('falls back to the built-in default when nothing is configured', () => {
@@ -42,5 +47,22 @@ describe('resolveDispatchErrorMessage', () => {
 
   it('trims surrounding whitespace from the resolved value', () => {
     expect(resolveDispatchErrorMessage('  hi there  ', {})).toBe('hi there');
+  });
+});
+
+describe('resolveErrorHandoffMessage', () => {
+  it('defaults to the built-in handoff message (promises a human, not a retry)', () => {
+    expect(resolveErrorHandoffMessage({})).toBe(DEFAULT_ERROR_HANDOFF_MESSAGE);
+    expect(DEFAULT_ERROR_HANDOFF_MESSAGE).toContain('entrar em contato');
+  });
+
+  it('honors OMNI_AGENT_ERROR_HANDOFF_MESSAGE', () => {
+    expect(resolveErrorHandoffMessage({ OMNI_AGENT_ERROR_HANDOFF_MESSAGE: 'A human will reach out shortly.' })).toBe(
+      'A human will reach out shortly.',
+    );
+  });
+
+  it('ignores a blank override and falls back to default', () => {
+    expect(resolveErrorHandoffMessage({ OMNI_AGENT_ERROR_HANDOFF_MESSAGE: '   ' })).toBe(DEFAULT_ERROR_HANDOFF_MESSAGE);
   });
 });

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -616,6 +616,11 @@ export async function triggerErrorHandoff(
 
   // Step 1 — deliver the HANDOFF payload. ONLY a delivery failure may return
   // false (the user got nothing, so the caller's plain-error fallback is safe).
+  // Channel sendMessage signals failure two ways: a thrown error OR a falsy
+  // `success` flag (e.g. Gupshup returns { success:false } when the instance
+  // isn't connected or the provider rejects) — both must short-circuit here,
+  // else we'd pause the agent and suppress the fallback while the user got
+  // nothing.
   let sendResult: Awaited<ReturnType<typeof plugin.sendMessage>>;
   try {
     sendResult = await plugin.sendMessage(instance.id, {
@@ -625,6 +630,14 @@ export async function triggerErrorHandoff(
     });
   } catch (err) {
     log.error('agent_dispatch_error_handoff_failed', { instanceId: instance.id, chatId, error: String(err) });
+    return false;
+  }
+  if (!sendResult?.success) {
+    log.error('agent_dispatch_error_handoff_delivery_failed', {
+      instanceId: instance.id,
+      chatId,
+      error: sendResult?.error,
+    });
     return false;
   }
 

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -603,7 +603,7 @@ export function resolveErrorHandoffMessage(env: Record<string, string | undefine
  * plain error message when this returns `false` (non-handoff channel, missing
  * plugin, or a delivery failure).
  */
-async function triggerErrorHandoff(
+export async function triggerErrorHandoff(
   services: Services,
   db: Database,
   channel: ChannelType,
@@ -614,44 +614,53 @@ async function triggerErrorHandoff(
   const plugin = await getPlugin(channel);
   if (plugin?.capabilities?.canHandoff !== true) return false;
 
+  // Step 1 — deliver the HANDOFF payload. ONLY a delivery failure may return
+  // false (the user got nothing, so the caller's plain-error fallback is safe).
+  let sendResult: Awaited<ReturnType<typeof plugin.sendMessage>>;
   try {
-    const sendResult = await plugin.sendMessage(instance.id, {
+    sendResult = await plugin.sendMessage(instance.id, {
       to: chatId,
       content: { type: 'text', text: message },
       metadata: { isHandoff: true, motivoHandoff: 'agent_dispatch_error' },
     });
+  } catch (err) {
+    log.error('agent_dispatch_error_handoff_failed', { instanceId: instance.id, chatId, error: String(err) });
+    return false;
+  }
 
-    // Pause the agent + disarm follow-ups + audit. The HANDOFF payload already
-    // reached the user, so even if the chat row can't be resolved we report the
-    // handoff as done (true) — we just can't persist the side-effects.
+  // Step 2 — persist side-effects (pause + disarm + audit) best-effort. The
+  // message already reached the user, so a failure here must NOT flip the result
+  // to false — that would make the caller send a SECOND (plain error) message.
+  try {
     const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
     if (chat) {
       const settings = (chat.settings as Record<string, unknown> | null) ?? {};
       await services.chats.update(chat.id, { settings: { ...settings, agentPaused: true } });
       await services.followUpLifecycle.disarm({ chatId: chat.id, instanceId: instance.id, reason: 'handoff' });
-      db.insert(handoffLogs)
-        .values({
-          instanceId: instance.id,
-          chatUuid: chat.id,
-          chatId,
-          toPhone: chatId,
-          text: message,
-          extraInfo: null,
-          agentId: instance.agentId ?? null,
-          externalMessageId: sendResult?.messageId ?? null,
-          handoffFields: null,
-          sentAt: new Date(),
-          metadata: { instanceChannel: channel, channelHandoffSupported: true, motivoHandoff: 'agent_dispatch_error' },
-        })
-        .catch((err: unknown) => log.warn('Failed to persist error-handoff log', { error: String(err) }));
+      await db.insert(handoffLogs).values({
+        instanceId: instance.id,
+        chatUuid: chat.id,
+        chatId,
+        toPhone: chatId,
+        text: message,
+        extraInfo: null,
+        agentId: instance.agentId ?? null,
+        externalMessageId: sendResult?.messageId ?? null,
+        handoffFields: null,
+        sentAt: new Date(),
+        metadata: { instanceChannel: channel, channelHandoffSupported: true, motivoHandoff: 'agent_dispatch_error' },
+      });
     }
-
-    log.info('agent_dispatch_error_handoff', { instanceId: instance.id, chatId, channel });
-    return true;
   } catch (err) {
-    log.error('agent_dispatch_error_handoff_failed', { instanceId: instance.id, chatId, error: String(err) });
-    return false;
+    log.warn('agent_dispatch_error_handoff_side_effects_failed', {
+      instanceId: instance.id,
+      chatId,
+      error: String(err),
+    });
   }
+
+  log.info('agent_dispatch_error_handoff', { instanceId: instance.id, chatId, channel });
+  return true;
 }
 
 /**

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -65,7 +65,7 @@ import {
   getJourneyTracker,
 } from '@omni/core';
 import type { AgentProvider, Database } from '@omni/db';
-import { agentSessions, agents, instances } from '@omni/db';
+import { agentSessions, agents, handoffLogs, instances } from '@omni/db';
 import type { ChannelType, Instance } from '@omni/db';
 import { createMediaProcessingService } from '@omni/media-processing';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
@@ -575,6 +575,103 @@ async function sendErrorFeedback(
   const errorMsg = error instanceof Error ? error.message : String(error);
   log.error('agent_dispatch_error', { channel, instanceId, chatId, error: errorMsg });
   await sendTextMessage(channel, instanceId, chatId, message);
+}
+
+/**
+ * Default message sent to the customer when an agent error triggers a human
+ * handoff on a native-handoff channel (Gupshup). Distinct from
+ * {@link DEFAULT_DISPATCH_ERROR_MESSAGE}: this one promises a human follow-up
+ * (the chat is routed to an attendant) instead of asking the user to retry.
+ * Override globally with `OMNI_AGENT_ERROR_HANDOFF_MESSAGE`.
+ */
+export const DEFAULT_ERROR_HANDOFF_MESSAGE =
+  'Tô com um probleminha técnico aqui agora. Logo alguém do time vai entrar em contato com você.';
+
+/** Resolve the error-handoff message: env override → built-in default. */
+export function resolveErrorHandoffMessage(env: Record<string, string | undefined> = process.env): string {
+  return env.OMNI_AGENT_ERROR_HANDOFF_MESSAGE?.trim() || DEFAULT_ERROR_HANDOFF_MESSAGE;
+}
+
+/**
+ * System-initiated handoff when a customer-facing agent error occurs on a
+ * channel with native handoff (Gupshup). Mirrors the side-effects of
+ * `POST /messages/send/handoff` (routes/v2/messages.ts): deliver `message` AS
+ * the native HANDOFF payload (which both shows the text and routes the chat to
+ * a human queue), pause the agent, disarm follow-ups, and write an audit row.
+ *
+ * Returns `true` when the handoff was dispatched; the caller falls back to the
+ * plain error message when this returns `false` (non-handoff channel, missing
+ * plugin, or a delivery failure).
+ */
+async function triggerErrorHandoff(
+  services: Services,
+  db: Database,
+  channel: ChannelType,
+  instance: DispatchInstance,
+  chatId: string,
+  message: string,
+): Promise<boolean> {
+  const plugin = await getPlugin(channel);
+  if (plugin?.capabilities?.canHandoff !== true) return false;
+
+  try {
+    const sendResult = await plugin.sendMessage(instance.id, {
+      to: chatId,
+      content: { type: 'text', text: message },
+      metadata: { isHandoff: true, motivoHandoff: 'agent_dispatch_error' },
+    });
+
+    // Pause the agent + disarm follow-ups + audit. The HANDOFF payload already
+    // reached the user, so even if the chat row can't be resolved we report the
+    // handoff as done (true) — we just can't persist the side-effects.
+    const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
+    if (chat) {
+      const settings = (chat.settings as Record<string, unknown> | null) ?? {};
+      await services.chats.update(chat.id, { settings: { ...settings, agentPaused: true } });
+      await services.followUpLifecycle.disarm({ chatId: chat.id, instanceId: instance.id, reason: 'handoff' });
+      db.insert(handoffLogs)
+        .values({
+          instanceId: instance.id,
+          chatUuid: chat.id,
+          chatId,
+          toPhone: chatId,
+          text: message,
+          extraInfo: null,
+          agentId: instance.agentId ?? null,
+          externalMessageId: sendResult?.messageId ?? null,
+          handoffFields: null,
+          sentAt: new Date(),
+          metadata: { instanceChannel: channel, channelHandoffSupported: true, motivoHandoff: 'agent_dispatch_error' },
+        })
+        .catch((err: unknown) => log.warn('Failed to persist error-handoff log', { error: String(err) }));
+    }
+
+    log.info('agent_dispatch_error_handoff', { instanceId: instance.id, chatId, channel });
+    return true;
+  } catch (err) {
+    log.error('agent_dispatch_error_handoff_failed', { instanceId: instance.id, chatId, error: String(err) });
+    return false;
+  }
+}
+
+/**
+ * Customer-facing handling of a fatal dispatch failure: a human handoff on
+ * native-handoff channels (Gupshup — special message + agent pause), otherwise
+ * the plain {@link resolveDispatchErrorMessage} reply.
+ */
+async function handleDispatchFailure(
+  services: Services,
+  db: Database,
+  channel: ChannelType,
+  instance: DispatchInstance,
+  chatId: string,
+  error: unknown,
+): Promise<void> {
+  const handedOff = await triggerErrorHandoff(services, db, channel, instance, chatId, resolveErrorHandoffMessage());
+  if (handedOff) return;
+  // Per-instance override tier is null until the `agentErrorMessage` column
+  // lands (see resolveDispatchErrorMessage note) — env + default for now.
+  await sendErrorFeedback(channel, instance.id, chatId, error, resolveDispatchErrorMessage(null)).catch(() => {});
 }
 
 function sleep(ms: number): Promise<void> {
@@ -2463,7 +2560,23 @@ async function dispatchViaProvider(
       const chatAfterRun = await services.chats.findByExternalIdSmart(instance.id, chatId);
       const handoffTriggered = (chatAfterRun?.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
 
-      if (result && result.parts.length > 0 && !handoffTriggered) {
+      // When the provider blocked a leaked error and substituted the customer-safe
+      // fallback, route to a human on native-handoff channels (Gupshup) instead of
+      // forwarding the generic fallback text. Non-handoff channels fall through and
+      // send the fallback parts as before.
+      let errorHandoffDone = false;
+      if (result?.metadata.customerErrorBlocked === true && !handoffTriggered) {
+        errorHandoffDone = await triggerErrorHandoff(
+          services,
+          db,
+          channel,
+          instance,
+          chatId,
+          resolveErrorHandoffMessage(),
+        );
+      }
+
+      if (result && result.parts.length > 0 && !handoffTriggered && !errorHandoffDone) {
         const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
         const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
         // Apply before_message_write hooks to each response part before sending
@@ -3463,15 +3576,7 @@ async function processAgentResponse(
       error: String(error),
       traceId,
     });
-    sendErrorFeedback(
-      channel,
-      instance.id,
-      chatId,
-      error,
-      // Per-instance override tier is null until the `agentErrorMessage` column
-      // lands (see resolveDispatchErrorMessage note) — env + default for now.
-      resolveDispatchErrorMessage(null),
-    ).catch(() => {});
+    await handleDispatchFailure(services, db, channel, instance, chatId, error);
   } finally {
     ackHandle.remove();
   }

--- a/packages/core/src/providers/__tests__/agno-provider.test.ts
+++ b/packages/core/src/providers/__tests__/agno-provider.test.ts
@@ -219,6 +219,21 @@ describe('AgnoAgentProvider', () => {
     expect(result.parts).toEqual([SAFE_PROVIDER_ERROR_MESSAGE]);
     expect(result.parts.join(' ')).not.toContain('Anthropic');
     expect(result.parts.join(' ')).not.toContain('credit balance');
+    // Signals the dispatcher to hand off to a human on native-handoff channels.
+    expect(result.metadata.customerErrorBlocked).toBe(true);
+  });
+
+  it('does not flag a normal response as a blocked customer error', async () => {
+    const client = createClientReturning('Sure! Your order ships tomorrow.');
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const result = await provider.trigger(createTrigger());
+
+    expect(result.parts).toEqual(['Sure! Your order ships tomorrow.']);
+    expect(result.metadata.customerErrorBlocked).toBe(false);
   });
 
   it('replaces raw API key errors before building outbound message parts', async () => {

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -72,8 +72,9 @@ export class AgnoAgentProvider implements IAgentProvider {
     const response = await this.client.run(request);
 
     const customerContent = toSafeCustomerFallback(response.content);
+    const customerErrorBlocked = customerContent !== response.content;
 
-    if (customerContent !== response.content) {
+    if (customerErrorBlocked) {
       log.error('Blocked provider error from customer-facing Agno response', {
         agentId: this.config.agentId,
         runId: response.runId,
@@ -112,6 +113,7 @@ export class AgnoAgentProvider implements IAgentProvider {
               outputTokens: response.metrics.outputTokens,
             }
           : undefined,
+        customerErrorBlocked,
       },
     };
   }

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -523,6 +523,14 @@ export interface AgentTriggerResult {
       inputTokens?: number;
       outputTokens?: number;
     };
+    /**
+     * True when the response text was replaced by the customer-safe error
+     * fallback (a provider/billing/secret error was blocked — see
+     * `toSafeCustomerFallback`). The dispatcher uses this to trigger a human
+     * handoff on channels that support it (Gupshup) instead of forwarding the
+     * generic fallback message.
+     */
+    customerErrorBlocked?: boolean;
   };
 }
 


### PR DESCRIPTION
On Gupshup instances, any customer-facing agent error now routes the chat to a **human** instead of sending a dead-end error reply.

## Behavior
When an error would otherwise show the user a generic error message, on a native-handoff channel we instead:
1. Send **"Tô com um probleminha técnico aqui agora. Logo alguém do time vai entrar em contato com você."** AS the native Gupshup `HANDOFF` payload — one shot: delivers the text to the user **and** signals the human queue.
2. Set `chats.settings.agentPaused = true` (agent stops replying).
3. Disarm any active follow-up sequence (`reason: 'handoff'`).
4. Write a `handoff_logs` audit row.

This mirrors exactly what `POST /messages/send/handoff` does — just triggered automatically on error.

## Covers both error surfaces (per the ask)
- **Dispatch failure after retries** — the old English "Sorry, I ran into an issue…" path (`sendErrorFeedback`).
- **Provider-leaked error** blocked by the customer-safe guard — `agno-provider` now sets `result.metadata.customerErrorBlocked`, and the dispatcher reads it. (Gupshup is `canStreamResponse: false`, so this only flows through non-stream `trigger()` — no streaming plumbing needed.)

## Scope / safety
- Gated on `plugin.capabilities.canHandoff === true` — **Gupshup-only today**, but generalizes to any future native-handoff channel without code changes.
- **Non-handoff channels are unchanged** — they still get the plain error message.
- `triggerErrorHandoff` is resilient: on a delivery failure it returns `false` and the caller falls back to the normal error message.
- Message overridable via `OMNI_AGENT_ERROR_HANDOFF_MESSAGE`.

## Design note
I kept the route (`POST /messages/send/handoff`) **untouched** — it has no test coverage and uses a different plugin-access path (`channelRegistry`) than the dispatcher (`getPlugin`). `triggerErrorHandoff` is a dispatcher-local mirror of the route's side-effects, with a comment cross-referencing it. A future refactor could extract a shared `executeHandoff` once the route gets test coverage.

## Tests
- `resolveErrorHandoffMessage` precedence (env override / blank fallthrough).
- `agno-provider` sets `customerErrorBlocked: true` on a blocked error and `false` on a normal response.
- Full pre-push suite green.

## Not covered
The reaction-trigger send path (emoji reactions) doesn't apply the error-handoff — reactions producing a customer-facing provider error is an edge case; left as a follow-up if needed.