### PR TITLE
fix(media): remote-mode batch processing, strict media config, public presign endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ API_MANAGED=true
 # Selects where ingested media (images, audio, video, documents) is stored.
 #   local  → on-disk under MEDIA_STORAGE_PATH (default). No S3 vars needed.
 #   remote → S3/MinIO object store; agents receive short-lived presigned URLs.
+# ONLY local and remote are accepted — any other value fails loudly on boot.
 # In remote mode the OMNI_MEDIA_S3_BUCKET/ACCESS_KEY/SECRET_KEY are REQUIRED and
 # the API fails loudly on boot if any are missing (no silent fallback to disk).
 OMNI_MEDIA_MODE=local
@@ -71,6 +72,11 @@ OMNI_MEDIA_MODE=local
 # S3-compatible endpoint. For MinIO or self-hosted S3 set e.g.
 # http://localhost:9000; leave empty for real AWS S3 (SDK derives from region).
 # OMNI_MEDIA_S3_ENDPOINT=
+# Optional externally-reachable endpoint used ONLY to generate presigned GET
+# URLs. Set it when the agent runtime cannot resolve the internal endpoint
+# (e.g. in-cluster http://minio:9000); uploads/reads keep using
+# OMNI_MEDIA_S3_ENDPOINT. Leave empty to presign with the endpoint above.
+# OMNI_MEDIA_S3_PUBLIC_ENDPOINT=
 # Bucket that already exists (for external S3) or is bootstrapped (bundled MinIO).
 # OMNI_MEDIA_S3_BUCKET=omni-media
 # AWS region for SigV4 signing. Default us-east-1.

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
       "version": "2.260704.5",
       "dependencies": {
         "@omni/core": "workspace:*",
+        "zod": "^3.24.1",
       },
       "devDependencies": {
         "bun-types": "^1.1.42",

--- a/docs/_internal/remote-media-mode.md
+++ b/docs/_internal/remote-media-mode.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote Media Mode (S3/MinIO)"
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-04
 tags: [media, storage, s3, minio, remote, presigned-url]
 status: current
 ---
@@ -36,12 +36,19 @@ is missing, the API throws rather than silently falling back to local disk. This
 prevents a misconfigured deployment from writing media to an ephemeral pod
 filesystem it will later lose.
 
+The mode value itself is validated the same way: only `local` and `remote` are
+accepted (unset defaults to `local`). Any other value — `s3`, `minio`, `aws`,
+a typo — throws on boot instead of silently selecting local disk. All
+`OMNI_MEDIA_*` parsing goes through a Zod schema in
+`packages/channel-sdk/src/media-backends/config.ts`.
+
 ## Configuration (`OMNI_MEDIA_*`)
 
 | Var | Default | Purpose |
 |-----|---------|---------|
-| `OMNI_MEDIA_MODE` | `local` | `local` \| `remote`. Selects the backend. |
+| `OMNI_MEDIA_MODE` | `local` | `local` \| `remote`. Selects the backend. Any other value **throws on boot**. |
 | `OMNI_MEDIA_S3_ENDPOINT` | _(empty)_ | S3-compatible endpoint (e.g. `http://minio:9000`). Empty → real AWS S3, derived from region. |
+| `OMNI_MEDIA_S3_PUBLIC_ENDPOINT` | _(empty)_ | Optional externally-reachable endpoint used **only** to generate presigned GET URLs. Uploads/reads keep using `OMNI_MEDIA_S3_ENDPOINT`. Empty → presign with `OMNI_MEDIA_S3_ENDPOINT`. |
 | `OMNI_MEDIA_S3_BUCKET` | — | Bucket name. **Required** in remote mode. |
 | `OMNI_MEDIA_S3_REGION` | `us-east-1` | AWS region for SigV4 signing. |
 | `OMNI_MEDIA_S3_ACCESS_KEY` | — | Access key id. **Required** in remote mode. |
@@ -69,6 +76,13 @@ fresh and expire quickly:
 
 The presigned URL retrieves the exact stored bytes with the original
 content-type; once the TTL elapses the object store returns a `4xx`.
+
+When the agent runtime lives outside the cluster/network that hosts the object
+store, set `OMNI_MEDIA_S3_PUBLIC_ENDPOINT` to the externally-reachable host
+(e.g. an Ingress/LoadBalancer in front of MinIO). Presigned URLs are then
+signed against that host, while the API keeps uploading/reading through
+`OMNI_MEDIA_S3_ENDPOINT`. Without it, a URL like `http://minio:9000/…` is only
+fetchable by co-located workloads.
 
 ## Kubernetes default: remote + bundled MinIO
 
@@ -112,11 +126,16 @@ The full remote path — store → presign at dispatch → GET returns the store
 bytes — is covered against a real `minio/minio` container by:
 
 - `packages/api/src/services/__tests__/s3-backend-remote.test.ts` (backend
-  round-trip)
+  round-trip, public presign endpoint, no orphaned objects on empty/aborted
+  streams)
 - `packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts`
   (dispatch emits `ProviderFile.url`)
 - `packages/api/src/plugins/__tests__/media-remote-e2e.test.ts` (store through
   `MediaStorageService`, drive dispatch, `fetch()` the presigned URL, assert the
   bytes)
+- `packages/api/src/plugins/__tests__/media-processor-remote.test.ts` (realtime
+  processing fetches S3 bytes into a temp file and cleans it up)
+- `packages/api/src/services/__tests__/batch-jobs-remote.test.ts` (batch
+  `processItem` succeeds on items whose stored reference is an S3 key)
 
 These skip with a clear reason when Docker is unavailable.

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -16,10 +16,6 @@
  * @see media-processing-realtime wish
  */
 
