### PR TITLE
feat(deploy): realm matrix docs + disposable-cluster self-host smoke

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,8 +1,14 @@
 # =============================================================================
-# omni deploy — OrbStack k8s helpers
+# omni deploy — k8s helpers (local OrbStack/k3d dev + realm deploys)
 # =============================================================================
 # Run from repo root: `make -C deploy <target>`  (or `cd deploy && make ...`).
 # Docker build context is the repo root (one level up).
+#
+# REALM selects the values overlay for lint/template/deploy (see README.md):
+#   make -C deploy deploy                REALM=dev (default, local self-host)
+#   make -C deploy template REALM=homolog HELM_EXTRA='--set ingress.host=…'
+#   make -C deploy deploy   REALM=prod    HELM_EXTRA='--set ingress.host=…'
+# Explicit VALUES=… still wins over REALM (backward compatible).
 # =============================================================================
 
 SHELL          := /bin/bash
@@ -14,7 +20,11 @@ TAG            ?= dev
 IMAGE_REF      := $(IMAGE):$(TAG)
 NAMESPACE      ?= omni
 RELEASE        ?= omni
-VALUES         ?= $(CHART)/values-dev.yaml
+REALM          ?= dev
+VALUES         ?= $(CHART)/values-$(REALM).yaml
+# Extra helm args for template/deploy (e.g. --set ingress.host=… for
+# homolog/prod, whose overlays fail-fast without a host).
+HELM_EXTRA     ?=
 PORT           ?= 8882
 
 .DEFAULT_GOAL := help
@@ -32,13 +42,18 @@ build: ## Build omni-api image (arm64) into OrbStack's shared store
 	# the image in the local store even under a non-default builder driver.
 	docker buildx build --platform $(PLATFORM) -f $(CURDIR)/Dockerfile -t $(IMAGE_REF) --load $(ROOT)
 
+.PHONY: build-autopg
+build-autopg: ## Build autopg:dev image from deploy/autopg.Dockerfile
+	docker buildx build --platform $(PLATFORM) -f $(CURDIR)/autopg.Dockerfile \
+	  -t autopg:dev --load $(CURDIR)
+
 .PHONY: lint
 lint: ## helm lint the umbrella chart
-	helm lint $(CHART) -f $(VALUES)
+	helm lint $(CHART) -f $(VALUES) $(HELM_EXTRA)
 
 .PHONY: template
 template: ## Render manifests locally (no cluster)
-	helm template $(RELEASE) $(CHART) -f $(VALUES)
+	helm template $(RELEASE) $(CHART) -f $(VALUES) $(HELM_EXTRA)
 
 .PHONY: deps
 deps: ## helm dependency build (vendor subcharts into charts/)
@@ -49,7 +64,7 @@ deploy: ## Install/upgrade the release to ns $(NAMESPACE)
 	helm dependency build $(CHART) || true
 	helm upgrade --install $(RELEASE) $(CHART) \
 	  --namespace $(NAMESPACE) --create-namespace \
-	  -f $(VALUES) --wait --timeout 5m
+	  -f $(VALUES) $(HELM_EXTRA) --wait --timeout 5m
 
 .PHONY: status
 status: ## Rollout status + pods
@@ -77,3 +92,100 @@ uninstall: ## Remove the release
 smoke: ## Run the image locally (expects DB-connect wait without a DB)
 	docker run --rm -e DATABASE_URL='postgresql://omni:omni@127.0.0.1:5432/omni' \
 	  -e NATS_URL='nats://127.0.0.1:4222' $(IMAGE_REF)
