### PR TITLE
chore: promote dev → homolog (deploy realms: overlays, appVersion auto-sync)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "author": {
         "name": "Automagik"
       },

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -36,6 +36,10 @@ on:
       - 'apps/**'
       - 'deploy/Dockerfile'
       - 'deploy/autopg.Dockerfile'
+      # Chart/values-only promotions still advance appVersion (version.yml
+      # stamps deploy/helm/omni/Chart.yaml); without this filter the stamped
+      # tag would never get an image built (stranded-tag case).
+      - 'deploy/helm/**'
       - 'bun.lock'
       - '.github/workflows/image-publish.yml'
   workflow_dispatch:

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -55,6 +55,12 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  # GitHub-native build provenance for the published images — this is what
+  # makes the documented `gh attestation verify oci://…` command
+  # (deploy/README.md) actually pass. `id-token` signs via OIDC/Sigstore;
+  # `attestations` stores the provenance in the repo's Attestations API.
+  id-token: write
+  attestations: write
 
 jobs:
   build-push:
@@ -95,6 +101,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
@@ -112,6 +119,16 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+
+      # GitHub-native provenance (Attestations API + registry referrer), so
+      # `gh attestation verify oci://…` works as deploy/README.md documents.
+      # BuildKit's inline `provenance: true` above is NOT visible to `gh`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   # Packages the automagik-dev/autopg release tarball as a container image
   # (that repo publishes no image of its own). The Helm chart's prod overlay
@@ -154,6 +171,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: deploy
@@ -174,3 +192,11 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ env.AUTOPG_VERSION }}
+
+      # Same GitHub-native provenance as omni-api above (see that comment).
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -41,6 +41,14 @@ permissions:
 
 concurrency:
   # Serialize per target branch so dev and homolog bumps cannot overwrite each other.
+  # KNOWN GAP (documented, not fixed here): the group key includes event_name,
+  # so a dev→homolog promotion PR can fire this job twice for one merge —
+  # once via pull_request-closed and again via workflow_run (the merge commit
+  # "Merge pull request … /dev" passes the guard below) — in SEPARATE groups
+  # that run concurrently. Worst case is a duplicate bump/publish, not a loop:
+  # the bump commit itself never re-triggers (it fails the startsWith
+  # 'Merge pull request' guard). A real dedupe needs a gate job or step-level
+  # skip plumbing; deferred to keep this workflow's shape stable.
   group: version-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.base.ref || github.ref_name }}
   cancel-in-progress: false
 
@@ -146,7 +154,7 @@ jobs:
         env:
           OMNI_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
 
-      - name: Sync package.json versions
+      - name: Sync versions (package.json + chart appVersion)
         run: bun scripts/sync-versions.ts ${{ steps.version.outputs.version }}
 
       - name: Format versioned JSON (Biome)
@@ -169,11 +177,21 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          git add -A '*.json' bun.lock
+          # Chart.yaml is listed explicitly: the '*.json' pathspec would
+          # silently drop the appVersion stamp sync-versions.ts just wrote,
+          # and verify-versions.ts (CI Quality Gate) fails on the drift.
+          git add -A '*.json' bun.lock deploy/helm/omni/Chart.yaml
           if git diff --cached --quiet; then
-            echo "No package.json or bun.lock changes to commit"
+            echo "No version file changes to commit"
           else
