### PR TITLE
fix(helm): homolog+prod overlays on external RDS/S3 with ingress-host fail-fast

### DIFF
--- a/deploy/helm/omni/templates/ingress.yaml
+++ b/deploy/helm/omni/templates/ingress.yaml
@@ -1,4 +1,16 @@
 {{- if .Values.ingress.enabled }}
+{{- /*
+Fail-fast host guard: an enabled ingress with an EMPTY host is always operator
+error — nginx would treat the rule as catch-all and serve omni on every
+hostname hitting the controller. Cloud overlays (values-prod / values-homolog)
+opt in by setting `ingress.host: ""` explicitly, forcing the real FQDN through
+`--set ingress.host=…` per realm. NOTE: base values.yaml defaults host to
+`omni.local`, so an overlay that does NOT null the host inherits that default
+and bypasses this guard — cloud overlays MUST keep `ingress.host: ""`.
+*/}}
+{{- if not .Values.ingress.host }}
+{{- fail "ingress.enabled=true but ingress.host is empty — this overlay requires the realm FQDN at deploy time: --set ingress.host=<fqdn> (see values-prod.yaml / values-homolog.yaml `ingress.host`)" }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -15,7 +27,9 @@ spec:
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- /* tpl: lets overlays write hosts: ['{{ .Values.ingress.host }}'] so the
+    TLS block tracks the --set host; plain strings pass through unchanged. */}}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}

--- a/deploy/helm/omni/values-homolog.yaml
+++ b/deploy/helm/omni/values-homolog.yaml
@@ -1,15 +1,17 @@
 # =============================================================================
-# Production overlay — dedicated AWS cluster, external RDS + real S3.
+# Homolog (HML) overlay — dedicated AWS cluster, external RDS + real S3.
 #   helm upgrade --install omni deploy/helm/omni -n omni \
-#     -f deploy/helm/omni/values-prod.yaml \
-#     --set ingress.host=<prod fqdn>
+#     -f deploy/helm/omni/values-homolog.yaml \
+#     --set ingress.host=<hml fqdn>
 #
-# Realm shape (shared with values-homolog.yaml — separate clusters, one shape):
+# Realm shape (shared with values-prod.yaml — separate clusters, one shape):
 #   - NO bundled datastores: autopg + MinIO are OFF. Postgres is external RDS
 #     (database.existingSecret), media is real AWS S3 (media.s3.existingSecret).
 #   - image.tag "" → v<Chart.appVersion>, the tag image-publish.yml publishes.
 #   - ingress.host is intentionally EMPTY: the chart fail-fasts unless the
 #     realm FQDN is passed via --set ingress.host=… (see templates/ingress.yaml).
+# HML differs from prod only in sizing (lighter resources / JetStream stores)
+# and its own bucket + hostname.
 #
 # Required pre-created Secrets (same namespace as the release):
 #   omni-db        key DATABASE_URL — full RDS URL, e.g.
@@ -20,26 +22,18 @@
 # =============================================================================
 
 image:
-  repository: ghcr.io/automagik-dev/omni-api   # set to your registry/path
+  repository: ghcr.io/automagik-dev/omni-api
   # "" → v<Chart.appVersion>: the latest PUBLISHED release (image-publish.yml
-  # pushes v<packages/cli version> on merges to main). Pin an explicit v-tag
-  # only to hold prod back from the chart's tracked release.
+  # pushes v<packages/cli version> on merges to main).
   tag: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 
-# ONE replica, HPA off (see values.yaml "replicas + scaling"): a single
-# WhatsApp credential maps to one live Baileys socket, so concurrent replicas
-# risk key-ratchet corruption / duplicate sends until single-socket ownership
-# (leader election) exists. Scale out only for HTTP/API + non-WhatsApp
-# traffic — the chart then auto-adds a PDB + pod anti-affinity, and
-# migrate-on-boot serializes via a Postgres advisory lock.
+# ONE replica, HPA off — same WhatsApp/Baileys single-socket constraint as prod
+# (see values.yaml "replicas + scaling").
 replicaCount: 1
 autoscaling:
   enabled: false
-  minReplicas: 1
-  maxReplicas: 6
-  targetCPUUtilizationPercentage: 75
 
 config:
   LOG_LEVEL: "info"
@@ -50,7 +44,7 @@ ingress:
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-  # REQUIRED at deploy time: --set ingress.host=<prod fqdn>. Deliberately ""
+  # REQUIRED at deploy time: --set ingress.host=<hml fqdn>. Deliberately ""
   # (NOT omitted — base values.yaml defaults host to omni.local, which would
   # silently bypass the chart's empty-host fail-fast). The tls hosts entry is
   # templated so it tracks whatever host is set.
@@ -62,9 +56,9 @@ ingress:
       hosts:
         - "{{ .Values.ingress.host }}"
 
-# DATABASE_URL comes from a pre-created external Secret pointing at RDS —
-# the bundled autopg is OFF in this realm (autopg.enabled below). Create it
-# before the first deploy:
+# DATABASE_URL comes from a pre-created external Secret pointing at the HML
+# RDS instance — the bundled autopg is OFF in this realm (autopg.enabled
+# below). Create it before the first deploy:
 #   kubectl -n omni create secret generic omni-db \
 #     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=require'
 database:
@@ -78,35 +72,33 @@ secret:
   env: {}
     # OPENAI_API_KEY: ""
     # ANTHROPIC_API_KEY: ""
-    # SENTRY_DSN: ""
-    # OTEL_EXPORTER_OTLP_ENDPOINT: ""
 
 resources:
   requests:
-    cpu: 250m
-    memory: 512Mi
+    cpu: 100m
+    memory: 256Mi
   limits:
-    cpu: "2"
-    memory: 2Gi
+    cpu: "1"
+    memory: 1Gi
 
 nats:
   enabled: true
   jetstream:
     enabled: true
-    memStore: 512Mi
-    fileStore: 4Gi
+    memStore: 256Mi
+    fileStore: 2Gi
   persistence:
-    size: 8Gi
+    size: 4Gi
     # storageClass: gp3
 
-# Prod media backend: an EXTERNAL managed S3 bucket (real AWS S3 — endpoint
+# HML media backend: an EXTERNAL managed S3 bucket (real AWS S3 — endpoint
 # empty so the SDK derives it from region; forcePathStyle false). Creds come
 # from the pre-created omni-media-s3 Secret (never plaintext in rendered
 # output); the bucket is provisioned out of band and must already exist.
 media:
   mode: remote
   s3:
-    bucket: omni-media
+    bucket: omni-media-hml               # bucket names are global — use the HML one
     region: us-east-1
     forcePathStyle: false
     presignTtlSeconds: 3600
@@ -114,7 +106,7 @@ media:
     # publicEndpoint stays unset: real S3 endpoints are already publicly
     # reachable, so presigned GET URLs work as-is. It exists for split-endpoint
     # setups (e.g. in-cluster MinIO presigning through an external hostname).
-    # publicEndpoint: "https://media.example.com"
+    # publicEndpoint: "https://media-hml.example.com"
     existingSecret: "omni-media-s3"      # must hold the two keys below
     accessKeyKey: "OMNI_MEDIA_S3_ACCESS_KEY"
     secretKeyKey: "OMNI_MEDIA_S3_SECRET_KEY"


### PR DESCRIPTION
## What

Group 1 (G-VALUES) of wish `omni-deploy-realms`: the three Helm overlays now render the three realms.

- **dev** — unchanged: bundled autopg + MinIO + NATS, local image, `omni.felipe.namastex.io` ingress.
- **homolog (NEW: `values-homolog.yaml`)** and **prod (`values-prod.yaml` rework)** — separate AWS clusters, one shape: `autopg.enabled: false` + `minio.enabled: false`; DATABASE_URL from pre-created Secret `omni-db` (key `DATABASE_URL`, external RDS); media `mode: remote` against real AWS S3 (creds from Secret `omni-media-s3`, `endpoint`/`publicEndpoint` empty — SDK derives from region, real S3 endpoints are already public); `image.tag: ""` → `v<Chart.appVersion>`; replicas 1, HPA off.
- **`templates/ingress.yaml`** — fail-fast guard: `fail` when ingress is enabled and `ingress.host` is empty. Cloud overlays opt in by setting `ingress.host: ""` explicitly (base default `omni.local` would otherwise silently bypass the guard), forcing `--set ingress.host=<fqdn>` per realm. The `tls` block is now `tpl`-rendered so overlay TLS hosts (`{{ .Values.ingress.host }}`) track the `--set` host; plain strings pass through byte-identically.

`networkPolicy.enabled` is left at its default in cloud overlays — the chart's only NetworkPolicy guards the bundled autopg, so nothing renders while autopg is off (documented in both overlays).

## Acceptance evidence

**All three overlays lint + render + kubeconform clean** — the wish validation script exits 0:

```
helm lint (base / prod+host / homolog+host):  1 chart(s) linted, 0 chart(s) failed  ×3
kubeconform -strict /tmp/wish-hml.yaml:  Valid: 8, Invalid: 0, Errors: 0
kubeconform -strict /tmp/wish-prod.yaml: Valid: 8, Invalid: 0, Errors: 0
kubeconform -strict /tmp/wish-dev.yaml:  Valid: 22, Invalid: 0, Errors: 0
```

**Cloud renders — no autopg/MinIO, v-tag image, existingSecret DB, remote media:** grep gates all pass — no `app.kubernetes.io/name: autopg`, no `minio` (case-insensitive) in either cloud render; `image: "ghcr.io/automagik-dev/omni-api:v2.260704.4"`; `DATABASE_URL` via `secretKeyRef {name: omni-db, key: DATABASE_URL}`; ConfigMap carries `OMNI_MEDIA_MODE: "remote"` + full `OMNI_MEDIA_S3_*` set, S3 creds by `secretKeyRef` to `omni-media-s3` only.

**Cloud renders FAIL without host:**

```
Error: execution error at (omni/templates/ingress.yaml:12:4): ingress.enabled=true but
ingress.host is empty — this overlay requires the realm FQDN at deploy time:
--set ingress.host=<fqdn> (see values-prod.yaml / values-homolog.yaml `ingress.host`)
```

**Dev render unchanged:** byte-compared `helm template … values-dev.yaml` on this branch vs `origin/dev` — identical except the two per-render random passwords (autopg `superuser-password`, MinIO `OMNI_MEDIA_S3_SECRET_KEY`), which differ between any two renders of the *same* tree (verified by rendering origin/dev twice). PR #772 ingress (`omni.felipe.namastex.io`) intact.

## Deviations

- `ingress.tls` is now passed through `tpl` so cloud TLS hosts can reference `ingress.host` instead of going stale against the `--set` value — minimal template surface, dev output byte-identical.
- Prod's explicit `tag: "v2.260704.4"` pin dropped for `tag: ""` (appVersion-driven v-tag) per deliverable 2.