+
+# -----------------------------------------------------------------------------
+# deploy-smoke — prove the OSS self-host path installs end-to-end on a
+# disposable local cluster, then tear it down (cleanup runs even on failure).
+#
+# Required tools: docker (daemon running), helm, kubectl, and k3d OR kind.
+#   If neither k3d nor kind is installed, k3d is auto-installed via
+#   `brew install k3d` (Homebrew required only in that case).
+#
+# What it does:
+#   1. ensures the self-host images exist locally (omni-api:dev via `build`,
+#      autopg:dev via `build-autopg`) — the dev overlay uses pullPolicy: Never;
+#   2. creates a fresh disposable cluster under a temp KUBECONFIG (your
+#      default kubeconfig/context is never touched) and imports the images;
+#   3. `helm install --wait --timeout $(SMOKE_TIMEOUT)` with the self-host
+#      overlay (values-dev.yaml);
+#   4. asserts every pod is Ready and GET /health answers 200;
+#   5. deletes the cluster in an EXIT trap — the target exits non-zero when
+#      any step (including the install) fails, and teardown still runs.
+#
+# k3d is preferred: k3s ships servicelb, so the dev overlay's LoadBalancer
+# Services get an IP and `helm --wait` completes. kind has no LB provider, so
+# on kind the smoke overrides service.type=ClusterIP + nats.externalAccess=false
+# (everything else keeps the values-dev self-host shape).
+#
+# Variables:
+#   SMOKE_CLUSTER  cluster name                     (default omni-smoke)
+#   SMOKE_TIMEOUT  helm --wait timeout              (default 10m)
+#   SMOKE_PORT     host port for the /health check  (default 18882)
+#   SMOKE_SET      extra helm args, e.g. failure-injection overrides
+# -----------------------------------------------------------------------------
+SMOKE_CLUSTER ?= omni-smoke
+SMOKE_TIMEOUT ?= 10m
+SMOKE_PORT    ?= 18882
+SMOKE_SET     ?=
+
+.PHONY: deploy-smoke
+deploy-smoke: ## End-to-end self-host install on a disposable k3d/kind cluster
+	@set -euo pipefail; \
+	docker info >/dev/null 2>&1 || { echo "deploy-smoke: docker daemon is not running" >&2; exit 1; }; \
+	for t in helm kubectl; do \
+	  command -v $$t >/dev/null || { echo "deploy-smoke: missing required tool: $$t" >&2; exit 1; }; \
+	done; \
+	if command -v k3d >/dev/null; then provider=k3d; \
+	elif command -v kind >/dev/null; then provider=kind; \
+	else \
+	  echo "deploy-smoke: neither k3d nor kind found — installing k3d via Homebrew…"; \
+	  command -v brew >/dev/null || { echo "deploy-smoke: brew not found; install k3d or kind manually" >&2; exit 1; }; \
+	  brew install k3d; provider=k3d; \
+	fi; \
+	docker image inspect $(IMAGE_REF) >/dev/null 2>&1 || \
+	  docker buildx build --platform $(PLATFORM) -f $(CURDIR)/Dockerfile -t $(IMAGE_REF) --load $(ROOT); \
+	docker image inspect autopg:dev  >/dev/null 2>&1 || \
+	  docker buildx build --platform $(PLATFORM) -f $(CURDIR)/autopg.Dockerfile -t autopg:dev --load $(CURDIR); \
+	export KUBECONFIG="$$(mktemp "$${TMPDIR:-/tmp}/omni-smoke-kubeconfig.XXXXXX")"; \
+	cleanup() { rc=$$?; \
+	  echo "deploy-smoke: tearing down cluster $(SMOKE_CLUSTER) (exit=$$rc)…"; \
+	  if [ "$$provider" = k3d ]; then k3d cluster delete $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; \
+	  else kind delete cluster --name $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; fi; \
+	  rm -f "$$KUBECONFIG"; exit $$rc; }; \
+	trap cleanup EXIT; \
+	echo "deploy-smoke: creating disposable $$provider cluster $(SMOKE_CLUSTER)…"; \
+	extra_set=""; \
+	if [ "$$provider" = k3d ]; then \
+	  k3d cluster delete $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; \
+	  k3d cluster create $(SMOKE_CLUSTER) --k3s-arg '--disable=traefik@server:0' \
+	    --kubeconfig-update-default=false --kubeconfig-switch-context=false \
+	    --wait --timeout 180s; \
+	  k3d kubeconfig get $(SMOKE_CLUSTER) > "$$KUBECONFIG"; \
+	  echo "deploy-smoke: importing local images (omni-api is ~2.6GB — takes a minute)…"; \
+	  k3d image import $(IMAGE_REF) autopg:dev -c $(SMOKE_CLUSTER); \
+	else \
+	  kind delete cluster --name $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; \
+	  kind create cluster --name $(SMOKE_CLUSTER) --kubeconfig "$$KUBECONFIG" --wait 180s; \
+	  kind load docker-image $(IMAGE_REF) autopg:dev --name $(SMOKE_CLUSTER); \
+	  extra_set="--set service.type=ClusterIP --set nats.externalAccess=false"; \
+	fi; \
+	helm dependency build $(CHART); \
+	echo "deploy-smoke: helm install (self-host overlay, --wait $(SMOKE_TIMEOUT))…"; \
+	helm install $(RELEASE) $(CHART) \
+	  --namespace $(NAMESPACE) --create-namespace \
+	  -f $(CHART)/values-dev.yaml $$extra_set $(SMOKE_SET) \
+	  --wait --timeout $(SMOKE_TIMEOUT); \
+	echo "deploy-smoke: asserting all pods Ready…"; \
+	kubectl -n $(NAMESPACE) get pods; \
+	kubectl -n $(NAMESPACE) get pods --field-selector=status.phase!=Succeeded,status.phase!=Failed -o name \
+	  | xargs kubectl -n $(NAMESPACE) wait --for=condition=Ready --timeout=180s; \
+	echo "deploy-smoke: GET /health through port-forward…"; \
+	kubectl -n $(NAMESPACE) port-forward svc/$(RELEASE) $(SMOKE_PORT):$(PORT) >/dev/null 2>&1 & pf_pid=$$!; \
+	ok=""; \
+	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
+	  sleep 2; \
+	  if curl -fsS "localhost:$(SMOKE_PORT)/health" >/dev/null 2>&1; then ok=1; break; fi; \
+	done; \
+	kill $$pf_pid 2>/dev/null || true; \
+	[ -n "$$ok" ] || { echo "deploy-smoke: /health never returned 200" >&2; exit 1; }; \
+	echo "deploy-smoke: PASS — self-host stack (values-dev.yaml) installed end-to-end on $$provider"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,127 @@
+# Omni Deployment
+
+Omni ships as a single Helm umbrella chart — [`deploy/helm/omni`](helm/omni) —
+deployed to three *realms*. Every realm installs the **same chart**; only the
+values overlay changes. The bundled datastores (autopg Postgres, MinIO, NATS)
+turn on or off per realm, so the chart covers both fully self-contained
+self-hosting and Namastex's managed AWS clusters.
+
+## Realm matrix
+
+| Realm | Cluster | Values file | Images / channel | Database | Media | Who deploys |
+|---|---|---|---|---|---|---|
+| **dev** | Local k8s (OrbStack, k3d, kind, …) — the self-host shape | [`values-dev.yaml`](helm/omni/values-dev.yaml) | Locally built `omni-api:dev` + `autopg:dev` (`pullPolicy: Never`); tracks the `dev` branch you build from | Bundled **autopg** subchart (Postgres 18, in-cluster) | Bundled **MinIO** (in-cluster S3) | You — `make -C deploy deploy` |
+| **homolog (HML)** | Dedicated AWS cluster | [`values-homolog.yaml`](helm/omni/values-homolog.yaml) | `ghcr.io/automagik-dev/omni-api` — `tag: ""` → `v<Chart.appVersion>`; the `:homolog` tag tracks the `homolog` branch | External **RDS** via pre-created Secret `omni-db` (`DATABASE_URL`) | Real **AWS S3** (`omni-media-hml`) via Secret `omni-media-s3` | Namastex |
+| **prod** | Dedicated AWS cluster (separate from HML) | [`values-prod.yaml`](helm/omni/values-prod.yaml) | `ghcr.io/automagik-dev/omni-api` — `tag: ""` → `v<Chart.appVersion>` (v-tags published on merge to `main`; `:main` also available) | External **RDS** via Secret `omni-db` (`DATABASE_URL`) | Real **AWS S3** (`omni-media`) via Secret `omni-media-s3` | Namastex |
+
+Notes that apply across the matrix:
+
+- **Promotion flow**: `dev` (local realm) → `homolog` branch (= the HML image
+  channel) → `main` (= prod releases), via rolling PRs that a human merges.
+- **homolog/prod require `--set ingress.host=<fqdn>`** — the overlays leave the
+  host empty on purpose and the chart fail-fasts without it:
+
+  ```bash
+  make -C deploy deploy REALM=homolog HELM_EXTRA='--set ingress.host=omni-hml.example.com'
+  make -C deploy deploy REALM=prod    HELM_EXTRA='--set ingress.host=omni.example.com'
+  ```
+
+- **homolog/prod pre-created Secrets** (same namespace as the release; see the
+  header comments in each values file for exact commands):
+  - `omni-db` — key `DATABASE_URL`, the full RDS connection URL.
+  - `omni-media-s3` — keys `OMNI_MEDIA_S3_ACCESS_KEY` + `OMNI_MEDIA_S3_SECRET_KEY`.
+- **One replica per realm** — a WhatsApp credential maps to a single live
+  Baileys socket; see the "replicas + scaling" notes in
+  [`values.yaml`](helm/omni/values.yaml) before scaling out.
+
+## Self-hosting (the supported OSS path)
+
+**The bundled autopg + MinIO + NATS stack — the `values-dev.yaml` shape — IS
+the supported self-host path.** You do not need AWS, RDS, or an S3 account to
+run Omni: `autopg.enabled: true` gives you an in-cluster Postgres 18 with
+scoped-role provisioning, `minio.enabled: true` gives you an in-cluster S3 for
+media, and NATS/JetStream is bundled as first-party templates. The AWS
+RDS + real-S3 shape (homolog/prod overlays) is **Namastex's cloud path**, not a
+requirement — self-hosters only graduate to external datastores if they want
+managed durability.
+
+Quickstart on any local/self-managed cluster:
+
+```bash
+# 1. Build the images (or use the public GHCR images — see below)
+make -C deploy build          # omni-api:dev
+make -C deploy build-autopg   # autopg:dev
+
+# 2. Install (defaults: REALM=dev → values-dev.yaml, namespace omni)
+make -C deploy deploy
+
+# 3. Check it
+make -C deploy status
+make -C deploy health
+```
+
+To skip local builds entirely, point the dev-shape install at the public
+registry images instead:
+
+```bash
+helm upgrade --install omni deploy/helm/omni -n omni --create-namespace \
+  -f deploy/helm/omni/values-dev.yaml \
+  --set image.repository=ghcr.io/automagik-dev/omni-api \
+  --set image.tag=v<version> --set image.pullPolicy=IfNotPresent \
+  --set autopg.image.repository=ghcr.io/automagik-dev/autopg \
+  --set autopg.image.tag=v3.0.7 --set autopg.image.pullPolicy=IfNotPresent
+```
+
+Adjust `ingress.host`, the dev-only passwords, and `service.type` in a copy of
+`values-dev.yaml` for anything beyond a throwaway install.
+
+### Public images — no pull secret
+
+`ghcr.io/automagik-dev/omni-api` and `ghcr.io/automagik-dev/autopg` are
+**public**. Pulling them needs no registry credentials of any kind:
+`imagePullSecrets` stays `[]` in every overlay, and nothing in this repo will
+ever ask you to configure registry auth for these images.
+
+Provenance is verifiable — the publish workflow attaches SLSA provenance
+attestations:
+
+```bash
+gh attestation verify oci://ghcr.io/automagik-dev/omni-api:v<version> -R automagik-dev/omni
+```
+
+### Proving the self-host path end-to-end
+
+`deploy-smoke` spins up a fresh disposable k3d (or kind) cluster, imports the
+locally built images, runs the full `values-dev.yaml` install with
+`helm install --wait`, asserts every pod is Ready and `/health` answers, then
+deletes the cluster — teardown runs even when the install fails, and the
+target exits non-zero on failure:
+
+```bash
+make -C deploy deploy-smoke
+```
+
+Requires Docker running, `helm`, `kubectl`, and `k3d` or `kind` (auto-installs
+k3d via Homebrew if neither is present). See the target header in
+[`Makefile`](Makefile) for tunables (`SMOKE_TIMEOUT`, `SMOKE_SET`, …).
+
+## Makefile reference
+
+Run everything as `make -C deploy <target>` from the repo root.
+
+| Target | What it does |
+|---|---|
+| `build` | Build `omni-api:dev` (BuildKit, repo-root context) |
+| `build-autopg` | Build `autopg:dev` from `autopg.Dockerfile` |
+| `deps` | `helm dependency build` (vendors the autopg subchart) |
+| `lint` / `template` | Lint / render the chart with the selected realm overlay |
+| `deploy` | `helm upgrade --install --wait` to namespace `$(NAMESPACE)` |
+| `status` / `logs` / `health` | Rollout status, API logs, port-forward + `GET /health` |
+| `smoke` | Run the image alone in Docker (no cluster) |
+| `deploy-smoke` | Full disposable-cluster install proof (see above) |
+| `uninstall` | Remove the release |
+
+Key variables: `REALM=dev|homolog|prod` picks the values overlay
+(`VALUES=…` still overrides it directly); `HELM_EXTRA='--set …'` appends
+arbitrary helm args (required for homolog/prod ingress hosts);
+`NAMESPACE`/`RELEASE` default to `omni`.

