### PR TITLE
fix(helm): make prod overlay deployable (PR #770 H1-H6, MED-3/5/6, LOWs)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,19 +20,37 @@
 # pinned to the toolchain that generated it. Override with --build-arg.
 ARG BUN_VERSION=1.3.9
 
+# ---- manifests: prune the context to workspace package.json files ------------
+# Throwaway stage that extracts ONLY the lockfile + every workspace manifest.
+# The deps stage COPYs from here, so its `bun install` layer is invalidated
+# only when dependencies actually change — not on every source edit.
+FROM oven/bun:${BUN_VERSION} AS manifests
+WORKDIR /src
+COPY package.json bun.lock ./
+COPY packages ./packages
+COPY apps ./apps
+# Vendored file: tarballs (e.g. channel-whatsapp's baileys .tgz) are install
+# inputs too — bun install fails without them, and like the manifests they
+# only change when dependencies change.
+RUN mkdir -p /manifests \
+  && cp --parents package.json bun.lock /manifests/ \
+  && find packages apps -maxdepth 2 -name package.json -exec cp --parents {} /manifests/ \; \
+  && find packages apps -path '*/vendor/*.tgz' -exec cp --parents {} /manifests/ \;
+
 # ---- deps: full monorepo install (dev deps needed to build) -----------------
 FROM oven/bun:${BUN_VERSION} AS deps
 ENV HUSKY=0
 WORKDIR /src
-# Manifests first for better layer caching of the install step.
-COPY package.json bun.lock ./
-COPY packages ./packages
-COPY apps ./apps
+# Manifests only → the install layer caches until dependencies change.
+COPY --from=manifests /manifests ./
 # --ignore-scripts: skip the monorepo's postinstall (ensure-libicu-symlinks,
 # husky) — irrelevant to producing the server bundle and its ICU symlinks would
 # not carry to the separate runtime base anyway. Deps resolve on disk for the
 # bundler regardless.
 RUN bun install --frozen-lockfile --ignore-scripts
+# Source arrives AFTER the install so code edits don't re-run bun install.
+COPY packages ./packages
+COPY apps ./apps
 
 # ---- builder: bundle the server + copy migrations ---------------------------
 FROM deps AS builder
@@ -58,15 +76,14 @@ RUN bun -e 'const p = await Bun.file("orig-package.json").json(); await Bun.writ
 
 # ---- runtime: slim, non-root ------------------------------------------------
 FROM oven/bun:${BUN_VERSION}-slim AS runtime
-# omni-api is stateless: creds/session live in Postgres, not on disk.
-# PGSERVE_EMBEDDED/NATS_MANAGED=false → use external DATABASE_URL / NATS_URL
-# instead of the in-process embedded pgserve / self-managed nats. HOME is an
-# ephemeral writable dir (no PVC needed) for any home-relative scratch writes.
+# omni-api is stateless: creds/session live in Postgres, not on disk. The
+# containerized API is driven entirely by DATABASE_URL + NATS_URL (embedded
+# pgserve was removed; NATS_MANAGED only matters to the PM2 ecosystem config,
+# which does not run here — neither env var is needed). HOME is an ephemeral
+# writable dir (no PVC needed) for any home-relative scratch writes.
 ENV NODE_ENV=production \
     API_HOST=0.0.0.0 \
     API_PORT=8882 \
-    PGSERVE_EMBEDDED=false \
-    NATS_MANAGED=false \
     HOME=/home/bun
 WORKDIR /app
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -26,7 +26,11 @@ help: ## Show this help
 
 .PHONY: build
 build: ## Build omni-api image (arm64) into OrbStack's shared store
-	docker build --platform $(PLATFORM) -f $(CURDIR)/Dockerfile -t $(IMAGE_REF) $(ROOT)
+	# buildx forces BuildKit regardless of DOCKER_BUILDKIT/daemon defaults, so
+	# deploy/Dockerfile.dockerignore is always honored (classic builder would
+	# silently ship the full context: .git, node_modules, data/). --load lands
+	# the image in the local store even under a non-default builder driver.
+	docker buildx build --platform $(PLATFORM) -f $(CURDIR)/Dockerfile -t $(IMAGE_REF) --load $(ROOT)
 
 .PHONY: lint
 lint: ## helm lint the umbrella chart

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -3,7 +3,11 @@ name: omni
 description: Omni — multi-channel messaging API (Bun/Hono) with Postgres (autopg) and NATS/JetStream
 type: application
 version: 0.1.0
-appVersion: "2.260703"
+# appVersion tracks the latest PUBLISHED omni release (packages/cli version):
+# image-publish.yml pushes ghcr.io/automagik-dev/omni-api:v<version> on merge
+# to main, and the chart's default image tag is v<appVersion>. Bump this only
+# to versions that exist on GHCR.
+appVersion: "2.260704.4"
 keywords:
   - omni
   - messaging
@@ -15,12 +19,11 @@ sources:
 maintainers:
   - name: automagik-dev
 dependencies:
-  # autopg — Postgres chart built separately by the lead and vendored into
-  # charts/autopg/ from scratchpad/autopg/deploy/helm/autopg at integration.
-  # A minimal PLACEHOLDER chart lives at charts/autopg/ so this umbrella
-  # renders/lints standalone; the lead replaces it with the real one.
-  # Keep the name `autopg`; its values live under the top-level `autopg:` key.
-  # Toggle with `autopg.enabled` so an external Postgres can be used instead.
+  # autopg — the REAL vendored PostgreSQL 18 chart (from automagik-dev/autopg),
+  # not a placeholder: single-replica StatefulSet + scoped-role provisioning +
+  # a published `<release>-autopg-app` DATABASE_URL Secret. Do not rip it out.
+  # Its values live under the top-level `autopg:` key; toggle with
+  # `autopg.enabled` to use an external Postgres instead.
   - name: autopg
     version: "0.1.0"
     repository: "file://./charts/autopg"

--- a/deploy/helm/omni/charts/autopg/templates/NOTES.txt
+++ b/deploy/helm/omni/charts/autopg/templates/NOTES.txt
@@ -15,6 +15,11 @@ Provisioned apps (scoped role owns schema public in its db):
     password: kubectl -n {{ $.Release.Namespace }} get secret {{ include "autopg.secretName" $ }} -o jsonpath='{.data.{{ .role }}-password}' | base64 -d
     URL: postgresql://{{ .role }}:$PASSWORD@{{ include "autopg.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.port }}/{{ .db }}
 {{- end }}
+{{- if .Values.appSecret.enabled }}
+
+App connection Secret (ready DATABASE_URL, password percent-encoded):
+  kubectl -n {{ .Release.Namespace }} get secret {{ include "autopg.appSecretName" . }} -o jsonpath='{.data.DATABASE_URL}' | base64 -d
+{{- end }}
 
 Quick check:
   kubectl -n {{ .Release.Namespace }} exec -it {{ include "autopg.fullname" . }}-0 -- pg_isready -h 127.0.0.1 -p {{ .Values.port }}

--- a/deploy/helm/omni/charts/autopg/templates/_helpers.tpl
+++ b/deploy/helm/omni/charts/autopg/templates/_helpers.tpl
@@ -65,6 +65,22 @@ The Secret name holding passwords — an existing one if provided, else managed.
 {{- end -}}
 
 {{/*
+The Secret name publishing the app DATABASE_URL (consumed by the omni
+umbrella chart — keep in sync with "omni.databaseSecretName" there).
+*/}}
+{{- define "autopg.appSecretName" -}}
+{{- printf "%s-app" (include "autopg.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Image reference. tag "" => v<Chart.appVersion>, the autopg release the
+published image bakes in.
+*/}}
+{{- define "autopg.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) -}}
+{{- end -}}
+
+{{/*
 Secret key for a provisioned app role's password.
 */}}
 {{- define "autopg.appPasswordKey" -}}

--- a/deploy/helm/omni/charts/autopg/templates/provision-job.yaml
+++ b/deploy/helm/omni/charts/autopg/templates/provision-job.yaml
@@ -1,20 +1,36 @@
 {{- if .Values.provisionJob.enabled -}}
+{{- /*
+Deliberately a REGULAR resource, NOT a post-install hook (H3): under
+`helm install --wait`, hooks only run after all main resources are Ready —
+but omni-api cannot become Ready until the role this Job creates exists, so a
+hook deadlocks the first install (omni-api not Ready → --wait blocks → hook
+never runs → timeout). A pre-install hook can't work either: at pre-install
+time the autopg StatefulSet does not exist yet (hooks block resource
+creation), so there is no server to provision. As a regular resource the Job
+is created alongside the StatefulSet and runs as soon as postgres accepts
+connections; omni-api's own boot retry loop rides out the gap.
+
+Job specs are immutable, so each release revision gets its own Job name and
+finished Jobs are garbage-collected via ttlSecondsAfterFinished. The pod's
+app.kubernetes.io/name is suffixed -provision so the autopg Services (which
+select on name+instance) never route :5432 traffic to this pod, and so the
+umbrella chart's NetworkPolicy can whitelist it precisely.
+*/ -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "autopg.fullname" . }}-provision
+  name: {{ include "autopg.fullname" . }}-provision-{{ .Release.Revision }}
   labels:
     {{- include "autopg.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    app.kubernetes.io/component: provision
 spec:
   backoffLimit: {{ .Values.provisionJob.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.provisionJob.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:
-        {{- include "autopg.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "autopg.name" . }}-provision
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: provision
     spec:
       restartPolicy: Never
@@ -26,7 +42,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: provision
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "autopg.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: PGHOST

--- a/deploy/helm/omni/charts/autopg/templates/secret.yaml
+++ b/deploy/helm/omni/charts/autopg/templates/secret.yaml
@@ -1,9 +1,20 @@
-{{- if not .Values.auth.existingSecret -}}
-{{/*
-Managed password Secret. Values are preserved across upgrades by looking up the
-existing Secret first, so auto-generated passwords stay stable. Explicit values
-in values.yaml always win.
-*/}}
+{{- /*
+Password Secrets. TWO Secrets render from this single file so their password
+resolution is shared and can never disagree within a render:
+
+  1. <fullname>-auth — superuser-password + <role>-password per provisioned
+     app, consumed by the provision Job via secretKeyRef. Skipped when
+     auth.existingSecret names an externally managed Secret (same keys).
+  2. <fullname>-app  — key DATABASE_URL: a ready postgresql:// URL for the
+     FIRST provisionedApps entry, password percent-encoded (urlquery). This is
+     the contract the omni umbrella chart consumes. Toggle: appSecret.enabled.
+
+Auto-generated passwords are preserved across upgrades by looking up the
+existing Secret first; explicit values always win. GITOPS NOTE: `lookup`
+returns empty under `helm template` / ArgoCD / Flux template rendering — see
+values.yaml `auth:` for the required existingSecret setup.
+*/ -}}
+{{- $fullname := include "autopg.fullname" . -}}
 {{- $secretName := include "autopg.secretName" . -}}
 {{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
 {{- $existingData := dict -}}
@@ -19,6 +30,24 @@ in values.yaml always win.
 {{- $super = randAlphaNum 24 -}}
 {{- end -}}
 {{- end -}}
+
+{{- /* per-app passwords, resolved once and shared by both Secrets */ -}}
+{{- $appPws := dict -}}
+{{- range .Values.provisionedApps -}}
+{{- $key := printf "%s-password" .role -}}
+{{- $pw := .password -}}
+{{- if not $pw -}}
+{{- if hasKey $existingData $key -}}
+{{- $pw = index $existingData $key | b64dec -}}
+{{- else if and $.Values.auth.existingSecret $.Values.appSecret.enabled -}}
+{{- fail (printf "autopg: auth.existingSecret %q is missing key %q (or could not be read at render time — helm template / GitOps dry-run has no cluster access). Provide the key, or set appSecret.enabled=false and manage DATABASE_URL yourself." $.Values.auth.existingSecret $key) -}}
+{{- else -}}
+{{- $pw = randAlphaNum 24 -}}
+{{- end -}}
+{{- end -}}
+{{- $_ := set $appPws .role $pw -}}
+{{- end -}}
+{{- if not .Values.auth.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -29,15 +58,21 @@ type: Opaque
 stringData:
   {{ $superKey }}: {{ $super | quote }}
   {{- range .Values.provisionedApps }}
-  {{- $key := printf "%s-password" .role -}}
-  {{- $pw := .password -}}
-  {{- if not $pw -}}
-  {{- if hasKey $existingData $key -}}
-  {{- $pw = index $existingData $key | b64dec -}}
-  {{- else -}}
-  {{- $pw = randAlphaNum 24 -}}
-  {{- end -}}
+  {{ printf "%s-password" .role }}: {{ index $appPws .role | quote }}
   {{- end }}
-  {{ $key }}: {{ $pw | quote }}
-  {{- end }}
-{{- end -}}
+{{- end }}
+{{- if and .Values.appSecret.enabled (gt (len .Values.provisionedApps) 0) }}
+{{- $first := index .Values.provisionedApps 0 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "autopg.appSecretName" . }}
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Ready-to-consume URL for the first provisioned app. Password is
+  # percent-encoded so @ : / ? # survive URL parsing.
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s.%s.svc.cluster.local:%v/%s" $first.role (index $appPws $first.role | urlquery) $fullname .Release.Namespace (.Values.port | int) $first.db | quote }}
+{{- end }}

--- a/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
+++ b/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
               mountPath: /data
       containers:
         - name: autopg
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "autopg.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["autopg", "postmaster"]
           args:
@@ -87,17 +87,19 @@ spec:
                   - -ec
                   - |
                     HBA=/var/lib/autopg/data/pgdata/pg_hba.conf
-                    {{- if eq .Values.hostAuth.cidr "all" }}
-                    RULE="host all all all {{ .Values.hostAuth.method }}"
-                    {{- else }}
-                    RULE="host all all {{ .Values.hostAuth.cidr }} {{ .Values.hostAuth.method }}"
-                    {{- end }}
                     for i in $(seq 1 90); do
                       pg_isready -h /var/run/autopg -p {{ .Values.port }} -q && break
                       sleep 2
                     done
+                    CHANGED=0
+                    {{- range .Values.hostAuth.cidrs }}
+                    RULE="host all all {{ . }} {{ $.Values.hostAuth.method }}"
                     if ! grep -qxF "$RULE" "$HBA" 2>/dev/null; then
                       printf '# added by autopg chart (in-cluster peer access)\n%s\n' "$RULE" >> "$HBA"
+                      CHANGED=1
+                    fi
+                    {{- end }}
+                    if [ "$CHANGED" = "1" ]; then
                       psql -h /var/run/autopg -p {{ .Values.port }} -U postgres -d postgres \
                         -c 'SELECT pg_reload_conf();'
                     fi
@@ -128,10 +130,17 @@ spec:
               mountPath: /var/lib/autopg/settings.json
               subPath: settings.json
               readOnly: true
+            # The postmaster's --socket-dir: an explicit writable emptyDir so
+            # the socket does not depend on a writable container rootfs (and
+            # survives a future readOnlyRootFilesystem hardening).
+            - name: run
+              mountPath: /var/run/autopg
       volumes:
         - name: settings
           configMap:
             name: {{ include "autopg.fullname" . }}-settings
+        - name: run
+          emptyDir: {}
         {{- if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}

--- a/deploy/helm/omni/charts/autopg/values.yaml
+++ b/deploy/helm/omni/charts/autopg/values.yaml
@@ -2,12 +2,15 @@
 # -----------------------------------------------------------------------------
 
 image:
-  repository: autopg
-  # Image tag. Tracks the autopg release baked into the image (Chart.appVersion).
-  tag: dev
-  # For OrbStack/local images built into the shared docker store, use Never (or
-  # IfNotPresent). Use IfNotPresent/Always once the image is pushed to a registry.
-  pullPolicy: Never
+  # Published by the omni repo's image-publish workflow as
+  # ghcr.io/automagik-dev/autopg:v<autopg release> (Chart.appVersion), plus
+  # :v<omni cli version> and :main.
+  repository: ghcr.io/automagik-dev/autopg
+  # Image tag. "" => v<Chart.appVersion>, the autopg release baked into the
+  # published image. The dev overlay swaps in a locally-built image
+  # (repository autopg, tag dev, pullPolicy Never).
+  tag: ""
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""
@@ -41,7 +44,26 @@ auth:
   # Name of an existing Secret to source passwords from instead of managing one
   # here. When set, keys must be: superuser-password, and <role>-password for
   # each provisioned app. Empty => the chart creates and manages the Secret.
+  #
+  # GITOPS NOTE: auto-generated password stability relies on helm `lookup`,
+  # which returns EMPTY under `helm template` / ArgoCD / Flux template
+  # rendering — passwords would regenerate every sync while the database keeps
+  # the old ones (auth failures / CrashLoop). Template-rendering GitOps MUST
+  # set existingSecret to an externally managed Secret (and see
+  # appSecret.enabled below for the DATABASE_URL contract).
   existingSecret: ""
+
+# -----------------------------------------------------------------------------
+# App connection Secret (the contract the omni umbrella chart consumes).
+#
+# When enabled, the chart publishes Secret `<fullname>-app` holding key
+# DATABASE_URL — a ready postgresql:// URL for the FIRST provisionedApps entry,
+# with the password percent-encoded. Disable only if you assemble/manage the
+# URL yourself (e.g. GitOps with auth.existingSecret rendered without cluster
+# access — the chart fails loudly in that combination and tells you so).
+# -----------------------------------------------------------------------------
+appSecret:
+  enabled: true
 
 # -----------------------------------------------------------------------------
 # Scoped-role provisioning (post-install / post-upgrade hook Job)
@@ -97,9 +119,17 @@ settings:
 # -----------------------------------------------------------------------------
 hostAuth:
   enabled: true
-  # Source range. "all" => any host (0.0.0.0/0 + ::/0). Set a pod/service CIDR
-  # to tighten (e.g. "10.0.0.0/8"). Auth still requires a valid password.
-  cidr: "all"
+  # Source ranges appended as pg_hba host rules. Defaults to the RFC1918
+  # private ranges — every mainstream CNI's pod/service CIDR falls inside them
+  # while the public internet and IPv6-any stay rejected (the old default was
+  # the pg_hba keyword "all"). Tighten further to your cluster's actual pod
+  # CIDR when known (e.g. ["10.244.0.0/16"]). Auth still requires a valid
+  # password, and the omni umbrella chart layers a NetworkPolicy on top
+  # restricting :5432 to omni-api + the provision Job.
+  cidrs:
+    - "10.0.0.0/8"
+    - "172.16.0.0/12"
+    - "192.168.0.0/16"
   # scram-sha-256 (recommended) | md5 | password. Must match the server's
   # password_encryption (PG14+ default is scram-sha-256).
   method: "scram-sha-256"
@@ -149,12 +179,19 @@ podSecurityContext:
   runAsNonRoot: true
   fsGroup: 1000
 
-# Provisioning Job knobs.
+# Provisioning Job knobs. The Job is a REGULAR resource (not a Helm hook): it
+# is created together with the StatefulSet and runs as soon as postgres accepts
+# connections, so a first `helm install --wait` cannot deadlock on it (hooks
+# only run after all main resources are Ready, but omni-api can't become Ready
+# until the role this Job creates exists). Each revision gets its own Job name
+# (Job specs are immutable) and finished Jobs are garbage-collected via TTL.
 provisionJob:
   enabled: true
   backoffLimit: 6
   # Seconds the Job waits for the server to accept connections before giving up.
   readyTimeoutSeconds: 300
+  # Seconds a finished provision Job lingers before the TTL controller deletes it.
+  ttlSecondsAfterFinished: 900
 
 nodeSelector: {}
 tolerations: []

--- a/deploy/helm/omni/templates/NOTES.txt
+++ b/deploy/helm/omni/templates/NOTES.txt
@@ -6,9 +6,8 @@ omni-api (stateless)
   Health  : GET /health
 
 Wiring
-  DATABASE_URL : {{ if .Values.database.existingSecret }}secret {{ .Values.database.existingSecret }}[{{ .Values.database.urlKey }}]{{ else }}assembled → db "{{ .Values.database.name }}" @ {{ default "<UNSET database.host>" .Values.database.host }}:{{ .Values.database.port }} as "{{ .Values.database.user }}"{{ end }}
+  DATABASE_URL : {{ with include "omni.databaseSecretName" . }}secret {{ . }}[{{ $.Values.database.urlKey }}]{{ else }}assembled → db "{{ .Values.database.name }}" @ {{ default "<UNSET database.host>" .Values.database.host }}:{{ .Values.database.port }} as "{{ .Values.database.user }}"{{ end }}
   NATS_URL     : {{ include "omni.natsUrl" . }}
-  Infra split  : PGSERVE_EMBEDDED={{ index .Values.config "PGSERVE_EMBEDDED" }}, NATS_MANAGED={{ index .Values.config "NATS_MANAGED" }}
   NATS bundled : {{ .Values.nats.enabled }}
   autopg dep   : {{ if .Values.autopg.enabled }}enabled{{ else }}disabled (external Postgres){{ end }}
 
@@ -20,11 +19,12 @@ Check it:
   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "omni.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
   curl -s localhost:{{ .Values.service.port }}/health | jq
 
-{{- if not .Values.database.existingSecret }}
+{{- if not (include "omni.databaseSecretName" .) }}
 {{- if not .Values.database.host }}
 
-WARNING: database.host is unset and database.existingSecret is empty — omni-api
-         has no Postgres to reach. Set database.host to the autopg Service, or
-         database.existingSecret to a Secret holding a full DATABASE_URL.
+WARNING: no DATABASE_URL source — database.host and database.existingSecret are
+         unset and the bundled autopg is disabled. Set database.host to your
+         Postgres Service, or database.existingSecret to a Secret holding a
+         full DATABASE_URL, or enable autopg.
 {{- end }}
 {{- end }}

--- a/deploy/helm/omni/templates/_helpers.tpl
+++ b/deploy/helm/omni/templates/_helpers.tpl
@@ -38,11 +38,23 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels for the omni-api workload.
+Base selector labels shared by every workload in this chart. The component
+label is deliberately NOT set here — each workload appends its own
+app.kubernetes.io/component exactly once (api/minio/nats/...), so no manifest
+carries a duplicate key (kubeconform -strict / kubectl --strict reject those).
 */}}
 {{- define "omni.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "omni.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels for the omni-api workload. Rendered output is IDENTICAL to the
+pre-split selector (name+instance+component: api), so the api Deployment's
+immutable spec.selector is stable across upgrades.
+*/}}
+{{- define "omni.apiSelectorLabels" -}}
+{{ include "omni.selectorLabels" . }}
 app.kubernetes.io/component: api
 {{- end }}
 
@@ -65,12 +77,48 @@ Name of the chart-minted Secret (assembled DATABASE_URL + optional secret.env).
 {{- end }}
 
 {{/*
+The autopg subchart's fullname as seen from this parent chart — mirrors
+charts/autopg/templates/_helpers.tpl "autopg.fullname" (subchart values are
+coalesced under .Values.autopg, so nameOverride/fullnameOverride are visible).
+*/}}
+{{- define "omni.autopg.fullname" -}}
+{{- $av := .Values.autopg | default dict -}}
+{{- if $av.fullnameOverride -}}
+{{- $av.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "autopg" $av.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the Secret omni-api reads DATABASE_URL from (Option A), or "" when the
+chart assembles the URL itself (Option B). Resolution order:
+  1. database.existingSecret — explicit operator override.
+  2. bundled autopg (autopg.enabled) with no database.host set — the autopg
+     subchart publishes <release>-autopg-app holding a ready, percent-encoded
+     DATABASE_URL (see charts/autopg/templates/secret.yaml).
+  3. "" — Option B: assemble from database.* (requires database.host).
+*/}}
+{{- define "omni.databaseSecretName" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.existingSecret -}}
+{{- else if and .Values.autopg.enabled (not .Values.database.host) -}}
+{{- printf "%s-app" (include "omni.autopg.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Whether the chart-minted Secret renders at all: it does when DATABASE_URL is
-assembled here (no external DB secret) OR when secret.env has entries.
+assembled here (no external/autopg DB secret) OR when secret.env has entries.
 Returns "true" / "".
 */}}
 {{- define "omni.mintsSecret" -}}
-{{- if or (not .Values.database.existingSecret) (gt (len (default (dict) .Values.secret.env)) 0) -}}
+{{- if or (not (include "omni.databaseSecretName" .)) (gt (len (default (dict) .Values.secret.env)) 0) -}}
 true
 {{- end -}}
 {{- end }}

--- a/deploy/helm/omni/templates/deployment.yaml
+++ b/deploy/helm/omni/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "omni.fullname" . }}
   labels:
     {{- include "omni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -11,8 +12,10 @@ spec:
   strategy:
     type: {{ .Values.strategy.type }}
   selector:
+    # NOTE: spec.selector is immutable on upgrade — omni.apiSelectorLabels
+    # renders the exact label set this Deployment has always used.
     matchLabels:
-      {{- include "omni.selectorLabels" . | nindent 6 }}
+      {{- include "omni.apiSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -23,7 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "omni.selectorLabels" . | nindent 8 }}
+        {{- include "omni.apiSelectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -58,10 +61,22 @@ spec:
               done
               mc mb --ignore-existing "omni/{{ .Values.media.s3.bucket }}"
               echo "media bucket omni/{{ .Values.media.s3.bucket }} is ready"
+              # Also provision the scoped app user here (idempotent, same as the
+              # bootstrap Job) so the api container never starts before its S3
+              # credential exists — post-install hooks run after pods on a
+              # first `--wait` install, so the Job alone would leave a window.
+              if [ "$OMNI_MEDIA_S3_ACCESS_KEY" != "$MINIO_ROOT_USER" ]; then
+                mc admin user add omni "$OMNI_MEDIA_S3_ACCESS_KEY" "$OMNI_MEDIA_S3_SECRET_KEY"
+                mc admin policy attach omni readwrite --user "$OMNI_MEDIA_S3_ACCESS_KEY" \
+                  || echo "readwrite policy already attached"
+                echo "app user $OMNI_MEDIA_S3_ACCESS_KEY is ready"
+              fi
       {{- end }}
       containers:
         - name: omni-api
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          # image.tag "" → v<Chart.appVersion>, the tag scheme image-publish.yml
+          # actually pushes (v<packages/cli version>).
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -70,7 +85,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           envFrom:
-            # Non-secret config (API_PORT, PGSERVE_EMBEDDED=false, NATS_MANAGED=false, NATS_URL, ...)
+            # Non-secret config (API_HOST, API_PORT, NATS_URL, OMNI_MEDIA_*, ...)
             - configMapRef:
                 name: {{ include "omni.fullname" . }}-config
             {{- if include "omni.mintsSecret" . }}
@@ -84,13 +99,13 @@ spec:
                 name: {{ .Values.secret.existingSecret }}
             {{- end }}
           env:
-            {{- if .Values.database.existingSecret }}
-            # --- DATABASE_URL from the autopg-published Secret (Option A) ---
+            {{- with include "omni.databaseSecretName" . }}
+            # --- DATABASE_URL from an external / autopg-published Secret (Option A) ---
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.database.existingSecret }}
-                  key: {{ .Values.database.urlKey }}
+                  name: {{ . }}
+                  key: {{ $.Values.database.urlKey }}
             {{- end }}
             {{- if include "omni.media.remote" . }}
             # --- S3 creds by reference only (never plaintext in rendered env) ---
@@ -144,9 +159,22 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1) }}
+      # Default soft anti-affinity for the >1-replica case: prefer spreading
+      # api replicas across nodes so a single node failure/drain cannot take
+      # every replica down at once. Override via .Values.affinity.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    {{- include "omni.apiSelectorLabels" . | nindent 20 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/deploy/helm/omni/templates/hpa.yaml
+++ b/deploy/helm/omni/templates/hpa.yaml
@@ -1,7 +1,10 @@
 {{- if .Values.autoscaling.enabled }}
 {{- /*
-HPA is present but disabled by default. omni-api holds a live WhatsApp/Baileys
-socket, so keep minReplicas at 1 until session/socket ownership moves off-node.
+HPA is DISABLED by default (autoscaling.enabled=false, minReplicas 1): api
+replicas share WhatsApp session state via Postgres, but a single WhatsApp
+credential still maps to ONE live Baileys socket at the protocol level, so
+autoscaling is only safe for HTTP/API + non-WhatsApp traffic. Enable it
+deliberately — see the "replicas + scaling" note in values.yaml.
 */ -}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/deploy/helm/omni/templates/minio.yaml
+++ b/deploy/helm/omni/templates/minio.yaml
@@ -13,21 +13,42 @@ ordered-before-serving two ways:
      bucket exists.
 */ -}}
 {{- if not .Values.media.s3.existingSecret }}
+{{- /*
+App creds are DISTINCT from the root user: the bootstrap Job (and the per-pod
+initContainer) provision a scoped `minio.appUser` with the builtin readwrite
+policy, and omni-api consumes only that user via OMNI_MEDIA_S3_* — never the
+root/admin credential. An empty appPassword auto-generates a stable random
+preserved across upgrades via helm lookup (same GitOps caveat as autopg:
+template-rendering GitOps must pin minio.appPassword or use
+media.s3.existingSecret). Remaining bundled-MinIO assumptions: in-cluster
+ClusterIP + plaintext http:// only — keep media.s3.presignTtlSeconds as low as
+the workflow tolerates, and use an external S3 + existingSecret in prod.
+*/ -}}
+{{- $minioSecretName := include "omni.minio.fullname" . }}
+{{- $minioExisting := lookup "v1" "Secret" .Release.Namespace $minioSecretName }}
+{{- $appPw := .Values.minio.appPassword }}
+{{- if not $appPw }}
+{{- if and $minioExisting (hasKey $minioExisting.data "OMNI_MEDIA_S3_SECRET_KEY") }}
+{{- $appPw = index $minioExisting.data "OMNI_MEDIA_S3_SECRET_KEY" | b64dec }}
+{{- else }}
+{{- $appPw = randAlphaNum 32 }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "omni.minio.fullname" . }}
+  name: {{ $minioSecretName }}
   labels:
     {{- include "omni.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio
 type: Opaque
 stringData:
-  # MinIO server root creds — also serve as the S3 access/secret keys consumed
-  # by omni-api (OMNI_MEDIA_S3_ACCESS_KEY / _SECRET_KEY) via secretKeyRef.
+  # MinIO server root creds (server boot + bucket/user provisioning only).
   MINIO_ROOT_USER: {{ .Values.minio.rootUser | quote }}
   MINIO_ROOT_PASSWORD: {{ .Values.minio.rootPassword | quote }}
-  OMNI_MEDIA_S3_ACCESS_KEY: {{ .Values.minio.rootUser | quote }}
-  OMNI_MEDIA_S3_SECRET_KEY: {{ .Values.minio.rootPassword | quote }}
+  # Scoped app creds consumed by omni-api via secretKeyRef (LOW-8: not root).
+  OMNI_MEDIA_S3_ACCESS_KEY: {{ .Values.minio.appUser | quote }}
+  OMNI_MEDIA_S3_SECRET_KEY: {{ $appPw | quote }}
 ---
 {{- end }}
 apiVersion: v1
@@ -159,4 +180,13 @@ spec:
               done
               mc mb --ignore-existing "omni/{{ .Values.media.s3.bucket }}"
               echo "bucket omni/{{ .Values.media.s3.bucket }} is ready"
+              # Provision the scoped app user omni-api consumes (distinct from
+              # root). `mc admin user add` also resets the password if the user
+              # exists, so re-runs converge on the Secret's current value.
+              if [ "$OMNI_MEDIA_S3_ACCESS_KEY" != "$MINIO_ROOT_USER" ]; then
+                mc admin user add omni "$OMNI_MEDIA_S3_ACCESS_KEY" "$OMNI_MEDIA_S3_SECRET_KEY"
+                mc admin policy attach omni readwrite --user "$OMNI_MEDIA_S3_ACCESS_KEY" \
+                  || echo "readwrite policy already attached"
+                echo "app user $OMNI_MEDIA_S3_ACCESS_KEY is ready"
+              fi
 {{- end }}

--- a/deploy/helm/omni/templates/networkpolicy.yaml
+++ b/deploy/helm/omni/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- /*
+NetworkPolicy locking down the bundled autopg Postgres (H6): its postmaster
+hardcodes superuser postgres/postgres and CANNOT rotate it, so nothing but
+network reachability protects the superuser. This policy allows :5432 ingress
+ONLY from the omni-api pods and autopg's own provision Job pods (which create
+the scoped role); everything else in the cluster is denied.
+
+Lives in the umbrella chart (not the autopg subchart) because only the parent
+knows both label sets. NOTE: it is enforced only on clusters whose CNI
+implements NetworkPolicy — on clusters without enforcement, do not run the
+bundled autopg next to untrusted workloads (see values.yaml `autopg:` notes).
+*/ -}}
+{{- if and .Values.autopg.enabled .Values.networkPolicy.enabled }}
+{{- $autopgName := default "autopg" (.Values.autopg | default dict).nameOverride }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "omni.autopg.fullname" . }}
+  labels:
+    {{- include "omni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: autopg
+spec:
+  # The autopg postgres pod (the provision Job pods carry a different
+  # app.kubernetes.io/name so they are NOT selected here).
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $autopgName }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # omni-api pods (same namespace)
+        - podSelector:
+            matchLabels:
+              {{- include "omni.apiSelectorLabels" . | nindent 14 }}
+        # autopg's provision Job pods (role/db bootstrap)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ $autopgName }}-provision
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: {{ ((.Values.autopg | default dict).port) | default 5432 }}
+{{- end }}

--- a/deploy/helm/omni/templates/pdb.yaml
+++ b/deploy/helm/omni/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- /*
+PodDisruptionBudget for the omni-api Deployment — only rendered when more than
+one replica is possible (replicaCount > 1 or HPA on). With a single replica a
+minAvailable:1 PDB would block node drains forever, so it is skipped.
+*/ -}}
+{{- if and .Values.podDisruptionBudget.enabled (or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1)) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "omni.fullname" . }}
+  labels:
+    {{- include "omni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "omni.apiSelectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/omni/templates/secret.yaml
+++ b/deploy/helm/omni/templates/secret.yaml
@@ -7,7 +7,7 @@ The omni Secret holds:
 There is NO OMNI_API_KEY — omni auth keys live in Postgres, not env.
 Rendered only when there is at least one key to store.
 */ -}}
-{{- $assembleDbUrl := not .Values.database.existingSecret -}}
+{{- $assembleDbUrl := not (include "omni.databaseSecretName" .) -}}
 {{- $hasExtra := gt (len (default (dict) .Values.secret.env)) 0 -}}
 {{- if or $assembleDbUrl $hasExtra }}
 apiVersion: v1
@@ -20,10 +20,11 @@ type: Opaque
 stringData:
   {{- if $assembleDbUrl }}
   {{- if not .Values.database.host }}
-  {{- fail "database.host is required (set it to the autopg Service DNS) when database.existingSecret is not used" }}
+  {{- fail "database.host is required (set it to the autopg Service DNS) when neither database.existingSecret nor the bundled autopg (autopg.enabled) provides a DATABASE_URL Secret" }}
   {{- end }}
   {{- $q := ternary (printf "?sslmode=%s" .Values.database.sslmode) "" (ne (default "" .Values.database.sslmode) "") }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@%s:%v/%s%s" .Values.database.user .Values.database.password .Values.database.host .Values.database.port .Values.database.name $q | quote }}
+  {{- /* password is percent-encoded (urlquery) so @ : / ? # survive in the URL */}}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s:%v/%s%s" .Values.database.user (.Values.database.password | urlquery) .Values.database.host .Values.database.port .Values.database.name $q | quote }}
   {{- end }}
   {{- range $k, $v := .Values.secret.env }}
   {{ $k }}: {{ $v | quote }}

--- a/deploy/helm/omni/templates/service.yaml
+++ b/deploy/helm/omni/templates/service.yaml
@@ -4,10 +4,11 @@ metadata:
   name: {{ include "omni.fullname" . }}
   labels:
     {{- include "omni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   type: {{ .Values.service.type }}
   selector:
-    {{- include "omni.selectorLabels" . | nindent 4 }}
+    {{- include "omni.apiSelectorLabels" . | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/deploy/helm/omni/values-prod.yaml
+++ b/deploy/helm/omni/values-prod.yaml
@@ -7,16 +7,24 @@
 
 image:
   repository: ghcr.io/automagik-dev/omni-api   # set to your registry/path
-  tag: "2.260703"                              # pin a released tag
+  # Pin a tag that EXISTS on GHCR. image-publish.yml pushes v<packages/cli
+  # version> (plus :main, :main-<sha12>) on merges to main — v2.260704.4 is
+  # the latest published release at pin time. Leave "" to track the chart's
+  # appVersion (v<appVersion>).
+  tag: "v2.260704.4"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 
-# omni-api is stateless (session state in Postgres) → HPA on, min 2 for HA.
-# Integration note: validate concurrent replicas for WhatsApp *credentials*
-# (one live Baileys socket per credential at the protocol level).
+# ONE replica, HPA off (see values.yaml "replicas + scaling"): a single
+# WhatsApp credential maps to one live Baileys socket, so concurrent replicas
+# risk key-ratchet corruption / duplicate sends until single-socket ownership
+# (leader election) exists. Scale out only for HTTP/API + non-WhatsApp
+# traffic — the chart then auto-adds a PDB + pod anti-affinity, and
+# migrate-on-boot serializes via a Postgres advisory lock.
+replicaCount: 1
 autoscaling:
-  enabled: true
-  minReplicas: 2
+  enabled: false
+  minReplicas: 1
   maxReplicas: 6
   targetCPUUtilizationPercentage: 75
 
@@ -37,9 +45,12 @@ ingress:
       hosts:
         - omni.example.com
 
-# Prefer an existing Secret published by autopg (full DATABASE_URL) in prod.
+# DATABASE_URL comes from the Secret the autopg subchart publishes:
+# `<release>-autopg-app`, key DATABASE_URL (password percent-encoded). With
+# existingSecret/host left empty the chart auto-derives that name for ANY
+# release name — set existingSecret only to point at your own Secret instead.
 database:
-  existingSecret: "omni-autopg-app"   # Secret holding DATABASE_URL
+  existingSecret: ""
   urlKey: "DATABASE_URL"
 
 secret:
@@ -91,5 +102,16 @@ media:
 minio:
   enabled: false
 
+# Bundled autopg Postgres. SECURITY: assumes a single-tenant cluster + the
+# chart's NetworkPolicy (networkPolicy.enabled, on by default) — the autopg
+# superuser password is hardcoded and unrotatable, see values.yaml `autopg:`.
 autopg:
   enabled: true
+  image:
+    # v<autopg release> — matches charts/autopg Chart.yaml appVersion (3.0.7).
+    # Published by the omni image-publish workflow; NOTE: a prod deploy before
+    # the first publish run to ghcr.io/automagik-dev/autopg will
+    # ImagePullBackOff. Leave tag "" to track the subchart's appVersion.
+    repository: ghcr.io/automagik-dev/autopg
+    tag: "v3.0.7"
+    pullPolicy: IfNotPresent

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -8,32 +8,44 @@ nameOverride: ""
 fullnameOverride: ""
 
 # ---- omni-api image ---------------------------------------------------------
+# Published by .github/workflows/image-publish.yml on merges to main as
+# ghcr.io/automagik-dev/omni-api:v<packages/cli version> (plus :main and
+# :main-<sha12>). tag "" => v<Chart.appVersion> — Chart.yaml appVersion tracks
+# the latest PUBLISHED release. The dev overlay swaps in a locally-built image
+# (repository omni-api, tag dev, pullPolicy Never).
 image:
-  repository: omni-api
-  tag: dev
-  # OrbStack shares its image store with k8s, so a locally-built image needs
-  # no registry. Use Never (dev) / IfNotPresent or Always (prod).
+  repository: ghcr.io/automagik-dev/omni-api
+  tag: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 
 # ---- replicas + scaling -----------------------------------------------------
-# omni-api is STATELESS: WhatsApp/Baileys auth state is persisted in Postgres
-# via the storage abstraction (createStorageAuthState / clearAuthState), not on
-# local disk — so there is no per-pod session file to anchor. Replicas share
-# session state through the DB, so the HPA is ON by default.
+# Default: ONE replica, HPA OFF. omni-api persists WhatsApp/Baileys auth state
+# in Postgres (no per-pod session file), but a single WhatsApp *credential*
+# still maps to ONE live Baileys socket at the protocol level — 2+ replicas
+# binding the same credential risk key-ratchet corruption, duplicate sends,
+# and session resets that force re-pairing. Until single-socket ownership
+# (leader election) exists, scale out ONLY for HTTP/API traffic and
+# non-WhatsApp channels, and do so deliberately.
 #
-# NOTE for integration: a single WhatsApp *credential* still maps to one live
-# Baileys socket at the protocol level — validate concurrent-replica behaviour
-# for WhatsApp instances (key-ratchet races) at integration. The horizontal
-# win is unconditional for HTTP/API traffic and non-WhatsApp channels.
-replicaCount: 2
+# When you do run >1 replica (replicaCount > 1 or autoscaling.enabled), the
+# chart automatically adds a PodDisruptionBudget (podDisruptionBudget below)
+# and soft pod anti-affinity, and migrate-on-boot serializes via a Postgres
+# advisory lock.
+replicaCount: 1
 
 autoscaling:
-  enabled: true
-  minReplicas: 2
+  enabled: false
+  minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: ""
+
+# PodDisruptionBudget — rendered only when >1 replica is possible (a
+# minAvailable:1 PDB on a single replica would block node drains).
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
 
 # Stateless → RollingUpdate for zero-downtime rollouts.
 strategy:
@@ -55,16 +67,15 @@ ingress:
   tls: []
 
 # ---- app config (non-secret → ConfigMap / plain env) ------------------------
+# The containerized API is driven entirely by DATABASE_URL + NATS_URL.
+# (PGSERVE_EMBEDDED / NATS_MANAGED are NOT set: embedded pgserve was removed —
+# the API only warns if PGSERVE_EMBEDDED=true — and NATS_MANAGED is read only
+# by the PM2 ecosystem config, which does not run in the container.)
 config:
   API_HOST: "0.0.0.0"
   API_PORT: "8882"
   NODE_ENV: "production"
   LOG_LEVEL: "info"
-  # Split-out infra: use the external autopg pod + nats StatefulSet, NOT omni's
-  # in-process embedded pgserve / self-managed nats. Without these the api tries
-  # to boot its own pg/nats and ignores DATABASE_URL / NATS_URL.
-  PGSERVE_EMBEDDED: "false"
-  NATS_MANAGED: "false"
 
 # Free-form extra non-secret env (key: value) merged into the ConfigMap.
 extraConfig: {}
@@ -79,23 +90,24 @@ env:
 # omni-api needs DATABASE_URL=postgresql://<role>:<pw>@<host>:5432/omni, where
 # <role> OWNS the omni tables (migrations ALTER them on boot).
 #
-# INTEGRATION (lead): the autopg subchart provisions db `omni` + a scoped owner
-# role and (ideally) publishes a Secret containing a ready DATABASE_URL. Point
-# omni at it via database.existingSecret / database.urlKey. Otherwise the chart
-# assembles DATABASE_URL from the fields below and stores it in the omni Secret.
+# The autopg subchart provisions db `omni` + a scoped owner role and publishes
+# Secret `<release>-autopg-app` holding a ready, percent-encoded DATABASE_URL.
+# When autopg.enabled and both existingSecret/host below are empty, the chart
+# wires omni-api to that Secret AUTOMATICALLY — the defaults just work.
 database:
-  # Option A (preferred at integration): consume a Secret that already holds a
-  # full DATABASE_URL (e.g. the one autopg emits). When set, host/user/password
-  # below are ignored.
-  existingSecret: ""      # e.g. "<release>-autopg-app"
-  urlKey: "DATABASE_URL"  # key within existingSecret holding the URL
+  # Option A: consume a Secret that already holds a full DATABASE_URL. When
+  # set, host/user/password below are ignored. Leave empty with autopg.enabled
+  # to auto-consume `<release>-autopg-app`.
+  existingSecret: ""
+  urlKey: "DATABASE_URL"  # key within the Secret holding the URL
 
-  # Option B (chart-assembled URL, stored in the omni Secret):
-  host: ""                # REQUIRED if existingSecret empty → autopg Service DNS
+  # Option B (chart-assembled URL, stored in the omni Secret; used when
+  # existingSecret is empty AND host is set — e.g. an external Postgres):
+  host: ""                # external Postgres / autopg Service DNS
   port: 5432
   name: omni
   user: omni              # scoped role that OWNS the omni tables
-  password: ""            # set via -f / --set-string
+  password: ""            # set via -f / --set-string (percent-encoded at render)
   sslmode: ""             # e.g. "disable" / "require"; empty → omit
 
 # ---- secret (DB creds + optional provider keys) -----------------------------
@@ -175,12 +187,29 @@ extraVolumeMounts: []
 # Subchart / bundled-dependency values
 # =============================================================================
 
-# ---- autopg (placeholder subchart; lead vendors the real chart) -------------
+# ---- autopg (vendored PostgreSQL 18 subchart) --------------------------------
+# The REAL autopg chart is vendored at charts/autopg/ — it is NOT a
+# placeholder. It runs Postgres 18 as a single-replica StatefulSet, provisions
+# db `omni` + a scoped owner role, and publishes Secret `<release>-autopg-app`
+# with a ready DATABASE_URL that this chart auto-consumes (see database.*).
+# Its Service is `<release>-autopg:5432`. Full knobs: charts/autopg/values.yaml
+# (set them under this `autopg:` key).
+#
+# SECURITY (read before enabling on a shared cluster): autopg's postmaster
+# HARDCODES superuser postgres/postgres and it cannot be rotated (rotation
+# crash-loops the pod — see charts/autopg/values.yaml `auth:`). Keeping
+# enabled=true therefore assumes (1) a single-tenant cluster/namespace, and
+# (2) the NetworkPolicy this chart ships (networkPolicy.enabled below)
+# restricting :5432 to omni-api + the provision Job — which only bites on
+# CNIs that enforce NetworkPolicy. On shared clusters without enforcement,
+# set enabled=false and point database.* at a managed Postgres instead.
 autopg:
   enabled: true
-  # The lead's real autopg values go here. The placeholder chart at
-  # charts/autopg/ only needs `enabled`. Document the Service name it exposes
-  # and set `database.host` (above) to it, e.g. "<release>-autopg".
+
+# NetworkPolicy around the bundled autopg: allow :5432 ingress only from
+# omni-api and autopg's provision Job. Rendered only when autopg.enabled.
+networkPolicy:
+  enabled: true
 
 # ---- bundled NATS + JetStream ----------------------------------------------
 nats:
@@ -206,7 +235,7 @@ nats:
 
 # ---- media backend (OMNI_MEDIA_*) -------------------------------------------
 # Selects the omni-api media storage backend. Mirrors resolveMediaBackendConfig
-# in packages/api/src/services/media-backends/config.ts.
+# in packages/channel-sdk/src/media-backends/config.ts.
 #   mode=local  → on-disk storage, no S3 env emitted (default).
 #   mode=remote → S3/MinIO; the OMNI_MEDIA_S3_* env is wired from s3.* below.
 media:
@@ -238,10 +267,17 @@ minio:
   enabled: false
   image: minio/minio:RELEASE.2024-01-16T16-07-38Z
   pullPolicy: IfNotPresent
-  # Root creds double as the S3 access/secret keys omni-api consumes. Override
-  # via --set-string / -f. Ignored when media.s3.existingSecret is set.
+  # Root creds boot the MinIO server and provision the bucket + app user.
+  # omni-api does NOT use them — it consumes the scoped app creds below.
+  # Ignored when media.s3.existingSecret is set.
   rootUser: omni
   rootPassword: ""       # REQUIRED when minio.enabled and no existingSecret
+  # Scoped S3 app user minted for omni-api (builtin readwrite policy) —
+  # distinct from root. Empty appPassword => auto-generate a stable random
+  # preserved across upgrades (helm lookup; template-rendering GitOps must pin
+  # it or use media.s3.existingSecret).
+  appUser: omni-media
+  appPassword: ""
   service:
     port: 9000           # S3 API
     consolePort: 9001    # web console

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -19,6 +19,13 @@ import type { Database } from './client';
 
 const log = createLogger('db:migrate');
 
+/**
+ * Advisory lock key serializing migrate-on-boot across concurrent processes
+ * (e.g. multiple k8s replicas booting at once). Arbitrary constant — must be
+ * unique among any advisory locks this application ever takes.
+ */
+const MIGRATION_LOCK_ID = 772_005_770;
+
 function countMigrationFiles(migrationsFolder: string): number {
   const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
   const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
@@ -28,6 +35,15 @@ function countMigrationFiles(migrationsFolder: string): number {
 /**
  * Apply pending migrations and validate that all files are applied.
  *
+ * The whole run is serialized under a Postgres advisory lock: the drizzle
+ * postgres-js migrator takes no lock of its own, so two pods booting
+ * concurrently would race `CREATE ... IF NOT EXISTS` on drizzle's bookkeeping
+ * catalog (not concurrency-safe → unique violations / transient CrashLoop).
+ * `pg_advisory_xact_lock` is acquired inside a wrapper transaction — a single
+ * dedicated connection holds it and it is released automatically on
+ * commit/rollback (even if the process dies mid-migration), so concurrent
+ * boots queue up and then find the work already done.
+ *
  * @param db - Drizzle database instance
  * @param migrationsFolder - Path to the drizzle migrations folder
  * @throws if the applied count in DB is less than the number of migration files
@@ -35,21 +51,27 @@ function countMigrationFiles(migrationsFolder: string): number {
 export async function applyMigrations(db: Database, migrationsFolder: string): Promise<void> {
   const fileCount = countMigrationFiles(migrationsFolder);
 
-  await migrate(db, { migrationsFolder });
+  await db.transaction(async (tx) => {
+    log.info('Acquiring migration advisory lock', { lockId: MIGRATION_LOCK_ID });
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(${MIGRATION_LOCK_ID})`);
+    log.info('Migration advisory lock acquired');
 
-  // Guard: Drizzle silently skips migrations whose journal 'when' timestamp
-  // is earlier than the last applied migration's created_at.
-  // Detect this by comparing file count against applied row count.
-  const result = await db.execute(sql`SELECT count(*) AS count FROM drizzle.__drizzle_migrations`);
-  const appliedCount = Number((result[0] as { count: string }).count);
+    await migrate(db, { migrationsFolder });
 
-  if (appliedCount < fileCount) {
-    throw new Error(
-      `Migration count mismatch: ${appliedCount} applied, ${fileCount} files. ${fileCount - appliedCount} migration(s) were silently skipped. Ensure _journal.json "when" timestamps are strictly increasing.`,
-    );
-  }
+    // Guard: Drizzle silently skips migrations whose journal 'when' timestamp
+    // is earlier than the last applied migration's created_at.
+    // Detect this by comparing file count against applied row count.
+    const result = await db.execute(sql`SELECT count(*) AS count FROM drizzle.__drizzle_migrations`);
+    const appliedCount = Number((result[0] as { count: string }).count);
 
-  log.info('All migrations applied', { appliedCount, fileCount });
+    if (appliedCount < fileCount) {
+      throw new Error(
+        `Migration count mismatch: ${appliedCount} applied, ${fileCount} files. ${fileCount - appliedCount} migration(s) were silently skipped. Ensure _journal.json "when" timestamps are strictly increasing.`,
+      );
+    }
+
+    log.info('All migrations applied', { appliedCount, fileCount });
+  });
 }
 
 // Script entry point (bun run src/migrate.ts)


### PR DESCRIPTION
Fixes the G-HELM group of the PR #770 review findings (`docs/_internal/PR-770-REVIEW.md`): **H1 (values side), H2, H3, H4, H5, H6, MED-3, MED-5, MED-6, LOW-8, LOW-11, LOW-13, LOW-14, LOW-15, LOW-16, LOW-17, LOW-19, LOW-20, LOW-21, LOW-22**. Scope: `deploy/**` + `packages/db/src/migrate.ts` (MED-5 grant) only.

## What changed, per finding

| Finding | Fix |
|---|---|
| **H1 / H4** | Prod pins tags that exist on GHCR: `omni-api:v2.260704.4` (latest published; dev's `2.260704.5` publishes on next main merge) and `autopg → ghcr.io/automagik-dev/autopg:v3.0.7` with `pullPolicy: IfNotPresent`. Empty `image.tag` now defaults to `v<Chart.appVersion>` (both charts), and appVersions are synced: omni `2.260704.4` (LOW-14), autopg `3.0.7`. |
| **H2 / LOW-13** | The autopg subchart now publishes Secret **`<release>-autopg-app`** with key **`DATABASE_URL`**, password percent-encoded via `urlquery`. Both Secrets (`-auth` + `-app`) render from one template file with shared password resolution, so they can never disagree within a render. The umbrella chart auto-derives the secret name for **any** release name (`omni.databaseSecretName`), which also makes the **default** `helm template` render pass (it previously failed on `database.host is required`). Umbrella Option-B assembled URLs also `urlquery` the password. |
| **H3** | Provision Job converted from `post-install` hook to a **regular resource** (see ordering argument below). Job immutability handled via revision-suffixed name (`-provision-<revision>`) + `ttlSecondsAfterFinished: 900`. Job pods get `app.kubernetes.io/name: autopg-provision` so the autopg Services (selecting on name+instance) never route `:5432` to a probe-less Job pod. |
| **H5 / LOW-15 / LOW-22** | Defaults: `replicaCount: 1`, `autoscaling.enabled: false`, `minReplicas: 1` — base *and* prod overlay. The WhatsApp single-socket constraint (key-ratchet races, duplicate sends) is documented in values.yaml/hpa.yaml: HPA is only safe for HTTP/API + non-WhatsApp traffic. For the >1-replica case the chart auto-renders a PodDisruptionBudget (`minAvailable: 1`) and soft `podAntiAffinity` (skipped at 1 replica — a PDB there would block node drains). hpa.yaml's contradictory comment fixed. |
| **H6** | `hostAuth.cidr: "all"` → `hostAuth.cidrs: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]` (RFC1918 — covers every mainstream CNI pod CIDR while rejecting public/IPv6-any; tighten further per-cluster). New **NetworkPolicy** (umbrella, `networkPolicy.enabled: true`) allows `:5432` ingress only from omni-api pods + the provision Job pods. `autopg.enabled` keeps its default but now documents the single-tenant + NetworkPolicy-enforcing-CNI assumption, with explicit guidance to use managed Postgres on shared clusters. **No password rotation** — the postmaster hardcodes `postgres/postgres` and rotation crash-loops the pod. |
| **MED-3** | `omni.selectorLabels` no longer hardcodes `component: api`; each workload emits the key exactly once (see selector-immutability note below). |
| **MED-5** | `applyMigrations` wraps the migrate run in `pg_advisory_xact_lock` inside a dedicated wrapper transaction — one connection holds the lock, auto-released on commit/rollback even on crash, so concurrent pod boots serialize. |
| **MED-6** | GitOps `lookup` caveat documented at both charts' secrets; `auth.existingSecret` is honored by the app secret (passwords sourced from it), and the chart **fails loudly** when it can't be read at render time (template-rendering GitOps) instead of silently regenerating, with instructions (`appSecret.enabled=false` + own DATABASE_URL secret). |
| **LOW-8** | Bundled MinIO now mints **scoped app creds** (`minio.appUser: omni-media` + generated stable secret, builtin `readwrite` policy) provisioned idempotently by both the bootstrap Job and the per-pod initContainer; omni-api never sees root creds. Remaining assumptions (in-cluster plaintext http, presign TTL guidance) documented. |
| **LOW-11 / LOW-19** | Comment path fixed to `packages/channel-sdk/src/media-backends/config.ts`; "autopg is a PLACEHOLDER" comments replaced with reality (real vendored chart, do not rip out). |
| **LOW-16** | Dead `PGSERVE_EMBEDDED` / `NATS_MANAGED` env dropped from `deploy/Dockerfile` ENV + Helm ConfigMap/NOTES (API only warns if `PGSERVE_EMBEDDED=true`; `NATS_MANAGED` is PM2-only). Only those env lines touched; Dockerfile core intact. |
| **LOW-17** | New throwaway `manifests` stage prunes the context to `package.json` files + lockfile (+ vendored `file:` tarballs, which are install inputs — `bun install` fails without `channel-whatsapp/vendor/*.tgz`); the deps stage installs from that, then COPYs source **after** the install layer. |
| **LOW-20** | `make -C deploy build` uses `docker buildx build ... --load` — BuildKit guaranteed, so `Dockerfile.dockerignore` is always honored. |
| **LOW-21** | `emptyDir` mounted at `/var/run/autopg` (postmaster `--socket-dir`) — no reliance on a writable rootfs. |

## H3 ordering argument

`make deploy` runs `helm upgrade --install --wait`. Helm's contract: **hooks run only after all main resources are Ready** on install. omni-api's readiness requires the `omni` role → which only the provision Job creates → which (as a post-install hook) required omni-api Ready first: a deadlock that bites exactly the first install. Alternatives rejected:
- **pre-install hook**: hooks block main-resource creation, and at pre-install time the autopg StatefulSet doesn't exist — there is no server to provision.
- **omni-api initContainer waiting for the role**: just moves the wait; the Job would still not run under `--wait` (and it needs a psql-capable image + DATABASE_URL duplication).

As a **regular resource** the Job is created in the same apply as the StatefulSet + Deployment, retries `pg_isready` for up to 300s (`backoffLimit: 6`), and provisions the role as soon as postgres accepts connections. omni-api's existing boot behavior (30×1s DB wait → exit → container restart with backoff) rides out the gap well inside the 5-minute `--wait` budget (helm `--wait` does not wait for Job completion without `--wait-for-jobs`). Verified in the render: no `helm.sh/hook` annotations remain on it; `omni-autopg-provision-1` + `ttlSecondsAfterFinished: 900` present.

## MED-3 selector-immutability reasoning

A Deployment's `spec.selector.matchLabels` is immutable. The api Deployment has always selected on `name+instance+component: api`, so instead of shrinking that selector (upgrade failure), the shared `omni.selectorLabels` drops the hardcoded `component: api` and a new `omni.apiSelectorLabels` re-adds it for the api Deployment/Service — the rendered api selector is **byte-identical** to before. minio/nats keep appending their own component to the base labels, now emitting the key exactly once; their *effective* stored selectors are unchanged too (the k8s API had already applied last-wins on the old duplicate-key YAML), so no selector changes anywhere on upgrade. Proven by `kubeconform -strict`: previously 8 duplicate-key errors on the dev render, now 0 across default/dev/prod.

## Decision log (for human veto)

1. **Prod DB strategy — bundled autopg with a published image** (recommended default from the review): G-CICD publishes `ghcr.io/automagik-dev/autopg` and this PR pins `v3.0.7` + implements the `<release>-autopg-app` DATABASE_URL contract. *Alternative surfaced:* `autopg.enabled: false` + managed Postgres (`database.*` / `database.existingSecret` are fully wired for it). Chose continuity with the shipped design.
2. **H6 via cidr tightening + NetworkPolicy, not password rotation**: the autopg postmaster hardcodes superuser `postgres/postgres` for its in-process admin pool; rotation crash-loops the pod on every recreation (the provision Job even pins it back). Only network reachability can protect it, hence RFC1918 pg_hba rules + a NetworkPolicy scoping `:5432` to omni-api + the provision Job, plus documented single-tenant gating of `autopg.enabled`.
3. **C1' autopg tag scheme**: prod pins `v3.0.7` = the autopg release the image bakes in (`charts/autopg` `appVersion`), matching G-CICD's publish tags (`v3.0.7`, `v<omni cli version>`, `main`); empty tag defaults to `v<appVersion>`.

> ⚠️ **Deploy-ordering caveat**: `ghcr.io/automagik-dev/autopg:v3.0.7` does **not exist yet**. It publishes only after this PR + G-CICD's publish-job PR promote to main and the image-publish workflow runs. A prod install before that will ImagePullBackOff on the autopg pods (omni-api `v2.260704.4` already exists).

## Verification evidence

```
$ helm lint deploy/helm/omni            # + -f values-prod.yaml, -f values-dev.yaml
1 chart(s) linted, 0 chart(s) failed    # all three

$ helm template omni deploy/helm/omni [-f values-prod|-f values-dev]  # all render; default previously FAILED
$ kubeconform -strict -summary <render>
prod:    Valid: 16, Invalid: 0, Errors: 0
dev:     Valid: 22, Invalid: 0, Errors: 0    # was: Valid 12, Errors 8 (duplicate app.kubernetes.io/component)
default: Valid: 15, Invalid: 0, Errors: 0    # was: render error (database.host required)

# Gate greps on the prod render:
image: "ghcr.io/automagik-dev/omni-api:v2.260704.4"
image: "ghcr.io/automagik-dev/autopg:v3.0.7"   (+ imagePullPolicy: IfNotPresent, both autopg pods)
kind: Secret / name: omni-autopg-app / DATABASE_URL: "postgresql://omni:<pw>@omni-autopg.default.svc.cluster.local:5432/omni"
secretKeyRef: name: omni-autopg-app / key: DATABASE_URL   # matches the rendered Secret; pw identical to -auth secret
kind: NetworkPolicy (1) — :5432 from omni-api + autopg-provision only
replicas: 1 (omni-api; autopg + nats STS are 1 by design); no HPA/PDB rendered at 1 replica

# H2 adversarial (old vs new prod render):
OLD: "omni-autopg-app" appears exactly once — as a Deployment secretKeyRef; no kind:Secret with that name
NEW: Secret omni-autopg-app rendered (key DATABASE_URL) + matching secretKeyRef

# LOW-13 adversarial:
--set-string database.password='p@ss:w/rd?#1' →
  DATABASE_URL: "postgresql://omni:p%40ss%3Aw%2Frd%3F%231@pg.example.com:5432/omni"

# Release-name-agnostic contract:
helm template prod1 ... → Secret prod1-autopg-app + secretKeyRef prod1-autopg-app

# LOW-17:
docker build --platform linux/arm64 -f deploy/Dockerfile -t omni-api:g-helm-test .   # exit 0
# then append a comment to packages/api/src/index.ts and rebuild:
#15 [deps 4/6] RUN bun install --frozen-lockfile --ignore-scripts
#15 CACHED                                    # install layer survives source-only edits

# MED-5:
make typecheck → Tasks: 21 successful, 21 total
bun test packages/db → 11 pass, 0 fail
bunx biome check packages/db/src/migrate.ts → clean
```

No-regress checks: dev overlay (PR #772) intact — ingress `omni.felipe.namastex.io`, local `omni-api:dev`/`autopg:dev` images with `pullPolicy: Never`, assembled dev DATABASE_URL unchanged. Dockerfile core (multi-stage, non-root, ffmpeg, migrations path) untouched beyond the granted env lines + deps-stage cache order.
