### PR TITLE
feat(instances): per-instance allow-first-party opt-out for self-owned senders

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { instances } from '@omni/db';
 
 // ---------------------------------------------------------------------------
 // We need to test internal classes and functions that are NOT exported.
@@ -26,7 +27,13 @@ import { afterEach, describe, expect, it, mock } from 'bun:test';
 // ---------------------------------------------------------------------------
 
 // Import exported symbols
-import { type DispatcherCleanup, __test__, resolveQuotedMessage, setupAgentDispatcher } from '../agent-dispatcher';
+import {
+  type DispatcherCleanup,
+  __test__,
+  isFirstPartyInstanceSender,
+  resolveQuotedMessage,
+  setupAgentDispatcher,
+} from '../agent-dispatcher';
 
 // We need to mock the plugin loader to avoid real FS/channel-sdk imports
 mock.module('../loader', () => ({
@@ -2196,6 +2203,111 @@ describe('agent-dispatcher', () => {
       expect(findChatSpy.mock.calls.length).toBe(perDeliveryCalls * 3);
 
       cleanup();
+    });
+  });
+
+  // ======================================================================
+  // First-party cross-instance gate (allowFirstParty opt-out)
+  //
+  // Loop protection drops inbound messages whose sender phone matches ANOTHER
+  // active instance's owner (isFirstPartyInstanceSender). `allowFirstParty`
+  // opts an instance out of that drop so it can reply to messages the operator
+  // sends from their own personal number (another instance's owner).
+  // ======================================================================
+  describe('first-party cross-instance gate (allowFirstParty)', () => {
+    let cleanup: DispatcherCleanup;
+
+    afterEach(() => {
+      cleanup?.();
+    });
+
+    const CURRENT_OWNER = '5511986780008:12@s.whatsapp.net';
+    const OTHER_OWNER = '5512982298888:43@s.whatsapp.net';
+    const OTHER_PHONE = '5512982298888';
+
+    // db mock, branching on the queried table:
+    //  - `select().from(instances).where()` (awaited) → active-owner rows, so
+    //    isFirstPartyInstanceSender sees OTHER_OWNER as a second active owner.
+    //  - `select().from(agents).where().limit(1)` → the agent row for
+    //    applyAgentFkOverrides.
+    function createFirstPartyDb() {
+      const agentRow = {
+        id: 'agent-uuid-1',
+        agentProviderId: 'provider-1',
+        agentType: 'agent',
+        metadata: { providerAgentId: 'default-agent' },
+        configPath: null,
+      };
+      const ownerRows = [{ ownerIdentifier: CURRENT_OWNER }, { ownerIdentifier: OTHER_OWNER }];
+      const insertChain = (row: { eventId?: string }) => ({
+        onConflictDoNothing: () => ({ returning: async () => [{ eventId: row.eventId ?? 'mock-evt' }] }),
+      });
+      return {
+        select: () => ({
+          from: (table: unknown) => ({
+            where: () =>
+              table === instances ? Promise.resolve(ownerRows) : { limit: () => Promise.resolve([agentRow]) },
+          }),
+        }),
+        insert: () => ({ values: (row: { eventId?: string }) => insertChain(row) }),
+      } as unknown as import('@omni/db').Database;
+    }
+
+    // Fire a message whose sender (OTHER_PHONE) is OTHER_OWNER's phone — a
+    // first-party cross-instance sender — into an instance owned by
+    // CURRENT_OWNER. Returns the agentRunner so callers can assert whether
+    // dispatch proceeded (getSenderName is only reached past the gate).
+    async function fireFirstPartyMessage(allowFirstParty: boolean) {
+      const eventBus = createMockEventBus();
+      const agentRunner = {
+        getInstanceWithProvider: mock(async () =>
+          createMockInstance({ ownerIdentifier: CURRENT_OWNER, allowFirstParty }),
+        ),
+        getSenderName: mock(async () => 'Felipe'),
+        run: mock(async () => ({
+          parts: ['resp'],
+          metadata: { runId: 'r', sessionId: 's', status: 'completed' },
+        })),
+      };
+      const services = createMockServices({ agentRunner });
+      cleanup = await setupAgentDispatcher(
+        eventBus as unknown as import('@omni/core').EventBus,
+        services,
+        createFirstPartyDb(),
+      );
+      await eventBus.fire(
+        'message.received',
+        createMessageEvent({
+          payload: {
+            externalId: 'fp-1',
+            chatId: `${OTHER_PHONE}@s.whatsapp.net`,
+            from: OTHER_PHONE,
+            content: { type: 'text', text: 'hi from my other phone' },
+            rawPayload: { resolvedSenderPhone: OTHER_PHONE },
+          },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return agentRunner;
+    }
+
+    it('is still detected as a first-party sender by isFirstPartyInstanceSender', () => {
+      const detected = isFirstPartyInstanceSender(
+        { from: OTHER_PHONE, rawPayload: { resolvedSenderPhone: OTHER_PHONE } },
+        CURRENT_OWNER,
+        [CURRENT_OWNER, OTHER_OWNER],
+      );
+      expect(detected).toBe(true);
+    });
+
+    it('drops the message when allowFirstParty is false (default loop-protection)', async () => {
+      const agentRunner = await fireFirstPartyMessage(false);
+      expect(agentRunner.getSenderName.mock.calls.length).toBe(0);
+    });
+
+    it('dispatches the message when allowFirstParty is true (opt-out)', async () => {
+      const agentRunner = await fireFirstPartyMessage(true);
+      expect(agentRunner.getSenderName.mock.calls.length).toBe(1);
     });
   });
 });

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -4638,8 +4638,16 @@ async function shouldProcessMessage(
     return null;
   }
 
+  // Loop protection: drop messages whose sender matches ANOTHER active
+  // instance's owner. Opt-out per instance via `allowFirstParty` so a user's
+  // "assistant" instance can reply to messages from their own personal number
+  // (another instance's owner). The separate "message from self" self-skip
+  // above is unaffected — an instance still never replies to its own outbound.
   const activeOwnerIdentifiers = await listActiveOwnerIdentifiers(db);
-  if (isFirstPartyInstanceSender(payload, instance.ownerIdentifier, activeOwnerIdentifiers)) {
+  if (
+    !instance.allowFirstParty &&
+    isFirstPartyInstanceSender(payload, instance.ownerIdentifier, activeOwnerIdentifiers)
+  ) {
     log.info('Skipping first-party cross-instance message', {
       instanceId: instance.id,
     });

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -232,6 +232,14 @@ const createInstanceSchema = z.object({
     .describe(
       'When true, requests targeting this instance MUST carry a verified X-Genie-Signature. Bearer-only requests get 401. Default: false (additive rollout).',
     ),
+  // First-party cross-instance opt-in. Optional + default(false) — existing
+  // instances keep loop-protection (drop) until an operator opts in.
+  allowFirstParty: z
+    .boolean()
+    .default(false)
+    .describe(
+      'When true, this instance processes (does not drop) inbound messages whose sender matches another active instance owner. Lets an "assistant" instance reply to messages from the operator\'s own personal number. Default: false (loop-protection drop).',
+    ),
 });
 
 // Update instance schema - allow null to clear values (only for nullable DB fields)
@@ -280,6 +288,7 @@ const updateInstanceSchema = createInstanceSchema.partial().extend({
   // Strip the .default(false) from the create-time schema so a PATCH that
   // omits this key doesn't silently flip the stored value back to false.
   requireGenieSignature: z.boolean().optional(),
+  allowFirstParty: z.boolean().optional(),
 });
 
 /**

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -142,6 +142,9 @@ function applyMiscFields(body: Record<string, unknown>, opts: Record<string, unk
   // `--no-require-genie-signature` (false) automatically when the option is
   // declared with `--require-genie-signature` syntax.
   setBool(body, 'requireGenieSignature', opts.requireGenieSignature);
+  // First-party cross-instance opt-in. Commander pairs `--allow-first-party`
+  // (true) and `--no-allow-first-party` (false) automatically.
+  setBool(body, 'allowFirstParty', opts.allowFirstParty);
   if (opts.triggerEvents !== undefined) {
     const raw = opts.triggerEvents as string;
     body.triggerEvents = raw === 'null' ? null : raw.split(',').map((s) => s.trim());
@@ -392,6 +395,15 @@ export function createInstancesCommand(): Command {
       'Require a verified X-Genie-Signature on requests targeting this instance. Bearer-only requests will be rejected with 401.',
     )
     .option('--no-require-genie-signature', 'Allow bearer-only requests targeting this instance (default).')
+    // First-party cross-instance opt-in
+    .option(
+      '--allow-first-party',
+      'Process (do not drop) inbound messages whose sender matches another active instance owner. Lets this instance reply to messages from your own personal number.',
+    )
+    .option(
+      '--no-allow-first-party',
+      'Drop inbound messages whose sender matches another active instance owner (default, loop-protection).',
+    )
     // Default
     .option('--is-default', 'Set as default instance for channel')
     .action(async (options: Record<string, unknown>) => {
@@ -926,6 +938,15 @@ export function createInstancesCommand(): Command {
       'Require a verified X-Genie-Signature on requests targeting this instance. Bearer-only requests will be rejected with 401.',
     )
     .option('--no-require-genie-signature', 'Allow bearer-only requests targeting this instance (default).')
+    // First-party cross-instance opt-in
+    .option(
+      '--allow-first-party',
+      'Process (do not drop) inbound messages whose sender matches another active instance owner. Lets this instance reply to messages from your own personal number.',
+    )
+    .option(
+      '--no-allow-first-party',
+      'Drop inbound messages whose sender matches another active instance owner (default, loop-protection).',
+    )
     .action(async (rawId: string, options: Record<string, unknown>) => {
       const client = getClient();
 

--- a/packages/db/drizzle/0038_instances_allow_first_party.sql
+++ b/packages/db/drizzle/0038_instances_allow_first_party.sql
@@ -1,0 +1,22 @@
+-- Per-instance first-party cross-instance opt-in.
+--
+-- Adds `instances.allow_first_party` (default false). When true, the agent
+-- dispatcher will NOT drop inbound messages whose sender phone matches another
+-- active instance's owner. This lets a user's "assistant" instance reply to
+-- messages sent from their own personal number (which is another instance's
+-- owner) instead of silently dropping them via loop protection.
+--
+-- Default false preserves current loop-protection behavior for every existing
+-- instance. Opt in per-instance via:
+--
+--   omni instances update <id> --allow-first-party
+--
+-- Does NOT affect the separate "message from self" self-skip — an instance
+-- still never replies to its own outbound. See `isFirstPartyInstanceSender`
+-- and the gate in packages/api/src/plugins/agent-dispatcher.ts.
+--
+-- Hand-written (not `drizzle-kit generate`) to avoid the gupshup column
+-- rename prompts that block non-interactive runs in this repo.
+
+ALTER TABLE "instances"
+  ADD COLUMN IF NOT EXISTS "allow_first_party" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1777950000000,
       "tag": "0037_message_debounce_max_wait",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1778040000000,
+      "tag": "0038_instances_allow_first_party",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -886,6 +886,20 @@ export const instances = pgTable(
      */
     requireGenieSignature: boolean('require_genie_signature').notNull().default(false),
 
+    // ---- First-party cross-instance opt-in ----
+    /**
+     * When true, this instance PROCESSES (does not drop) inbound messages whose
+     * sender phone matches ANOTHER active instance's owner. This lets a user run
+     * instance A as an "assistant" number that replies to messages A receives
+     * from their own personal number (which is instance B's owner).
+     *
+     * Default false preserves the loop-protection default: cross-instance
+     * first-party senders are dropped (see `isFirstPartyInstanceSender` in
+     * agent-dispatcher.ts). This does NOT affect the "message from self"
+     * self-skip — an instance still never replies to its own outbound.
+     */
+    allowFirstParty: boolean('allow_first_party').notNull().default(false),
+
     // ---- Timestamps ----
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),


### PR DESCRIPTION
## Problem

Omni drops a WhatsApp message when the sender's phone matches **another** active omni instance's owner (loop protection via `isFirstPartyInstanceSender`). This is correct default behavior, but it blocks a legitimate use case: running instance A as an "assistant" number that should accept and reply to messages the operator sends from their personal number (instance B's owner). Today A's dispatch is skipped because B is another active owner.

## Change

Add a per-instance opt-out, `allow_first_party` (default `false` — zero behavior change for every existing instance).

- **db**: new `instances.allow_first_party` boolean column (`packages/db/src/schema.ts`) + hand-written migration `0038_instances_allow_first_party.sql`. Auto-applied on API boot via `applyMigrations` (`packages/api/src/index.ts`), so the k8s autopg DB picks it up on deploy.
- **dispatcher gate** (`packages/api/src/plugins/agent-dispatcher.ts`): the first-party cross-instance drop is now gated on `!instance.allowFirstParty`. When `true`, a first-party cross-instance sender is processed instead of dropped. The separate **"message from self"** self-skip (sender == the instance's own number) is **unchanged** — an instance still never replies to its own outbound.
- **API** (`packages/api/src/routes/v2/instances.ts`): `allowFirstParty` accepted on the create (`default(false)`) and update (`.optional()`) zod schemas; the generic PATCH handler persists it. `GET /instances/:id` already returns the full sanitized row, so `omni instances get <id> --json` surfaces it with no extra code.
- **CLI** (`packages/cli/src/commands/instances.ts`): `--allow-first-party` / `--no-allow-first-party` on `instances create` and `instances update` (mirrors the `--require-genie-signature` boolean-pair pattern).

## Tests

`packages/api/src/plugins/__tests__/agent-dispatcher.test.ts` — new `first-party cross-instance gate (allowFirstParty)` block:
- `isFirstPartyInstanceSender` still returns `true` for the first-party sender.
- dispatch **drops** the message when `allowFirstParty` is `false` (getSenderName never reached).
- dispatch **proceeds** when `allowFirstParty` is `true`.

## Verify

- `bun run typecheck` → 21/21
- `bun run lint` → biome clean
- `bun test packages/api/src/plugins/__tests__/agent-dispatcher*.test.ts` → 135 pass
- `bun test packages/db` → 11 pass; `bun test packages/cli` → 502 pass
- instances route/middleware tests → 30 pass

## Notes

- Default `false` preserves loop-protection for all existing instances.
- SDK `types.generated.ts` is not regenerated (the field surfaces via raw response passthrough, same as `requireGenieSignature`).