### PR TITLE
fix(helm): expose OMNI_MEDIA_S3_PUBLIC_ENDPOINT for presigned URLs

### DIFF
--- a/deploy/helm/omni/templates/configmap.yaml
+++ b/deploy/helm/omni/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
   {{- if include "omni.media.remote" . }}
   OMNI_MEDIA_MODE: "remote"
   OMNI_MEDIA_S3_ENDPOINT: {{ include "omni.media.s3Endpoint" . | quote }}
+  {{- with .Values.media.s3.publicEndpoint }}
+  OMNI_MEDIA_S3_PUBLIC_ENDPOINT: {{ . | quote }}
+  {{- end }}
   OMNI_MEDIA_S3_BUCKET: {{ .Values.media.s3.bucket | quote }}
   OMNI_MEDIA_S3_REGION: {{ .Values.media.s3.region | quote }}
   OMNI_MEDIA_S3_FORCE_PATH_STYLE: {{ .Values.media.s3.forcePathStyle | quote }}

--- a/deploy/helm/omni/values-prod.yaml
+++ b/deploy/helm/omni/values-prod.yaml
@@ -93,6 +93,12 @@ media:
     forcePathStyle: false
     presignTtlSeconds: 3600
     endpoint: ""                         # empty → real AWS S3 from region
+    # Presign GET URLs against a public endpoint instead of `endpoint` —
+    # required when agents consuming presigned media URLs run OUTSIDE the
+    # cluster and cannot reach the internal S3 endpoint. Uploads/reads are
+    # unaffected. Leave unset when `endpoint` is already publicly reachable
+    # (e.g. real AWS S3).
+    # publicEndpoint: "https://media.example.com"
     existingSecret: "omni-media-s3"      # must hold the two keys below
     accessKeyKey: "OMNI_MEDIA_S3_ACCESS_KEY"
     secretKeyKey: "OMNI_MEDIA_S3_SECRET_KEY"

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -252,6 +252,12 @@ media:
     # minio.enabled) or to let the AWS SDK derive it from region (real S3). Set
     # explicitly to point at an external S3-compatible endpoint.
     endpoint: ""
+    # Optional externally-reachable endpoint used ONLY to presign GET URLs
+    # (OMNI_MEDIA_S3_PUBLIC_ENDPOINT). Uploads/reads keep using endpoint above.
+    # Set when consumers of presigned URLs (e.g. agents) live outside the
+    # cluster and cannot resolve the in-cluster endpoint. Empty → presign with
+    # the regular endpoint; no env var is emitted.
+    publicEndpoint: ""
     # PROD: reference an existing Secret holding the S3 creds instead of minting
     # them. When set, minio.enabled is typically false and no plaintext creds are
     # rendered. The Secret must contain the two keys below.


### PR DESCRIPTION
## Summary

Wires the `OMNI_MEDIA_S3_PUBLIC_ENDPOINT` env var (added to the API in #776) into the Helm chart. Follow-up to PR #770 review finding MED-1; see `docs/_internal/remote-media-mode.md`.

- **`values.yaml`**: new optional `media.s3.publicEndpoint` (default `""`), documented alongside the other `media.s3.*` values — externally-reachable endpoint used only to presign GET URLs; uploads/reads keep using `media.s3.endpoint`.
- **`templates/configmap.yaml`**: renders `OMNI_MEDIA_S3_PUBLIC_ENDPOINT` in the remote-mode block only when the value is set (`{{- with }}` — no empty-string env). Non-secret, so it lives in the ConfigMap like the other endpoint values; creds remain secretKeyRef-only.
- **`values-prod.yaml`**: commented example noting agents consuming presigned URLs from outside the cluster need it to reach the media store.

## Evidence (gates)

1. `helm lint` clean with default, dev, and prod values; `helm template` clean for all three.
2. `kubeconform -strict -summary` on the prod render: 16/16 resources valid (both with the value set and unset).
3. Render greps: `--set media.s3.publicEndpoint=https://media.example.com` on prod → `OMNI_MEDIA_S3_PUBLIC_ENDPOINT: "https://media.example.com"` appears exactly once (ConfigMap); unset → zero occurrences across default/dev/prod renders.
4. No regression: render diff vs `origin/dev` base for all three value files shows only chart-minted random passwords (expected `randAlphaNum` nondeterminism); values-dev ingress `omni.felipe.namastex.io` and PR #775 structure intact.