### PR TITLE
fix(media): use gemini audio model for gemini transcription, not the openai default

### DIFF
--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -22,6 +22,7 @@ import { createLogger, isValidUuid } from '@omni/core';
 import type { Database } from '@omni/db';
 import { mediaContent, messages, omniEvents } from '@omni/db';
 import {
+  GEMINI_AUDIO_MODEL,
   type MediaProcessingService,
   createMediaProcessingService,
   getMediaHealthTracker,
@@ -537,6 +538,7 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
     defaultLanguage,
     audioProvider,
     audioModel,
+    geminiAudioModel,
     audioPrompt,
     imagePrompt,
     videoPrompt,
@@ -548,6 +550,7 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
     services.settings.getString('media.default_language', 'DEFAULT_LANGUAGE', 'pt'),
     services.settings.getString('stt.provider', 'STT_PROVIDER', 'openai'),
     services.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-audio-mini'),
+    services.settings.getString('stt.gemini.model', 'GEMINI_STT_MODEL', GEMINI_AUDIO_MODEL),
     services.settings.getString('prompt.audio_transcription'),
     services.settings.getString('prompt.image_description'),
     services.settings.getString('prompt.video_description'),
@@ -561,6 +564,7 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
     defaultLanguage,
     audioProvider: audioProvider ?? 'openai',
     audioModel: audioModel ?? 'gpt-audio-mini',
+    geminiAudioModel: geminiAudioModel ?? GEMINI_AUDIO_MODEL,
     audioPrompt: audioPrompt ?? undefined,
   });
   const mediaStorage = new MediaStorageService(db);

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -29,6 +29,7 @@ import {
   messages,
 } from '@omni/db';
 import {
+  GEMINI_AUDIO_MODEL,
   type MediaProcessingService,
   type ProcessingResult,
   type ProcessorConfig,
@@ -155,16 +156,25 @@ export class BatchJobService {
   private async createMediaService(): Promise<MediaProcessingService> {
     let config: Partial<ProcessorConfig> | undefined;
     if (this.settings) {
-      const [groqApiKey, openaiApiKey, geminiApiKey, defaultLanguage, audioProvider, audioModel, audioPrompt] =
-        await Promise.all([
-          this.settings.getSecret('groq.api_key', 'GROQ_API_KEY'),
-          this.settings.getSecret('openai.api_key', 'OPENAI_API_KEY'),
-          this.settings.getSecret('gemini.api_key', 'GEMINI_API_KEY'),
-          this.settings.getString('media.default_language', 'DEFAULT_LANGUAGE', 'pt'),
-          this.settings.getString('stt.provider', 'STT_PROVIDER', 'openai'),
-          this.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-audio-mini'),
-          this.settings.getString('prompt.audio_transcription'),
-        ]);
+      const [
+        groqApiKey,
+        openaiApiKey,
+        geminiApiKey,
+        defaultLanguage,
+        audioProvider,
+        audioModel,
+        geminiAudioModel,
+        audioPrompt,
+      ] = await Promise.all([
+        this.settings.getSecret('groq.api_key', 'GROQ_API_KEY'),
+        this.settings.getSecret('openai.api_key', 'OPENAI_API_KEY'),
+        this.settings.getSecret('gemini.api_key', 'GEMINI_API_KEY'),
+        this.settings.getString('media.default_language', 'DEFAULT_LANGUAGE', 'pt'),
+        this.settings.getString('stt.provider', 'STT_PROVIDER', 'openai'),
+        this.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-audio-mini'),
+        this.settings.getString('stt.gemini.model', 'GEMINI_STT_MODEL', GEMINI_AUDIO_MODEL),
+        this.settings.getString('prompt.audio_transcription'),
+      ]);
       config = {
         groqApiKey: groqApiKey ?? undefined,
         openaiApiKey: openaiApiKey ?? undefined,
@@ -172,6 +182,7 @@ export class BatchJobService {
         defaultLanguage: defaultLanguage ?? 'pt',
         audioProvider: audioProvider ?? 'openai',
         audioModel: audioModel ?? 'gpt-audio-mini',
+        geminiAudioModel: geminiAudioModel ?? GEMINI_AUDIO_MODEL,
         audioPrompt: audioPrompt ?? undefined,
       };
     }

--- a/packages/media-processing/__tests__/processors.test.ts
+++ b/packages/media-processing/__tests__/processors.test.ts
@@ -103,6 +103,73 @@ describe('processors', () => {
       }
     });
 
+    it('uses a Gemini model (not the OpenAI default) when audioProvider is gemini', async () => {
+      const audioPath = join(tmpdir(), `omni-audio-gemini-${Date.now()}.mp3`);
+      await writeFile(audioPath, Buffer.from('fake-audio'));
+      const calls: Array<{ url: string }> = [];
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        calls.push({ url: String(url) });
+        return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: 'gemini transcript' }] } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+
+      try {
+        // audioModel is the OpenAI-chat model; it must NOT leak into the Gemini request.
+        const processorWithGemini = new AudioProcessor({
+          ...mockConfig,
+          geminiApiKey: 'test-gemini-key',
+          audioProvider: 'gemini',
+          audioModel: 'gpt-audio-mini',
+        });
+
+        const result = await processorWithGemini.process(audioPath, 'audio/mpeg', { language: 'pt-BR' });
+
+        expect(result.success).toBe(true);
+        expect(result.provider).toBe('gemini');
+        expect(result.model).toBe('gemini-3.1-flash-lite');
+        expect(result.content).toBe('gemini transcript');
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.url).toContain('gemini-3.1-flash-lite');
+        expect(calls[0]?.url).not.toContain('gpt-audio-mini');
+      } finally {
+        await rm(audioPath, { force: true });
+      }
+    });
+
+    it('honors a configured geminiAudioModel for gemini transcription', async () => {
+      const audioPath = join(tmpdir(), `omni-audio-gemini-override-${Date.now()}.mp3`);
+      await writeFile(audioPath, Buffer.from('fake-audio'));
+      const calls: Array<{ url: string }> = [];
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        calls.push({ url: String(url) });
+        return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+
+      try {
+        const processorWithGemini = new AudioProcessor({
+          ...mockConfig,
+          geminiApiKey: 'test-gemini-key',
+          audioProvider: 'gemini',
+          audioModel: 'gpt-audio-mini',
+          geminiAudioModel: 'gemini-3-flash-preview',
+        });
+
+        const result = await processorWithGemini.process(audioPath, 'audio/mpeg');
+
+        expect(result.success).toBe(true);
+        expect(result.model).toBe('gemini-3-flash-preview');
+        expect(calls[0]?.url).toContain('gemini-3-flash-preview');
+        expect(calls[0]?.url).not.toContain('gpt-audio-mini');
+      } finally {
+        await rm(audioPath, { force: true });
+      }
+    });
+
     it('normalizes once across fallback attempts and rejects oversized normalized audio', async () => {
       const dir = await mkdtemp(join(tmpdir(), 'omni-audio-normalize-'));
       const audioPath = join(dir, 'input.ogg');

--- a/packages/media-processing/src/index.ts
+++ b/packages/media-processing/src/index.ts
@@ -49,7 +49,13 @@ export type {
 export { DEFAULT_MEDIA_TIMEOUTS, getMediaTimeouts } from './types';
 
 // Models
-export { GEMINI_MODEL, OPENAI_VISION_MODEL, OPENAI_WHISPER_MODEL, GROQ_WHISPER_MODEL } from './models';
+export {
+  GEMINI_MODEL,
+  GEMINI_AUDIO_MODEL,
+  OPENAI_VISION_MODEL,
+  OPENAI_WHISPER_MODEL,
+  GROQ_WHISPER_MODEL,
+} from './models';
 
 // Prompts
 export {

--- a/packages/media-processing/src/processors/audio.ts
+++ b/packages/media-processing/src/processors/audio.ts
@@ -141,7 +141,13 @@ export class AudioProcessor extends BaseProcessor {
 
     if (provider === 'gemini') {
       return [
-        () => this.transcribeWithGemini(language, options, preferredModel ?? GEMINI_AUDIO_MODEL, getNormalizedAudio),
+        () =>
+          this.transcribeWithGemini(
+            language,
+            options,
+            this.resolveGeminiAudioModel(options?.model),
+            getNormalizedAudio,
+          ),
         () => this.transcribeWithOpenAiAudioChat(language, options, OPENAI_AUDIO_CHAT_MODEL, getNormalizedAudio),
         () => this.transcribeWithGroq(language, getNormalizedAudio),
       ];
@@ -157,6 +163,19 @@ export class AudioProcessor extends BaseProcessor {
           getNormalizedAudio,
         ),
     ];
+  }
+
+  /**
+   * Resolve the model for a Gemini transcription attempt.
+   *
+   * `config.audioModel` is the OpenAI-chat model and must never leak into Gemini
+   * — that leak made WhatsApp voice notes fail as `provider:gemini model:gpt-audio-mini`.
+   * A per-call override is honored only when it targets Gemini; otherwise fall back
+   * to the configured Gemini model, then the built-in default.
+   */
+  private resolveGeminiAudioModel(optionModel: string | undefined): string {
+    if (optionModel?.startsWith('gemini')) return optionModel;
+    return this.config.geminiAudioModel ?? GEMINI_AUDIO_MODEL;
   }
 
   private async transcribeWithOpenAiAudioChat(

--- a/packages/media-processing/src/service.ts
+++ b/packages/media-processing/src/service.ts
@@ -166,6 +166,7 @@ export function createMediaProcessingService(config?: Partial<ProcessorConfig>):
     geminiApiKey: config?.geminiApiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY,
     audioProvider: config?.audioProvider ?? process.env.STT_PROVIDER,
     audioModel: config?.audioModel ?? process.env.OPENAI_STT_MODEL,
+    geminiAudioModel: config?.geminiAudioModel ?? process.env.GEMINI_STT_MODEL,
     audioPrompt: config?.audioPrompt,
     audioGlossary: config?.audioGlossary,
     defaultLanguage: config?.defaultLanguage ?? process.env.DEFAULT_LANGUAGE ?? 'pt',

--- a/packages/media-processing/src/types.ts
+++ b/packages/media-processing/src/types.ts
@@ -46,8 +46,10 @@ export interface ProcessorConfig {
   openaiApiKey?: string;
   /** Preferred audio provider (openai, gemini, groq) */
   audioProvider?: string;
-  /** Preferred audio model */
+  /** Preferred OpenAI-chat audio model (used by the 'openai' provider; never sent to Gemini) */
   audioModel?: string;
+  /** Preferred Gemini audio model (used by the 'gemini' provider; falls back to GEMINI_AUDIO_MODEL) */
+  geminiAudioModel?: string;
   /** Default audio transcription prompt/context */
   audioPrompt?: string;
   /** Default audio glossary */


### PR DESCRIPTION
## Problem

WhatsApp voice-note transcription via **gemini** always failed. Live evidence from the running server:

```
Audio transcription attempt failed provider:gemini model:gpt-audio-mini
```

Gemini was handed an **OpenAI** model name (`gpt-audio-mini`) and rejected the request.

## Root cause

In `packages/media-processing/src/processors/audio.ts`, `preferredModel = options?.model ?? this.config.audioModel`, and `config.audioModel` is the OpenAI-chat model (`gpt-audio-mini`, sourced from `stt.openai.model`). In the `provider === 'gemini'` attempt chain, that `preferredModel` was passed straight into `transcribeWithGemini(...)`, so the OpenAI model leaked into the Gemini call. The api plugin only ever read `stt.openai.model` — it never read `stt.gemini.model`. The openai/groq branches already used their own correct model constants; only the gemini branch was wrong.

## Fix — proper per-provider model wiring

- **`types.ts`**: add `geminiAudioModel?: string` to `ProcessorConfig`; document `audioModel` as the OpenAI-chat model (never sent to Gemini).
- **`processors/audio.ts`**: new `resolveGeminiAudioModel()` — the gemini branch now uses `config.geminiAudioModel` (honoring a per-call override only when it targets gemini) and falls back to `GEMINI_AUDIO_MODEL` (`gemini-3.1-flash-lite`), **never** `config.audioModel`. openai + groq branches unchanged; the gemini *fallback* inside the openai branch still passes `GEMINI_AUDIO_MODEL`.
- **`service.ts`**: thread `geminiAudioModel` through `createMediaProcessingService` (env fallback `GEMINI_STT_MODEL`).
- **`index.ts`**: export `GEMINI_AUDIO_MODEL`.
- **`plugins/media-processor.ts`** (live path) and **`services/batch-jobs.ts`** (batch reprocess path): read `stt.gemini.model` (default `gemini-3.1-flash-lite`) and pass it as `geminiAudioModel`.

Model now resolves as: per-call gemini override → `stt.gemini.model` setting / `GEMINI_STT_MODEL` env → `GEMINI_AUDIO_MODEL` default (`gemini-3.1-flash-lite`).

## Tests

Added two audio-processor tests: with `audioProvider: 'gemini'` and no per-call override, `transcribeWithGemini` is invoked with `gemini-3.1-flash-lite` (not `gpt-audio-mini`); and a configured `geminiAudioModel` override is honored.

## Verify

- `bun run typecheck` — green (21/21)
- `bun run lint` — biome clean
- `bun test packages/media-processing` — 93 pass / 0 fail
- `bun test packages/api/src/plugins/__tests__/media-processor-*.test.ts` — 5 pass / 0 fail

## Scope / not in this PR

Only fixes the **live** transcription path (media downloaded fresh to /tmp). A **separate** known issue remains: batch **reprocess** of already-stored media can fail with `ENOENT` because `resolveFilePath()` in `batch-jobs.ts` trusts a stale `message.mediaLocalPath` and only re-fetches (`storeFromUrl`) when that path is null — it never re-fetches from the S3/MinIO backend when the local file is gone. Not touched here. No k8s chart / Dockerfile changes.