### PR TITLE
feat(media): IRSA web-identity credentials for S3 media backend

### DIFF
--- a/deploy/helm/omni/templates/configmap.yaml
+++ b/deploy/helm/omni/templates/configmap.yaml
@@ -13,8 +13,13 @@ data:
   {{- end }}
   NATS_URL: {{ include "omni.natsUrl" . | quote }}
   # ---- media backend (non-secret) — OMNI_MEDIA_* ----------------------------
+  {{- if not .Values.media.s3.irsa }}
   # Secret creds (OMNI_MEDIA_S3_ACCESS_KEY / _SECRET_KEY) are injected by
   # secretKeyRef in the Deployment, never rendered here.
+  {{- else }}
+  # S3 credentials come from IRSA (STS AssumeRoleWithWebIdentity via the pod's
+  # ServiceAccount web-identity token) — no static key env exists anywhere.
+  {{- end }}
   {{- if include "omni.media.remote" . }}
   OMNI_MEDIA_MODE: "remote"
   OMNI_MEDIA_S3_ENDPOINT: {{ include "omni.media.s3Endpoint" . | quote }}

--- a/deploy/helm/omni/templates/deployment.yaml
+++ b/deploy/helm/omni/templates/deployment.yaml
@@ -107,7 +107,10 @@ spec:
                   name: {{ . }}
                   key: {{ $.Values.database.urlKey }}
             {{- end }}
-            {{- if include "omni.media.remote" . }}
+            {{- /* Under media.s3.irsa the two secretKeyRef envs are omitted
+            entirely: the pod authenticates to S3 via its ServiceAccount
+            web-identity token (IRSA) instead of static keys. */}}
+            {{- if and (include "omni.media.remote" .) (not .Values.media.s3.irsa) }}
             # --- S3 creds by reference only (never plaintext in rendered env) ---
             - name: OMNI_MEDIA_S3_ACCESS_KEY
               valueFrom:

--- a/deploy/helm/omni/values-hml-alb.yaml
+++ b/deploy/helm/omni/values-hml-alb.yaml
@@ -5,9 +5,11 @@
 # shape for the co-tenant realm on the shared `langwatch-hml` EKS cluster
 # (sa-east-1, namespace omni-hml). Ingress moves from nginx+cert-manager to the
 # AWS Load Balancer Controller (TLS terminates at the ALB with an ACM cert),
-# and the media bucket/region switch to this lane's real values. Everything
-# else (external RDS via `omni-db`, real S3 creds via `omni-media-s3`, single
-# replica, sizing) is inherited from values-homolog.yaml.
+# and the media bucket/region switch to this lane's real values, with S3 auth
+# via IRSA (media.s3.irsa + the ServiceAccount role-arn annotation below)
+# instead of the `omni-media-s3` static-key Secret. Everything else (external
+# RDS via `omni-db`, single replica, sizing) is inherited from
+# values-homolog.yaml.
 #
 # Exact deploy command (order of -f flags matters — this file LAST):
 #   helm upgrade --install omni deploy/helm/omni -n omni-hml \
@@ -54,10 +56,23 @@ ingress:
 # us-east-1) are WRONG for this co-tenant realm. The bucket below is the
 # Terraform-provisioned one in the LangWatch HML account, and region must
 # match it (endpoint stays "" → the SDK derives the sa-east-1 endpoint).
+# irsa: true switches S3 auth to the pod's web-identity token — the Deployment
+# renders NO OMNI_MEDIA_S3_ACCESS_KEY/_SECRET_KEY envs; omni-api exchanges the
+# projected ServiceAccount token via STS AssumeRoleWithWebIdentity using the
+# role-arn annotation below (injected as AWS_ROLE_ARN by the EKS pod identity
+# webhook). The `omni-media-s3` Secret homolog references becomes unused here.
 media:
   s3:
     bucket: nmstx-khal-omni-hml-media
     region: sa-east-1
+    irsa: true
+
+# IRSA: annotating the ServiceAccount makes the EKS pod identity webhook mount
+# a projected web-identity token and inject AWS_WEB_IDENTITY_TOKEN_FILE +
+# AWS_ROLE_ARN into omni-api's pod — no static S3 keys in this realm.
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::223744800379:role/omni-hml-media-irsa
 
 # DB TLS verify-full: the shared-RDS DATABASE_URL carries sslmode=require
 # (encrypts, but trusts any cert — the RDS CA is not in the container's trust

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -272,6 +272,14 @@ media:
     existingSecret: ""
     accessKeyKey: "OMNI_MEDIA_S3_ACCESS_KEY"
     secretKeyKey: "OMNI_MEDIA_S3_SECRET_KEY"
+    # IRSA (EKS): source S3 credentials from the pod's web-identity token
+    # instead of a Secret. When true the Deployment OMITS the two
+    # OMNI_MEDIA_S3_ACCESS_KEY/_SECRET_KEY secretKeyRef envs — the EKS pod
+    # identity webhook injects AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN
+    # (from the serviceAccount.annotations `eks.amazonaws.com/role-arn`) and
+    # omni-api exchanges that token via STS AssumeRoleWithWebIdentity. Set the
+    # role-arn annotation under serviceAccount.annotations when enabling this.
+    irsa: false
 
 # ---- bundled MinIO (S3-compatible object store) -----------------------------
 # Default OFF in the base values (no unused workload); the dev overlay turns it

--- a/packages/channel-sdk/src/index.ts
+++ b/packages/channel-sdk/src/index.ts
@@ -101,8 +101,10 @@ export {
   createMediaBackend,
   isMediaNotFoundError,
   LocalMediaBackend,
+  parseAssumeRoleWithWebIdentityResponse,
   resolveMediaBackendConfig,
   S3MediaBackend,
+  WebIdentityCredentialProvider,
 } from './media-backends';
 export type {
   MediaBackendConfig,
@@ -110,9 +112,13 @@ export type {
   MediaStorageBackend,
   MediaStorageMode,
   S3BackendConfig,
+  S3CredentialProvider,
+  S3CredentialSource,
+  S3WebIdentityParams,
   StoreMediaInput,
   StoreMediaResult,
   StoreStreamInput,
+  StsCredentials,
 } from './media-backends';
 
 // Explicit streaming type export for package root access

--- a/packages/channel-sdk/src/media-backends/__tests__/config-web-identity.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/config-web-identity.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Remote-mode credential matrix: static-only / irsa-only / both / neither.
+ *
+ * Locks the IRSA acceptance criteria on resolveMediaBackendConfig:
+ *  - static-only resolves to the EXACT pre-IRSA shape (no new defined keys);
+ *  - web-identity (AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN) alone is a
+ *    complete credential set — no static keys required;
+ *  - when BOTH sets are complete, web-identity is primary and the static pair
+ *    is retained (the backend's STS-outage fallback);
+ *  - only when NEITHER set is complete does it throw, listing both options.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { resolveMediaBackendConfig } from '../config';
+
+const REMOTE_BASE = {
+  OMNI_MEDIA_MODE: 'remote',
+  OMNI_MEDIA_S3_BUCKET: 'omni-media',
+} satisfies NodeJS.ProcessEnv;
+
+const STATIC_KEYS = {
+  OMNI_MEDIA_S3_ACCESS_KEY: 'static-access',
+  OMNI_MEDIA_S3_SECRET_KEY: 'static-secret',
+} satisfies NodeJS.ProcessEnv;
+
+const WEB_IDENTITY = {
+  AWS_WEB_IDENTITY_TOKEN_FILE: '/var/run/secrets/eks.amazonaws.com/serviceaccount/token',
+  AWS_ROLE_ARN: 'arn:aws:iam::123456789012:role/omni-media-irsa',
+} satisfies NodeJS.ProcessEnv;
+
+describe('resolveMediaBackendConfig credential matrix', () => {
+  it('static-only resolves byte-compatible with the pre-IRSA shape (no credential-mode keys)', () => {
+    const config = resolveMediaBackendConfig({ ...REMOTE_BASE, ...STATIC_KEYS });
+    expect(config).toEqual({
+      mode: 'remote',
+      s3: {
+        bucket: 'omni-media',
+        region: 'us-east-1',
+        accessKeyId: 'static-access',
+        secretKey: 'static-secret',
+        forcePathStyle: true,
+        presignTtlSeconds: 3600,
+      },
+    });
+    if (config.mode !== 'remote') throw new Error('unreachable');
+    // Assert key ABSENCE, not just undefined: toEqual ignores undefined props.
+    expect('credentialSource' in config.s3).toBe(false);
+    expect('webIdentity' in config.s3).toBe(false);
+  });
+
+  it('web-identity-only is a complete credential set — no static keys required', () => {
+    const config = resolveMediaBackendConfig({ ...REMOTE_BASE, ...WEB_IDENTITY, AWS_REGION: 'sa-east-1' });
+    if (config.mode !== 'remote') throw new Error('unreachable');
+    expect(config.s3.credentialSource).toBe('web-identity');
+    expect(config.s3.webIdentity).toEqual({
+      tokenFile: WEB_IDENTITY.AWS_WEB_IDENTITY_TOKEN_FILE,
+      roleArn: WEB_IDENTITY.AWS_ROLE_ARN,
+      stsRegion: 'sa-east-1',
+    });
+    expect(config.s3.accessKeyId).toBeUndefined();
+    expect(config.s3.secretKey).toBeUndefined();
+    expect(config.s3.bucket).toBe('omni-media');
+  });
+
+  it('stsRegion falls back to the S3 region when AWS_REGION is unset', () => {
+    const explicit = resolveMediaBackendConfig({ ...REMOTE_BASE, ...WEB_IDENTITY, OMNI_MEDIA_S3_REGION: 'eu-west-1' });
+    if (explicit.mode !== 'remote') throw new Error('unreachable');
+    expect(explicit.s3.webIdentity?.stsRegion).toBe('eu-west-1');
+
+    const defaulted = resolveMediaBackendConfig({ ...REMOTE_BASE, ...WEB_IDENTITY });
+    if (defaulted.mode !== 'remote') throw new Error('unreachable');
+    expect(defaulted.s3.webIdentity?.stsRegion).toBe('us-east-1');
+  });
+
+  it('both sets complete: web-identity is primary, static keys retained as fallback', () => {
+    const config = resolveMediaBackendConfig({ ...REMOTE_BASE, ...STATIC_KEYS, ...WEB_IDENTITY });
+    if (config.mode !== 'remote') throw new Error('unreachable');
+    expect(config.s3.credentialSource).toBe('web-identity');
+    expect(config.s3.webIdentity?.roleArn).toBe(WEB_IDENTITY.AWS_ROLE_ARN);
+    expect(config.s3.accessKeyId).toBe('static-access');
+    expect(config.s3.secretKey).toBe('static-secret');
+  });
+
+  it('neither set complete: throws listing BOTH credential options', () => {
+    const expectBothOptions = (env: NodeJS.ProcessEnv) => {
+      expect(() => resolveMediaBackendConfig(env)).toThrow(
+        /OMNI_MEDIA_S3_ACCESS_KEY \+ OMNI_MEDIA_S3_SECRET_KEY.*AWS_WEB_IDENTITY_TOKEN_FILE \+ AWS_ROLE_ARN/,
+      );
+    };
+    expectBothOptions(REMOTE_BASE);
+    // Half a static pair does not count as a complete set.
+    expectBothOptions({ ...REMOTE_BASE, OMNI_MEDIA_S3_ACCESS_KEY: 'static-access' });
+    // Half a web-identity pair does not count either.
+    expectBothOptions({ ...REMOTE_BASE, AWS_WEB_IDENTITY_TOKEN_FILE: '/var/run/token' });
+    expectBothOptions({ ...REMOTE_BASE, AWS_ROLE_ARN: 'arn:aws:iam::123456789012:role/x' });
+  });
+
+  it('bucket stays required regardless of the credential source', () => {
+    expect(() => resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 'remote', ...STATIC_KEYS })).toThrow(
+      /OMNI_MEDIA_S3_BUCKET/,
+    );
+    expect(() => resolveMediaBackendConfig({ OMNI_MEDIA_MODE: 'remote', ...WEB_IDENTITY })).toThrow(
+      /OMNI_MEDIA_S3_BUCKET/,
+    );
+  });
+});

