### PR TITLE
fix(chart): generous api liveness budget + LoadBalancer in dev overlay

### DIFF
--- a/deploy/helm/omni/values-dev.yaml
+++ b/deploy/helm/omni/values-dev.yaml
@@ -84,3 +84,9 @@ autopg:
       password: "omni-dev-password"
   persistence:
     size: 2Gi
+
+# Expose the api to the host (OrbStack assigns a LoadBalancer IP reachable
+# from the Mac) — the omni CLI on the host points at this endpoint.
+service:
+  type: LoadBalancer
+  port: 8882

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -114,18 +114,23 @@ secret:
 # ---- probes -----------------------------------------------------------------
 # GET /health → 200 {"status":"healthy",...} once DB + NATS are up (5s-cached).
 probes:
+  # Readiness sheds traffic while the event loop is busy — that is correct and
+  # can stay sensitive. Liveness must only kill a HUNG process: a fresh
+  # WhatsApp pairing's history sync can starve the loop for minutes (observed
+  # in the wild 2026-07-04: liveness killed the pod mid-sync, truncating the
+  # one-shot history backfill), so its budget is generous (~5 min).
   readiness:
     path: /health
     initialDelaySeconds: 10
     periodSeconds: 10
-    timeoutSeconds: 3
+    timeoutSeconds: 5
     failureThreshold: 6
   liveness:
     path: /health
     initialDelaySeconds: 45
     periodSeconds: 20
-    timeoutSeconds: 5
-    failureThreshold: 6
+    timeoutSeconds: 10
+    failureThreshold: 15
   # Migrations + DB readiness can take 30s+; startupProbe guards slow boots.
   startup:
     path: /health


### PR DESCRIPTION
## Two chart fixes from live operation (2026-07-04)

**1. Liveness budget (values.yaml)** — a fresh WhatsApp pairing's history sync starves the event loop for minutes. The 5s×6 liveness probe killed the pod mid-sync, truncating the one-shot history backfill. Liveness is now **10s×15 (~5 min)** — it should only kill a *hung* process, never a *busy* one. Readiness stays sensitive (shedding traffic under churn is correct behavior), bumped 3s→5s to reduce flap.

**2. LoadBalancer in the dev overlay (values-dev.yaml)** — OrbStack assigns LoadBalancer Services an IP reachable from the host, which is how the host's `omni` CLI points at the in-cluster server. Previously done via an out-of-band `kubectl patch`, which the next `helm upgrade` silently reverted (broke the CLI endpoint). Now chart-owned.

Both verified live: pod rolled, both WhatsApp instances reconnected from DB creds, `connected=2`, stable LB endpoint.