### PR TITLE
feat(deploy): add omni-hml ExternalSecrets for db and media-s3

### DIFF
--- a/deploy/k8s/omni-hml/externalsecrets.yaml
+++ b/deploy/k8s/omni-hml/externalsecrets.yaml
@@ -1,0 +1,56 @@
+# =============================================================================
+# ExternalSecrets for omni on the shared langwatch-hml EKS cluster (namespace
+# omni-hml, sa-east-1). External Secrets Operator materializes AWS Secrets
+# Manager entries under /khal/omni/hml/* into the k8s Secrets that the omni
+# Helm chart's values-homolog.yaml references (omni-db, omni-media-s3).
+#
+#   kubectl -n omni-hml apply -f deploy/k8s/omni-hml/externalsecrets.yaml
+#
+# Store: ClusterSecretStore khal-langwatch-hml (SecretsManager, sa-east-1). The
+# ESO IAM role has secretsmanager:GetSecretValue on /khal/omni/hml/*.
+#
+# NOTE: /khal/omni/hml/db is a JSON secret ({"DATABASE_URL": "postgresql://…"}),
+# matching the platform convention (cf. langwatch-db → property url), so the URL
+# is pulled via remoteRef.property DATABASE_URL — NOT the whole JSON blob.
+# =============================================================================
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: omni-db
+  namespace: omni-hml
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: khal-langwatch-hml
+  target:
+    name: omni-db
+    creationPolicy: Owner
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: /khal/omni/hml/db
+        property: DATABASE_URL
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: omni-media-s3
+  namespace: omni-hml
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: khal-langwatch-hml
+  target:
+    name: omni-media-s3
+    creationPolicy: Owner
+  data:
+    - secretKey: OMNI_MEDIA_S3_ACCESS_KEY
+      remoteRef:
+        key: /khal/omni/hml/media-s3
+        property: OMNI_MEDIA_S3_ACCESS_KEY
+    - secretKey: OMNI_MEDIA_S3_SECRET_KEY
+      remoteRef:
+        key: /khal/omni/hml/media-s3
+        property: OMNI_MEDIA_S3_SECRET_KEY


### PR DESCRIPTION
## What

Adds the two ExternalSecrets that materialize AWS Secrets Manager entries
under `/khal/omni/hml/*` into the k8s Secrets the omni Helm chart references
(`omni-db`, `omni-media-s3`) on the shared `langwatch-hml` EKS cluster
(namespace `omni-hml`, sa-east-1). Part of the omni-realms-provisioning wish
(Group 3 / G-K8S).

- `omni-db` → `DATABASE_URL` from SM `/khal/omni/hml/db`
- `omni-media-s3` → `OMNI_MEDIA_S3_ACCESS_KEY` + `OMNI_MEDIA_S3_SECRET_KEY`
  from SM `/khal/omni/hml/media-s3`

Store: `ClusterSecretStore khal-langwatch-hml` (SecretsManager, sa-east-1),
`refreshInterval: 1h`, `creationPolicy: Owner`.

## Deviation from the group brief

The brief specified `omni-db` should pull `/khal/omni/hml/db` with **no
property** (whole string). The live secret is actually **JSON**
(`{"DATABASE_URL": "postgresql://…"}`), matching the platform convention
(cf. `langwatch-db` → `property: url`). Pulling the whole blob would set
`DATABASE_URL` to the JSON object and break the app, so this manifest uses
`remoteRef.property: DATABASE_URL`. Verified: both ExternalSecrets pass
server-side dry-run against the v1 CRD, and the rendered omni Deployment
consumes `omni-db/DATABASE_URL` + `omni-media-s3/{ACCESS,SECRET}_KEY` exactly.

## Validation

- `kubectl apply --dry-run=server` (all manifests) — clean
- `helm template` with the G-K8S deploy flags renders an `alb`-class Ingress
  with the ACM cert ARN and image `v2.260705.12`; autopg + MinIO stay off
