### PR TITLE
ci(publish): build and push autopg image; SHA-pin actions; enable provenance

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -1,16 +1,30 @@
 # =============================================================================
-# Publish the omni-api container image to GHCR.
+# Publish the omni-api and autopg container images to GHCR.
 # =============================================================================
-# Builds deploy/Dockerfile (the k8s runtime image) and pushes it to
-# ghcr.io/<owner>/omni-api. This is the k8s image referenced by the Helm chart
-# (deploy/helm/omni) for non-dev (registry) deploys; the OrbStack dev overlay
-# keeps building locally and never pulls.
+# build-push         → deploy/Dockerfile        → ghcr.io/<owner>/omni-api
+# build-push-autopg  → deploy/autopg.Dockerfile → ghcr.io/<owner>/autopg
+#
+# These are the k8s images referenced by the Helm chart (deploy/helm/omni)
+# for non-dev (registry) deploys; the OrbStack dev overlay keeps building
+# locally and never pulls.
 #
 # Triggers:
 #   - push to main / homolog  → build + publish (the promotion targets)
 #   - workflow_dispatch        → manual rebuild
 # PRs do NOT publish (build is validated by the normal CI type/lint/test gate);
 # publishing is reserved for the protected branches.
+#
+# RELEASE NOTE (LOW-18): merges to `main` must NOT carry `[skip ci]` in the
+# merge commit message — GitHub then skips ALL workflows for that push,
+# including this publish, and the promoted version never gets an image.
+# Integration-branch tip commits often carry `[skip ci]` from the version-bump
+# bot, so prefer "Create a merge commit" or "Squash and merge" (with a clean
+# message) over "Rebase and merge", and check the final message before merging
+# a promotion PR.
+#
+# Actions are pinned to full commit SHAs (supply-chain hardening: this
+# workflow holds `packages: write`). Bump the SHA and the trailing version
+# comment together.
 # =============================================================================
 name: Publish Image
 
@@ -21,6 +35,7 @@ on:
       - 'packages/**'
       - 'apps/**'
       - 'deploy/Dockerfile'
+      - 'deploy/autopg.Dockerfile'
       - 'bun.lock'
       - '.github/workflows/image-publish.yml'
   workflow_dispatch:
@@ -43,31 +58,40 @@ jobs:
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve image version
         id: meta
         run: |
           VERSION="$(node -p "require('./packages/cli/package.json').version" 2>/dev/null || echo 0.0.0)"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "sha_short=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
-          echo "ref_name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=${VERSION}"
+            echo "sha_short=${GITHUB_SHA::12}"
+            echo "ref_name=${GITHUB_REF_NAME}"
+          } >> "$GITHUB_OUTPUT"
 