--- a/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
+++ b/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
@@ -29,6 +29,25 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
+        # Hand the socket-dir emptyDir ("run" volume) to the pod user
+        # (verified on k3d/k3s, 2026-07-05): stock kubelet's fsGroup pass only
+        # sets the GROUP on a fresh emptyDir (root:fsGroup + g+rwx/setgid) —
+        # the OWNER stays root, and autopg's boot-time chmod of its
+        # --socket-dir then fails with a fatal EPERM. OrbStack's kubelet also
+        # chowns the owner, which is why this never bit local verification.
+        # chown requires root, so this one init runs as root; every other
+        # container in the pod stays non-root.
+        - name: fix-run-dir
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "chown 1000:1000 /run-dir && chmod 700 /run-dir"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: run
+              mountPath: /run-dir
         # Repair PGDATA on every pod start (verified in the wild on a node
         # restart, 2026-07-03): kubelet's fsGroup pass re-applies setgid/g+w
         # to the volume on each mount, which postgres refuses (pgdata must be


### PR DESCRIPTION
Group 4 (G-DOCS-SMOKE) of wish `omni-deploy-realms`: document the realm matrix and prove the OSS self-host path installs end-to-end on a disposable local cluster.

## What

- **`deploy/README.md`** (new): realm matrix (dev / homolog / prod — cluster, values overlay, image channel, DB, media, deployer), promotion-flow notes, a self-hosting section stating the bundled autopg+MinIO+NATS stack (`values-dev.yaml` shape) IS the supported OSS self-host path while AWS RDS + real S3 is the Namastex cloud path, and a public-images note: `ghcr.io/automagik-dev/omni-api` + `ghcr.io/automagik-dev/autopg` are public, `imagePullSecrets` stays `[]`, provenance via `gh attestation verify oci://… -R automagik-dev/omni`.
- **`deploy/Makefile`**:
  - `REALM=dev|homolog|prod` selects the values overlay for `lint`/`template`/`deploy` (default `dev`; explicit `VALUES=` still wins — backward compatible). `HELM_EXTRA` passthrough for `--set ingress.host=…` (homolog/prod fail-fast without it).
  - `build-autopg` target (rebuilds `autopg:dev` from `deploy/autopg.Dockerfile`).
  - **`deploy-smoke`**: fresh disposable k3d cluster (kind fallback; auto-installs k3d via brew if neither) under a temp KUBECONFIG (never touches your default context), `k3d image import` of the locally-built `omni-api:dev` + `autopg:dev`, `helm install --wait --timeout 10m` with `values-dev.yaml`, asserts every non-terminal pod Ready + `GET /health` 200 through a port-forward, then deletes the cluster in an EXIT trap — teardown runs on failure too, and the target exits non-zero when the install fails.