--- a/packages/channel-sdk/src/media-backends/__tests__/s3-backend-web-identity.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/s3-backend-web-identity.test.ts
@@ -244,4 +244,28 @@ describe('S3MediaBackend web-identity credential wiring', () => {
     expect(provider.refreshCalls).toBe(0);
     expect(constructedOptions[0]?.sessionToken).toBe('token-1');
   });
+
+  it('does not refresh per-presign when the requested TTL equals the session duration (default config)', async () => {
+    // Model production: a healthy, freshly-minted credential is always a hair
+    // under full lifetime by signing time. Mint at T0 with full lifetime, then
+    // sign 1ms later so remaining (3599999ms) < requestedMs at ttl == max.
+    const T0 = Date.parse('2026-07-06T00:00:00.000Z');
+    const provider = new FakeProvider(() => credentialsAt('token-1', new Date(T0 + SESSION_DURATION_SECONDS * 1000)));
+    const backend = new S3MediaBackend(WEB_IDENTITY_CONFIG, { credentialProvider: provider, now: () => T0 + 1 });
+
+    // The default presignTtlSeconds equals SESSION_DURATION_SECONDS — the exact
+    // boundary the `<=`-vs-`<` guard governs.
+    let lastUrl = '';
+    for (let i = 0; i < 5; i++) {
+      lastUrl = await backend.presignedUrl(`inst-1/2026-07/msg-${i}.png`, SESSION_DURATION_SECONDS);
+    }
+
+    // A refresh can never satisfy a TTL == max lifetime, so it must NOT fire —
+    // no per-presign STS churn on the default config. The URL is clamped to the
+    // healthy cred's remaining life (3599999ms → 3599s), signed by the one
+    // client built for it (no rebuilds).
+    expect(provider.refreshCalls).toBe(0);
+    expect(constructedOptions).toHaveLength(1);
+    expect(new URL(lastUrl).searchParams.get('X-Amz-Expires')).toBe('3599');
+  });
 });

--- a/packages/channel-sdk/src/media-backends/__tests__/s3-backend-web-identity.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/s3-backend-web-identity.test.ts
@@ -1,0 +1,163 @@
+/**
+ * S3 backend credential wiring in web-identity (IRSA) mode — fully offline.
+ *
+ * Uses the same `Bun.S3Client` constructor trap as the sibling tests (presign
+ * is pure local SigV4 math, so no network is touched) plus an injected fake
+ * credential provider. Locks the G-CODE contract:
+ *  - web-identity mode builds the client LAZILY with the STS sessionToken and
+ *    REBUILDS it when the provider rotates the token (expiry-driven refresh);
+ *  - on STS failure it falls back to static keys when they exist, else
+ *    surfaces the error;
+ *  - static mode without a key pair fails loudly at construction.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { S3BackendConfig } from '../config';
+import { S3MediaBackend } from '../s3-backend';
+import type { S3CredentialProvider, StsCredentials } from '../web-identity';
+
+const WEB_IDENTITY_CONFIG: S3BackendConfig = {
+  endpoint: 'http://minio.internal:9000',
+  bucket: 'omni-media',
+  region: 'us-east-1',
+  credentialSource: 'web-identity',
+  webIdentity: {
+    tokenFile: '/var/run/secrets/eks.amazonaws.com/serviceaccount/token',
+    roleArn: 'arn:aws:iam::123456789012:role/omni-media-irsa',
+    stsRegion: 'us-east-1',
+  },
+  forcePathStyle: true,
+  presignTtlSeconds: 3600,
+};
+
+function credentials(sessionToken: string): StsCredentials {
+  return {
+    accessKeyId: `ASIA-${sessionToken}`,
+    secretAccessKey: `secret-${sessionToken}`,
+    sessionToken,
+    expiration: new Date(Date.now() + 3600_000),
+  };
+}
+
+/** Deterministic provider: yields whatever `produce` currently returns. */
+class FakeProvider implements S3CredentialProvider {
+  readonly source = 'web-identity' as const;
+  calls = 0;
+
+  constructor(private readonly produce: () => StsCredentials) {}
+
+  async getCredentials(): Promise<StsCredentials> {
+    this.calls++;
+    return this.produce();
+  }
+}
+
+type TrappedOptions = { accessKeyId?: string; sessionToken?: string } | undefined;
+
+describe('S3MediaBackend web-identity credential wiring', () => {
+  const OriginalS3Client = Bun.S3Client;
+  let constructedOptions: TrappedOptions[];
+
+  beforeEach(() => {
+    constructedOptions = [];
+    // Trap the native S3 client constructor to observe the credentials each
+    // client is built with. Cast through unknown: we replace a native class.
+    (Bun as unknown as { S3Client: unknown }).S3Client = class extends OriginalS3Client {
+      constructor(...args: ConstructorParameters<typeof OriginalS3Client>) {
+        constructedOptions.push(args[0] as TrappedOptions);
+        super(...args);
+      }
+    };
+  });
+
+  afterEach(() => {
+    (Bun as unknown as { S3Client: typeof OriginalS3Client }).S3Client = OriginalS3Client;
+  });
+
+  it('builds the client lazily with the STS session token and presigns with it', async () => {
+    const provider = new FakeProvider(() => credentials('token-1'));
+    const backend = new S3MediaBackend(WEB_IDENTITY_CONFIG, { credentialProvider: provider });
+
+    // No eager client in web-identity mode — credentials do not exist yet.
+    expect(constructedOptions).toHaveLength(0);
+
+    const url = await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(constructedOptions).toHaveLength(1);
+    expect(constructedOptions[0]?.accessKeyId).toBe('ASIA-token-1');
+    expect(constructedOptions[0]?.sessionToken).toBe('token-1');
+    expect(url).toContain('X-Amz-Security-Token=');
+    expect(url).toContain('X-Amz-Signature=');
+  });
+
+  it('rebuilds the client when the session token rotates and reuses it otherwise', async () => {
+    let current = credentials('token-1');
+    const provider = new FakeProvider(() => current);
+    const backend = new S3MediaBackend(WEB_IDENTITY_CONFIG, { credentialProvider: provider });
+
+    await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    // Same token → same client, no rebuild.
+    expect(constructedOptions).toHaveLength(1);
+
+    // The provider refreshed (e.g. ≤10 min to expiry) → new sessionToken.
+    current = credentials('token-2');
+    await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(constructedOptions).toHaveLength(2);
+    expect(constructedOptions[1]?.sessionToken).toBe('token-2');
+  });
+
+  it('falls back to static keys when the STS exchange fails and they exist', async () => {
+    const provider = new FakeProvider(() => {
+      throw new Error('sts is down');
+    });
+    const backend = new S3MediaBackend(
+      { ...WEB_IDENTITY_CONFIG, accessKeyId: 'static-access', secretKey: 'static-secret' },
+      { credentialProvider: provider },
+    );
+
+    const url = await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(constructedOptions).toHaveLength(1);
+    expect(constructedOptions[0]?.accessKeyId).toBe('static-access');
+    expect(constructedOptions[0]?.sessionToken).toBeUndefined();
+    expect(url).not.toContain('X-Amz-Security-Token=');
+
+    // The fallback client is cached — repeated failures do not rebuild it.
+    await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(constructedOptions).toHaveLength(1);
+    expect(provider.calls).toBe(2);
+  });
+
+  it('recovers onto web-identity credentials once STS works again', async () => {
+    let stsUp = false;
+    const provider = new FakeProvider(() => {
+      if (!stsUp) throw new Error('sts is down');
+      return credentials('token-1');
+    });
+    const backend = new S3MediaBackend(
+      { ...WEB_IDENTITY_CONFIG, accessKeyId: 'static-access', secretKey: 'static-secret' },
+      { credentialProvider: provider },
+    );
+
+    await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60); // static fallback
+    stsUp = true;
+    const url = await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+    expect(constructedOptions).toHaveLength(2);
+    expect(constructedOptions[1]?.sessionToken).toBe('token-1');
+    expect(url).toContain('X-Amz-Security-Token=');
+  });
+
+  it('surfaces the STS error when no static fallback exists', async () => {
+    const provider = new FakeProvider(() => {
+      throw new Error('sts is down');
+    });
+    const backend = new S3MediaBackend(WEB_IDENTITY_CONFIG, { credentialProvider: provider });
+
+    await expect(backend.presignedUrl('inst-1/2026-07/msg-1.png', 60)).rejects.toThrow('sts is down');
+    expect(constructedOptions).toHaveLength(0);
+  });
+
+  it('fails loudly at construction in static mode without a key pair', () => {
+    const { credentialSource: _credentialSource, webIdentity: _webIdentity, ...staticShape } = WEB_IDENTITY_CONFIG;
+    expect(() => new S3MediaBackend(staticShape)).toThrow(/static mode requires accessKeyId \+ secretKey/);
+  });
+});

