### PR TITLE
feat(deploy): refresh prod overlay to hardened IRSA shape with HA baseline

### DIFF
--- a/deploy/helm/omni/values-prod-alb.yaml
+++ b/deploy/helm/omni/values-prod-alb.yaml
@@ -1,0 +1,72 @@
+# =============================================================================
+# Prod co-tenant ALB delta — layered AFTER values-prod.yaml, never alone.
+#
+# This is NOT a standalone overlay: it is a DELTA that re-flavors the prod
+# shape for the production realm on the `langwatch-prod` EKS cluster
+# (sa-east-1, acct 278522730053, namespace omni). Ingress moves from
+# nginx+cert-manager to the AWS Load Balancer Controller (TLS terminates at
+# the ALB with an ACM cert), and the ServiceAccount gains the IRSA role-arn
+# annotation that media.s3.irsa (set in values-prod.yaml) relies on.
+# Everything else (external RDS via `omni-db` + verify-full TLS, IRSA-only
+# media on nmstx-khal-omni-prod-media, 2 pinned replicas + PDB, NATS on gp3,
+# sizing) is inherited from values-prod.yaml.
+#
+# Exact deploy command (order of -f flags matters — this file LAST):
+#   helm upgrade --install omni deploy/helm/omni -n omni \
+#     -f deploy/helm/omni/values-prod.yaml \
+#     -f deploy/helm/omni/values-prod-alb.yaml \
+#     --set ingress.host=omni.khal.ai \
+#     --set 'ingress.annotations.alb\.ingress\.kubernetes\.io/certificate-arn=<acm-cert-arn>' \
+#     --set 'serviceAccount.annotations.eks\.amazonaws\.com/role-arn=<media-irsa-role-arn>' \
+#     --wait
+#
+# TWO AWS ARNs are deliberately NOT set in-file — both are environment-specific
+# resource identifiers that only exist after the tenant Terraform is applied,
+# so they are supplied at deploy time via the --set flags above (the dots in
+# the annotation KEYS must be escaped with `\.`):
+#   - the ACM certificate ARN for omni.khal.ai (ALB TLS), same pattern as
+#     values-hml-alb.yaml;
+#   - the media IRSA role ARN for the ServiceAccount annotation. (Unlike
+#     values-hml-alb.yaml, which pins its already-provisioned role in-file,
+#     prod's role does not exist at authoring time — pin it here once the
+#     tenant apply has minted it, if drift-free files are preferred over
+#     --set flags.)
+#
+# Secrets in this realm are ESO-materialized from Secrets Manager
+# `/khal/omni/prod/*` into the `omni-db` Secret that values-prod.yaml already
+# references. There is NO media-key Secret anywhere: S3 auth is IRSA-only
+# (one-way door — prod never mints static keys).
+# =============================================================================
+
+ingress:
+  # AWS Load Balancer Controller provisions an internet-facing ALB for
+  # ingressClassName `alb`; TLS terminates at the ALB using the ACM cert
+  # passed via --set (see header), so no in-cluster TLS material is needed.
+  className: alb
+  annotations:
+    # Helm map-merge cannot DELETE a key inherited from an earlier -f file, but
+    # a `null` override removes it at coalesce time — and even if a literal
+    # `cluster-issuer: null` ever rendered, it is harmless for an alb-class
+    # Ingress (cert-manager only acts on real issuer values, which must NOT
+    # leak into this realm: there is no cert-manager/nginx on this cluster).
+    cert-manager.io/cluster-issuer: null
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    # alb.ingress.kubernetes.io/certificate-arn: supplied at deploy time via
+    # --set (see header) — never commit an account-specific ARN here.
+  # Empty list REPLACES prod's cert-manager tls block wholesale (helm replaces
+  # lists, it does not merge them): TLS lives at the ALB, so the rendered
+  # Ingress must carry no `tls:` section at all.
+  tls: []
+
+# IRSA: annotating the ServiceAccount makes the EKS pod identity webhook mount
+# a projected web-identity token and inject AWS_WEB_IDENTITY_TOKEN_FILE +
+# AWS_ROLE_ARN into omni-api's pod — no static S3 keys in this realm. The
+# role ARN is supplied at deploy time via --set (see header); its trust policy
+# subject is system:serviceaccount:omni:omni (release `omni` in namespace
+# `omni` → ServiceAccount `omni`).
+# serviceAccount:
+#   annotations:
+#     eks.amazonaws.com/role-arn: <media-irsa-role-arn, via --set — see header>