-            git commit -m "chore(version): bump to ${VERSION} [skip ci]"
+            # No [skip ci] (D8): homolog bumps MUST trigger image-publish so
+            # the stamped appVersion gets a matching image built from the
+            # bump commit. Blanket removal is safe on the dev path too — no
+            # workflow push-triggers on dev for these paths (CI/image-publish
+            # push branches are [main, homolog] only). Loop-safe: this
+            # commit's message fails version.yml's own startsWith
+            # 'Merge pull request' workflow_run guard.
+            git commit -m "chore(version): bump to ${VERSION}"
           fi
 
           git tag "v${VERSION}"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -124,7 +124,26 @@ jobs:
           # runs bump homolog because HML images are built from homolog.
           ref: ${{ steps.context.outputs.checkout_ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Machine-account PAT for the bump push (checkout persists this
+          # credential, so the branch push in "Commit and tag" inherits it).
+          # Why: bump commits no longer carry the skip-ci token (D8), so each
+          # bump push to dev re-fires any OPEN rolling PR's pull_request runs;
+          # when the push actor is github-actions[bot], GitHub holds those
+          # runs at `action_required`, wedging the PR until a human closes/
+          # reopens it. Pushing as a machine account avoids the bot-actor hold.
+          # Fallback: while VERSION_BUMP_PAT is unset/empty this expression
+          # resolves to github.token — exactly the old behavior — so this is
+          # safe to merge before the secret exists.
+          # Secret spec: fine-grained PAT on a machine account (e.g.
+          # automagik-bot) scoped to automagik-dev/omni, Contents: read+write.
+          # NOTE: unlike GITHUB_TOKEN, PAT pushes DO fire on:push workflows.
+          # Branch push: desired on homolog (image-publish builds the bump
+          # commit's image, per D8); CI on the homolog bump is a harmless
+          # extra run — Version's workflow_run guard keys on the head-commit
+          # MESSAGE, not the actor, and bump messages fail the startsWith
+          # 'Merge pull request' check, so no re-fire loop. The v* TAG push
+          # must NOT use the PAT: see "Commit and tag" below.
+          token: ${{ secrets.VERSION_BUMP_PAT || github.token }}
 
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2
         with:
@@ -174,6 +193,10 @@ jobs:
           bun install
 
       - name: Commit and tag
+        env:
+          # For the tag push below ONLY — the branch push rides the
+          # checkout-persisted credential (VERSION_BUMP_PAT when configured).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -195,9 +218,28 @@ jobs:
           fi
 
           git tag "v${VERSION}"
-          # Push the current commit to the target branch explicitly so the
-          # version bump commit and its tag are both reachable from the branch.
-          git push --atomic origin HEAD:refs/heads/${{ steps.context.outputs.push_ref }} "refs/tags/v${VERSION}"
+
+          # Split push (was --atomic): the two refs need DIFFERENT credentials.
+          # Branch push uses the checkout-persisted credential (machine PAT
+          # when VERSION_BUMP_PAT is set) so the push actor is not
+          # github-actions[bot] — see the checkout step for why.
+          git push origin HEAD:refs/heads/${{ steps.context.outputs.push_ref }}
+
+          # Tag push stays on GITHUB_TOKEN DELIBERATELY: GITHUB_TOKEN pushes
+          # never fire on:push workflows (GitHub anti-recursion), so
+          # release.yml runs only via the explicit dispatch step below, which
+          # passes the correct channel. A PAT-pushed v* tag would ALSO fire
+          # release.yml's push:tags path, where channel falls through to
+          # 'stable' — duplicating the release pipeline AND promoting a
+          # dev/homolog cut to the stable channel. The -c flag blanks the
+          # checkout-persisted auth header for this one invocation so the
+          # URL-embedded GITHUB_TOKEN wins. Losing --atomic is safe with
+          # branch-first ordering: a tag-push failure self-heals on re-run
+          # (same derived version → no version-file diff → re-tag HEAD →
+          # no-op branch push → tag push retries).
+          git -c http.https://github.com/.extraheader= \
+            push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/v${VERSION}"
 
       # Dispatch the signed-tarball release pipeline (build → sign-attest →
       # publish) via release.yml's workflow_dispatch entry. GITHUB_TOKEN-

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.6",
+      "version": "2.260705.7",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.8",
+      "version": "2.260705.9",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.3",
+      "version": "2.260705.4",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.7",
+      "version": "2.260705.8",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.10",
+      "version": "2.260705.11",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.4",
+      "version": "2.260705.6",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260705.9",
+      "version": "2.260705.10",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,8 +1,14 @@
 # =============================================================================
-# omni deploy — OrbStack k8s helpers
+# omni deploy — k8s helpers (local OrbStack/k3d dev + realm deploys)
 # =============================================================================
 # Run from repo root: `make -C deploy <target>`  (or `cd deploy && make ...`).
 # Docker build context is the repo root (one level up).
+#
+# REALM selects the values overlay for lint/template/deploy (see README.md):
+#   make -C deploy deploy                REALM=dev (default, local self-host)
+#   make -C deploy template REALM=homolog HELM_EXTRA='--set ingress.host=…'
+#   make -C deploy deploy   REALM=prod    HELM_EXTRA='--set ingress.host=…'
+# Explicit VALUES=… still wins over REALM (backward compatible).
 # =============================================================================
 
 SHELL          := /bin/bash
@@ -14,7 +20,11 @@ TAG            ?= dev
 IMAGE_REF      := $(IMAGE):$(TAG)
 NAMESPACE      ?= omni
 RELEASE        ?= omni
-VALUES         ?= $(CHART)/values-dev.yaml
+REALM          ?= dev
+VALUES         ?= $(CHART)/values-$(REALM).yaml
+# Extra helm args for template/deploy (e.g. --set ingress.host=… for
+# homolog/prod, whose overlays fail-fast without a host).
+HELM_EXTRA     ?=
 PORT           ?= 8882
 
 .DEFAULT_GOAL := help
@@ -32,13 +42,18 @@ build: ## Build omni-api image (arm64) into OrbStack's shared store
 	# the image in the local store even under a non-default builder driver.
 	docker buildx build --platform $(PLATFORM) -f $(CURDIR)/Dockerfile -t $(IMAGE_REF) --load $(ROOT)
 
+.PHONY: build-autopg
+build-autopg: ## Build autopg:dev image from deploy/autopg.Dockerfile
+	docker buildx build --platform $(PLATFORM) -f $(CURDIR)/autopg.Dockerfile \
+	  -t autopg:dev --load $(CURDIR)
+
 .PHONY: lint
 lint: ## helm lint the umbrella chart
-	helm lint $(CHART) -f $(VALUES)
+	helm lint $(CHART) -f $(VALUES) $(HELM_EXTRA)
 
 .PHONY: template
 template: ## Render manifests locally (no cluster)
-	helm template $(RELEASE) $(CHART) -f $(VALUES)
+	helm template $(RELEASE) $(CHART) -f $(VALUES) $(HELM_EXTRA)
 
 .PHONY: deps
 deps: ## helm dependency build (vendor subcharts into charts/)
@@ -49,7 +64,7 @@ deploy: ## Install/upgrade the release to ns $(NAMESPACE)
 	helm dependency build $(CHART) || true
 	helm upgrade --install $(RELEASE) $(CHART) \
 	  --namespace $(NAMESPACE) --create-namespace \
-	  -f $(VALUES) --wait --timeout 5m
+	  -f $(VALUES) $(HELM_EXTRA) --wait --timeout 5m
 
 .PHONY: status
 status: ## Rollout status + pods
@@ -77,3 +92,100 @@ uninstall: ## Remove the release
 smoke: ## Run the image locally (expects DB-connect wait without a DB)
 	docker run --rm -e DATABASE_URL='postgresql://omni:omni@127.0.0.1:5432/omni' \
 	  -e NATS_URL='nats://127.0.0.1:4222' $(IMAGE_REF)
+
+# -----------------------------------------------------------------------------
+# deploy-smoke — prove the OSS self-host path installs end-to-end on a
+# disposable local cluster, then tear it down (cleanup runs even on failure).
+#
+# Required tools: docker (daemon running), helm, kubectl, and k3d OR kind.
+#   If neither k3d nor kind is installed, k3d is auto-installed via
+#   `brew install k3d` (Homebrew required only in that case).
+#
+# What it does:
+#   1. ensures the self-host images exist locally (omni-api:dev via `build`,
+#      autopg:dev via `build-autopg`) — the dev overlay uses pullPolicy: Never;
+#   2. creates a fresh disposable cluster under a temp KUBECONFIG (your
+#      default kubeconfig/context is never touched) and imports the images;
+#   3. `helm install --wait --timeout $(SMOKE_TIMEOUT)` with the self-host
+#      overlay (values-dev.yaml);
+#   4. asserts every pod is Ready and GET /health answers 200;
+#   5. deletes the cluster in an EXIT trap — the target exits non-zero when
+#      any step (including the install) fails, and teardown still runs.
+#
+# k3d is preferred: k3s ships servicelb, so the dev overlay's LoadBalancer
+# Services get an IP and `helm --wait` completes. kind has no LB provider, so
+# on kind the smoke overrides service.type=ClusterIP + nats.externalAccess=false
+# (everything else keeps the values-dev self-host shape).
+#
+# Variables:
+#   SMOKE_CLUSTER  cluster name                     (default omni-smoke)
+#   SMOKE_TIMEOUT  helm --wait timeout              (default 10m)
+#   SMOKE_PORT     host port for the /health check  (default 18882)
+#   SMOKE_SET      extra helm args, e.g. failure-injection overrides
+# -----------------------------------------------------------------------------
+SMOKE_CLUSTER ?= omni-smoke
+SMOKE_TIMEOUT ?= 10m
+SMOKE_PORT    ?= 18882
+SMOKE_SET     ?=
+
+.PHONY: deploy-smoke
+deploy-smoke: ## End-to-end self-host install on a disposable k3d/kind cluster
+	@set -euo pipefail; \
+	docker info >/dev/null 2>&1 || { echo "deploy-smoke: docker daemon is not running" >&2; exit 1; }; \
+	for t in helm kubectl; do \
+	  command -v $$t >/dev/null || { echo "deploy-smoke: missing required tool: $$t" >&2; exit 1; }; \
+	done; \
+	if command -v k3d >/dev/null; then provider=k3d; \
+	elif command -v kind >/dev/null; then provider=kind; \
+	else \
+	  echo "deploy-smoke: neither k3d nor kind found — installing k3d via Homebrew…"; \
+	  command -v brew >/dev/null || { echo "deploy-smoke: brew not found; install k3d or kind manually" >&2; exit 1; }; \
+	  brew install k3d; provider=k3d; \
+	fi; \
+	docker image inspect $(IMAGE_REF) >/dev/null 2>&1 || \
+	  docker buildx build --platform $(PLATFORM) -f $(CURDIR)/Dockerfile -t $(IMAGE_REF) --load $(ROOT); \
+	docker image inspect autopg:dev  >/dev/null 2>&1 || \
+	  docker buildx build --platform $(PLATFORM) -f $(CURDIR)/autopg.Dockerfile -t autopg:dev --load $(CURDIR); \
+	export KUBECONFIG="$$(mktemp "$${TMPDIR:-/tmp}/omni-smoke-kubeconfig.XXXXXX")"; \
+	cleanup() { rc=$$?; \
+	  echo "deploy-smoke: tearing down cluster $(SMOKE_CLUSTER) (exit=$$rc)…"; \
+	  if [ "$$provider" = k3d ]; then k3d cluster delete $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; \
+	  else kind delete cluster --name $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; fi; \
+	  rm -f "$$KUBECONFIG"; exit $$rc; }; \
+	trap cleanup EXIT; \
+	echo "deploy-smoke: creating disposable $$provider cluster $(SMOKE_CLUSTER)…"; \
+	extra_set=""; \
+	if [ "$$provider" = k3d ]; then \
+	  k3d cluster delete $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; \
+	  k3d cluster create $(SMOKE_CLUSTER) --k3s-arg '--disable=traefik@server:0' \
+	    --kubeconfig-update-default=false --kubeconfig-switch-context=false \
+	    --wait --timeout 180s; \
+	  k3d kubeconfig get $(SMOKE_CLUSTER) > "$$KUBECONFIG"; \
+	  echo "deploy-smoke: importing local images (omni-api is ~2.6GB — takes a minute)…"; \
+	  k3d image import $(IMAGE_REF) autopg:dev -c $(SMOKE_CLUSTER); \
+	else \
+	  kind delete cluster --name $(SMOKE_CLUSTER) >/dev/null 2>&1 || true; \
+	  kind create cluster --name $(SMOKE_CLUSTER) --kubeconfig "$$KUBECONFIG" --wait 180s; \
+	  kind load docker-image $(IMAGE_REF) autopg:dev --name $(SMOKE_CLUSTER); \
+	  extra_set="--set service.type=ClusterIP --set nats.externalAccess=false"; \
+	fi; \
+	helm dependency build $(CHART); \
+	echo "deploy-smoke: helm install (self-host overlay, --wait $(SMOKE_TIMEOUT))…"; \
+	helm install $(RELEASE) $(CHART) \
+	  --namespace $(NAMESPACE) --create-namespace \
+	  -f $(CHART)/values-dev.yaml $$extra_set $(SMOKE_SET) \
+	  --wait --timeout $(SMOKE_TIMEOUT); \
+	echo "deploy-smoke: asserting all pods Ready…"; \
+	kubectl -n $(NAMESPACE) get pods; \
+	kubectl -n $(NAMESPACE) get pods --field-selector=status.phase!=Succeeded,status.phase!=Failed -o name \
+	  | xargs kubectl -n $(NAMESPACE) wait --for=condition=Ready --timeout=180s; \
+	echo "deploy-smoke: GET /health through port-forward…"; \
+	kubectl -n $(NAMESPACE) port-forward svc/$(RELEASE) $(SMOKE_PORT):$(PORT) >/dev/null 2>&1 & pf_pid=$$!; \
+	ok=""; \
+	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
+	  sleep 2; \
+	  if curl -fsS "localhost:$(SMOKE_PORT)/health" >/dev/null 2>&1; then ok=1; break; fi; \
+	done; \
+	kill $$pf_pid 2>/dev/null || true; \
+	[ -n "$$ok" ] || { echo "deploy-smoke: /health never returned 200" >&2; exit 1; }; \
+	echo "deploy-smoke: PASS — self-host stack (values-dev.yaml) installed end-to-end on $$provider"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,11 +83,14 @@ Adjust `ingress.host`, the dev-only passwords, and `service.type` in a copy of
 ever ask you to configure registry auth for these images.
 
 Provenance is verifiable — the publish workflow attaches SLSA provenance
-attestations:
+attestations (GitHub-native, via `actions/attest-build-provenance`):
 
 ```bash
 gh attestation verify oci://ghcr.io/automagik-dev/omni-api:v<version> -R automagik-dev/omni
 ```
+
+Only images published after attestation support landed (July 2026) carry
+these; older tags report "no attestations found".
 
 ### Proving the self-host path end-to-end
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,127 @@
+# Omni Deployment
+
+Omni ships as a single Helm umbrella chart — [`deploy/helm/omni`](helm/omni) —
+deployed to three *realms*. Every realm installs the **same chart**; only the
+values overlay changes. The bundled datastores (autopg Postgres, MinIO, NATS)
+turn on or off per realm, so the chart covers both fully self-contained
+self-hosting and Namastex's managed AWS clusters.
+
+## Realm matrix
+
+| Realm | Cluster | Values file | Images / channel | Database | Media | Who deploys |
+|---|---|---|---|---|---|---|
+| **dev** | Local k8s (OrbStack, k3d, kind, …) — the self-host shape | [`values-dev.yaml`](helm/omni/values-dev.yaml) | Locally built `omni-api:dev` + `autopg:dev` (`pullPolicy: Never`); tracks the `dev` branch you build from | Bundled **autopg** subchart (Postgres 18, in-cluster) | Bundled **MinIO** (in-cluster S3) | You — `make -C deploy deploy` |
+| **homolog (HML)** | Dedicated AWS cluster | [`values-homolog.yaml`](helm/omni/values-homolog.yaml) | `ghcr.io/automagik-dev/omni-api` — `tag: ""` → `v<Chart.appVersion>`; the `:homolog` tag tracks the `homolog` branch | External **RDS** via pre-created Secret `omni-db` (`DATABASE_URL`) | Real **AWS S3** (`omni-media-hml`) via Secret `omni-media-s3` | Namastex |
+| **prod** | Dedicated AWS cluster (separate from HML) | [`values-prod.yaml`](helm/omni/values-prod.yaml) | `ghcr.io/automagik-dev/omni-api` — `tag: ""` → `v<Chart.appVersion>` (v-tags published on merge to `main`; `:main` also available) | External **RDS** via Secret `omni-db` (`DATABASE_URL`) | Real **AWS S3** (`omni-media`) via Secret `omni-media-s3` | Namastex |
+
+Notes that apply across the matrix:
+
+- **Promotion flow**: `dev` (local realm) → `homolog` branch (= the HML image
+  channel) → `main` (= prod releases), via rolling PRs that a human merges.
+- **homolog/prod require `--set ingress.host=<fqdn>`** — the overlays leave the
+  host empty on purpose and the chart fail-fasts without it:
+
+  ```bash
+  make -C deploy deploy REALM=homolog HELM_EXTRA='--set ingress.host=omni-hml.example.com'
+  make -C deploy deploy REALM=prod    HELM_EXTRA='--set ingress.host=omni.example.com'
+  ```
+
+- **homolog/prod pre-created Secrets** (same namespace as the release; see the
+  header comments in each values file for exact commands):
+  - `omni-db` — key `DATABASE_URL`, the full RDS connection URL.
+  - `omni-media-s3` — keys `OMNI_MEDIA_S3_ACCESS_KEY` + `OMNI_MEDIA_S3_SECRET_KEY`.
+- **One replica per realm** — a WhatsApp credential maps to a single live
+  Baileys socket; see the "replicas + scaling" notes in
+  [`values.yaml`](helm/omni/values.yaml) before scaling out.
+
+## Self-hosting (the supported OSS path)
+
+**The bundled autopg + MinIO + NATS stack — the `values-dev.yaml` shape — IS
+the supported self-host path.** You do not need AWS, RDS, or an S3 account to
+run Omni: `autopg.enabled: true` gives you an in-cluster Postgres 18 with
+scoped-role provisioning, `minio.enabled: true` gives you an in-cluster S3 for
+media, and NATS/JetStream is bundled as first-party templates. The AWS
+RDS + real-S3 shape (homolog/prod overlays) is **Namastex's cloud path**, not a
+requirement — self-hosters only graduate to external datastores if they want
+managed durability.
+
+Quickstart on any local/self-managed cluster:
+
+```bash
+# 1. Build the images (or use the public GHCR images — see below)
+make -C deploy build          # omni-api:dev
+make -C deploy build-autopg   # autopg:dev
+
+# 2. Install (defaults: REALM=dev → values-dev.yaml, namespace omni)
+make -C deploy deploy
+
+# 3. Check it
+make -C deploy status
+make -C deploy health
+```
+
+To skip local builds entirely, point the dev-shape install at the public
+registry images instead:
+
+```bash
+helm upgrade --install omni deploy/helm/omni -n omni --create-namespace \
+  -f deploy/helm/omni/values-dev.yaml \
+  --set image.repository=ghcr.io/automagik-dev/omni-api \
+  --set image.tag=v<version> --set image.pullPolicy=IfNotPresent \
+  --set autopg.image.repository=ghcr.io/automagik-dev/autopg \
+  --set autopg.image.tag=v3.0.7 --set autopg.image.pullPolicy=IfNotPresent
+```
+
+Adjust `ingress.host`, the dev-only passwords, and `service.type` in a copy of
+`values-dev.yaml` for anything beyond a throwaway install.
+
+### Public images — no pull secret
+
+`ghcr.io/automagik-dev/omni-api` and `ghcr.io/automagik-dev/autopg` are
+**public**. Pulling them needs no registry credentials of any kind:
+`imagePullSecrets` stays `[]` in every overlay, and nothing in this repo will
+ever ask you to configure registry auth for these images.
+
+Provenance is verifiable — the publish workflow attaches SLSA provenance
+attestations:
+
+```bash
+gh attestation verify oci://ghcr.io/automagik-dev/omni-api:v<version> -R automagik-dev/omni
+```
+
+### Proving the self-host path end-to-end
+
+`deploy-smoke` spins up a fresh disposable k3d (or kind) cluster, imports the
+locally built images, runs the full `values-dev.yaml` install with
+`helm install --wait`, asserts every pod is Ready and `/health` answers, then
+deletes the cluster — teardown runs even when the install fails, and the
+target exits non-zero on failure:
+
+```bash
+make -C deploy deploy-smoke
+```
+
+Requires Docker running, `helm`, `kubectl`, and `k3d` or `kind` (auto-installs
+k3d via Homebrew if neither is present). See the target header in
+[`Makefile`](Makefile) for tunables (`SMOKE_TIMEOUT`, `SMOKE_SET`, …).
+
+## Makefile reference
+
+Run everything as `make -C deploy <target>` from the repo root.
+
+| Target | What it does |
+|---|---|
+| `build` | Build `omni-api:dev` (BuildKit, repo-root context) |
+| `build-autopg` | Build `autopg:dev` from `autopg.Dockerfile` |
+| `deps` | `helm dependency build` (vendors the autopg subchart) |
+| `lint` / `template` | Lint / render the chart with the selected realm overlay |
+| `deploy` | `helm upgrade --install --wait` to namespace `$(NAMESPACE)` |
+| `status` / `logs` / `health` | Rollout status, API logs, port-forward + `GET /health` |
+| `smoke` | Run the image alone in Docker (no cluster) |
+| `deploy-smoke` | Full disposable-cluster install proof (see above) |
+| `uninstall` | Remove the release |
+
+Key variables: `REALM=dev|homolog|prod` picks the values overlay
+(`VALUES=…` still overrides it directly); `HELM_EXTRA='--set …'` appends
+arbitrary helm args (required for homolog/prod ingress hosts);
+`NAMESPACE`/`RELEASE` default to `omni`.

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -3,11 +3,14 @@ name: omni
 description: Omni — multi-channel messaging API (Bun/Hono) with Postgres (autopg) and NATS/JetStream
 type: application
 version: 0.1.0
-# appVersion tracks the latest PUBLISHED omni release (packages/cli version):
-# image-publish.yml pushes ghcr.io/automagik-dev/omni-api:v<version> on merge
-# to main, and the chart's default image tag is v<appVersion>. Bump this only
-# to versions that exist on GHCR.
-appVersion: "2.260704.4"
+# appVersion = the version this tree publishes when promoted. Every version
+# bump (version.yml → scripts/sync-versions.ts) stamps this line in lockstep
+# with every package.json, and image-publish.yml pushes
+# ghcr.io/automagik-dev/omni-api:v<appVersion> when the tree lands on main or
+# homolog. The chart's default image tag is v<appVersion>, so a promoted tree
+# always references exactly the image its own promotion publishes. Do not edit
+# by hand — scripts/verify-versions.ts fails CI on drift.
+appVersion: "2.260705.3"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.10"
+appVersion: "2.260705.11"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.6"
+appVersion: "2.260705.7"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.9"
+appVersion: "2.260705.10"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.3"
+appVersion: "2.260705.4"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.4"
+appVersion: "2.260705.6"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.7"
+appVersion: "2.260705.8"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260705.8"
+appVersion: "2.260705.9"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
+++ b/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
@@ -29,6 +29,25 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
+        # Hand the socket-dir emptyDir ("run" volume) to the pod user
+        # (verified on k3d/k3s, 2026-07-05): stock kubelet's fsGroup pass only
+        # sets the GROUP on a fresh emptyDir (root:fsGroup + g+rwx/setgid) —
+        # the OWNER stays root, and autopg's boot-time chmod of its
+        # --socket-dir then fails with a fatal EPERM. OrbStack's kubelet also
+        # chowns the owner, which is why this never bit local verification.
+        # chown requires root, so this one init runs as root; every other
+        # container in the pod stays non-root.
+        - name: fix-run-dir
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "chown 1000:1000 /run-dir && chmod 700 /run-dir"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: run
+              mountPath: /run-dir
         # Repair PGDATA on every pod start (verified in the wild on a node
         # restart, 2026-07-03): kubelet's fsGroup pass re-applies setgid/g+w
         # to the volume on each mount, which postgres refuses (pgdata must be

--- a/deploy/helm/omni/templates/ingress.yaml
+++ b/deploy/helm/omni/templates/ingress.yaml
@@ -1,4 +1,16 @@
 {{- if .Values.ingress.enabled }}
+{{- /*
+Fail-fast host guard: an enabled ingress with an EMPTY host is always operator
+error — nginx would treat the rule as catch-all and serve omni on every
+hostname hitting the controller. Cloud overlays (values-prod / values-homolog)
+opt in by setting `ingress.host: ""` explicitly, forcing the real FQDN through
+`--set ingress.host=…` per realm. NOTE: base values.yaml defaults host to
+`omni.local`, so an overlay that does NOT null the host inherits that default
+and bypasses this guard — cloud overlays MUST keep `ingress.host: ""`.
+*/}}
+{{- if not .Values.ingress.host }}
+{{- fail "ingress.enabled=true but ingress.host is empty — this overlay requires the realm FQDN at deploy time: --set ingress.host=<fqdn> (see values-prod.yaml / values-homolog.yaml `ingress.host`)" }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -15,7 +27,9 @@ spec:
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- /* tpl: lets overlays write hosts: ['{{ .Values.ingress.host }}'] so the
+    TLS block tracks the --set host; plain strings pass through unchanged. */}}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}

--- a/deploy/helm/omni/values-homolog.yaml
+++ b/deploy/helm/omni/values-homolog.yaml
@@ -15,7 +15,7 @@
 #
 # Required pre-created Secrets (same namespace as the release):
 #   omni-db        key DATABASE_URL — full RDS URL, e.g.
-#                  postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=require
+#                  postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full
 #                  (password percent-encoded; the role must OWN the omni tables —
 #                  migrations ALTER them on boot)
 #   omni-media-s3  keys OMNI_MEDIA_S3_ACCESS_KEY + OMNI_MEDIA_S3_SECRET_KEY
@@ -60,7 +60,7 @@ ingress:
 # RDS instance — the bundled autopg is OFF in this realm (autopg.enabled
 # below). Create it before the first deploy:
 #   kubectl -n omni create secret generic omni-db \
-#     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=require'
+#     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full'
 database:
   existingSecret: "omni-db"
   urlKey: "DATABASE_URL"

--- a/deploy/helm/omni/values-homolog.yaml
+++ b/deploy/helm/omni/values-homolog.yaml
@@ -1,15 +1,17 @@
 # =============================================================================
-# Production overlay — dedicated AWS cluster, external RDS + real S3.
+# Homolog (HML) overlay — dedicated AWS cluster, external RDS + real S3.
 #   helm upgrade --install omni deploy/helm/omni -n omni \
-#     -f deploy/helm/omni/values-prod.yaml \
-#     --set ingress.host=<prod fqdn>
+#     -f deploy/helm/omni/values-homolog.yaml \
+#     --set ingress.host=<hml fqdn>
 #
-# Realm shape (shared with values-homolog.yaml — separate clusters, one shape):
+# Realm shape (shared with values-prod.yaml — separate clusters, one shape):
 #   - NO bundled datastores: autopg + MinIO are OFF. Postgres is external RDS
 #     (database.existingSecret), media is real AWS S3 (media.s3.existingSecret).
 #   - image.tag "" → v<Chart.appVersion>, the tag image-publish.yml publishes.
 #   - ingress.host is intentionally EMPTY: the chart fail-fasts unless the
 #     realm FQDN is passed via --set ingress.host=… (see templates/ingress.yaml).
+# HML differs from prod only in sizing (lighter resources / JetStream stores)
+# and its own bucket + hostname.
 #
 # Required pre-created Secrets (same namespace as the release):
 #   omni-db        key DATABASE_URL — full RDS URL, e.g.
@@ -20,26 +22,18 @@
 # =============================================================================
 
 image:
-  repository: ghcr.io/automagik-dev/omni-api   # set to your registry/path
+  repository: ghcr.io/automagik-dev/omni-api
   # "" → v<Chart.appVersion>: the latest PUBLISHED release (image-publish.yml
-  # pushes v<packages/cli version> on merges to main). Pin an explicit v-tag
-  # only to hold prod back from the chart's tracked release.
+  # pushes v<packages/cli version> on merges to main).
   tag: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 
-# ONE replica, HPA off (see values.yaml "replicas + scaling"): a single
-# WhatsApp credential maps to one live Baileys socket, so concurrent replicas
-# risk key-ratchet corruption / duplicate sends until single-socket ownership
-# (leader election) exists. Scale out only for HTTP/API + non-WhatsApp
-# traffic — the chart then auto-adds a PDB + pod anti-affinity, and
-# migrate-on-boot serializes via a Postgres advisory lock.
+# ONE replica, HPA off — same WhatsApp/Baileys single-socket constraint as prod
+# (see values.yaml "replicas + scaling").
 replicaCount: 1
 autoscaling:
   enabled: false
-  minReplicas: 1
-  maxReplicas: 6
-  targetCPUUtilizationPercentage: 75
 
 config:
   LOG_LEVEL: "info"
@@ -50,7 +44,7 @@ ingress:
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-  # REQUIRED at deploy time: --set ingress.host=<prod fqdn>. Deliberately ""
+  # REQUIRED at deploy time: --set ingress.host=<hml fqdn>. Deliberately ""
   # (NOT omitted — base values.yaml defaults host to omni.local, which would
   # silently bypass the chart's empty-host fail-fast). The tls hosts entry is
   # templated so it tracks whatever host is set.
@@ -62,9 +56,9 @@ ingress:
       hosts:
         - "{{ .Values.ingress.host }}"
 
-# DATABASE_URL comes from a pre-created external Secret pointing at RDS —
-# the bundled autopg is OFF in this realm (autopg.enabled below). Create it
-# before the first deploy:
+# DATABASE_URL comes from a pre-created external Secret pointing at the HML
+# RDS instance — the bundled autopg is OFF in this realm (autopg.enabled
+# below). Create it before the first deploy:
 #   kubectl -n omni create secret generic omni-db \
 #     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=require'
 database:
@@ -78,35 +72,33 @@ secret:
   env: {}
     # OPENAI_API_KEY: ""
     # ANTHROPIC_API_KEY: ""
-    # SENTRY_DSN: ""
-    # OTEL_EXPORTER_OTLP_ENDPOINT: ""
 
 resources:
   requests:
-    cpu: 250m
-    memory: 512Mi
+    cpu: 100m
+    memory: 256Mi
   limits:
-    cpu: "2"
-    memory: 2Gi
+    cpu: "1"
+    memory: 1Gi
 
 nats:
   enabled: true
   jetstream:
     enabled: true
-    memStore: 512Mi
-    fileStore: 4Gi
+    memStore: 256Mi
+    fileStore: 2Gi
   persistence:
-    size: 8Gi
+    size: 4Gi
     # storageClass: gp3
 
-# Prod media backend: an EXTERNAL managed S3 bucket (real AWS S3 — endpoint
+# HML media backend: an EXTERNAL managed S3 bucket (real AWS S3 — endpoint
 # empty so the SDK derives it from region; forcePathStyle false). Creds come
 # from the pre-created omni-media-s3 Secret (never plaintext in rendered
 # output); the bucket is provisioned out of band and must already exist.
 media:
   mode: remote
   s3:
-    bucket: omni-media
+    bucket: omni-media-hml               # bucket names are global — use the HML one
     region: us-east-1
     forcePathStyle: false
     presignTtlSeconds: 3600
@@ -114,7 +106,7 @@ media:
     # publicEndpoint stays unset: real S3 endpoints are already publicly
     # reachable, so presigned GET URLs work as-is. It exists for split-endpoint
     # setups (e.g. in-cluster MinIO presigning through an external hostname).
-    # publicEndpoint: "https://media.example.com"
+    # publicEndpoint: "https://media-hml.example.com"
     existingSecret: "omni-media-s3"      # must hold the two keys below
     accessKeyKey: "OMNI_MEDIA_S3_ACCESS_KEY"
     secretKeyKey: "OMNI_MEDIA_S3_SECRET_KEY"

--- a/deploy/helm/omni/values-prod.yaml
+++ b/deploy/helm/omni/values-prod.yaml
@@ -13,9 +13,11 @@
 #
 # Required pre-created Secrets (same namespace as the release):
 #   omni-db        key DATABASE_URL — full RDS URL, e.g.
-#                  postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=require
+#                  postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full
 #                  (password percent-encoded; the role must OWN the omni tables —
-#                  migrations ALTER them on boot)
+#                  migrations ALTER them on boot. sslmode=require is a working
+#                  minimum but does NOT verify the server cert — verify-full
+#                  needs the RDS CA bundle available to the client)
 #   omni-media-s3  keys OMNI_MEDIA_S3_ACCESS_KEY + OMNI_MEDIA_S3_SECRET_KEY
 # =============================================================================
 
@@ -66,7 +68,7 @@ ingress:
 # the bundled autopg is OFF in this realm (autopg.enabled below). Create it
 # before the first deploy:
 #   kubectl -n omni create secret generic omni-db \
-#     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=require'
+#     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full'
 database:
   existingSecret: "omni-db"
   urlKey: "DATABASE_URL"
@@ -106,6 +108,8 @@ nats:
 media:
   mode: remote
   s3:
+    # S3 bucket names are GLOBALLY unique — this generic placeholder will very
+    # likely collide; override with your org-prefixed bucket (e.g. acme-omni-media).
     bucket: omni-media
     region: us-east-1
     forcePathStyle: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/*"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts
@@ -16,7 +16,13 @@ const bytes = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
 
 // Mock Baileys so `downloadMediaMessage('stream')` yields a Readable without a
 // real WhatsApp socket. Only the runtime export used by download.ts is stubbed.
+// `mock.module` replaces the module PROCESS-WIDE for every test file that runs
+// after this one, so the real module must be spread in: dropping the other
+// exports breaks unrelated suites that import `initAuthCreds`, `Browsers`,
+// `makeWASocket`, etc. (file-order dependent — Linux CI hits it, macOS may not).
+const realBaileys = await import('baileys');
 mock.module('baileys', () => ({
+  ...realBaileys,
   downloadMediaMessage: mock(async () => Readable.from([bytes])),
 }));
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.7",
+  "version": "2.260705.8",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.9",
+  "version": "2.260705.10",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.3",
+  "version": "2.260705.4",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.8",
+  "version": "2.260705.9",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.4",
+  "version": "2.260705.6",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.10",
+  "version": "2.260705.11",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260705.6",
+  "version": "2.260705.7",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/scripts/lib/version-fields.ts
+++ b/scripts/lib/version-fields.ts
@@ -153,7 +153,7 @@ function chartAppVersionField(): VersionField {
         return false;
       }
 
-      const updated = content.replace(lineRe, `appVersion: "${version}"`);
+      const updated = content.replace(lineRe, () => `appVersion: "${version}"`);
       writeFileSync(absPath, updated, 'utf-8');
       return true;
     },

--- a/scripts/lib/version-fields.ts
+++ b/scripts/lib/version-fields.ts
@@ -5,10 +5,11 @@
  *   - scripts/sync-versions.ts  — writes a single calver to every entry
  *   - scripts/verify-versions.ts — fails CI if any entry drifts from root
  *
- * Three kinds of entries are returned (in this order):
+ * Four kinds of entries are returned (in this order):
  *   1. Standard package.json files (root + every workspace package)
  *   2. The omni Claude plugin manifest (plugins/omni/.claude-plugin/plugin.json)
  *   3. The marketplace plugin entry (.claude-plugin/marketplace.json -> plugins[name=omni])
+ *   4. The umbrella Helm chart appVersion (deploy/helm/omni/Chart.yaml)
  */
 
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
@@ -23,6 +24,14 @@ const EXCLUDED_WORKSPACE_PACKAGES = new Set(['audio-decode-shim']);
 
 /** Marketplace plugin entry that this repo owns and keeps in sync. */
 const MARKETPLACE_PLUGIN_NAME = 'omni';
+
+/**
+ * Umbrella Helm chart whose `appVersion` must track the release version.
+ * Scoped strictly to this one file — the vendored subchart at
+ * deploy/helm/omni/charts/autopg/Chart.yaml is versioned independently
+ * (it tracks autopg releases, not omni releases) and must never be touched.
+ */
+const UMBRELLA_CHART_PATH = 'deploy/helm/omni/Chart.yaml';
 
 export type VersionField = {
   /** Path relative to the repo root, used for human-readable output. */
@@ -109,6 +118,48 @@ function marketplacePluginField(): VersionField {
   };
 }
 
+/**
+ * Build a VersionField for the umbrella Helm chart's `appVersion` line.
+ *
+ * Line-based on purpose: Chart.yaml carries load-bearing comments (the
+ * appVersion contract, the autopg dependency rationale) that a YAML/JSON
+ * round-trip would strip. Only the single `appVersion: "..."` line is
+ * rewritten; every other byte of the file is preserved.
+ */
+function chartAppVersionField(): VersionField {
+  const absPath = join(repoRoot, UMBRELLA_CHART_PATH);
+  // Anchored to the top-level key at column 0; matches the first (only)
+  // appVersion line. Chart.yaml appVersion is always double-quoted here so
+  // calver values like 2.260705.3 are never YAML-coerced.
+  const lineRe = /^appVersion: "([^"\n]*)"[ \t]*$/m;
+
+  return {
+    path: UMBRELLA_CHART_PATH,
+    description: 'umbrella helm chart appVersion',
+    read(): string | null {
+      if (!existsSync(absPath)) return null;
+      const content = readFileSync(absPath, 'utf-8');
+      return content.match(lineRe)?.[1] ?? null;
+    },
+    write(version: string): boolean {
+      const content = readFileSync(absPath, 'utf-8');
+      const current = content.match(lineRe)?.[1];
+
+      if (current === undefined) {
+        throw new Error(`${UMBRELLA_CHART_PATH} has no top-level appVersion: "..." line`);
+      }
+
+      if (current === version) {
+        return false;
+      }
+
+      const updated = content.replace(lineRe, `appVersion: "${version}"`);
+      writeFileSync(absPath, updated, 'utf-8');
+      return true;
+    },
+  };
+}
+
 /** Walk packages/* and apps/* and yield package.json paths (excluding the deny list). */
 function findWorkspacePackageJsonPaths(): string[] {
   const paths: string[] = [];
@@ -138,6 +189,7 @@ function findWorkspacePackageJsonPaths(): string[] {
  *   2. workspace package.json files (alphabetical, packages/ before apps/)
  *   3. plugins/omni/.claude-plugin/plugin.json
  *   4. .claude-plugin/marketplace.json (omni entry)
+ *   5. deploy/helm/omni/Chart.yaml (appVersion)
  */
 export function getAllVersionFields(): VersionField[] {
   const fields: VersionField[] = [];
@@ -151,6 +203,8 @@ export function getAllVersionFields(): VersionField[] {
   fields.push(topLevelJsonField('plugins/omni/.claude-plugin/plugin.json', 'omni claude plugin manifest'));
 
   fields.push(marketplacePluginField());
+
+  fields.push(chartAppVersionField());
 
   return fields;
 }


### PR DESCRIPTION
Second HML promotion of the day — carries the omni-deploy-realms wish (13 commits): #786 realm overlays (values-homolog.yaml, AWS-shape prod), #787 appVersion auto-sync + D8, #789 autopg socket-dir fix from the k3d smoke, #790 docs, heal commits.

Purely additive: homolog has 0 unique commits vs dev beyond its own version bumps.

**Criterion-5 evidence leg (realms wish):** after merge, the D8 bump-commit run on homolog publishes the image — verify its tag equals the post-bump `Chart.appVersion` (compare the bump-commit run, NOT the cancelled merge-commit run).

§19: Felipe merges via UI (Create a merge commit).

https://claude.ai/code/session_017CmAF5Cbko9haq3Lzxtjfa