### PR TITLE
feat(debounce): presence mode + maxWaitMs cap + flushAll shutdown drain

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1236,7 +1236,7 @@
 
     "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
 
-    "baileys": ["baileys@vendor/baileys-v7.0.0-rc10.tgz", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "git+https://github.com/whiskeysockets/libsignal-node", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.3", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-VBpKeS+6o73yBqvClQgBe0PM1y51F720F5L+fz9qHoQEVQbBoIxUf3Nb4iIKlfEIbi6bnVd+DfiE6Y/CQN5YJg=="],
+    "baileys": ["baileys@vendor/baileys-v7.0.0-rc10.tgz", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "git+https://github.com/whiskeysockets/libsignal-node", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.3", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -1696,7 +1696,7 @@
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
-    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d", "sha512-5q4/OuDQaMYx3RpDqMqS3WYyqjrsSMpU8ipQZtpYnm5l6DwNoLV9oIYMDK0NILKW+tyk3tVCIA11BMYQ+A1+GA=="],
+    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d"],
 
     "libsodium": ["libsodium@0.7.16", "", {}, "sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q=="],
 

--- a/docs/guides/typing-debounce.md
+++ b/docs/guides/typing-debounce.md
@@ -1,0 +1,92 @@
+# Typing-Aware Inbound Batching (Presence Debounce)
+
+When a human sends a burst of short messages — "hi", "quick question", "about my
+order", "#12345" — you usually want the agent to see them as **one turn**, not
+fire four separate replies. omni's message debouncer already batches inbound
+messages per `instanceId:chatId` and hands the whole batch to the agent as a
+single dispatch. The **`presence`** mode makes that batching typing-aware:
+accumulate while the user is still composing, flush shortly after they stop.
+
+## How it works
+
+The debouncer buffers incoming messages and starts a quiet-window timer.
+
+- Each `presence.typing` event (piped end-to-end from the channel) **restarts**
+  the quiet window, so the batch grows for as long as the user keeps typing.
+- When typing stops, the batch flushes `minMs` later (the quiet window).
+- A hard **`maxWaitMs`** cap, measured from the *first* buffered message,
+  guarantees a flush even if the user never stops typing — so a
+  continuously-composing user can't starve the agent forever.
+
+`presence` mode is sugar for `fixed` + `restartOnTyping` + the `maxWaitMs` cap.
+You can achieve the same behavior manually with
+`mode=fixed, restartOnTyping=true, minMs=5000` plus a `maxWaitMs` value — but
+`presence` gives operators a single intuitive toggle with sensible defaults.
+
+## Enable it
+
+### Defaults
+
+Selecting `presence` mode applies these defaults when the tuning columns are
+left unset:
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `minMs` | `5000` | quiet window — flush 5s after the user stops typing |
+| `maxWaitMs` | `30000` | hard cap — flush at most 30s after the first message |
+
+Override either to taste.
+
+### Via CLI
+
+```bash
+omni instances update <instance-id> \
+  --debounce-mode presence \
+  --debounce-min 5000 \
+  --debounce-max-wait 30000
+```
+
+### Per instance (API)
+
+```bash
+curl -X PATCH "https://your-api/api/v2/instances/<instance-id>" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-key>" \
+  -d '{
+        "messageDebounceMode": "presence",
+        "messageDebounceMinMs": 5000,
+        "messageDebounceMaxWaitMs": 30000
+      }'
+```
+
+### Per route override
+
+`presence` mode and `messageDebounceMaxWaitMs` are also settable as per-route
+overrides on `agent_routes` (null = inherit from the instance), so a specific
+chat or user can use typing-aware batching while the instance default stays
+`disabled`/`randomized`.
+
+## Tuning
+
+- **`minMs` (quiet window)** — how long to wait after the last keystroke/message
+  before dispatching. Higher = fewer, larger batches; lower = snappier replies.
+- **`maxWaitMs` (hard cap)** — the ceiling on total batch age. Prevents a
+  never-ending typer from indefinitely delaying the agent. Set `null` for no cap
+  (not recommended for `presence` mode).
+
+## Requirements
+
+- The channel must emit typing presence. For WhatsApp this is piped
+  automatically (`presence.update` → `presence.typing` → the debouncer). Channels
+  that don't emit typing simply fall back to the `minMs` window with no restarts.
+
+## Consumer impact
+
+**Zero change for agents.** The agent (and the genie/SDK consumers) already
+receives one turn per flush via the normal dispatch path — this only changes
+*when* that turn closes. Nothing downstream needs to know a batch was
+typing-debounced.
+
+Buffered messages are also **no longer dropped on shutdown**: graceful teardown
+now drains pending batches (`flushAll`) instead of discarding them, so a burst
+that lands moments before a restart is still delivered.

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -1147,7 +1147,7 @@ describe('agent-dispatcher', () => {
   // Cleanup
   // ======================================================================
   describe('cleanup function', () => {
-    it('clears timers and buffers on cleanup', async () => {
+    it('flushes pending buffers on cleanup (does not drop)', async () => {
       const eventBus = createMockEventBus();
       const agentRunner = {
         getInstanceWithProvider: mock(async () =>
@@ -1171,16 +1171,14 @@ describe('agent-dispatcher', () => {
         mockDb,
       );
 
-      // Buffer a message (debounce set to 5000ms)
+      // Buffer a message (debounce set to 5000ms — the timer will NOT fire on its own)
       await eventBus.fire('message.received', createMessageEvent());
 
-      // Call cleanup before debounce fires
-      cleanup();
+      // Graceful shutdown drains pending buffers via flushAll() rather than
+      // dropping them — the buffered message is delivered as a final turn.
+      await cleanup();
 
-      // Wait — the run should NOT fire because cleanup cleared the timer
-      await new Promise((resolve) => setTimeout(resolve, 200));
-
-      expect(agentRunner.run).not.toHaveBeenCalled();
+      expect(agentRunner.run).toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/plugins/__tests__/message-debouncer.test.ts
+++ b/packages/api/src/plugins/__tests__/message-debouncer.test.ts
@@ -30,6 +30,7 @@ const fixedConfig: DebounceConfig = {
   maxMs: 100,
   restartOnTyping: false,
   groupMs: null,
+  maxWaitMs: null,
 };
 
 const disabledConfig: DebounceConfig = {
@@ -38,6 +39,7 @@ const disabledConfig: DebounceConfig = {
   maxMs: 0,
   restartOnTyping: false,
   groupMs: null,
+  maxWaitMs: null,
 };
 
 function wait(ms: number): Promise<void> {
@@ -188,6 +190,7 @@ describe('MessageDebouncer', () => {
         maxMs: 120,
         restartOnTyping: false,
         groupMs: null,
+        maxWaitMs: null,
       };
 
       debouncer = new MessageDebouncer(async (_chatKey, messages) => {
@@ -219,6 +222,7 @@ describe('MessageDebouncer', () => {
         maxMs: 100,
         restartOnTyping: true,
         groupMs: null,
+        maxWaitMs: null,
       };
 
       debouncer = new MessageDebouncer(async (_chatKey, messages) => {
@@ -261,6 +265,7 @@ describe('MessageDebouncer', () => {
         maxMs: 100,
         restartOnTyping: true,
         groupMs: null,
+        maxWaitMs: null,
       };
 
       debouncer = new MessageDebouncer(async (_chatKey, messages) => {
@@ -294,6 +299,7 @@ describe('MessageDebouncer', () => {
         maxMs: 100,
         restartOnTyping: false,
         groupMs: null,
+        maxWaitMs: null,
       };
 
       debouncer = new MessageDebouncer(async (_chatKey, messages) => {
@@ -429,6 +435,148 @@ describe('MessageDebouncer', () => {
       // Second batch should flush automatically
       expect(flushCalls.length).toBe(2);
       expect(flushCalls[1]!.messages.length).toBe(2);
+    });
+  });
+
+  describe('presence mode — maxWaitMs hard cap', () => {
+    it('caps at maxWaitMs even under continuous typing', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+      const start = Date.now();
+      let flushedAt = 0;
+
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+        flushedAt = Date.now() - start;
+      });
+
+      const presenceConfig: DebounceConfig = {
+        mode: 'presence',
+        minMs: 100, // quiet window after typing stops
+        maxMs: 100,
+        restartOnTyping: true,
+        groupMs: null,
+        maxWaitMs: 500, // hard cap from the first buffered message
+      };
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('m1'), presenceConfig);
+
+      // Type every 80ms (< minMs) so the quiet-window timer keeps restarting.
+      // Without the cap this batch would never flush; the cap forces it at ~500ms.
+      for (let i = 0; i < 8; i++) {
+        await wait(80);
+        debouncer.onUserTyping('inst-1', 'chat-1', presenceConfig);
+      }
+
+      expect(flushCalls.length).toBe(1);
+      expect(flushCalls[0]!.length).toBe(1);
+      // Flushed around the 500ms cap, not extended by the ongoing typing.
+      expect(flushedAt).toBeGreaterThanOrEqual(450);
+      expect(flushedAt).toBeLessThan(680);
+    });
+
+    it('flushes minMs after typing stops when still under the cap', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+      });
+
+      const presenceConfig: DebounceConfig = {
+        mode: 'presence',
+        minMs: 100,
+        maxMs: 100,
+        restartOnTyping: true,
+        groupMs: null,
+        maxWaitMs: 5000,
+      };
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('m1'), presenceConfig);
+      // One typing burst at 60ms restarts the 100ms quiet window.
+      await wait(60);
+      debouncer.onUserTyping('inst-1', 'chat-1', presenceConfig);
+      // At 110ms the original window would have fired; the restart holds it back.
+      await wait(50);
+      expect(flushCalls.length).toBe(0);
+      // 100ms after the typing event → flush.
+      await wait(80);
+      expect(flushCalls.length).toBe(1);
+    });
+  });
+
+  describe('flushAll() — shutdown drains instead of dropping', () => {
+    const longConfig: DebounceConfig = {
+      mode: 'fixed',
+      minMs: 10_000, // window never fires on its own during the test
+      maxMs: 10_000,
+      restartOnTyping: false,
+      groupMs: null,
+      maxWaitMs: null,
+    };
+
+    it('delivers pending buffers instead of dropping them', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+      });
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('a'), longConfig);
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('b'), longConfig);
+      expect(flushCalls.length).toBe(0);
+
+      await debouncer.flushAll();
+
+      expect(flushCalls.length).toBe(1);
+      expect(flushCalls[0]!.length).toBe(2);
+    });
+
+    it('flushes every buffered chat across keys', async () => {
+      const byKey: Record<string, number> = {};
+      debouncer = new MessageDebouncer(async (chatKey, messages) => {
+        byKey[chatKey] = (byKey[chatKey] ?? 0) + messages.length;
+      });
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('a'), longConfig);
+      debouncer.buffer('inst-1', 'chat-2', makeMessage('b'), longConfig);
+      debouncer.buffer('inst-2', 'chat-1', makeMessage('c'), longConfig);
+
+      await debouncer.flushAll();
+
+      expect(byKey['inst-1:chat-1']).toBe(1);
+      expect(byKey['inst-1:chat-2']).toBe(1);
+      expect(byKey['inst-2:chat-1']).toBe(1);
+    });
+
+    it('clear() drops pending buffers — the shutdown gap flushAll closes', async () => {
+      const flushCalls: BufferedMessage[][] = [];
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        flushCalls.push([...messages]);
+      });
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('a'), longConfig);
+      debouncer.clear();
+      await wait(50);
+
+      // Regression contrast: clear() is the lossy path; flushAll() is not.
+      expect(flushCalls.length).toBe(0);
+    });
+  });
+
+  describe('per-instanceId:chatId isolation', () => {
+    it('keeps buffers separate across instances and chats', async () => {
+      const byKey: Record<string, number> = {};
+      debouncer = new MessageDebouncer(async (chatKey, messages) => {
+        byKey[chatKey] = (byKey[chatKey] ?? 0) + messages.length;
+      });
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('a1'), fixedConfig);
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('a2'), fixedConfig);
+      debouncer.buffer('inst-1', 'chat-2', makeMessage('b1'), fixedConfig);
+      debouncer.buffer('inst-2', 'chat-1', makeMessage('c1'), fixedConfig);
+
+      await wait(150);
+
+      expect(byKey['inst-1:chat-1']).toBe(2);
+      expect(byKey['inst-1:chat-2']).toBe(1);
+      expect(byKey['inst-2:chat-1']).toBe(1);
     });
   });
 });

--- a/packages/api/src/plugins/__tests__/route-config-merge.test.ts
+++ b/packages/api/src/plugins/__tests__/route-config-merge.test.ts
@@ -71,6 +71,7 @@ function makeNullRoute(overrides: Record<string, unknown> = {}) {
     messageDebounceMaxMs: null,
     messageDebounceGroupMs: null,
     messageDebounceRestartOnTyping: null,
+    messageDebounceMaxWaitMs: null,
     messageSplitDelayMode: null,
     messageSplitDelayFixedMs: null,
     messageSplitDelayMinMs: null,

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -384,13 +384,22 @@ class ReactionDedup {
 // Helper Functions
 // ============================================================================
 
+/** 'presence' mode defaults when the instance/route leaves the tuning columns unset. */
+const PRESENCE_DEFAULT_MIN_MS = 5_000; // quiet window after the user stops typing
+const PRESENCE_DEFAULT_MAX_WAIT_MS = 30_000; // hard cap under continuous typing
+
 function getDebounceConfig(instance: Instance): DebounceConfig {
+  const mode = instance.messageDebounceMode ?? 'disabled';
+  const isPresence = mode === 'presence';
   return {
-    mode: instance.messageDebounceMode ?? 'disabled',
-    minMs: instance.messageDebounceMinMs ?? 0,
+    mode,
+    // 'presence' is sugar for fixed + restartOnTyping + a hard cap. Apply sane
+    // defaults when the columns are unset (0/null) so operators only flip mode.
+    minMs: instance.messageDebounceMinMs || (isPresence ? PRESENCE_DEFAULT_MIN_MS : 0),
     maxMs: instance.messageDebounceMaxMs ?? 0,
-    restartOnTyping: instance.messageDebounceRestartOnTyping ?? false,
+    restartOnTyping: isPresence ? true : (instance.messageDebounceRestartOnTyping ?? false),
     groupMs: (instance as Record<string, unknown>).messageDebounceGroupMs as number | null,
+    maxWaitMs: instance.messageDebounceMaxWaitMs ?? (isPresence ? PRESENCE_DEFAULT_MAX_WAIT_MS : null),
   };
 }
 
@@ -4071,6 +4080,7 @@ function mergeRouteOverrides(instance: Instance, route: ResolvedRoute): Dispatch
     messageDebounceMaxMs: route.messageDebounceMaxMs ?? instance.messageDebounceMaxMs,
     messageDebounceGroupMs: route.messageDebounceGroupMs ?? instance.messageDebounceGroupMs,
     messageDebounceRestartOnTyping: route.messageDebounceRestartOnTyping ?? instance.messageDebounceRestartOnTyping,
+    messageDebounceMaxWaitMs: route.messageDebounceMaxWaitMs ?? instance.messageDebounceMaxWaitMs,
     messageSplitDelayMode:
       (route.messageSplitDelayMode as Instance['messageSplitDelayMode']) ?? instance.messageSplitDelayMode,
     messageSplitDelayFixedMs: route.messageSplitDelayFixedMs ?? instance.messageSplitDelayFixedMs,
@@ -5377,7 +5387,9 @@ export async function setupAgentDispatcher(
   return async () => {
     log.info('Shutting down agent dispatcher');
     clearInterval(mediaCleanupInterval);
-    debouncer.clear();
+    // flushAll (not clear) so a burst buffered right before shutdown is
+    // delivered as a final turn instead of silently dropped.
+    await debouncer.flushAll();
 
     // Reject any pending media promises on shutdown
     for (const [mediaId, pending] of mediaCompletions.entries()) {

--- a/packages/api/src/plugins/agent-responder.ts
+++ b/packages/api/src/plugins/agent-responder.ts
@@ -52,7 +52,7 @@ interface MessageMetadata {
 }
 
 interface DebounceConfig {
-  mode: 'disabled' | 'fixed' | 'randomized';
+  mode: 'disabled' | 'fixed' | 'randomized' | 'presence';
   minMs: number;
   maxMs: number;
   restartOnTyping: boolean;

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -37,11 +37,18 @@ export interface DispatchMetadata {
 }
 
 export interface DebounceConfig {
-  mode: 'disabled' | 'fixed' | 'randomized';
+  mode: 'disabled' | 'fixed' | 'randomized' | 'presence';
   minMs: number;
   maxMs: number;
   restartOnTyping: boolean;
   groupMs: number | null;
+  /**
+   * Hard cap on how long a batch may accumulate, measured from the FIRST
+   * buffered message. Null = no cap (legacy behavior). When set, the timer is
+   * clamped so a continuously-typing user still flushes at
+   * `firstBufferedAt + maxWaitMs` instead of restarting forever.
+   */
+  maxWaitMs: number | null;
 }
 
 // ============================================================================
@@ -52,10 +59,15 @@ export class MessageDebouncer {
   private buffers: Map<string, BufferedMessage[]> = new Map();
   private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private inFlight: Set<string> = new Set();
+  /** Timestamp of the first buffered message per chat — anchors the maxWaitMs cap. */
+  private firstBufferedAt: Map<string, number> = new Map();
   private onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>;
+  /** Injectable clock — defaults to Date.now; overridable for deterministic tests. */
+  private now: () => number;
 
-  constructor(onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>) {
+  constructor(onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>, now: () => number = Date.now) {
     this.onFlush = onFlush;
+    this.now = now;
   }
 
   private getChatKey(instanceId: string, chatId: string): string {
@@ -67,6 +79,10 @@ export class MessageDebouncer {
     const buffer = this.buffers.get(chatKey) ?? [];
     buffer.push(message);
     this.buffers.set(chatKey, buffer);
+
+    // Anchor the max-wait window on the first message of a fresh batch so the
+    // cap survives any number of timer restarts (typing or new messages).
+    if (!this.firstBufferedAt.has(chatKey)) this.firstBufferedAt.set(chatKey, this.now());
 
     // If this chat is currently being processed, just accumulate — don't start
     // a new timer. The flush completion handler will pick up these messages.
@@ -81,7 +97,10 @@ export class MessageDebouncer {
     // finally-block re-flush will pick up any pending messages.  Restarting
     // here would race with that re-flush and could cause a double-dispatch.
     if (this.inFlight.has(chatKey)) return;
-    if (config.restartOnTyping && this.buffers.has(chatKey)) {
+    // 'presence' mode is sugar for fixed + restartOnTyping + a max-wait cap, so
+    // typing always restarts its window regardless of the restartOnTyping flag.
+    const restarts = config.restartOnTyping || config.mode === 'presence';
+    if (restarts && this.buffers.has(chatKey)) {
       log.debug('Restarting debounce timer on user typing', { chatKey });
       this.restartTimer(chatKey, config, true);
     }
@@ -90,11 +109,12 @@ export class MessageDebouncer {
   private restartTimer(chatKey: string, config: DebounceConfig, force = false): void {
     const existing = this.timers.get(chatKey);
 
-    // In 'fixed' mode, the timer is a fixed collection window from the first
-    // message — do NOT restart it when subsequent messages arrive.
-    // However, typing events force-restart even in fixed mode so the user
-    // has time to finish composing before the agent is dispatched.
-    if (config.mode === 'fixed' && existing && !force) return;
+    // In 'fixed' / 'presence' mode the timer is a fixed collection window from
+    // the first message — do NOT restart it when subsequent messages arrive.
+    // However, typing events force-restart so the user has time to finish
+    // composing before the agent is dispatched.
+    const fixedWindow = config.mode === 'fixed' || config.mode === 'presence';
+    if (fixedWindow && existing && !force) return;
 
     if (existing) clearTimeout(existing);
 
@@ -104,6 +124,7 @@ export class MessageDebouncer {
         delay = 0;
         break;
       case 'fixed':
+      case 'presence':
         delay = config.minMs;
         break;
       case 'randomized':
@@ -113,8 +134,23 @@ export class MessageDebouncer {
         delay = 0;
     }
 
+    delay = this.applyMaxWaitCap(chatKey, config, delay);
+
     const timer = setTimeout(() => this.flush(chatKey), delay);
     this.timers.set(chatKey, timer);
+  }
+
+  /**
+   * Clamp the next fire so a batch never accumulates past
+   * `firstBufferedAt + maxWaitMs`. No-op when maxWaitMs is unset, keeping
+   * disabled/fixed/randomized behavior byte-identical.
+   */
+  private applyMaxWaitCap(chatKey: string, config: DebounceConfig, delay: number): number {
+    if (config.maxWaitMs == null || config.maxWaitMs <= 0) return delay;
+    const firstAt = this.firstBufferedAt.get(chatKey);
+    if (firstAt == null) return delay;
+    const remaining = firstAt + config.maxWaitMs - this.now();
+    return Math.max(0, Math.min(delay, remaining));
   }
 
   private async flush(chatKey: string): Promise<void> {
@@ -122,6 +158,7 @@ export class MessageDebouncer {
     const timer = this.timers.get(chatKey);
     this.buffers.delete(chatKey);
     this.timers.delete(chatKey);
+    this.firstBufferedAt.delete(chatKey);
     if (timer) clearTimeout(timer);
 
     if (!messages?.length) return;
@@ -144,10 +181,30 @@ export class MessageDebouncer {
     }
   }
 
+  /**
+   * Flush every non-empty buffer, awaiting each dispatch, then drop residual
+   * timers. Unlike {@link clear}, buffered messages are DELIVERED rather than
+   * discarded — use this on graceful shutdown / connection close so a burst
+   * that arrived just before teardown is not lost.
+   *
+   * Reuses {@link flush} so the in-flight guard + finally-block re-flush
+   * semantics are preserved (messages arriving mid-flush are re-flushed).
+   */
+  async flushAll(): Promise<void> {
+    const chatKeys = [...this.buffers.keys()];
+    await Promise.all(chatKeys.map((chatKey) => this.flush(chatKey)));
+    // flush() already clears per-key state; drop any residual timers/anchors
+    // (e.g. empty windows) so the debouncer is left clean.
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+    this.firstBufferedAt.clear();
+  }
+
   clear(): void {
     for (const timer of this.timers.values()) clearTimeout(timer);
     this.buffers.clear();
     this.timers.clear();
+    this.firstBufferedAt.clear();
     this.inFlight.clear();
   }
 }

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -83,9 +83,9 @@ const createInstanceSchema = z.object({
     .nullable()
     .describe('Content types that receive file path (e.g. image, video, document). Default: all except audio'),
   messageDebounceMode: z
-    .enum(['disabled', 'fixed', 'randomized'])
+    .enum(['disabled', 'fixed', 'randomized', 'presence'])
     .default('randomized')
-    .describe('Message debounce mode: disabled, fixed delay, or randomized delay'),
+    .describe('Message debounce mode: disabled, fixed delay, randomized delay, or presence (typing-aware)'),
   messageDebounceMinMs: z
     .number()
     .int()
@@ -106,6 +106,15 @@ const createInstanceSchema = z.object({
     .nullable()
     .default(null)
     .describe('Debounce delay for group chats in milliseconds (null = use messageDebounceMinMs)'),
+  messageDebounceMaxWaitMs: z
+    .number()
+    .int()
+    .min(0)
+    .nullable()
+    .default(null)
+    .describe(
+      'Presence-mode hard cap in milliseconds — flush at firstBuffered + this even under continuous typing (null = no cap)',
+    ),
   messageSplitDelayMode: z
     .enum(['disabled', 'fixed', 'randomized'])
     .default('randomized')

--- a/packages/api/src/schemas/openapi/agent-routes.ts
+++ b/packages/api/src/schemas/openapi/agent-routes.ts
@@ -62,7 +62,7 @@ export const AgentRouteSchema = z.object({
 
   // Debounce overrides (null = inherit from instance)
   messageDebounceMode: z
-    .enum(['disabled', 'fixed', 'randomized'])
+    .enum(['disabled', 'fixed', 'randomized', 'presence'])
     .nullable()
     .openapi({ description: 'Debounce mode override' }),
   messageDebounceMinMs: z
@@ -87,6 +87,12 @@ export const AgentRouteSchema = z.object({
     .boolean()
     .nullable()
     .openapi({ description: 'Restart debounce on typing override' }),
+  messageDebounceMaxWaitMs: z
+    .number()
+    .int()
+    .nonnegative()
+    .nullable()
+    .openapi({ description: 'Presence-mode hard cap (ms) override; null = no cap' }),
 
   // Split delay overrides (null = inherit from instance)
   messageSplitDelayMode: z
@@ -156,7 +162,10 @@ export const CreateAgentRouteRequestSchema = z.object({
   agentGatePrompt: z.string().optional().openapi({ description: 'Response gate prompt' }),
 
   // Debounce overrides
-  messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized']).optional().openapi({ description: 'Debounce mode' }),
+  messageDebounceMode: z
+    .enum(['disabled', 'fixed', 'randomized', 'presence'])
+    .optional()
+    .openapi({ description: 'Debounce mode' }),
   messageDebounceMinMs: z.number().int().nonnegative().optional().openapi({ description: 'Debounce min delay (ms)' }),
   messageDebounceMaxMs: z.number().int().nonnegative().optional().openapi({ description: 'Debounce max delay (ms)' }),
   messageDebounceGroupMs: z
@@ -166,6 +175,12 @@ export const CreateAgentRouteRequestSchema = z.object({
     .optional()
     .openapi({ description: 'Debounce group chat delay (ms)' }),
   messageDebounceRestartOnTyping: z.boolean().optional().openapi({ description: 'Restart debounce on typing' }),
+  messageDebounceMaxWaitMs: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .openapi({ description: 'Presence-mode hard cap (ms); null = no cap' }),
 
   // Split delay overrides
   messageSplitDelayMode: z
@@ -223,7 +238,7 @@ export const UpdateAgentRouteRequestSchema = z.object({
 
   // Debounce overrides
   messageDebounceMode: z
-    .enum(['disabled', 'fixed', 'randomized'])
+    .enum(['disabled', 'fixed', 'randomized', 'presence'])
     .nullable()
     .optional()
     .openapi({ description: 'Debounce mode' }),
@@ -253,6 +268,13 @@ export const UpdateAgentRouteRequestSchema = z.object({
     .nullable()
     .optional()
     .openapi({ description: 'Restart debounce on typing' }),
+  messageDebounceMaxWaitMs: z
+    .number()
+    .int()
+    .nonnegative()
+    .nullable()
+    .optional()
+    .openapi({ description: 'Presence-mode hard cap (ms); null = no cap' }),
 
   // Split delay overrides
   messageSplitDelayMode: z

--- a/packages/api/src/services/__tests__/route-resolver.test.ts
+++ b/packages/api/src/services/__tests__/route-resolver.test.ts
@@ -39,6 +39,7 @@ function createRoute(overrides: Partial<ResolvedRoute> = {}): ResolvedRoute {
     messageDebounceMaxMs: null,
     messageDebounceGroupMs: null,
     messageDebounceRestartOnTyping: null,
+    messageDebounceMaxWaitMs: null,
     messageSplitDelayMode: null,
     messageSplitDelayFixedMs: null,
     messageSplitDelayMinMs: null,

--- a/packages/api/src/services/route-resolver.ts
+++ b/packages/api/src/services/route-resolver.ts
@@ -46,6 +46,7 @@ export interface ResolvedRoute {
   messageDebounceMaxMs: number | null;
   messageDebounceGroupMs: number | null;
   messageDebounceRestartOnTyping: boolean | null;
+  messageDebounceMaxWaitMs: number | null;
   // Split delay overrides
   messageSplitDelayMode: string | null;
   messageSplitDelayFixedMs: number | null;

--- a/packages/api/src/services/routes.ts
+++ b/packages/api/src/services/routes.ts
@@ -74,6 +74,7 @@ export class RouteService {
       messageDebounceMaxMs: data.messageDebounceMaxMs ?? null,
       messageDebounceGroupMs: data.messageDebounceGroupMs ?? null,
       messageDebounceRestartOnTyping: data.messageDebounceRestartOnTyping ?? null,
+      messageDebounceMaxWaitMs: data.messageDebounceMaxWaitMs ?? null,
       messageSplitDelayMode: data.messageSplitDelayMode ?? null,
       messageSplitDelayFixedMs: data.messageSplitDelayFixedMs ?? null,
       messageSplitDelayMinMs: data.messageSplitDelayMinMs ?? null,

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -96,6 +96,7 @@ function applyDebounceFields(body: Record<string, unknown>, opts: Record<string,
   if (opts.debounceMax !== undefined) body.messageDebounceMaxMs = opts.debounceMax;
   setBool(body, 'messageDebounceRestartOnTyping', opts.debounceRestartOnTyping);
   if (opts.debounceGroup !== undefined) body.messageDebounceGroupMs = opts.debounceGroup;
+  if (opts.debounceMaxWait !== undefined) body.messageDebounceMaxWaitMs = opts.debounceMaxWait;
 }
 
 /** Extract split-delay fields from CLI options into body */
@@ -328,11 +329,14 @@ export function createInstancesCommand(): Command {
     .option('--no-enable-auto-split', 'Disable auto-split')
     .option('--message-format-mode <mode>', 'Format mode: convert or passthrough')
     // Debounce
-    .option('--debounce-mode <mode>', 'Debounce mode: disabled, fixed, or randomized')
+    .option('--debounce-mode <mode>', 'Debounce mode: disabled, fixed, randomized, or presence')
     .option('--debounce-min <ms>', 'Minimum debounce delay in ms', (v) => Number.parseInt(v, 10))
     .option('--debounce-max <ms>', 'Maximum debounce delay in ms', (v) => Number.parseInt(v, 10))
     .option('--debounce-restart-on-typing', 'Restart debounce timer on typing')
     .option('--debounce-group <ms>', 'Group chat debounce in ms', (v) => Number.parseInt(v, 10))
+    .option('--debounce-max-wait <ms>', 'Presence-mode hard cap in ms (flush even under continuous typing)', (v) =>
+      Number.parseInt(v, 10),
+    )
     // Split delay (between agent-reply chunks)
     .option('--split-delay-mode <mode>', 'Split delay mode: disabled, fixed, or randomized')
     .option('--split-delay-fixed <ms>', 'Fixed delay between split chunks in ms', (v) => Number.parseInt(v, 10))
@@ -857,12 +861,15 @@ export function createInstancesCommand(): Command {
     .option('--no-enable-auto-split', 'Disable auto-split')
     .option('--message-format-mode <mode>', 'Format mode: convert or passthrough')
     // Debounce
-    .option('--debounce-mode <mode>', 'Debounce mode: disabled, fixed, or randomized')
+    .option('--debounce-mode <mode>', 'Debounce mode: disabled, fixed, randomized, or presence')
     .option('--debounce-min <ms>', 'Minimum debounce delay in ms', (v) => Number.parseInt(v, 10))
     .option('--debounce-max <ms>', 'Maximum debounce delay in ms', (v) => Number.parseInt(v, 10))
     .option('--debounce-restart-on-typing', 'Restart debounce timer on typing')
     .option('--no-debounce-restart-on-typing', 'Do not restart debounce on typing')
     .option('--debounce-group <ms>', 'Group chat debounce in ms (use "null" to inherit)', (v) =>
+      v === 'null' ? null : Number.parseInt(v, 10),
+    )
+    .option('--debounce-max-wait <ms>', 'Presence-mode hard cap in ms (use "null" to inherit)', (v) =>
       v === 'null' ? null : Number.parseInt(v, 10),
     )
     // Split delay (between agent-reply chunks)

--- a/packages/core/src/schemas/agent-route.ts
+++ b/packages/core/src/schemas/agent-route.ts
@@ -64,11 +64,12 @@ export const AgentRouteSchema = z.object({
   agentGatePrompt: z.string().nullable(),
 
   // Debounce overrides (null = inherit from instance)
-  messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized']).nullable(),
+  messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized', 'presence']).nullable(),
   messageDebounceMinMs: z.number().int().nonnegative().nullable(),
   messageDebounceMaxMs: z.number().int().nonnegative().nullable(),
   messageDebounceGroupMs: z.number().int().nonnegative().nullable(),
   messageDebounceRestartOnTyping: z.boolean().nullable(),
+  messageDebounceMaxWaitMs: z.number().int().nonnegative().nullable(),
 
   // Split delay overrides (null = inherit from instance)
   messageSplitDelayMode: z.enum(['disabled', 'fixed', 'randomized']).nullable(),
@@ -118,11 +119,12 @@ export const CreateAgentRouteSchema = z
     agentGatePrompt: z.string().optional(),
 
     // Debounce overrides
-    messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized']).optional(),
+    messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized', 'presence']).optional(),
     messageDebounceMinMs: z.number().int().nonnegative().optional(),
     messageDebounceMaxMs: z.number().int().nonnegative().optional(),
     messageDebounceGroupMs: z.number().int().nonnegative().optional(),
     messageDebounceRestartOnTyping: z.boolean().optional(),
+    messageDebounceMaxWaitMs: z.number().int().nonnegative().optional(),
 
     // Split delay overrides
     messageSplitDelayMode: z.enum(['disabled', 'fixed', 'randomized']).optional(),
@@ -169,11 +171,12 @@ export const UpdateAgentRouteSchema = z.object({
   agentGatePrompt: z.string().optional().nullable(),
 
   // Debounce overrides
-  messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized']).optional().nullable(),
+  messageDebounceMode: z.enum(['disabled', 'fixed', 'randomized', 'presence']).optional().nullable(),
   messageDebounceMinMs: z.number().int().nonnegative().optional().nullable(),
   messageDebounceMaxMs: z.number().int().nonnegative().optional().nullable(),
   messageDebounceGroupMs: z.number().int().nonnegative().optional().nullable(),
   messageDebounceRestartOnTyping: z.boolean().optional().nullable(),
+  messageDebounceMaxWaitMs: z.number().int().nonnegative().optional().nullable(),
 
   // Split delay overrides
   messageSplitDelayMode: z.enum(['disabled', 'fixed', 'randomized']).optional().nullable(),

--- a/packages/db/drizzle/0037_message_debounce_max_wait.sql
+++ b/packages/db/drizzle/0037_message_debounce_max_wait.sql
@@ -1,0 +1,22 @@
+-- Presence-debounce max-wait cap (presence-debounce-batching design, 2026-07).
+--
+-- Adds `message_debounce_max_wait_ms` to both the `instances` table and the
+-- per-route `agent_routes` override table. It is the hard cap for the new
+-- 'presence' debounce mode: a batch flushes at `firstBuffered + maxWaitMs`
+-- even while the user keeps typing, so a continuously-composing user can never
+-- starve the agent. NULL = no cap (the legacy fixed/randomized behavior).
+--
+-- The 'presence' mode itself is a TypeScript-layer literal (message-debouncer
+-- DebounceConfig + the `debounceMode` const in schema.ts). The DB stores mode
+-- as a free varchar(20) with no CHECK constraint, so no enum migration is
+-- needed here — only the new nullable column.
+--
+-- Hand-written (not `drizzle-kit generate`) to match the repo convention from
+-- 0032+ and avoid the gupshup column-rename prompts that block non-interactive
+-- runs.
+
+ALTER TABLE "instances"
+  ADD COLUMN IF NOT EXISTS "message_debounce_max_wait_ms" integer;
+
+ALTER TABLE "agent_routes"
+  ADD COLUMN IF NOT EXISTS "message_debounce_max_wait_ms" integer;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1777860000000,
       "tag": "0036_timestamptz_migration",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1777950000000,
+      "tag": "0037_message_debounce_max_wait",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -57,7 +57,7 @@ export type AgentSystem = (typeof agentSystems)[number];
 export const agentEntityTypes = ['assistant', 'workflow', 'team', 'tool'] as const;
 export type AgentEntityType = (typeof agentEntityTypes)[number];
 
-export const debounceMode = ['disabled', 'fixed', 'randomized'] as const;
+export const debounceMode = ['disabled', 'fixed', 'randomized', 'presence'] as const;
 export type DebounceMode = (typeof debounceMode)[number];
 
 export const splitDelayMode = ['disabled', 'fixed', 'randomized'] as const;
@@ -404,6 +404,8 @@ export const agentRoutes = pgTable(
     messageDebounceMaxMs: integer('message_debounce_max_ms'),
     messageDebounceGroupMs: integer('message_debounce_group_ms'),
     messageDebounceRestartOnTyping: boolean('message_debounce_restart_on_typing'),
+    /** Hard cap (ms) for 'presence' mode — flush at firstBuffered + this even under continuous typing. NULL = no cap. */
+    messageDebounceMaxWaitMs: integer('message_debounce_max_wait_ms'),
 
     // ---- Split delay overrides (NULL = inherit from instance) ----
     messageSplitDelayMode: varchar('message_split_delay_mode', { length: 20 }).$type<SplitDelayMode>(),
@@ -756,6 +758,8 @@ export const instances = pgTable(
     messageDebounceMaxMs: integer('message_debounce_max_ms').notNull().default(0),
     /** Restart debounce timer when user is typing (requires channel support) */
     messageDebounceRestartOnTyping: boolean('message_debounce_restart_on_typing').notNull().default(false),
+    /** Hard cap (ms) for 'presence' mode — flush at firstBuffered + this even under continuous typing. NULL = no cap. */
+    messageDebounceMaxWaitMs: integer('message_debounce_max_wait_ms'),
 
     // ---- Smart Response Gate ----
     agentGateEnabled: boolean('agent_gate_enabled').notNull().default(false),

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -3790,7 +3790,7 @@ export interface components {
              * @description Debounce mode override
              * @enum {string|null}
              */
-            messageDebounceMode: "disabled" | "fixed" | "randomized" | null;
+            messageDebounceMode: "disabled" | "fixed" | "randomized" | "presence" | null;
             /** @description Debounce min delay (ms) override */
             messageDebounceMinMs: number | null;
             /** @description Debounce max delay (ms) override */
@@ -3799,6 +3799,8 @@ export interface components {
             messageDebounceGroupMs: number | null;
             /** @description Restart debounce on typing override */
             messageDebounceRestartOnTyping: boolean | null;
+            /** @description Presence-mode hard cap (ms) override; null = no cap */
+            messageDebounceMaxWaitMs: number | null;
             /**
              * @description Split delay mode override
              * @enum {string|null}
@@ -3908,7 +3910,7 @@ export interface components {
              * @description Debounce mode
              * @enum {string}
              */
-            messageDebounceMode?: "disabled" | "fixed" | "randomized";
+            messageDebounceMode?: "disabled" | "fixed" | "randomized" | "presence";
             /** @description Debounce min delay (ms) */
             messageDebounceMinMs?: number;
             /** @description Debounce max delay (ms) */
@@ -3917,6 +3919,8 @@ export interface components {
             messageDebounceGroupMs?: number;
             /** @description Restart debounce on typing */
             messageDebounceRestartOnTyping?: boolean;
+            /** @description Presence-mode hard cap (ms); null = no cap */
+            messageDebounceMaxWaitMs?: number;
             /**
              * @description Split delay mode
              * @enum {string}
@@ -4007,7 +4011,7 @@ export interface components {
              * @description Debounce mode
              * @enum {string|null}
              */
-            messageDebounceMode?: "disabled" | "fixed" | "randomized" | null;
+            messageDebounceMode?: "disabled" | "fixed" | "randomized" | "presence" | null;
             /** @description Debounce min delay (ms) */
             messageDebounceMinMs?: number | null;
             /** @description Debounce max delay (ms) */
@@ -4016,6 +4020,8 @@ export interface components {
             messageDebounceGroupMs?: number | null;
             /** @description Restart debounce on typing */
             messageDebounceRestartOnTyping?: boolean | null;
+            /** @description Presence-mode hard cap (ms); null = no cap */
+            messageDebounceMaxWaitMs?: number | null;
             /**
              * @description Split delay mode
              * @enum {string|null}
@@ -11572,7 +11578,7 @@ export interface operations {
                              * @description Debounce mode override
                              * @enum {string|null}
                              */
-                            messageDebounceMode: "disabled" | "fixed" | "randomized" | null;
+                            messageDebounceMode: "disabled" | "fixed" | "randomized" | "presence" | null;
                             /** @description Debounce min delay (ms) override */
                             messageDebounceMinMs: number | null;
                             /** @description Debounce max delay (ms) override */
@@ -11581,6 +11587,8 @@ export interface operations {
                             messageDebounceGroupMs: number | null;
                             /** @description Restart debounce on typing override */
                             messageDebounceRestartOnTyping: boolean | null;
+                            /** @description Presence-mode hard cap (ms) override; null = no cap */
+                            messageDebounceMaxWaitMs: number | null;
                             /**
                              * @description Split delay mode override
                              * @enum {string|null}
@@ -11727,7 +11735,7 @@ export interface operations {
                      * @description Debounce mode
                      * @enum {string}
                      */
-                    messageDebounceMode?: "disabled" | "fixed" | "randomized";
+                    messageDebounceMode?: "disabled" | "fixed" | "randomized" | "presence";
                     /** @description Debounce min delay (ms) */
                     messageDebounceMinMs?: number;
                     /** @description Debounce max delay (ms) */
@@ -11736,6 +11744,8 @@ export interface operations {
                     messageDebounceGroupMs?: number;
                     /** @description Restart debounce on typing */
                     messageDebounceRestartOnTyping?: boolean;
+                    /** @description Presence-mode hard cap (ms); null = no cap */
+                    messageDebounceMaxWaitMs?: number;
                     /**
                      * @description Split delay mode
                      * @enum {string}
@@ -11861,7 +11871,7 @@ export interface operations {
                              * @description Debounce mode override
                              * @enum {string|null}
                              */
-                            messageDebounceMode: "disabled" | "fixed" | "randomized" | null;
+                            messageDebounceMode: "disabled" | "fixed" | "randomized" | "presence" | null;
                             /** @description Debounce min delay (ms) override */
                             messageDebounceMinMs: number | null;
                             /** @description Debounce max delay (ms) override */
@@ -11870,6 +11880,8 @@ export interface operations {
                             messageDebounceGroupMs: number | null;
                             /** @description Restart debounce on typing override */
                             messageDebounceRestartOnTyping: boolean | null;
+                            /** @description Presence-mode hard cap (ms) override; null = no cap */
+                            messageDebounceMaxWaitMs: number | null;
                             /**
                              * @description Split delay mode override
                              * @enum {string|null}
@@ -12076,7 +12088,7 @@ export interface operations {
                              * @description Debounce mode override
                              * @enum {string|null}
                              */
-                            messageDebounceMode: "disabled" | "fixed" | "randomized" | null;
+                            messageDebounceMode: "disabled" | "fixed" | "randomized" | "presence" | null;
                             /** @description Debounce min delay (ms) override */
                             messageDebounceMinMs: number | null;
                             /** @description Debounce max delay (ms) override */
@@ -12085,6 +12097,8 @@ export interface operations {
                             messageDebounceGroupMs: number | null;
                             /** @description Restart debounce on typing override */
                             messageDebounceRestartOnTyping: boolean | null;
+                            /** @description Presence-mode hard cap (ms) override; null = no cap */
+                            messageDebounceMaxWaitMs: number | null;
                             /**
                              * @description Split delay mode override
                              * @enum {string|null}
@@ -12305,7 +12319,7 @@ export interface operations {
                      * @description Debounce mode
                      * @enum {string|null}
                      */
-                    messageDebounceMode?: "disabled" | "fixed" | "randomized" | null;
+                    messageDebounceMode?: "disabled" | "fixed" | "randomized" | "presence" | null;
                     /** @description Debounce min delay (ms) */
                     messageDebounceMinMs?: number | null;
                     /** @description Debounce max delay (ms) */
@@ -12314,6 +12328,8 @@ export interface operations {
                     messageDebounceGroupMs?: number | null;
                     /** @description Restart debounce on typing */
                     messageDebounceRestartOnTyping?: boolean | null;
+                    /** @description Presence-mode hard cap (ms); null = no cap */
+                    messageDebounceMaxWaitMs?: number | null;
                     /**
                      * @description Split delay mode
                      * @enum {string|null}
@@ -12433,7 +12449,7 @@ export interface operations {
                              * @description Debounce mode override
                              * @enum {string|null}
                              */
-                            messageDebounceMode: "disabled" | "fixed" | "randomized" | null;
+                            messageDebounceMode: "disabled" | "fixed" | "randomized" | "presence" | null;
                             /** @description Debounce min delay (ms) override */
                             messageDebounceMinMs: number | null;
                             /** @description Debounce max delay (ms) override */
@@ -12442,6 +12458,8 @@ export interface operations {
                             messageDebounceGroupMs: number | null;
                             /** @description Restart debounce on typing override */
                             messageDebounceRestartOnTyping: boolean | null;
+                            /** @description Presence-mode hard cap (ms) override; null = no cap */
+                            messageDebounceMaxWaitMs: number | null;
                             /**
                              * @description Split delay mode override
                              * @enum {string|null}


### PR DESCRIPTION
Implements `docs/design/presence-debounce-batching.md` (merged plan). Extends omni's **existing** active inbound debouncer — no new module, no `message.received` schema change.

## What

- **`presence` mode** — sugar for `fixed` + `restartOnTyping` + a hard `maxWaitMs` cap, so a continuously-typing user still flushes (the previous debouncer had no cap → could buffer forever). Enable per-instance/route; "flush ~5s after the user stops typing" now has a bounded worst case.
- **`flushAll()` shutdown drain** — the graceful-shutdown cleanup previously called `clear()`, which **dropped** buffered messages (the real bug). It now `flushAll()`s — delivers pending batches on shutdown, then clears. The setup-**error** path keeps `clear()` (drop-on-failure is correct).
- **Config plumbing** — `'presence'` + `message_debounce_max_wait_ms` threaded through core zod (base/create/update), openapi mirror, instances route, route-resolver, dispatcher merge, CLI (`--debounce-max-wait`), and SDK regen. Hand-written migration `0037` (idempotent `ADD COLUMN IF NOT EXISTS`, nullable — safe on a populated DB). Defaults: `minMs 5000`, `maxWaitMs 30000`, `restartOnTyping true`.
- **Docs** — `docs/guides/typing-debounce.md`. **Tests** — cap-under-continuous-typing, flushAll-delivers, per-chat isolation, existing-mode parity.

## Safety

- `disabled | fixed | randomized` are **byte-identical** — the cap is a no-op when `maxWaitMs` is null/≤0.
- **Zero `message.received` schema change** (single-media, all 7 channels) — coalescing already happens over the buffer array; consumers (genie) need no change.
- A pre-push regression was caught + fixed: the existing `agent-dispatcher > cleanup` test asserted the *old* drop-on-cleanup behavior; it's updated to assert flush-on-cleanup (the intended fix).

## Validation

`bun test` (full, repo root) **4077 pass / 0 fail / 294 skip**; `bun run typecheck` 21/21; `bun run lint` clean. SHIP-reviewed.

Merge → dev (omni is dev → homolog → main).