--- a/packages/channel-sdk/src/media-backends/__tests__/s3-backend-web-identity.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/s3-backend-web-identity.test.ts
@@ -12,9 +12,26 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { configureLogging, getLogConfig } from '@omni/core';
 import type { S3BackendConfig } from '../config';
 import { S3MediaBackend } from '../s3-backend';
-import type { S3CredentialProvider, StsCredentials } from '../web-identity';
+import { type S3CredentialProvider, SESSION_DURATION_SECONDS, type StsCredentials } from '../web-identity';
+
+/** Swallow + collect everything the logger writes to stdout while `run` executes. */
+async function captureStdout(run: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const original = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await run();
+  } finally {
+    process.stdout.write = original;
+  }
+  return chunks.join('');
+}
 
 const WEB_IDENTITY_CONFIG: S3BackendConfig = {
   endpoint: 'http://minio.internal:9000',
@@ -31,24 +48,42 @@ const WEB_IDENTITY_CONFIG: S3BackendConfig = {
 };
 
 function credentials(sessionToken: string): StsCredentials {
+  return credentialsAt(sessionToken, new Date(Date.now() + 3600_000));
+}
+
+/** Credential with an explicit expiration — for exercising the presign TTL guard. */
+function credentialsAt(sessionToken: string, expiration: Date): StsCredentials {
   return {
     accessKeyId: `ASIA-${sessionToken}`,
     secretAccessKey: `secret-${sessionToken}`,
     sessionToken,
-    expiration: new Date(Date.now() + 3600_000),
+    expiration,
   };
 }
 
-/** Deterministic provider: yields whatever `produce` currently returns. */
+/**
+ * Deterministic provider: `getCredentials` yields whatever `produce` returns;
+ * `forceRefresh` yields `produceOnRefresh` (defaults to `produce`). Tracks the
+ * two call counts separately so tests can assert a pre-sign refresh happened.
+ */
 class FakeProvider implements S3CredentialProvider {
   readonly source = 'web-identity' as const;
   calls = 0;
+  refreshCalls = 0;
 
-  constructor(private readonly produce: () => StsCredentials) {}
+  constructor(
+    private readonly produce: () => StsCredentials,
+    private readonly produceOnRefresh: () => StsCredentials = produce,
+  ) {}
 
   async getCredentials(): Promise<StsCredentials> {
     this.calls++;
     return this.produce();
+  }
+
+  async forceRefresh(): Promise<StsCredentials> {
+    this.refreshCalls++;
+    return this.produceOnRefresh();
   }
 }
 
@@ -159,5 +194,54 @@ describe('S3MediaBackend web-identity credential wiring', () => {
   it('fails loudly at construction in static mode without a key pair', () => {
     const { credentialSource: _credentialSource, webIdentity: _webIdentity, ...staticShape } = WEB_IDENTITY_CONFIG;
     expect(() => new S3MediaBackend(staticShape)).toThrow(/static mode requires accessKeyId \+ secretKey/);
+  });
+
+  it('refreshes a near-expiry credential before signing so the URL gets its full TTL', async () => {
+    const T0 = Date.parse('2026-07-06T00:00:00.000Z');
+    const provider = new FakeProvider(
+      () => credentialsAt('token-near', new Date(T0 + 30_000)), // only 30s of life left
+      () => credentialsAt('token-fresh', new Date(T0 + SESSION_DURATION_SECONDS * 1000)), // full-lifetime refresh
+    );
+    const backend = new S3MediaBackend(WEB_IDENTITY_CONFIG, { credentialProvider: provider, now: () => T0 });
+
+    const url = await backend.presignedUrl('inst-1/2026-07/msg-1.png', 60);
+
+    // The 30s-of-life credential cannot cover a 60s URL, so a force-refresh runs
+    // and the client is built with the fresh credential, which signs the URL.
+    expect(provider.refreshCalls).toBe(1);
+    expect(constructedOptions).toHaveLength(1);
+    expect(constructedOptions[0]?.sessionToken).toBe('token-fresh');
+    const params = new URL(url).searchParams;
+    expect(params.get('X-Amz-Security-Token')).toBe('token-fresh');
+    expect(params.get('X-Amz-Expires')).toBe('60'); // full requested TTL, not clamped
+  });
+
+  it('clamps URL expiry to the credential lifetime when the requested TTL exceeds it, warning once', async () => {
+    const T0 = Date.parse('2026-07-06T00:00:00.000Z');
+    const provider = new FakeProvider(() => credentialsAt('token-1', new Date(T0 + SESSION_DURATION_SECONDS * 1000)));
+    const backend = new S3MediaBackend(WEB_IDENTITY_CONFIG, { credentialProvider: provider, now: () => T0 });
+
+    const oversizedTtl = SESSION_DURATION_SECONDS * 2; // longer than any credential can live
+    const previous = getLogConfig();
+    configureLogging({ level: 'info', modules: '*' }); // make the warn deterministic, env aside
+    let firstUrl = '';
+    try {
+      const output = await captureStdout(async () => {
+        firstUrl = await backend.presignedUrl('inst-1/2026-07/msg-1.png', oversizedTtl);
+        await backend.presignedUrl('inst-1/2026-07/msg-2.png', oversizedTtl); // second clamp
+      });
+      // The cap is warned exactly once across repeated clamps, not once per URL.
+      const capWarnings = output.split('Presign TTL exceeds temporary-credential lifetime').length - 1;
+      expect(capWarnings).toBe(1);
+    } finally {
+      configureLogging({ level: previous.level, modules: previous.modules });
+    }
+
+    // A URL cannot outlive its signing credential: expiry is clamped to the full
+    // credential lifetime, never the requested 2x TTL. An unsatisfiable TTL is
+    // not chased with a refresh — the healthy credential is signed as-is.
+    expect(new URL(firstUrl).searchParams.get('X-Amz-Expires')).toBe(String(SESSION_DURATION_SECONDS));
+    expect(provider.refreshCalls).toBe(0);
+    expect(constructedOptions[0]?.sessionToken).toBe('token-1');
   });
 });

--- a/packages/channel-sdk/src/media-backends/__tests__/web-identity.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/web-identity.test.ts
@@ -193,4 +193,65 @@ describe('WebIdentityCredentialProvider', () => {
     expect((await provider.getCredentials()).accessKeyId).toBe('ASIA-TEST');
     expect(fetchCount).toBe(2);
   });
+
+  it('serves the still-valid cached credential when a refresh exchange fails', async () => {
+    const T0 = Date.parse('2026-01-01T00:00:00.000Z');
+    let nowMs = T0;
+    let fetchCount = 0;
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      {
+        fetchImpl: async () => {
+          fetchCount++;
+          // First exchange succeeds (cred valid until T0+1h); every later one throws.
+          if (fetchCount === 1) {
+            return new Response(stsXml({ sessionToken: 'token-1', expiration: '2026-01-01T01:00:00.000Z' }), {
+              status: 200,
+            });
+          }
+          throw new Error('STS unreachable');
+        },
+        now: () => nowMs,
+      },
+    );
+
+    // Prime the cache.
+    expect((await provider.getCredentials()).sessionToken).toBe('token-1');
+    expect(fetchCount).toBe(1);
+
+    // Advance into the refresh margin (599s of life left ≤ 10 min): the refresh
+    // fetch throws, but the cached cred still has ~10 min left, so it is served.
+    nowMs = T0 + (3600 - 599) * 1000;
+    const served = await provider.getCredentials();
+    expect(served.sessionToken).toBe('token-1');
+    expect(fetchCount).toBe(2); // it did attempt a refresh before falling back
+  });
+
+  it('throws when a refresh fails and no still-valid credential is cached', async () => {
+    const T0 = Date.parse('2026-01-01T00:00:00.000Z');
+    let nowMs = T0;
+    let fetchCount = 0;
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      {
+        fetchImpl: async () => {
+          fetchCount++;
+          if (fetchCount === 1) {
+            return new Response(stsXml({ sessionToken: 'token-1', expiration: '2026-01-01T01:00:00.000Z' }), {
+              status: 200,
+            });
+          }
+          throw new Error('STS unreachable');
+        },
+        now: () => nowMs,
+      },
+    );
+
+    expect((await provider.getCredentials()).sessionToken).toBe('token-1');
+
+    // Advance past expiry: the cached cred is no longer usable, so a failed
+    // refresh must surface the error rather than serve a dead credential.
+    nowMs = T0 + 3600 * 1000 + 1000;
+    await expect(provider.getCredentials()).rejects.toThrow(/STS unreachable/);
+  });
 });