+      # LOW-23: arm64 is built under QEMU emulation (slow for the Bun
+      # install/build stages). The repo is public, so native
+      # `ubuntu-24.04-arm` runners are free; the upgrade path is a
+      # per-platform matrix (push-by-digest) + `buildx imagetools create`
+      # manifest merge. Deliberately not done here: the QEMU path is proven
+      # on main and a split cannot be validated before a main promotion.
+      # Revisit if arm64 builds start timing out or OOMing.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/Dockerfile
@@ -77,10 +101,72 @@ jobs:
             ${{ env.IMAGE }}:${{ steps.meta.outputs.ref_name }}
             ${{ env.IMAGE }}:${{ steps.meta.outputs.ref_name }}-${{ steps.meta.outputs.sha_short }}
             ${{ env.IMAGE }}:v${{ steps.meta.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
+          cache-from: type=gha,scope=omni-api
+          cache-to: type=gha,mode=max,scope=omni-api
+          provenance: true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+
+  # Packages the automagik-dev/autopg release tarball as a container image
+  # (that repo publishes no image of its own). The Helm chart's prod overlay
+  # pins ghcr.io/<owner>/autopg:v<AUTOPG_VERSION>; the v<cli-version> /
+  # <branch> / <branch>-<sha> tags ride along so every omni promotion has a
+  # matching autopg tag (contract C1').
+  build-push-autopg:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/autopg
+      # autopg release baked into deploy/autopg.Dockerfile. Bump together
+      # with that file's AUTOPG_VERSION/PG_RUNTIME_VERSION defaults.
+      AUTOPG_VERSION: 3.0.7
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Resolve image version
+        id: meta
+        run: |
+          VERSION="$(node -p "require('./packages/cli/package.json').version" 2>/dev/null || echo 0.0.0)"
+          {
+            echo "version=${VERSION}"
+            echo "sha_short=${GITHUB_SHA::12}"
+            echo "ref_name=${GITHUB_REF_NAME}"
+          } >> "$GITHUB_OUTPUT"
+
+      # QEMU is fine here: the Dockerfile is download-only (the fetch stage
+      # runs on the build platform; only apt-get runs emulated).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: deploy
+          file: deploy/autopg.Dockerfile
+          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: true
+          build-args: |
+            AUTOPG_VERSION=${{ env.AUTOPG_VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.ref_name }}
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.ref_name }}-${{ steps.meta.outputs.sha_short }}
+            ${{ env.IMAGE }}:v${{ steps.meta.outputs.version }}
+            ${{ env.IMAGE }}:v${{ env.AUTOPG_VERSION }}
+          cache-from: type=gha,scope=autopg
+          cache-to: type=gha,mode=max,scope=autopg
+          provenance: true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.AUTOPG_VERSION }}

