### PR TITLE
fix(events): reconnect NATS client after server restart and surface real publisher state in health

### DIFF
--- a/packages/api/src/__tests__/health-nats.test.ts
+++ b/packages/api/src/__tests__/health-nats.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the /health NATS check.
+ *
+ * Regression coverage for the 2026-07-06 prod incident: /health hardcoded
+ * `nats: { status: 'ok', details: { connected: true } }` while the event-bus
+ * publisher's NATS connection was permanently dead after a server restart —
+ * every publish threw "Not connected to NATS" behind a green health check.
+ * The check must reflect the publisher's real connection state
+ * (EventBus.isConnected(), the same state the publish path gates on).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import { Hono } from 'hono';
+import { getHealth } from '../routes/health';
+import type { AppVariables, HealthResponse } from '../types';
+
+function fakeEventBus(connected: boolean): EventBus {
+  return { isConnected: () => connected } as unknown as EventBus;
+}
+
+function createApp(eventBus: EventBus | null) {
+  const app = new Hono<{ Variables: AppVariables }>();
+
+  // Minimal db fake: SELECT 1 succeeds, instance stats are unavailable
+  // (getHealth swallows instance-stats errors).
+  const fakeDb = {
+    execute: async () => [],
+    select: () => {
+      throw new Error('instance stats not available in tests');
+    },
+  } as unknown as AppVariables['db'];
+
+  app.use('*', async (c, next) => {
+    c.set('db', fakeDb);
+    c.set('eventBus', eventBus);
+    c.set('channelRegistry', null);
+    await next();
+  });
+  app.get('/health', getHealth);
+
+  return app;
+}
+
+describe('GET /health NATS check', () => {
+  test('reports ok when the publisher connection is up', async () => {
+    const app = createApp(fakeEventBus(true));
+    const res = await app.request('/health');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as HealthResponse;
+    expect(body.status).toBe('healthy');
+    expect(body.checks.nats.status).toBe('ok');
+    expect(body.checks.nats.details).toEqual({ connected: true });
+  });
+
+  test('reports error + degraded when the publisher connection is dead', async () => {
+    const app = createApp(fakeEventBus(false));
+    const res = await app.request('/health');
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthResponse;
+    expect(body.status).toBe('degraded');
+    expect(body.checks.nats.status).toBe('error');
+    expect(body.checks.nats.details).toEqual({ connected: false });
+    expect(body.checks.nats.error).toBeTruthy();
+  });
+
+  test('reports ok with connected=false when no event bus is configured', async () => {
+    const app = createApp(null);
+    const res = await app.request('/health');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as HealthResponse;
+    expect(body.checks.nats.status).toBe('ok');
+    expect(body.checks.nats.details).toEqual({ connected: false, reason: 'Not configured' });
+  });
+});

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -36,11 +36,15 @@ export const getHealth = async (c: Context<{ Variables: AppVariables }>) => {
     };
   }
 
-  // Check NATS (if available)
+  // Check NATS (if available). Must reflect the publisher's real connection
+  // state: a hardcoded `connected: true` masked dead publishers after a NATS
+  // server restart (green health while every publish threw "Not connected").
   let natsCheck: HealthCheck;
   if (eventBus) {
-    // TODO: Add actual NATS health check when eventBus is implemented
-    natsCheck = { status: 'ok', details: { connected: true } };
+    const connected = eventBus.isConnected();
+    natsCheck = connected
+      ? { status: 'ok', details: { connected: true } }
+      : { status: 'error', details: { connected: false }, error: 'NATS connection is not established' };
   } else {
     natsCheck = { status: 'ok', details: { connected: false, reason: 'Not configured' } };
   }