--- a/packages/channel-sdk/src/media-backends/__tests__/web-identity.test.ts
+++ b/packages/channel-sdk/src/media-backends/__tests__/web-identity.test.ts
@@ -1,0 +1,196 @@
+/**
+ * STS AssumeRoleWithWebIdentity credential provider (fully offline).
+ *
+ * The XML parse step is a pure function; the provider takes injected
+ * `fetchImpl` + `now` seams, so every path here — request shape, caching,
+ * expiry-triggered refresh, malformed responses, missing/empty token file —
+ * runs without any network or real clock.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WebIdentityCredentialProvider, parseAssumeRoleWithWebIdentityResponse } from '../web-identity';
+
+function stsXml({
+  accessKeyId = 'ASIA-TEST',
+  secretAccessKey = 'secret-test',
+  sessionToken = 'token-test',
+  expiration = '2026-01-01T01:00:00.000Z',
+}: Partial<Record<'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'expiration', string>> = {}): string {
+  return `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <SessionToken>${sessionToken}</SessionToken>
+      <SecretAccessKey>${secretAccessKey}</SecretAccessKey>
+      <Expiration>${expiration}</Expiration>
+      <AccessKeyId>${accessKeyId}</AccessKeyId>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`;
+}
+
+describe('parseAssumeRoleWithWebIdentityResponse', () => {
+  it('extracts all four credential fields from a valid response', () => {
+    const credentials = parseAssumeRoleWithWebIdentityResponse(stsXml());
+    expect(credentials.accessKeyId).toBe('ASIA-TEST');
+    expect(credentials.secretAccessKey).toBe('secret-test');
+    expect(credentials.sessionToken).toBe('token-test');
+    expect(credentials.expiration).toBeInstanceOf(Date);
+    expect(credentials.expiration.toISOString()).toBe('2026-01-01T01:00:00.000Z');
+  });
+
+  it('throws on a response missing a credential field', () => {
+    const withoutToken = stsXml().replace(/<SessionToken>[^<]+<\/SessionToken>/, '');
+    expect(() => parseAssumeRoleWithWebIdentityResponse(withoutToken)).toThrow(/Malformed STS.*sessionToken/);
+  });
+
+  it('throws on garbage that is not an STS response at all', () => {
+    expect(() => parseAssumeRoleWithWebIdentityResponse('<html>welcome to a captive portal</html>')).toThrow(
+      /Malformed STS AssumeRoleWithWebIdentity response/,
+    );
+  });
+
+  it('throws on an unparseable Expiration timestamp', () => {
+    expect(() => parseAssumeRoleWithWebIdentityResponse(stsXml({ expiration: 'not-a-date' }))).toThrow(
+      /Malformed STS.*expiration/,
+    );
+  });
+});
+
+describe('WebIdentityCredentialProvider', () => {
+  let tmpDir: string;
+  let tokenFile: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'web-identity-test-'));
+    tokenFile = join(tmpDir, 'token');
+    // Trailing newline on purpose: the provider must trim the projected token.
+    writeFileSync(tokenFile, 'header.payload.signature\n');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const PARAMS = { roleArn: 'arn:aws:iam::123456789012:role/media', stsRegion: 'sa-east-1' };
+
+  it('reports its source as web-identity for logging', () => {
+    const provider = new WebIdentityCredentialProvider({ ...PARAMS, tokenFile });
+    expect(provider.source).toBe('web-identity');
+  });
+
+  it('POSTs an unsigned AssumeRoleWithWebIdentity form to the regional STS endpoint', async () => {
+    const requests: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      {
+        fetchImpl: async (input, init) => {
+          requests.push({ url: String(input), init });
+          return new Response(stsXml(), { status: 200 });
+        },
+      },
+    );
+
+    const credentials = await provider.getCredentials();
+    expect(credentials.accessKeyId).toBe('ASIA-TEST');
+
+    expect(requests).toHaveLength(1);
+    const request = requests[0];
+    if (!request) throw new Error('unreachable');
+    expect(request.url).toBe('https://sts.sa-east-1.amazonaws.com/');
+    expect(request.init?.method).toBe('POST');
+    const body = new URLSearchParams(String(request.init?.body));
+    expect(body.get('Action')).toBe('AssumeRoleWithWebIdentity');
+    expect(body.get('Version')).toBe('2011-06-15');
+    expect(body.get('RoleArn')).toBe(PARAMS.roleArn);
+    expect(body.get('RoleSessionName')).toBe('omni-media');
+    expect(body.get('WebIdentityToken')).toBe('header.payload.signature'); // trimmed
+    expect(body.get('DurationSeconds')).toBe('3600');
+    // Unsigned: the token IS the auth — no SigV4 Authorization header.
+    expect(new Headers(request.init?.headers).has('authorization')).toBe(false);
+  });
+
+  it('caches credentials and refreshes only within 10 minutes of expiry', async () => {
+    const T0 = Date.parse('2026-01-01T00:00:00.000Z');
+    let nowMs = T0;
+    let fetchCount = 0;
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      {
+        fetchImpl: async () => {
+          fetchCount++;
+          // Each exchange mints creds valid until T0+1h (first) / T0+2h (second).
+          const expiration = fetchCount === 1 ? '2026-01-01T01:00:00.000Z' : '2026-01-01T02:00:00.000Z';
+          return new Response(stsXml({ sessionToken: `token-${fetchCount}`, expiration }), { status: 200 });
+        },
+        now: () => nowMs,
+      },
+    );
+
+    // First call fetches; immediate second call is served from cache.
+    expect((await provider.getCredentials()).sessionToken).toBe('token-1');
+    expect((await provider.getCredentials()).sessionToken).toBe('token-1');
+    expect(fetchCount).toBe(1);
+
+    // 601s of life left (> 10 min margin) — still cached.
+    nowMs = T0 + (3600 - 601) * 1000;
+    expect((await provider.getCredentials()).sessionToken).toBe('token-1');
+    expect(fetchCount).toBe(1);
+
+    // 599s left (≤ 10 min margin) — refresh kicks in.
+    nowMs = T0 + (3600 - 599) * 1000;
+    expect((await provider.getCredentials()).sessionToken).toBe('token-2');
+    expect(fetchCount).toBe(2);
+  });
+
+  it('rejects with the token path when the token file is missing, without calling STS', async () => {
+    let fetched = false;
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile: join(tmpDir, 'does-not-exist') },
+      {
+        fetchImpl: async () => {
+          fetched = true;
+          return new Response(stsXml(), { status: 200 });
+        },
+      },
+    );
+    await expect(provider.getCredentials()).rejects.toThrow(/Cannot read web-identity token file.*does-not-exist/);
+    expect(fetched).toBe(false);
+  });
+
+  it('rejects when the token file is empty', async () => {
+    writeFileSync(tokenFile, '  \n');
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      { fetchImpl: async () => new Response(stsXml(), { status: 200 }) },
+    );
+    await expect(provider.getCredentials()).rejects.toThrow(/token file .* is empty/);
+  });
+
+  it('rejects with the HTTP status on an STS error response', async () => {
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      { fetchImpl: async () => new Response('<ErrorResponse>AccessDenied</ErrorResponse>', { status: 403 }) },
+    );
+    await expect(provider.getCredentials()).rejects.toThrow(/AssumeRoleWithWebIdentity failed \(HTTP 403\)/);
+  });
+
+  it('rejects on a 200 response with a malformed body and retries on the next call', async () => {
+    let fetchCount = 0;
+    const provider = new WebIdentityCredentialProvider(
+      { ...PARAMS, tokenFile },
+      {
+        fetchImpl: async () => {
+          fetchCount++;
+          return fetchCount === 1 ? new Response('<oops/>', { status: 200 }) : new Response(stsXml(), { status: 200 });
+        },
+      },
+    );
+    await expect(provider.getCredentials()).rejects.toThrow(/Malformed STS/);
+    // A failed exchange must not poison the cache — the next call retries.
+    expect((await provider.getCredentials()).accessKeyId).toBe('ASIA-TEST');
+    expect(fetchCount).toBe(2);
+  });
+});

--- a/packages/channel-sdk/src/media-backends/config.ts
+++ b/packages/channel-sdk/src/media-backends/config.ts
@@ -5,11 +5,32 @@
  * unvalidated external inputs). `OMNI_MEDIA_MODE` selects the backend and
  * defaults to `local` when unset; ONLY `local` and `remote` are accepted — any
  * other value throws loudly, so a typo (`s3`, `minio`, ...) cannot silently
- * fall back to local disk. `remote` additionally requires S3 credentials and
- * fails loudly when they are missing.
+ * fall back to local disk. `remote` additionally requires a bucket plus ONE
+ * complete credential set — static keys (`OMNI_MEDIA_S3_ACCESS_KEY` +
+ * `OMNI_MEDIA_S3_SECRET_KEY`) or IRSA web-identity
+ * (`AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`) — and fails loudly listing
+ * both options when neither is complete. When BOTH sets are present,
+ * web-identity is primary and the static pair is retained as a fallback.
  */
 
 import { z } from 'zod';