--- a/deploy/autopg.Dockerfile
+++ b/deploy/autopg.Dockerfile
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1.7
+# =============================================================================
+# autopg — containerized Postgres 18 runtime (github.com/automagik-dev/autopg)
+# =============================================================================
+# autopg ships signed per-arch release tarballs but no container image. This
+# Dockerfile turns the v${AUTOPG_VERSION} release tarball into the image run
+# by the Helm chart (deploy/helm/omni/charts/autopg), mirroring the known-good
+# local `autopg:dev` recipe.
+#
+# Build (download-only; needs no files from the build context):
+#
+#   docker build -f deploy/autopg.Dockerfile --platform linux/arm64 \
+#     --build-arg AUTOPG_VERSION=3.0.7 -t autopg:dev deploy/
+#
+# Layout contract (from autopg's src/postgres.js at the same tag):
+#   /usr/local/bin/autopg                              the autopg binary
+#   $AUTOPG_CONFIG_DIR/bin/<platformKey>/{bin,lib,share}  postgres runtime
+#   $AUTOPG_CONFIG_DIR/bin/<platformKey>/.version      MUST equal the
+#     PINNED_PG_VERSION baked into that autopg release, or autopg discards
+#     the runtime and re-downloads it from npm on boot.
+# where <platformKey> is `linux-x64` (amd64) or `linux-arm64` (arm64).
+# =============================================================================
+
+ARG AUTOPG_VERSION=3.0.7
+# Must match PINNED_PG_VERSION in autopg's src/postgres.js for the
+# AUTOPG_VERSION above (v3.0.7 pins 18.3.0-beta.17). Bump both together.
+ARG PG_RUNTIME_VERSION=18.3.0-beta.17
+
+# ---- fetch: download, verify, and unpack the release tarball ----------------
+# Runs on the build platform (no target-arch execution — pure download/copy).
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS fetch
+ARG AUTOPG_VERSION
+ARG PG_RUNTIME_VERSION
+ARG TARGETARCH
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# Map TARGETARCH → release-asset suffix + autopg runtime platform key.
+# amd64 uses the glibc build (final base is debian bookworm).
+RUN set -eu; \
+  case "${TARGETARCH}" in \
+    amd64) ASSET_ARCH=linux-x64-glibc; PLATFORM_KEY=linux-x64 ;; \
+    arm64) ASSET_ARCH=linux-arm64;     PLATFORM_KEY=linux-arm64 ;; \
+    *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac; \
+  TARBALL="autopg-${AUTOPG_VERSION}-${ASSET_ARCH}.tar.gz"; \
+  BASE_URL="https://github.com/automagik-dev/autopg/releases/download/v${AUTOPG_VERSION}"; \
+  cd /tmp; \
+  curl -fsSL -o "${TARBALL}" "${BASE_URL}/${TARBALL}"; \
+  curl -fsSL -o "${TARBALL}.sha256" "${BASE_URL}/${TARBALL}.sha256"; \
+  echo "$(cat "${TARBALL}.sha256")  ${TARBALL}" | sha256sum -c -; \
+  mkdir -p /unpack; \
+  tar -xzf "${TARBALL}" -C /unpack; \
+  RUNTIME_DIR="/stage/var/lib/autopg/bin/${PLATFORM_KEY}"; \
+  mkdir -p /stage/usr/local/bin "${RUNTIME_DIR}"; \
+  mv /unpack/autopg/autopg /stage/usr/local/bin/autopg; \
+  chmod 0755 /stage/usr/local/bin/autopg; \
+  mv /unpack/autopg/postgres/bin /unpack/autopg/postgres/lib /unpack/autopg/postgres/share \
+     "${RUNTIME_DIR}/"; \
+  printf '%s\n' "${PG_RUNTIME_VERSION}" > "${RUNTIME_DIR}/.version"; \
+  test -x "${RUNTIME_DIR}/bin/postgres"; \
+  test -x "${RUNTIME_DIR}/bin/initdb"; \
+  rm -rf /tmp/"${TARBALL}" /tmp/"${TARBALL}.sha256" /unpack
+
+# ---- runtime -----------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG AUTOPG_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates postgresql-client \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd -g 1000 autopg \
+  && useradd -u 1000 -g 1000 -d /var/lib/autopg -s /usr/sbin/nologin autopg
+
+ENV HOME=/var/lib/autopg \
+    AUTOPG_CONFIG_DIR=/var/lib/autopg
+
+COPY --from=fetch /stage/ /
+
+RUN mkdir -p /var/lib/autopg/data /var/run/autopg \
+  && chown -R autopg:autopg /var/lib/autopg /var/run/autopg
+
+LABEL org.opencontainers.image.title="autopg" \
+      org.opencontainers.image.description="autopg postmaster (embedded PostgreSQL 18) packaged from the automagik-dev/autopg release tarball" \
+      org.opencontainers.image.source="https://github.com/automagik-dev/omni" \
+      org.opencontainers.image.url="https://github.com/automagik-dev/autopg" \
+      org.opencontainers.image.version="${AUTOPG_VERSION}"
+
+USER autopg
+WORKDIR /var/lib/autopg
+EXPOSE 5432
+
+ENTRYPOINT ["autopg", "postmaster"]
+CMD ["--port", "5432", "--data", "/var/lib/autopg/data/pgdata", "--socket-dir", "/var/run/autopg", "--log", "info"]

--- a/deploy/autopg.Dockerfile.dockerignore
+++ b/deploy/autopg.Dockerfile.dockerignore
@@ -1,0 +1,3 @@
+# autopg.Dockerfile is download-only: it copies nothing from the build
+# context, so exclude everything to keep the context upload at zero.
+*


### PR DESCRIPTION
Part of the PR #770 autonomous fix orchestration (group G-CICD). Findings from `docs/_internal/PR-770-REVIEW.md`.

## Findings addressed

