### PR TITLE
fix(test): stop process-wide baileys mock leak in media-remote-ingest test

### DIFF
--- a/packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts
@@ -16,7 +16,13 @@ const bytes = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
 
 // Mock Baileys so `downloadMediaMessage('stream')` yields a Readable without a
 // real WhatsApp socket. Only the runtime export used by download.ts is stubbed.
+// `mock.module` replaces the module PROCESS-WIDE for every test file that runs
+// after this one, so the real module must be spread in: dropping the other
+// exports breaks unrelated suites that import `initAuthCreds`, `Browsers`,
+// `makeWASocket`, etc. (file-order dependent — Linux CI hits it, macOS may not).
+const realBaileys = await import('baileys');
 mock.module('baileys', () => ({
+  ...realBaileys,
   downloadMediaMessage: mock(async () => Readable.from([bytes])),
 }));
 


### PR DESCRIPTION
## Diagnosis

The 12 CI failures (runs 28747109981 / 28747112589) were caused by a **file-order-dependent `mock.module` leak**, not bun 1.3.14. Runs replayed by the turbo cache masked it since ~07-03.

`packages/channel-whatsapp/src/__tests__/media-remote-ingest.test.ts` did:

```ts
mock.module('baileys', () => ({
  downloadMediaMessage: mock(async () => Readable.from([bytes])),
}));
```

Bun's `mock.module` applies **process-wide**, and bun runs all test files in one process. When the mock registers before the real `baileys` module has been loaded (Linux CI file ordering), the factory *defines* the entire module — every export not returned by the factory ceases to exist. Suites that then transitively import real baileys exports (`initAuthCreds` via `src/auth.ts`, `Browsers`, default `makeWASocket`) die with `Export named 'initAuthCreds' not found`. On macOS the file ordering loads real baileys first, so bun merges the mock into the already-loaded module and everything appears fine — which is why it never reproduced locally. `channel-sdk/compliance.test.ts` and `output-redactor.test.ts` were collateral of the same crash.

## Fix

Spread the real module into the mock factory so only `downloadMediaMessage` is stubbed:

```ts
const realBaileys = await import('baileys');
mock.module('baileys', () => ({
  ...realBaileys,
  downloadMediaMessage: mock(async () => Readable.from([bytes])),
}));
```

Test behavior and assertions are unchanged.

## Red (before fix) — forced-order repro

`bun test media-remote-ingest.test.ts silent-prekey-error.test.ts socket-defaults.test.ts`

```
packages/channel-whatsapp/src/__tests__/silent-prekey-error.test.ts:

# Unhandled error between tests
SyntaxError: Export named 'initAuthCreds' not found in module '.../node_modules/baileys/lib/index.js'.
      at loadAndEvaluateModule (2:1)

packages/channel-whatsapp/src/__tests__/socket-defaults.test.ts:

# Unhandled error between tests
SyntaxError: Export named 'Browsers' not found in module '.../node_modules/baileys/lib/index.js'.
      at loadAndEvaluateModule (2:1)

 1 pass
 2 fail
 2 errors
Ran 3 tests across 3 files. [88.00ms]
```

Exact same errors as CI, reproduced on macOS once the order is forced.

## Green (after fix)

Same forced-order command:

```
 7 pass
 0 fail
 24 expect() calls
Ran 7 tests across 3 files. [218.00ms]
```

Full package suite — `bun test packages/channel-whatsapp`:

```
 398 pass
 0 fail
 1192 expect() calls
Ran 398 tests across 28 files. [20.55s]
```

`make test-api` (exit 0):

```
 1175 pass
 0 fail
```

Cross-package forced order (leak source first, then CI collateral) — `bun test media-remote-ingest.test.ts packages/channel-sdk/src/__tests__/compliance.test.ts`:

```
 163 pass
 0 fail
```

Pre-push full suite: 4196 pass / 300 skip / 0 fail across 332 files.

## Audit of other `mock.module` sites (replaces vs spreads)

- `packages/api/src/plugins/__tests__/agent-dispatcher.test.ts:47` — mocks `@omni/core` without spreading, **left as-is**: the file's own static import of `../agent-dispatcher` loads real `@omni/core` before the mock registers, so bun always merges into the loaded module (order-independent, verified with a forced-order run: dispatcher first, then `output-redactor.test.ts` — 93 pass / 0 fail). Only 4 exports are deliberately overridden; the file documents why.
- `packages/channel-discord/src/__tests__/voice-manager.test.ts:26` — `@omni/voice-client`: already spreads the real module. OK.
- `packages/channel-slack/src/__tests__/bolt-client-http.test.ts:18` — `@slack/bolt`: replaces, **left as-is**: the only runtime imports from `@slack/bolt` in the repo are `App` + `HTTPReceiver` (both provided by the mock); every other import is type-only. Spreading would trigger the real `App` auth side effects the mock exists to avoid.
- `packages/core/src/providers/__tests__/nats-genie-provider.test.ts:68` — `nats`: replaces, **left as-is**: it provides every runtime export used anywhere in the repo (`StringCodec`, `connect`, `headers`, `AckPolicy`, `DeliverPolicy`, `RetentionPolicy`, `StorageType`); remaining namespace accesses cannot hard-fail at load time.
- `packages/api/src/providers/gemini/*.test.ts` — `./client` (package-local): each of the 5 files re-mocks before importing its module under test. Latent nit: `imagegen.test.ts` omits `GEMINI_MODELS` from its factory, which could bite a future non-mocking consumer of `./client` loaded after it — currently green everywhere, out of scope here (not `baileys`/`@omni/core`).
- `packages/cli/src/__tests__/{history,react-context,resolve}.test.ts` — `../output.js` / `../client.js` (package-local, self-contained pattern with existing in-repo commentary). Left.
- `packages/api/src/plugins/__tests__/agent-dispatch*.test.ts` — `../loader` (package-local single-export module). Left.