## Deviation (flagged): one surgical fix inside `deploy/helm/**`

The smoke immediately caught a real self-host-breaking bug: on **stock kubelets (k3s/kind — i.e. every non-OrbStack cluster)** the autopg pod crashloops at boot:

```
EPERM: operation not permitted, chmod '/var/run/autopg'
```

Root cause: kubelet's fsGroup pass on a fresh emptyDir only sets the **group** (`root:1000`, `g+rwx+setgid`) — the **owner stays root** — and autopg's boot-time `chmod` of its `--socket-dir` is fatal. OrbStack's kubelet also chowns the owner (`drwx------ 1000:1000` verified on the healthy OrbStack pod), which is why all prior OrbStack-based verification passed. Reproduced minimally on k3d with a busybox pod using the chart's exact pod securityContext (`chmod: /w: Operation not permitted`).

No values-level knob can fix owner semantics (socket dir + args are hardcoded in the chart, autopg is a compiled binary), so this PR adds a 12-line `fix-run-dir` init container to the vendored autopg subchart — chowns the `run` emptyDir to the pod user, mirroring the chart's existing documented `fix-pgdata` pattern. Verified by hot-patching the live failing install: autopg was Ready seconds later and the whole release converged. Homolog/prod are unaffected (`autopg.enabled: false` there).