| Finding | Fix |
|---------|-----|
| **H1** (publish side) | New `deploy/autopg.Dockerfile` + `build-push-autopg` job publishing `ghcr.io/automagik-dev/autopg`. autopg's own repo ships no image; this packages its signed v3.0.7 release tarball (sha256-verified in-build) into the exact layout the known-good local `autopg:dev` image uses. |
| **LOW-6** | Every action SHA-pinned with a `# vX.Y.Z` comment (latest release of the same major): `actions/checkout@34e11487… # v4.3.1`, `docker/setup-qemu-action@c7c53464… # v3.7.0`, `docker/setup-buildx-action@8d2750c6… # v3.12.0`, `docker/login-action@c94ce9fb… # v3.7.0`, `docker/build-push-action@10e90e36… # v6.19.2`. Tags dereferenced to commits via the git ref API. |
| **LOW-7** | `provenance: true` on both build jobs (omni-api included). |
| **LOW-18** | Workflow header now documents that merges to `main` must not carry `[skip ci]` and to prefer "Create a merge commit"/"Squash" over "Rebase and merge". (No `CONTRIBUTING.md` exists at repo root, so the note lives in the workflow only.) |
| **LOW-23** | Disposition: **QEMU kept, documented**. The repo is public so `ubuntu-24.04-arm` is free, but a per-platform split (push-by-digest + `imagetools create` manifest merge) cannot be validated before a main promotion — breaking the publish pipeline for a PLAUSIBLE-severity LOW is the exact risk the review flags. The upgrade path is documented in a comment at the QEMU step. |

## Tag contract C1' (pinned by G-HELM)

`build-push-autopg` publishes exactly:
- `ghcr.io/automagik-dev/autopg:v<omni-cli-version>` — same extraction as omni-api (`node -p "require('./packages/cli/package.json').version"`)
- `ghcr.io/automagik-dev/autopg:v3.0.7` — the `AUTOPG_VERSION` baked into the Dockerfile; **this is the tag values-prod pins**
- `ghcr.io/automagik-dev/autopg:main` and `:main-<sha12>` (on main pushes)

`deploy/autopg.Dockerfile` was added to the workflow path filters; trigger/permissions model otherwise unchanged.

## Dockerfile correctness (verified against autopg source, not assumed)

- Tarball layout confirmed by downloading `autopg-3.0.7-linux-arm64.tar.gz`: `autopg/autopg` (binary) + `autopg/postgres/{bin,lib,share}` (runtime). Sidecar `.sha256` matches.
- Runtime contract from `src/postgres.js@v3.0.7`: cache dir is `$AUTOPG_CONFIG_DIR/bin/<platformKey>` (`linux-x64`/`linux-arm64`) and is only accepted when `bin/{initdb,postgres}` exist **and** the `.version` marker equals `PINNED_PG_VERSION = 18.3.0-beta.17` — otherwise autopg re-downloads from npm at boot. The Dockerfile writes that marker; the smoke test confirms no download happens.
- amd64 maps to the `linux-x64-glibc` asset (final base is `debian:bookworm-slim`); arm64 to `linux-arm64`.

## Verification evidence

1. `actionlint .github/workflows/image-publish.yml` — clean.
2. `docker build -f deploy/autopg.Dockerfile --build-arg AUTOPG_VERSION=3.0.7 --platform linux/arm64 …` — succeeds; in-build `sha256sum -c` prints `autopg-3.0.7-linux-arm64.tar.gz: OK`.
3. Runtime smoke (reproduces H1's gap, then proves the fix):
   - `docker run --rm --entrypoint autopg … --version` → `autopg 3.0.7`
   - `docker run -d --rm --name autopg-smoke …` then `docker exec autopg-smoke pg_isready -h 127.0.0.1 -p 5432` → `127.0.0.1:5432 - accepting connections` after ~3 s; 0 errors in logs; no npm download activity (baked runtime + `.version` marker accepted); `pgdata` initialized under `/var/lib/autopg/data`.
4. `--platform linux/amd64` build also completes (QEMU); `/var/lib/autopg/bin/linux-x64/{bin/postgres,bin/initdb}` executable, `.version` = `18.3.0-beta.17`.
5. Grep-confirmed the autopg job's tag expressions produce exactly the C1' set and both jobs share the identical version extraction.

## Deployment note

The image publishes on the **next promotion to `main`** (or a manual `workflow_dispatch`) — the prod Helm deploy (G-HELM's `values-prod.yaml` pinning `v3.0.7`) depends on that publish having run. First push creates the `autopg` GHCR package linked to this repo.
