### PR TITLE
ci(version): stamp umbrella chart appVersion on every version bump

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -36,6 +36,10 @@ on:
       - 'apps/**'
       - 'deploy/Dockerfile'
       - 'deploy/autopg.Dockerfile'
+      # Chart/values-only promotions still advance appVersion (version.yml
+      # stamps deploy/helm/omni/Chart.yaml); without this filter the stamped
+      # tag would never get an image built (stranded-tag case).
+      - 'deploy/helm/**'
       - 'bun.lock'
       - '.github/workflows/image-publish.yml'
   workflow_dispatch:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -41,6 +41,14 @@ permissions:
 
 concurrency:
   # Serialize per target branch so dev and homolog bumps cannot overwrite each other.
+  # KNOWN GAP (documented, not fixed here): the group key includes event_name,
+  # so a dev→homolog promotion PR can fire this job twice for one merge —
+  # once via pull_request-closed and again via workflow_run (the merge commit
+  # "Merge pull request … /dev" passes the guard below) — in SEPARATE groups
+  # that run concurrently. Worst case is a duplicate bump/publish, not a loop:
+  # the bump commit itself never re-triggers (it fails the startsWith
+  # 'Merge pull request' guard). A real dedupe needs a gate job or step-level
+  # skip plumbing; deferred to keep this workflow's shape stable.
   group: version-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.base.ref || github.ref_name }}
   cancel-in-progress: false
 
@@ -146,7 +154,7 @@ jobs:
         env:
           OMNI_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
 
-      - name: Sync package.json versions
+      - name: Sync versions (package.json + chart appVersion)
         run: bun scripts/sync-versions.ts ${{ steps.version.outputs.version }}
 
       - name: Format versioned JSON (Biome)
@@ -169,11 +177,21 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          git add -A '*.json' bun.lock
+          # Chart.yaml is listed explicitly: the '*.json' pathspec would
+          # silently drop the appVersion stamp sync-versions.ts just wrote,
+          # and verify-versions.ts (CI Quality Gate) fails on the drift.
+          git add -A '*.json' bun.lock deploy/helm/omni/Chart.yaml
           if git diff --cached --quiet; then
-            echo "No package.json or bun.lock changes to commit"
+            echo "No version file changes to commit"
           else
-            git commit -m "chore(version): bump to ${VERSION} [skip ci]"
+            # No [skip ci] (D8): homolog bumps MUST trigger image-publish so
+            # the stamped appVersion gets a matching image built from the
+            # bump commit. Blanket removal is safe on the dev path too — no
+            # workflow push-triggers on dev for these paths (CI/image-publish
+            # push branches are [main, homolog] only). Loop-safe: this
+            # commit's message fails version.yml's own startsWith
+            # 'Merge pull request' workflow_run guard.
+            git commit -m "chore(version): bump to ${VERSION}"
           fi
 
           git tag "v${VERSION}"

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -3,11 +3,14 @@ name: omni
 description: Omni — multi-channel messaging API (Bun/Hono) with Postgres (autopg) and NATS/JetStream
 type: application
 version: 0.1.0
-# appVersion tracks the latest PUBLISHED omni release (packages/cli version):
-# image-publish.yml pushes ghcr.io/automagik-dev/omni-api:v<version> on merge
-# to main, and the chart's default image tag is v<appVersion>. Bump this only
-# to versions that exist on GHCR.
-appVersion: "2.260704.4"
+# appVersion = the version this tree publishes when promoted. Every version
+# bump (version.yml → scripts/sync-versions.ts) stamps this line in lockstep
+# with every package.json, and image-publish.yml pushes
+# ghcr.io/automagik-dev/omni-api:v<appVersion> when the tree lands on main or
+# homolog. The chart's default image tag is v<appVersion>, so a promoted tree
+# always references exactly the image its own promotion publishes. Do not edit
+# by hand — scripts/verify-versions.ts fails CI on drift.
+appVersion: "2.260705.3"
 keywords:
   - omni
   - messaging

--- a/scripts/lib/version-fields.ts
+++ b/scripts/lib/version-fields.ts
@@ -5,10 +5,11 @@
  *   - scripts/sync-versions.ts  — writes a single calver to every entry
  *   - scripts/verify-versions.ts — fails CI if any entry drifts from root
  *
