### PR TITLE
chore(release): promote dev→homolog — publish @homolog 2.260624.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- ci: trigger @homolog publish (sync 2.260624.5 from main) -->
 <!-- ci: re-trigger @latest publish for v2.260624.4 (rolling promotion #730 rebased a [skip ci] head, skipping the main CI → version.yml @latest publish) -->
 <p align="center">
   <picture>


### PR DESCRIPTION
Triggers the @homolog npm publish for the main→homolog sync (already merged as 7207bc85). The merge-commit message pattern 'from automagik-dev/promote/dev-to-homolog-*' satisfies version.yml's homolog gate (contains /dev). Merge as a **merge commit**.