--- a/packages/core/src/events/bus.ts
+++ b/packages/core/src/events/bus.ts
@@ -173,7 +173,11 @@ export interface EventBusConfig {
 
   /** Reconnect configuration */
   reconnect?: {
-    /** Maximum number of reconnect attempts (default: 10) */
+    /**
+     * Maximum number of initial-connect attempts (default: 10).
+     * Once established, the transport reconnects indefinitely so a NATS
+     * server restart never permanently kills the publisher.
+     */
     maxRetries: number;
     /** Initial delay between retries in ms (default: 1000) */
     delayMs: number;

--- a/packages/core/src/events/nats/__tests__/client.test.ts
+++ b/packages/core/src/events/nats/__tests__/client.test.ts
@@ -1,0 +1,201 @@
+/**
+ * NatsEventBus connection-resilience tests.
+ *
+ * Regression coverage for the 2026-07-06 prod incident: after a NATS server
+ * restart, running pods kept a permanently dead connection (finite transport
+ * reconnect budget exhausted, `closed()` resolved, nothing rebuilt it) and
+ * every publish threw "Not connected to NATS. Call connect() first." while
+ * /health kept reporting the bus as connected.
+ *
+ * Covers:
+ *   - transport connects with infinite reconnect (maxReconnectAttempts: -1)
+ *   - publish recovers after the underlying connection closes (lazy rebuild)
+ *   - closed()-handler rebuilds the connection without waiting for a publish
+ *   - isConnected() reflects the real state of the publisher connection
+ *
+ * The `nats` module is mocked (same approach as nats-genie-provider.test.ts)
+ * so no live broker is required.
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mock the nats module before importing the client
+// ---------------------------------------------------------------------------
+
+class FakeNatsConnection {
+  private closedFlag = false;
+  private resolveClosed!: (err?: Error) => void;
+  private readonly closedPromise = new Promise<Error | undefined>((resolve) => {
+    this.resolveClosed = resolve;
+  });
+
+  readonly publish = mock(async (_subject: string, _data: Uint8Array, _opts?: unknown) => ({ seq: 1 }));
+
+  isClosed(): boolean {
+    return this.closedFlag;
+  }
+
+  closed(): Promise<Error | undefined> {
+    return this.closedPromise;
+  }
+
+  status(): AsyncIterable<{ type: string }> {
+    // Never yields — keeps the status loop pending like an idle connection
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => new Promise<IteratorResult<{ type: string }>>(() => {}),
+      }),
+    };
+  }
+
+  jetstream(): { publish: FakeNatsConnection['publish'] } {
+    return { publish: this.publish };
+  }
+
+  jetstreamManager(): unknown {
+    return {
+      streams: {
+        info: async () => {
+          throw new Error('stream not found');
+        },
+        add: async () => ({}),
+        update: async () => ({}),
+      },
+    };
+  }
+
+  async drain(): Promise<void> {
+    this.markClosed();
+  }
+
+  /** Simulate the server closing the connection (reconnect budget exhausted) */
+  simulateServerClose(err?: Error): void {
+    this.markClosed(err);
+  }
+
+  private markClosed(err?: Error): void {
+    this.closedFlag = true;
+    this.resolveClosed(err);
+  }
+}
+
+const connections: FakeNatsConnection[] = [];
+const connectOptions: Array<Record<string, unknown>> = [];
+
+const connectMock = mock(async (opts: Record<string, unknown>) => {
+  connectOptions.push(opts);
+  const conn = new FakeNatsConnection();
+  connections.push(conn);
+  return conn;
+});
+
+mock.module('nats', () => ({
+  AckPolicy: { Explicit: 'explicit' },
+  DeliverPolicy: { All: 'all', Last: 'last', New: 'new', StartTime: 'by_start_time' },
+  RetentionPolicy: { Limits: 'limits' },
+  StorageType: { File: 'file' },
+  StringCodec: () => ({
+    encode: (s: string) => new TextEncoder().encode(s),
+    decode: (b: Uint8Array) => new TextDecoder().decode(b),
+  }),
+  headers: () => {
+    const values = new Map<string, string>();
+    return {
+      set: (key: string, value: string) => values.set(key, value),
+      get: (key: string) => values.get(key),
+      values,
+    };
+  },
+  connect: connectMock,
+}));
+
+// Import AFTER mocks are registered (dynamic import — static imports are
+// hoisted above mock.module by the ESM transform).
+const { NatsEventBus } = await import('../client');
+
+const flushReconnect = () => new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+beforeEach(() => {
+  connections.length = 0;
+  connectOptions.length = 0;
+  connectMock.mockClear();
+});
+
+describe('NatsEventBus connection resilience', () => {
+  it('connects with infinite transport reconnect', async () => {
+    const bus = new NatsEventBus();
+    await bus.connect();
+
+    expect(connectOptions[0]?.maxReconnectAttempts).toBe(-1);
+    expect(connectOptions[0]?.reconnect).toBe(true);
+    expect(bus.isConnected()).toBe(true);
+
+    await bus.close();
+  });
+
+  it('recovers publishing after the underlying connection closes', async () => {
+    const bus = new NatsEventBus();
+    await bus.connect();
+
+    const first = connections[0];
+    expect(first).toBeDefined();
+
+    // First publish goes through connection #1
+    await bus.publishGeneric('custom.test.reconnect', { attempt: 1 });
+    expect(first?.publish).toHaveBeenCalledTimes(1);
+
+    // Server kills the connection (e.g. NATS statefulset restart)
+    first?.simulateServerClose();
+    expect(bus.isConnected()).toBe(false);
+
+    // Publish must rebuild the connection instead of throwing forever
+    const result = await bus.publishGeneric('custom.test.reconnect', { attempt: 2 });
+
+    expect(result.sequence).toBe(1);
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(connections[1]?.publish).toHaveBeenCalledTimes(1);
+    expect(bus.isConnected()).toBe(true);
+
+    await bus.close();
+  });
+
+  it('rebuilds the connection via the closed() handler without a publish', async () => {
+    const bus = new NatsEventBus();
+    await bus.connect();
+
+    connections[0]?.simulateServerClose(new Error('server gone'));
+    await flushReconnect();
+
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(bus.isConnected()).toBe(true);
+
+    await bus.close();
+  });
+
+  it('does not rebuild the connection on intentional close()', async () => {
+    const bus = new NatsEventBus();
+    await bus.connect();
+
+    await bus.close();
+    await flushReconnect();
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(bus.isConnected()).toBe(false);
+  });
+
+  it('isConnected() reflects the real publisher connection state', async () => {
+    const bus = new NatsEventBus();
+    expect(bus.isConnected()).toBe(false);
+
+    await bus.connect();
+    expect(bus.isConnected()).toBe(true);
+
+    connections[0]?.simulateServerClose();
+    expect(bus.isConnected()).toBe(false);
+
+    // Let the background rebuild settle before cleanup
+    await flushReconnect();
+    await bus.close();
+  });
+});

--- a/packages/core/src/events/nats/client.ts
+++ b/packages/core/src/events/nats/client.ts
@@ -93,6 +93,13 @@ const DEFAULTS = {
 } as const;
 
 /**
+ * How long a publish waits for an in-flight connection rebuild before
+ * failing. The rebuild keeps running in the background, so later publishes
+ * succeed as soon as the server is reachable again.
+ */
+const ENSURE_CONNECTED_WAIT_MS = 5_000;
+
+/**
  * Internal config type with properly typed credentials
  */
 interface InternalConfig {
@@ -118,6 +125,7 @@ export class NatsEventBus implements EventBus {
   private readonly subscriptionManager = new SubscriptionManager();
   private connectionAttempts = 0;
   private isClosing = false;
+  private pendingReconnect: Promise<void> | null = null;
 
   constructor(config: EventBusConfig = {}) {
     this.config = {
@@ -143,7 +151,13 @@ export class NatsEventBus implements EventBus {
       servers: this.config.url,
       name: this.config.serviceName,
       reconnect: true,
-      maxReconnectAttempts: this.config.reconnect.maxRetries,
+      // Retry forever: a NATS pod move/upgrade can outlast any finite budget,
+      // and once the budget is exhausted the connection closes permanently —
+      // every publish then throws until the process restarts. Infinite retry
+      // keeps the same connection object (and its subscriptions) alive across
+      // arbitrarily long server outages. `maxRetries` still bounds the outer
+      // retry loop in connect() below.
+      maxReconnectAttempts: -1,
       reconnectTimeWait: this.config.reconnect.delayMs,
       waitOnFirstConnect: true,
     };
@@ -220,7 +234,7 @@ export class NatsEventBus implements EventBus {
     payload: unknown,
     metadata?: Partial<OmniEvent['metadata']>,
   ): Promise<PublishResult> {
-    this.ensureConnected();
+    await this.ensureConnected();
 
     const eventId = crypto.randomUUID();
     const timestamp = Date.now();
@@ -552,8 +566,56 @@ export class NatsEventBus implements EventBus {
 
   /**
    * Ensure connected before operations
+   *
+   * When the underlying connection object is dead (e.g. the server closed it
+   * before infinite transport reconnect was in place), rebuild it instead of
+   * failing every publish until the process restarts. Waits a bounded amount
+   * of time for the rebuild; the rebuild keeps running in the background so
+   * subsequent calls succeed once the server is reachable again.
    */
-  private ensureConnected(): void {
+  private async ensureConnected(): Promise<void> {
+    if (this.isConnected()) return;
+    if (this.isClosing) {
+      throw new Error('Not connected to NATS. Call connect() first.');
+    }
+
+    const reconnect = this.scheduleReconnect();
+    const winner = await Promise.race([
+      reconnect.then(() => 'connected' as const),
+      this.sleep(ENSURE_CONNECTED_WAIT_MS).then(() => 'timeout' as const),
+    ]);
+
+    if (winner === 'timeout' || !this.isConnected()) {
+      throw new Error('Not connected to NATS. Reconnect in progress.');
+    }
+  }
+
+  /**
+   * Rebuild the connection after the previous one died. Deduplicates
+   * concurrent callers onto a single in-flight attempt.
+   */
+  private scheduleReconnect(): Promise<void> {
+    if (!this.pendingReconnect) {
+      log.warn('Connection lost, rebuilding', { url: this.config.url });
+      this.pendingReconnect = (async () => {
+        this.nc = null;
+        this.js = null;
+        this.jsm = null;
+        await this.connect();
+      })().finally(() => {
+        this.pendingReconnect = null;
+      });
+      // Waiters observe failures through their own awaits; without this
+      // guard a timed-out waiter would leave the rejection unhandled.
+      this.pendingReconnect.catch(() => {});
+    }
+    return this.pendingReconnect;
+  }
+
+  /**
+   * Synchronous connectivity assertion for paths that cannot await a rebuild
+   */
+  private assertConnected(): void {
     if (!this.isConnected()) {
       throw new Error('Not connected to NATS. Call connect() first.');
     }
@@ -564,7 +626,7 @@ export class NatsEventBus implements EventBus {
    * Throws if not connected
    */
   private requireJetStream(): JetStreamClient {
-    this.ensureConnected();
+    this.assertConnected();
     if (!this.js) {
       throw new Error('JetStream not initialized');
     }
@@ -576,7 +638,7 @@ export class NatsEventBus implements EventBus {
    * Throws if not connected
    */
   private requireJetStreamManager(): JetStreamManager {
-    this.ensureConnected();
+    this.assertConnected();
     if (!this.jsm) {
       throw new Error('JetStreamManager not initialized');
     }
@@ -587,12 +649,21 @@ export class NatsEventBus implements EventBus {
    * Setup connection event handlers
    */
   private setupConnectionHandlers(): void {
-    if (!this.nc) return;
+    const nc = this.nc;
+    if (!nc) return;
+
+    // Rebuild when the connection dies underneath us (e.g. server closed it)
+    // and it was not an intentional close(). Without this, publishing stays
+    // broken until the next ensureConnected() call — or forever if none comes.
+    nc.closed().then((err) => {
+      if (this.isClosing || this.nc !== nc) return;
+      log.error('Connection closed unexpectedly', { error: err ? String(err) : 'none' });
+      this.scheduleReconnect();
+    });
 
     // Handle connection status events
     (async () => {
-      if (!this.nc) return;
-      for await (const status of this.nc.status()) {
+      for await (const status of nc.status()) {
         switch (status.type) {
           case 'disconnect':
             log.warn('Disconnected from NATS');


### PR DESCRIPTION
## Root cause

Two independent defects combined into a silent prod outage of all event publishing:

1. **Publisher permanently dies after a NATS server restart.** `NatsEventBus.connect()` (`packages/core/src/events/nats/client.ts`) created the connection with `maxReconnectAttempts: this.config.reconnect.maxRetries` (default **10**) and `reconnectTimeWait: 1000`. A NATS pod move/upgrade that outlasts ~10s exhausts the transport's reconnect budget, nats.js resolves `closed()`, and the connection object is dead forever. Nothing rebuilt it: there was no `closed()` handler, and `ensureConnected()` only checked `nc.isClosed()` and threw — so **every subsequent publish threw until the process was restarted**.
2. **Health lied.** `packages/api/src/routes/health.ts` hardcoded the NATS check: `natsCheck = { status: 'ok', details: { connected: true } }` (with a `// TODO: Add actual NATS health check`). It never consulted the event bus, so a dead publisher reported green.

## Prod evidence (2026-07-06, after `kubectl rollout restart statefulset omni-nats`)

```
Error: Not connected to NATS. Call connect() first.
    at ensureConnected (dist/server/index.js:22993)
    at publishInternal (dist/server/index.js:22805)
    at publish → publishEventInternal → emitQrCode (whatsapp QR distribution died silently)
```

Meanwhile `GET /health` kept reporting `"nats":{"status":"ok","details":{"connected":true}}`. Only a rolling restart of the deployment recovered publishing.

## Fix

**Publisher resilience** (`packages/core/src/events/nats/client.ts`):
- `maxReconnectAttempts: -1` — infinite transport reconnect (with the existing `reconnectTimeWait` backoff), so an established connection (and its subscriptions) survives arbitrarily long server outages instead of closing permanently. `reconnect.maxRetries` still bounds the outer initial-connect retry loop.
- `closed()` handler — if the connection still dies underneath us (and it wasn't an intentional `close()`), the bus rebuilds the connection in the background.
- `ensureConnected()` is now async: when the connection object is dead it schedules a single deduplicated rebuild and waits up to 5s for it instead of permanently throwing; the rebuild continues in the background so later publishes succeed as soon as NATS is reachable.

**Health integrity** (`packages/api/src/routes/health.ts`):
- The `/health` NATS check now reads `eventBus.isConnected()` — the exact same state the publish path gates on. A dead publisher reports `checks.nats.status: "error"`, overall `degraded`, HTTP 503 (so probes/LBs can react).

## Test coverage (`bun test`, mocked NATS — no live broker)

- `packages/core/src/events/nats/__tests__/client.test.ts` (new):
  - connects with infinite transport reconnect (`maxReconnectAttempts: -1`)
  - publish recovers after the underlying connection closes (simulated server close → rebuild → publish succeeds on the new connection)
  - `closed()` handler rebuilds the connection in the background without a publish
  - no rebuild on intentional `close()`
  - `isConnected()` reflects the real publisher connection state
- `packages/api/src/__tests__/health-nats.test.ts` (new):
  - `/health` reports `ok/connected: true` when the publisher is up
  - `/health` reports `error/connected: false` + `degraded` + 503 when the publisher connection is dead
  - unconfigured event bus keeps prior `ok / Not configured` behavior

## Gates

- `bun run typecheck` clean in `packages/core` and `packages/api`
- `bun run lint` (biome, repo-wide): clean, zero warnings
- `bun test` packages/core: 792 pass / 0 fail; packages/api: 1178 pass / 0 fail (300 pre-existing env-gated skips)
