### PR TITLE
ci(test): execute S3/MinIO integration suites in CI; ungate dispatcher local tests (PR #770 H8, MED-4)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint configuration (https://github.com/rhysd/actionlint)
+#
+# Every CI job runs on Blacksmith-hosted runners (https://blacksmith.sh).
+# actionlint only knows GitHub-hosted labels, so declare the custom labels
+# here; otherwise every `runs-on:` line reports a runner-label false positive.
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,11 @@ jobs:
 
       - name: Wait for database
         run: |
-          for i in $(seq 1 30); do
-            pg_isready -h localhost -p 5432 >/dev/null 2>&1 && \
-              echo "Database ready" && exit 0 || sleep 1
+          for _ in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 >/dev/null 2>&1; then
+              echo "Database ready" && exit 0
+            fi
+            sleep 1
           done
           echo "Database failed to start" && exit 1
 
@@ -139,6 +141,72 @@ jobs:
         run: bun test --env-file=.env
         env:
           NODE_ENV: test
+
+  remote-media-tests:
+    name: Remote Media (S3/MinIO integration)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Setup environment
+        run: |
+          cp .env.example .env
+          sed -i 's/localhost:8432/localhost:5432/g; s/PGSERVE_PORT=8432/PGSERVE_PORT=5432/' .env
+
+      - name: Test (S3/MinIO integration suites)
+        # The shared MinIO harness (packages/api/src/__tests__/minio-harness.ts)
+        # docker-runs its OWN `minio/minio` container on a random high port, so
+        # no `services:` container or endpoint env is needed — only Docker on
+        # the runner plus the `MINIO_INTEGRATION=1` opt-in. Without that flag
+        # the suites deterministically skip whenever `CI=true` (PR #770 H8).
+        # These suites use mocked DBs and no NATS, so this job skips the
+        # autopg/NATS bring-up the quality gate needs.
+        shell: bash
+        env:
+          NODE_ENV: test
+          MINIO_INTEGRATION: '1'
+        run: |
+          bun test --env-file=.env \
+            packages/api/src/services/__tests__/s3-backend-remote.test.ts \
+            packages/api/src/services/__tests__/batch-jobs-remote.test.ts \
+            packages/api/src/plugins/__tests__/media-remote-e2e.test.ts \
+            packages/api/src/plugins/__tests__/media-processor-remote.test.ts \
+            packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts \
+            2>&1 | tee remote-media-tests.log
+
+      - name: Verify suites executed (not skipped)
+        # Guard against the H8 regression: with the MinIO gate closed the run
+        # still exits 0 — every test skips ("0 pass") and no real S3 backend is
+        # ever constructed. Demand positive evidence of execution so a silent
+        # re-skip (renamed opt-in env, Docker gone from the runner) fails
+        # loudly instead of reporting a green no-op.
+        run: |
+          if ! grep -q "Initialized S3 media backend" remote-media-tests.log; then
+            echo "::error::No S3 backend was constructed — the S3/MinIO suites did not execute (PR #770 H8)"
+            exit 1
+          fi
+          if grep -qE "^ 0 pass" remote-media-tests.log; then
+            echo "::error::0 tests passed — the S3/MinIO suites were skipped, not executed (PR #770 H8)"
+            exit 1
+          fi
+          echo "S3/MinIO suites executed against a real MinIO (S3 backend init lines + non-zero pass count present)"
 
   smoke-test:
     name: Smoke Test (Fresh Environment)
@@ -200,9 +268,11 @@ jobs:
 
       - name: Wait for database
         run: |
-          for i in $(seq 1 30); do
-            pg_isready -h localhost -p 5432 >/dev/null 2>&1 && \
-              echo "Database ready" && exit 0 || sleep 1
+          for _ in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 >/dev/null 2>&1; then
+              echo "Database ready" && exit 0
+            fi
+            sleep 1
           done
           echo "Database failed to start" && exit 1
 
@@ -226,9 +296,11 @@ jobs:
 
       - name: Wait for API
         run: |
-          for i in $(seq 1 15); do
-            curl --fail --silent http://localhost:8882/api/v2/health > /dev/null 2>&1 && \
-              echo "API is healthy" && exit 0 || sleep 2
+          for _ in $(seq 1 15); do
+            if curl --fail --silent http://localhost:8882/api/v2/health > /dev/null 2>&1; then
+              echo "API is healthy" && exit 0
+            fi
+            sleep 2
           done
           echo "API failed to start" && exit 1
 

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts
@@ -9,8 +9,10 @@
  *     (remote) / local path (local) into the in-text media line.
  *   - A presign minted with a short TTL is rejected by MinIO once it expires.
  *
- * If Docker is unavailable the whole suite skips with a clear reason (mirrors
- * the Group-1 s3-backend round-trip test).
+ * If Docker is unavailable the MinIO-backed suite skips with a clear reason
+ * (mirrors the Group-1 s3-backend round-trip test). The local-mode tests need
+ * no Docker at all, so they live in an ungated describe below (same split as
+ * media-processor-remote.test.ts) and run everywhere — including plain CI.
  */
 
 import { beforeAll, describe, expect, it } from 'bun:test';
@@ -61,7 +63,6 @@ function bufferedMessage(opts: {
 
 describe.skipIf(!hasDocker)('remote-mode media dispatch (MinIO)', () => {
   let remoteService: MediaStorageService;
-  let localService: MediaStorageService;
   const imageKey = 'inst-1/2026-07/img-1.png';
   const audioKey = 'inst-1/2026-07/aud-1.ogg';
   const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
@@ -82,11 +83,6 @@ describe.skipIf(!hasDocker)('remote-mode media dispatch (MinIO)', () => {
 
     const remoteBackend = new S3MediaBackend(s3Config);
     remoteService = new MediaStorageService({} as unknown as Database, undefined, remoteBackend);
-    localService = new MediaStorageService(
-      {} as unknown as Database,
-      MEDIA_BASE_PATH,
-      new LocalMediaBackend(MEDIA_BASE_PATH),
-    );
 
     // Seed the objects the dispatch code will presign.
     await remoteBackend.store({ key: imageKey, buffer: imageBytes, mimeType: 'image/png' });
@@ -121,6 +117,42 @@ describe.skipIf(!hasDocker)('remote-mode media dispatch (MinIO)', () => {
     expect(files).toHaveLength(0);
   });
 
+  it('remote: processed-media text carries the presigned URL', async () => {
+    const ref = await resolveDispatchMediaPath(remoteService, imageKey);
+    expect(ref).toContain(`/${BUCKET}/${imageKey}`);
+    expect(ref).toContain('X-Amz-Signature=');
+
+    const text = formatProcessedMedia('image', ref, 'a cat', true);
+    expect(text).toContain(ref!);
+    expect(text).toContain('a cat');
+    expect(text).toContain('http');
+  });
+
+  it('rejects an expired presign (TTL honored by MinIO)', async () => {
+    const url = await remoteService.presignedUrl(imageKey, 1);
+    // Wait past the 1s TTL (plus MinIO clock-skew slack).
+    await new Promise((r) => setTimeout(r, 2500));
+    const res = await harnessFetch(url);
+    expect(res.status).not.toBe(200);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  }, 15_000);
+});
+
+// Local-mode dispatch needs no MinIO/Docker: resolution is pure path math over
+// MEDIA_BASE_PATH (no filesystem reads). Ungated so it runs everywhere,
+// including the plain CI test job (PR #770 MED-4) — mirrors the
+// media-processor-remote.test.ts "local read (no MinIO)" split.
+describe('local-mode media dispatch (no MinIO)', () => {
+  let localService: MediaStorageService;
+
+  beforeAll(() => {
+    localService = new MediaStorageService(
+      {} as unknown as Database,
+      MEDIA_BASE_PATH,
+      new LocalMediaBackend(MEDIA_BASE_PATH),
+    );
+  });
+
   it('local: extractMediaFiles resolves a local path into ProviderFile.path (no url)', async () => {
     const files = await extractMediaFiles(
       [bufferedMessage({ type: 'image', mimeType: 'image/png', mediaUrl: '/api/v2/media/inst-1/2026-07/img-1.png' })],
@@ -133,17 +165,6 @@ describe.skipIf(!hasDocker)('remote-mode media dispatch (MinIO)', () => {
     expect(files[0]?.url).toBeUndefined();
   });
 
-  it('remote: processed-media text carries the presigned URL', async () => {
-    const ref = await resolveDispatchMediaPath(remoteService, imageKey);
-    expect(ref).toContain(`/${BUCKET}/${imageKey}`);
-    expect(ref).toContain('X-Amz-Signature=');
-
-    const text = formatProcessedMedia('image', ref, 'a cat', true);
-    expect(text).toContain(ref!);
-    expect(text).toContain('a cat');
-    expect(text).toContain('http');
-  });
-
   it('local: processed-media text carries the local path', async () => {
     const ref = await resolveDispatchMediaPath(localService, 'inst-1/2026-07/img-1.png');
     expect(ref).toBe(resolve(join(MEDIA_BASE_PATH, 'inst-1/2026-07/img-1.png')));
@@ -152,15 +173,6 @@ describe.skipIf(!hasDocker)('remote-mode media dispatch (MinIO)', () => {
     expect(text).toContain(ref!);
     expect(text).not.toContain('X-Amz-Signature');
   });
-
-  it('rejects an expired presign (TTL honored by MinIO)', async () => {
-    const url = await remoteService.presignedUrl(imageKey, 1);
-    // Wait past the 1s TTL (plus MinIO clock-skew slack).
-    await new Promise((r) => setTimeout(r, 2500));
-    const res = await harnessFetch(url);
-    expect(res.status).not.toBe(200);
-    expect(res.status).toBeGreaterThanOrEqual(400);
-  }, 15_000);
 });
 
 describe.skipIf(hasDocker)('remote-mode media dispatch (MinIO) (skipped)', () => {


### PR DESCRIPTION
Implements PR #770 review findings **H8** and **MED-4** (G-CI-TESTS, Wave 2).

## H8 — S3/MinIO integration suites now EXECUTE in CI

The five remote-media suites gate on `minioIntegrationEnabled()` (`packages/api/src/__tests__/minio-harness.ts`): under `CI=true` they deterministically skip unless `MINIO_INTEGRATION=1`, which was set nowhere. Green CI therefore executed **zero** real S3 assertions — a presign/TTL/multipart regression in `s3-backend.ts` would merge green.

**Mechanism chosen:** dedicated `remote-media-tests` job with `MINIO_INTEGRATION=1`. The harness **docker-runs its own `minio/minio` container** on a random high port (pre-pulls the image, 120s readiness budget, self-teardown), so no `services:` container and no endpoint env are needed — only Docker on the runner, which Blacksmith runners have (the harness docstring's flake notes were observed on them). The suites use mocked DBs and no NATS, so the job skips the autopg/NATS bring-up entirely: quality-gate runtime and failure surface are untouched, and the new leg stays small (~2-4 min).

Suites executed:
- `packages/api/src/services/__tests__/s3-backend-remote.test.ts`
- `packages/api/src/services/__tests__/batch-jobs-remote.test.ts`
- `packages/api/src/plugins/__tests__/media-remote-e2e.test.ts`
- `packages/api/src/plugins/__tests__/media-processor-remote.test.ts`
- `packages/api/src/plugins/__tests__/agent-dispatcher-media-remote.test.ts`

**Self-enforcing guard:** a follow-up step demands positive execution evidence — `Initialized S3 media backend` lines AND a non-zero pass count in the test log — so if the gate ever silently flips back to skipping (renamed opt-in env, Docker gone), the job fails loudly instead of green-no-op'ing. Guard logic exercised locally against both an executed log (passes) and a gate-closed log (trips).

## MED-4 — dispatcher local-mode tests ungated

The two `local:` tests in `agent-dispatcher-media-remote.test.ts` exercise pure path math (`extractMediaFiles` / `resolveDispatchMediaPath` / `formatProcessedMedia` — verified: no filesystem reads) and need no Docker, yet sat inside `describe.skipIf(!hasDocker)`. Hoisted into an ungated `describe('local-mode media dispatch (no MinIO)')`, mirroring the `media-processor-remote.test.ts` local/remote split. They now run everywhere, including the plain Quality Gate test job.

Local proof: `CI=true bun test …/agent-dispatcher-media-remote.test.ts` → **2 pass, 6 skip, 0 fail** (local tests execute; Docker gating intact for the rest).

## actionlint hygiene

Gate required `actionlint .github/workflows/ci.yml` **clean**. Added `.github/actionlint.yaml` declaring the `blacksmith-4vcpu-ubuntu-2404` runner label (kills the runner-label false positive on every job, including sibling workflows) and fixed the pre-existing shellcheck findings (SC2015 / SC2034) in the three wait-for-database/API loops — behavior-identical rewrites. `actionlint` is now clean repo-wide. Note: `actionlint.yaml` is one file outside this group's nominal tree (flagged deliberately; no sibling group owns it).

## Local verification

- `actionlint` (repo-wide): clean
- `CI=true bun test agent-dispatcher-media-remote.test.ts`: 2 pass / 6 skip / 0 fail
- `NODE_ENV=test MINIO_INTEGRATION=1 CI=true bun test --env-file=.env <five suites>` (exact CI command): **19 pass, 5 skip*, 0 fail — 94 expect() calls, 6.1s** (*the 5 skips are the intentional `(skipped)` reason-marker placeholders)
- `tsc --noEmit` (packages/api): clean; biome: clean

## CI-log evidence (run 28722011358, job `Remote Media (S3/MinIO integration)` — SUCCESS in 21s)

From the job log (`gh api repos/automagik-dev/omni/actions/jobs/85173034328/logs`):

- **11x** `"msg":"Initialized S3 media backend"` lines — real `S3MediaBackend` instances constructed against the harness's dockerized MinIO
- **0x** `MinIO integration disabled` skip markers
- **Five distinct per-suite buckets** created on the MinIO container (one per suite, via `uniqueBucket`):
  - `omni-media-test-alad302u` (s3-backend-remote)
  - `omni-batch-jobs-test-qjhirw1o` (batch-jobs-remote)
  - `omni-media-e2e-test-xrzqsv49` (media-remote-e2e)
  - `omni-media-processor-test-r80dgep3` (media-processor-remote)
  - `omni-media-dispatch-test-khax9qg4` (agent-dispatcher-media-remote)
- Test summary:
  ```
   19 pass
   5 skip
   0 fail
  Ran 24 tests across 5 files. [6.59s]
  ```
  (the 5 skips are the intentional `(skipped)`-reason marker placeholders each suite carries)
- Guard step output: `S3/MinIO suites executed against a real MinIO (S3 backend init lines + non-zero pass count present)`

Existing jobs unaffected: Smoke Test passed; the wall-clock cost of the new leg is ~21s on a warm cache.
