### PR TITLE
ci(publish): attest image build provenance for gh attestation verify

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -55,6 +55,12 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  # GitHub-native build provenance for the published images — this is what
+  # makes the documented `gh attestation verify oci://…` command
+  # (deploy/README.md) actually pass. `id-token` signs via OIDC/Sigstore;
+  # `attestations` stores the provenance in the repo's Attestations API.
+  id-token: write
+  attestations: write
 
 jobs:
   build-push:
@@ -95,6 +101,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
@@ -112,6 +119,16 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+
+      # GitHub-native provenance (Attestations API + registry referrer), so
+      # `gh attestation verify oci://…` works as deploy/README.md documents.
+      # BuildKit's inline `provenance: true` above is NOT visible to `gh`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   # Packages the automagik-dev/autopg release tarball as a container image
   # (that repo publishes no image of its own). The Helm chart's prod overlay
@@ -154,6 +171,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: deploy
@@ -174,3 +192,11 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ env.AUTOPG_VERSION }}
+
+      # Same GitHub-native provenance as omni-api above (see that comment).
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,11 +83,14 @@ Adjust `ingress.host`, the dev-only passwords, and `service.type` in a copy of
 ever ask you to configure registry auth for these images.
 
 Provenance is verifiable — the publish workflow attaches SLSA provenance
-attestations:
+attestations (GitHub-native, via `actions/attest-build-provenance`):
 
 ```bash
 gh attestation verify oci://ghcr.io/automagik-dev/omni-api:v<version> -R automagik-dev/omni
 ```
+
+Only images published after attestation support landed (July 2026) carry
+these; older tags report "no attestations found".
 
 ### Proving the self-host path end-to-end
 


### PR DESCRIPTION
## What

Resolves a MEDIUM finding from the post-merge review of #789: `deploy/README.md` documents

```bash
gh attestation verify oci://ghcr.io/automagik-dev/omni-api:v<version> -R automagik-dev/omni
```

but `image-publish.yml` only set BuildKit inline provenance (`provenance: true` on docker/build-push-action), which is embedded in the OCI image and never populates GitHub's Attestations API. `sign-attest.yml` attests release **tarballs** only. The documented command therefore returned "no attestations found" for every image tag.

## Changes (additive only — workflow structure from #774 untouched)

- `.github/workflows/image-publish.yml`
  - top-level permissions: add `id-token: write` + `attestations: write` (kept `contents: read`, `packages: write`)
  - both build-push steps (`build-push` and `build-push-autopg`) get `id: build` to expose `outputs.digest`
  - after each build: `actions/attest-build-provenance` with `subject-name: ${{ env.IMAGE }}` (`ghcr.io/<owner>/omni-api` / `ghcr.io/<owner>/autopg`), `subject-digest: ${{ steps.build.outputs.digest }}`, `push-to-registry: true` (GHCR login already done in-job)
- `deploy/README.md` — command shape was already the canonical form, left as-is; clarified the attestations are GitHub-native and **added a transitional note**: only images published after this change carry attestations; older tags still report "no attestations found".

## Evidence

- SHA pin: `gh api repos/actions/attest-build-provenance/git/ref/tags/v4.1.1` → `{"type":"commit","sha":"0f67c3f4856b2e3261c31976d6725780e5e4c373"}` — matches the pinned SHA and `# v4.1.1` comment (consistent with LOW-6 pinning convention).
- `actionlint .github/workflows/image-publish.yml` → clean.
- Grep-confirmed: both jobs expose `outputs.digest` via `id: build`; both attest steps reference the right subject-name/digest; `id-token`/`attestations` write appear exactly once at the effective (workflow) scope.
- Pre-push suite: 4196 pass / 0 fail.

## Honest caveat

The attestation only materializes on the **next homolog/main publish run**. Until then `gh attestation verify` still fails for all existing tags — the README transitional note covers this.