### PR TITLE
chore(deploy): retire omni-media-s3 ExternalSecret (S3 via IRSA)

### DIFF
--- a/deploy/k8s/omni-hml/externalsecrets.yaml
+++ b/deploy/k8s/omni-hml/externalsecrets.yaml
@@ -2,7 +2,7 @@
 # ExternalSecrets for omni on the shared langwatch-hml EKS cluster (namespace
 # omni-hml, sa-east-1). External Secrets Operator materializes AWS Secrets
 # Manager entries under /khal/omni/hml/* into the k8s Secrets that the omni
-# Helm chart's values-homolog.yaml references (omni-db, omni-media-s3).
+# Helm chart's values-homolog.yaml references (omni-db).
 #
 #   kubectl -n omni-hml apply -f deploy/k8s/omni-hml/externalsecrets.yaml
 #
@@ -12,6 +12,12 @@
 # NOTE: /khal/omni/hml/db is a JSON secret ({"DATABASE_URL": "postgresql://…"}),
 # matching the platform convention (cf. langwatch-db → property url), so the URL
 # is pulled via remoteRef.property DATABASE_URL — NOT the whole JSON blob.
+#
+# Media S3 credentials are NO LONGER delivered via ExternalSecret: as of
+# 2026-07-06 the omni pod authenticates to S3 through IRSA (web-identity, role
+# omni-hml-media-irsa) — see values-hml-alb.yaml `media.s3.irsa`. The former
+# `omni-media-s3` ExternalSecret + the `/khal/omni/hml/media-s3` SM secret and
+# the static IAM user keys were retired (oneform-drivers).
 # =============================================================================
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -31,26 +37,3 @@ spec:
       remoteRef:
         key: /khal/omni/hml/db
         property: DATABASE_URL
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: omni-media-s3
-  namespace: omni-hml
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: khal-langwatch-hml
-  target:
-    name: omni-media-s3
-    creationPolicy: Owner
-  data:
-    - secretKey: OMNI_MEDIA_S3_ACCESS_KEY
-      remoteRef:
-        key: /khal/omni/hml/media-s3
-        property: OMNI_MEDIA_S3_ACCESS_KEY
-    - secretKey: OMNI_MEDIA_S3_SECRET_KEY
-      remoteRef:
-        key: /khal/omni/hml/media-s3
-        property: OMNI_MEDIA_S3_SECRET_KEY


### PR DESCRIPTION
## Summary
Final step of wish `omni-backlog-sweep` (G-ROLLOUT). IRSA is live and soak-proven on hml — the omni pod now authenticates to S3 via web-identity (role `omni-hml-media-irsa`), confirmed by 2 clean STS credential refreshes and a media round-trip on refreshed creds, 0 credential errors.

Removes the now-unused `omni-media-s3` ExternalSecret from `deploy/k8s/omni-hml/externalsecrets.yaml` (the `omni-db` ExternalSecret stays). The pod spec no longer references the static-key Secret (chart renders `media.s3.irsa: true` → no `OMNI_MEDIA_S3_ACCESS_KEY` env).

**Paired with** oneform-drivers retirement PR (deletes the `omni-hml-media` IAM access keys + `/khal/omni/hml/media-s3` SM secret). The live `kubectl delete externalsecret omni-media-s3 -n omni-hml` is a gated action run alongside this merge.

## Validation
- `kubectl apply --dry-run=client` → clean; manifest carries only `omni-db`.
- No chart/app change; hml already runs IRSA (helm rev4, v2.260705.19).