### PR TITLE
feat(helm): add HML co-tenant ALB values delta and realm docs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,6 +12,7 @@ self-hosting and Namastex's managed AWS clusters.
 |---|---|---|---|---|---|---|
 | **dev** | Local k8s (OrbStack, k3d, kind, …) — the self-host shape | [`values-dev.yaml`](helm/omni/values-dev.yaml) | Locally built `omni-api:dev` + `autopg:dev` (`pullPolicy: Never`); tracks the `dev` branch you build from | Bundled **autopg** subchart (Postgres 18, in-cluster) | Bundled **MinIO** (in-cluster S3) | You — `make -C deploy deploy` |
 | **homolog (HML)** | Dedicated AWS cluster | [`values-homolog.yaml`](helm/omni/values-homolog.yaml) | `ghcr.io/automagik-dev/omni-api` — `tag: ""` → `v<Chart.appVersion>`; the `:homolog` tag tracks the `homolog` branch | External **RDS** via pre-created Secret `omni-db` (`DATABASE_URL`) | Real **AWS S3** (`omni-media-hml`) via Secret `omni-media-s3` | Namastex |
+| **HML co-tenant (ALB)** | Shared `langwatch-hml` EKS cluster (sa-east-1), namespace `omni-hml` | [`values-homolog.yaml`](helm/omni/values-homolog.yaml) **+** [`values-hml-alb.yaml`](helm/omni/values-hml-alb.yaml) delta (in that order) | `ghcr.io/automagik-dev/omni-api` — `v<Chart.appVersion>` from public GHCR (no pull secret) | Shared RDS instance, **own `omni` database** — `omni-db` Secret ESO-synced from Secrets Manager `/khal/omni/hml/db` | Real **AWS S3** (`nmstx-khal-omni-hml-media`, sa-east-1) — `omni-media-s3` Secret ESO-synced from `/khal/omni/hml/media-s3` | Namastex |
 | **prod** | Dedicated AWS cluster (separate from HML) | [`values-prod.yaml`](helm/omni/values-prod.yaml) | `ghcr.io/automagik-dev/omni-api` — `tag: ""` → `v<Chart.appVersion>` (v-tags published on merge to `main`; `:main` also available) | External **RDS** via Secret `omni-db` (`DATABASE_URL`) | Real **AWS S3** (`omni-media`) via Secret `omni-media-s3` | Namastex |
 
 Notes that apply across the matrix:
@@ -25,6 +26,25 @@ Notes that apply across the matrix:
   make -C deploy deploy REALM=homolog HELM_EXTRA='--set ingress.host=omni-hml.example.com'
   make -C deploy deploy REALM=prod    HELM_EXTRA='--set ingress.host=omni.example.com'
   ```
+
+- **HML co-tenant (ALB) deploy command** — the co-tenant realm rides on the
+  shared `langwatch-hml` cluster, so ingress is the AWS Load Balancer
+  Controller instead of nginx/cert-manager. Layer the ALB delta AFTER the
+  homolog overlay and pass the ACM certificate ARN at deploy time (see the
+  header of [`values-hml-alb.yaml`](helm/omni/values-hml-alb.yaml)):
+
+  ```bash
+  helm upgrade --install omni deploy/helm/omni -n omni-hml \
+    -f deploy/helm/omni/values-homolog.yaml \
+    -f deploy/helm/omni/values-hml-alb.yaml \
+    --set ingress.host=hml.omni.khal.ai \
+    --set 'ingress.annotations.alb\.ingress\.kubernetes\.io/certificate-arn=<acm-cert-arn>' \
+    --wait
+  ```
+
+  The `omni-db` / `omni-media-s3` Secrets in `omni-hml` are materialized by
+  External Secrets Operator from Secrets Manager `/khal/omni/hml/*` — do not
+  create them by hand in this realm.
 
 - **homolog/prod pre-created Secrets** (same namespace as the release; see the
   header comments in each values file for exact commands):

--- a/deploy/helm/omni/values-hml-alb.yaml
+++ b/deploy/helm/omni/values-hml-alb.yaml
@@ -1,0 +1,70 @@
+# =============================================================================
+# HML co-tenant ALB delta — layered AFTER values-homolog.yaml, never alone.
+#
+# This is NOT a standalone overlay: it is a DELTA that re-flavors the homolog
+# shape for the co-tenant realm on the shared `langwatch-hml` EKS cluster
+# (sa-east-1, namespace omni-hml). Ingress moves from nginx+cert-manager to the
+# AWS Load Balancer Controller (TLS terminates at the ALB with an ACM cert),
+# and the media bucket/region switch to this lane's real values. Everything
+# else (external RDS via `omni-db`, real S3 creds via `omni-media-s3`, single
+# replica, sizing) is inherited from values-homolog.yaml.
+#
+# Exact deploy command (order of -f flags matters — this file LAST):
+#   helm upgrade --install omni deploy/helm/omni -n omni-hml \
+#     -f deploy/helm/omni/values-homolog.yaml \
+#     -f deploy/helm/omni/values-hml-alb.yaml \
+#     --set ingress.host=hml.omni.khal.ai \
+#     --set 'ingress.annotations.alb\.ingress\.kubernetes\.io/certificate-arn=<acm-cert-arn>' \
+#     --wait
+#
+# The ACM certificate ARN is deliberately NOT set in-file: it is an
+# environment-specific AWS resource identifier that only exists after the
+# tenant Terraform is applied, so it is supplied at deploy time via the
+# --set above (the dots in the annotation key must be escaped with `\.`).
+#
+# Secrets in this realm are ESO-materialized from Secrets Manager
+# `/khal/omni/hml/{db,media-s3}` into the `omni-db` / `omni-media-s3` Secrets
+# that values-homolog.yaml already references — no secret keys change here.
+# =============================================================================
+
+ingress:
+  # AWS Load Balancer Controller provisions an internet-facing ALB for
+  # ingressClassName `alb`; TLS terminates at the ALB using the ACM cert
+  # passed via --set (see header), so no in-cluster TLS material is needed.
+  className: alb
+  annotations:
+    # Helm map-merge cannot DELETE a key inherited from an earlier -f file, but
+    # a `null` override removes it at coalesce time — and even if a literal
+    # `cluster-issuer: null` ever rendered, it is harmless for an alb-class
+    # Ingress (cert-manager only acts on real issuer values, which must NOT
+    # leak into this realm: there is no cert-manager/nginx on this cluster).
+    cert-manager.io/cluster-issuer: null
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    # alb.ingress.kubernetes.io/certificate-arn: supplied at deploy time via
+    # --set (see header) — never commit an account-specific ARN here.
+  # Empty list REPLACES homolog's cert-manager tls block wholesale (helm
+  # replaces lists, it does not merge them): TLS lives at the ALB, so the
+  # rendered Ingress must carry no `tls:` section at all.
+  tls: []
+
+# Lane-correct media backend: the homolog defaults (bucket omni-media-hml,
+# us-east-1) are WRONG for this co-tenant realm. The bucket below is the
+# Terraform-provisioned one in the LangWatch HML account, and region must
+# match it (endpoint stays "" → the SDK derives the sa-east-1 endpoint).
+media:
+  s3:
+    bucket: nmstx-khal-omni-hml-media
+    region: sa-east-1
+
+# NATS JetStream persistence: values-homolog.yaml leaves storageClass unset,
+# which uses the cluster's DEFAULT StorageClass. The langwatch-hml EKS default
+# could not be verified from here (likely gp3 via the EBS CSI driver, but gp2
+# in-tree defaults still exist on older clusters). Keep this commented and
+# override-ready: uncomment (or pass --set nats.persistence.storageClass=gp3)
+# ONLY after `kubectl get storageclass` shows the default is not gp3/EBS-CSI.
+# nats:
+#   persistence:
+#     storageClass: gp3


### PR DESCRIPTION
## Summary

Group 2 (G-CHART) of wish `omni-realms-provisioning`: ALB-flavored values delta + co-tenant realm docs.

- **`deploy/helm/omni/values-hml-alb.yaml`** — a DELTA layered AFTER `values-homolog.yaml` (never standalone) for the co-tenant realm on the shared `langwatch-hml` EKS cluster (sa-east-1, namespace `omni-hml`):
  - `ingress.className: alb` + AWS Load Balancer Controller annotations (`scheme: internet-facing`, `target-type: ip`, `listen-ports: '[{"HTTPS":443}]'`, `healthcheck-path: /health`)
  - `certificate-arn` deliberately NOT in-file — supplied at deploy: `--set 'ingress.annotations.alb\.ingress\.kubernetes\.io/certificate-arn=<arn>'`
  - inherited `cert-manager.io/cluster-issuer` neutralized via `null` override (helm map-merge can't delete; the literal `: null` render is harmless for an alb-class Ingress — no real issuer value leaks)
  - `tls: []` — empty list replaces homolog's tls block wholesale; rendered Ingress carries no `tls:` section
  - lane-correct media backend: `media.s3.bucket: nmstx-khal-omni-hml-media`, `media.s3.region: sa-east-1`
  - NATS `storageClass: gp3` left commented + override-ready (cluster default StorageClass unverified; rationale in-file)
- **`deploy/README.md`** — co-tenant realm matrix row (shared RDS / own `omni` database, S3 via ESO-synced Secrets from `/khal/omni/hml/*`, public GHCR images) + the exact layered helm deploy command.

## Validation (exact wish script, exit 0)

```
==> Linting deploy/helm/omni
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
Summary: 8 resources found in 1 file - Valid: 8, Invalid: 0, Errors: 0, Skipped: 0
VALIDATION_EXIT=0
```

All greps passed: `ingressClassName: alb`, `alb.ingress.kubernetes.io/healthcheck-path`, `nmstx-khal-omni-hml-media`, `sa-east-1` present; no cert-manager issuer value leaked; no `tls:` block in the rendered Ingress; README mentions the co-tenant/langwatch-hml realm.

## Existing overlays unchanged

Rendered `values-dev` / `values-homolog` / `values-prod` before and after:

- homolog: byte-identical
- prod: byte-identical
- dev: identical modulo the two per-render `randAlphaNum` dev passwords (autopg superuser + MinIO app secret) — confirmed by rendering dev twice back-to-back on the same tree (same 2 fields churn)

## Rendered Ingress (homolog + delta)

```yaml
  annotations:
    alb.ingress.kubernetes.io/healthcheck-path: /health
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
    cert-manager.io/cluster-issuer: null
spec:
  ingressClassName: alb
```

Pre-push suite: 4196 pass / 0 fail.
