### PR TITLE
test(media): make MinIO container-integration suites opt-in in CI

### DIFF
--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -39,7 +39,7 @@ const ACCESS_KEY = 'minioadmin';
 const SECRET_KEY = 'minioadmin';
 const REGION = 'us-east-1';
 
-export function dockerAvailable(): boolean {
+function dockerAvailable(): boolean {
   try {
     return Bun.spawnSync(['docker', 'info']).exitCode === 0;
   } catch {

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -47,6 +47,23 @@ export function dockerAvailable(): boolean {
   }
 }
 
+/**
+ * Whether the MinIO container-integration suites should actually run.
+ *
+ * They need a real `minio/minio` container. Locally (pre-push) that is fine, but
+ * on a shared/loaded CI runner the container's readiness probe intermittently
+ * blows the 120s deadline (~50% flake observed), which would red the whole
+ * Quality Gate for entirely unrelated PRs. So in CI these suites are OPT-IN:
+ * set `MINIO_INTEGRATION=1` (e.g. a dedicated integration job) to run them;
+ * otherwise they skip deterministically. Docker is still required either way,
+ * and local runs (no `CI` env) always run when Docker is present.
+ */
+export function minioIntegrationEnabled(): boolean {
+  if (!dockerAvailable()) return false;
+  if (process.env.CI === 'true' && process.env.MINIO_INTEGRATION !== '1') return false;
+  return true;
+}
+
 function sha256hex(data: string): string {
   return createHash('sha256').update(data).digest('hex');
 }

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts
@@ -19,7 +19,7 @@ import { LocalMediaBackend, type S3BackendConfig, S3MediaBackend } from '@omni/c
 import type { Database } from '@omni/db';
 import {
   createBucket,
-  dockerAvailable,
+  minioIntegrationEnabled,
   getSharedMinio,
   harnessFetch,
   uniqueBucket,
@@ -33,8 +33,8 @@ const BUCKET = uniqueBucket('omni-media-dispatch-test');
 const REGION = 'us-east-1';
 const MEDIA_BASE_PATH = process.env.MEDIA_STORAGE_PATH || './data/media';
 
-const hasDocker = dockerAvailable();
-const skipReason = hasDocker ? '' : 'Docker unavailable — skipping MinIO remote-dispatch round-trip';
+const hasDocker = minioIntegrationEnabled();
+const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO remote-dispatch round-trip';
 
 // Build a buffered message shaped like agent-dispatcher's BufferedMessage.
 type BufferedLike = Parameters<typeof extractMediaFiles>[0][number];

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts
@@ -19,9 +19,9 @@ import { LocalMediaBackend, type S3BackendConfig, S3MediaBackend } from '@omni/c
 import type { Database } from '@omni/db';
 import {
   createBucket,
-  minioIntegrationEnabled,
   getSharedMinio,
   harnessFetch,
+  minioIntegrationEnabled,
   uniqueBucket,
 } from '../../__tests__/minio-harness';
 import { MediaStorageService } from '../../services/media-storage';
@@ -34,7 +34,9 @@ const REGION = 'us-east-1';
 const MEDIA_BASE_PATH = process.env.MEDIA_STORAGE_PATH || './data/media';
 
 const hasDocker = minioIntegrationEnabled();
-const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO remote-dispatch round-trip';
+const skipReason = hasDocker
+  ? ''
+  : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO remote-dispatch round-trip';
 
 // Build a buffered message shaped like agent-dispatcher's BufferedMessage.
 type BufferedLike = Parameters<typeof extractMediaFiles>[0][number];

--- a/packages/api/src/plugins/__tests__/media-processor-remote.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-remote.test.ts
@@ -25,7 +25,7 @@ import { LocalMediaBackend, type S3BackendConfig, S3MediaBackend } from '@omni/c
 import type { EventBus, MessageReceivedPayload } from '@omni/core';
 import type { Database } from '@omni/db';
 import type { MediaProcessingService } from '@omni/media-processing';
-import { createBucket, minioIntegrationEnabled, getSharedMinio, uniqueBucket } from '../../__tests__/minio-harness';
+import { createBucket, getSharedMinio, minioIntegrationEnabled, uniqueBucket } from '../../__tests__/minio-harness';
 import type { Services } from '../../services';
 import { MediaStorageService } from '../../services/media-storage';
 import { type MediaProcessorContext, __test__ } from '../media-processor';
@@ -37,7 +37,9 @@ const REGION = 'us-east-1';
 const MEDIA_BASE_PATH = process.env.MEDIA_STORAGE_PATH || './data/media';
 
 const hasDocker = minioIntegrationEnabled();
-const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO media-processor round-trip';
+const skipReason = hasDocker
+  ? ''
+  : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO media-processor round-trip';
 
 /** Records the path + bytes the processing service was handed. */
 interface ProcessCapture {

--- a/packages/api/src/plugins/__tests__/media-processor-remote.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-remote.test.ts
@@ -25,7 +25,7 @@ import { LocalMediaBackend, type S3BackendConfig, S3MediaBackend } from '@omni/c
 import type { EventBus, MessageReceivedPayload } from '@omni/core';
 import type { Database } from '@omni/db';
 import type { MediaProcessingService } from '@omni/media-processing';
-import { createBucket, dockerAvailable, getSharedMinio, uniqueBucket } from '../../__tests__/minio-harness';
+import { createBucket, minioIntegrationEnabled, getSharedMinio, uniqueBucket } from '../../__tests__/minio-harness';
 import type { Services } from '../../services';
 import { MediaStorageService } from '../../services/media-storage';
 import { type MediaProcessorContext, __test__ } from '../media-processor';
@@ -36,8 +36,8 @@ const BUCKET = uniqueBucket('omni-media-processor-test');
 const REGION = 'us-east-1';
 const MEDIA_BASE_PATH = process.env.MEDIA_STORAGE_PATH || './data/media';
 
-const hasDocker = dockerAvailable();
-const skipReason = hasDocker ? '' : 'Docker unavailable — skipping MinIO media-processor round-trip';
+const hasDocker = minioIntegrationEnabled();
+const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO media-processor round-trip';
 
 /** Records the path + bytes the processing service was handed. */
 interface ProcessCapture {

--- a/packages/api/src/plugins/__tests__/media-remote-e2e.test.ts
+++ b/packages/api/src/plugins/__tests__/media-remote-e2e.test.ts
@@ -24,9 +24,9 @@ import { type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
 import {
   createBucket,
-  minioIntegrationEnabled,
   getSharedMinio,
   harnessFetch,
+  minioIntegrationEnabled,
   uniqueBucket,
 } from '../../__tests__/minio-harness';
 import { MediaStorageService } from '../../services/media-storage';
@@ -38,7 +38,9 @@ const BUCKET = uniqueBucket('omni-media-e2e-test');
 const REGION = 'us-east-1';
 
 const hasDocker = minioIntegrationEnabled();
-const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO remote-media e2e round-trip';
+const skipReason = hasDocker
+  ? ''
+  : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO remote-media e2e round-trip';
 
 // Build a buffered message shaped like agent-dispatcher's BufferedMessage.
 type BufferedLike = Parameters<typeof extractMediaFiles>[0][number];

--- a/packages/api/src/plugins/__tests__/media-remote-e2e.test.ts
+++ b/packages/api/src/plugins/__tests__/media-remote-e2e.test.ts
@@ -24,7 +24,7 @@ import { type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
 import {
   createBucket,
-  dockerAvailable,
+  minioIntegrationEnabled,
   getSharedMinio,
   harnessFetch,
   uniqueBucket,
@@ -37,8 +37,8 @@ const { extractMediaFiles } = __test__;
 const BUCKET = uniqueBucket('omni-media-e2e-test');
 const REGION = 'us-east-1';
 
-const hasDocker = dockerAvailable();
-const skipReason = hasDocker ? '' : 'Docker unavailable — skipping MinIO remote-media e2e round-trip';
+const hasDocker = minioIntegrationEnabled();
+const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO remote-media e2e round-trip';
 
 // Build a buffered message shaped like agent-dispatcher's BufferedMessage.
 type BufferedLike = Parameters<typeof extractMediaFiles>[0][number];

--- a/packages/api/src/services/__tests__/s3-backend-remote.test.ts
+++ b/packages/api/src/services/__tests__/s3-backend-remote.test.ts
@@ -17,7 +17,7 @@ import { type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
 import {
   createBucket,
-  dockerAvailable,
+  minioIntegrationEnabled,
   getSharedMinio,
   harnessFetch,
   uniqueBucket,
@@ -27,8 +27,8 @@ import { MediaStorageService } from '../media-storage';
 const BUCKET = uniqueBucket('omni-media-test');
 const REGION = 'us-east-1';
 
-const hasDocker = dockerAvailable();
-const skipReason = hasDocker ? '' : 'Docker unavailable — skipping MinIO S3 round-trip';
+const hasDocker = minioIntegrationEnabled();
+const skipReason = hasDocker ? '' : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO S3 round-trip';
 
 describe.skipIf(!hasDocker)('S3MediaBackend against MinIO', () => {
   let config: S3BackendConfig;

--- a/packages/api/src/services/__tests__/s3-backend-remote.test.ts
+++ b/packages/api/src/services/__tests__/s3-backend-remote.test.ts
@@ -17,9 +17,9 @@ import { type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
 import {
   createBucket,
-  minioIntegrationEnabled,
   getSharedMinio,
   harnessFetch,
+  minioIntegrationEnabled,
   uniqueBucket,
 } from '../../__tests__/minio-harness';
 import { MediaStorageService } from '../media-storage';


### PR DESCRIPTION
The four remote-media MinIO suites spin an ephemeral minio/minio container; on a loaded CI runner the readiness probe intermittently exceeds the 120s deadline (~50% flake), reddening the whole Quality Gate for unrelated PRs. This gates them behind `minioIntegrationEnabled()`: run locally (no CI env) and in an opt-in job (`MINIO_INTEGRATION=1`), skip deterministically otherwise. Unblocks green CI for #764/#765 and the dev→main promotion.