+
+/** How the S3 backend sources its credentials. */
+export type S3CredentialSource = 'static' | 'web-identity';
+
+/**
+ * IRSA / web-identity parameters. On EKS the pod identity webhook injects the
+ * source env vars automatically when the ServiceAccount carries the
+ * `eks.amazonaws.com/role-arn` annotation.
+ */
+export interface S3WebIdentityParams {
+  /** Path to the projected ServiceAccount token (`AWS_WEB_IDENTITY_TOKEN_FILE`). */
+  tokenFile: string;
+  /** IAM role to assume (`AWS_ROLE_ARN`). */
+  roleArn: string;
+  /** Region for the STS endpoint (`AWS_REGION`, falling back to the S3 region). */
+  stsRegion: string;
+}
 
 export interface S3BackendConfig {
   /** Custom endpoint (e.g. MinIO `http://minio:9000`); omit for real AWS S3. */
@@ -22,8 +43,22 @@ export interface S3BackendConfig {
   publicEndpoint?: string;
   bucket: string;
   region: string;
-  accessKeyId: string;
-  secretKey: string;
+  /**
+   * Static key pair (`OMNI_MEDIA_S3_ACCESS_KEY` / `_SECRET_KEY`). Optional
+   * because web-identity mode can run without static keys; when BOTH
+   * credential sets are configured, web-identity is primary and this pair is
+   * kept as an STS-outage fallback.
+   */
+  accessKeyId?: string;
+  secretKey?: string;
+  /**
+   * Credential sourcing mode. Absent (or 'static') → the static key pair
+   * above, byte-compatible with the pre-IRSA config shape. 'web-identity' →
+   * STS AssumeRoleWithWebIdentity using `webIdentity`.
+   */
+  credentialSource?: S3CredentialSource;
+  /** Present when `credentialSource` is 'web-identity'. */
+  webIdentity?: S3WebIdentityParams;
   /** MinIO and most self-hosted S3 need path-style addressing. Default true. */
   forcePathStyle: boolean;
   /** Default TTL applied when a caller does not pass an explicit one. */
@@ -91,12 +126,18 @@ const MediaEnvSchema = z.object({
   OMNI_MEDIA_S3_SECRET_KEY: optionalTrimmedString,
   OMNI_MEDIA_S3_FORCE_PATH_STYLE: boolFromEnv(true),
   OMNI_MEDIA_S3_PRESIGN_TTL_SECONDS: ttlFromEnv(DEFAULT_PRESIGN_TTL_SECONDS),
+  // IRSA / web-identity surface — injected by the EKS pod identity webhook
+  // when the ServiceAccount carries the eks.amazonaws.com/role-arn annotation.
+  AWS_WEB_IDENTITY_TOKEN_FILE: optionalTrimmedString,
+  AWS_ROLE_ARN: optionalTrimmedString,
+  AWS_REGION: optionalTrimmedString,
 });
 
 /**
  * Resolve the media backend configuration from the environment.
  * @throws when `OMNI_MEDIA_MODE` is neither `local` nor `remote` (unset → local),
- *   or when `OMNI_MEDIA_MODE=remote` but required S3 credentials are missing.
+ *   or when `OMNI_MEDIA_MODE=remote` but the bucket is missing or NEITHER
+ *   credential set (static keys / IRSA web-identity) is complete.
  */
 export function resolveMediaBackendConfig(env: NodeJS.ProcessEnv = process.env): MediaBackendConfig {
   const parsed = MediaEnvSchema.safeParse(env);
@@ -112,31 +153,45 @@ export function resolveMediaBackendConfig(env: NodeJS.ProcessEnv = process.env):
   const bucket = vars.OMNI_MEDIA_S3_BUCKET;
   const accessKeyId = vars.OMNI_MEDIA_S3_ACCESS_KEY;
   const secretKey = vars.OMNI_MEDIA_S3_SECRET_KEY;
+  const tokenFile = vars.AWS_WEB_IDENTITY_TOKEN_FILE;
+  const roleArn = vars.AWS_ROLE_ARN;
 
-  if (!bucket || !accessKeyId || !secretKey) {
-    const missing = (
-      [
-        ['OMNI_MEDIA_S3_BUCKET', bucket],
-        ['OMNI_MEDIA_S3_ACCESS_KEY', accessKeyId],
-        ['OMNI_MEDIA_S3_SECRET_KEY', secretKey],
-      ] as const
-    )
-      .filter(([, value]) => !value)
-      .map(([name]) => name);
-    throw new Error(`OMNI_MEDIA_MODE=remote requires these env vars: ${missing.join(', ')}`);
+  const staticComplete = accessKeyId !== undefined && secretKey !== undefined;
+  const webIdentityComplete = tokenFile !== undefined && roleArn !== undefined;
+
+  if (!bucket || (!staticComplete && !webIdentityComplete)) {
+    const missing: string[] = [];
+    if (!bucket) missing.push('OMNI_MEDIA_S3_BUCKET');
+    if (!staticComplete && !webIdentityComplete) {
+      missing.push(
+        'credentials — either static keys (OMNI_MEDIA_S3_ACCESS_KEY + OMNI_MEDIA_S3_SECRET_KEY) or IRSA web-identity (AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN)',
+      );
+    }
+    throw new Error(`OMNI_MEDIA_MODE=remote requires: ${missing.join(', ')}`);
   }
 
+  const region = vars.OMNI_MEDIA_S3_REGION ?? DEFAULT_REGION;
   return {
     mode: 'remote',
     s3: {
       endpoint: vars.OMNI_MEDIA_S3_ENDPOINT,
       publicEndpoint: vars.OMNI_MEDIA_S3_PUBLIC_ENDPOINT,
       bucket,
-      region: vars.OMNI_MEDIA_S3_REGION ?? DEFAULT_REGION,
+      region,
       accessKeyId,
       secretKey,
       forcePathStyle: vars.OMNI_MEDIA_S3_FORCE_PATH_STYLE,
       presignTtlSeconds: vars.OMNI_MEDIA_S3_PRESIGN_TTL_SECONDS,
+      // Web-identity (when complete) is PRIMARY; static keys above — when also
+      // present — stay available as the backend's STS-outage fallback. In the
+      // static-only path these keys are omitted entirely, keeping the resolved
+      // shape byte-compatible with the pre-IRSA config.
+      ...(tokenFile !== undefined && roleArn !== undefined
+        ? {
+            credentialSource: 'web-identity' as const,
+            webIdentity: { tokenFile, roleArn, stsRegion: vars.AWS_REGION ?? region },
+          }
+        : {}),
     },
   };
 }

--- a/packages/channel-sdk/src/media-backends/index.ts
+++ b/packages/channel-sdk/src/media-backends/index.ts
@@ -11,11 +11,14 @@ import { LocalMediaBackend } from './local-backend';
 import { S3MediaBackend } from './s3-backend';
 import type { MediaStorageBackend } from './types';
 
-export type { MediaBackendConfig, S3BackendConfig } from './config';
+export type { MediaBackendConfig, S3BackendConfig, S3CredentialSource, S3WebIdentityParams } from './config';
 export { resolveMediaBackendConfig } from './config';
 export { LocalMediaBackend } from './local-backend';
+export type { S3MediaBackendOptions } from './s3-backend';
 export { S3MediaBackend } from './s3-backend';
 export { isMediaNotFoundError } from './types';
+export type { S3CredentialProvider, StsCredentials } from './web-identity';
+export { parseAssumeRoleWithWebIdentityResponse, WebIdentityCredentialProvider } from './web-identity';
 export type {
   MediaObjectStat,
   MediaStorageBackend,

--- a/packages/channel-sdk/src/media-backends/s3-backend.ts
+++ b/packages/channel-sdk/src/media-backends/s3-backend.ts
@@ -326,12 +326,15 @@ export class S3MediaBackend implements MediaStorageBackend {
       return presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
     }
 
-    // Refresh only for a TTL a fresh credential could actually satisfy. A
-    // request longer than the max credential lifetime can never be honoured, so
-    // chasing it with a refresh would churn STS on every presign — clamp the
-    // healthy credential instead.
+    // Refresh only for a TTL a fresh credential could actually satisfy. Strict
+    // `<`: a request AT the max lifetime is also unsatisfiable, because by
+    // signing time a freshly-minted credential's remaining life is always a
+    // hair under full lifetime — with `<=` the default TTL (== session duration)
+    // would force a refresh on every presign that still ends up clamped, i.e.
+    // pure STS churn. Only a strictly-shorter TTL leaves headroom a refresh can
+    // fill; at or above the ceiling we clamp the healthy credential instead.
     const maxLifetimeMs = SESSION_DURATION_SECONDS * 1000;
-    if (requestedMs <= maxLifetimeMs && credentials.expiration.getTime() - this.now() < requestedMs) {
+    if (requestedMs < maxLifetimeMs && credentials.expiration.getTime() - this.now() < requestedMs) {
       credentials = await this.refreshForPresign(state, credentials);
     }
     const { presignClient } = this.buildOrReuseWebIdentityClients(state, credentials);

--- a/packages/channel-sdk/src/media-backends/s3-backend.ts
+++ b/packages/channel-sdk/src/media-backends/s3-backend.ts
@@ -30,7 +30,12 @@ import {
   type StoreStreamInput,
   isMediaNotFoundError,
 } from './types';
-import { type S3CredentialProvider, type StsCredentials, WebIdentityCredentialProvider } from './web-identity';
+import {
+  type S3CredentialProvider,
+  SESSION_DURATION_SECONDS,
+  type StsCredentials,
+  WebIdentityCredentialProvider,
+} from './web-identity';
 
 const log = createLogger('services:media-backends:s3');
 
@@ -94,6 +99,12 @@ export interface S3MediaBackendOptions {
    * the backend would otherwise build from `config.webIdentity`.
    */
   credentialProvider?: S3CredentialProvider;
+  /**
+   * Injection seam for tests — defaults to `Date.now`. Used only by the
+   * presign TTL guard to compare a temporary credential's expiration against
+   * the requested URL lifetime.
+   */
+  now?: () => number;
 }
 
 export class S3MediaBackend implements MediaStorageBackend {
@@ -102,10 +113,14 @@ export class S3MediaBackend implements MediaStorageBackend {
   private readonly config: S3BackendConfig;
   private readonly state: CredentialState;
   private presignTtlSeconds: number;
+  private readonly now: () => number;
+  /** Guards the presign-TTL-cap warning so it logs once per backend, not per URL. */
+  private presignTtlCapWarned = false;
 
   constructor(config: S3BackendConfig, options: S3MediaBackendOptions = {}) {
     this.config = config;
     this.presignTtlSeconds = config.presignTtlSeconds;
+    this.now = options.now ?? Date.now;
     this.state =
       config.credentialSource === 'web-identity'
         ? { source: 'web-identity', provider: resolveProvider(config, options), current: null, staticFallback: null }
@@ -140,6 +155,16 @@ export class S3MediaBackend implements MediaStorageBackend {
     } catch (error) {
       return this.fallbackToStaticClients(state, error);
     }
+    return this.buildOrReuseWebIdentityClients(state, credentials);
+  }
+
+  /**
+   * Return the client pair for `credentials`, rebuilding the `Bun.S3Client`
+   * pair only when the sessionToken changed (a refresh). Pure client bookkeeping
+   * with no credential fetching, so both {@link resolveWebIdentityClients} and
+   * the presign path can drive it with credentials they already hold.
+   */
+  private buildOrReuseWebIdentityClients(state: WebIdentityState, credentials: StsCredentials): S3Clients {
     if (!state.current || state.current.sessionToken !== credentials.sessionToken) {
       const clients = buildClients(this.config, {
         accessKeyId: credentials.accessKeyId,
@@ -270,8 +295,82 @@ export class S3MediaBackend implements MediaStorageBackend {
   }
 
   async presignedUrl(key: string, ttlSeconds: number = this.presignTtlSeconds): Promise<string> {
-    const { presignClient } = await this.resolveClients();
-    return presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
+    // Static credentials never expire, so the signed URL honours `ttlSeconds`
+    // outright — leave that path untouched.
+    if (this.state.source === 'static') {
+      return this.state.clients.presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
+    }
+    return this.presignWithTtlGuarantee(this.state, key, ttlSeconds);
+  }
+
+  /**
+   * Presign under temporary (web-identity) credentials. A URL signed by a
+   * temporary credential is only valid until that credential expires, so a URL
+   * minted late in a credential's life would honour far less than `ttlSeconds`.
+   * Guarantee the requested TTL by refreshing the credential when it has less
+   * than `ttlSeconds` of life left; when `ttlSeconds` exceeds the maximum
+   * credential lifetime the URL cannot outlive the credential, so clamp
+   * `expiresIn` to the credential's remaining life (and warn once) rather than
+   * promise a TTL the URL will not honour.
+   */
+  private async presignWithTtlGuarantee(state: WebIdentityState, key: string, ttlSeconds: number): Promise<string> {
+    const requestedMs = ttlSeconds * 1000;
+
+    let credentials: StsCredentials;
+    try {
+      credentials = await state.provider.getCredentials();
+    } catch (error) {
+      // STS is down with no still-valid cache: the static fallback keys do not
+      // expire, so sign with the requested TTL and no guard.
+      const { presignClient } = this.fallbackToStaticClients(state, error);
+      return presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
+    }
+
+    // Refresh only for a TTL a fresh credential could actually satisfy. A
+    // request longer than the max credential lifetime can never be honoured, so
+    // chasing it with a refresh would churn STS on every presign — clamp the
+    // healthy credential instead.
+    const maxLifetimeMs = SESSION_DURATION_SECONDS * 1000;
+    if (requestedMs <= maxLifetimeMs && credentials.expiration.getTime() - this.now() < requestedMs) {
+      credentials = await this.refreshForPresign(state, credentials);
+    }
+    const { presignClient } = this.buildOrReuseWebIdentityClients(state, credentials);
+
+    const remainingMs = credentials.expiration.getTime() - this.now();
+    let expiresIn = ttlSeconds;
+    if (requestedMs > remainingMs) {
+      expiresIn = Math.max(1, Math.floor(remainingMs / 1000));
+      this.warnPresignTtlCapped(ttlSeconds, expiresIn);
+    }
+    return presignClient.presign(key, { expiresIn, method: 'GET' });
+  }
+
+  /**
+   * Force a fresh credential ahead of signing. If the exchange fails, keep the
+   * still-valid current credential (the caller clamps the URL to its remaining
+   * life) rather than failing the presign outright.
+   */
+  private async refreshForPresign(state: WebIdentityState, current: StsCredentials): Promise<StsCredentials> {
+    try {
+      return await state.provider.forceRefresh();
+    } catch (error) {
+      log.warn('Presign credential refresh failed; signing with the current credential', {
+        source: state.provider.source,
+        error: String(error),
+      });
+      return current;
+    }
+  }
+
+  /** Warn once per backend that a presign TTL was capped to the credential lifetime. */
+  private warnPresignTtlCapped(requestedTtlSeconds: number, effectiveTtlSeconds: number): void {
+    if (this.presignTtlCapWarned) return;
+    this.presignTtlCapWarned = true;
+    log.warn('Presign TTL exceeds temporary-credential lifetime; capping URL expiry to the credential remaining life', {
+      requestedTtlSeconds,
+      effectiveTtlSeconds,
+      maxCredentialLifetimeSeconds: SESSION_DURATION_SECONDS,
+    });
   }
 }
 

--- a/packages/channel-sdk/src/media-backends/s3-backend.ts
+++ b/packages/channel-sdk/src/media-backends/s3-backend.ts
@@ -7,6 +7,16 @@
  * (MinIO) makes the client address buckets path-style by default, which is what
  * self-hosted S3 expects; `forcePathStyle: false` opts into virtual-hosted
  * addressing for providers that require it.
+ *
+ * Credential sourcing (see config.ts):
+ * - static (default): the OMNI_MEDIA_S3_* key pair, client built eagerly in
+ *   the constructor — byte-compatible with the pre-IRSA behavior.
+ * - web-identity (IRSA): temporary credentials from STS
+ *   AssumeRoleWithWebIdentity via {@link WebIdentityCredentialProvider}. The
+ *   `Bun.S3Client` carries a `sessionToken` and is REBUILT whenever the
+ *   provider refreshes it; on STS failure the backend falls back to the static
+ *   key pair when one is configured, else surfaces the error. Storage and
+ *   streaming logic is identical in both modes.
  */
 
 import { createLogger } from '@omni/core';
@@ -20,48 +30,144 @@ import {
   type StoreStreamInput,
   isMediaNotFoundError,
 } from './types';
+import { type S3CredentialProvider, type StsCredentials, WebIdentityCredentialProvider } from './web-identity';
 
 const log = createLogger('services:media-backends:s3');
 
-export class S3MediaBackend implements MediaStorageBackend {
-  readonly mode = 'remote' as const;
-
-  private client: Bun.S3Client;
+interface S3Clients {
+  client: Bun.S3Client;
   /**
    * Client used ONLY for `presign()`. When `publicEndpoint` is configured this
    * signs URLs against the externally-reachable host (so agent runtimes outside
    * the cluster can fetch them); uploads/reads keep using `client` and the
    * internal `endpoint`. Without `publicEndpoint` this IS `client`.
    */
-  private presignClient: Bun.S3Client;
+  presignClient: Bun.S3Client;
+}
+
+interface ResolvedS3Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+/** Build the storage + presign client pair for one set of credentials. */
+function buildClients(config: S3BackendConfig, credentials: ResolvedS3Credentials): S3Clients {
+  const clientOptions = {
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    ...(credentials.sessionToken ? { sessionToken: credentials.sessionToken } : {}),
+    bucket: config.bucket,
+    region: config.region,
+    ...(config.forcePathStyle ? {} : { virtualHostedStyle: true }),
+  };
+  const client = new Bun.S3Client({
+    ...clientOptions,
+    ...(config.endpoint ? { endpoint: config.endpoint } : {}),
+  });
+  const presignClient = config.publicEndpoint
+    ? new Bun.S3Client({ ...clientOptions, endpoint: config.publicEndpoint })
+    : client;
+  return { client, presignClient };
+}
+
+/** The static key pair from config, or null when it is incomplete. */
+function staticCredentials(config: S3BackendConfig): ResolvedS3Credentials | null {
+  if (!config.accessKeyId || !config.secretKey) return null;
+  return { accessKeyId: config.accessKeyId, secretAccessKey: config.secretKey };
+}
+
+interface WebIdentityState {
+  source: 'web-identity';
+  provider: S3CredentialProvider;
+  /** Clients built for the provider's current sessionToken; rebuilt on refresh. */
+  current: (S3Clients & { sessionToken: string }) | null;
+  /** Lazily built static-key clients used only when the STS exchange fails. */
+  staticFallback: S3Clients | null;
+}
+
+type CredentialState = { source: 'static'; clients: S3Clients } | WebIdentityState;
+
+export interface S3MediaBackendOptions {
+  /**
+   * Injection seam for tests — replaces the {@link WebIdentityCredentialProvider}
+   * the backend would otherwise build from `config.webIdentity`.
+   */
+  credentialProvider?: S3CredentialProvider;
+}
+
+export class S3MediaBackend implements MediaStorageBackend {
+  readonly mode = 'remote' as const;
+
+  private readonly config: S3BackendConfig;
+  private readonly state: CredentialState;
   private presignTtlSeconds: number;
 
-  constructor(config: S3BackendConfig) {
+  constructor(config: S3BackendConfig, options: S3MediaBackendOptions = {}) {
+    this.config = config;
     this.presignTtlSeconds = config.presignTtlSeconds;
-    const clientOptions = {
-      accessKeyId: config.accessKeyId,
-      secretAccessKey: config.secretKey,
-      bucket: config.bucket,
-      region: config.region,
-      ...(config.forcePathStyle ? {} : { virtualHostedStyle: true }),
-    };
-    this.client = new Bun.S3Client({
-      ...clientOptions,
-      ...(config.endpoint ? { endpoint: config.endpoint } : {}),
-    });
-    this.presignClient = config.publicEndpoint
-      ? new Bun.S3Client({ ...clientOptions, endpoint: config.publicEndpoint })
-      : this.client;
+    this.state =
+      config.credentialSource === 'web-identity'
+        ? { source: 'web-identity', provider: resolveProvider(config, options), current: null, staticFallback: null }
+        : { source: 'static', clients: buildClients(config, requireStaticCredentials(config)) };
     log.info('Initialized S3 media backend', {
       bucket: config.bucket,
       endpoint: config.endpoint ?? 'aws',
       publicEndpoint: config.publicEndpoint ?? config.endpoint ?? 'aws',
       forcePathStyle: config.forcePathStyle,
+      credentialSource: this.state.source,
     });
   }
 
+  /**
+   * Resolve the client pair for the current credentials. Static mode returns
+   * the constructor-built pair (zero overhead). Web-identity mode asks the
+   * provider (cached until ~10 min before expiry) and rebuilds the
+   * `Bun.S3Client` pair whenever the sessionToken changed; when the STS
+   * exchange fails it falls back to the static key pair if one exists.
+   */
+  private async resolveClients(): Promise<S3Clients> {
+    if (this.state.source === 'static') {
+      return this.state.clients;
+    }
+    return this.resolveWebIdentityClients(this.state);
+  }
+
+  private async resolveWebIdentityClients(state: WebIdentityState): Promise<S3Clients> {
+    let credentials: StsCredentials;
+    try {
+      credentials = await state.provider.getCredentials();
+    } catch (error) {
+      return this.fallbackToStaticClients(state, error);
+    }
+    if (!state.current || state.current.sessionToken !== credentials.sessionToken) {
+      const clients = buildClients(this.config, {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken,
+      });
+      const event = state.current ? 'S3 credentials refreshed' : 'S3 credentials acquired';
+      state.current = { ...clients, sessionToken: credentials.sessionToken };
+      log.info(event, { source: state.provider.source, expiration: credentials.expiration.toISOString() });
+    }
+    return state.current;
+  }
+
+  /** STS failed: use the static key pair when configured, else surface. */
+  private fallbackToStaticClients(state: WebIdentityState, error: unknown): S3Clients {
+    const credentials = staticCredentials(this.config);
+    if (!credentials) throw error;
+    log.warn('Web-identity credential exchange failed; falling back to static S3 keys', {
+      source: 'static',
+      error: String(error),
+    });
+    state.staticFallback ??= buildClients(this.config, credentials);
+    return state.staticFallback;
+  }
+
   async store({ key, buffer, mimeType }: StoreMediaInput): Promise<StoreMediaResult> {
-    await this.client.write(key, buffer, mimeType ? { type: mimeType } : undefined);
+    const { client } = await this.resolveClients();
+    await client.write(key, buffer, mimeType ? { type: mimeType } : undefined);
     log.debug('Uploaded media to S3', { key, size: buffer.length });
     return { reference: key, size: buffer.length, mimeType };
   }
@@ -80,7 +186,8 @@ export class S3MediaBackend implements MediaStorageBackend {
    * commits a 0-byte object.
    */
   async storeStream({ key, stream, mimeType, maxSizeBytes }: StoreStreamInput): Promise<StoreMediaResult> {
-    const writer = this.client.file(key, mimeType ? { type: mimeType } : undefined).writer();
+    const { client } = await this.resolveClients();
+    const writer = client.file(key, mimeType ? { type: mimeType } : undefined).writer();
     let size = 0;
     try {
       for await (const chunk of stream) {
@@ -97,14 +204,14 @@ export class S3MediaBackend implements MediaStorageBackend {
       // complete object (verified against MinIO), so the delete is what
       // actually prevents an orphaned partial object.
       await Promise.resolve(writer.end(error as Error)).catch(() => {});
-      await this.deleteQuietly(key);
+      await this.deleteQuietly(client, key);
       throw error;
     }
     await writer.end();
     if (size === 0) {
       // Mirror the local backend: an empty stream must not leave a stored
       // object behind (writer.end() commits a 0-byte object without this).
-      await this.deleteQuietly(key);
+      await this.deleteQuietly(client, key);
       log.debug('Removed empty media object from S3', { key });
       return { reference: key, size, mimeType };
     }
@@ -113,23 +220,25 @@ export class S3MediaBackend implements MediaStorageBackend {
   }
 
   /** Best-effort delete for cleanup paths — never masks the original error. */
-  private async deleteQuietly(key: string): Promise<void> {
+  private async deleteQuietly(client: Bun.S3Client, key: string): Promise<void> {
     try {
-      await this.client.delete(key);
+      await client.delete(key);
     } catch (error) {
       log.warn('Failed to delete orphaned S3 object', { key, error: String(error) });
     }
   }
 
   async read(key: string): Promise<Buffer> {
-    const bytes = await this.client.file(key).arrayBuffer();
+    const { client } = await this.resolveClients();
+    const bytes = await client.file(key).arrayBuffer();
     log.debug('Read media from S3', { key, size: bytes.byteLength });
     return Buffer.from(bytes);
   }
 
   async stat(key: string): Promise<MediaObjectStat | null> {
+    const { client } = await this.resolveClients();
     try {
-      const info = await this.client.file(key).stat();
+      const info = await client.file(key).stat();
       return { size: info.size };
     } catch (error) {
       // Bun's S3Client throws S3Error code 'NoSuchKey' for a missing object;
@@ -146,7 +255,8 @@ export class S3MediaBackend implements MediaStorageBackend {
    * object. Verified against MinIO: `slice(10, 20)` returns bytes 10..19.
    */
   async readRange(key: string, start: number, endInclusive: number): Promise<Buffer> {
-    const bytes = await this.client
+    const { client } = await this.resolveClients();
+    const bytes = await client
       .file(key)
       .slice(start, endInclusive + 1)
       .arrayBuffer();
@@ -155,10 +265,30 @@ export class S3MediaBackend implements MediaStorageBackend {
 
   /** Streaming S3 GET — chunks flow to the consumer without heap buffering. */
   async readStream(key: string): Promise<ReadableStream<Uint8Array>> {
-    return this.client.file(key).stream();
+    const { client } = await this.resolveClients();
+    return client.file(key).stream();
   }
 
   async presignedUrl(key: string, ttlSeconds: number = this.presignTtlSeconds): Promise<string> {
-    return this.presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
+    const { presignClient } = await this.resolveClients();
+    return presignClient.presign(key, { expiresIn: ttlSeconds, method: 'GET' });
   }
+}
+
+/** Provider for web-identity mode: the injected test seam or the real one. */
+function resolveProvider(config: S3BackendConfig, options: S3MediaBackendOptions): S3CredentialProvider {
+  if (options.credentialProvider) return options.credentialProvider;
+  if (!config.webIdentity) {
+    throw new Error('credentialSource=web-identity requires webIdentity params (tokenFile, roleArn, stsRegion)');
+  }
+  return new WebIdentityCredentialProvider(config.webIdentity);
+}
+
+/** Static mode requires the key pair — config resolution guarantees it. */
+function requireStaticCredentials(config: S3BackendConfig): ResolvedS3Credentials {
+  const credentials = staticCredentials(config);
+  if (!credentials) {
+    throw new Error('S3 media backend in static mode requires accessKeyId + secretKey');
+  }
+  return credentials;
 }

--- a/packages/channel-sdk/src/media-backends/web-identity.ts
+++ b/packages/channel-sdk/src/media-backends/web-identity.ts
@@ -1,0 +1,167 @@
+/**
+ * IRSA / web-identity S3 credentials via STS `AssumeRoleWithWebIdentity`.
+ *
+ * On EKS, the pod identity webhook mounts a projected ServiceAccount token and
+ * injects `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` when the
+ * ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation.
+ * Exchanging that token for temporary S3 credentials is a single UNSIGNED
+ * HTTPS call — the web-identity token IS the authentication, so no SigV4
+ * signing and no `@aws-sdk` dependency are needed (repo rule: Bun-native only).
+ *
+ * {@link WebIdentityCredentialProvider} caches the minted credentials and
+ * refreshes them once they are within {@link REFRESH_MARGIN_MS} of expiry,
+ * re-reading the token file on every exchange (kubelet rotates the projected
+ * token). The XML parse step ({@link parseAssumeRoleWithWebIdentityResponse})
+ * is a pure function so it is unit-testable without any network.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { z } from 'zod';
+import type { S3WebIdentityParams } from './config';
+
+/** Temporary credentials minted by STS AssumeRoleWithWebIdentity. */
+export interface StsCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+  expiration: Date;
+}
+
+/**
+ * Credential-source contract the S3 backend consumes. `source` is surfaced in
+ * logs so operators can tell how a running pod authenticates to S3.
+ */
+export interface S3CredentialProvider {
+  readonly source: 'web-identity';
+  getCredentials(): Promise<StsCredentials>;
+}
+
+/** Refresh window: mint fresh credentials once within 10 min of expiry. */
+const REFRESH_MARGIN_MS = 10 * 60 * 1000;
+const STS_API_VERSION = '2011-06-15';
+const ROLE_SESSION_NAME = 'omni-media';
+const SESSION_DURATION_SECONDS = 3600;
+
+/** Zod gate over the fields extracted from the STS XML (external input). */
+const StsCredentialsSchema = z.object({
+  accessKeyId: z.string().min(1),
+  secretAccessKey: z.string().min(1),
+  sessionToken: z.string().min(1),
+  expiration: z.coerce.date(),
+});
+
+/** First text content of `<tag>…</tag>` in `xml`, or undefined when absent. */
+function xmlTagText(xml: string, tag: string): string | undefined {
+  const match = xml.match(new RegExp(`<${tag}>([^<]+)</${tag}>`));
+  return match?.[1];
+}
+
+/**
+ * Parse an STS `AssumeRoleWithWebIdentity` XML response into credentials.
+ * Pure (no I/O) so malformed-response handling is unit-testable offline.
+ * @throws when any of AccessKeyId/SecretAccessKey/SessionToken/Expiration is
+ *   missing, empty, or (for Expiration) not a parseable timestamp.
+ */
+export function parseAssumeRoleWithWebIdentityResponse(xml: string): StsCredentials {
+  const parsed = StsCredentialsSchema.safeParse({
+    accessKeyId: xmlTagText(xml, 'AccessKeyId'),
+    secretAccessKey: xmlTagText(xml, 'SecretAccessKey'),
+    sessionToken: xmlTagText(xml, 'SessionToken'),
+    expiration: xmlTagText(xml, 'Expiration'),
+  });
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; ');
+    throw new Error(`Malformed STS AssumeRoleWithWebIdentity response: ${issues}`);
+  }
+  return parsed.data;
+}
+
+/** Minimal fetch shape — injection seam so tests never touch the network. */
+export type StsFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface WebIdentityProviderOptions {
+  /** Injection seam for tests — defaults to the global fetch. */
+  fetchImpl?: StsFetch;
+  /** Injection seam for tests — defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Caching credential provider over STS `AssumeRoleWithWebIdentity`.
+ *
+ * `getCredentials()` returns the cached credentials while they have more than
+ * {@link REFRESH_MARGIN_MS} of life left, and otherwise performs a fresh
+ * token exchange (single-flighted, so concurrent callers share one request).
+ */
+export class WebIdentityCredentialProvider implements S3CredentialProvider {
+  readonly source = 'web-identity' as const;
+
+  private readonly params: S3WebIdentityParams;
+  private readonly fetchImpl: StsFetch;
+  private readonly now: () => number;
+  private cached: StsCredentials | null = null;
+  /** Single-flight guard: concurrent refreshes share one STS exchange. */
+  private inflight: Promise<StsCredentials> | null = null;
+
+  constructor(params: S3WebIdentityParams, options: WebIdentityProviderOptions = {}) {
+    this.params = params;
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => fetch(input, init));
+    this.now = options.now ?? Date.now;
+  }
+
+  async getCredentials(): Promise<StsCredentials> {
+    if (this.cached && this.cached.expiration.getTime() - this.now() > REFRESH_MARGIN_MS) {
+      return this.cached;
+    }
+    this.inflight ??= this.assumeRole()
+      .then((credentials) => {
+        this.cached = credentials;
+        return credentials;
+      })
+      .finally(() => {
+        this.inflight = null;
+      });
+    return this.inflight;
+  }
+
+  /**
+   * Perform the unsigned STS exchange: POST the web-identity token to the
+   * regional STS endpoint and parse the XML response. The token file is
+   * re-read on EVERY exchange — kubelet rotates the projected token.
+   */
+  private async assumeRole(): Promise<StsCredentials> {
+    const token = await this.readToken();
+    const body = new URLSearchParams({
+      Action: 'AssumeRoleWithWebIdentity',
+      Version: STS_API_VERSION,
+      RoleArn: this.params.roleArn,
+      RoleSessionName: ROLE_SESSION_NAME,
+      WebIdentityToken: token,
+      DurationSeconds: String(SESSION_DURATION_SECONDS),
+    });
+    const response = await this.fetchImpl(`https://sts.${this.params.stsRegion}.amazonaws.com/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    if (!response.ok) {
+      const detail = (await response.text().catch(() => '')).slice(0, 500);
+      throw new Error(`STS AssumeRoleWithWebIdentity failed (HTTP ${response.status}): ${detail}`);
+    }
+    return parseAssumeRoleWithWebIdentityResponse(await response.text());
+  }
+
+  private async readToken(): Promise<string> {
+    let raw: string;
+    try {
+      raw = await readFile(this.params.tokenFile, 'utf8');
+    } catch (error) {
+      throw new Error(`Cannot read web-identity token file "${this.params.tokenFile}": ${String(error)}`);
+    }
+    const token = raw.trim();
+    if (!token) {
+      throw new Error(`Web-identity token file "${this.params.tokenFile}" is empty`);
+    }
+    return token;
+  }
+}

--- a/packages/channel-sdk/src/media-backends/web-identity.ts
+++ b/packages/channel-sdk/src/media-backends/web-identity.ts
@@ -16,8 +16,11 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { createLogger } from '@omni/core';
 import { z } from 'zod';
 import type { S3WebIdentityParams } from './config';
+
+const log = createLogger('services:media-backends:web-identity');
 
 /** Temporary credentials minted by STS AssumeRoleWithWebIdentity. */
 export interface StsCredentials {
@@ -34,13 +37,27 @@ export interface StsCredentials {
 export interface S3CredentialProvider {
   readonly source: 'web-identity';
   getCredentials(): Promise<StsCredentials>;
+  /**
+   * Mint a fresh credential regardless of cache freshness, updating the cache.
+   * The S3 backend calls this before signing a presigned URL whose TTL exceeds
+   * the current credential's remaining life, so the URL is signed by a
+   * full-lifetime credential rather than one about to expire.
+   */
+  forceRefresh(): Promise<StsCredentials>;
 }
 
 /** Refresh window: mint fresh credentials once within 10 min of expiry. */
 const REFRESH_MARGIN_MS = 10 * 60 * 1000;
+/**
+ * Safety floor for serving a cached credential after a failed refresh: only
+ * reuse the cache when it still has more than this much life left, so a served
+ * credential does not expire mid-operation.
+ */
+const STALE_SERVE_FLOOR_MS = 60 * 1000;
 const STS_API_VERSION = '2011-06-15';
 const ROLE_SESSION_NAME = 'omni-media';
-const SESSION_DURATION_SECONDS = 3600;
+/** Requested STS session lifetime — the ceiling on a temporary credential's life. */
+export const SESSION_DURATION_SECONDS = 3600;
 
 /** Zod gate over the fields extracted from the STS XML (external input). */
 const StsCredentialsSchema = z.object({
@@ -113,6 +130,28 @@ export class WebIdentityCredentialProvider implements S3CredentialProvider {
     if (this.cached && this.cached.expiration.getTime() - this.now() > REFRESH_MARGIN_MS) {
       return this.cached;
     }
+    try {
+      return await this.refresh();
+    } catch (error) {
+      return this.serveStaleOrThrow(error);
+    }
+  }
+
+  /**
+   * Force a fresh STS exchange regardless of cache freshness, updating the
+   * cache. Unlike {@link getCredentials} this does NOT serve a stale credential
+   * on failure — the caller (presign) decides how to degrade.
+   */
+  async forceRefresh(): Promise<StsCredentials> {
+    return this.refresh();
+  }
+
+  /**
+   * Single-flighted STS exchange shared by the refresh-margin path and
+   * {@link forceRefresh}: concurrent callers await one request, and the minted
+   * credential replaces the cache.
+   */
+  private refresh(): Promise<StsCredentials> {
     this.inflight ??= this.assumeRole()
       .then((credentials) => {
         this.cached = credentials;
@@ -122,6 +161,25 @@ export class WebIdentityCredentialProvider implements S3CredentialProvider {
         this.inflight = null;
       });
     return this.inflight;
+  }
+
+  /**
+   * The refresh exchange failed while inside the refresh margin. In
+   * web-identity-only mode a brief STS blip must not break media ops when a
+   * usable credential is still cached: serve the cached credential while it has
+   * more than {@link STALE_SERVE_FLOOR_MS} of life left, otherwise rethrow.
+   */
+  private serveStaleOrThrow(error: unknown): StsCredentials {
+    const cached = this.cached;
+    const remainingMs = cached ? cached.expiration.getTime() - this.now() : 0;
+    if (cached && remainingMs > STALE_SERVE_FLOOR_MS) {
+      log.warn(`STS refresh failed, serving cached credential valid for ${Math.floor(remainingMs / 1000)}s`, {
+        source: this.source,
+        error: String(error),
+      });
+      return cached;
+    }
+    throw error;
   }
 
   /**


### PR DESCRIPTION
## Summary
Group **G-CODE** of wish `omni-backlog-sweep`. The omni media S3 backend can now source credentials from **IRSA** (STS AssumeRoleWithWebIdentity) instead of static IAM keys — no new deps, `Bun.S3Client` and all storage/streaming logic untouched. Static-key mode stays first-class for MinIO/self-hosted/CI. Enables retiring the long-lived `omni-hml-media` access keys (G-ROLLOUT).

## What changed
- **`packages/channel-sdk/src/media-backends/web-identity.ts`** (new): reads the projected token file on every exchange (kubelet rotation-safe), POSTs an **unsigned** `AssumeRoleWithWebIdentity` to regional STS, Zod-validates the XML, caches + single-flight refreshes ≥10 min before expiry, serves a still-valid cached cred on a transient STS blip, exposes `forceRefresh()`.
- **`config.ts`**: remote mode resolves `static` (both `OMNI_MEDIA_S3_*`) OR `web-identity` (`AWS_WEB_IDENTITY_TOKEN_FILE`+`AWS_ROLE_ARN`); both present → web-identity primary, static fallback; neither → throws listing both. Static-only shape byte-compatible.
- **`s3-backend.ts`**: web-identity builds `Bun.S3Client` with `sessionToken`, rebuilds on refresh, falls back to static on STS failure else surfaces; **presign TTL guarantee** — refreshes before signing so a URL gets its full TTL, clamps + warns-once when the requested TTL exceeds the credential lifetime (no over-promise), and does NOT churn STS at the ttl==session-duration boundary.
- **Chart**: `media.s3.irsa` toggle (default false) omits the static-key envs when true; `values-hml-alb.yaml` sets `irsa: true` + SA annotation `eks.amazonaws.com/role-arn: …/omni-hml-media-irsa`. **irsa:false render is byte-identical to today** (verified).

## Validation
- `bun test packages/channel-sdk/src/media-backends/` → **52 pass / 0 fail**; full channel-sdk suite 323 pass.
- `biome check` clean; `tsc --noEmit` clean in channel-sdk **and** api; no `any`.
- `helm lint` (homolog+hml-alb) 0 failed; renders verified: homolog carries static-key envs, hml-alb carries the role-arn annotation and NO static-key env; irsa:false byte-identical to origin/dev.

## Review trail
Independent review: **SHIP** (0 HIGH/CRIT). Two LOW hardenings applied (serve-stale on transient STS failure; presign full-TTL guarantee), then a re-review caught + fixed a MEDIUM boundary churn bug (`<=`→`<` at ttl==session-duration) with a proven regression test. Depends on oneform-drivers PR #4 (IRSA role `omni-hml-media-irsa`) being applied before G-ROLLOUT flips hml to `irsa: true`.