### PR TITLE
chore: rolling promotion dev → main (publish @latest 2.260624.x)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "author": {
         "name": "Automagik"
       },

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ API_MANAGED=true
 # A2A_SEND_WAIT_MS=30000
 
 # -----------------------------------------------------------------------------
+# Agent dispatch backpressure
+# -----------------------------------------------------------------------------
+# Bounds concurrent Omni -> agent/provider dispatches per instance. This keeps
+# traffic spikes or maintenance reloads from stampeding a downstream agent API.
+# OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT=8
+# OMNI_AGENT_DISPATCH_QUEUE_MAX_DEPTH=100
+# OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS=60000
+# OMNI_AGENT_DISPATCH_PER_CHAT_CONCURRENCY=1
+
+# -----------------------------------------------------------------------------
 # Sentry (Error Tracking & Performance Monitoring)
 # DSN is hardcoded to the Omni project — override to redirect, set empty to disable
 # -----------------------------------------------------------------------------

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260624.3",
+      "version": "2.260624.4",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260624.2",
+      "version": "2.260624.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260622.1",
+      "version": "2.260624.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260624.1",
+      "version": "2.260622.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260622.1",
+      "version": "2.260624.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260619.3",
+      "version": "2.260622.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/core": "workspace:*",
       },
@@ -166,7 +166,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -215,7 +215,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -236,7 +236,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -273,7 +273,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -289,7 +289,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -303,7 +303,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -322,7 +322,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -330,7 +330,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -344,7 +344,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260619.2",
+      "version": "2.260619.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/__tests__/messages-presence.test.ts
+++ b/packages/api/src/__tests__/messages-presence.test.ts
@@ -19,6 +19,20 @@ function createMockPlugin(
   overrides: Partial<{
     canSendTyping: boolean;
     sendTyping: (instanceId: string, chatId: string, duration?: number) => Promise<void>;
+    sendPresenceStatus: (
+      instanceId: string,
+      chatId: string,
+      type: 'typing' | 'recording' | 'paused',
+      duration?: number,
+      options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+    ) => Promise<{
+      delivered: boolean;
+      method: string;
+      threadId?: string;
+      status?: string;
+      loadingMessages?: string[];
+      reason?: string;
+    }>;
   }> = {},
 ) {
   return {
@@ -43,6 +57,7 @@ function createMockPlugin(
       maxFileSize: 100 * 1024 * 1024,
     },
     sendTyping: overrides.sendTyping ?? mock(async () => {}),
+    ...(overrides.sendPresenceStatus ? { sendPresenceStatus: overrides.sendPresenceStatus } : {}),
   };
 }
 
