### PR TITLE
chore(release): re-trigger @latest npm publish for v2.260624.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- ci: re-trigger @latest publish for v2.260624.4 (rolling promotion #730 rebased a [skip ci] head, skipping the main CI → version.yml @latest publish) -->
 <p align="center">
   <picture>
     <img src=".github/assets/omni-header-2.png" alt="Omni — One API, Every Channel" width="800" />


### PR DESCRIPTION
Empty/no-op commit to re-trigger the main CI → `version.yml(main)` → npm `@latest` publish.

**Why:** the dev→main rolling promotion (#730) merged via rebase, so main's HEAD became a `chore(version): bump … [skip ci]` commit. The `[skip ci]` skipped the push-to-main CI, so `version.yml`'s `workflow_run(main)` trigger never fired — npm `@latest` is stuck at 2.260619.3 while the GH release v2.260624.4 and `@next` are current.

Merging this (non-skip head) fires the main CI → `version.yml` publishes `@latest` (will carry a fresh build number, same code) and bumps dev.

**Follow-up:** configure the rolling dev→main PR to merge as a **merge commit** (not rebase) so the HEAD is never `[skip ci]` — prevents this from recurring on every promotion.