### PR TITLE
fix(media): harden media read path, scope enforcement, and URL fetch (PR #770 LOW-1/2/5/9/10)

### DIFF
--- a/packages/api/src/middleware/__tests__/scope-enforcer-media.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-media.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Instance-allowlist enforcement over GET /media/:instanceId/* (PR #770 LOW-9).
+ *
+ * Before this fix the scope enforcer extracted instance targets only from
+ * /instances/ and /chats/ paths, so the media route was invisible to
+ * instanceAllowlist: a broad media:read key could fetch ANY instance's media
+ * (given a leaked messageId) while an allowlisted key was denied even its OWN
+ * media (null target against a non-empty allowlist).
+ *
+ * Strategy mirrors scope-enforcer-host-scopes.test.ts: mount ONLY the scope
+ * enforcer in front of a stub media route, pre-set `apiKey` on the context,
+ * and assert status codes. No DB, no real media backend — this locks down the
+ * authorization decision, while media-route.test.ts covers the serving.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { ApiKeyData, AppVariables } from '../../types';
+import { scopeEnforcerMiddleware } from '../scope-enforcer';
+
+const OWN_INSTANCE = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const OTHER_INSTANCE = '99999999-8888-4777-8666-555555555555';
+
+interface KeyOverrides {
+  scopes?: string[];
+  profile?: ApiKeyData['profile'];
+  instanceAllowlist?: string[];
+}
+
+function mountWithKey(overrides: KeyOverrides = {}): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    const apiKey: ApiKeyData = {
+      id: 'k-media',
+      name: 'media-test',
+      scopes: overrides.scopes ?? ['media:read'],
+      instanceIds: null,
+      expiresAt: null,
+      profile: overrides.profile ?? null,
+      chatAllowlist: [],
+      instanceAllowlist: overrides.instanceAllowlist ?? [],
+      outboundRecipientAllowlist: [],
+    };
+    c.set('apiKey', apiKey);
+    await next();
+  });
+  app.use('*', scopeEnforcerMiddleware);
+  // Stub the actual media handler — enforcement happens before it runs.
+  app.get('/api/v2/media/:instanceId/*', (c) => c.json({ served: c.req.param('instanceId') }));
+  app.post('/api/v2/media/tts', (c) => c.json({ ok: true }));
+  return app;
+}
+
+function mediaPath(instanceId: string): string {
+  return `/api/v2/media/${instanceId}/2026-07/msg-1.ogg`;
+}
+
+describe('scope-enforcer × GET /media/:instanceId/* (LOW-9)', () => {
+  test('instance-allowlisted key CAN read its own instance media', async () => {
+    const app = mountWithKey({ profile: 'personal', instanceAllowlist: [OWN_INSTANCE] });
+    const res = await app.request(mediaPath(OWN_INSTANCE));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { served: string };
+    expect(json.served).toBe(OWN_INSTANCE);
+  });
+
+  test('instance-allowlisted key CANNOT read another instance media', async () => {
+    const app = mountWithKey({ profile: 'personal', instanceAllowlist: [OWN_INSTANCE] });
+    const res = await app.request(mediaPath(OTHER_INSTANCE));
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: { lock: string; attempted: string } };
+    expect(json.error.lock).toBe('instanceAllowlist');
+    expect(json.error.attempted).toBe(OTHER_INSTANCE);
+  });
+
+  test('legacy allowlisted key (profile=null, non-empty list) is scoped the same way', async () => {
+    const app = mountWithKey({ instanceAllowlist: [OWN_INSTANCE] });
+    expect((await app.request(mediaPath(OWN_INSTANCE))).status).toBe(200);
+    expect((await app.request(mediaPath(OTHER_INSTANCE))).status).toBe(403);
+  });
+
+  test('broad key (no allowlist) still reads any instance media', async () => {
+    const app = mountWithKey();
+    expect((await app.request(mediaPath(OWN_INSTANCE))).status).toBe(200);
+    expect((await app.request(mediaPath(OTHER_INSTANCE))).status).toBe(200);
+  });
+
+  test('wildcard key without allowlist still reads any instance media', async () => {
+    const app = mountWithKey({ scopes: ['*'] });
+    expect((await app.request(mediaPath(OTHER_INSTANCE))).status).toBe(200);
+  });
+
+  test('legacy key still uses POST /media verbs (no instance lock, no regression)', async () => {
+    const app = mountWithKey({ scopes: ['tts:synthesize'] });
+    const res = await app.request('/api/v2/media/tts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'hello' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /media verbs never treat the verb segment as an instance target', async () => {
+    // Adversarial: if "tts" were extracted as the path instance, this absurd
+    // allowlist would ALLOW the request. The GET-only gate keeps the target
+    // null, so the active lock denies with attempted="" (missing target), not
+    // attempted="tts".
+    const app = mountWithKey({
+      profile: 'personal',
+      instanceAllowlist: ['tts'],
+      scopes: ['tts:synthesize'],
+    });
+    const res = await app.request('/api/v2/media/tts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'hello' }),
+    });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: { lock: string; attempted: string } };
+    expect(json.error.lock).toBe('instanceAllowlist');
+    expect(json.error.attempted).toBe('');
+  });
+});

--- a/packages/api/src/middleware/__tests__/scope-enforcer.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer.test.ts
@@ -265,6 +265,20 @@ describe('extractLockTargets — route & body target extraction', () => {
     expect(t.instance).toBe('path-inst');
   });
 
+  // ── GET /media/:instanceId/* embeds the instance in the path (PR #770 LOW-9) ──
+
+  test('GET /media/:instanceId/* — first path segment becomes the instance target', () => {
+    const t = extractLockTargets('GET', '/api/v2/media/inst-9/2026-07/msg-1.ogg', null);
+    expect(t.instance).toBe('inst-9');
+    expect(t.chat).toBeNull();
+    expect(t.recipient).toBeNull();
+  });
+
+  test('POST /media/tts — the verb segment is NOT treated as an instance target', () => {
+    const t = extractLockTargets('POST', '/api/v2/media/tts', { text: 'hello' });
+    expect(t.instance).toBeNull();
+  });
+
   test('body is still used when neither path nor header supplies the target', () => {
     const t = extractLockTargets(
       'POST',
@@ -319,5 +333,17 @@ describe('Integration scenarios from wish acceptance criteria', () => {
     const r = enforceInstanceAllowlist(key, targets.instance);
     expect(r.allowed).toBe(false);
     expect(r.attempted).toBe('other-inst');
+  });
+
+  test('instance-allowlisted key CAN read its own media and CANNOT read another instance media (LOW-9)', () => {
+    const key = mkKey({ profile: 'personal', instanceAllowlist: ['inst-own'] });
+
+    const own = extractLockTargets('GET', '/api/v2/media/inst-own/2026-07/msg-1.jpg', null);
+    expect(enforceInstanceAllowlist(key, own.instance).allowed).toBe(true);
+
+    const other = extractLockTargets('GET', '/api/v2/media/inst-other/2026-07/msg-2.jpg', null);
+    const denied = enforceInstanceAllowlist(key, other.instance);
+    expect(denied.allowed).toBe(false);
+    expect(denied.attempted).toBe('inst-other');
   });
 });

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -207,6 +207,22 @@ const OUTBOUND_SEND_PREFIXES = ['/messages/send'];
 const PATH_INSTANCE_PREFIXES = ['/instances/'];
 const PATH_CHAT_PREFIXES = ['/chats/'];
 
+/**
+ * `GET /media/:instanceId/*` embeds the instance as the first path segment.
+ * GET-only on purpose: the POST verbs under /media (tts, stt, imagine, vision,
+ * film, music) put an action name in that segment, not an instance — treating
+ * "tts" as an instance target would deny every allowlisted key those verbs.
+ * Without this extraction the media path is invisible to instanceAllowlist:
+ * broad keys can read ANY instance's media while allowlisted keys are denied
+ * even their own (target=null against a non-empty list).
+ */
+const PATH_MEDIA_INSTANCE_PREFIX = '/media/';
+
+function mediaPathInstance(method: string, cleanPath: string): string | null {
+  if (method !== 'GET') return null;
+  return firstPathSegment(cleanPath, PATH_MEDIA_INSTANCE_PREFIX);
+}
+
 function firstPathSegment(cleanPath: string, prefix: string): string | null {
   if (!cleanPath.startsWith(prefix)) return null;
   const rest = cleanPath.slice(prefix.length);
@@ -266,8 +282,10 @@ export function extractLockTargets(
   const cleanPath = normalizePath(rawPath);
   const { instanceId, to, chatId } = readBodyTargets(body);
 
-  // Path-param extraction: /instances/:id, /chats/:id
-  const pathInstance = PATH_INSTANCE_PREFIXES.map((p) => firstPathSegment(cleanPath, p)).find((v) => v != null) ?? null;
+  // Path-param extraction: /instances/:id, /chats/:id, GET /media/:instanceId/*
+  const pathInstance =
+    PATH_INSTANCE_PREFIXES.map((p) => firstPathSegment(cleanPath, p)).find((v) => v != null) ??
+    mediaPathInstance(method, cleanPath);
   const pathChat = PATH_CHAT_PREFIXES.map((p) => firstPathSegment(cleanPath, p)).find((v) => v != null) ?? null;
   const headerInstance = headers?.instance && headers.instance.length > 0 ? headers.instance : null;
   const headerChat = headers?.chat && headers.chat.length > 0 ? headers.chat : null;

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-ssrf.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-ssrf.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SSRF guard on the agent dispatcher's history-sync media download
+ * (PR #770 LOW-10).
+ *
+ * `downloadToTempFile` fetches `mediaUrl` values that originate from channel
+ * history payloads. It must refuse private/metadata targets BEFORE any
+ * connection is attempted, and still work for public platform hosts.
+ */
+
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { rm } from 'node:fs/promises';
+import { __test__ } from '../agent-dispatcher';
+
+const { downloadToTempFile } = __test__;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('downloadToTempFile — SSRF deny-list (LOW-10)', () => {
+  it('refuses a cloud-metadata URL without connecting', async () => {
+    const fetchMock = mock(async () => new Response('never'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await downloadToTempFile('http://169.254.169.254/latest/meta-data/', 'image/jpeg');
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('refuses an RFC1918 URL without connecting', async () => {
+    const fetchMock = mock(async () => new Response('never'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await downloadToTempFile('http://10.0.0.5/media/file.ogg', 'audio/ogg');
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('still downloads from a public host (literal public IP, no DNS dependency)', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetchMock = mock(async () => new Response(bytes, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await downloadToTempFile('https://93.184.216.34/media/file.bin', 'application/octet-stream');
+    expect(result).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    if (result) {
+      expect(await Bun.file(result).bytes()).toEqual(bytes);
+      await rm(result, { force: true });
+    }
+  });
+});

--- a/packages/api/src/plugins/__tests__/media-remote-e2e.test.ts
+++ b/packages/api/src/plugins/__tests__/media-remote-e2e.test.ts
@@ -119,10 +119,12 @@ describe.skipIf(!hasDocker)('remote media e2e: stored media → presigned Provid
     expect(Array.from(downloaded)).toEqual(Array.from(imageBytes));
   });
 
-  it('serves remote-stored media through the backend-aware route read (GET /media path)', async () => {
-    // The persisted mediaUrl points at GET /api/v2/media/<key>, which serves via
-    // readMediaViaBackend — in remote mode that must S3-GET the key, not 404 on
-    // a local-disk lookup (PR #761 review finding).
+  it('serves remote-stored media through the backend-aware service read', async () => {
+    // readMediaViaBackend must S3-GET the key in remote mode, not 404 on a
+    // local-disk lookup (PR #761 review finding). The GET /media route now
+    // serves via stat + ranged/streaming reads (PR #770 LOW-2, covered by
+    // routes/v2/__tests__/media-route.test.ts); this locks the service-level
+    // whole-buffer read contract.
     const stored = await remoteService.storeFromBuffer(
       'inst-1',
       'msg-e2e-route',

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -87,6 +87,7 @@ import type { MediaStorageService } from '../services/media-storage';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
+import { fetchMediaUrl } from '../utils/safe-media-fetch';
 import { AgentDispatchLimiter, loadAgentDispatchLimiterConfig } from './agent-dispatch-limiter';
 import { getPlugin } from './loader';
 import {
@@ -3105,7 +3106,10 @@ function mimeToContentType(mimeType: string): 'audio' | 'image' | 'video' | 'doc
  */
 async function downloadToTempFile(url: string, mimeType: string): Promise<string | null> {
   try {
-    const res = await fetch(url);
+    // SSRF-guarded: rejects private/metadata targets (initial URL and every
+    // redirect hop) before connecting — history-sync mediaUrl values originate
+    // from channel payloads, not from operator config.
+    const res = await fetchMediaUrl(url);
     if (!res.ok) return null;
 
     const buffer = Buffer.from(await res.arrayBuffer());
@@ -5553,6 +5557,7 @@ export const setupAgentResponder = setupAgentDispatcher;
 export const __test__ = {
   buildContextMessages,
   awaitMediaProcessing,
+  downloadToTempFile,
   mediaCompletions,
   mediaResultCache,
   checkProcessedColumn,

--- a/packages/api/src/routes/v2/__tests__/media-route.test.ts
+++ b/packages/api/src/routes/v2/__tests__/media-route.test.ts
@@ -1,0 +1,312 @@
+/**
+ * GET /media/:instanceId/* serving contract (PR #770 LOW-1 + LOW-2).
+ *
+ * LOW-1 — the route must distinguish "object gone" (404) from "backend down
+ * right now" (503) so clients retry transient S3/disk failures instead of
+ * caching a lying 404.
+ *
+ * LOW-2 — bytes are served WITHOUT full-object buffering: Range requests
+ * fetch exactly the requested bytes (positional read / S3 ranged GET) and
+ * full GETs stream. Status/header semantics (200/206, Content-Range,
+ * Accept-Ranges, Content-Type, Content-Length) must hold in local AND remote
+ * mode.
+ *
+ * Local mode runs everywhere; the remote (MinIO container) suite follows the
+ * shared harness opt-in rules. Both live in ONE file because they inject the
+ * media route's module-level storage singleton — test files may run
+ * concurrently in one Bun process, but tests within a file are sequential.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type MediaStorageBackend, type S3BackendConfig, S3MediaBackend } from '@omni/channel-sdk';
+import type { Database } from '@omni/db';
+import { Hono } from 'hono';
+import { createBucket, getSharedMinio, minioIntegrationEnabled, uniqueBucket } from '../../../__tests__/minio-harness';
+import { MediaStorageService } from '../../../services/media-storage';
+import type { AppVariables } from '../../../types';
+import { __test__, mediaRoutes } from '../media';
+
+const fakeDb = {} as unknown as Database;
+const INSTANCE_ID = '11111111-2222-4333-8444-555555555555';
+
+function buildApp(): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.route('/api/v2/media', mediaRoutes);
+  return app;
+}
+
+/** A patterned payload where every byte is position-derived (range proofs). */
+function patternedBuffer(size: number): Buffer {
+  const buffer = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) buffer[i] = (i * 7 + (i >> 8)) & 0xff;
+  return buffer;
+}
+
+afterEach(() => {
+  __test__.setMediaStorage(null);
+});
+
+describe('GET /media/:instanceId/* — local mode', () => {
+  let tmpDir: string;
+  let service: MediaStorageService;
+  let storedKey: string;
+  const payload = patternedBuffer(64 * 1024);
+  const app = buildApp();
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'media-route-local-'));
+    service = new MediaStorageService(fakeDb, tmpDir);
+    const stored = await service.storeFromBuffer(
+      INSTANCE_ID,
+      'msg-local-1',
+      payload,
+      'video/mp4',
+      new Date('2026-07-01T00:00:00Z'),
+    );
+    storedKey = stored.localPath;
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function url(): string {
+    return `http://local.test/api/v2/media/${storedKey}`;
+  }
+
+  it('serves a full GET with 200, exact bytes and streaming-compatible headers', async () => {
+    __test__.setMediaStorage(service);
+    const res = await app.request(url());
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('video/mp4');
+    expect(res.headers.get('Content-Length')).toBe(String(payload.length));
+    expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(res.headers.get('Cache-Control')).toContain('max-age=31536000');
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(payload)).toBe(true);
+  });
+
+  it('serves a bounded Range request with 206 and exactly the requested bytes', async () => {
+    __test__.setMediaStorage(service);
+    const res = await app.request(url(), { headers: { Range: 'bytes=1000-2999' } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes 1000-2999/${payload.length}`);
+    expect(res.headers.get('Content-Length')).toBe('2000');
+    expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(res.headers.get('Content-Type')).toBe('video/mp4');
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(payload.subarray(1000, 3000))).toBe(true);
+  });
+
+  it('serves an open-ended Range request to the end of the object', async () => {
+    __test__.setMediaStorage(service);
+    const start = payload.length - 512;
+    const res = await app.request(url(), { headers: { Range: `bytes=${start}-` } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes ${start}-${payload.length - 1}/${payload.length}`);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(payload.subarray(start))).toBe(true);
+  });
+
+  it('clamps a Range whose end exceeds the object size', async () => {
+    __test__.setMediaStorage(service);
+    const res = await app.request(url(), { headers: { Range: `bytes=0-${payload.length + 5000}` } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes 0-${payload.length - 1}/${payload.length}`);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.length).toBe(payload.length);
+  });
+
+  it('answers 416 for a Range starting beyond the object', async () => {
+    __test__.setMediaStorage(service);
+    const res = await app.request(url(), { headers: { Range: `bytes=${payload.length}-` } });
+    expect(res.status).toBe(416);
+    expect(res.headers.get('Content-Range')).toBe(`bytes */${payload.length}`);
+  });
+
+  it('returns 404 for a missing object', async () => {
+    __test__.setMediaStorage(service);
+    const res = await app.request(`http://local.test/api/v2/media/${INSTANCE_ID}/2026-07/nope.mp4`);
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 for an invalid instance id (regression)', async () => {
+    __test__.setMediaStorage(service);
+    const res = await app.request('http://local.test/api/v2/media/not-a-uuid/2026-07/x.mp4');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 (not 404) when the backend fails transiently', async () => {
+    const transient = new Error('connect ECONNREFUSED') as Error & { code: string };
+    transient.code = 'ConnectionRefused';
+    const failingBackend: MediaStorageBackend = {
+      mode: 'remote',
+      store: async ({ key, buffer, mimeType }) => ({ reference: key, size: buffer.length, mimeType }),
+      storeStream: async ({ key, mimeType }) => ({ reference: key, size: 0, mimeType }),
+      read: async () => {
+        throw transient;
+      },
+      stat: async () => {
+        throw transient;
+      },
+      readRange: async () => {
+        throw transient;
+      },
+      readStream: async () => {
+        throw transient;
+      },
+      presignedUrl: async (key) => `https://s3.example/${key}`,
+    };
+    __test__.setMediaStorage(new MediaStorageService(fakeDb, undefined, failingBackend));
+
+    const res = await app.request(url());
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe('MEDIA_BACKEND_UNAVAILABLE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remote mode against a real MinIO container
+// ---------------------------------------------------------------------------
+
+const hasMinio = minioIntegrationEnabled();
+const skipReason = hasMinio
+  ? ''
+  : 'MinIO integration disabled (CI opt-in / no Docker) — skipping remote media route suite';
+
+describe.skipIf(!hasMinio)('GET /media/:instanceId/* — remote mode (MinIO)', () => {
+  const BUCKET = uniqueBucket('omni-media-route-test');
+  const app = buildApp();
+  let remoteService: MediaStorageService;
+  let minioEndpoint: string;
+  let minioAccessKey: string;
+  let minioSecretKey: string;
+  let storedKey: string;
+  // Multi-MB object so range serving is meaningfully exercised (4 MiB spans
+  // multiple S3 ranged-GET chunks and would be an obvious heap hit if buffered
+  // per seek).
+  const payload = patternedBuffer(4 * 1024 * 1024);
+
+  beforeAll(async () => {
+    const minio = await getSharedMinio();
+    minioEndpoint = minio.endpoint;
+    minioAccessKey = minio.accessKey;
+    minioSecretKey = minio.secretKey;
+    await createBucket(minio.endpoint, BUCKET);
+
+    const s3Config: S3BackendConfig = {
+      endpoint: minio.endpoint,
+      bucket: BUCKET,
+      region: minio.region,
+      accessKeyId: minio.accessKey,
+      secretKey: minio.secretKey,
+      forcePathStyle: true,
+      presignTtlSeconds: 3600,
+    };
+    remoteService = new MediaStorageService(fakeDb, undefined, new S3MediaBackend(s3Config));
+
+    const stored = await remoteService.storeFromBuffer(
+      INSTANCE_ID,
+      'msg-remote-1',
+      payload,
+      'video/mp4',
+      new Date('2026-07-01T00:00:00Z'),
+    );
+    storedKey = stored.localPath;
+  }, 180_000);
+
+  function url(): string {
+    return `http://local.test/api/v2/media/${storedKey}`;
+  }
+
+  it('serves a Range request via a ranged S3 GET: 206 with exactly the requested bytes', async () => {
+    __test__.setMediaStorage(remoteService);
+    const start = 1024 * 1024;
+    const end = 2 * 1024 * 1024 - 1; // exactly 1 MiB
+    const res = await app.request(url(), { headers: { Range: `bytes=${start}-${end}` } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes ${start}-${end}/${payload.length}`);
+    expect(res.headers.get('Content-Length')).toBe(String(end - start + 1));
+    expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(res.headers.get('Content-Type')).toBe('video/mp4');
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.length).toBe(end - start + 1);
+    expect(body.equals(payload.subarray(start, end + 1))).toBe(true);
+  });
+
+  it('serves a full GET as a 200 stream with the exact object bytes and length', async () => {
+    __test__.setMediaStorage(remoteService);
+    const res = await app.request(url());
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Length')).toBe(String(payload.length));
+    expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+
+    // Consume incrementally (as a video element would) and verify the bytes.
+    const reader = res.body?.getReader();
+    expect(reader).toBeDefined();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    for (;;) {
+      const { done, value } = await reader!.read();
+      if (done) break;
+      chunks.push(value);
+      received += value.byteLength;
+    }
+    expect(received).toBe(payload.length);
+    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+  });
+
+  it('returns 404 for a missing S3 key (NoSuchKey) — LOW-1 not-found path', async () => {
+    __test__.setMediaStorage(remoteService);
+    const res = await app.request(`http://local.test/api/v2/media/${INSTANCE_ID}/2026-07/does-not-exist.mp4`);
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 503 when the S3 endpoint is unreachable — LOW-1 transient path', async () => {
+    const unreachable: S3BackendConfig = {
+      endpoint: 'http://127.0.0.1:9', // discard port — nothing listens
+      bucket: BUCKET,
+      region: 'us-east-1',
+      accessKeyId: minioAccessKey,
+      secretKey: minioSecretKey,
+      forcePathStyle: true,
+      presignTtlSeconds: 3600,
+    };
+    __test__.setMediaStorage(new MediaStorageService(fakeDb, undefined, new S3MediaBackend(unreachable)));
+
+    const res = await app.request(url());
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe('MEDIA_BACKEND_UNAVAILABLE');
+  });
+
+  it('returns 503 when credentials are rejected — LOW-1 config-failure path', async () => {
+    const badCreds: S3BackendConfig = {
+      endpoint: minioEndpoint,
+      bucket: BUCKET,
+      region: 'us-east-1',
+      accessKeyId: 'wrong-access-key',
+      secretKey: 'wrong-secret-key',
+      forcePathStyle: true,
+      presignTtlSeconds: 3600,
+    };
+    __test__.setMediaStorage(new MediaStorageService(fakeDb, undefined, new S3MediaBackend(badCreds)));
+
+    const res = await app.request(url());
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe('MEDIA_BACKEND_UNAVAILABLE');
+  });
+});
+
+describe.skipIf(hasMinio)('GET /media route remote mode (MinIO) (skipped)', () => {
+  it.skip(skipReason || 'skipped', () => {});
+});

--- a/packages/api/src/routes/v2/media.ts
+++ b/packages/api/src/routes/v2/media.ts
@@ -715,7 +715,15 @@ mediaRoutes.post('/music', zValidator('json', musicRequestSchema), async (c) => 
 /**
  * GET /media/:instanceId/* - Serve stored media files
  *
- * Supports range requests for audio/video streaming.
+ * Supports range requests for audio/video streaming. Bytes are served through
+ * the active backend WITHOUT full-object buffering: Range requests fetch only
+ * the requested bytes (positional file read / S3 ranged GET) and full GETs
+ * stream (local file stream / S3 streaming GET) — a browser seeking through a
+ * multi-GB remote video never pulls whole objects into API memory.
+ *
+ * Error contract: a missing object is 404; a backend that is down/misconfigured
+ * (S3 unreachable, bad credentials, missing bucket) is 503 so clients retry
+ * instead of treating a transient outage as gone-forever.
  */
 mediaRoutes.get('/:instanceId/*', async (c) => {
   const instanceId = c.req.param('instanceId');
@@ -752,50 +760,76 @@ mediaRoutes.get('/:instanceId/*', async (c) => {
   const db = c.get('services');
   const storage = getMediaStorage(db);
 
-  // Read the bytes via the active backend (local disk or S3 in remote mode —
-  // a plain disk read would 404 for remote-stored media).
-  const result = await storage.readMediaViaBackend(relativePath);
-
-  if (!result) {
-    return c.json({ error: { code: 'NOT_FOUND', message: 'Media not found' } }, 404);
-  }
-
-  const buffer = result.buffer;
-  const fileSize = result.size;
-  const mimeType = storage.getMimeType(path);
-
-  // Handle range requests for streaming
-  const rangeHeader = c.req.header('Range');
-
-  if (rangeHeader) {
-    const matches = rangeHeader.match(/bytes=(\d+)-(\d*)/);
-    if (matches?.[1]) {
-      const start = Number.parseInt(matches[1], 10);
-      const end = matches[2] ? Number.parseInt(matches[2], 10) : fileSize - 1;
-      const chunkSize = end - start + 1;
-
-      return new Response(buffer.subarray(start, end + 1), {
-        status: 206,
-        headers: {
-          'Content-Type': mimeType,
-          'Content-Length': String(chunkSize),
-          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
-          'Accept-Ranges': 'bytes',
-        },
-      });
+  try {
+    // Stat first: resolves existence + size without reading bytes, and is the
+    // gate that turns backend outages into 503 before any body is committed.
+    const stat = await storage.statMedia(relativePath);
+    if (!stat) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'Media not found' } }, 404);
     }
-  }
 
-  // Return full file
-  return new Response(buffer, {
-    status: 200,
-    headers: {
-      'Content-Type': mimeType,
-      'Content-Length': String(fileSize),
-      'Accept-Ranges': 'bytes',
-      'Cache-Control': 'public, max-age=31536000', // 1 year cache (content-addressable)
-    },
-  });
+    const fileSize = stat.size;
+    const mimeType = storage.getMimeType(path);
+
+    // Handle range requests for streaming
+    const rangeHeader = c.req.header('Range');
+
+    if (rangeHeader) {
+      const matches = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+      if (matches?.[1]) {
+        const start = Number.parseInt(matches[1], 10);
+        const requestedEnd = matches[2] ? Number.parseInt(matches[2], 10) : fileSize - 1;
+        // Clamp to the object per RFC 7233 (also keeps Content-Length honest).
+        const end = Math.min(requestedEnd, fileSize - 1);
+
+        if (start >= fileSize || start > end) {
+          return new Response(null, {
+            status: 416,
+            headers: { 'Content-Range': `bytes */${fileSize}`, 'Accept-Ranges': 'bytes' },
+          });
+        }
+
+        const chunk = await storage.readMediaRange(relativePath, start, end);
+
+        return new Response(chunk, {
+          status: 206,
+          headers: {
+            'Content-Type': mimeType,
+            'Content-Length': String(end - start + 1),
+            'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+            'Accept-Ranges': 'bytes',
+          },
+        });
+      }
+    }
+
+    // Return full file as a stream (never a whole-object heap Buffer)
+    const stream = await storage.readMediaStream(relativePath);
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        'Content-Type': mimeType,
+        'Content-Length': String(fileSize),
+        'Accept-Ranges': 'bytes',
+        'Cache-Control': 'public, max-age=31536000', // 1 year cache (content-addressable)
+      },
+    });
+  } catch (err) {
+    // statMedia/read* rethrow anything that is NOT object-not-found: transient
+    // S3/disk failures surface as 503 so clients retry instead of caching a 404.
+    log.error('Media backend read failed', { relativePath, error: String(err) });
+    return c.json(
+      { error: { code: 'MEDIA_BACKEND_UNAVAILABLE', message: 'Media storage backend unavailable, retry later' } },
+      503,
+    );
+  }
 });
+
+/** Test-only hooks: inject/reset the module-level storage singleton. */
+export const __test__ = {
+  setMediaStorage(service: MediaStorageService | null): void {
+    mediaStorage = service;
+  },
+};
 
 export { mediaRoutes };

--- a/packages/api/src/services/__tests__/media-storage.test.ts
+++ b/packages/api/src/services/__tests__/media-storage.test.ts
@@ -11,10 +11,40 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { MediaStorageBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
+import { UnsafeMediaUrlError } from '../../utils/safe-media-fetch';
 import { MediaStorageService } from '../media-storage';
 
 const fakeDb = {} as unknown as Database;
+
+/** Backend stub whose read/stat throw a supplied error (LOW-1 contract tests). */
+function stubBackend(readError: Error & { code?: string }): MediaStorageBackend {
+  return {
+    mode: 'remote' as const,
+    store: async ({ key, buffer, mimeType }) => ({ reference: key, size: buffer.length, mimeType }),
+    storeStream: async ({ key, mimeType }) => ({ reference: key, size: 0, mimeType }),
+    read: async () => {
+      throw readError;
+    },
+    stat: async () => {
+      throw readError;
+    },
+    readRange: async () => {
+      throw readError;
+    },
+    readStream: async () => {
+      throw readError;
+    },
+    presignedUrl: async (key) => `https://s3.example/${key}`,
+  };
+}
+
+function codedError(code: string, message = code): Error & { code: string } {
+  const error = new Error(message) as Error & { code: string };
+  error.code = code;
+  return error;
+}
 
 describe('MediaStorageService.storeFromUrl (omni#500)', () => {
   let tmpDir: string;
@@ -139,5 +169,77 @@ describe('MediaStorageService.storeFromUrl (omni#500)', () => {
     expect(calls).toHaveLength(2);
     expect(calls[0]?.authorization).toBe('Bearer test-token');
     expect(calls[1]?.authorization).toBe('Bearer test-token');
+  });
+
+  // ── SSRF deny-list (PR #770 LOW-10) ──────────────────────────────────────
+
+  it('refuses to fetch cloud-metadata URLs before connecting', async () => {
+    const fetchMock = mock(async () => new Response('should never be reached'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(
+      service.storeFromUrl('inst-1', 'msg-1', 'http://169.254.169.254/latest/meta-data/', 'image/png'),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('refuses to fetch RFC1918 URLs before connecting', async () => {
+    const fetchMock = mock(async () => new Response('should never be reached'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(
+      service.storeFromUrl('inst-1', 'msg-1', 'http://10.8.0.12/internal/file.bin', 'application/octet-stream'),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('refuses a redirect that hops from a public host into a private range', async () => {
+    const fetchMock = mock(
+      async () => new Response(null, { status: 302, headers: { location: 'http://192.168.0.10/steal' } }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(
+      service.storeFromUrl('inst-1', 'msg-1', 'https://93.184.216.34/media.png', 'image/png'),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the public hop was requested
+  });
+
+  it('refuses non-http(s) media URLs', async () => {
+    const fetchMock = mock(async () => new Response('nope'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const service = new MediaStorageService(fakeDb, tmpDir);
+
+    await expect(service.storeFromUrl('inst-1', 'msg-1', 'file:///etc/passwd', 'text/plain')).rejects.toThrow(
+      UnsafeMediaUrlError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('MediaStorageService.readMediaViaBackend error contract (PR #770 LOW-1)', () => {
+  it('returns null for a missing object (local ENOENT)', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'media-low1-'));
+    try {
+      const service = new MediaStorageService(fakeDb, tmp);
+      expect(await service.readMediaViaBackend('inst-1/2026-07/missing.png')).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for a missing object (S3 NoSuchKey)', async () => {
+    const service = new MediaStorageService(fakeDb, undefined, stubBackend(codedError('NoSuchKey')));
+    expect(await service.readMediaViaBackend('inst-1/2026-07/missing.png')).toBeNull();
+  });
+
+  it('rethrows transient backend failures instead of masking them as missing', async () => {
+    for (const code of ['ConnectionRefused', 'InvalidAccessKeyId', 'NoSuchBucket', 'UnknownError']) {
+      const service = new MediaStorageService(fakeDb, undefined, stubBackend(codedError(code)));
+      await expect(service.readMediaViaBackend('inst-1/2026-07/key.png')).rejects.toThrow(code);
+    }
   });
 });

--- a/packages/api/src/services/media-storage.ts
+++ b/packages/api/src/services/media-storage.ts
@@ -5,16 +5,25 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { extname, join } from 'node:path';
 
-import { type MediaStorageBackend, createMediaBackend } from '@omni/channel-sdk';
+import {
+  type MediaObjectStat,
+  type MediaStorageBackend,
+  createMediaBackend,
+  isMediaNotFoundError,
+} from '@omni/channel-sdk';
 import { createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
 import { messages } from '@omni/db';
 import { eq } from 'drizzle-orm';
+
+import { type MediaFetchOptions, fetchMediaUrl } from '../utils/safe-media-fetch';
+
+export type { MediaFetchOptions } from '../utils/safe-media-fetch';
 
 const log = createLogger('services:media-storage');
 
@@ -42,16 +51,6 @@ export interface MaterializedMedia {
   cleanup: () => Promise<void>;
 }
 
-export interface MediaFetchOptions extends RequestInit {
-  /**
-   * Host suffixes where Authorization should be preserved across manual
-   * redirects. Fetch strips Authorization on cross-origin redirects; some
-   * private media URLs redirect inside the platform-owned domain and still
-   * require the same token.
-   */
-  preserveAuthRedirectHostSuffixes?: string[];
-}
-
 function normalizeMimeType(value: string | null | undefined): string | undefined {
   return value?.split(';')[0]?.trim().toLowerCase() || undefined;
 }
@@ -74,61 +73,6 @@ function shouldRejectHtmlMedia(
   const expected = normalizeMimeType(expectedMimeType);
   if (!expected || isHtmlMime(expected)) return false;
   return isHtmlMime(responseMimeType) || looksLikeHtml(buffer);
-}
-
-function hostMatchesSuffix(hostname: string, suffix: string): boolean {
-  const normalizedHost = hostname.toLowerCase();
-  const normalizedSuffix = suffix.toLowerCase();
-  return normalizedHost === normalizedSuffix || normalizedHost.endsWith(`.${normalizedSuffix}`);
-}
-
-function shouldPreserveAuthForRedirect(url: URL, suffixes: string[] | undefined): boolean {
-  return Boolean(suffixes?.some((suffix) => hostMatchesSuffix(url.hostname, suffix)));
-}
-
-function headersWithOptionalAuthorization(
-  headers: RequestInit['headers'] | undefined,
-  preserveAuthorization: boolean,
-): Headers {
-  const nextHeaders = new Headers(headers);
-  if (!preserveAuthorization) nextHeaders.delete('authorization');
-  return nextHeaders;
-}
-
-async function fetchWithOptionalAuthenticatedRedirects(
-  url: string,
-  fetchOptions?: MediaFetchOptions,
-): Promise<Response> {
-  const { preserveAuthRedirectHostSuffixes, ...init } = fetchOptions ?? {};
-  if (!preserveAuthRedirectHostSuffixes?.length) {
-    return fetch(url, init);
-  }
-
-  let currentUrl = new URL(url);
-  let currentHeaders = new Headers(init.headers);
-
-  for (let redirects = 0; redirects <= 5; redirects++) {
-    const response: Response = await fetch(currentUrl.toString(), {
-      ...init,
-      headers: currentHeaders,
-      redirect: 'manual',
-    });
-
-    if (response.status < 300 || response.status >= 400) return response;
-
-    const location: string | null = response.headers.get('location');
-    if (!location) return response;
-
-    const nextUrl: URL = new URL(location, currentUrl);
-    const preserveAuthorization =
-      shouldPreserveAuthForRedirect(currentUrl, preserveAuthRedirectHostSuffixes) &&
-      shouldPreserveAuthForRedirect(nextUrl, preserveAuthRedirectHostSuffixes);
-
-    currentHeaders = headersWithOptionalAuthorization(init.headers, preserveAuthorization);
-    currentUrl = nextUrl;
-  }
-
-  throw new Error('Failed to download media: too many redirects');
 }
 
 /**
@@ -280,8 +224,10 @@ export class MediaStorageService {
     timestamp?: Date,
     fetchOptions?: MediaFetchOptions,
   ): Promise<StoredMediaResult> {
-    // Fetch the media (fetchOptions allows callers to supply auth headers, e.g. Slack bot token)
-    const response = await fetchWithOptionalAuthenticatedRedirects(url, fetchOptions);
+    // Fetch the media (fetchOptions allows callers to supply auth headers, e.g.
+    // Slack bot token). The fetch is SSRF-guarded: private/metadata targets are
+    // rejected before connecting, on the initial URL and on every redirect hop.
+    const response = await fetchMediaUrl(url, fetchOptions);
     if (!response.ok) {
       throw new Error(`Failed to download media: ${response.status}`);
     }
@@ -307,40 +253,50 @@ export class MediaStorageService {
   }
 
   /**
-   * Read media file
-   */
-  readMedia(relativePath: string): { buffer: Buffer; size: number } | null {
-    const fullPath = join(this.basePath, relativePath);
-
-    if (!existsSync(fullPath)) {
-      return null;
-    }
-
-    try {
-      const buffer = readFileSync(fullPath);
-      const stat = statSync(fullPath);
-      return {
-        buffer,
-        size: Number(stat.size),
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  /**
-   * Backend-aware variant of readMedia: serves stored media in BOTH modes
-   * (local disk read or S3 GET). In remote mode the stored reference is an S3
-   * key with no file under basePath, so readMedia's disk lookup would 404 —
-   * the GET /media route must use this instead. Returns null when missing.
+   * Backend-aware read: serves stored media in BOTH modes (local disk read or
+   * S3 GET). In remote mode the stored reference is an S3 key with no file
+   * under basePath, so a disk lookup would 404 — readers must go through the
+   * backend.
+   *
+   * Returns `null` ONLY when the object does not exist (local ENOENT / S3
+   * NoSuchKey). Transient or config failures (endpoint unreachable, bad
+   * credentials, missing bucket) are rethrown so callers can surface a
+   * retryable 5xx instead of a lying 404.
    */
   async readMediaViaBackend(relativePath: string): Promise<{ buffer: Buffer; size: number } | null> {
     try {
       const buffer = await this.backend.read(relativePath);
       return { buffer, size: buffer.length };
-    } catch {
-      return null;
+    } catch (error) {
+      if (isMediaNotFoundError(error)) return null;
+      throw error;
     }
+  }
+
+  /**
+   * Stat a stored reference without reading its bytes. `null` means the object
+   * does not exist; transient backend failures are rethrown (same contract as
+   * {@link readMediaViaBackend}).
+   */
+  async statMedia(reference: string): Promise<MediaObjectStat | null> {
+    return this.backend.stat(reference);
+  }
+
+  /**
+   * Read an inclusive byte range of a stored reference. The backend fetches
+   * only the requested bytes (positional file read / S3 ranged GET), so Range
+   * serving never buffers the whole object.
+   */
+  async readMediaRange(reference: string, start: number, endInclusive: number): Promise<Buffer> {
+    return this.backend.readRange(reference, start, endInclusive);
+  }
+
+  /**
+   * Stream the full bytes of a stored reference without heap buffering
+   * (local file stream / S3 streaming GET).
+   */
+  async readMediaStream(reference: string): Promise<ReadableStream<Uint8Array>> {
+    return this.backend.readStream(reference);
   }
 
   /**

--- a/packages/api/src/utils/__tests__/safe-media-fetch.test.ts
+++ b/packages/api/src/utils/__tests__/safe-media-fetch.test.ts
@@ -1,0 +1,187 @@
+/**
+ * SSRF guard tests for caller-influenced media URL fetching (PR #770 LOW-10).
+ *
+ * The deny-list must reject cloud-metadata/link-local, RFC1918, loopback and
+ * non-http(s) targets before any connection is made — on the initial URL and
+ * on every redirect hop — while leaving public platform CDNs (WhatsApp,
+ * Telegram's fixed api.telegram.org, Slack) untouched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import {
+  UnsafeMediaUrlError,
+  assertSafeMediaUrl,
+  fetchMediaUrl,
+  isMediaUrlGuardEnabled,
+  isPrivateOrReservedAddress,
+} from '../safe-media-fetch';
+
+const publicLookup = async () => [{ address: '93.184.216.34' }];
+const privateLookup = async () => [{ address: '10.1.2.3' }];
+const failingLookup = async () => {
+  throw new Error('ENOTFOUND');
+};
+
+const originalFetch = globalThis.fetch;
+const originalGuardEnv = process.env.OMNI_MEDIA_URL_GUARD;
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, 'OMNI_MEDIA_URL_GUARD');
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalGuardEnv === undefined) {
+    Reflect.deleteProperty(process.env, 'OMNI_MEDIA_URL_GUARD');
+  } else {
+    process.env.OMNI_MEDIA_URL_GUARD = originalGuardEnv;
+  }
+});
+
+describe('isPrivateOrReservedAddress', () => {
+  it.each([
+    '169.254.169.254', // cloud metadata / link-local
+    '169.254.0.1',
+    '10.0.0.1', // RFC1918
+    '10.255.255.255',
+    '172.16.0.1',
+    '172.31.255.254',
+    '192.168.1.1',
+    '127.0.0.1', // loopback
+    '127.1.2.3',
+    '0.0.0.0',
+    '0.1.2.3',
+  ])('denies %s', (address) => {
+    expect(isPrivateOrReservedAddress(address)).toBe(true);
+  });
+
+  it.each([
+    '::1', // loopback
+    '::', // unspecified
+    'fc00::1', // ULA fc00::/7
+    'fd12:3456::1',
+    'fe80::1', // link-local fe80::/10
+    'febf::1',
+    '::ffff:10.0.0.1', // IPv4-mapped private
+    '::ffff:169.254.169.254',
+  ])('denies IPv6 %s', (address) => {
+    expect(isPrivateOrReservedAddress(address)).toBe(true);
+  });
+
+  it.each([
+    '8.8.8.8',
+    '93.184.216.34',
+    '172.32.0.1', // just outside 172.16/12
+    '172.15.255.255',
+    '192.167.0.1',
+    '2606:4700::1111', // public IPv6
+    'fec0::1', // outside fe80::/10
+  ])('allows public %s', (address) => {
+    expect(isPrivateOrReservedAddress(address)).toBe(false);
+  });
+});
+
+describe('assertSafeMediaUrl', () => {
+  it('rejects non-http(s) schemes', async () => {
+    await expect(assertSafeMediaUrl(new URL('file:///etc/passwd'), publicLookup)).rejects.toThrow(UnsafeMediaUrlError);
+    await expect(assertSafeMediaUrl(new URL('ftp://example.com/x'), publicLookup)).rejects.toThrow(UnsafeMediaUrlError);
+  });
+
+  it('rejects non-http(s) schemes even when the guard is disabled', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('file:///etc/passwd'), publicLookup, { OMNI_MEDIA_URL_GUARD: 'off' }),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+  });
+
+  it('rejects literal metadata/private/loopback IPs without touching DNS', async () => {
+    const lookup = mock(publicLookup);
+    await expect(assertSafeMediaUrl(new URL('http://169.254.169.254/latest/meta-data/'), lookup)).rejects.toThrow(
+      UnsafeMediaUrlError,
+    );
+    await expect(assertSafeMediaUrl(new URL('https://10.0.0.8/internal'), lookup)).rejects.toThrow(UnsafeMediaUrlError);
+    await expect(assertSafeMediaUrl(new URL('http://[::1]:8882/media'), lookup)).rejects.toThrow(UnsafeMediaUrlError);
+    expect(lookup).toHaveBeenCalledTimes(0);
+  });
+
+  it('rejects hostnames that resolve to private addresses', async () => {
+    await expect(assertSafeMediaUrl(new URL('https://internal.example.com/x'), privateLookup)).rejects.toThrow(
+      /resolves to private address/,
+    );
+  });
+
+  it('allows hostnames that resolve publicly', async () => {
+    await expect(assertSafeMediaUrl(new URL('https://mmg.whatsapp.net/v/media.enc'), publicLookup)).resolves.toBe(
+      undefined,
+    );
+  });
+
+  it('passes through when DNS resolution fails (fetch will fail identically)', async () => {
+    await expect(assertSafeMediaUrl(new URL('https://does-not-resolve.invalid/x'), failingLookup)).resolves.toBe(
+      undefined,
+    );
+  });
+
+  it('allows private targets when OMNI_MEDIA_URL_GUARD=off (lab/MinIO escape hatch)', async () => {
+    const env = { OMNI_MEDIA_URL_GUARD: 'off' };
+    await expect(assertSafeMediaUrl(new URL('http://127.0.0.1:9000/bucket/key'), privateLookup, env)).resolves.toBe(
+      undefined,
+    );
+    expect(isMediaUrlGuardEnabled(env)).toBe(false);
+    expect(isMediaUrlGuardEnabled({})).toBe(true);
+  });
+});
+
+describe('fetchMediaUrl — SSRF policy on every hop', () => {
+  it('refuses a private initial URL before any fetch happens', async () => {
+    const fetchMock = mock(async () => new Response('nope'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(fetchMediaUrl('http://169.254.169.254/latest/meta-data/')).rejects.toThrow(UnsafeMediaUrlError);
+    await expect(fetchMediaUrl('http://10.20.30.40/file.bin')).rejects.toThrow(UnsafeMediaUrlError);
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('refuses a redirect hop into a private range (public → metadata)', async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/latest/meta-data/' } }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(fetchMediaUrl('https://93.184.216.34/media.bin')).rejects.toThrow(UnsafeMediaUrlError);
+    // Only the public hop was fetched; the metadata hop was blocked pre-connect.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves Authorization across a same-origin redirect and strips it cross-origin', async () => {
+    const calls: Array<{ url: string; authorization: string | null }> = [];
+    globalThis.fetch = mock(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      calls.push({ url: String(input), authorization: headers.get('authorization') });
+      if (calls.length === 1) {
+        return new Response(null, { status: 302, headers: { location: 'https://93.184.216.34/step2' } });
+      }
+      if (calls.length === 2) {
+        return new Response(null, { status: 302, headers: { location: 'https://93.184.216.35/other-origin' } });
+      }
+      return new Response('ok', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const res = await fetchMediaUrl('https://93.184.216.34/step1', {
+      headers: { Authorization: 'Bearer tok' },
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(3);
+    expect(calls[0]?.authorization).toBe('Bearer tok'); // initial
+    expect(calls[1]?.authorization).toBe('Bearer tok'); // same-origin hop keeps it
+    expect(calls[2]?.authorization).toBeNull(); // cross-origin hop strips it
+  });
+
+  it('gives up after too many redirects', async () => {
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 302, headers: { location: 'https://93.184.216.34/loop' } }),
+    ) as unknown as typeof fetch;
+
+    await expect(fetchMediaUrl('https://93.184.216.34/loop')).rejects.toThrow('too many redirects');
+  });
+});

--- a/packages/api/src/utils/safe-media-fetch.ts
+++ b/packages/api/src/utils/safe-media-fetch.ts
@@ -1,0 +1,199 @@
+/**
+ * SSRF-guarded fetch for caller-influenced media URLs.
+ *
+ * `storeFromUrl` (media ingest) and the agent dispatcher's history-sync
+ * download fetch URLs that originate from channel payloads. Today those URLs
+ * come from platform CDNs (WhatsApp, Telegram, Slack), but nothing in the
+ * pipeline guaranteed that — a crafted URL could point the API at cloud
+ * metadata (169.254.169.254), RFC1918 services, or loopback. This module
+ * centralizes the deny-list and a redirect-safe fetch that re-applies the
+ * policy on every hop.
+ *
+ * Policy (deny before connecting):
+ * - non-http(s) schemes — always rejected, even when the guard is disabled
+ *   (Bun's fetch can read `file://`).
+ * - IPv4: 0.0.0.0/8, 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16 (link-local /
+ *   cloud metadata), 172.16.0.0/12, 192.168.0.0/16.
+ * - IPv6: `::` (unspecified), `::1` (loopback), fc00::/7 (ULA), fe80::/10
+ *   (link-local), plus IPv4-mapped forms re-checked as IPv4.
+ * - Hostnames are resolved via DNS and every resolved address is checked. A
+ *   failed resolution passes through — fetch performs the same lookup and
+ *   fails identically, so failing open here adds no reachability while keeping
+ *   offline unit runs (mocked fetch) deterministic.
+ *
+ * Redirects: Bun's auto-follow cannot inspect intermediate hops, so
+ * {@link fetchMediaUrl} always follows redirects manually (`redirect:
+ * "manual"`, ≤5 hops) and validates each Location target before requesting it.
+ *
+ * Escape hatch: `OMNI_MEDIA_URL_GUARD=off` disables the private-range checks
+ * (NOT the scheme check) for deployments that intentionally fetch media from
+ * private hosts (e.g. a lab MinIO serving media URLs on RFC1918). Default is
+ * enforced.
+ */
+
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export class UnsafeMediaUrlError extends Error {
+  constructor(url: string, reason: string) {
+    super(`Refusing to fetch media URL: ${reason} (${url})`);
+    this.name = 'UnsafeMediaUrlError';
+  }
+}
+
+/** Injectable resolver so tests can simulate DNS without network. */
+export type AddressLookup = (hostname: string) => Promise<Array<{ address: string }>>;
+
+const defaultLookup: AddressLookup = async (hostname) => lookup(hostname, { all: true });
+
+/** Private-range checks are on unless explicitly switched off. */
+export function isMediaUrlGuardEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.OMNI_MEDIA_URL_GUARD?.trim().toLowerCase() !== 'off';
+}
+
+function isDeniedIpv4(address: string): boolean {
+  const octets = address.split('.').map((part) => Number.parseInt(part, 10));
+  const [a, b] = octets;
+  if (a === undefined || b === undefined) return true;
+  if (a === 0) return true; // 0.0.0.0/8 ("this network", incl. 0.0.0.0)
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local / metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  return false;
+}
+
+function isDeniedIpv6(address: string): boolean {
+  const normalized = address.toLowerCase();
+  if (normalized === '::' || normalized === '::1') return true; // unspecified / loopback
+  // IPv4-mapped (::ffff:a.b.c.d) — apply the IPv4 policy to the embedded address.
+  const mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped?.[1]) return isDeniedIpv4(mapped[1]);
+  const firstHextet = normalized.split(':', 1)[0] ?? '';
+  if (firstHextet.startsWith('fc') || firstHextet.startsWith('fd')) return true; // fc00::/7 ULA
+  if (/^fe[89ab]/.test(firstHextet)) return true; // fe80::/10 link-local
+  return false;
+}
+
+/** Whether a literal IP address falls in a denied (private/reserved) range. */
+export function isPrivateOrReservedAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) return isDeniedIpv4(address);
+  if (family === 6) return isDeniedIpv6(address);
+  return true; // not an IP at all — callers only pass resolved addresses
+}
+
+/**
+ * Validate a single URL against the SSRF policy. Throws
+ * {@link UnsafeMediaUrlError} when the URL must not be fetched.
+ */
+export async function assertSafeMediaUrl(
+  url: URL,
+  resolveAddresses: AddressLookup = defaultLookup,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new UnsafeMediaUrlError(url.toString(), `scheme ${url.protocol} is not allowed`);
+  }
+
+  if (!isMediaUrlGuardEnabled(env)) return;
+
+  // URL keeps IPv6 literals bracketed ([::1]) — strip for the family check.
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+
+  if (isIP(hostname) !== 0) {
+    if (isPrivateOrReservedAddress(hostname)) {
+      throw new UnsafeMediaUrlError(url.toString(), `address ${hostname} is in a private or reserved range`);
+    }
+    return;
+  }
+
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await resolveAddresses(hostname);
+  } catch {
+    // Resolution failure: fetch will perform the same lookup and fail with its
+    // own error — nothing private became reachable by passing here.
+    return;
+  }
+  for (const { address } of addresses) {
+    if (isPrivateOrReservedAddress(address)) {
+      throw new UnsafeMediaUrlError(url.toString(), `host ${hostname} resolves to private address ${address}`);
+    }
+  }
+}
+
+export interface MediaFetchOptions extends RequestInit {
+  /**
+   * Host suffixes where Authorization should be preserved across manual
+   * redirects. Fetch strips Authorization on cross-origin redirects; some
+   * private media URLs redirect inside the platform-owned domain and still
+   * require the same token.
+   */
+  preserveAuthRedirectHostSuffixes?: string[];
+}
+
+const MAX_MEDIA_REDIRECTS = 5;
+
+function hostMatchesSuffix(hostname: string, suffix: string): boolean {
+  const normalizedHost = hostname.toLowerCase();
+  const normalizedSuffix = suffix.toLowerCase();
+  return normalizedHost === normalizedSuffix || normalizedHost.endsWith(`.${normalizedSuffix}`);
+}
+
+function shouldPreserveAuthForRedirect(url: URL, suffixes: string[] | undefined): boolean {
+  return Boolean(suffixes?.some((suffix) => hostMatchesSuffix(url.hostname, suffix)));
+}
+
+function headersWithOptionalAuthorization(
+  headers: RequestInit['headers'] | undefined,
+  preserveAuthorization: boolean,
+): Headers {
+  const nextHeaders = new Headers(headers);
+  if (!preserveAuthorization) nextHeaders.delete('authorization');
+  return nextHeaders;
+}
+
+/**
+ * Fetch a media URL with the SSRF policy applied to the initial URL AND every
+ * redirect hop. Redirects are followed manually so no hop escapes the check.
+ *
+ * Authorization is preserved across a hop when the redirect stays same-origin
+ * (standard fetch semantics) or when both hop hosts match
+ * `preserveAuthRedirectHostSuffixes` (platform-owned domains like Slack's
+ * files.slack.com → files-pri.slack.com).
+ */
+export async function fetchMediaUrl(url: string, fetchOptions?: MediaFetchOptions): Promise<Response> {
+  const { preserveAuthRedirectHostSuffixes, ...init } = fetchOptions ?? {};
+
+  let currentUrl = new URL(url);
+  await assertSafeMediaUrl(currentUrl);
+  let currentHeaders = new Headers(init.headers);
+
+  for (let redirects = 0; redirects <= MAX_MEDIA_REDIRECTS; redirects++) {
+    const response: Response = await fetch(currentUrl.toString(), {
+      ...init,
+      headers: currentHeaders,
+      redirect: 'manual',
+    });
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location: string | null = response.headers.get('location');
+    if (!location) return response;
+
+    const nextUrl: URL = new URL(location, currentUrl);
+    await assertSafeMediaUrl(nextUrl);
+
+    const preserveAuthorization =
+      nextUrl.origin === currentUrl.origin ||
+      (shouldPreserveAuthForRedirect(currentUrl, preserveAuthRedirectHostSuffixes) &&
+        shouldPreserveAuthForRedirect(nextUrl, preserveAuthRedirectHostSuffixes));
+
+    currentHeaders = headersWithOptionalAuthorization(init.headers, preserveAuthorization);
+    currentUrl = nextUrl;
+  }
+
+  throw new Error('Failed to download media: too many redirects');
+}

--- a/packages/channel-sdk/src/index.ts
+++ b/packages/channel-sdk/src/index.ts
@@ -97,9 +97,16 @@ export type { DownloadGuard, DownloadGuardConfig, DownloadGuardContext } from '.
 // Media storage backends (shared by @omni/api and channel plugins)
 // ─────────────────────────────────────────────────────────────
 
-export { createMediaBackend, LocalMediaBackend, resolveMediaBackendConfig, S3MediaBackend } from './media-backends';
+export {
+  createMediaBackend,
+  isMediaNotFoundError,
+  LocalMediaBackend,
+  resolveMediaBackendConfig,
+  S3MediaBackend,
+} from './media-backends';
 export type {
   MediaBackendConfig,
+  MediaObjectStat,
   MediaStorageBackend,
   MediaStorageMode,
   S3BackendConfig,

--- a/packages/channel-sdk/src/media-backends/__tests__/backend.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/backend.test.ts
@@ -16,6 +16,7 @@ import { Readable } from 'node:stream';
 import { createMediaBackend } from '../index';
 import { LocalMediaBackend } from '../local-backend';
 import { S3MediaBackend } from '../s3-backend';
+import { isMediaNotFoundError } from '../types';
 
 describe('createMediaBackend', () => {
   const OriginalS3Client = Bun.S3Client;
@@ -106,7 +107,7 @@ describe('LocalMediaBackend', () => {
     await expect(backend.presignedUrl('inst-1/2026-07/msg-1.png')).rejects.toThrow(/remote mode/);
   });
 
-  it('rejects keys that escape the storage root (store, storeStream, read)', async () => {
+  it('rejects keys that escape the storage root (store, storeStream, read, stat, readRange, readStream)', async () => {
     const backend = new LocalMediaBackend(tmpDir);
     const escapingKey = join('..', 'omni-escape-test.txt');
     const buffer = Buffer.from([1]);
@@ -117,6 +118,9 @@ describe('LocalMediaBackend', () => {
     await expect(backend.storeStream({ key: escapingKey, stream, mimeType: 'text/plain' })).rejects.toThrow(
       /storage root/,
     );
+    await expect(backend.stat(escapingKey)).rejects.toThrow(/storage root/);
+    await expect(backend.readRange(escapingKey, 0, 0)).rejects.toThrow(/storage root/);
+    await expect(backend.readStream(escapingKey)).rejects.toThrow(/storage root/);
 
     // Nothing escaped the root.
     expect(existsSync(join(tmpDir, '..', 'omni-escape-test.txt'))).toBe(false);
@@ -128,5 +132,66 @@ describe('LocalMediaBackend', () => {
     await backend.store({ key, buffer: Buffer.from([9, 9]), mimeType: 'application/octet-stream' });
     const bytes = await backend.read(key);
     expect(Array.from(bytes)).toEqual([9, 9]);
+  });
+
+  it('stat returns size for existing keys and null for missing ones', async () => {
+    const backend = new LocalMediaBackend(tmpDir);
+    const key = join('inst-1', '2026-07', 'msg-stat.bin');
+    await backend.store({ key, buffer: Buffer.from([1, 2, 3]), mimeType: 'application/octet-stream' });
+
+    expect(await backend.stat(key)).toEqual({ size: 3 });
+    expect(await backend.stat(join('inst-1', '2026-07', 'missing.bin'))).toBeNull();
+  });
+
+  it('readRange returns exactly the inclusive byte range without reading the whole file', async () => {
+    const backend = new LocalMediaBackend(tmpDir);
+    const key = join('inst-1', '2026-07', 'msg-range.bin');
+    const payload = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+    await backend.store({ key, buffer: payload, mimeType: 'application/octet-stream' });
+
+    const chunk = await backend.readRange(key, 10, 19);
+    expect(Array.from(chunk)).toEqual(Array.from(payload.subarray(10, 20)));
+
+    // Clamped at EOF: asking past the end returns only what exists.
+    const tail = await backend.readRange(key, 250, 300);
+    expect(Array.from(tail)).toEqual(Array.from(payload.subarray(250)));
+  });
+
+  it('readStream yields the full bytes and rejects with ENOENT for missing keys', async () => {
+    const backend = new LocalMediaBackend(tmpDir);
+    const key = join('inst-1', '2026-07', 'msg-stream.bin');
+    const payload = Buffer.from([5, 6, 7, 8]);
+    await backend.store({ key, buffer: payload, mimeType: 'application/octet-stream' });
+
+    const stream = await backend.readStream(key);
+    const bytes = Buffer.from(await new Response(stream).arrayBuffer());
+    expect(bytes.equals(payload)).toBe(true);
+
+    await expect(backend.readStream(join('inst-1', '2026-07', 'missing.bin'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+});
+
+describe('isMediaNotFoundError', () => {
+  function coded(code: string): Error {
+    const error = new Error(code) as Error & { code: string };
+    error.code = code;
+    return error;
+  }
+
+  it('classifies local ENOENT and S3 NoSuchKey as not-found', () => {
+    expect(isMediaNotFoundError(coded('ENOENT'))).toBe(true);
+    expect(isMediaNotFoundError(coded('NoSuchKey'))).toBe(true);
+  });
+
+  it('classifies transient/config failures as NOT not-found', () => {
+    expect(isMediaNotFoundError(coded('ConnectionRefused'))).toBe(false);
+    expect(isMediaNotFoundError(coded('InvalidAccessKeyId'))).toBe(false);
+    expect(isMediaNotFoundError(coded('NoSuchBucket'))).toBe(false);
+    expect(isMediaNotFoundError(coded('UnknownError'))).toBe(false);
+    expect(isMediaNotFoundError(new Error('plain'))).toBe(false);
+    expect(isMediaNotFoundError(null)).toBe(false);
+    expect(isMediaNotFoundError('NoSuchKey')).toBe(false);
   });
 });

--- a/packages/channel-sdk/src/media-backends/index.ts
+++ b/packages/channel-sdk/src/media-backends/index.ts
@@ -15,7 +15,9 @@ export type { MediaBackendConfig, S3BackendConfig } from './config';
 export { resolveMediaBackendConfig } from './config';
 export { LocalMediaBackend } from './local-backend';
 export { S3MediaBackend } from './s3-backend';
+export { isMediaNotFoundError } from './types';
 export type {
+  MediaObjectStat,
   MediaStorageBackend,
   MediaStorageMode,
   StoreMediaInput,

--- a/packages/channel-sdk/src/media-backends/local-backend.ts
+++ b/packages/channel-sdk/src/media-backends/local-backend.ts
@@ -7,12 +7,19 @@
  */
 
 import { createWriteStream, existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { mkdir, readFile, rm } from 'node:fs/promises';
+import { mkdir, open, readFile, rm, stat } from 'node:fs/promises';
 import { dirname, resolve, sep } from 'node:path';
 import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { DownloadTooLargeError } from '../download-guard';
-import type { MediaStorageBackend, StoreMediaInput, StoreMediaResult, StoreStreamInput } from './types';
+import {
+  type MediaObjectStat,
+  type MediaStorageBackend,
+  type StoreMediaInput,
+  type StoreMediaResult,
+  type StoreStreamInput,
+  isMediaNotFoundError,
+} from './types';
 
 export class LocalMediaBackend implements MediaStorageBackend {
   readonly mode = 'local' as const;
@@ -83,6 +90,36 @@ export class LocalMediaBackend implements MediaStorageBackend {
 
   async read(key: string): Promise<Buffer> {
     return readFile(this.getSafePath(key));
+  }
+
+  async stat(key: string): Promise<MediaObjectStat | null> {
+    try {
+      const info = await stat(this.getSafePath(key));
+      return { size: Number(info.size) };
+    } catch (error) {
+      if (isMediaNotFoundError(error)) return null;
+      throw error;
+    }
+  }
+
+  async readRange(key: string, start: number, endInclusive: number): Promise<Buffer> {
+    const length = endInclusive - start + 1;
+    const handle = await open(this.getSafePath(key), 'r');
+    try {
+      const buffer = Buffer.alloc(length);
+      const { bytesRead } = await handle.read(buffer, 0, length, start);
+      return bytesRead === length ? buffer : buffer.subarray(0, bytesRead);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async readStream(key: string): Promise<ReadableStream<Uint8Array>> {
+    const path = this.getSafePath(key);
+    // Surface a missing file as ENOENT NOW (Bun.file streams error lazily,
+    // after the Response has already committed a 200).
+    await stat(path);
+    return Bun.file(path).stream();
   }
 
   async presignedUrl(_key?: string, _ttlSeconds?: number): Promise<string> {

--- a/packages/channel-sdk/src/media-backends/s3-backend.ts
+++ b/packages/channel-sdk/src/media-backends/s3-backend.ts
@@ -12,7 +12,14 @@
 import { createLogger } from '@omni/core';
 import { DownloadTooLargeError } from '../download-guard';
 import type { S3BackendConfig } from './config';
-import type { MediaStorageBackend, StoreMediaInput, StoreMediaResult, StoreStreamInput } from './types';
+import {
+  type MediaObjectStat,
+  type MediaStorageBackend,
+  type StoreMediaInput,
+  type StoreMediaResult,
+  type StoreStreamInput,
+  isMediaNotFoundError,
+} from './types';
 
 const log = createLogger('services:media-backends:s3');
 
@@ -118,6 +125,37 @@ export class S3MediaBackend implements MediaStorageBackend {
     const bytes = await this.client.file(key).arrayBuffer();
     log.debug('Read media from S3', { key, size: bytes.byteLength });
     return Buffer.from(bytes);
+  }
+
+  async stat(key: string): Promise<MediaObjectStat | null> {
+    try {
+      const info = await this.client.file(key).stat();
+      return { size: info.size };
+    } catch (error) {
+      // Bun's S3Client throws S3Error code 'NoSuchKey' for a missing object;
+      // anything else (ConnectionRefused, InvalidAccessKeyId, NoSuchBucket…)
+      // is a transient/config failure the caller must NOT treat as 404.
+      if (isMediaNotFoundError(error)) return null;
+      throw error;
+    }
+  }
+
+  /**
+   * Ranged S3 GET via `S3File.slice` — fetches exactly `[start, endInclusive]`
+   * (Blob-style exclusive end, hence `endInclusive + 1`), never the whole
+   * object. Verified against MinIO: `slice(10, 20)` returns bytes 10..19.
+   */
+  async readRange(key: string, start: number, endInclusive: number): Promise<Buffer> {
+    const bytes = await this.client
+      .file(key)
+      .slice(start, endInclusive + 1)
+      .arrayBuffer();
+    return Buffer.from(bytes);
+  }
+
+  /** Streaming S3 GET — chunks flow to the consumer without heap buffering. */
+  async readStream(key: string): Promise<ReadableStream<Uint8Array>> {
+    return this.client.file(key).stream();
   }
 
   async presignedUrl(key: string, ttlSeconds: number = this.presignTtlSeconds): Promise<string> {

--- a/packages/channel-sdk/src/media-backends/types.ts
+++ b/packages/channel-sdk/src/media-backends/types.ts
@@ -50,6 +50,30 @@ export interface StoreMediaResult {
   mimeType?: string;
 }
 
+/** Metadata for a stored object, fetched without reading its bytes. */
+export interface MediaObjectStat {
+  /** Object size in bytes. */
+  size: number;
+}
+
+/**
+ * Whether an error thrown by a backend read/stat means "the object does not
+ * exist" — as opposed to a transient or configuration failure (endpoint down,
+ * bad credentials, missing bucket) that callers must surface as retryable.
+ *
+ * Signals (verified against Bun 1.3.9 + MinIO):
+ * - local: `readFile`/`stat` throw with `code: 'ENOENT'`.
+ * - remote: `Bun.S3Client` throws `S3Error` with `code: 'NoSuchKey'` for a
+ *   missing object. Unreachable endpoints yield `ConnectionRefused`, bad
+ *   credentials `InvalidAccessKeyId`, a missing bucket `NoSuchBucket` — none
+ *   of which mean the object is gone.
+ */
+export function isMediaNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  return code === 'ENOENT' || code === 'NoSuchKey';
+}
+
 export interface MediaStorageBackend {
   readonly mode: MediaStorageMode;
 
@@ -79,6 +103,29 @@ export interface MediaStorageBackend {
    * filesystem path and cannot read an S3 key directly.
    */
   read(key: string): Promise<Buffer>;
+
+  /**
+   * Stat a previously stored `key` without reading its bytes. Returns `null`
+   * when the object does not exist; throws on transient/config failures
+   * (endpoint unreachable, bad credentials, …) so callers can distinguish
+   * "gone" from "down right now".
+   */
+  stat(key: string): Promise<MediaObjectStat | null>;
+
+  /**
+   * Read an inclusive byte range `[start, endInclusive]` of a stored `key`.
+   * Backends fetch ONLY the requested bytes (`fs` positional read / S3 ranged
+   * GET) — never the whole object — so Range-request serving stays O(range),
+   * not O(object).
+   */
+  readRange(key: string, start: number, endInclusive: number): Promise<Buffer>;
+
+  /**
+   * Open a byte stream over the full object without buffering it in the heap
+   * (local file stream / S3 streaming GET). Used to serve full-object GETs of
+   * potentially multi-GB media.
+   */
+  readStream(key: string): Promise<ReadableStream<Uint8Array>>;
 
   /**
    * Presign a time-limited GET URL for a previously stored `key`.

--- a/packages/channel-telegram/src/__tests__/media-remote-ingest.test.ts
+++ b/packages/channel-telegram/src/__tests__/media-remote-ingest.test.ts
@@ -32,6 +32,15 @@ class RecordingRemoteBackend implements MediaStorageBackend {
   async read(_key: string): Promise<Buffer> {
     return Buffer.alloc(0);
   }
+  async stat(_key: string): Promise<{ size: number } | null> {
+    return null;
+  }
+  async readRange(_key: string, _start: number, _endInclusive: number): Promise<Buffer> {
+    return Buffer.alloc(0);
+  }
+  async readStream(_key: string): Promise<ReadableStream<Uint8Array>> {
+    return new Blob([]).stream();
+  }
   async presignedUrl(key: string): Promise<string> {
     return `https://s3.example/${key}?X-Amz-Signature=deadbeef`;
   }

--- a/packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts
@@ -44,6 +44,15 @@ class RecordingRemoteBackend implements MediaStorageBackend {
   async read(_key: string): Promise<Buffer> {
     return Buffer.alloc(0);
   }
+  async stat(_key: string): Promise<{ size: number } | null> {
+    return null;
+  }
+  async readRange(_key: string, _start: number, _endInclusive: number): Promise<Buffer> {
+    return Buffer.alloc(0);
+  }
+  async readStream(_key: string): Promise<ReadableStream<Uint8Array>> {
+    return new Blob([]).stream();
+  }
   async presignedUrl(key: string): Promise<string> {
     return `https://s3.example/${key}?X-Amz-Signature=deadbeef`;
   }

--- a/packages/channel-whatsapp/src/__tests__/media.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/media.test.ts
@@ -15,12 +15,7 @@ import {
   buildStickerContent,
   buildVideoContent,
 } from '../senders/media';
-import {
-  generateFilename,
-  getExtension,
-  getWhatsAppMediaDownloadMaxBytes,
-  writeMediaStreamToFile,
-} from '../utils/download';
+import { getExtension, getWhatsAppMediaDownloadMaxBytes, writeMediaStreamToFile } from '../utils/download';
 
 describe('Media Utilities', () => {
   describe('getExtension', () => {
@@ -54,23 +49,6 @@ describe('Media Utilities', () => {
 
     it('returns .bin for unknown types', () => {
       expect(getExtension('application/x-custom')).toBe('.bin');
-    });
-  });
-
-  describe('generateFilename', () => {
-    it('uses original filename if provided', () => {
-      expect(generateFilename('image/jpeg', 'photo.jpg')).toBe('photo.jpg');
-    });
-
-    it('generates UUID filename with correct extension', () => {
-      const filename = generateFilename('image/png');
-      expect(filename).toMatch(/^[a-f0-9-]+\.png$/);
-    });
-
-    it('generates different filenames each call', () => {
-      const filename1 = generateFilename('audio/ogg');
-      const filename2 = generateFilename('audio/ogg');
-      expect(filename1).not.toBe(filename2);
     });
   });
 

--- a/packages/channel-whatsapp/src/index.ts
+++ b/packages/channel-whatsapp/src/index.ts
@@ -46,13 +46,11 @@ export type { MessageStatus, ReadReceiptMode, ReadReceiptConfig } from './receip
 
 // Media utilities
 export {
-  downloadMedia,
   downloadMediaToBuffer,
   detectMediaType,
   getExtension,
-  generateFilename,
 } from './utils/download';
-export type { DownloadResult, DetectedMedia } from './utils/download';
+export type { DetectedMedia } from './utils/download';
 
 // Senders
 export * from './senders';

--- a/packages/channel-whatsapp/src/utils/download.ts
+++ b/packages/channel-whatsapp/src/utils/download.ts
@@ -4,10 +4,9 @@
  * Handles downloading media from Baileys messages and saving to local storage.
  */
 
-import { randomUUID } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { DownloadTooLargeError, type MediaStorageBackend } from '@omni/channel-sdk';
@@ -29,20 +28,6 @@ export function getWhatsAppMediaDownloadMaxBytes(): number {
   const parsed = Number.parseInt(overrideMb, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_WHATSAPP_MEDIA_MAX_DOWNLOAD_BYTES;
   return parsed * 1024 * 1024;
-}
-
-/**
- * Result of downloading media
- */
-export interface DownloadResult {
-  /** Local file path where media was saved */
-  localPath: string;
-  /** MIME type of the media */
-  mimeType: string;
-  /** File size in bytes */
-  size: number;
-  /** Original filename if available */
-  filename?: string;
 }
 
 export interface DownloadToFileResult {
@@ -162,62 +147,6 @@ export function getExtension(mimeType: string): string {
   if (mimeType.startsWith('application/')) return '.bin';
 
   return '.bin';
-}
-
-/**
- * Generate a unique filename for downloaded media
- */
-export function generateFilename(mimeType: string, originalFilename?: string): string {
-  if (originalFilename) {
-    return originalFilename;
-  }
-
-  const uuid = randomUUID();
-  const ext = getExtension(mimeType);
-  return `${uuid}${ext}`;
-}
-
-/**
- * Download media from a Baileys message
- *
- * @param msg - Baileys WAMessage containing media
- * @param basePath - Base directory to save media
- * @returns Download result with local path and metadata
- */
-export async function downloadMedia(msg: WAMessage, basePath: string): Promise<DownloadResult | null> {
-  const mediaInfo = detectMediaType(msg);
-  if (!mediaInfo) {
-    return null;
-  }
-
-  try {
-    // Download the media buffer
-    const buffer = await downloadMediaMessage(msg, 'buffer', {});
-
-    if (!buffer || !(buffer instanceof Buffer)) {
-      return null;
-    }
-
-    // Generate filename and path
-    const filename = generateFilename(mediaInfo.mimeType, mediaInfo.filename);
-    const localPath = join(basePath, mediaInfo.type, filename);
-
-    // Ensure directory exists
-    await mkdir(dirname(localPath), { recursive: true });
-
-    // Write file
-    await writeFile(localPath, buffer);
-
-    return {
-      localPath,
-      mimeType: mediaInfo.mimeType,
-      size: buffer.length,
-      filename: mediaInfo.filename,
-    };
-  } catch (_error) {
-    // Download failed - could be expired or unavailable
-    return null;
-  }
 }
 
 /**


### PR DESCRIPTION
Wave 2 of the PR #770 autonomous fix orchestration (G-MEDIA-LOW). Implements review findings LOW-1, LOW-2, LOW-5, LOW-9, LOW-10 from `docs/_internal/PR-770-REVIEW.md`. Source-only changes in `packages/api` and `packages/channel-*`; no deploy/CI/db changes.

## LOW-1 — 404 vs 5xx on the media read path

`readMediaViaBackend` swallowed every backend error into `null`, so a transient S3 outage surfaced as `404 Media not found` and clients cached "gone forever".

- Probed Bun 1.3.9 `Bun.S3Client` against MinIO: missing object throws `S3Error` with `code: 'NoSuchKey'` (read AND stat); unreachable endpoint → `ConnectionRefused`; bad credentials → `InvalidAccessKeyId`/`UnknownError`; missing bucket → `NoSuchBucket`.
- New `isMediaNotFoundError()` (channel-sdk) classifies `ENOENT`/`NoSuchKey` as not-found; everything else rethrows.
- `GET /media/:instanceId/*` now returns **404** only for a truly missing object and **503 `MEDIA_BACKEND_UNAVAILABLE`** for transient/config failures.
- Evidence: `media-route.test.ts` — MinIO missing key → 404; unreachable endpoint → 503; rejected credentials → 503. `media-storage.test.ts` — ENOENT/NoSuchKey → null; `ConnectionRefused`/`InvalidAccessKeyId`/`NoSuchBucket`/`UnknownError` → rethrow.

## LOW-2 — no full-object buffering on `GET /media/*`

The route buffered the ENTIRE object per request — including for every Range seek of a large remote video (WhatsApp media can reach 2 GB → OOM risk).

- `MediaStorageBackend` grew `stat(key)`, `readRange(key, start, endInclusive)` (S3 `slice()` ranged GET / positional `fs` read) and `readStream(key)` (S3 streaming GET / file stream).
- Route flow: `stat` (existence + size, and the 503 gate) → Range requests read ONLY the requested bytes → full GETs stream the body.
- Exact 200/206/Content-Range/Accept-Ranges/Content-Type semantics preserved for local AND remote; end-beyond-size is now clamped per RFC 7233 (previously Content-Length could exceed the actual body), and a start beyond EOF returns 416.
- Evidence: `media-route.test.ts` MinIO suite — 4 MiB object, `Range: bytes=1048576-2097151` → 206 with byte-exact 1 MiB (`body.equals(payload.subarray(...))`); full GET → 200 streamed, byte-exact, correct Content-Length. Same matrix in local mode.

## LOW-5 — dead footguns deleted

- `MediaStorageService.readMedia` (guard-less disk read) — zero callers, deleted. `readMediaViaBackend` kept (media processing + tests).
- WhatsApp `downloadMedia` + `generateFilename` + `DownloadResult` (joined attacker-controlled document `fileName` into a path) — zero runtime callers verified via `rg`, deleted along with their exports and tests. `getExtension`, `downloadMediaToBuffer`, `downloadMediaToFile`, `downloadMediaToBackend`, `writeMediaStreamToFile` remain (live).
- knip reports no new findings (remaining items pre-exist in `admin.ts`/`cli`/`voice-client`).

## LOW-9 — media path visible to instance allowlists

`GET /media/:instanceId/*` was invisible to the scope enforcer's path-target extraction: broad keys could read ANY instance's media; allowlisted keys were denied their OWN media.

- `extractLockTargets` now extracts the instance from `/media/` **for GET only** — the POST verbs (`/media/tts` etc.) carry an action name in that segment, and treating it as an instance target would break them.
- Evidence (acceptance criterion): `scope-enforcer-media.test.ts` mounts the real middleware — allowlisted key reads its own instance media (200) and is denied another instance's (403, `lock=instanceAllowlist`, correct `attempted`); broad and wildcard keys unaffected; adversarial test proves the `tts` segment is never treated as an instance target (a key allowlisted for literal `"tts"` is still denied).

## LOW-10 — SSRF deny-list on media URL fetching

`storeFromUrl` and the dispatcher's history-sync `downloadToTempFile` fetched channel-supplied URLs with no private-range checks.

- New `packages/api/src/utils/safe-media-fetch.ts` (searched `@omni/core` first — no existing URL-validation utility): denies non-http(s) schemes (unconditionally — Bun fetch can read `file://`), 0.0.0.0/8, 10/8, 127/8, 169.254/16 (metadata), 172.16/12, 192.168/16, `::`/`::1`, fc00::/7, fe80::/10, and IPv4-mapped IPv6; hostnames are DNS-resolved and every address checked (resolution failure passes through — fetch fails identically, keeps offline/mocked-fetch tests deterministic).
- **Redirect policy choice:** `fetchMediaUrl` always follows redirects manually (`redirect: "manual"`, ≤5 hops) and re-validates every `Location` before connecting — Bun's auto-follow cannot inspect hops. Authorization is preserved on same-origin hops (standard fetch semantics) or when both hosts match `preserveAuthRedirectHostSuffixes` (Slack behavior unchanged, covered by the existing test).
- Gating: `OMNI_MEDIA_URL_GUARD=off` opt-out for deployments that intentionally fetch media from private hosts; default enforced. Telegram (`api.telegram.org`, public) and the MinIO test suites (which use `Bun.S3Client`/presigned fetches, not the guarded paths) are unaffected — verified by the full local + MinIO runs.
- Evidence: `safe-media-fetch.test.ts` (deny-range matrix, redirect hop into 169.254.169.254 blocked after exactly 1 fetch, auth preservation matrix); `media-storage.test.ts` (`storeFromUrl` refuses metadata/RFC1918/`file://` with fetch never called, refuses public→192.168.x redirect); `agent-dispatcher-ssrf.test.ts` (`downloadToTempFile` refuses metadata/10.x pre-connect, still downloads public hosts).

## Gates

- `make typecheck` clean, `make lint` (biome) zero warnings, `bunx knip` no new findings.
- `make test-api` green (full local-mode regression).
- `MINIO_INTEGRATION=1 CI=true bun test` over s3-backend-remote, media-remote-e2e, media-processor-remote, agent-dispatcher-media-remote, batch-jobs-remote + the new media-route suite — green.
- Review's "checked and clean" list preserved: local path-traversal guard now also covers `stat`/`readRange`/`readStream` (test extended), presign flow untouched, media-route auth semantics unchanged (same mount, stricter targets), realtime dispatch untouched.