@@ -58,6 +73,7 @@ function createMockChannelRegistry(plugin: ReturnType<typeof createMockPlugin> |
 describeWithDb('POST /messages/send/presence', () => {
   let db: Database;
   let testInstance: Instance;
+  let testSlackInstance: Instance;
   const insertedInstanceIds: string[] = [];
 
   beforeAll(async () => {
@@ -76,6 +92,19 @@ describeWithDb('POST /messages/send/presence', () => {
     }
     testInstance = instance;
     insertedInstanceIds.push(instance.id);
+
+    const [slackInstance] = await db
+      .insert(instances)
+      .values({
+        name: `test-slack-presence-${Date.now()}`,
+        channel: 'slack' as const,
+      })
+      .returning();
+    if (!slackInstance) {
+      throw new Error('Failed to create Slack test instance');
+    }
+    testSlackInstance = slackInstance;
+    insertedInstanceIds.push(slackInstance.id);
   });
 
   afterAll(async () => {
@@ -200,7 +229,64 @@ describeWithDb('POST /messages/send/presence', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { code: string; message: string } };
     expect(body.error.code).toBe('CAPABILITY_NOT_SUPPORTED');
-    expect(body.error.message).toContain('typing indicators');
+    expect(body.error.message).toContain('typing indicators or thread status');
+  });
+
+  test('uses Slack thread status sender when native typing capability is false', async () => {
+    const sendPresenceStatusMock = mock(
+      async (
+        _instanceId: string,
+        _chatId: string,
+        _type: 'typing' | 'recording' | 'paused',
+        _duration?: number,
+        options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+      ) => ({
+        delivered: true,
+        method: 'assistant.threads.setStatus',
+        threadId: options?.threadId,
+        status: options?.status ?? 'is typing...',
+        loadingMessages: options?.loadingMessages,
+      }),
+    );
+    const mockPlugin = createMockPlugin({ canSendTyping: false, sendPresenceStatus: sendPresenceStatusMock });
+    const { app } = createTestApp(mockPlugin);
+
+    const res = await app.request('/messages/send/presence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instanceId: testSlackInstance.id,
+        to: 'C12345',
+        type: 'typing',
+        threadId: '1234567890.001',
+        status: 'analisando contexto...',
+        loadingMessages: ['Lendo contexto...', 'Chamando ferramentas...'],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { delivered: boolean; method: string; threadId?: string; status?: string; loadingMessages?: string[] };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.delivered).toBe(true);
+    expect(body.data.method).toBe('assistant.threads.setStatus');
+    expect(body.data.threadId).toBe('1234567890.001');
+    expect(body.data.status).toBe('analisando contexto...');
+    expect(body.data.loadingMessages).toEqual(['Lendo contexto...', 'Chamando ferramentas...']);
+    expect(sendPresenceStatusMock).toHaveBeenCalledTimes(1);
+    expect(sendPresenceStatusMock.mock.calls[0]).toEqual([
+      testSlackInstance.id,
+      'C12345',
+      'typing',
+      0,
+      {
+        threadId: '1234567890.001',
+        status: 'analisando contexto...',
+        loadingMessages: ['Lendo contexto...', 'Chamando ferramentas...'],
+      },
+    ]);
   });
 
   test('validates duration bounds (max 30000)', async () => {

--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-handoff.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-handoff.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for triggerErrorHandoff — the system-initiated handoff on agent errors
+ * for native-handoff channels (Gupshup).
+ *
+ * The critical invariant (gemini review on #741): once the HANDOFF message is
+ * delivered, a failure in the persistence side-effects must STILL return true,
+ * so the caller does NOT send a second (plain error) message to the user.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+// Configurable plugin mock for `getPlugin`. Tests mutate `pluginState` per case.
+const pluginState: {
+  canHandoff: boolean;
+  sendMessage: (...args: unknown[]) => Promise<{ success: boolean; messageId?: string; error?: string }>;
+} = {
+  canHandoff: true,
+  sendMessage: mock(() => Promise.resolve({ success: true, messageId: 'msg-1' })),
+};
+
+mock.module('../loader', () => ({
+  getPlugin: mock(() =>
+    Promise.resolve({
+      capabilities: { canHandoff: pluginState.canHandoff },
+      sendMessage: pluginState.sendMessage,
+    }),
+  ),
+}));
+
+import { triggerErrorHandoff } from '../agent-dispatcher';
+
+// Minimal stand-ins; only the fields triggerErrorHandoff touches are present.
+function makeServices(overrides: Record<string, unknown> = {}) {
+  return {
+    chats: {
+      findByExternalIdSmart: mock(() => Promise.resolve({ id: 'chat-uuid', settings: {} })),
+      update: mock(() => Promise.resolve(undefined)),
+    },
+    followUpLifecycle: { disarm: mock(() => Promise.resolve(undefined)) },
+    ...overrides,
+  } as never;
+}
+
+function makeDb() {
+  return { insert: () => ({ values: mock(() => Promise.resolve(undefined)) }) } as never;
+}
+
+const instance = { id: 'inst-1', agentId: 'agent-1' } as never;
+
+describe('triggerErrorHandoff', () => {
+  it('returns false on a non-handoff channel (no message sent)', async () => {
+    pluginState.canHandoff = false;
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'whatsapp' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(false);
+    pluginState.canHandoff = true;
+  });
+
+  it('returns false when the HANDOFF message delivery throws (safe to fall back)', async () => {
+    pluginState.sendMessage = mock(() => Promise.reject(new Error('network down')));
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(false);
+    pluginState.sendMessage = mock(() => Promise.resolve({ success: true, messageId: 'msg-1' }));
+  });
+
+  it('returns false when sendMessage reports success:false (not connected / rejected)', async () => {
+    // Gupshup returns { success:false } without throwing — must still fall back,
+    // not pause the agent and swallow the message.
+    pluginState.sendMessage = mock(() => Promise.resolve({ success: false, error: 'not connected' }));
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(false);
+    pluginState.sendMessage = mock(() => Promise.resolve({ success: true, messageId: 'msg-1' }));
+  });
+
+  it('returns true even when a side-effect fails — no double message', async () => {
+    // Message delivered, but chats.update throws. Must still return true.
+    const services = makeServices({
+      chats: {
+        findByExternalIdSmart: mock(() => Promise.resolve({ id: 'chat-uuid', settings: {} })),
+        update: mock(() => Promise.reject(new Error('db down'))),
+      },
+    });
+    const ok = await triggerErrorHandoff(services, makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(true);
+  });
+
+  it('returns true on the happy path (message + side-effects persisted)', async () => {
+    const ok = await triggerErrorHandoff(makeServices(), makeDb(), 'gupshup' as never, instance, '5511999', 'oi');
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for resolveDispatchErrorMessage — issue #737.
+ *
+ * Precedence: per-instance `agentErrorMessage` → `OMNI_AGENT_DISPATCH_ERROR_MESSAGE`
+ * env → built-in default. Blank/whitespace values fall through to the next tier.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+// Mock the plugin loader to avoid real FS/channel-sdk imports — same pattern
+// as agent-dispatcher-retry.test.ts. Without this the module init crashes
+// loading the parent agent-dispatcher.ts.
+mock.module('../loader', () => ({
+  getPlugin: mock(() => Promise.resolve(undefined)),
+}));
+
+import { DEFAULT_DISPATCH_ERROR_MESSAGE, resolveDispatchErrorMessage } from '../agent-dispatcher';
+
+describe('resolveDispatchErrorMessage', () => {
+  it('falls back to the built-in default when nothing is configured', () => {
+    expect(resolveDispatchErrorMessage(null, {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+    expect(resolveDispatchErrorMessage(undefined, {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+  });
+
+  it('uses the env override when no per-instance value is set', () => {
+    const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'Estamos com um problema, tente novamente.' };
+    expect(resolveDispatchErrorMessage(null, env)).toBe('Estamos com um problema, tente novamente.');
+  });
+
+  it('prefers the per-instance value over env and default', () => {
+    const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env message' };
+    expect(resolveDispatchErrorMessage('instance message', env)).toBe('instance message');
+  });
+
+  it('ignores blank/whitespace-only values and falls through', () => {
+    const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: '  ' };
+    // Blank instance + blank env → default.
+    expect(resolveDispatchErrorMessage('   ', env)).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+    // Blank instance + valid env → env.
+    expect(resolveDispatchErrorMessage('  ', { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env msg' })).toBe('env msg');
+  });
+
+  it('trims surrounding whitespace from the resolved value', () => {
+    expect(resolveDispatchErrorMessage('  hi there  ', {})).toBe('hi there');
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
@@ -14,7 +14,12 @@ mock.module('../loader', () => ({
   getPlugin: mock(() => Promise.resolve(undefined)),
 }));
 
-import { DEFAULT_DISPATCH_ERROR_MESSAGE, resolveDispatchErrorMessage } from '../agent-dispatcher';
+import {
+  DEFAULT_DISPATCH_ERROR_MESSAGE,
+  DEFAULT_ERROR_HANDOFF_MESSAGE,
+  resolveDispatchErrorMessage,
+  resolveErrorHandoffMessage,
+} from '../agent-dispatcher';
 
 describe('resolveDispatchErrorMessage', () => {
   it('falls back to the built-in default when nothing is configured', () => {
@@ -42,5 +47,22 @@ describe('resolveDispatchErrorMessage', () => {
 
   it('trims surrounding whitespace from the resolved value', () => {
     expect(resolveDispatchErrorMessage('  hi there  ', {})).toBe('hi there');
+  });
+});
+
+describe('resolveErrorHandoffMessage', () => {
+  it('defaults to the built-in handoff message (promises a human, not a retry)', () => {
+    expect(resolveErrorHandoffMessage({})).toBe(DEFAULT_ERROR_HANDOFF_MESSAGE);
+    expect(DEFAULT_ERROR_HANDOFF_MESSAGE).toContain('entrar em contato');
+  });
+
+  it('honors OMNI_AGENT_ERROR_HANDOFF_MESSAGE', () => {
+    expect(resolveErrorHandoffMessage({ OMNI_AGENT_ERROR_HANDOFF_MESSAGE: 'A human will reach out shortly.' })).toBe(
+      'A human will reach out shortly.',
+    );
+  });
+
+  it('ignores a blank override and falls back to default', () => {
+    expect(resolveErrorHandoffMessage({ OMNI_AGENT_ERROR_HANDOFF_MESSAGE: '   ' })).toBe(DEFAULT_ERROR_HANDOFF_MESSAGE);
   });
 });

--- a/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, mock } from 'bun:test';
+import {
+  AgentDispatchLimiter,
+  AgentDispatchQueueFullError,
+  AgentDispatchQueueTimeoutError,
+  loadAgentDispatchLimiterConfig,
+} from '../agent-dispatch-limiter';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function logger() {
+  return {
+    debug: mock((_message: string, _fields?: Record<string, unknown>) => {}),
+    info: mock((_message: string, _fields?: Record<string, unknown>) => {}),
+    warn: mock((_message: string, _fields?: Record<string, unknown>) => {}),
+  };
+}
+
+async function flushStartedRuns() {
+  await Promise.resolve();
+}
+
+const CTX = { instanceId: 'inst-1', chatId: 'chat-1', traceId: 'trace-1' };
+
+describe('loadAgentDispatchLimiterConfig', () => {
+  it('uses safe defaults when env is empty', () => {
+    expect(loadAgentDispatchLimiterConfig({})).toEqual({
+      defaultConcurrency: 8,
+      maxQueueDepth: 100,
+      maxQueueWaitMs: 60_000,
+      perChatConcurrency: 1,
+    });
+  });
+
+  it('parses positive integer env overrides', () => {
+    expect(
+      loadAgentDispatchLimiterConfig({
+        OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT: '12',
+        OMNI_AGENT_DISPATCH_QUEUE_MAX_DEPTH: '50',
+        OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS: '30000',
+        OMNI_AGENT_DISPATCH_PER_CHAT_CONCURRENCY: '2',
+      }),
+    ).toEqual({
+      defaultConcurrency: 12,
+      maxQueueDepth: 50,
+      maxQueueWaitMs: 30_000,
+      perChatConcurrency: 2,
+    });
+  });
+
+  it('falls back and warns on invalid env values', () => {
+    const log = logger();
+    const cfg = loadAgentDispatchLimiterConfig({ OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT: '0' }, log);
+    expect(cfg.defaultConcurrency).toBe(8);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AgentDispatchLimiter', () => {
+  it('runs immediately under capacity', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const run = mock(async () => 'ok');
+
+    await expect(limiter.run(CTX, run)).resolves.toBe('ok');
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 0, queueDepth: 0 });
+  });
+
+  it('enqueues when global capacity is full and starts after completion', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const secondRun = mock(async () => 'second');
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const secondPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, secondRun);
+
+    expect(secondRun).toHaveBeenCalledTimes(0);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 1, queueDepth: 1 });
+
+    first.resolve();
+    await firstPromise;
+    await expect(secondPromise).resolves.toBe('second');
+    expect(secondRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes dispatches for the same chat by default', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 2, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const secondRun = mock(async () => 'second');
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const secondPromise = limiter.run(CTX, secondRun);
+
+    expect(secondRun).toHaveBeenCalledTimes(0);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 1, queueDepth: 1 });
+
+    first.resolve();
+    await firstPromise;
+    await expect(secondPromise).resolves.toBe('second');
+    expect(secondRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows different chats to run concurrently up to global capacity', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 2, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const second = deferred();
+    const firstRun = mock(async () => first.promise);
+    const secondRun = mock(async () => second.promise);
+
+    const firstPromise = limiter.run(CTX, firstRun);
+    const secondPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, secondRun);
+    await flushStartedRuns();
+
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondRun).toHaveBeenCalledTimes(1);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 2, queueDepth: 0 });
+
+    first.resolve();
+    second.resolve();
+    await firstPromise;
+    await secondPromise;
+  });
+
+  it('throws AgentDispatchQueueFullError when pending depth exceeds max', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 1, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const queuedPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, async () => 'queued');
+
+    await expect(limiter.run({ ...CTX, chatId: 'chat-3' }, async () => 'full')).rejects.toBeInstanceOf(
+      AgentDispatchQueueFullError,
+    );
+
+    first.resolve();
+    await firstPromise;
+    await queuedPromise;
+  });
+
+  it('throws AgentDispatchQueueTimeoutError when queued longer than max wait', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 5, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const timedOut = limiter.run({ ...CTX, chatId: 'chat-2' }, async () => 'too-late');
+
+    await expect(timedOut).rejects.toBeInstanceOf(AgentDispatchQueueTimeoutError);
+    first.resolve();
+    await firstPromise;
+  });
+
+  it('releases counters when callback throws', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 1, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+
+    await expect(
+      limiter.run(CTX, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 0, queueDepth: 0 });
+  });
+
+  it('does not deadlock behind a busy chat at the front of the queue', async () => {
+    const limiter = new AgentDispatchLimiter(
+      { defaultConcurrency: 2, maxQueueDepth: 10, maxQueueWaitMs: 1000, perChatConcurrency: 1 },
+      logger(),
+    );
+    const first = deferred();
+    const blocker = deferred();
+    const sameChatRun = mock(async () => 'same-chat');
+    const otherChatRun = mock(async () => blocker.promise);
+
+    const firstPromise = limiter.run(CTX, async () => first.promise);
+    const sameChatPromise = limiter.run(CTX, sameChatRun);
+    const otherChatPromise = limiter.run({ ...CTX, chatId: 'chat-2' }, otherChatRun);
+    await flushStartedRuns();
+
+    expect(sameChatRun).toHaveBeenCalledTimes(0);
+    expect(otherChatRun).toHaveBeenCalledTimes(1);
+    expect(limiter.getSnapshot('inst-1')).toMatchObject({ activeCount: 2, queueDepth: 1 });
+
+    blocker.resolve();
+    await otherChatPromise;
+    expect(sameChatRun).toHaveBeenCalledTimes(0);
+
+    first.resolve();
+    await firstPromise;
+    await expect(sameChatPromise).resolves.toBe('same-chat');
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-limiter.test.ts
@@ -35,7 +35,7 @@ describe('loadAgentDispatchLimiterConfig', () => {
     expect(loadAgentDispatchLimiterConfig({})).toEqual({
       defaultConcurrency: 8,
       maxQueueDepth: 100,
-      maxQueueWaitMs: 60_000,
+      maxQueueWaitMs: 600_000,
       perChatConcurrency: 1,
     });
   });

--- a/packages/api/src/plugins/__tests__/message-persistence.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence.test.ts
@@ -37,10 +37,7 @@ describe('extractPlatformTimestamp', () => {
   test('handles Long object (protobuf uint64) with non-zero low, zero high', () => {
     // Baileys emits messageTimestamp as { low, high, unsigned } after deepSanitize
     const ts = 1746665253; // 2025-05-08
-    const result = extractPlatformTimestamp(
-      { messageTimestamp: { low: ts, high: 0, unsigned: false } },
-      FALLBACK,
-    );
+    const result = extractPlatformTimestamp({ messageTimestamp: { low: ts, high: 0, unsigned: false } }, FALLBACK);
     expect(result).not.toBeNull();
     expect(result!.getTime()).toBe(ts * 1000);
   });
@@ -51,10 +48,7 @@ describe('extractPlatformTimestamp', () => {
     const hi = 1;
     const lo = 1;
     const expectedTs = hi * 0x100000000 + lo; // 4294967297 seconds
-    const result = extractPlatformTimestamp(
-      { messageTimestamp: { low: lo, high: hi, unsigned: false } },
-      FALLBACK,
-    );
+    const result = extractPlatformTimestamp({ messageTimestamp: { low: lo, high: hi, unsigned: false } }, FALLBACK);
     expect(result).not.toBeNull();
     expect(result!.getTime()).toBe(expectedTs * 1000);
   });

--- a/packages/api/src/plugins/__tests__/message-persistence.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { extractPlatformTimestamp } from '../message-persistence';
+
+describe('extractPlatformTimestamp', () => {
+  const FALLBACK = Date.now();
+
+  test('returns null when rawPayload is undefined', () => {
+    expect(extractPlatformTimestamp(undefined, FALLBACK)).toBeNull();
+  });
+
+  test('returns null when messageTimestamp is missing', () => {
+    expect(extractPlatformTimestamp({}, FALLBACK)).toBeNull();
+  });
+
+  test('returns null when messageTimestamp is 0', () => {
+    expect(extractPlatformTimestamp({ messageTimestamp: 0 }, FALLBACK)).toBeNull();
+  });
+
+  test('returns null when messageTimestamp is empty string', () => {
+    expect(extractPlatformTimestamp({ messageTimestamp: '' }, FALLBACK)).toBeNull();
+  });
+
+  test('handles number timestamp in seconds', () => {
+    const ts = 1746665253; // 2025-05-08
+    const result = extractPlatformTimestamp({ messageTimestamp: ts }, FALLBACK);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(ts * 1000);
+  });
+
+  test('handles string timestamp in seconds', () => {
+    const ts = '1746665253';
+    const result = extractPlatformTimestamp({ messageTimestamp: ts }, FALLBACK);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(1746665253 * 1000);
+  });
+
+  test('handles Long object (protobuf uint64) with non-zero low, zero high', () => {
+    // Baileys emits messageTimestamp as { low, high, unsigned } after deepSanitize
+    const ts = 1746665253; // 2025-05-08
+    const result = extractPlatformTimestamp(
+      { messageTimestamp: { low: ts, high: 0, unsigned: false } },
+      FALLBACK,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(ts * 1000);
+  });
+
+  test('handles Long object with high bits set (timestamps after 2038)', () => {
+    // 2^32 = 4294967296; simulate ts = 4294967296 + 1 (just past the 2038 boundary)
+    // In a signed int32, this would be low = 1, high = 1
+    const hi = 1;
+    const lo = 1;
+    const expectedTs = hi * 0x100000000 + lo; // 4294967297 seconds
+    const result = extractPlatformTimestamp(
+      { messageTimestamp: { low: lo, high: hi, unsigned: false } },
+      FALLBACK,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(expectedTs * 1000);
+  });
+
+  test('Long with negative low (signed int32 > 2^31 seconds) reconstructs correctly via >>> 0', () => {
+    // 2147483648 = 0x80000000 — in int32 this is -2147483648
+    // This is January 19, 2038 03:14:08 UTC
+    const tsSeconds = 2147483648;
+    // In a Long: high = 0, low = -2147483648 (signed int32 wrapping)
+    const signedLow = -2147483648; // 0x80000000 as int32
+    const result = extractPlatformTimestamp(
+      { messageTimestamp: { low: signedLow, high: 0, unsigned: false } },
+      FALLBACK,
+    );
+    expect(result).not.toBeNull();
+    // (signedLow >>> 0) = 2147483648, which is the correct seconds value
+    expect(result!.getTime()).toBe(tsSeconds * 1000);
+  });
+
+  test('handles already-millisecond timestamp (>= 1e12)', () => {
+    const tsMs = 1746665253000; // already in ms
+    const result = extractPlatformTimestamp({ messageTimestamp: tsMs }, FALLBACK);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(tsMs);
+  });
+
+  test('does NOT fall back to fallback when messageTimestamp is present', () => {
+    const ts = 1746665253;
+    const wrongFallback = Date.now(); // very different from ts
+    const result = extractPlatformTimestamp({ messageTimestamp: ts }, wrongFallback);
+    expect(result).not.toBeNull();
+    expect(result!.getTime()).toBe(ts * 1000);
+    expect(result!.getTime()).not.toBeCloseTo(wrongFallback, -3);
+  });
+});

--- a/packages/api/src/plugins/agent-dispatch-limiter.ts
+++ b/packages/api/src/plugins/agent-dispatch-limiter.ts
@@ -1,0 +1,268 @@
+const DEFAULT_AGENT_DISPATCH_CONCURRENCY = 8;
+const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_DEPTH = 100;
+const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS = 60_000;
+const DEFAULT_AGENT_DISPATCH_PER_CHAT_CONCURRENCY = 1;
+
+interface LoggerLike {
+  debug: (message: string, fields?: Record<string, unknown>) => void;
+  info: (message: string, fields?: Record<string, unknown>) => void;
+  warn: (message: string, fields?: Record<string, unknown>) => void;
+}
+
+export interface AgentDispatchLimiterConfig {
+  defaultConcurrency: number;
+  maxQueueDepth: number;
+  maxQueueWaitMs: number;
+  perChatConcurrency: number;
+}
+
+export interface AgentDispatchContext {
+  instanceId: string;
+  chatId: string;
+  traceId?: string;
+}
+
+export interface AgentDispatchQueueSnapshot {
+  [key: string]: unknown;
+  instanceId: string;
+  chatId: string;
+  traceId?: string;
+  activeCount: number;
+  queueDepth: number;
+  maxConcurrency: number;
+  maxQueueDepth: number;
+  waitMs?: number;
+}
+
+interface InstanceQueue {
+  instanceId: string;
+  activeCount: number;
+  pending: QueueItem<unknown>[];
+}
+
+interface QueueItem<T> {
+  context: AgentDispatchContext;
+  enqueuedAt: number;
+  run: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+  timeout: ReturnType<typeof setTimeout> | null;
+}
+
+export class AgentDispatchQueueFullError extends Error {
+  constructor(public readonly snapshot: AgentDispatchQueueSnapshot) {
+    super(
+      `Agent dispatch queue full for instance ${snapshot.instanceId}: ${snapshot.queueDepth}/${snapshot.maxQueueDepth} pending`,
+    );
+    this.name = 'AgentDispatchQueueFullError';
+  }
+}
+
+export class AgentDispatchQueueTimeoutError extends Error {
+  constructor(public readonly snapshot: AgentDispatchQueueSnapshot) {
+    super(
+      `Agent dispatch queue timed out for instance ${snapshot.instanceId} chat ${snapshot.chatId} after ${snapshot.waitMs ?? 0}ms`,
+    );
+    this.name = 'AgentDispatchQueueTimeoutError';
+  }
+}
+
+function parsePositiveInt(
+  env: Record<string, string | undefined>,
+  key: string,
+  fallback: number,
+  logger?: Pick<LoggerLike, 'warn'>,
+): number {
+  const raw = env[key];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger?.warn('Invalid agent dispatch limiter env value, using default', { key, value: raw, fallback });
+    return fallback;
+  }
+  return parsed;
+}
+
+export function loadAgentDispatchLimiterConfig(
+  env: Record<string, string | undefined> = process.env,
+  logger?: Pick<LoggerLike, 'warn'>,
+): AgentDispatchLimiterConfig {
+  return {
+    defaultConcurrency: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_CONCURRENCY_DEFAULT',
+      DEFAULT_AGENT_DISPATCH_CONCURRENCY,
+      logger,
+    ),
+    maxQueueDepth: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_QUEUE_MAX_DEPTH',
+      DEFAULT_AGENT_DISPATCH_QUEUE_MAX_DEPTH,
+      logger,
+    ),
+    maxQueueWaitMs: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS',
+      DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS,
+      logger,
+    ),
+    perChatConcurrency: parsePositiveInt(
+      env,
+      'OMNI_AGENT_DISPATCH_PER_CHAT_CONCURRENCY',
+      DEFAULT_AGENT_DISPATCH_PER_CHAT_CONCURRENCY,
+      logger,
+    ),
+  };
+}
+
+export class AgentDispatchLimiter {
+  private readonly queues = new Map<string, InstanceQueue>();
+  private readonly chatActiveCounts = new Map<string, number>();
+
+  constructor(
+    private readonly config: AgentDispatchLimiterConfig,
+    private readonly logger?: LoggerLike,
+  ) {}
+
+  run<T>(context: AgentDispatchContext, run: () => Promise<T>): Promise<T> {
+    const queue = this.getQueue(context.instanceId);
+    if (this.canStart(queue, context)) {
+      return new Promise<T>((resolve, reject) => {
+        this.startItem(queue, {
+          context,
+          enqueuedAt: Date.now(),
+          run,
+          resolve,
+          reject,
+          timeout: null,
+        });
+      });
+    }
+
+    if (queue.pending.length >= this.config.maxQueueDepth) {
+      const snapshot = this.snapshot(queue, context);
+      this.logger?.warn('agent_dispatch_queue_full', snapshot);
+      return Promise.reject(new AgentDispatchQueueFullError(snapshot));
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const item: QueueItem<T> = {
+        context,
+        enqueuedAt: Date.now(),
+        run,
+        resolve,
+        reject,
+        timeout: null,
+      };
+      item.timeout = setTimeout(() => {
+        const idx = queue.pending.indexOf(item as QueueItem<unknown>);
+        if (idx < 0) return;
+        queue.pending.splice(idx, 1);
+        const snapshot = this.snapshot(queue, context, Date.now() - item.enqueuedAt);
+        this.logger?.warn('agent_dispatch_queue_timeout', snapshot);
+        reject(new AgentDispatchQueueTimeoutError(snapshot));
+        this.drain(queue);
+      }, this.config.maxQueueWaitMs);
+      if (typeof item.timeout === 'object' && item.timeout && 'unref' in item.timeout) {
+        item.timeout.unref();
+      }
+
+      queue.pending.push(item as QueueItem<unknown>);
+      this.logger?.info('agent_dispatch_queue_enqueued', this.snapshot(queue, context));
+      this.drain(queue);
+    });
+  }
+
+  getSnapshot(instanceId: string): {
+    activeCount: number;
+    queueDepth: number;
+    maxConcurrency: number;
+    maxQueueDepth: number;
+  } {
+    const queue = this.getQueue(instanceId);
+    return {
+      activeCount: queue.activeCount,
+      queueDepth: queue.pending.length,
+      maxConcurrency: this.config.defaultConcurrency,
+      maxQueueDepth: this.config.maxQueueDepth,
+    };
+  }
+
+  private getQueue(instanceId: string): InstanceQueue {
+    let queue = this.queues.get(instanceId);
+    if (!queue) {
+      queue = { instanceId, activeCount: 0, pending: [] };
+      this.queues.set(instanceId, queue);
+    }
+    return queue;
+  }
+
+  private canStart(queue: InstanceQueue, context: AgentDispatchContext): boolean {
+    return (
+      queue.activeCount < this.config.defaultConcurrency &&
+      (this.chatActiveCounts.get(this.chatKey(context)) ?? 0) < this.config.perChatConcurrency
+    );
+  }
+
+  private startItem<T>(queue: InstanceQueue, item: QueueItem<T>): void {
+    if (item.timeout) {
+      clearTimeout(item.timeout);
+      item.timeout = null;
+    }
+    const chatKey = this.chatKey(item.context);
+    queue.activeCount += 1;
+    this.chatActiveCounts.set(chatKey, (this.chatActiveCounts.get(chatKey) ?? 0) + 1);
+    const queueWaitMs = Date.now() - item.enqueuedAt;
+    this.logger?.info('agent_dispatch_queue_started', this.snapshot(queue, item.context, queueWaitMs));
+
+    Promise.resolve()
+      .then(item.run)
+      .then(item.resolve, item.reject)
+      .finally(() => {
+        queue.activeCount = Math.max(0, queue.activeCount - 1);
+        const chatActive = (this.chatActiveCounts.get(chatKey) ?? 1) - 1;
+        if (chatActive > 0) {
+          this.chatActiveCounts.set(chatKey, chatActive);
+        } else {
+          this.chatActiveCounts.delete(chatKey);
+        }
+        this.logger?.info(
+          'agent_dispatch_queue_finished',
+          this.snapshot(queue, item.context, Date.now() - item.enqueuedAt),
+        );
+        this.drain(queue);
+      });
+  }
+
+  private drain(queue: InstanceQueue): void {
+    let started = true;
+    while (started && queue.activeCount < this.config.defaultConcurrency) {
+      started = false;
+      for (let i = 0; i < queue.pending.length; i += 1) {
+        const item = queue.pending[i];
+        if (!item || !this.canStart(queue, item.context)) continue;
+        queue.pending.splice(i, 1);
+        this.startItem(queue, item);
+        started = true;
+        break;
+      }
+    }
+  }
+
+  private snapshot(queue: InstanceQueue, context: AgentDispatchContext, waitMs?: number): AgentDispatchQueueSnapshot {
+    return {
+      instanceId: context.instanceId,
+      chatId: context.chatId,
+      traceId: context.traceId,
+      activeCount: queue.activeCount,
+      queueDepth: queue.pending.length,
+      maxConcurrency: this.config.defaultConcurrency,
+      maxQueueDepth: this.config.maxQueueDepth,
+      waitMs,
+    };
+  }
+
+  private chatKey(context: AgentDispatchContext): string {
+    return `${context.instanceId}:${context.chatId}`;
+  }
+}

--- a/packages/api/src/plugins/agent-dispatch-limiter.ts
+++ b/packages/api/src/plugins/agent-dispatch-limiter.ts
@@ -1,6 +1,9 @@
 const DEFAULT_AGENT_DISPATCH_CONCURRENCY = 8;
 const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_DEPTH = 100;
-const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS = 60_000;
+// #738 — raised 60s → 600s so legitimately long agent runs (multi-tool loops,
+// slow upstream LLM/gateway) are not failed at the queue-wait gate. Override
+// via OMNI_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS.
+const DEFAULT_AGENT_DISPATCH_QUEUE_MAX_WAIT_MS = 600_000;
 const DEFAULT_AGENT_DISPATCH_PER_CHAT_CONCURRENCY = 1;
 
 interface LoggerLike {

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -527,19 +527,54 @@ async function sendTextMessage(
 }
 
 /**
+ * Built-in dispatch-failure message (#737). Kept in English for backwards
+ * compatibility — non-English deployments override it globally via the
+ * `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env var (a per-instance override tier is
+ * a planned follow-up; see {@link resolveDispatchErrorMessage}).
+ */
+export const DEFAULT_DISPATCH_ERROR_MESSAGE = '⚠️ Sorry, I ran into an issue processing your message. Please try again.';
+
+/**
+ * Resolve the customer-facing dispatch-failure message (#737). Precedence:
+ *   1. per-instance override (localized per deployment),
+ *   2. `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env (global override),
+ *   3. {@link DEFAULT_DISPATCH_ERROR_MESSAGE}.
+ * Blank/whitespace-only values are ignored so they fall through to the next tier.
+ *
+ * NOTE: the per-instance tier is wired through the first argument but no
+ * `instances` column exists yet — callers pass `null` today and rely on the
+ * env override. The column is a follow-up, deferred until the Drizzle snapshot
+ * drift in `packages/db` is reconciled (re-adding it now would re-propose
+ * already-migrated columns and crash auto-migrate). The tier is kept here +
+ * tested so dropping the column in is a one-line call-site change.
+ */
+export function resolveDispatchErrorMessage(
+  instanceErrorMessage: string | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const instanceMsg = instanceErrorMessage?.trim();
+  if (instanceMsg) return instanceMsg;
+  const envMsg = env.OMNI_AGENT_DISPATCH_ERROR_MESSAGE?.trim();
+  if (envMsg) return envMsg;
+  return DEFAULT_DISPATCH_ERROR_MESSAGE;
+}
+
+/**
  * Send error feedback to user when agent dispatch fails.
  * Fire-and-forget — errors during feedback delivery are silently swallowed.
+ * `message` is the already-resolved customer-facing text (see
+ * {@link resolveDispatchErrorMessage}).
  */
 async function sendErrorFeedback(
   channel: ChannelType,
   instanceId: string,
   chatId: string,
   error: unknown,
+  message: string,
 ): Promise<void> {
   const errorMsg = error instanceof Error ? error.message : String(error);
   log.error('agent_dispatch_error', { channel, instanceId, chatId, error: errorMsg });
-  const text = '⚠️ Sorry, I ran into an issue processing your message. Please try again.';
-  await sendTextMessage(channel, instanceId, chatId, text);
+  await sendTextMessage(channel, instanceId, chatId, message);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -3336,7 +3371,9 @@ async function processAgentResponse(
   // messages that arrived during the handoff window and should not be processed.
   if (chatSettings?.agentResumedAt) {
     const resumedAt = new Date(chatSettings.agentResumedAt).getTime();
-    const msgTimestamp = (extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()) ?? new Date()).getTime();
+    const msgTimestamp = (
+      extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()) ?? new Date()
+    ).getTime();
     if (msgTimestamp < resumedAt) {
       log.debug('Dropping pre-resume message (arrived during handoff window)', {
         instanceId: instance.id,
@@ -3426,7 +3463,15 @@ async function processAgentResponse(
       error: String(error),
       traceId,
     });
-    sendErrorFeedback(channel, instance.id, chatId, error).catch(() => {});
+    sendErrorFeedback(
+      channel,
+      instance.id,
+      chatId,
+      error,
+      // Per-instance override tier is null until the `agentErrorMessage` column
+      // lands (see resolveDispatchErrorMessage note) — env + default for now.
+      resolveDispatchErrorMessage(null),
+    ).catch(() => {});
   } finally {
     ackHandle.remove();
   }
@@ -3499,7 +3544,7 @@ function createOpenClawProviderInstance(provider: AgentProvider, instance: Dispa
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
   const providerConfig: OpenClawProviderConfig = {
     defaultAgentId: resolveRequiredAgentId(instance, schemaConfig, provider.id, 'defaultAgentId'),
-    agentTimeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 120) as number) * 1000,
+    agentTimeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 600) as number) * 1000,
     sendAckTimeoutMs: 10_000,
     prefixSenderName: instance.agentPrefixSenderName ?? true,
   };
@@ -3569,7 +3614,7 @@ function createClaudeCodeProviderInstance(
     },
     createSessionStorage(db, provider.id),
     {
-      timeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 120) as number) * 1000,
+      timeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 600) as number) * 1000,
       enableAutoSplit: instance.enableAutoSplit ?? true,
       prefixSenderName: instance.agentPrefixSenderName ?? true,
       streamConfig: schemaConfig.streamConfig as
@@ -3592,7 +3637,9 @@ function createWebhookProvider(provider: AgentProvider): IAgentProvider {
     webhookUrl: provider.baseUrl,
     apiKey: provider.apiKey ?? undefined,
     mode: (schemaConfig.mode as 'round-trip' | 'fire-and-forget') ?? 'round-trip',
-    timeoutMs: (provider.defaultTimeout ?? 30) * 1000,
+    // #738 — aligned to the 600s provider default (was 30s) so webhook agents
+    // get the same budget as every other provider when no explicit timeout set.
+    timeoutMs: (provider.defaultTimeout ?? 600) * 1000,
     retries: (schemaConfig.retries as number) ?? 1,
   });
 }

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3336,7 +3336,7 @@ async function processAgentResponse(
   // messages that arrived during the handoff window and should not be processed.
   if (chatSettings?.agentResumedAt) {
     const resumedAt = new Date(chatSettings.agentResumedAt).getTime();
-    const msgTimestamp = extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()).getTime();
+    const msgTimestamp = (extractPlatformTimestamp(firstMessage.payload.rawPayload, Date.now()) ?? new Date()).getTime();
     if (msgTimestamp < resumedAt) {
       log.debug('Dropping pre-resume message (arrived during handoff window)', {
         instanceId: instance.id,
@@ -4334,7 +4334,7 @@ export function isInboundTooStale(
   if (maxAgeMinutes <= 0) {
     return { stale: false, ageMs: 0, maxAgeMs };
   }
-  const platformTs = extractPlatformTimestamp(rawPayload, now);
+  const platformTs = extractPlatformTimestamp(rawPayload, now) ?? new Date(now);
   const ageMs = now - platformTs.getTime();
   return { stale: ageMs > maxAgeMs, ageMs, maxAgeMs };
 }

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -65,7 +65,7 @@ import {
   getJourneyTracker,
 } from '@omni/core';
 import type { AgentProvider, Database } from '@omni/db';
-import { agentSessions, agents, instances } from '@omni/db';
+import { agentSessions, agents, handoffLogs, instances } from '@omni/db';
 import type { ChannelType, Instance } from '@omni/db';
 import { createMediaProcessingService } from '@omni/media-processing';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
@@ -575,6 +575,125 @@ async function sendErrorFeedback(
   const errorMsg = error instanceof Error ? error.message : String(error);
   log.error('agent_dispatch_error', { channel, instanceId, chatId, error: errorMsg });
   await sendTextMessage(channel, instanceId, chatId, message);
+}
+
+/**
+ * Default message sent to the customer when an agent error triggers a human
+ * handoff on a native-handoff channel (Gupshup). Distinct from
+ * {@link DEFAULT_DISPATCH_ERROR_MESSAGE}: this one promises a human follow-up
+ * (the chat is routed to an attendant) instead of asking the user to retry.
+ * Override globally with `OMNI_AGENT_ERROR_HANDOFF_MESSAGE`.
+ */
+export const DEFAULT_ERROR_HANDOFF_MESSAGE =
+  'Tô com um probleminha técnico aqui agora. Logo alguém do time vai entrar em contato com você.';
+
+/** Resolve the error-handoff message: env override → built-in default. */
+export function resolveErrorHandoffMessage(env: Record<string, string | undefined> = process.env): string {
+  return env.OMNI_AGENT_ERROR_HANDOFF_MESSAGE?.trim() || DEFAULT_ERROR_HANDOFF_MESSAGE;
+}
+
+/**
+ * System-initiated handoff when a customer-facing agent error occurs on a
+ * channel with native handoff (Gupshup). Mirrors the side-effects of
+ * `POST /messages/send/handoff` (routes/v2/messages.ts): deliver `message` AS
+ * the native HANDOFF payload (which both shows the text and routes the chat to
+ * a human queue), pause the agent, disarm follow-ups, and write an audit row.
+ *
+ * Returns `true` when the handoff was dispatched; the caller falls back to the
+ * plain error message when this returns `false` (non-handoff channel, missing
+ * plugin, or a delivery failure).
+ */
+export async function triggerErrorHandoff(
+  services: Services,
+  db: Database,
+  channel: ChannelType,
+  instance: DispatchInstance,
+  chatId: string,
+  message: string,
+): Promise<boolean> {
+  const plugin = await getPlugin(channel);
+  if (plugin?.capabilities?.canHandoff !== true) return false;
+
+  // Step 1 — deliver the HANDOFF payload. ONLY a delivery failure may return
+  // false (the user got nothing, so the caller's plain-error fallback is safe).
+  // Channel sendMessage signals failure two ways: a thrown error OR a falsy
+  // `success` flag (e.g. Gupshup returns { success:false } when the instance
+  // isn't connected or the provider rejects) — both must short-circuit here,
+  // else we'd pause the agent and suppress the fallback while the user got
+  // nothing.
+  let sendResult: Awaited<ReturnType<typeof plugin.sendMessage>>;
+  try {
+    sendResult = await plugin.sendMessage(instance.id, {
+      to: chatId,
+      content: { type: 'text', text: message },
+      metadata: { isHandoff: true, motivoHandoff: 'agent_dispatch_error' },
+    });
+  } catch (err) {
+    log.error('agent_dispatch_error_handoff_failed', { instanceId: instance.id, chatId, error: String(err) });
+    return false;
+  }
+  if (!sendResult?.success) {
+    log.error('agent_dispatch_error_handoff_delivery_failed', {
+      instanceId: instance.id,
+      chatId,
+      error: sendResult?.error,
+    });
+    return false;
+  }
+
+  // Step 2 — persist side-effects (pause + disarm + audit) best-effort. The
+  // message already reached the user, so a failure here must NOT flip the result
+  // to false — that would make the caller send a SECOND (plain error) message.
+  try {
+    const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
+    if (chat) {
+      const settings = (chat.settings as Record<string, unknown> | null) ?? {};
+      await services.chats.update(chat.id, { settings: { ...settings, agentPaused: true } });
+      await services.followUpLifecycle.disarm({ chatId: chat.id, instanceId: instance.id, reason: 'handoff' });
+      await db.insert(handoffLogs).values({
+        instanceId: instance.id,
+        chatUuid: chat.id,
+        chatId,
+        toPhone: chatId,
+        text: message,
+        extraInfo: null,
+        agentId: instance.agentId ?? null,
+        externalMessageId: sendResult?.messageId ?? null,
+        handoffFields: null,
+        sentAt: new Date(),
+        metadata: { instanceChannel: channel, channelHandoffSupported: true, motivoHandoff: 'agent_dispatch_error' },
+      });
+    }
+  } catch (err) {
+    log.warn('agent_dispatch_error_handoff_side_effects_failed', {
+      instanceId: instance.id,
+      chatId,
+      error: String(err),
+    });
+  }
+
+  log.info('agent_dispatch_error_handoff', { instanceId: instance.id, chatId, channel });
+  return true;
+}
+
+/**
+ * Customer-facing handling of a fatal dispatch failure: a human handoff on
+ * native-handoff channels (Gupshup — special message + agent pause), otherwise
+ * the plain {@link resolveDispatchErrorMessage} reply.
+ */
+async function handleDispatchFailure(
+  services: Services,
+  db: Database,
+  channel: ChannelType,
+  instance: DispatchInstance,
+  chatId: string,
+  error: unknown,
+): Promise<void> {
+  const handedOff = await triggerErrorHandoff(services, db, channel, instance, chatId, resolveErrorHandoffMessage());
+  if (handedOff) return;
+  // Per-instance override tier is null until the `agentErrorMessage` column
+  // lands (see resolveDispatchErrorMessage note) — env + default for now.
+  await sendErrorFeedback(channel, instance.id, chatId, error, resolveDispatchErrorMessage(null)).catch(() => {});
 }
 
 function sleep(ms: number): Promise<void> {
@@ -2463,7 +2582,23 @@ async function dispatchViaProvider(
       const chatAfterRun = await services.chats.findByExternalIdSmart(instance.id, chatId);
       const handoffTriggered = (chatAfterRun?.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
 
-      if (result && result.parts.length > 0 && !handoffTriggered) {
+      // When the provider blocked a leaked error and substituted the customer-safe
+      // fallback, route to a human on native-handoff channels (Gupshup) instead of
+      // forwarding the generic fallback text. Non-handoff channels fall through and
+      // send the fallback parts as before.
+      let errorHandoffDone = false;
+      if (result?.metadata.customerErrorBlocked === true && !handoffTriggered) {
+        errorHandoffDone = await triggerErrorHandoff(
+          services,
+          db,
+          channel,
+          instance,
+          chatId,
+          resolveErrorHandoffMessage(),
+        );
+      }
+
+      if (result && result.parts.length > 0 && !handoffTriggered && !errorHandoffDone) {
         const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
         const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
         // Apply before_message_write hooks to each response part before sending
@@ -3463,15 +3598,7 @@ async function processAgentResponse(
       error: String(error),
       traceId,
     });
-    sendErrorFeedback(
-      channel,
-      instance.id,
-      chatId,
-      error,
-      // Per-instance override tier is null until the `agentErrorMessage` column
-      // lands (see resolveDispatchErrorMessage note) — env + default for now.
-      resolveDispatchErrorMessage(null),
-    ).catch(() => {});
+    await handleDispatchFailure(services, db, channel, instance, chatId, error);
   } finally {
     ackHandle.remove();
   }

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -86,6 +86,7 @@ import { resolveKhalSessionId } from '../services/agent-session-identity';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
+import { AgentDispatchLimiter, loadAgentDispatchLimiterConfig } from './agent-dispatch-limiter';
 import { getPlugin } from './loader';
 import {
   type BufferedMessage,
@@ -97,6 +98,7 @@ import { extractPlatformTimestamp } from './message-persistence';
 import { createSessionStorage } from './session-storage';
 
 const log = createLogger('agent-dispatcher');
+const agentDispatchLimiter = new AgentDispatchLimiter(loadAgentDispatchLimiterConfig(process.env, log), log);
 
 /**
  * Test-only DI hook for NatsGenieProvider constructor. In production this is
@@ -3369,48 +3371,54 @@ async function processAgentResponse(
     senderAgentId,
   });
 
-  await sendTypingPresence(channel, instance.id, chatId, 'composing');
-
   // ── Auto-ack text message (pre-dispatch, fire-and-forget) ──
   const inst = instance as unknown as Record<string, unknown>;
   const agentAckMessage = (inst.agentAckMessage as string) ?? null;
-  if (agentAckMessage) {
-    sendTextMessage(channel, instance.id, chatId, agentAckMessage).catch((err) => {
-      log.warn('Failed to send agent ack message', { instanceId: instance.id, chatId, error: String(err) });
-    });
-  }
-
-  // ── Per-thread lazy init ──
-  const perThreadExtraContext = await resolvePerThreadExtraContext(
-    db,
-    services,
-    instance,
-    channel,
-    chatId,
-    senderId,
-    firstMessage,
-  );
 
   try {
-    await runWithTransientDispatchRetry(
-      () =>
-        dispatchToAgent(
+    await agentDispatchLimiter.run({ instanceId: instance.id, chatId, traceId }, async () => {
+      await sendTypingPresence(channel, instance.id, chatId, 'composing');
+      try {
+        if (agentAckMessage) {
+          sendTextMessage(channel, instance.id, chatId, agentAckMessage).catch((err) => {
+            log.warn('Failed to send agent ack message', { instanceId: instance.id, chatId, error: String(err) });
+          });
+        }
+
+        // ── Per-thread lazy init ──
+        const perThreadExtraContext = await resolvePerThreadExtraContext(
+          db,
           services,
           instance,
-          messages,
-          triggerType,
           channel,
           chatId,
           senderId,
-          personId,
-          senderName,
-          traceId,
-          senderAgentId,
-          perThreadExtraContext,
-          db,
-        ),
-      { instanceId: instance.id, chatId, traceId },
-    );
+          firstMessage,
+        );
+
+        await runWithTransientDispatchRetry(
+          () =>
+            dispatchToAgent(
+              services,
+              instance,
+              messages,
+              triggerType,
+              channel,
+              chatId,
+              senderId,
+              personId,
+              senderName,
+              traceId,
+              senderAgentId,
+              perThreadExtraContext,
+              db,
+            ),
+          { instanceId: instance.id, chatId, traceId },
+        );
+      } finally {
+        await sendTypingPresence(channel, instance.id, chatId, 'paused');
+      }
+    });
   } catch (error) {
     log.error('agent_dispatch_failed_after_retries', {
       instanceId: instance.id,
@@ -3421,7 +3429,6 @@ async function processAgentResponse(
     sendErrorFeedback(channel, instance.id, chatId, error).catch(() => {});
   } finally {
     ackHandle.remove();
-    await sendTypingPresence(channel, instance.id, chatId, 'paused');
   }
 }
 

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -5,7 +5,8 @@
  * This is the bridge between the event-based system and the unified message model.
  *
  * Flow:
- * - message.received → find/create chat → create message (source: 'realtime')
+ * - message.received (realtime)     → find/create chat → create message (source: 'realtime')
+ * - message.received (history-sync) → find/create chat → create message (source: 'sync')
  * - message.sent → find/create chat → create message (source: 'realtime', isFromMe: true)
  * - message.delivered/read → update message delivery status
  *
@@ -150,10 +151,14 @@ function findLongStrings(obj: unknown, prefix = '', minLength = 200): Record<str
 }
 
 /**
- * Extract platform timestamp from raw payload
+ * Extract platform timestamp from raw payload.
+ * Returns null when no timestamp can be extracted (caller decides what to do).
  */
-export function extractPlatformTimestamp(rawPayload: Record<string, unknown> | undefined, fallback: number): Date {
-  if (!rawPayload?.messageTimestamp) return new Date(fallback);
+export function extractPlatformTimestamp(
+  rawPayload: Record<string, unknown> | undefined,
+  _fallback: number,
+): Date | null {
+  if (!rawPayload?.messageTimestamp) return null;
 
   const ts = rawPayload.messageTimestamp;
   let tsNum: number | null = null;
@@ -164,10 +169,14 @@ export function extractPlatformTimestamp(rawPayload: Record<string, unknown> | u
     tsNum = Number(ts);
   } else if (typeof ts === 'object' && ts !== null && 'low' in ts) {
     // Protobuf Long format: { low: number, high: number, unsigned: boolean }
-    tsNum = (ts as { low: number }).low;
+    // Use unsigned right-shift (>>> 0) to treat both halves as uint32 before combining,
+    // so timestamps after 2038 (where low bit 31 is set) reconstruct correctly.
+    const lo = (ts as { low: number; high?: number }).low >>> 0;
+    const hi = ((ts as { low: number; high?: number }).high ?? 0) >>> 0;
+    tsNum = hi * 0x100000000 + lo;
   }
 
-  if (!tsNum || Number.isNaN(tsNum)) return new Date(fallback);
+  if (!tsNum || Number.isNaN(tsNum)) return null;
 
   // WhatsApp timestamps are in seconds, convert to milliseconds
   return new Date(tsNum < 1e12 ? tsNum * 1000 : tsNum);
@@ -390,6 +399,7 @@ interface MessageMetadata {
   personId?: string;
   platformIdentityId?: string;
   channelType?: string;
+  ingestMode?: 'realtime' | 'history-sync';
 }
 
 /** Check if a chat name should be updated given a new incoming name */
@@ -631,6 +641,7 @@ async function handleMessageReceived(
   eventTimestamp: number,
 ): Promise<void> {
   const channel = (metadata.channelType ?? 'whatsapp') as ChannelType;
+  const isHistorySync = metadata.ingestMode === 'history-sync';
 
   const chatExternalId = truncate(payload.chatId, 255) ?? payload.chatId;
   const messageExternalId = truncate(payload.externalId, 255) ?? payload.externalId;
@@ -698,11 +709,25 @@ async function handleMessageReceived(
   const quotedMessage = rawPayload?.quotedMessage as Record<string, unknown> | undefined;
   const platformTimestamp = extractPlatformTimestamp(rawPayload, eventTimestamp);
 
+  // For history-sync messages, messageTimestamp is the source of truth.
+  // If it's missing (null), we have no reliable timestamp to preserve — skip rather than
+  // storing with event.timestamp (= Date.now()), which would be misleading.
+  if (isHistorySync && platformTimestamp === null) {
+    log.debug('Skipping history-sync message without messageTimestamp', {
+      externalId: payload.externalId,
+      chatId: payload.chatId,
+    });
+    return;
+  }
+
   const { message, created } = await services.messages.findOrCreate(chat.id, messageExternalId, {
-    source: 'realtime',
+    source: isHistorySync ? 'sync' : 'realtime',
     messageType: mapContentType(payload.content.type),
     textContent: sanitizeText(payload.content.text),
-    platformTimestamp,
+    // platformTimestamp is null only for realtime messages without messageTimestamp;
+    // fall back to event.timestamp (≈ now) — acceptable for realtime, not for history-sync
+    // (history-sync null case is already handled above with early return).
+    platformTimestamp: platformTimestamp ?? new Date(eventTimestamp),
     senderPlatformUserId: truncate(payload.from, 255),
     senderDisplayName,
     senderPersonId: personId,
@@ -727,7 +752,7 @@ async function handleMessageReceived(
     rawPayload,
     message.id,
     sanitizeText(payload.content.text) ?? undefined,
-    platformTimestamp,
+    platformTimestamp ?? new Date(eventTimestamp),
     payload.from,
   );
 
@@ -739,7 +764,14 @@ async function handleMessageReceived(
   await maybeRecordParticipantActivity(services, chat.id, payload.from);
 
   // Step 7/8: Update chat + instance recency (edits should not bump recency)
-  maybeUpdateRecency(services, metadata.instanceId, chat.id, rawPayload, payload, platformTimestamp);
+  maybeUpdateRecency(
+    services,
+    metadata.instanceId,
+    chat.id,
+    rawPayload,
+    payload,
+    platformTimestamp ?? new Date(eventTimestamp),
+  );
 }
 
 /**

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -52,7 +52,7 @@ import { sentryEnabled } from '../../lib/sentry-scrub';
 import { optionalDateParam } from '../../schemas/date-query';
 import type { Services } from '../../services';
 import { ApiKeyService } from '../../services/api-keys';
-import { MediaStorageService } from '../../services/media-storage';
+import { type MediaFetchOptions, MediaStorageService } from '../../services/media-storage';
 import type { ApiKeyData, AppVariables } from '../../types';
 import { isHardTerminalOutcome, resolveCloseContactConfig } from './_close-contact-config';
 
@@ -683,6 +683,7 @@ messagesRoutes.get('/by-external', async (c) => {
 const messageRefSchema = z.union([
   z.object({ messageId: z.string().uuid() }),
   z.object({ chatId: z.string().uuid(), externalId: z.string().min(1) }),
+  z.object({ instanceId: z.string().uuid(), chatExternalId: z.string().min(1), externalId: z.string().min(1) }),
 ]);
 
 // Lazy singleton for MediaStorageService (same pattern as media.ts)
@@ -706,6 +707,27 @@ async function resolveMessageFromRef(
     // getById throws NotFoundError (→ 404) if missing
     return services.messages.getById(ref.messageId);
   }
+  if ('chatExternalId' in ref) {
+    const chat = await services.chats.findByExternalIdSmart(ref.instanceId, ref.chatExternalId);
+    if (!chat) {
+      throw new OmniError({
+        code: ERROR_CODES.NOT_FOUND,
+        message: `Chat not found for instanceId=${ref.instanceId}, chatExternalId=${ref.chatExternalId}`,
+        context: { instanceId: ref.instanceId, chatExternalId: ref.chatExternalId },
+        recoverable: false,
+      });
+    }
+    const found = await services.messages.getByExternalId(chat.id, ref.externalId);
+    if (!found) {
+      throw new OmniError({
+        code: ERROR_CODES.NOT_FOUND,
+        message: `Message not found for chatExternalId=${ref.chatExternalId}, externalId=${ref.externalId}`,
+        context: { instanceId: ref.instanceId, chatExternalId: ref.chatExternalId, externalId: ref.externalId },
+        recoverable: false,
+      });
+    }
+    return found;
+  }
   const found = await services.messages.getByExternalId(ref.chatId, ref.externalId);
   if (!found) {
     throw new OmniError({
@@ -716,6 +738,16 @@ async function resolveMessageFromRef(
     });
   }
   return found;
+}
+
+function buildMediaDownloadFetchOptions(instance: Record<string, unknown>): MediaFetchOptions | undefined {
+  if (instance.channel !== 'slack') return undefined;
+  const slackBotToken = typeof instance.slackBotToken === 'string' ? instance.slackBotToken : undefined;
+  if (!slackBotToken) return undefined;
+  return {
+    headers: { Authorization: `Bearer ${slackBotToken}` },
+    preserveAuthRedirectHostSuffixes: ['slack.com'],
+  };
 }
 
 /**
@@ -747,6 +779,7 @@ messagesRoutes.post('/media/download', zValidator('json', messageRefSchema), asy
       recoverable: false,
     });
   }
+  const instance = await services.instances.getById(instanceId);
   checkInstanceAccess(apiKey, instanceId);
 
   // 3. Validate message has media
@@ -791,6 +824,7 @@ messagesRoutes.post('/media/download', zValidator('json', messageRefSchema), asy
         mediaUrl,
         message.mediaMimeType ?? undefined,
         message.platformTimestamp ?? undefined,
+        buildMediaDownloadFetchOptions(instance as Record<string, unknown>),
       );
       mediaLocalPath = result.localPath;
       await mediaStorage.updateMessageLocalPath(message.id, result.localPath);
@@ -814,7 +848,7 @@ messagesRoutes.post('/media/download', zValidator('json', messageRefSchema), asy
   }
 
   // 6. Build download URL — mediaLocalPath is guaranteed non-null here (either cached or just downloaded)
-  const downloadUrl = `/api/v2/media/${instanceId}/${mediaLocalPath as string}`;
+  const downloadUrl = `/api/v2/media/${mediaLocalPath as string}`;
 
   return c.json({
     data: {

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -2220,15 +2220,51 @@ const sendPresenceSchema = z.object({
   instanceId: z.string().uuid().describe('Instance ID to send from'),
   to: z.string().min(1).describe('Chat ID to show presence in'),
   type: z.enum(['typing', 'recording', 'paused']).describe('Presence type'),
+  threadId: z.string().min(1).optional().describe('Thread timestamp/id for thread-scoped presence surfaces'),
+  status: z.string().min(1).max(100).optional().describe('Custom status text for channels that support it'),
+  loadingMessages: z
+    .array(z.string().min(1).max(100))
+    .max(10)
+    .optional()
+    .describe('Rotating loading messages for channels that support them'),
   duration: z
     .number()
     .int()
     .min(0)
     .max(30000)
     .optional()
-    .default(5000)
-    .describe('Duration in ms before auto-pause (default 5000, 0 = until paused)'),
+    .describe('Duration in ms before auto-pause; omit for channel default, 0 = until paused'),
 });
+
+type SendPresenceInput = z.infer<typeof sendPresenceSchema>;
+
+type PresenceStatusResult = {
+  delivered?: boolean;
+  method?: string;
+  threadId?: string;
+  status?: string;
+  loadingMessages?: string[];
+  reason?: string;
+};
+
+type PresenceStatusSender = {
+  sendPresenceStatus: (
+    instanceId: string,
+    chatId: string,
+    type: SendPresenceInput['type'],
+    duration?: number,
+    options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+  ) => Promise<PresenceStatusResult | undefined>;
+};
+
+function hasPresenceStatusSender(plugin: unknown): plugin is PresenceStatusSender {
+  return (
+    typeof plugin === 'object' &&
+    plugin !== null &&
+    'sendPresenceStatus' in plugin &&
+    typeof (plugin as { sendPresenceStatus?: unknown }).sendPresenceStatus === 'function'
+  );
+}
 
 /**
  * POST /messages/send/presence - Send presence indicator (typing, recording)
@@ -2236,42 +2272,55 @@ const sendPresenceSchema = z.object({
  * Shows typing/recording indicator in a chat. Auto-pauses after duration.
  * - WhatsApp: supports typing, recording, paused
  * - Discord: supports typing only (recording/paused treated as typing)
+ * - Slack: supports AI Assistant thread status via assistant.threads.setStatus
  */
 messagesRoutes.post('/send/presence', zValidator('json', sendPresenceSchema), async (c) => {
-  const { instanceId, to, type, duration } = c.req.valid('json');
+  const { instanceId, to, type, duration, threadId, status, loadingMessages } = c.req.valid('json');
   const services = c.get('services');
   checkInstanceAccess(c.get('apiKey'), instanceId);
 
-  const { instance, plugin } = await getPluginForInstance(
-    services,
-    c.get('channelRegistry'),
-    instanceId,
-    'canSendTyping',
-  );
+  const { instance, plugin } = await getPluginForInstance(services, c.get('channelRegistry'), instanceId);
 
   // Resolve recipient (handles person ID to platform ID resolution)
   const resolvedTo = await resolveRecipient(to, instance.channel, services);
 
-  // Check if plugin has sendTyping method
-  if (!('sendTyping' in plugin) || typeof plugin.sendTyping !== 'function') {
+  const canSendNativeTyping = plugin.capabilities.canSendTyping === true;
+  const canSendThreadStatus = hasPresenceStatusSender(plugin);
+
+  if (!canSendNativeTyping && !canSendThreadStatus) {
     throw new OmniError({
       code: ERROR_CODES.CAPABILITY_NOT_SUPPORTED,
-      message: `Channel ${instance.channel} plugin does not implement sendTyping`,
+      message: `Channel ${instance.channel} does not support typing indicators or thread status`,
       context: { channelType: instance.channel },
       recoverable: false,
     });
   }
 
-  // For paused type, send with 0 duration to immediately stop
-  const effectiveDuration = type === 'paused' ? 0 : duration;
+  // Native typing indicators keep the historical short burst default.
+  // Slack thread status follows Slack's loading-state model: omit duration to
+  // persist until reply cleanup, explicit pause, or Slack's own timeout.
+  const effectiveDuration = type === 'paused' ? 0 : (duration ?? (canSendThreadStatus ? 0 : 5000));
 
   // If recording type and plugin is discord, still use sendTyping (Discord only supports typing)
   // WhatsApp plugin handles all three types internally
-  await (plugin as { sendTyping: (instanceId: string, chatId: string, duration?: number) => Promise<void> }).sendTyping(
-    instanceId,
-    resolvedTo,
-    effectiveDuration,
-  );
+  const presenceResult = canSendThreadStatus
+    ? await plugin.sendPresenceStatus(instanceId, resolvedTo, type, effectiveDuration, {
+        threadId,
+        status,
+        loadingMessages,
+      })
+    : await (async (): Promise<PresenceStatusResult> => {
+        if (!('sendTyping' in plugin) || typeof plugin.sendTyping !== 'function') {
+          throw new OmniError({
+            code: ERROR_CODES.CAPABILITY_NOT_SUPPORTED,
+            message: `Channel ${instance.channel} plugin does not implement sendTyping`,
+            context: { channelType: instance.channel },
+            recoverable: false,
+          });
+        }
+        await plugin.sendTyping(instanceId, resolvedTo, effectiveDuration);
+        return { delivered: true, method: 'typing_indicator' };
+      })();
 
   return c.json({
     success: true,
@@ -2280,6 +2329,12 @@ messagesRoutes.post('/send/presence', zValidator('json', sendPresenceSchema), as
       chatId: resolvedTo,
       type,
       duration: effectiveDuration,
+      threadId: presenceResult?.threadId ?? threadId,
+      delivered: presenceResult?.delivered ?? true,
+      method: presenceResult?.method ?? 'typing_indicator',
+      reason: presenceResult?.reason,
+      status: presenceResult?.status,
+      loadingMessages: presenceResult?.loadingMessages,
     },
   });
 });

--- a/packages/api/src/schemas/openapi/messages.ts
+++ b/packages/api/src/schemas/openapi/messages.ts
@@ -79,14 +79,28 @@ export const SendPresenceSchema = z.object({
   instanceId: z.string().uuid().openapi({ description: 'Instance ID to send from' }),
   to: z.string().min(1).openapi({ description: 'Chat ID to show presence in' }),
   type: z.enum(['typing', 'recording', 'paused']).openapi({ description: 'Presence type' }),
+  threadId: z
+    .string()
+    .optional()
+    .openapi({ description: 'Thread timestamp/id for thread-scoped presence surfaces such as Slack AI Assistant' }),
+  status: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .openapi({ description: 'Custom status text for channels that support text status, such as Slack AI Assistant' }),
+  loadingMessages: z
+    .array(z.string().min(1).max(100))
+    .max(10)
+    .optional()
+    .openapi({ description: 'Rotating loading messages for channels that support them, such as Slack AI Assistant' }),
   duration: z
     .number()
     .int()
     .min(0)
     .max(30000)
     .optional()
-    .default(5000)
-    .openapi({ description: 'Duration in ms before auto-pause (default 5000, 0 = until paused)' }),
+    .openapi({ description: 'Duration in ms before auto-pause; omit for channel default, 0 = until paused' }),
 });
 
 // Presence response
@@ -95,6 +109,15 @@ export const PresenceResponseSchema = z.object({
   chatId: z.string().openapi({ description: 'Chat ID where presence was sent' }),
   type: z.string().openapi({ description: 'Presence type sent' }),
   duration: z.number().openapi({ description: 'Duration in ms' }),
+  threadId: z.string().optional().openapi({ description: 'Thread timestamp/id used by the presence renderer' }),
+  delivered: z.boolean().optional().openapi({ description: 'Whether the channel reported the status as delivered' }),
+  method: z.string().optional().openapi({ description: 'Channel-specific presence method used' }),
+  reason: z.string().optional().openapi({ description: 'Reason when the channel no-opped or failed best-effort' }),
+  status: z.string().optional().openapi({ description: 'Channel-specific status text sent' }),
+  loadingMessages: z
+    .array(z.string())
+    .optional()
+    .openapi({ description: 'Channel-specific rotating loading messages sent' }),
 });
 
 // Mark message read request
@@ -293,7 +316,7 @@ export function registerMessageSchemas(registry: OpenAPIRegistry): void {
     tags: ['Messages', 'Presence'],
     summary: 'Send presence indicator',
     description:
-      'Send typing/recording indicator in a chat. Auto-pauses after duration. WhatsApp supports typing, recording, paused. Discord only supports typing.',
+      'Send typing/recording indicator in a chat. WhatsApp supports typing, recording, paused. Discord supports typing. Slack supports AI Assistant thread status via threadId or the active thread cache; omit duration to keep Slack status until reply cleanup or Slack timeout.',
     request: { body: { content: { 'application/json': { schema: SendPresenceSchema } } } },
     responses: {
       200: {

--- a/packages/api/src/services/__tests__/media-storage.test.ts
+++ b/packages/api/src/services/__tests__/media-storage.test.ts
@@ -67,4 +67,77 @@ describe('MediaStorageService.storeFromUrl (omni#500)', () => {
     expect(result.mimeType).toBe('audio/mpeg');
     expect(result.localPath).toBe(join('inst-1', '2026-04', 'msg-1.mp3'));
   });
+
+  it('rejects HTML bodies when a non-HTML media type is expected', async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response('<!DOCTYPE html><html><body>login required</body></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        }),
+    ) as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(
+      service.storeFromUrl('inst-1', 'msg-1', 'https://files.slack.com/private/photo.png', 'image/png'),
+    ).rejects.toThrow('Downloaded media content mismatch');
+  });
+
+  it('does not reject plain text that mentions HTML snippets', async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response('Slack note: use <html> only in documentation snippets.', {
+          status: 200,
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        }),
+    ) as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    const result = await service.storeFromUrl(
+      'inst-1',
+      'msg-1',
+      'https://files.slack.com/private/note.txt',
+      'text/plain',
+      new Date('2026-04-23T00:00:00Z'),
+    );
+
+    expect(result.localPath).toBe(join('inst-1', '2026-04', 'msg-1.txt'));
+    expect(result.mimeType).toBe('text/plain');
+  });
+
+  it('preserves Authorization across allowed private-media redirects', async () => {
+    const calls: Array<{ url: string; authorization: string | null }> = [];
+    globalThis.fetch = mock(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      calls.push({ url: String(input), authorization: headers.get('authorization') });
+      if (calls.length === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: 'https://files-pri.slack.com/files-pri/photo.png' },
+        });
+      }
+      return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      });
+    }) as unknown as typeof fetch;
+
+    const service = new MediaStorageService(fakeDb, tmpDir);
+    const result = await service.storeFromUrl(
+      'inst-1',
+      'msg-1',
+      'https://files.slack.com/download/photo.png',
+      'image/png',
+      new Date('2026-04-23T00:00:00Z'),
+      {
+        headers: { Authorization: 'Bearer test-token' },
+        preserveAuthRedirectHostSuffixes: ['slack.com'],
+      },
+    );
+
+    expect(result.localPath).toBe(join('inst-1', '2026-04', 'msg-1.png'));
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.authorization).toBe('Bearer test-token');
+    expect(calls[1]?.authorization).toBe('Bearer test-token');
+  });
 });

--- a/packages/api/src/services/media-storage.ts
+++ b/packages/api/src/services/media-storage.ts
@@ -28,6 +28,95 @@ export interface StoredMediaResult {
   mimeType?: string;
 }
 
+export interface MediaFetchOptions extends RequestInit {
+  /**
+   * Host suffixes where Authorization should be preserved across manual
+   * redirects. Fetch strips Authorization on cross-origin redirects; some
+   * private media URLs redirect inside the platform-owned domain and still
+   * require the same token.
+   */
+  preserveAuthRedirectHostSuffixes?: string[];
+}
+
+function normalizeMimeType(value: string | null | undefined): string | undefined {
+  return value?.split(';')[0]?.trim().toLowerCase() || undefined;
+}
+
+function isHtmlMime(value: string | null | undefined): boolean {
+  const mimeType = normalizeMimeType(value);
+  return mimeType === 'text/html' || mimeType === 'application/xhtml+xml';
+}
+
+function looksLikeHtml(buffer: Buffer): boolean {
+  const preview = buffer.subarray(0, 512).toString('utf8').trimStart().toLowerCase();
+  return preview.startsWith('<!doctype html') || preview.startsWith('<html>') || preview.startsWith('<html ');
+}
+
+function shouldRejectHtmlMedia(
+  expectedMimeType: string | undefined,
+  responseMimeType: string | undefined,
+  buffer: Buffer,
+): boolean {
+  const expected = normalizeMimeType(expectedMimeType);
+  if (!expected || isHtmlMime(expected)) return false;
+  return isHtmlMime(responseMimeType) || looksLikeHtml(buffer);
+}
+
+function hostMatchesSuffix(hostname: string, suffix: string): boolean {
+  const normalizedHost = hostname.toLowerCase();
+  const normalizedSuffix = suffix.toLowerCase();
+  return normalizedHost === normalizedSuffix || normalizedHost.endsWith(`.${normalizedSuffix}`);
+}
+
+function shouldPreserveAuthForRedirect(url: URL, suffixes: string[] | undefined): boolean {
+  return Boolean(suffixes?.some((suffix) => hostMatchesSuffix(url.hostname, suffix)));
+}
+
+function headersWithOptionalAuthorization(
+  headers: RequestInit['headers'] | undefined,
+  preserveAuthorization: boolean,
+): Headers {
+  const nextHeaders = new Headers(headers);
+  if (!preserveAuthorization) nextHeaders.delete('authorization');
+  return nextHeaders;
+}
+
+async function fetchWithOptionalAuthenticatedRedirects(
+  url: string,
+  fetchOptions?: MediaFetchOptions,
+): Promise<Response> {
+  const { preserveAuthRedirectHostSuffixes, ...init } = fetchOptions ?? {};
+  if (!preserveAuthRedirectHostSuffixes?.length) {
+    return fetch(url, init);
+  }
+
+  let currentUrl = new URL(url);
+  let currentHeaders = new Headers(init.headers);
+
+  for (let redirects = 0; redirects <= 5; redirects++) {
+    const response: Response = await fetch(currentUrl.toString(), {
+      ...init,
+      headers: currentHeaders,
+      redirect: 'manual',
+    });
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location: string | null = response.headers.get('location');
+    if (!location) return response;
+
+    const nextUrl: URL = new URL(location, currentUrl);
+    const preserveAuthorization =
+      shouldPreserveAuthForRedirect(currentUrl, preserveAuthRedirectHostSuffixes) &&
+      shouldPreserveAuthForRedirect(nextUrl, preserveAuthRedirectHostSuffixes);
+
+    currentHeaders = headersWithOptionalAuthorization(init.headers, preserveAuthorization);
+    currentUrl = nextUrl;
+  }
+
+  throw new Error('Failed to download media: too many redirects');
+}
+
 /**
  * Get file extension from mime type
  */
@@ -175,16 +264,23 @@ export class MediaStorageService {
     url: string,
     mimeType?: string,
     timestamp?: Date,
-    fetchOptions?: RequestInit,
+    fetchOptions?: MediaFetchOptions,
   ): Promise<StoredMediaResult> {
     // Fetch the media (fetchOptions allows callers to supply auth headers, e.g. Slack bot token)
-    const response = await fetch(url, fetchOptions);
+    const response = await fetchWithOptionalAuthenticatedRedirects(url, fetchOptions);
     if (!response.ok) {
       throw new Error(`Failed to download media: ${response.status}`);
     }
 
+    const responseContentType = response.headers.get('content-type') ?? undefined;
     const buffer = Buffer.from(await response.arrayBuffer());
-    const contentType = mimeType ?? response.headers.get('content-type') ?? undefined;
+    if (shouldRejectHtmlMedia(mimeType, responseContentType, buffer)) {
+      throw new Error(
+        `Downloaded media content mismatch: expected ${mimeType}, received ${responseContentType ?? 'unknown content type'}`,
+      );
+    }
+
+    const contentType = mimeType ?? responseContentType;
 
     return this.storeFromBuffer(instanceId, messageId, buffer, contentType, timestamp);
   }

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/src/__tests__/identity.test.ts
+++ b/packages/channel-gupshup/src/__tests__/identity.test.ts
@@ -61,9 +61,7 @@ describe('toGupshupPhone', () => {
   });
 
   it('returns empty string for non-string input (contract violation, no crash)', () => {
-    // biome-ignore lint/suspicious/noExplicitAny: simulating a runtime contract violation
-    expect(toGupshupPhone(undefined as any)).toBe('');
-    // biome-ignore lint/suspicious/noExplicitAny: simulating a runtime contract violation
-    expect(toGupshupPhone(null as any)).toBe('');
+    expect(toGupshupPhone(undefined as unknown as string)).toBe('');
+    expect(toGupshupPhone(null as unknown as string)).toBe('');
   });
 });

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/src/__tests__/files.test.ts
+++ b/packages/channel-slack/src/__tests__/files.test.ts
@@ -4,12 +4,20 @@
  * Tests Group D: File Handling + Polish
  */
 
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 
 import { SLACK_CAPABILITIES } from '../capabilities';
-import { extractFileInfo, getContentTypeFromMime } from '../handlers/files';
+import { downloadSlackFile, extractFileInfo, getContentTypeFromMime } from '../handlers/files';
 import { extractMessageMeta } from '../handlers/messages';
 import type { SlackFileInfo } from '../types';
+
+const noop = () => undefined;
+const noopLogger = { debug: noop, info: noop, warn: noop, error: noop };
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 // ─────────────────────────────────────────────────────────────
 // File info extraction
@@ -133,6 +141,82 @@ describe('getContentTypeFromMime', () => {
     expect(getContentTypeFromMime('text/plain')).toBe('document');
     expect(getContentTypeFromMime('application/json')).toBe('document');
     expect(getContentTypeFromMime('application/octet-stream')).toBe('document');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Private file downloads
+// ─────────────────────────────────────────────────────────────
+
+describe('downloadSlackFile', () => {
+  it('preserves bot token auth across Slack private file redirects', async () => {
+    const calls: Array<{ url: string; authorization: string | null }> = [];
+    globalThis.fetch = mock(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      calls.push({ url: String(input), authorization: headers.get('authorization') });
+      if (calls.length === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: 'https://files-pri.slack.com/files-pri/photo.png' },
+        });
+      }
+      return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { 'content-type': 'image/png', 'content-length': '4' },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await downloadSlackFile(
+      'https://files.slack.com/download/photo.png',
+      'xoxb-test-token',
+      noopLogger as never,
+      'image/png',
+    );
+
+    expect(result.mimeType).toBe('image/png');
+    expect(result.buffer.length).toBe(4);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.authorization).toBe('Bearer xoxb-test-token');
+    expect(calls[1]?.authorization).toBe('Bearer xoxb-test-token');
+  });
+
+  it('rejects Slack login HTML when image bytes were expected', async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response('<!DOCTYPE html><html><body>login required</body></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8', 'content-length': '56' },
+        }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      downloadSlackFile(
+        'https://files.slack.com/download/photo.png',
+        'xoxb-test-token',
+        noopLogger as never,
+        'image/png',
+      ),
+    ).rejects.toThrow('Slack returned HTML');
+  });
+
+  it('does not reject text files that mention HTML snippets', async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response('Markdown docs can mention <html> tags without being HTML.', {
+          status: 200,
+          headers: { 'content-type': 'text/plain; charset=utf-8', 'content-length': '57' },
+        }),
+    ) as unknown as typeof fetch;
+
+    const result = await downloadSlackFile(
+      'https://files.slack.com/download/readme.txt',
+      'xoxb-test-token',
+      noopLogger as never,
+      'text/plain',
+    );
+
+    expect(result.mimeType).toBe('text/plain; charset=utf-8');
+    expect(result.buffer.toString('utf8')).toContain('<html>');
   });
 });
 

--- a/packages/channel-slack/src/handlers/files.ts
+++ b/packages/channel-slack/src/handlers/files.ts
@@ -15,6 +15,60 @@ import type { SlackFileInfo } from '../types';
 const downloadGuard = createDownloadGuard();
 import { SlackError, SlackErrorCode } from '../types';
 
+function normalizeMimeType(value: string | null | undefined): string | undefined {
+  return value?.split(';')[0]?.trim().toLowerCase() || undefined;
+}
+
+function isHtmlMime(value: string | null | undefined): boolean {
+  const mimeType = normalizeMimeType(value);
+  return mimeType === 'text/html' || mimeType === 'application/xhtml+xml';
+}
+
+function looksLikeHtml(buffer: Buffer): boolean {
+  const preview = buffer.subarray(0, 512).toString('utf8').trimStart().toLowerCase();
+  return preview.startsWith('<!doctype html') || preview.startsWith('<html>') || preview.startsWith('<html ');
+}
+
+function hostMatchesSuffix(hostname: string, suffix: string): boolean {
+  const normalizedHost = hostname.toLowerCase();
+  const normalizedSuffix = suffix.toLowerCase();
+  return normalizedHost === normalizedSuffix || normalizedHost.endsWith(`.${normalizedSuffix}`);
+}
+
+function isSlackHost(url: URL): boolean {
+  return hostMatchesSuffix(url.hostname, 'slack.com');
+}
+
+function headersWithOptionalAuthorization(botToken: string, preserveAuthorization: boolean): Headers {
+  const headers = new Headers();
+  if (preserveAuthorization) headers.set('Authorization', `Bearer ${botToken}`);
+  headers.set('Accept', 'application/octet-stream');
+  return headers;
+}
+
+async function fetchSlackPrivateUrl(url: string, botToken: string): Promise<Response> {
+  let currentUrl = new URL(url);
+  let preserveAuthorization = true;
+
+  for (let redirects = 0; redirects <= 5; redirects++) {
+    const response: Response = await fetch(currentUrl.toString(), {
+      headers: headersWithOptionalAuthorization(botToken, preserveAuthorization),
+      redirect: 'manual',
+    });
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location: string | null = response.headers.get('location');
+    if (!location) return response;
+
+    const nextUrl: URL = new URL(location, currentUrl);
+    preserveAuthorization = isSlackHost(currentUrl) && isSlackHost(nextUrl);
+    currentUrl = nextUrl;
+  }
+
+  throw new SlackError(SlackErrorCode.FILE_DOWNLOAD_FAILED, 'Failed to download file: too many redirects');
+}
+
 /**
  * Extract file info from a Slack message event
  */
@@ -42,15 +96,12 @@ export async function downloadSlackFile(
   url: string,
   botToken: string,
   logger: Logger,
+  expectedMimeType?: string,
 ): Promise<{ buffer: Buffer; mimeType: string }> {
   logger.debug('Downloading file from Slack CDN', { url: url.substring(0, 50) });
 
   try {
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${botToken}`,
-      },
-    });
+    const response = await fetchSlackPrivateUrl(url, botToken);
 
     if (!response.ok) {
       throw new SlackError(
@@ -64,6 +115,12 @@ export async function downloadSlackFile(
 
     const buffer = Buffer.from(await response.arrayBuffer());
     const mimeType = response.headers.get('content-type') ?? 'application/octet-stream';
+    if (!isHtmlMime(expectedMimeType) && (isHtmlMime(mimeType) || looksLikeHtml(buffer))) {
+      throw new SlackError(
+        SlackErrorCode.FILE_DOWNLOAD_FAILED,
+        `Failed to download file bytes: Slack returned HTML instead of ${expectedMimeType ?? 'media'}`,
+      );
+    }
 
     logger.debug('File downloaded successfully', { size: buffer.length, mimeType });
 

--- a/packages/channel-slack/src/handlers/typing.test.ts
+++ b/packages/channel-slack/src/handlers/typing.test.ts
@@ -21,13 +21,16 @@ function makeLogger(): Logger {
 }
 
 function makeClientWithAssistant() {
-  const setStatusCalls: Array<{ channel_id: string; thread_ts: string; status: string }> = [];
+  const setStatusCalls: Array<{ channel_id: string; thread_ts: string; status: string; loading_messages?: string[] }> =
+    [];
   const client = {
     assistant: {
       threads: {
-        setStatus: mock(async (args: { channel_id: string; thread_ts: string; status: string }) => {
-          setStatusCalls.push(args);
-        }),
+        setStatus: mock(
+          async (args: { channel_id: string; thread_ts: string; status: string; loading_messages?: string[] }) => {
+            setStatusCalls.push(args);
+          },
+        ),
       },
     },
   };
@@ -57,7 +60,7 @@ describe('setSlackThreadStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: undefined,
@@ -65,6 +68,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
+    expect(result).toBe(false);
     expect(setStatusCalls.length).toBe(0);
   });
 
@@ -72,19 +76,22 @@ describe('setSlackThreadStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
       status: 'is typing...',
+      loadingMessages: ['Checking context...', 'Calling tools...'],
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls.length).toBe(1);
     expect(setStatusCalls[0]).toEqual({
       channel_id: 'C12345',
       thread_ts: '1234567890.001',
       status: 'is typing...',
+      loading_messages: ['Checking context...', 'Calling tools...'],
     });
   });
 
@@ -92,7 +99,7 @@ describe('setSlackThreadStatus', () => {
     const { client, apiCalls } = makeClientWithApiCall();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
@@ -100,6 +107,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
+    expect(result).toBe(true);
     expect(apiCalls.length).toBe(1);
     expect(apiCalls[0]?.method).toBe('assistant.threads.setStatus');
     expect(apiCalls[0]?.args).toEqual({
@@ -113,15 +121,15 @@ describe('setSlackThreadStatus', () => {
     const { client } = makeClientWithoutAssistant();
     const logger = makeLogger();
 
-    await expect(
-      setSlackThreadStatus({
-        client: client as never,
-        channelId: 'C12345',
-        threadTs: '1234567890.001',
-        status: 'is typing...',
-        logger,
-      }),
-    ).resolves.toBeUndefined();
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+
+    expect(result).toBe(false);
   });
 
   it('does not throw when API call fails', async () => {
@@ -131,25 +139,28 @@ describe('setSlackThreadStatus', () => {
     });
     const logger = makeLogger();
 
-    await expect(
-      setSlackThreadStatus({
-        client: client as never,
-        channelId: 'C12345',
-        threadTs: '1234567890.001',
-        status: 'is typing...',
-        logger,
-      }),
-    ).resolves.toBeUndefined();
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+
+    expect(result).toBe(false);
 
     // Should have logged the failure
-    expect((logger.warn as ReturnType<typeof mock>).mock.calls.length).toBeGreaterThan(0);
+    const warnCalls = (logger.warn as ReturnType<typeof mock>).mock.calls;
+    expect(warnCalls.length).toBeGreaterThan(0);
+    expect(warnCalls[0]?.[1]).toMatchObject({ clearing: false, statusLength: 'is typing...'.length });
+    expect(warnCalls[0]?.[1]).not.toHaveProperty('status');
   });
 
   it('can clear typing status with empty string', async () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setSlackThreadStatus({
+    const result = await setSlackThreadStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
@@ -157,6 +168,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls[0]?.status).toBe('');
   });
 });
@@ -170,13 +182,14 @@ describe('setTypingStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setTypingStatus({
+    const result = await setTypingStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls[0]?.status).toBe('is typing...');
   });
 
@@ -184,12 +197,13 @@ describe('setTypingStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await setTypingStatus({
+    const result = await setTypingStatus({
       client: client as never,
       channelId: 'C12345',
       logger,
     });
 
+    expect(result).toBe(false);
     expect(setStatusCalls.length).toBe(0);
   });
 });
@@ -199,13 +213,14 @@ describe('clearTypingStatus', () => {
     const { client, setStatusCalls } = makeClientWithAssistant();
     const logger = makeLogger();
 
-    await clearTypingStatus({
+    const result = await clearTypingStatus({
       client: client as never,
       channelId: 'C12345',
       threadTs: '1234567890.001',
       logger,
     });
 
+    expect(result).toBe(true);
     expect(setStatusCalls[0]?.status).toBe('');
   });
 });

--- a/packages/channel-slack/src/handlers/typing.ts
+++ b/packages/channel-slack/src/handlers/typing.ts
@@ -2,12 +2,14 @@
  * Slack thread typing indicator helper
  *
  * Uses assistant.threads.setStatus to show/clear typing status in Slack threads.
- * Only works for thread messages — channel-level messages are a no-op.
+ * Requires a Slack thread timestamp; for top-level channel messages, use the
+ * source message timestamp as the thread timestamp.
  *
- * Requires the "Agents & AI Apps" feature flag on the Slack App.
+ * Requires Slack Web API scope `chat:write`. The legacy `assistant:write` scope
+ * is also accepted by Slack during their transition period.
  * Failures are swallowed gracefully — typing never blocks message processing.
  *
- * @see https://api.slack.com/methods/assistant.threads.setStatus
+ * @see https://docs.slack.dev/reference/methods/assistant.threads.setStatus/
  */
 
 import type { Logger } from '@omni/channel-sdk';
@@ -26,18 +28,20 @@ export async function setSlackThreadStatus(params: {
   channelId: string;
   threadTs?: string;
   status: string;
+  loadingMessages?: string[];
   logger: Logger;
   instanceId?: string;
-}): Promise<void> {
-  const { client, channelId, threadTs, status, logger, instanceId } = params;
+}): Promise<boolean> {
+  const { client, channelId, threadTs, status, loadingMessages, logger, instanceId } = params;
 
   // Thread-only guard
-  if (!threadTs) return;
+  if (!threadTs) return false;
 
   const payload = {
     channel_id: channelId,
     thread_ts: threadTs,
     status,
+    ...(loadingMessages?.length ? { loading_messages: loadingMessages } : {}),
   };
 
   try {
@@ -52,21 +56,26 @@ export async function setSlackThreadStatus(params: {
 
     if (typeof clientAny.assistant?.threads?.setStatus === 'function') {
       await clientAny.assistant.threads.setStatus(payload);
-      return;
+      return true;
     }
 
     if (typeof clientAny.apiCall === 'function') {
       await clientAny.apiCall('assistant.threads.setStatus', payload);
+      return true;
     }
   } catch (err) {
     logger.warn('setSlackThreadStatus: failed', {
       instanceId,
       channelId,
       threadTs,
-      status,
+      clearing: status.length === 0,
+      statusLength: status.length,
+      loadingMessageCount: loadingMessages?.length ?? 0,
       error: String(err),
     });
   }
+
+  return false;
 }
 
 /**
@@ -78,7 +87,7 @@ export async function setTypingStatus(params: {
   threadTs?: string;
   logger: Logger;
   instanceId?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   return setSlackThreadStatus({ ...params, status: TYPING_STATUS });
 }
 
@@ -91,6 +100,6 @@ export async function clearTypingStatus(params: {
   threadTs?: string;
   logger: Logger;
   instanceId?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   return setSlackThreadStatus({ ...params, status: CLEAR_STATUS });
 }

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -40,7 +40,7 @@ import { downloadSlackFile, extractFileInfo, getContentTypeFromMime } from './ha
 import { setupInteractionHandlers } from './handlers/interactions';
 import { type SlackDebouncedArgs, setupMessageHandlers } from './handlers/messages';
 import { setupReactionHandlers } from './handlers/reactions';
-import { clearTypingStatus, setTypingStatus } from './handlers/typing';
+import { clearTypingStatus, setSlackThreadStatus } from './handlers/typing';
 import { uploadFile, uploadFileFromUrl } from './senders/media';
 import { createNativeStreamSender } from './senders/native-stream';
 import { createSlackStreamSender } from './senders/stream';
@@ -50,6 +50,17 @@ import { SlackError, SlackErrorCode } from './types';
 
 /** Download size guard — 50MB default; applied to inbound file metadata before dispatching */
 const downloadGuard = createDownloadGuard();
+
+type SlackPresenceType = 'typing' | 'recording' | 'paused';
+
+type SlackPresenceStatusResult = {
+  delivered: boolean;
+  method: 'assistant.threads.setStatus';
+  threadId?: string;
+  status?: string;
+  loadingMessages?: string[];
+  reason?: 'not_connected' | 'no_active_thread' | 'slack_status_failed';
+};
 
 /**
  * Resolve Slack credentials from config, options, and credentials sources.
@@ -130,6 +141,12 @@ export class SlackPlugin extends BaseChannelPlugin {
   private activeThreads = new Map<string, string>();
 
   /**
+   * Pending auto-clear timers per active status thread.
+   * Key: `${instanceId}:${channelId}:${threadTs}`
+   */
+  private presenceStatusTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /**
    * Pending ack reactions awaiting removal after reply.
    * Key: `${instanceId}:${channelId}:${messageTs}`, Value: emoji name
    */
@@ -168,6 +185,10 @@ export class SlackPlugin extends BaseChannelPlugin {
       cache.dispose();
     }
     this.threadCaches.clear();
+    for (const timer of this.presenceStatusTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.presenceStatusTimers.clear();
     this.activeThreads.clear();
     this.pendingAckReactions.clear();
   }
@@ -303,6 +324,11 @@ export class SlackPlugin extends BaseChannelPlugin {
     }
     for (const key of this.activeThreads.keys()) {
       if (key.startsWith(`${instanceId}:`)) this.activeThreads.delete(key);
+    }
+    for (const [key, timer] of this.presenceStatusTimers) {
+      if (!key.startsWith(`${instanceId}:`)) continue;
+      clearTimeout(timer);
+      this.presenceStatusTimers.delete(key);
     }
     for (const key of this.pendingAckReactions.keys()) {
       if (key.startsWith(`${instanceId}:`)) this.pendingAckReactions.delete(key);
@@ -456,31 +482,103 @@ export class SlackPlugin extends BaseChannelPlugin {
    * hence `canSendTyping: false` in capabilities. This method exists for the
    * thread context but silently no-ops when no active thread is tracked.
    *
-   * No auto-refresh needed: the status persists until explicitly cleared
-   * (duration === 0) or the assistant replies.
+   * Slack clears status when the assistant replies, when status is set to an
+   * empty string, or after Slack's own timeout. Omni can also clear earlier
+   * when callers pass an explicit duration.
    */
   async sendTyping(instanceId: string, chatId: string, duration?: number): Promise<void> {
+    await this.sendPresenceStatus(instanceId, chatId, duration === 0 ? 'paused' : 'typing', duration);
+  }
+
+  /**
+   * Send Slack's official AI Assistant thread status.
+   *
+   * This is intentionally separate from `canSendTyping`: Slack does not expose
+   * generic channel typing for bots, but `assistant.threads.setStatus` is the
+   * official status surface for AI assistant threads.
+   */
+  async sendPresenceStatus(
+    instanceId: string,
+    chatId: string,
+    type: SlackPresenceType,
+    duration?: number,
+    options?: { threadId?: string; status?: string; loadingMessages?: string[] },
+  ): Promise<SlackPresenceStatusResult> {
+    const method = 'assistant.threads.setStatus' as const;
     const connection = this.connections.get(instanceId);
-    if (!connection) return;
+    if (!connection) return { delivered: false, method, reason: 'not_connected' };
 
-    const threadTs = this.activeThreads.get(`${instanceId}:${chatId}`);
-    if (!threadTs) return; // Thread-only guard
+    const threadTs = options?.threadId ?? this.activeThreads.get(`${instanceId}:${chatId}`);
+    if (!threadTs) return { delivered: false, method, reason: 'no_active_thread' };
 
-    if (duration === 0) {
-      await clearTypingStatus({
-        client: connection.client,
-        channelId: chatId,
-        threadTs,
-        logger: this.logger,
-      });
-    } else {
-      await setTypingStatus({
-        client: connection.client,
-        channelId: chatId,
-        threadTs,
-        logger: this.logger,
-      });
+    const shouldClear = type === 'paused';
+    const status = shouldClear ? '' : (options?.status ?? (type === 'recording' ? 'is recording...' : 'is typing...'));
+    const timerKey = this.presenceStatusTimerKey(instanceId, chatId, threadTs);
+
+    const delivered =
+      status === ''
+        ? await clearTypingStatus({
+            client: connection.client,
+            channelId: chatId,
+            threadTs,
+            logger: this.logger,
+          })
+        : await setSlackThreadStatus({
+            client: connection.client,
+            channelId: chatId,
+            threadTs,
+            status,
+            loadingMessages: options?.loadingMessages,
+            logger: this.logger,
+          });
+
+    if (delivered) {
+      this.clearPresenceStatusTimer(timerKey);
     }
+
+    if (delivered && status !== '' && duration && duration > 0) {
+      const timer = setTimeout(() => {
+        if (this.presenceStatusTimers.get(timerKey) !== timer) return;
+        this.presenceStatusTimers.delete(timerKey);
+        clearTypingStatus({
+          client: connection.client,
+          channelId: chatId,
+          threadTs,
+          logger: this.logger,
+        }).catch((err) => {
+          this.logger.warn('Slack presence status auto-clear failed', {
+            instanceId,
+            channelId: chatId,
+            threadTs,
+            error: String(err),
+          });
+        });
+      }, duration);
+      this.presenceStatusTimers.set(timerKey, timer);
+      timer.unref?.();
+    }
+
+    return delivered
+      ? { delivered: true, method, threadId: threadTs, status, loadingMessages: options?.loadingMessages }
+      : {
+          delivered: false,
+          method,
+          threadId: threadTs,
+          status,
+          loadingMessages: options?.loadingMessages,
+          reason: 'slack_status_failed',
+        };
+  }
+
+  private presenceStatusTimerKey(instanceId: string, channelId: string, threadTs: string): string {
+    return `${instanceId}:${channelId}:${threadTs}`;
+  }
+
+  private clearPresenceStatusTimer(timerKey: string): void {
+    const timer = this.presenceStatusTimers.get(timerKey);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.presenceStatusTimers.delete(timerKey);
   }
 
   /**
@@ -891,6 +989,7 @@ export class SlackPlugin extends BaseChannelPlugin {
       threadTs: resolvedThread,
       logger: this.logger,
     });
+    this.clearPresenceStatusTimer(this.presenceStatusTimerKey(instanceId, channelId, resolvedThread));
   }
 
   /**

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3842,13 +3842,24 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
 
     const timestamp = this.getMessageTimestamp(msg);
 
+    // Messages without a timestamp cannot be reliably ordered or filtered.
+    // Skip them instead of fabricating a misleading ingest-time timestamp.
+    if (!timestamp) {
+      this.logger.debug('Skipping history message without timestamp', {
+        instanceId,
+        messageId: msg.key.id,
+        chatId: msg.key.remoteJid,
+      });
+      return;
+    }
+
     // Filter by date range if specified
     if (syncState?.since && timestamp < syncState.since) {
       this.logger.debug('Skipping history message - before since', {
         instanceId,
         messageId: msg.key.id,
         chatId: msg.key.remoteJid,
-        timestamp: new Date(timestamp).toISOString(),
+        timestamp: timestamp.toISOString(),
         since: new Date(syncState.since).toISOString(),
       });
       return;
@@ -3858,7 +3869,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         instanceId,
         messageId: msg.key.id,
         chatId: msg.key.remoteJid,
-        timestamp: new Date(timestamp).toISOString(),
+        timestamp: timestamp.toISOString(),
         until: new Date(syncState.until).toISOString(),
       });
       return;
@@ -3970,12 +3981,15 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   }
 
   /**
-   * Get timestamp from a message
+   * Get timestamp from a message.
+   * Returns null when messageTimestamp is absent or zero — callers must handle this
+   * explicitly rather than silently falling back to the current time.
    * @internal
    */
-  private getMessageTimestamp(msg: WAMessage): Date {
-    if (!msg.messageTimestamp) return new Date();
+  private getMessageTimestamp(msg: WAMessage): Date | null {
+    if (!msg.messageTimestamp) return null;
     const ts = typeof msg.messageTimestamp === 'number' ? msg.messageTimestamp : Number(msg.messageTimestamp);
+    if (!ts || Number.isNaN(ts)) return null;
     return new Date(ts * 1000);
   }
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3830,6 +3830,41 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    *
    * @internal
    */
+  /**
+   * Date-range gate for a history message. Returns false (and logs the reason)
+   * when the message falls outside the active sync window. Extracted from
+   * {@link processHistoryMessage} to keep that method within the biome
+   * cognitive-complexity budget.
+   */
+  private isHistoryMessageWithinSyncRange(
+    msg: WAMessage,
+    timestamp: Date,
+    syncState: { since?: Date; until?: Date } | undefined,
+    instanceId: string,
+  ): boolean {
+    if (syncState?.since && timestamp < syncState.since) {
+      this.logger.debug('Skipping history message - before since', {
+        instanceId,
+        messageId: msg.key?.id,
+        chatId: msg.key?.remoteJid,
+        timestamp: timestamp.toISOString(),
+        since: new Date(syncState.since).toISOString(),
+      });
+      return false;
+    }
+    if (syncState?.until && timestamp > syncState.until) {
+      this.logger.debug('Skipping history message - after until', {
+        instanceId,
+        messageId: msg.key?.id,
+        chatId: msg.key?.remoteJid,
+        timestamp: timestamp.toISOString(),
+        until: new Date(syncState.until).toISOString(),
+      });
+      return false;
+    }
+    return true;
+  }
+
   private async processHistoryMessage(
     instanceId: string,
     msg: WAMessage,
@@ -3854,24 +3889,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     }
 
     // Filter by date range if specified
-    if (syncState?.since && timestamp < syncState.since) {
-      this.logger.debug('Skipping history message - before since', {
-        instanceId,
-        messageId: msg.key.id,
-        chatId: msg.key.remoteJid,
-        timestamp: timestamp.toISOString(),
-        since: new Date(syncState.since).toISOString(),
-      });
-      return;
-    }
-    if (syncState?.until && timestamp > syncState.until) {
-      this.logger.debug('Skipping history message - after until', {
-        instanceId,
-        messageId: msg.key.id,
-        chatId: msg.key.remoteJid,
-        timestamp: timestamp.toISOString(),
-        until: new Date(syncState.until).toISOString(),
-      });
+    if (!this.isHistoryMessageWithinSyncRange(msg, timestamp, syncState, instanceId)) {
       return;
     }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -40,6 +40,14 @@ function readFileAsBase64(path: string): string {
   return buffer.toString('base64');
 }
 
+function parseLoadingMessages(value?: string): string[] | undefined {
+  const messages = value
+    ?.split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return messages?.length ? messages : undefined;
+}
+
 /** Send options type */
 interface SendOptions {
   instance?: string;
@@ -71,6 +79,8 @@ interface SendOptions {
   color?: number;
   url?: string;
   presence?: string;
+  status?: string;
+  loadingMessages?: string;
   tts?: string;
   voiceId?: string;
   presenceDelay?: number;
@@ -225,6 +235,9 @@ const messageSenders = {
       instanceId,
       to,
       type: presence as 'typing' | 'recording' | 'paused',
+      threadId: options.threadId,
+      status: options.status,
+      loadingMessages: parseLoadingMessages(options.loadingMessages),
     });
     output.success('Presence sent', result);
   },
@@ -389,6 +402,8 @@ function buildGroupedSendHelp(): string {
 
   const presenceOptions: OptionDef[] = [
     { flags: '--presence <type>', description: 'Send typing/recording/paused indicator' },
+    { flags: '--status <text>', description: 'Custom status text for channels that support it' },
+    { flags: '--loading-messages <items>', description: 'Comma-separated rotating loading messages' },
   ];
 
   const ttsOptions: OptionDef[] = [
@@ -493,6 +508,8 @@ export function createSendCommand(): Command {
     .option('--url <url>', 'Embed URL')
     // Presence
     .option('--presence <type>', 'Send presence indicator (typing, recording, paused)')
+    .option('--status <text>', 'Custom status text for channels that support it')
+    .option('--loading-messages <items>', 'Comma-separated rotating loading messages')
     // TTS
     .option('--tts <text>', 'Send TTS voice note (text-to-speech)')
     .option('--voice-id <id>', 'ElevenLabs voice ID for TTS')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/src/providers/__tests__/agno-provider.test.ts
+++ b/packages/core/src/providers/__tests__/agno-provider.test.ts
@@ -219,6 +219,21 @@ describe('AgnoAgentProvider', () => {
     expect(result.parts).toEqual([SAFE_PROVIDER_ERROR_MESSAGE]);
     expect(result.parts.join(' ')).not.toContain('Anthropic');
     expect(result.parts.join(' ')).not.toContain('credit balance');
+    // Signals the dispatcher to hand off to a human on native-handoff channels.
+    expect(result.metadata.customerErrorBlocked).toBe(true);
+  });
+
+  it('does not flag a normal response as a blocked customer error', async () => {
+    const client = createClientReturning('Sure! Your order ships tomorrow.');
+    const provider = new AgnoAgentProvider('agno-1', 'Agno', client, {
+      agentId: 'agent-1',
+      agentType: 'agent',
+    });
+
+    const result = await provider.trigger(createTrigger());
+
+    expect(result.parts).toEqual(['Sure! Your order ships tomorrow.']);
+    expect(result.metadata.customerErrorBlocked).toBe(false);
   });
 
   it('replaces raw API key errors before building outbound message parts', async () => {

--- a/packages/core/src/providers/__tests__/customer-safe-errors.test.ts
+++ b/packages/core/src/providers/__tests__/customer-safe-errors.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for customer-safe-errors — the guard that stops raw provider/billing
+ * errors (and leaked secrets) from reaching customers.
+ *
+ * Focus:
+ * - the tightened `Bearer` branch no longer false-positives on benign English
+ *   (gemini review on #739), while still catching real leaked tokens;
+ * - the existing provider/secret patterns still trip;
+ * - the message is overridable via OMNI_SAFE_PROVIDER_ERROR_MESSAGE.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  SAFE_PROVIDER_ERROR_MESSAGE,
+  resolveSafeProviderErrorMessage,
+  toSafeCustomerFallback,
+} from '../customer-safe-errors';
+
+describe('toSafeCustomerFallback — Bearer false positives', () => {
+  it.each([
+    'Bearer of bad news: your appointment was cancelled.',
+    'She was the bearer of glad tidings today.',
+    'Bearer token required.',
+    'Please become a Bearer of good will.',
+  ])('does NOT block benign English after "bearer": %s', (text) => {
+    expect(toSafeCustomerFallback(text)).toBe(text);
+  });
+
+  it.each([
+    // Low-entropy placeholders (not real secrets) that still satisfy the 20+ char rule.
+    'Authorization failed: Bearer EXAMPLE0EXAMPLE0EXAMPLE0EXAMPLE0',
+    'Bearer PLACEHOLDERTOKENPLACEHOLDERTOKEN',
+  ])('still blocks a real leaked bearer token: %s', (text) => {
+    expect(toSafeCustomerFallback(text)).toBe(SAFE_PROVIDER_ERROR_MESSAGE);
+  });
+});
+
+describe('toSafeCustomerFallback — existing leak patterns still trip', () => {
+  it.each([
+    'litellm.AuthenticationError: invalid key',
+    'ModelProviderError: upstream 500',
+    'your credit balance is too low to run this',
+    'sk-EXAMPLEKEYPLACEHOLDER',
+    'api_key=EXAMPLE_PLACEHOLDER',
+    'Received API Key for the wrong org',
+  ])('blocks: %s', (text) => {
+    expect(toSafeCustomerFallback(text)).toBe(SAFE_PROVIDER_ERROR_MESSAGE);
+  });
+
+  it('passes through ordinary agent replies untouched', () => {
+    const ok = 'Sure! Your order #1234 ships tomorrow.';
+    expect(toSafeCustomerFallback(ok)).toBe(ok);
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(toSafeCustomerFallback(null)).toBe('');
+    expect(toSafeCustomerFallback(undefined)).toBe('');
+  });
+});
+
+describe('resolveSafeProviderErrorMessage', () => {
+  it('defaults to the pt-BR message when no env override', () => {
+    expect(resolveSafeProviderErrorMessage({})).toBe(SAFE_PROVIDER_ERROR_MESSAGE);
+  });
+
+  it('honors OMNI_SAFE_PROVIDER_ERROR_MESSAGE', () => {
+    const env = { OMNI_SAFE_PROVIDER_ERROR_MESSAGE: 'We hit a snag, please try again shortly.' };
+    expect(resolveSafeProviderErrorMessage(env)).toBe('We hit a snag, please try again shortly.');
+    // ...and the override flows through the blocking path too.
+    expect(toSafeCustomerFallback('litellm.APIError: boom', env)).toBe('We hit a snag, please try again shortly.');
+  });
+
+  it('ignores a blank override and falls back to default', () => {
+    expect(resolveSafeProviderErrorMessage({ OMNI_SAFE_PROVIDER_ERROR_MESSAGE: '   ' })).toBe(
+      SAFE_PROVIDER_ERROR_MESSAGE,
+    );
+  });
+});

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -21,7 +21,9 @@ import {
   type StreamChunk,
 } from './types';
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+// #738 — aligned to the 600s agent-dispatch default so a caller that omits an
+// explicit timeout gets the same generous budget as the rest of the pipeline.
+const DEFAULT_TIMEOUT_MS = 600_000;
 
 export class AgnoClient implements IAgentClient {
   private readonly baseUrl: string;

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -72,8 +72,9 @@ export class AgnoAgentProvider implements IAgentProvider {
     const response = await this.client.run(request);
 
     const customerContent = toSafeCustomerFallback(response.content);
+    const customerErrorBlocked = customerContent !== response.content;
 
-    if (customerContent !== response.content) {
+    if (customerErrorBlocked) {
       log.error('Blocked provider error from customer-facing Agno response', {
         agentId: this.config.agentId,
         runId: response.runId,
@@ -112,6 +113,7 @@ export class AgnoAgentProvider implements IAgentProvider {
               outputTokens: response.metrics.outputTokens,
             }
           : undefined,
+        customerErrorBlocked,
       },
     };
   }

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from '../logger';
-import { SAFE_PROVIDER_ERROR_MESSAGE, toSafeCustomerFallback } from './customer-safe-errors';
+import { resolveSafeProviderErrorMessage, toSafeCustomerFallback } from './customer-safe-errors';
 import { buildProviderRequestContext } from './execution-context';
 import { createTraceContextFromTraceId } from './trace-context';
 import type {
@@ -160,7 +160,7 @@ export class AgnoAgentProvider implements IAgentProvider {
         traceId: context.traceId,
         error: message,
       });
-      yield { phase: 'error', error: SAFE_PROVIDER_ERROR_MESSAGE };
+      yield { phase: 'error', error: resolveSafeProviderErrorMessage() };
     }
   }
 

--- a/packages/core/src/providers/customer-safe-errors.ts
+++ b/packages/core/src/providers/customer-safe-errors.ts
@@ -1,16 +1,46 @@
+/**
+ * Default customer-facing message shown when a raw provider/billing error is
+ * intercepted before it reaches the user. Defaults to pt-BR (the deployments
+ * this guard was built for); override globally with the
+ * `OMNI_SAFE_PROVIDER_ERROR_MESSAGE` env var for other locales.
+ */
 const SAFE_PROVIDER_ERROR_MESSAGE =
   'Tô com um probleminha técnico aqui agora. Já estou avisando o time. Pode tentar de novo em alguns minutos? 🙏';
 
+/**
+ * Patterns that mark text as a leaked provider/billing/secret error which must
+ * never reach a customer.
+ *
+ * NOTE on the `Bearer` branch: it requires a 20+ char token run so it matches
+ * a real leaked credential (`Bearer eyJhbGciOi...`) but NOT benign English
+ * that happens to follow the word "bearer" — e.g. "bearer of bad news". The
+ * previous `Bearer\s+[A-Za-z0-9._-]+` matched any word and black-holed valid
+ * agent replies (gemini review on #739).
+ */
 const PROVIDER_ERROR_PATTERN =
-  /(litellm\.(BadRequestError|AuthenticationError|RateLimitError|APIError)|ModelProviderError|AnthropicException|Authentication Error|Invalid proxy server token|Received API Key|Available Model Group Fallbacks|credit balance is too low|Plans\s*&\s*Billing|\bsk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]+|api[_ -]?key\s*[=:])/i;
+  /(litellm\.(BadRequestError|AuthenticationError|RateLimitError|APIError)|ModelProviderError|AnthropicException|Authentication Error|Invalid proxy server token|Received API Key|Available Model Group Fallbacks|credit balance is too low|Plans\s*&\s*Billing|\bsk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]{20,}|api[_ -]?key\s*[=:])/i;
 
 function isUnsafeCustomerFacingProviderText(text: string | undefined | null): boolean {
   return Boolean(text && PROVIDER_ERROR_PATTERN.test(text));
 }
 
-export function toSafeCustomerFallback(text: string | undefined | null): string {
+/**
+ * Resolve the customer-facing provider-error message. Precedence:
+ *   1. `OMNI_SAFE_PROVIDER_ERROR_MESSAGE` env (global locale override),
+ *   2. {@link SAFE_PROVIDER_ERROR_MESSAGE} (pt-BR default).
+ * Blank/whitespace-only overrides are ignored.
+ */
+export function resolveSafeProviderErrorMessage(env: Record<string, string | undefined> = process.env): string {
+  const override = env.OMNI_SAFE_PROVIDER_ERROR_MESSAGE?.trim();
+  return override || SAFE_PROVIDER_ERROR_MESSAGE;
+}
+
+export function toSafeCustomerFallback(
+  text: string | undefined | null,
+  env: Record<string, string | undefined> = process.env,
+): string {
   if (isUnsafeCustomerFacingProviderText(text)) {
-    return SAFE_PROVIDER_ERROR_MESSAGE;
+    return resolveSafeProviderErrorMessage(env);
   }
   return text ?? '';
 }

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -523,6 +523,14 @@ export interface AgentTriggerResult {
       inputTokens?: number;
       outputTokens?: number;
     };
+    /**
+     * True when the response text was replaced by the customer-safe error
+     * fallback (a provider/billing/secret error was blocked — see
+     * `toSafeCustomerFallback`). The dispatcher uses this to trigger a human
+     * handoff on channels that support it (Gupshup) instead of forwarding the
+     * generic fallback message.
+     */
+    customerErrorBlocked?: boolean;
   };
 }
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1062,6 +1062,9 @@ export interface SendPresenceBody {
   instanceId: string;
   to: string;
   type: 'typing' | 'recording' | 'paused';
+  threadId?: string;
+  status?: string;
+  loadingMessages?: string[];
   duration?: number;
 }
 
@@ -1073,6 +1076,12 @@ export interface SendPresenceResult {
   chatId: string;
   type: string;
   duration: number;
+  threadId?: string;
+  delivered?: boolean;
+  method?: string;
+  reason?: string;
+  status?: string;
+  loadingMessages?: string[];
 }
 
 /**
@@ -1937,12 +1946,17 @@ export function createOmniClient(config: OmniClientConfig) {
         });
         const json = (await resp.json()) as { data?: SendPresenceResult };
         if (!resp.ok) throw OmniApiError.from(json, resp.status);
+        const inferredDuration =
+          body.duration ?? (body.threadId || body.status || body.loadingMessages?.length ? 0 : 5000);
         return (
           json?.data ?? {
             instanceId: body.instanceId,
             chatId: body.to,
             type: body.type,
-            duration: body.duration ?? 5000,
+            duration: inferredDuration,
+            threadId: body.threadId,
+            status: body.status,
+            loadingMessages: body.loadingMessages,
           }
         );
       },

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -539,7 +539,7 @@ export interface paths {
         put?: never;
         /**
          * Send presence indicator
-         * @description Send typing/recording indicator in a chat. Auto-pauses after duration. WhatsApp supports typing, recording, paused. Discord only supports typing.
+         * @description Send typing/recording indicator in a chat. WhatsApp supports typing, recording, paused. Discord supports typing. Slack supports AI Assistant thread status via threadId or the active thread cache; omit duration to keep Slack status until reply cleanup or Slack timeout.
          */
         post: operations["sendPresence"];
         delete?: never;
@@ -2832,11 +2832,14 @@ export interface components {
              * @enum {string}
              */
             type: "typing" | "recording" | "paused";
-            /**
-             * @description Duration in ms before auto-pause (default 5000, 0 = until paused)
-             * @default 5000
-             */
-            duration: number;
+            /** @description Thread timestamp/id for thread-scoped presence surfaces such as Slack AI Assistant */
+            threadId?: string;
+            /** @description Custom status text for channels that support text status, such as Slack AI Assistant */
+            status?: string;
+            /** @description Rotating loading messages for channels that support them, such as Slack AI Assistant */
+            loadingMessages?: string[];
+            /** @description Duration in ms before auto-pause; omit for channel default, 0 = until paused */
+            duration?: number;
         };
         PresenceResponse: {
             /**
@@ -2850,6 +2853,18 @@ export interface components {
             type: string;
             /** @description Duration in ms */
             duration: number;
+            /** @description Thread timestamp/id used by the presence renderer */
+            threadId?: string;
+            /** @description Whether the channel reported the status as delivered */
+            delivered?: boolean;
+            /** @description Channel-specific presence method used */
+            method?: string;
+            /** @description Reason when the channel no-opped or failed best-effort */
+            reason?: string;
+            /** @description Channel-specific status text sent */
+            status?: string;
+            /** @description Channel-specific rotating loading messages sent */
+            loadingMessages?: string[];
         };
         MarkMessageReadRequest: {
             /**
@@ -7643,10 +7658,13 @@ export interface operations {
                      * @enum {string}
                      */
                     type: "typing" | "recording" | "paused";
-                    /**
-                     * @description Duration in ms before auto-pause (default 5000, 0 = until paused)
-                     * @default 5000
-                     */
+                    /** @description Thread timestamp/id for thread-scoped presence surfaces such as Slack AI Assistant */
+                    threadId?: string;
+                    /** @description Custom status text for channels that support text status, such as Slack AI Assistant */
+                    status?: string;
+                    /** @description Rotating loading messages for channels that support them, such as Slack AI Assistant */
+                    loadingMessages?: string[];
+                    /** @description Duration in ms before auto-pause; omit for channel default, 0 = until paused */
                     duration?: number;
                 };
             };
@@ -7672,6 +7690,18 @@ export interface operations {
                             type: string;
                             /** @description Duration in ms */
                             duration: number;
+                            /** @description Thread timestamp/id used by the presence renderer */
+                            threadId?: string;
+                            /** @description Whether the channel reported the status as delivered */
+                            delivered?: boolean;
+                            /** @description Channel-specific presence method used */
+                            method?: string;
+                            /** @description Reason when the channel no-opped or failed best-effort */
+                            reason?: string;
+                            /** @description Channel-specific status text sent */
+                            status?: string;
+                            /** @description Channel-specific rotating loading messages sent */
+                            loadingMessages?: string[];
                         };
                     };
                 };

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260619.2",
+  "version": "2.260619.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260622.1",
+  "version": "2.260624.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260624.3",
+  "version": "2.260624.4",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260619.3",
+  "version": "2.260622.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260624.1",
+  "version": "2.260622.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260624.2",
+  "version": "2.260624.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260622.1",
+  "version": "2.260624.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
Rolling promotion dev→main, merged as a **merge commit** so the head is `Merge pull request … from automagik-dev/dev` — the exact pattern `version.yml`'s workflow_run(main) gate requires to publish npm `@latest`.

Context: the prior promotion (#730) was rebase-merged, leaving a `[skip ci]` version-bump head, so `@latest` never published (stuck at 2.260619.3) even though the GH release v2.260624.4, signed tarballs, and `@next` are current. This re-promotion as a merge commit fixes that.

Same code as v2.260624.4 (clean merge, no conflicts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer presence/status updates, including thread-specific status text, loading messages, and clearer delivery details in supported channels.
  * Improved Slack file downloads and media handling with better redirect support and safer content checks.
  * Expanded agent handoff behavior so blocked errors can escalate more gracefully on supported channels.

* **Bug Fixes**
  * Improved timestamp handling for message history and sync flows.
  * Increased queue wait and provider timeout limits to reduce premature failures during longer runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->