- * Three kinds of entries are returned (in this order):
+ * Four kinds of entries are returned (in this order):
  *   1. Standard package.json files (root + every workspace package)
  *   2. The omni Claude plugin manifest (plugins/omni/.claude-plugin/plugin.json)
  *   3. The marketplace plugin entry (.claude-plugin/marketplace.json -> plugins[name=omni])
+ *   4. The umbrella Helm chart appVersion (deploy/helm/omni/Chart.yaml)
  */
 
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
@@ -23,6 +24,14 @@ const EXCLUDED_WORKSPACE_PACKAGES = new Set(['audio-decode-shim']);
 
 /** Marketplace plugin entry that this repo owns and keeps in sync. */
 const MARKETPLACE_PLUGIN_NAME = 'omni';
+
+/**
+ * Umbrella Helm chart whose `appVersion` must track the release version.
+ * Scoped strictly to this one file — the vendored subchart at
+ * deploy/helm/omni/charts/autopg/Chart.yaml is versioned independently
+ * (it tracks autopg releases, not omni releases) and must never be touched.
+ */
+const UMBRELLA_CHART_PATH = 'deploy/helm/omni/Chart.yaml';
 
 export type VersionField = {
   /** Path relative to the repo root, used for human-readable output. */
@@ -109,6 +118,48 @@ function marketplacePluginField(): VersionField {
   };
 }
 