## Evidence

Adversarial run — unpullable image override (`SMOKE_TIMEOUT=120s SMOKE_SET='--set image.repository=ghcr.io/automagik-dev/omni-api-does-not-exist …'`) exits non-zero and still tears down (153s, zero k3d containers left):

```
deploy-smoke: helm install (self-host overlay, --wait 120s)…
Error: INSTALLATION FAILED: resource Deployment/omni/omni not ready. status: InProgress, message: Available: 0/1
context deadline exceeded
deploy-smoke: tearing down cluster omni-smoke (exit=1)…
make: *** [deploy-smoke] Error 1
```

PASS run (wish validation block, exits 0) tail:

```
STATIC_GREPS_OK
...
deploy-smoke: asserting all pods Ready…
NAME                            READY   STATUS      RESTARTS   AGE
omni-67ff65f56c-sknsx           1/1     Running     0          53s
omni-autopg-0                   1/1     Running     0          53s
omni-autopg-provision-1-mrkhk   0/1     Completed   0          53s
omni-minio-0                    1/1     Running     0          53s
omni-nats-0                     1/1     Running     0          53s
pod/omni-67ff65f56c-sknsx condition met
pod/omni-autopg-0 condition met
pod/omni-minio-0 condition met
pod/omni-nats-0 condition met
deploy-smoke: GET /health through port-forward…
deploy-smoke: PASS — self-host stack (values-dev.yaml) installed end-to-end on k3d
deploy-smoke: tearing down cluster omni-smoke (exit=0)…
VALIDATION_RC=0 SMOKE_DURATION=95s
```

Smoke duration: **95s** (fresh k3d cluster + image import + full install + teardown).