--- a/deploy/helm/omni/values-prod.yaml
+++ b/deploy/helm/omni/values-prod.yaml
@@ -1,28 +1,43 @@
 # =============================================================================
-# Production overlay — dedicated AWS cluster, external RDS + real S3.
+# Production overlay — external RDS + real S3 via IRSA, HA baseline.
 #   helm upgrade --install omni deploy/helm/omni -n omni \
 #     -f deploy/helm/omni/values-prod.yaml \
 #     --set ingress.host=<prod fqdn>
+# The LIVE prod realm (omni.khal.ai, co-tenant on the langwatch-prod EKS
+# cluster) layers values-prod-alb.yaml on top — see THAT file's header for the
+# exact deploy command with the ALB/ACM/IRSA --set flags.
 #
 # Realm shape (shared with values-homolog.yaml — separate clusters, one shape):
 #   - NO bundled datastores: autopg + MinIO are OFF. Postgres is external RDS
-#     (database.existingSecret), media is real AWS S3 (media.s3.existingSecret).
+#     (database.existingSecret), media is real AWS S3.
 #   - image.tag "" → v<Chart.appVersion>, the tag image-publish.yml publishes.
 #   - ingress.host is intentionally EMPTY: the chart fail-fasts unless the
 #     realm FQDN is passed via --set ingress.host=… (see templates/ingress.yaml).
+# Prod hardens beyond homolog:
+#   - IRSA-ONLY media auth (media.s3.irsa) — no static S3 keys exist ANYWHERE
+#     in this realm, by design a one-way door (hml retired its keys; prod
+#     never mints any).
+#   - DB TLS verify-full via the mounted RDS CA bundle (database.sslCaConfigMap).
+#   - HA baseline: 2 pinned replicas + PDB + the chart's automatic soft pod
+#     anti-affinity; NATS JetStream on an explicit gp3 PVC.
+#   - Heavier resources / JetStream stores than homolog.
 #
-# Required pre-created Secrets (same namespace as the release):
-#   omni-db        key DATABASE_URL — full RDS URL, e.g.
-#                  postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full
-#                  (password percent-encoded; the role must OWN the omni tables —
-#                  migrations ALTER them on boot. sslmode=require is a working
-#                  minimum but does NOT verify the server cert — verify-full
-#                  needs the RDS CA bundle available to the client)
-#   omni-media-s3  keys OMNI_MEDIA_S3_ACCESS_KEY + OMNI_MEDIA_S3_SECRET_KEY
+# Required pre-created resources (same namespace as the release):
+#   Secret omni-db          key DATABASE_URL — full RDS URL, e.g.
+#                           postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full
+#                           (password percent-encoded; the role must OWN the
+#                           omni tables — migrations ALTER them on boot.
+#                           verify-full actually verifies here because
+#                           database.sslCaConfigMap below mounts the RDS CA)
+#   ConfigMap rds-ca-bundle key sa-east-1-bundle.pem — the regional RDS CA
+#                           bundle (see deploy/k8s/omni-hml/rds-ca-configmap.yaml
+#                           for the hml counterpart and the trust-store source)
+#   NO omni-media-s3 Secret — S3 auth is IRSA-only (media.s3.irsa below plus
+#   the ServiceAccount role-arn annotation supplied via values-prod-alb.yaml).
 # =============================================================================
 
 image:
-  repository: ghcr.io/automagik-dev/omni-api   # set to your registry/path
+  repository: ghcr.io/automagik-dev/omni-api
   # "" → v<Chart.appVersion>: the latest PUBLISHED release (image-publish.yml
   # pushes v<packages/cli version> on merges to main). Pin an explicit v-tag
   # only to hold prod back from the chart's tracked release.