-import { randomUUID } from 'node:crypto';
-import { rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { extname, join } from 'node:path';
 import type { ChannelType, EventBus, MessageReceivedPayload } from '@omni/core';
 import { createLogger, isValidUuid } from '@omni/core';
 import type { Database } from '@omni/db';
@@ -142,16 +138,6 @@ interface MediaResolution {
 }
 
 /**
- * Media bytes materialized as a local filesystem path for the processing
- * service (which only accepts a path and reads whole files off disk), paired
- * with a cleanup that removes any temp file created for it.
- */
-interface ProcessableMedia {
-  path: string;
-  cleanup: () => Promise<void>;
-}
-
-/**
  * Build fetch options for authenticated media downloads.
  * Slack private URLs require a bot-token Authorization header — we look it up
  * from the instances table so credentials never enter the event payload or DB.
@@ -269,41 +255,6 @@ async function resolveMediaPath(
   return {
     messageId: message.id,
     filePath,
-  };
-}
-
-/**
- * Materialize the stored media as a local filesystem path the processing
- * service can read.
- *
- * - `local`: the bytes already live at `{basePath}/{key}`, so hand back that
- *   path directly with a no-op cleanup (byte-for-byte the previous behavior).
- * - `remote`: `filePath` is an S3 key, not a local path. Fetch the bytes via
- *   the storage backend and write them to an `os.tmpdir()` temp file, returning
- *   a cleanup that removes it. The temp file keeps the stored extension so
- *   processors that sniff by extension (e.g. audio duration) behave as on disk.
- */
-async function materializeForProcessing(ctx: MediaProcessorContext, filePath: string): Promise<ProcessableMedia> {
-  if (ctx.mediaStorage.getStorageMode() === 'local') {
-    return { path: join(ctx.mediaStorage.getBasePath(), filePath), cleanup: async () => {} };
-  }
-
-  const buffer = await ctx.mediaStorage.read(filePath);
-  const ext = extname(filePath) || '.bin';
-  const tempPath = join(tmpdir(), `omni-media-${randomUUID()}${ext}`);
-  try {
-    await writeFile(tempPath, buffer);
-  } catch (error) {
-    // A failed write (ENOSPC, permissions) can leave a partial file behind.
-    await rm(tempPath, { force: true }).catch(() => {});
-    throw error;
-  }
-
-  return {
-    path: tempPath,
-    cleanup: async () => {
-      await rm(tempPath, { force: true });
-    },
   };
 }
 
@@ -429,7 +380,7 @@ async function processMessageMedia(
 
   // Obtain a readable local path for the bytes. In remote mode this fetches the
   // S3 object into a temp file; in local mode it resolves the on-disk path.
-  const processable = await materializeForProcessing(ctx, media.filePath);
+  const processable = await ctx.mediaStorage.materializeForProcessing(media.filePath);
 
   log.info('Processing media', { messageId: media.messageId, mimeType, filePath: processable.path });
 
@@ -716,7 +667,6 @@ export const __test__ = {
   persistProcessingResult,
   resolveSafeMediaContentEventId,
   processMessageMedia,
-  materializeForProcessing,
 };
 
 export type { MediaProcessorContext };

--- a/packages/api/src/services/__tests__/batch-jobs-remote.test.ts
+++ b/packages/api/src/services/__tests__/batch-jobs-remote.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Batch-job media processing in remote mode against a real MinIO container.
+ *
+ * `BatchJobService.processItem` hands a *local filesystem path* to the media
+ * processing service, which reads whole files off disk. In remote mode the
+ * message's stored reference (`mediaLocalPath`) is an S3 KEY, not a local path,
+ * so the batch path must fetch the bytes from the storage backend into a temp
+ * file before processing — exactly what the realtime processor already does via
+ * `MediaStorageService.materializeForProcessing`. This suite asserts, end-to-end
+ * against `minio/minio`:
+ *   - a batch item whose `mediaLocalPath` is an S3 key SUCCEEDS in remote mode
+ *     (before the fix, `processItem` joined the S3 key onto the local base path
+ *     and every item failed with a file-not-found error);
+ *   - the bytes handed to the processing service are exactly the stored S3
+ *     object, via a temp file that is cleaned up afterwards — on success AND on
+ *     processing error;
+ *   - local mode still resolves `{basePath}/{key}` on disk, creates no temp
+ *     file, and does NOT delete the stored file.
+ *
+ * If Docker is unavailable the whole suite skips with a clear reason (mirrors
+ * the sibling media-processor-remote suite).
+ */
+
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { LocalMediaBackend, type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
+import type { Database, Message } from '@omni/db';
+import type { MediaProcessingService, ProcessingResult } from '@omni/media-processing';
+import { createBucket, getSharedMinio, minioIntegrationEnabled, uniqueBucket } from '../../__tests__/minio-harness';
+import { BatchJobService } from '../batch-jobs';
+import { MediaStorageService } from '../media-storage';
+
+const BUCKET = uniqueBucket('omni-batch-jobs-test');
+const REGION = 'us-east-1';
+const MEDIA_BASE_PATH = process.env.MEDIA_STORAGE_PATH || './data/media';
+
+const hasDocker = minioIntegrationEnabled();
+const skipReason = hasDocker
+  ? ''
+  : 'MinIO integration disabled (CI opt-in / no Docker) — skipping MinIO batch-jobs round-trip';
+
+/** Records the path + bytes the processing service was handed. */
+interface ProcessCapture {
+  path?: string;
+  bytes?: Buffer;
+}
+
+/**
+ * A fake MediaProcessingService that reads the file at the path it is given —
+ * proving the batch path materialized readable bytes — and returns a synthetic
+ * success (real transcription would need external API keys). Set
+ * `throwAfterRead` to exercise the cleanup-on-error path.
+ */
+function makeFakeMediaService(capture: ProcessCapture, throwAfterRead = false): MediaProcessingService {
+  return {
+    canProcess: () => true,
+    process: async (path: string) => {
+      capture.path = path;
+      capture.bytes = await readFile(path);
+      if (throwAfterRead) throw new Error('synthetic batch processing failure');
+      return {
+        success: true,
+        content: 'transcribed: batch hello',
+        contentFormat: 'text',
+        processingType: 'transcription',
+        provider: 'fake',
+        model: 'fake-model',
+        processingTimeMs: 1,
+        costCents: 0,
+      };
+    },
+  } as unknown as MediaProcessingService;
+}
+
+/** Chainable no-op DB — persistProcessingResult only writes; we assert elsewhere. */
+function makeMockDb(): Database {
+  return {
+    update: () => ({ set: () => ({ where: async () => {} }) }),
+    insert: () => ({ values: async () => {} }),
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => [] }) }) }),
+  } as unknown as Database;
+}
+
+/**
+ * The members under test are private on BatchJobService (TypeScript-only
+ * visibility). This narrow view injects the remote/local storage + fake media
+ * service and drives `processItem` directly, without touching `any`.
+ */
+interface BatchJobServiceInternals {
+  mediaStorage: MediaStorageService;
+  mediaServicePromise: Promise<MediaProcessingService> | null;
+  processItem(instanceId: string, message: Message, batchJobId: string): Promise<ProcessingResult>;
+}
+
+function makeBatchInternals(storage: MediaStorageService, mediaService: MediaProcessingService) {
+  const service = new BatchJobService(makeMockDb(), null);
+  const internals = service as unknown as BatchJobServiceInternals;
+  internals.mediaStorage = storage;
+  internals.mediaServicePromise = Promise.resolve(mediaService);
+  return internals;
+}
+
+function makeMessage(mediaLocalPath: string): Message {
+  return {
+    id: 'msg-batch-1',
+    mediaMimeType: 'audio/ogg',
+    mediaLocalPath,
+    mediaUrl: null,
+    textContent: null,
+    platformTimestamp: null,
+  } as unknown as Message;
+}
+
+describe.skipIf(!hasDocker)('batch-jobs remote mode (MinIO)', () => {
+  let remoteService: MediaStorageService;
+  const audioKey = 'inst-batch/2026-07/aud-batch.ogg';
+  // Distinctive bytes so a disk-read of the key (which does not exist locally)
+  // could never accidentally match the S3 object.
+  const audioBytes = Buffer.from([0x4f, 0x67, 0x67, 0x53, 0xaa, 0xbb, 0xcc, 0xdd]);
+
+  beforeAll(async () => {
+    const minio = await getSharedMinio();
+    await createBucket(minio.endpoint, BUCKET);
+
+    const s3Config: S3BackendConfig = {
+      endpoint: minio.endpoint,
+      bucket: BUCKET,
+      region: REGION,
+      accessKeyId: minio.accessKey,
+      secretKey: minio.secretKey,
+      forcePathStyle: true,
+      presignTtlSeconds: 3600,
+    };
+
+    const backend = new S3MediaBackend(s3Config);
+    remoteService = new MediaStorageService({} as unknown as Database, undefined, backend);
+    // Seed the audio object the batch item will fetch from S3.
+    await backend.store({ key: audioKey, buffer: audioBytes, mimeType: 'audio/ogg' });
+  }, 180_000);
+
+  it('succeeds on an item whose mediaLocalPath is an S3 key, feeding the stored bytes via a temp file', async () => {
+    const capture: ProcessCapture = {};
+    const internals = makeBatchInternals(remoteService, makeFakeMediaService(capture));
+
+    const result = await internals.processItem('inst-batch', makeMessage(audioKey), 'job-1');
+
+    // The item succeeds — before the remote-mode fix this was a guaranteed
+    // failure: processItem joined the S3 key onto the local base path and the
+    // processing service found no file there.
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('transcribed: batch hello');
+
+    // The processing service received a real, readable temp path — not the S3
+    // key and not a path under the local media base dir.
+    expect(capture.path).toBeDefined();
+    expect(capture.path).not.toBe(audioKey);
+    expect(capture.path).not.toContain(audioKey);
+    expect(capture.path).toContain('omni-media-');
+    expect(capture.path?.endsWith('.ogg')).toBe(true);
+
+    // The bytes handed to processing are exactly what was stored in S3.
+    expect(capture.bytes).toBeDefined();
+    expect(Array.from(capture.bytes ?? [])).toEqual(Array.from(audioBytes));
+
+    // The temp file is cleaned up after a successful process.
+    expect(capture.path).toBeDefined();
+    expect(existsSync(capture.path ?? '')).toBe(false);
+  });
+
+  it('removes the temp file even when processing throws', async () => {
+    const capture: ProcessCapture = {};
+    const internals = makeBatchInternals(remoteService, makeFakeMediaService(capture, /* throwAfterRead */ true));
+
+    await expect(internals.processItem('inst-batch', makeMessage(audioKey), 'job-2')).rejects.toThrow(
+      'synthetic batch processing failure',
+    );
+
+    // The temp file existed (bytes were read) but was removed by the finally block.
+    expect(capture.path).toBeDefined();
+    expect(existsSync(capture.path ?? '')).toBe(false);
+  });
+});
+
+describe('batch-jobs local mode (no MinIO)', () => {
+  const localKey = 'inst-batch-local/2026-07/aud-batch-local.ogg';
+  const localBytes = Buffer.from([0x11, 0x22, 0x33, 0x44, 0x55]);
+  const localFullPath = join(MEDIA_BASE_PATH, localKey);
+  let localService: MediaStorageService;
+
+  beforeAll(async () => {
+    localService = new MediaStorageService(
+      {} as unknown as Database,
+      MEDIA_BASE_PATH,
+      new LocalMediaBackend(MEDIA_BASE_PATH),
+    );
+    await mkdir(join(MEDIA_BASE_PATH, 'inst-batch-local', '2026-07'), { recursive: true });
+    await writeFile(localFullPath, localBytes);
+  });
+
+  it('reads the on-disk path (no temp file) and leaves the file in place', async () => {
+    const capture: ProcessCapture = {};
+    const internals = makeBatchInternals(localService, makeFakeMediaService(capture));
+
+    const result = await internals.processItem('inst-batch-local', makeMessage(localKey), 'job-3');
+
+    expect(result.success).toBe(true);
+
+    // Local mode hands the processor the canonical on-disk path (byte-for-byte
+    // the pre-remote behavior), never a temp file.
+    expect(capture.path).toBe(localFullPath);
+    expect(capture.path).not.toContain('omni-media-');
+    expect(Array.from(capture.bytes ?? [])).toEqual(Array.from(localBytes));
+
+    // The on-disk file is NOT deleted by batch processing in local mode.
+    expect(existsSync(localFullPath)).toBe(true);
+
+    await rm(localFullPath, { force: true });
+  });
+});
+
+describe.skipIf(hasDocker)('batch-jobs remote mode (MinIO) (skipped)', () => {
+  it.skip(skipReason || 'skipped', () => {});
+});

