### PR TITLE
feat(deploy): serve omni at omni.felipe.namastex.io via ingress-nginx wildcard

### DIFF
--- a/deploy/helm/omni/values-dev.yaml
+++ b/deploy/helm/omni/values-dev.yaml
@@ -21,10 +21,17 @@ config:
 
 ingress:
   enabled: true
-  className: ""          # OrbStack ships a default ingress controller
-  host: omni.k8s.orb.local
+  className: "nginx"     # ingress-nginx is the cluster default IngressClass
+  host: omni.felipe.namastex.io
   path: /
   pathType: Prefix
+  # TLS rides ingress-nginx's default wildcard cert
+  # (ingress-nginx/felipe-wildcard-tls, SANs *.felipe.namastex.io + apex) wired via
+  # --default-ssl-certificate, so no per-Ingress secretName is needed. The tls block
+  # only declares the host so nginx terminates HTTPS for it.
+  tls:
+    - hosts:
+        - omni.felipe.namastex.io
 
 # Dev DB wiring — the lead sets database.host to the autopg Service once the
 # real subchart is vendored (e.g. "omni-autopg"). Password via --set-string or


### PR DESCRIPTION
What

Point the dev overlay Ingress (deploy/helm/omni/values-dev.yaml) at:
- ingress.className: nginx (ingress-nginx = cluster default IngressClass)
- ingress.host: omni.felipe.namastex.io
- ingress.tls: declares the host so nginx terminates HTTPS; rides ingress-nginx default wildcard cert (ingress-nginx/felipe-wildcard-tls, SAN *.felipe.namastex.io) via --default-ssl-certificate — no per-Ingress secretName.

Additive, not breaking

The direct LoadBalancer path (service.type=LoadBalancer, port 8882) is unchanged — omni-api still answers on http://192.168.139.2:8882. Cutover adds the ingress route without removing direct access.

Verified live (helm release omni, ns omni, rev 10 deployed)
- mac curl -sf https://omni.felipe.namastex.io/api/v2/health -> 200, valid Lets Encrypt wildcard cert (no -k, ssl_verify=0).
- curl -sf http://192.168.139.2:8882/api/v2/health -> 200 (direct path intact).
- omni CLI on the ops VM repointed to the ingress URL; omni instances list works (both whatsapp instances).
- Pre-existing FAILED helm release (minio StatefulSet immutable-field conflict, rev 7-9) resolved data-safe via cascade=orphan STS recreate; PVC + omni-media bucket (15G) preserved.

Only deploy/helm/omni/values-dev.yaml changes in this PR.

Generated with Claude Code