### PR TITLE
chore(release): publish .well-known manifests for v2.260703.6

### DIFF
--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "channel": "dev",
+  "version": "2.260703.6",
+  "released_at": "2026-07-03T08:15:14Z",
+  "tarball_base": "https://github.com/automagik-dev/omni/releases/download/v2.260703.6",
+  "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
+}

--- a/.well-known/homolog.json
+++ b/.well-known/homolog.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "channel": "homolog",
+  "version": "2.260703.6",
+  "released_at": "2026-07-03T08:15:14Z",
+  "tarball_base": "https://github.com/automagik-dev/omni/releases/download/v2.260703.6",
+  "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
+}

--- a/.well-known/latest.json
+++ b/.well-known/latest.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "channel": "stable",
+  "version": "2.260703.6",
+  "released_at": "2026-07-03T08:15:14Z",
+  "tarball_base": "https://github.com/automagik-dev/omni/releases/download/v2.260703.6",
+  "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
+}


### PR DESCRIPTION
## What
Lands the three `.well-known/*.json` auto-update pointers at **`2.260703.6`** — `latest.json` (stable), `homolog.json`, `dev.json` — the exact content `release.yml` generates (schema_version 1, real `released_at`, `tarball_base` → `.../download/v2.260703.6`, all 4 platforms).

## Why
The `v2.260703.6` stable release (#756) published the GitHub Release + npm `@latest` correctly, but `release.yml`'s publish step **could not push the manifests to main** — branch protection blocks the release-bot:
```
##[warning] push to main failed (likely branch protection); update .well-known/*.json manually
```
So the stable pointer was stuck at the old version even though the release + npm were correct. This lands them via PR (bypassing the blocked direct push).

## Safe to merge
This PR is from `fix/…`, **not** `dev`, so its merge commit won't match `version.yml`'s `Merge pull request … /dev` trigger — **no release re-fires.** Merge method doesn't matter here.

## Durable follow-up (not this PR)
So this stops being a manual step every stable release, either grant the Actions bot push-to-main rights, or have `release.yml` open an auto-PR for the manifests instead of a direct push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published updated release metadata for the latest, dev, and homolog channels.
  * Added the new stable release version `2.260703.6` with updated download links and release timestamp.
  * Kept supported platform listings available for the stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->