--- a/packages/api/src/services/__tests__/s3-backend-remote.test.ts
+++ b/packages/api/src/services/__tests__/s3-backend-remote.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { Readable } from 'node:stream';
 import { type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
 import {
@@ -92,6 +93,70 @@ describe.skipIf(!hasDocker)('S3MediaBackend against MinIO', () => {
     const download = await harnessFetch(url);
     expect(download.status).toBe(200);
     expect(Array.from(new Uint8Array(await download.arrayBuffer()))).toEqual([1, 2, 3]);
+  });
+
+  it('presigns with the public endpoint while uploads keep using the internal endpoint', async () => {
+    // `localhost` aliases the container's `127.0.0.1` endpoint — a DIFFERENT
+    // host string signed into the URL, but the same server, so the test can
+    // actually fetch the public-endpoint presigned URL.
+    const publicEndpoint = (config.endpoint ?? '').replace('127.0.0.1', 'localhost');
+    expect(publicEndpoint).toContain('localhost');
+    const backend = new S3MediaBackend({ ...config, publicEndpoint });
+
+    const key = 'inst-1/2026-07/msg-public.png';
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]);
+    // The upload goes through the internal client (127.0.0.1 endpoint) — it
+    // succeeding proves storage did not switch to the public endpoint.
+    await backend.store({ key, buffer: bytes, mimeType: 'image/png' });
+
+    const url = await backend.presignedUrl(key, 60);
+    expect(url.startsWith(`${publicEndpoint}/`)).toBe(true);
+    expect(url).not.toContain('127.0.0.1');
+
+    // The public-host signature is valid and retrieves the stored bytes.
+    const download = await harnessFetch(url);
+    expect(download.status).toBe(200);
+    expect(Array.from(new Uint8Array(await download.arrayBuffer()))).toEqual(Array.from(bytes));
+  });
+
+  it('leaves no object behind for an empty stream (mirrors the local backend rm)', async () => {
+    const backend = new S3MediaBackend(config);
+    const key = 'inst-1/2026-07/msg-empty.bin';
+
+    const result = await backend.storeStream({
+      key,
+      stream: Readable.from([]),
+      mimeType: 'application/octet-stream',
+    });
+    expect(result.size).toBe(0);
+
+    // Without the cleanup, writer.end() commits a 0-byte object at the key.
+    const url = await backend.presignedUrl(key, 60);
+    const download = await harnessFetch(url);
+    expect(download.status).toBe(404);
+  });
+
+  it('leaves no object behind when the stream exceeds maxSizeBytes', async () => {
+    const backend = new S3MediaBackend(config);
+    const key = 'inst-1/2026-07/msg-too-large.bin';
+
+    async function* chunks(): AsyncGenerator<Buffer> {
+      yield Buffer.alloc(1024, 1);
+      yield Buffer.alloc(1024, 2);
+    }
+
+    await expect(
+      backend.storeStream({
+        key,
+        stream: Readable.from(chunks()),
+        mimeType: 'application/octet-stream',
+        maxSizeBytes: 1500,
+      }),
+    ).rejects.toThrow(/exceeds limit/);
+
+    const url = await backend.presignedUrl(key, 60);
+    const download = await harnessFetch(url);
+    expect(download.status).toBe(404);
   });
 });
 

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -14,7 +14,6 @@
  * @see media-processing-batch wish
  */
 