@@ -30,18 +45,35 @@ image:
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 
-# ONE replica, HPA off (see values.yaml "replicas + scaling"): a single
-# WhatsApp credential maps to one live Baileys socket, so concurrent replicas
-# risk key-ratchet corruption / duplicate sends until single-socket ownership
-# (leader election) exists. Scale out only for HTTP/API + non-WhatsApp
-# traffic — the chart then auto-adds a PDB + pod anti-affinity, and
-# migrate-on-boot serializes via a Postgres advisory lock.
-replicaCount: 1
+# HA baseline: TWO replicas, deliberately PINNED via the HPA below. The chart's
+# scaling guidance (values.yaml "replicas + scaling", hpa.yaml) still applies —
+# a single WhatsApp credential maps to ONE live Baileys socket at the protocol
+# level, so autoscaling is only safe for HTTP/API + non-WhatsApp traffic. Two
+# replicas buy zero-downtime rollouts and node-drain survival: the chart
+# auto-adds soft pod anti-affinity at >1 replica (see templates/deployment.yaml)
+# and migrate-on-boot serializes via a Postgres advisory lock.
+# NOTE: replicaCount is ignored by the Deployment while autoscaling.enabled
+# (the HPA owns the replica field); it is kept at 2 as documentation and as
+# the fallback if the HPA is ever disabled.
+replicaCount: 2
+
+# HPA pinned min=max=2: holds the Deployment at exactly two replicas — no
+# scale-out until 2-replica WhatsApp stability is proven. Raise maxReplicas
+# deliberately, and only for HTTP/API traffic (see hpa.yaml's warning).
 autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 6
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 2
+  # Inert while min==max (the HPA cannot move), but kept explicit so the
+  # rendered HPA carries a valid metrics block.
   targetCPUUtilizationPercentage: 75
+
+# PDB (minAvailable 1): guarantees one live api pod through voluntary
+# disruptions (node drains, cluster upgrades). Renders because >1 replica is
+# possible here — see templates/pdb.yaml.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
 
 config:
   LOG_LEVEL: "info"
@@ -56,6 +88,8 @@ ingress:
   # (NOT omitted — base values.yaml defaults host to omni.local, which would
   # silently bypass the chart's empty-host fail-fast). The tls hosts entry is
   # templated so it tracks whatever host is set.
+  # (The live prod realm replaces this whole nginx+cert-manager block with the
+  # AWS Load Balancer Controller via values-prod-alb.yaml.)
   host: ""
   path: /
   pathType: Prefix
@@ -65,13 +99,20 @@ ingress:
         - "{{ .Values.ingress.host }}"
 
 # DATABASE_URL comes from a pre-created external Secret pointing at RDS —
-# the bundled autopg is OFF in this realm (autopg.enabled below). Create it
-# before the first deploy:
+# the bundled autopg is OFF in this realm (autopg.enabled below). In the live
+# prod realm the Secret is ESO-materialized from Secrets Manager; for a manual
+# bring-up create it before the first deploy:
 #   kubectl -n omni create secret generic omni-db \
 #     --from-literal=DATABASE_URL='postgresql://omni:<pw>@<rds-endpoint>:5432/omni?sslmode=verify-full'
 database:
   existingSecret: "omni-db"
   urlKey: "DATABASE_URL"
+  # DB TLS verify-full: sslmode=require alone encrypts but trusts ANY server
+  # cert (the RDS CA is not in the container's trust store). Mounting the
+  # regional RDS CA bundle upgrades the connection to full chain + hostname
+  # verification in @omni/db. The ConfigMap must pre-exist (see header).
+  sslCaConfigMap: rds-ca-bundle
+  sslCaKey: sa-east-1-bundle.pem
 
 secret:
   # No OMNI_API_KEY — omni auth keys live in Postgres. Optionally supply
@@ -99,19 +140,19 @@ nats:
     fileStore: 4Gi
   persistence:
     size: 8Gi
-    # storageClass: gp3
+    # Explicit gp3 (EBS CSI), NOT the cluster default: JetStream durability
+    # must not depend on whichever StorageClass happens to be the default
+    # (older clusters still default to in-tree gp2).
+    storageClass: gp3
 
 # Prod media backend: an EXTERNAL managed S3 bucket (real AWS S3 — endpoint
-# empty so the SDK derives it from region; forcePathStyle false). Creds come
-# from the pre-created omni-media-s3 Secret (never plaintext in rendered
-# output); the bucket is provisioned out of band and must already exist.
+# empty so the SDK derives it from region; forcePathStyle false). The bucket is
+# Terraform-provisioned out of band and must already exist.
 media:
   mode: remote
   s3:
-    # S3 bucket names are GLOBALLY unique — this generic placeholder will very
-    # likely collide; override with your org-prefixed bucket (e.g. acme-omni-media).
-    bucket: omni-media
-    region: us-east-1
+    bucket: nmstx-khal-omni-prod-media   # Terraform-provisioned prod bucket
+    region: sa-east-1
     forcePathStyle: false
     presignTtlSeconds: 3600
     endpoint: ""                         # empty → real AWS S3 from region
@@ -119,9 +160,13 @@ media:
     # reachable, so presigned GET URLs work as-is. It exists for split-endpoint
     # setups (e.g. in-cluster MinIO presigning through an external hostname).
     # publicEndpoint: "https://media.example.com"
-    existingSecret: "omni-media-s3"      # must hold the two keys below
-    accessKeyKey: "OMNI_MEDIA_S3_ACCESS_KEY"
-    secretKeyKey: "OMNI_MEDIA_S3_SECRET_KEY"
+    # IRSA-ONLY auth: the Deployment renders NO OMNI_MEDIA_S3_ACCESS_KEY /
+    # _SECRET_KEY envs and no media Secret is referenced — omni-api exchanges
+    # the pod's projected ServiceAccount web-identity token via STS
+    # AssumeRoleWithWebIdentity. Requires the eks.amazonaws.com/role-arn
+    # ServiceAccount annotation, supplied at deploy time with
+    # values-prod-alb.yaml (see that file's header).
+    irsa: true
 
 # Bundled MinIO is OFF: media rides real AWS S3 (media.s3 above).
 minio:


### PR DESCRIPTION
## Wish
`omni-prod-realm` — Group 2 (G-CHART). Values-only chart work for the prod realm (`omni.khal.ai`, langwatch-prod EKS, acct 278522730053, namespace `omni`).

## What changed
**`deploy/helm/omni/values-prod.yaml`** (refreshed from the stale pre-IRSA shape):
- IRSA-only media auth: `media.s3.irsa: true`, all `omni-media-s3` existingSecret / `OMNI_MEDIA_S3_ACCESS_KEY`/`_SECRET_KEY` refs removed (one-way door — prod never mints static keys)
- Bucket `nmstx-khal-omni-prod-media`, region `sa-east-1`, endpoint `""` (SDK derives)
- DB TLS verify-full: `database.sslCaConfigMap: rds-ca-bundle` + `sslCaKey: sa-east-1-bundle.pem`
- HA baseline: `replicaCount: 2`, PDB enabled (minAvailable 1), HPA enabled pinned `min=max=2` (per hpa.yaml's Baileys single-socket warning)
- NATS JetStream on explicit `gp3` PVC (8Gi, memStore 512Mi / fileStore 4Gi)
- Kept: `ghcr.io/automagik-dev/omni-api`, `tag: ""` (tracks Chart appVersion), `ingress.host: ""` fail-fast

**`deploy/helm/omni/values-prod-alb.yaml`** (new — ALB delta layered LAST, mirrors `values-hml-alb.yaml`):
- `ingressClassName: alb`, internet-facing / target-type ip / HTTPS:443 / healthcheck-path `/health` annotations
- `cert-manager.io/cluster-issuer: null` removal trick + `tls: []` list replacement
- ACM cert ARN and media IRSA role ARN deliberately NOT in-file — supplied via `--set` at deploy time (prod's role doesn't exist until the tenant Terraform applies); header documents the exact helm command with `-f` ordering

## Note: includes dev←main catch-up
`origin/dev` is strictly behind `origin/main` (merge-base = dev tip). The IRSA chart support this overlay depends on (`media.s3.irsa` in values.yaml + deployment/configmap gating, PRs #802/#803) is on main only, so this branch is based on `origin/main`. The PR therefore also fast-forwards dev with already-main-merged commits — no new template changes are introduced here; my diff vs `origin/main` touches ONLY the two prod values files.

## Evidence
- Validation script (render + greps) PASS: PDB + HPA(2/2) + NATS PVC(gp3) present, zero `OMNI_MEDIA_S3_ACCESS_KEY` in render, `irsa: true` in values-prod.yaml
- hml/homolog regression: rendered `-f values-homolog.yaml -f values-hml-alb.yaml` (hml `--set` flags) and `-f values-homolog.yaml` alone from this branch and from `origin/main` — **byte-identical** in both combos; vs `origin/dev` the only delta is the pre-existing dev↔main drift listed above