+/**
+ * Build a VersionField for the umbrella Helm chart's `appVersion` line.
+ *
+ * Line-based on purpose: Chart.yaml carries load-bearing comments (the
+ * appVersion contract, the autopg dependency rationale) that a YAML/JSON
+ * round-trip would strip. Only the single `appVersion: "..."` line is
+ * rewritten; every other byte of the file is preserved.
+ */
+function chartAppVersionField(): VersionField {
+  const absPath = join(repoRoot, UMBRELLA_CHART_PATH);
+  // Anchored to the top-level key at column 0; matches the first (only)
+  // appVersion line. Chart.yaml appVersion is always double-quoted here so
+  // calver values like 2.260705.3 are never YAML-coerced.
+  const lineRe = /^appVersion: "([^"\n]*)"[ \t]*$/m;
+
+  return {
+    path: UMBRELLA_CHART_PATH,
+    description: 'umbrella helm chart appVersion',
+    read(): string | null {
+      if (!existsSync(absPath)) return null;
+      const content = readFileSync(absPath, 'utf-8');
+      return content.match(lineRe)?.[1] ?? null;
+    },
+    write(version: string): boolean {
+      const content = readFileSync(absPath, 'utf-8');
+      const current = content.match(lineRe)?.[1];
+
+      if (current === undefined) {
+        throw new Error(`${UMBRELLA_CHART_PATH} has no top-level appVersion: "..." line`);
+      }
+
+      if (current === version) {
+        return false;
+      }
+
+      const updated = content.replace(lineRe, `appVersion: "${version}"`);
+      writeFileSync(absPath, updated, 'utf-8');
+      return true;
+    },
+  };
+}
+
 /** Walk packages/* and apps/* and yield package.json paths (excluding the deny list). */
 function findWorkspacePackageJsonPaths(): string[] {
   const paths: string[] = [];
@@ -138,6 +189,7 @@ function findWorkspacePackageJsonPaths(): string[] {
  *   2. workspace package.json files (alphabetical, packages/ before apps/)
  *   3. plugins/omni/.claude-plugin/plugin.json
  *   4. .claude-plugin/marketplace.json (omni entry)
+ *   5. deploy/helm/omni/Chart.yaml (appVersion)
  */
 export function getAllVersionFields(): VersionField[] {
   const fields: VersionField[] = [];
@@ -151,6 +203,8 @@ export function getAllVersionFields(): VersionField[] {
   fields.push(topLevelJsonField('plugins/omni/.claude-plugin/plugin.json', 'omni claude plugin manifest'));
 
   fields.push(marketplacePluginField());
+
+  fields.push(chartAppVersionField());
 
   return fields;
 }


### PR DESCRIPTION
## Summary

Group 2 (G-VERSION-SYNC) of wish `omni-deploy-realms`: every version bump now stamps the umbrella chart's `appVersion`, so every promoted tree references exactly the image tag its own promotion publishes, on both channels (main and homolog).

### Changes

| File | Change |
|------|--------|
| `scripts/lib/version-fields.ts` | New comment-preserving, line-based YAML `VersionField` for `deploy/helm/omni/Chart.yaml` `appVersion` only. Registry-based, so `sync-versions.ts` writes it and `verify-versions.ts` (CI Quality Gate) guards it with zero changes to either script. The vendored `charts/autopg/Chart.yaml` is never touched (it versions autopg releases, not omni). |
| `deploy/helm/omni/Chart.yaml` | `appVersion` seeded to the current root version (`2.260705.3`) so verify-versions stays green in this PR; contract comment rewritten: appVersion = "the version this tree publishes when promoted". |
| `.github/workflows/version.yml` | Commit pathspec is now `git add -A '*.json' bun.lock deploy/helm/omni/Chart.yaml` — the previous `'*.json'` glob would silently drop the YAML stamp. Bump commit message drops `[skip ci]` (D8, see below). |
| `.github/workflows/image-publish.yml` | `on.push.paths` gains `deploy/helm/**` — closes the stranded-tag case where a chart/values-only promotion advances `appVersion` but builds no image. Path-filter lines only; the PR #774 structure is untouched. |

### D8 variant: blanket `[skip ci]` removal (deliberate)

The bump commit message is now `chore(version): bump to ${VERSION}` on **all** paths, not just homolog. Rationale:

- **Homolog path (the requirement):** the bump lands on `homolog` itself (`push_ref=homolog`). Without `[skip ci]`, image-publish fires on that push (the bump touches `packages/**` + `bun.lock` + now `deploy/helm/**`) and builds `v<appVersion>` from the exact tree that stamps it.
- **Dev path (why blanket is safe):** main-triggered and dev-PR bumps ride on `dev` (`push_ref=dev`). No workflow push-triggers on dev for these paths — `ci.yml` and `image-publish.yml` push branches are `[main, homolog]` only; `signing-identity-pin.yml` (main+dev) is path-filtered to SECURITY files; `rolling-pr.yml` is schedule-only. So removing `[skip ci]` there costs zero CI minutes.
- **Loop safety:** version.yml's `workflow_run` guard requires the head-commit message to start with `Merge pull request`; the bump message fails that, so a homolog bump's CI run can never re-trigger a bump.
- **Bonus:** dev's tip no longer carries `[skip ci]`, removing the LOW-18 hazard documented in image-publish.yml where a "Rebase and merge" promotion to main could inherit `[skip ci]` from the bump and skip the image build entirely.
- The conditional variant would add a branch to the commit step for no benefit and require rewriting the validation grep; blanket is simpler and strictly safer.

### Pre-existing double-fire risk (documented, not fixed)

`pull_request`-closed and `workflow_run` live in **separate concurrency groups** (the group key includes `event_name`). A dev→homolog promotion PR fires both: the closed event immediately, and `workflow_run` ~6 min later (the merge commit `Merge pull request … /dev` passes the guard). Worst case is a duplicate bump/publish for one merge — wasteful, not a loop (the bump commit fails the `Merge pull request` guard). This predates this PR and is orthogonal to the `[skip ci]` change (that filter inspects the *merge* commit, not the bump). No cheap dedupe exists: coalescing the concurrency groups only serializes (the second run still executes ~6 min later), and a real dedupe needs a gate job or step-level skip plumbing across ~9 steps — out of scope here. Documented as a KNOWN GAP comment on the concurrency block.

### Validation (all exit 0, run via script file with `set -euo pipefail`)

```
Sync complete: 22 updated, 0 already current (22 total)   # includes deploy/helm/omni/Chart.yaml
OK       deploy/helm/omni/Chart.yaml → 2.260705.3
OK: 22/22 files match                                      # verify-versions.ts
EXIT_CODE=0                                                # full AC block incl. actionlint
```

- `sync-versions.ts 2.999999.1` in a detached worktree: stamps `appVersion: "2.999999.1"`, `# appVersion` contract comment survives, `charts/autopg/Chart.yaml` byte-identical before/after.
- Simulated bump staging: `git add -A '*.json' bun.lock deploy/helm/omni/Chart.yaml` stages the Chart.yaml change (pathspec proven).
- `actionlint` clean on both workflows.
- Pre-push suite: 4196 pass / 0 fail (332 files).

Wish: `omni-deploy-realms` — Group 2 (G-VERSION-SYNC). Depends-on: none.