-import { join } from 'node:path';
 import type { BatchJobProgress, BatchJobType, EventBus } from '@omni/core';
 import { NotFoundError, createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
@@ -815,10 +814,19 @@ export class BatchJobService {
       return this.failedResult(resolved.reason);
     }
 
-    const fullPath = join(this.mediaStorage.getBasePath(), resolved.path);
-    const result = await mediaService.process(fullPath, mimeType, {
-      caption: message.textContent ?? undefined,
-    });
+    // Materialize a readable local path for the stored reference. In local mode
+    // this is `{basePath}/{path}` (no copy); in remote mode the reference is an
+    // S3 key, so the bytes are fetched into a temp file that MUST be cleaned up.
+    const materialized = await this.mediaStorage.materializeForProcessing(resolved.path);
+    let result: ProcessingResult;
+    try {
+      result = await mediaService.process(materialized.path, mimeType, {
+        caption: message.textContent ?? undefined,
+      });
+    } finally {
+      // Always remove any temp file fetched for remote processing (no-op in local mode).
+      await materialized.cleanup();
+    }
 
     if (result.success && result.content) {
       await this.persistProcessingResult(message.id, result, batchJobId);

--- a/packages/api/src/services/media-storage.ts
+++ b/packages/api/src/services/media-storage.ts
@@ -4,7 +4,10 @@
  * @see history-sync wish
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { extname, join } from 'node:path';
 
 import { type MediaStorageBackend, createMediaBackend } from '@omni/channel-sdk';
@@ -27,6 +30,16 @@ export interface StoredMediaResult {
   localPath: string;
   size: number;
   mimeType?: string;
+}
+
+/**
+ * Media bytes materialized as a local filesystem path for a processing service
+ * (which only accepts a path and reads whole files off disk), paired with a
+ * cleanup that removes any temp file created for it.
+ */
+export interface MaterializedMedia {
+  path: string;
+  cleanup: () => Promise<void>;
 }
 
 export interface MediaFetchOptions extends RequestInit {
@@ -412,5 +425,45 @@ export class MediaStorageService {
    */
   async presignedUrl(reference: string, ttlSeconds?: number): Promise<string> {
     return this.backend.presignedUrl(reference, ttlSeconds);
+  }
+
+  /**
+   * Materialize a stored reference as a local filesystem path a processing
+   * service can read, with a cleanup for any temp file created.
+   *
+   * - `local`: the bytes already live at `{basePath}/{reference}`, so hand back
+   *   that path directly with a no-op cleanup (byte-for-byte the pre-remote
+   *   behavior — no copy, and cleanup never deletes the stored file).
+   * - `remote`: `reference` is an S3 key, not a local path. Fetch the bytes via
+   *   the storage backend and write them to an `os.tmpdir()` temp file,
+   *   returning a cleanup that removes it. The temp file keeps the stored
+   *   extension so processors that sniff by extension (e.g. audio duration)
+   *   behave as on disk.
+   *
+   * Callers MUST invoke `cleanup` in a `finally` so remote temp files are
+   * removed on success and on processing error alike.
+   */
+  async materializeForProcessing(reference: string): Promise<MaterializedMedia> {
+    if (this.backend.mode === 'local') {
+      return { path: join(this.basePath, reference), cleanup: async () => {} };
+    }
+
+    const buffer = await this.backend.read(reference);
+    const ext = extname(reference) || '.bin';
+    const tempPath = join(tmpdir(), `omni-media-${randomUUID()}${ext}`);
+    try {
+      await writeFile(tempPath, buffer);
+    } catch (error) {
+      // A failed write (ENOSPC, permissions) can leave a partial file behind.
+      await rm(tempPath, { force: true }).catch(() => {});
+      throw error;
+    }
+
+    return {
+      path: tempPath,
+      cleanup: async () => {
+        await rm(tempPath, { force: true });
+      },
+    };
   }
 }

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -26,7 +26,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@omni/core": "workspace:*"
+    "@omni/core": "workspace:*",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "bun-types": "^1.1.42",

--- a/packages/channel-sdk/src/media-backends/__tests__/config.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/config.test.ts
@@ -3,6 +3,8 @@
  *
  * Locks the acceptance criteria: `OMNI_MEDIA_MODE` unset → local; `=remote` →
  * s3 with required credentials, and a loud failure when they are missing.
+ * Any OTHER mode value throws (a typo like `s3` must never silently fall back
+ * to local disk), matching the module's own docstring.
  */
 
 import { describe, expect, it } from 'bun:test';
@@ -20,9 +22,15 @@ describe('resolveMediaBackendConfig', () => {
     expect(resolveMediaBackendConfig({})).toEqual({ mode: 'local' });
   });
 
-  it('treats any non-remote value as local', () => {
+  it('accepts an explicit local mode', () => {
     expect(resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 'local' })).toEqual({ mode: 'local' });
-    expect(resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 'nonsense' })).toEqual({ mode: 'local' });
+    expect(resolveMediaBackendConfig({ OMNI_MEDIA_MODE: ' LOCAL ' })).toEqual({ mode: 'local' });
+  });
+
+  it('throws loudly on an unknown OMNI_MEDIA_MODE instead of falling back to local', () => {
+    expect(() => resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 's3' })).toThrow(/Invalid OMNI_MEDIA_MODE="s3"/);
+    expect(() => resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 'minio' })).toThrow(/expected "local" or "remote"/);
+    expect(() => resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 'nonsense' })).toThrow(/Invalid OMNI_MEDIA_MODE/);
   });
 
   it('is case-insensitive for the mode value', () => {
@@ -64,6 +72,27 @@ describe('resolveMediaBackendConfig', () => {
     const config = resolveMediaBackendConfig({ ...REMOTE_ENV, OMNI_MEDIA_S3_PRESIGN_TTL_SECONDS: 'abc' });
     if (config.mode !== 'remote') throw new Error('unreachable');
     expect(config.s3.presignTtlSeconds).toBe(3600);
+  });
+
+  it('parses the optional public presign endpoint separately from the internal endpoint', () => {
+    const config = resolveMediaBackendConfig({
+      ...REMOTE_ENV,
+      OMNI_MEDIA_S3_ENDPOINT: 'http://minio:9000',
+      OMNI_MEDIA_S3_PUBLIC_ENDPOINT: 'https://media.example.com',
+    });
+    if (config.mode !== 'remote') throw new Error('unreachable');
+    expect(config.s3.endpoint).toBe('http://minio:9000');
+    expect(config.s3.publicEndpoint).toBe('https://media.example.com');
+  });
+
+  it('leaves publicEndpoint undefined when unset or blank', () => {
+    const unset = resolveMediaBackendConfig(REMOTE_ENV);
+    if (unset.mode !== 'remote') throw new Error('unreachable');
+    expect(unset.s3.publicEndpoint).toBeUndefined();
+
+    const blank = resolveMediaBackendConfig({ ...REMOTE_ENV, OMNI_MEDIA_S3_PUBLIC_ENDPOINT: '   ' });
+    if (blank.mode !== 'remote') throw new Error('unreachable');
+    expect(blank.s3.publicEndpoint).toBeUndefined();
   });
 
   it('throws with the missing var names when remote credentials are incomplete', () => {

--- a/packages/channel-sdk/src/media-backends/__tests__/s3-backend.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/s3-backend.test.ts
@@ -1,0 +1,71 @@
+/**
+ * S3 backend endpoint wiring (offline — presigning is pure local SigV4 math).
+ *
+ * MED-1 contract: `OMNI_MEDIA_S3_PUBLIC_ENDPOINT` (config `publicEndpoint`) is
+ * used ONLY for `presignedUrl()`; uploads/reads keep using the internal
+ * `endpoint`. Verified by trapping the `Bun.S3Client` constructor (the same
+ * device backend.test.ts uses) and asserting which endpoint each constructed
+ * client carries, plus asserting the host baked into the presigned URL.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { S3MediaBackend } from '../s3-backend';
+
+const INTERNAL_ENDPOINT = 'http://minio.internal:9000';
+const PUBLIC_ENDPOINT = 'https://media.example.com';
+
+const BASE_CONFIG = {
+  endpoint: INTERNAL_ENDPOINT,
+  bucket: 'omni-media',
+  region: 'us-east-1',
+  accessKeyId: 'test-access',
+  secretKey: 'test-secret',
+  forcePathStyle: true,
+  presignTtlSeconds: 3600,
+};
+
+describe('S3MediaBackend public presign endpoint', () => {
+  const OriginalS3Client = Bun.S3Client;
+  let constructedEndpoints: Array<string | undefined>;
+
+  beforeEach(() => {
+    constructedEndpoints = [];
+    // Trap the native S3 client constructor to observe the endpoint each
+    // internal client is wired with. Cast through unknown: we replace a native class.
+    (Bun as unknown as { S3Client: unknown }).S3Client = class extends OriginalS3Client {
+      constructor(...args: ConstructorParameters<typeof OriginalS3Client>) {
+        constructedEndpoints.push(args[0]?.endpoint);
+        super(...args);
+      }
+    };
+  });
+
+  afterEach(() => {
+    (Bun as unknown as { S3Client: typeof OriginalS3Client }).S3Client = OriginalS3Client;
+  });
+
+  it('builds one client on the internal endpoint and presigns against it when no public endpoint is set', async () => {
+    const backend = new S3MediaBackend(BASE_CONFIG);
+
+    // Storage and presigning share the single internal-endpoint client.
+    expect(constructedEndpoints).toEqual([INTERNAL_ENDPOINT]);
+
+    const url = await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(url.startsWith(`${INTERNAL_ENDPOINT}/`)).toBe(true);
+    expect(url).toContain('X-Amz-Signature=');
+  });
+
+  it('presigns against the public endpoint while storage keeps the internal client', async () => {
+    const backend = new S3MediaBackend({ ...BASE_CONFIG, publicEndpoint: PUBLIC_ENDPOINT });
+
+    // Exactly two clients: the storage client first (internal endpoint — the
+    // one store/storeStream/read use), then the presign-only public client.
+    expect(constructedEndpoints).toEqual([INTERNAL_ENDPOINT, PUBLIC_ENDPOINT]);
+
+    // Presigned URLs carry the externally-reachable host, not the internal one.
+    const url = await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(url.startsWith(`${PUBLIC_ENDPOINT}/`)).toBe(true);
+    expect(url).not.toContain('minio.internal');
+    expect(url).toContain('X-Amz-Signature=');
+  });
+});

--- a/packages/channel-sdk/src/media-backends/config.ts
+++ b/packages/channel-sdk/src/media-backends/config.ts
@@ -1,16 +1,25 @@
 /**
  * Media backend configuration parsing.
  *
- * Reads `OMNI_MEDIA_*` env vars directly (mirroring how MediaStorageService
- * already reads `MEDIA_STORAGE_PATH`). `OMNI_MEDIA_MODE` selects the backend and
- * defaults to `local`; `remote` requires S3 credentials and fails loudly when
- * they are missing so a misconfigured deployment cannot silently fall back to
- * local disk.
+ * Parses the `OMNI_MEDIA_*` env vars through a Zod schema (repo rule: no
+ * unvalidated external inputs). `OMNI_MEDIA_MODE` selects the backend and
+ * defaults to `local` when unset; ONLY `local` and `remote` are accepted — any
+ * other value throws loudly, so a typo (`s3`, `minio`, ...) cannot silently
+ * fall back to local disk. `remote` additionally requires S3 credentials and
+ * fails loudly when they are missing.
  */
+
+import { z } from 'zod';
 
 export interface S3BackendConfig {
   /** Custom endpoint (e.g. MinIO `http://minio:9000`); omit for real AWS S3. */
   endpoint?: string;
+  /**
+   * Optional externally-reachable endpoint used ONLY for `presign()` URL
+   * generation. Uploads/reads keep using `endpoint`. Set this when the agent
+   * runtime cannot resolve the in-cluster endpoint (e.g. `http://minio:9000`).
+   */
+  publicEndpoint?: string;
   bucket: string;
   region: string;
   accessKeyId: string;
@@ -26,61 +35,108 @@ export type MediaBackendConfig = { mode: 'local' } | { mode: 'remote'; s3: S3Bac
 const DEFAULT_PRESIGN_TTL_SECONDS = 3600;
 const DEFAULT_REGION = 'us-east-1';
 
-function parseBool(value: string | undefined, defaultValue: boolean): boolean {
-  if (value === undefined) return defaultValue;
-  const normalized = value.trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-  return defaultValue;
+/** Trimmed optional string; empty/whitespace-only collapses to undefined. */
+const optionalTrimmedString = z
+  .string()
+  .optional()
+  .transform((value) => value?.trim() || undefined);
+
+/** Bool accepting 1/true/yes/on and 0/false/no/off; anything else → default. */
+function boolFromEnv(defaultValue: boolean) {
+  return z
+    .string()
+    .optional()
+    .transform((value) => {
+      if (value === undefined) return defaultValue;
+      const normalized = value.trim().toLowerCase();
+      if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+      if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+      return defaultValue;
+    });
 }
 
-function parseTtl(value: string | undefined, defaultValue: number): number {
-  if (value === undefined) return defaultValue;
-  const parsed = Number.parseInt(value.trim(), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+/** Positive-integer TTL; non-positive or unparseable values → default. */
+function ttlFromEnv(defaultValue: number) {
+  return z
+    .string()
+    .optional()
+    .transform((value) => {
+      if (value === undefined) return defaultValue;
+      const parsed = Number.parseInt(value.trim(), 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+    });
 }
 
 /**
+ * Schema over the `OMNI_MEDIA_*` env surface. Unknown keys on the env object
+ * are ignored (process.env carries the whole environment).
+ */
+const MediaEnvSchema = z.object({
+  OMNI_MEDIA_MODE: z
+    .string()
+    .optional()
+    .transform((value) => (value ?? 'local').trim().toLowerCase())
+    .pipe(
+      z.enum(['local', 'remote'], {
+        errorMap: (_issue, ctx) => ({
+          message: `Invalid OMNI_MEDIA_MODE="${String(ctx.data)}" — expected "local" or "remote" (unset defaults to local). Refusing to silently fall back to local disk.`,
+        }),
+      }),
+    ),
+  OMNI_MEDIA_S3_ENDPOINT: optionalTrimmedString,
+  OMNI_MEDIA_S3_PUBLIC_ENDPOINT: optionalTrimmedString,
+  OMNI_MEDIA_S3_BUCKET: optionalTrimmedString,
+  OMNI_MEDIA_S3_REGION: optionalTrimmedString,
+  OMNI_MEDIA_S3_ACCESS_KEY: optionalTrimmedString,
+  OMNI_MEDIA_S3_SECRET_KEY: optionalTrimmedString,
+  OMNI_MEDIA_S3_FORCE_PATH_STYLE: boolFromEnv(true),
+  OMNI_MEDIA_S3_PRESIGN_TTL_SECONDS: ttlFromEnv(DEFAULT_PRESIGN_TTL_SECONDS),
+});
+
+/**
  * Resolve the media backend configuration from the environment.
- * @throws when `OMNI_MEDIA_MODE=remote` but required S3 credentials are missing.
+ * @throws when `OMNI_MEDIA_MODE` is neither `local` nor `remote` (unset → local),
+ *   or when `OMNI_MEDIA_MODE=remote` but required S3 credentials are missing.
  */
 export function resolveMediaBackendConfig(env: NodeJS.ProcessEnv = process.env): MediaBackendConfig {
-  const mode = (env.OMNI_MEDIA_MODE ?? 'local').trim().toLowerCase();
-  if (mode !== 'remote') {
+  const parsed = MediaEnvSchema.safeParse(env);
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues.map((issue) => issue.message).join('; '));
+  }
+
+  const vars = parsed.data;
+  if (vars.OMNI_MEDIA_MODE !== 'remote') {
     return { mode: 'local' };
   }
 
-  const bucket = env.OMNI_MEDIA_S3_BUCKET?.trim();
-  const accessKeyId = env.OMNI_MEDIA_S3_ACCESS_KEY?.trim();
-  const secretKey = env.OMNI_MEDIA_S3_SECRET_KEY?.trim();
+  const bucket = vars.OMNI_MEDIA_S3_BUCKET;
+  const accessKeyId = vars.OMNI_MEDIA_S3_ACCESS_KEY;
+  const secretKey = vars.OMNI_MEDIA_S3_SECRET_KEY;
 
-  const missing = (
-    [
-      ['OMNI_MEDIA_S3_BUCKET', bucket],
-      ['OMNI_MEDIA_S3_ACCESS_KEY', accessKeyId],
-      ['OMNI_MEDIA_S3_SECRET_KEY', secretKey],
-    ] as const
-  )
-    .filter(([, value]) => !value)
-    .map(([name]) => name);
-
-  if (missing.length > 0) {
+  if (!bucket || !accessKeyId || !secretKey) {
+    const missing = (
+      [
+        ['OMNI_MEDIA_S3_BUCKET', bucket],
+        ['OMNI_MEDIA_S3_ACCESS_KEY', accessKeyId],
+        ['OMNI_MEDIA_S3_SECRET_KEY', secretKey],
+      ] as const
+    )
+      .filter(([, value]) => !value)
+      .map(([name]) => name);
     throw new Error(`OMNI_MEDIA_MODE=remote requires these env vars: ${missing.join(', ')}`);
   }
 
   return {
     mode: 'remote',
     s3: {
-      endpoint: env.OMNI_MEDIA_S3_ENDPOINT?.trim() || undefined,
-      // biome-ignore lint/style/noNonNullAssertion: presence enforced by the missing[] guard above
-      bucket: bucket!,
-      region: env.OMNI_MEDIA_S3_REGION?.trim() || DEFAULT_REGION,
-      // biome-ignore lint/style/noNonNullAssertion: presence enforced by the missing[] guard above
-      accessKeyId: accessKeyId!,
-      // biome-ignore lint/style/noNonNullAssertion: presence enforced by the missing[] guard above
-      secretKey: secretKey!,
-      forcePathStyle: parseBool(env.OMNI_MEDIA_S3_FORCE_PATH_STYLE, true),
-      presignTtlSeconds: parseTtl(env.OMNI_MEDIA_S3_PRESIGN_TTL_SECONDS, DEFAULT_PRESIGN_TTL_SECONDS),
+      endpoint: vars.OMNI_MEDIA_S3_ENDPOINT,
+      publicEndpoint: vars.OMNI_MEDIA_S3_PUBLIC_ENDPOINT,
+      bucket,
+      region: vars.OMNI_MEDIA_S3_REGION ?? DEFAULT_REGION,
+      accessKeyId,
+      secretKey,
+      forcePathStyle: vars.OMNI_MEDIA_S3_FORCE_PATH_STYLE,
+      presignTtlSeconds: vars.OMNI_MEDIA_S3_PRESIGN_TTL_SECONDS,
     },
   };
 }

--- a/packages/channel-sdk/src/media-backends/s3-backend.ts
+++ b/packages/channel-sdk/src/media-backends/s3-backend.ts
@@ -20,21 +20,35 @@ export class S3MediaBackend implements MediaStorageBackend {
   readonly mode = 'remote' as const;
 
   private client: Bun.S3Client;
+  /**
+   * Client used ONLY for `presign()`. When `publicEndpoint` is configured this
+   * signs URLs against the externally-reachable host (so agent runtimes outside
+   * the cluster can fetch them); uploads/reads keep using `client` and the
+   * internal `endpoint`. Without `publicEndpoint` this IS `client`.
+   */
+  private presignClient: Bun.S3Client;
   private presignTtlSeconds: number;
 
   constructor(config: S3BackendConfig) {
     this.presignTtlSeconds = config.presignTtlSeconds;
-    this.client = new Bun.S3Client({
+    const clientOptions = {
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretKey,
       bucket: config.bucket,
       region: config.region,
-      ...(config.endpoint ? { endpoint: config.endpoint } : {}),
       ...(config.forcePathStyle ? {} : { virtualHostedStyle: true }),
+    };
+    this.client = new Bun.S3Client({
+      ...clientOptions,
+      ...(config.endpoint ? { endpoint: config.endpoint } : {}),
     });
+    this.presignClient = config.publicEndpoint
+      ? new Bun.S3Client({ ...clientOptions, endpoint: config.publicEndpoint })
+      : this.client;
     log.info('Initialized S3 media backend', {
       bucket: config.bucket,
       endpoint: config.endpoint ?? 'aws',
+      publicEndpoint: config.publicEndpoint ?? config.endpoint ?? 'aws',
       forcePathStyle: config.forcePathStyle,
     });
   }
@@ -49,8 +63,14 @@ export class S3MediaBackend implements MediaStorageBackend {
    * Streaming/multipart upload — chunks flow straight to S3 via the native
    * `Bun.S3Client` writer, never buffering the whole payload (large WhatsApp
    * video/documents). Enforces `maxSizeBytes` mid-stream: on overflow the
-   * multipart upload is aborted (`writer.end(error)`) and the error rethrown,
-   * mirroring the local size-guard.
+   * writer is ended with the error and the error rethrown, mirroring the local
+   * size-guard. Like the local backend (which `rm`s the partial/empty file),
+   * no object is left behind for an empty or aborted stream: `delete(key)`
+   * runs best-effort in both paths. This is REQUIRED, not defensive —
+   * observed on Bun 1.3.9 against MinIO, `writer.end(error)` does NOT abort
+   * the upload: it commits the bytes written so far as a complete object
+   * (single-part and multipart alike), and `writer.end()` on an empty stream
+   * commits a 0-byte object.
    */
   async storeStream({ key, stream, mimeType, maxSizeBytes }: StoreStreamInput): Promise<StoreMediaResult> {
     const writer = this.client.file(key, mimeType ? { type: mimeType } : undefined).writer();
@@ -65,13 +85,33 @@ export class S3MediaBackend implements MediaStorageBackend {
         await writer.write(buffer);
       }
     } catch (error) {
-      // Abort the in-flight multipart upload so no partial object is committed.
+      // End the writer, then remove whatever it committed: Bun's S3 writer
+      // `end(error)` does NOT abort — it commits the bytes written so far as a
+      // complete object (verified against MinIO), so the delete is what
+      // actually prevents an orphaned partial object.
       await Promise.resolve(writer.end(error as Error)).catch(() => {});
+      await this.deleteQuietly(key);
       throw error;
     }
     await writer.end();
+    if (size === 0) {
+      // Mirror the local backend: an empty stream must not leave a stored
+      // object behind (writer.end() commits a 0-byte object without this).
+      await this.deleteQuietly(key);
+      log.debug('Removed empty media object from S3', { key });
+      return { reference: key, size, mimeType };
+    }
     log.debug('Streamed media to S3', { key, size });
     return { reference: key, size, mimeType };
+  }
+
+  /** Best-effort delete for cleanup paths — never masks the original error. */
+  private async deleteQuietly(key: string): Promise<void> {
+    try {
+      await this.client.delete(key);
+    } catch (error) {
+      log.warn('Failed to delete orphaned S3 object', { key, error: String(error) });
+    }
   }
 
   async read(key: string): Promise<Buffer> {
@@ -81,6 +121,6 @@ export class S3MediaBackend implements MediaStorageBackend {
   }
 
   async presignedUrl(key: string, ttlSeconds: number = this.presignTtlSeconds): Promise<string> {
-    return this.client.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
+    return this.presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
   }
 }

--- a/packages/media-processing/src/processors/audio.ts
+++ b/packages/media-processing/src/processors/audio.ts
@@ -134,7 +134,7 @@ export class AudioProcessor extends BaseProcessor {
             getNormalizedAudio,
           ),
         () => this.transcribeWithOpenAiTranscriptions(language, options, OPENAI_TRANSCRIBE_MODEL, getNormalizedAudio),
-        () => this.transcribeWithGemini(language, options, GEMINI_AUDIO_MODEL, getNormalizedAudio),
+        () => this.transcribeWithGemini(language, options, this.resolveGeminiAudioModel(undefined), getNormalizedAudio),
         () => this.transcribeWithGroq(language, getNormalizedAudio),
       ];
     }


### PR DESCRIPTION
## Summary

G-REMOTE group of the PR #770 fix orchestration (`docs/_internal/PR-770-REVIEW.md`). Makes remote-media mode production-ready in source: **H7, MED-1, MED-2, LOW-3, LOW-4, LOW-12**.

## Findings addressed

| ID | Fix |
|----|-----|
| **H7** | Batch media processing was 100% broken in remote mode: `processItem` joined the S3 key onto the local base path. Extracted the realtime processor's `materializeForProcessing` into a shared `MediaStorageService.materializeForProcessing(reference)` (local mode: direct `join(basePath, key)`, no copy; remote: fetch bytes into an `os.tmpdir()` temp file keyed by `randomUUID` + preserved extension). Reused in `media-processor.ts` (behavior-preserving, try/finally cleanup unchanged) and in `batch-jobs.ts` `processItem` with cleanup in `finally`. |
| **MED-2** | `OMNI_MEDIA_MODE` now accepts ONLY `local`/`remote` (unset → local). Any other value (`s3`, `minio`, a typo) throws loudly at boot instead of silently selecting local disk — the module docstring and `remote-media-mode.md` claim is now true. |
| **MED-1** | New optional `OMNI_MEDIA_S3_PUBLIC_ENDPOINT`, used ONLY for `presign()` URL generation via a dedicated presign-only `Bun.S3Client`; uploads/reads keep using `OMNI_MEDIA_S3_ENDPOINT`. `.env.example` and `docs/_internal/remote-media-mode.md` updated (doc/code parity kept exact). |
| **LOW-12** | All `OMNI_MEDIA_*` parsing moved to a Zod schema in `config.ts` (zod added to `@omni/channel-sdk` deps, same `^3.24.1` as core). Defaults, TTL parsing, bool parsing, and the loud throw on missing S3 creds preserved exactly; existing config tests kept passing and extended. |
| **LOW-3** | `storeStream` no longer leaves orphaned S3 objects: best-effort `delete(key)` on `size === 0` (mirrors `local-backend.ts:77-79` `rm`) and in the error/abort path. See the Bun observation below — the error-path delete is **required**, not defensive. |
| **LOW-4** | `audio.ts` openai-fallback chain now uses `this.resolveGeminiAudioModel(undefined)` instead of hardcoding `GEMINI_AUDIO_MODEL`, so configured `stt.gemini.model` / `GEMINI_STT_MODEL` overrides are honored on that path (consistent with the gemini-provider branch). |

## H7 red → green proof

New suite `packages/api/src/services/__tests__/batch-jobs-remote.test.ts` (minio-harness pattern): stores an object via the S3 backend, builds a batch item whose message `mediaLocalPath` is the S3 key, drives `processItem` with the remote backend active, and asserts success + exact bytes + temp-file cleanup (plus an ungated local-mode no-regression test).

**RED — run against UNFIXED code** (`MINIO_INTEGRATION=1 CI=true bun test packages/api/src/services/__tests__/batch-jobs-remote.test.ts`):

```
packages/api/src/services/__tests__/batch-jobs-remote.test.ts:
ENOENT: no such file or directory, open 'data/media/inst-batch/2026-07/aud-batch.ogg'
    path: "data/media/inst-batch/2026-07/aud-batch.ogg",
 syscall: "open",
   errno: -2,
    code: "ENOENT"

(fail) batch-jobs remote mode (MinIO) > succeeds on an item whose mediaLocalPath is an S3 key, feeding the stored bytes via a temp file [2.57ms]
...
Expected substring: "synthetic batch processing failure"
Received message: "ENOENT: no such file or directory, open 'data/media/inst-batch/2026-07/aud-batch.ogg'"
(fail) batch-jobs remote mode (MinIO) > removes the temp file even when processing throws [2.17ms]

 1 pass
 1 skip
 2 fail
```

Exactly the reviewed failure mode: the S3 key (`inst-batch/2026-07/aud-batch.ogg`) joined onto the local base path (`data/media/...`) → every remote-mode batch item errors.

**GREEN — same command after the fix:**

```
 3 pass
 1 skip
 0 fail
 19 expect() calls
Ran 4 tests across 1 file. [2.22s]
```

## Remote suites executed (not skipped)

`MINIO_INTEGRATION=1 CI=true bun test` over `s3-backend-remote`, `media-remote-e2e`, `media-processor-remote`, `agent-dispatcher-media-remote` + the new `batch-jobs-remote`:

```
 19 pass
 5 skip
 0 fail
 94 expect() calls
Ran 24 tests across 5 files. [5.63s]
```

Execution confirmed: 9 `Initialized S3 media backend` log lines against the MinIO container and **zero** `MinIO integration disabled` markers. The 5 skips are the pre-existing per-file `(skipped)` placeholder describes (one per suite), which register a skip when Docker IS available.

## Bun S3 writer `end(error)` observation (LOW-3)

Probed against a real MinIO container (Bun 1.3.9): **`writer.end(error)` does NOT abort the upload.** It commits the bytes written so far as a complete object — in both the single-part case (1 KiB written → 1024-byte object exists) and the multipart case (3×4 MiB written → 12,582,912-byte object exists). No dangling multipart temp state is left on MinIO disk (`/data/.minio.sys/multipart` empty), i.e. the upload is completed, not abandoned. So the review's "assumed to abort" was optimistic: without the new `delete(key)` in the catch path, every aborted/oversize stream left a committed partial object in S3. `writer.end()` on an empty stream likewise commits a 0-byte object. Both paths are now cleaned up and covered by MinIO integration tests.

## Gates

- `make typecheck` PASS · `make lint` (biome, zero warnings) PASS · `bunx knip` PASS (no new findings)
- `make test-api` PASS — 1105 pass / 0 fail (local-mode no-regression)
- 5 remote suites executing under `MINIO_INTEGRATION=1 CI=true` PASS — 19 pass / 0 fail
- `bun test packages/channel-sdk` PASS — 291 pass / 0 fail (config + s3-backend units)
- `bun test packages/media-processing` PASS — 93 pass / 0 fail
- pre-push hook (typecheck + full `bun test`, 4124 pass / 0 fail) PASS

## Follow-ups for other groups

- **G-HELM:** `OMNI_MEDIA_S3_PUBLIC_ENDPOINT` is NOT wired into the Helm chart (`deploy/**` is G-HELM's tree). The chart needs a `media.s3.publicEndpoint` value rendered to this env var for out-of-cluster agent runtimes.
- **G-CI-TESTS (H8):** the new `batch-jobs-remote` suite gates on `minioIntegrationEnabled()` like its siblings — it will start executing in CI once the `MINIO_INTEGRATION=1` leg lands.

## Not touched (per review "Checked and clean")

Realtime dispatch semantics, path-traversal guard, presign flow structure, media-route auth, `allowFirstParty`, migration 0038 — only the surgical changes above.
