### PR TITLE
feat(deploy): self-host backup tooling + data-safety knobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ version.json
 
 # Helm dependency build artifacts (unpacked charts/ is source of truth)
 deploy/helm/omni/charts/*.tgz
+
+# Personal per-machine helm overrides (never commit)
+deploy/helm/omni/values-local.yaml

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -66,6 +66,13 @@ deploy: ## Install/upgrade the release to ns $(NAMESPACE)
 	  --namespace $(NAMESPACE) --create-namespace \
 	  -f $(VALUES) $(HELM_EXTRA) --wait --timeout 5m
 
+.PHONY: redeploy
+redeploy: build ## Rebuild omni-api image + rollout restart (repick the fixed :dev tag)
+	# The dev image tag is fixed (:dev) with pullPolicy Never, so a plain `deploy`
+	# leaves the pod on the old image after a rebuild — force a rollout.
+	kubectl -n $(NAMESPACE) rollout restart deploy/$(RELEASE)
+	kubectl -n $(NAMESPACE) rollout status deploy/$(RELEASE) --timeout=5m
+
 .PHONY: status
 status: ## Rollout status + pods
 	kubectl -n $(NAMESPACE) rollout status deploy/$(RELEASE) --timeout=5m || true

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -136,6 +136,36 @@ Requires Docker running, `helm`, `kubectl`, and `k3d` or `kind` (auto-installs
 k3d via Homebrew if neither is present). See the target header in
 [`Makefile`](Makefile) for tunables (`SMOKE_TIMEOUT`, `SMOKE_SET`, …).
 
+### Data safety & backups (self-host)
+
+The bundled datastores hold real data — Postgres has your message history and the
+**WhatsApp/Baileys session state** (lose it and every instance re-pairs), and
+MinIO has media. Two things to set up:
+
+1. **Backups** — [`backup/omni-backup.sh`](backup/) dumps Postgres (logical
+   `pg_dump`, restore-verified) and mirrors the MinIO media to a local folder
+   (`~/omni-backups` by default, Time Machine–friendly), with a matching
+   [`backup/omni-restore.sh`](backup/). Nothing runs by default — wire it to
+   `launchd` (macOS) or a `systemd` timer (Linux); see
+   [`backup/README.md`](backup/README.md).
+
+2. **PVC retention** — `values-dev.yaml` sets
+   `persistentVolumeClaimRetentionPolicy: Retain` on the bundled StatefulSets, so
+   the data PVCs survive a `helm uninstall`. But the StorageClass's **PV reclaim
+   policy** is separate: on OrbStack/k3s `local-path` it defaults to `Delete`, so
+   deleting the *PVC* (or the namespace) still erases the data dir. Flip the live
+   PVs to `Retain` for a real safety net:
+
+   ```bash
+   for pv in $(kubectl get pv \
+     -o jsonpath='{range .items[?(@.spec.claimRef.namespace=="omni")]}{.metadata.name}{"\n"}{end}'); do
+     kubectl patch pv "$pv" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+   done
+   ```
+
+Local backups survive a cluster/OrbStack reset but not machine loss — keep
+`~/omni-backups` under Time Machine, or copy it off-box.
+
 ## Makefile reference
 
 Run everything as `make -C deploy <target>` from the repo root.
@@ -147,6 +177,7 @@ Run everything as `make -C deploy <target>` from the repo root.
 | `deps` | `helm dependency build` (vendors the autopg subchart) |
 | `lint` / `template` | Lint / render the chart with the selected realm overlay |
 | `deploy` | `helm upgrade --install --wait` to namespace `$(NAMESPACE)` |
+| `redeploy` | Rebuild the image + `rollout restart` (repick the fixed `:dev` tag) |
 | `status` / `logs` / `health` | Rollout status, API logs, port-forward + `GET /health` |
 | `smoke` | Run the image alone in Docker (no cluster) |
 | `deploy-smoke` | Full disposable-cluster install proof (see above) |

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -1,0 +1,149 @@
+# omni self-host backups
+
+Host-side backup + restore for a **bundled** (self-host) omni install — the
+`values-dev.yaml` shape with in-cluster autopg + MinIO. It logically dumps
+Postgres and mirrors the MinIO media bucket to a **local folder on your
+machine**, so a cluster/OrbStack reset (or a fat-fingered `kubectl delete`)
+doesn't take your WhatsApp/Baileys session state and media with it.
+
+> Managed realms (homolog/prod) use RDS + real S3 and back up through those —
+> this tooling is only for the bundled datastores.
+
+## What & why
+
+- **`omni-backup.sh`** — `pg_dump` (custom format) + `pg_dumpall --globals-only`
+  for Postgres, and `mc mirror` (incremental) for the media bucket.
+- **`omni-restore.sh`** — restore, or **verify** a dump into a throwaway
+  container (prove it's restorable, don't just hope).
+
+Both run from the host using throwaway `docker run` images
+(`postgres:18`, `minio/mc`) over a short-lived `kubectl port-forward`. Only
+**`docker` + `kubectl`** need to be installed — no Homebrew clients, no chart
+CronJob, no committed secrets (MinIO creds are read from the release Secret at
+run time).
+
+### The two traps this handles for you
+
+- **autopg has no v18 client.** The image ships only the Postgres *server*; its
+  in-container `pg_dump` is Debian v15 and refuses to dump the v18 server. The
+  script runs a version-matched `postgres:18` client instead.
+- **Ports 5432/9000 are often taken.** OrbStack exposes its own services there,
+  so the forwards default to **15432 / 19000**.
+
+## Quick start
+
+```bash
+# one-off backup (defaults: context orbstack, ns omni, -> ~/omni-backups)
+deploy/backup/omni-backup.sh
+
+# prove the newest dump restores (throwaway container, nothing live touched)
+deploy/backup/omni-restore.sh
+```
+
+### Configuration (env vars)
+
+| var | default | meaning |
+|---|---|---|
+| `KCTX` | `orbstack` | kube-context |
+| `NS` | `omni` | namespace |
+| `RELEASE` | `omni` | helm release name (drives service names) |
+| `OMNI_BACKUP_DIR` | `~/omni-backups` | destination folder |
+| `PG_DB` | `omni` | database to dump |
+| `MEDIA_BUCKET` | `omni-media` | MinIO bucket to mirror |
+| `PG_FWD_PORT` / `MINIO_FWD_PORT` | `15432` / `19000` | host ports for the forwards |
+| `RETENTION_DAYS` | `14` | prune pg dumps older than this (media mirror kept whole) |
+
+## Keep the backups safe (Time Machine)
+
+The default `~/omni-backups` lives under your home dir, so **Time Machine backs
+it up automatically** unless you've excluded `~`. Verify it isn't excluded:
+
+```bash
+tmutil isexcluded ~/omni-backups   # should print "[Included]"
+```
+
+Local backups survive a cluster/OrbStack reset but **not** loss of the machine —
+Time Machine (or an occasional copy to an external disk / object store) covers
+that. Pick an `OMNI_BACKUP_DIR` on a Time-Machine'd or synced volume.
+
+## Scheduling
+
+### macOS — launchd (daily 03:00)
+
+`~/Library/LaunchAgents/ai.namastex.omni-backup.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>ai.namastex.omni-backup</string>
+  <key>ProgramArguments</key><array>
+    <string>/bin/bash</string><string>-lc</string>
+    <string>/path/to/omni/deploy/backup/omni-backup.sh >> $HOME/omni-backups/backup.log 2>&1</string>
+  </array>
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>3</integer><key>Minute</key><integer>0</integer></dict>
+</dict></plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/ai.namastex.omni-backup.plist
+launchctl list | grep omni-backup      # confirm it's registered
+```
+
+(launchd runs a missed job at next wake if the Mac was asleep at 03:00.)
+
+### Linux — systemd timer
+
+`~/.config/systemd/user/omni-backup.service`:
+
+```ini
+[Service]
+Type=oneshot
+ExecStart=/path/to/omni/deploy/backup/omni-backup.sh
+```
+
+`~/.config/systemd/user/omni-backup.timer`:
+
+```ini
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+systemctl --user enable --now omni-backup.timer
+```
+
+## Restore runbook
+
+**Verify (safe, do this routinely):**
+
+```bash
+deploy/backup/omni-restore.sh            # newest dump -> throwaway postgres:18, prints row counts
+deploy/backup/omni-restore.sh --file ~/omni-backups/postgres/omni-YYYYMMDD-HHMM.dump
+```
+
+**Restore Postgres into the live cluster** (after data loss — restore into a
+fresh/empty DB, or `--clean` to drop objects first):
+
+```bash
+# recreate the app role/db from globals if the DB was lost entirely:
+#   kubectl -n omni exec -it omni-autopg-0 -- psql -U postgres < <(gunzip -c globals-*.sql.gz)
+deploy/backup/omni-restore.sh --target omni --clean --confirm
+```
+
+**Restore media** (overwrites the live bucket — guarded, run by hand):
+
+```bash
+kubectl -n omni port-forward --address 127.0.0.1 svc/omni-minio 19000:9000 &
+MU=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_USER}' | base64 -d)
+MP=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_PASSWORD}' | base64 -d)
+docker run --rm --add-host=host.docker.internal:host-gateway -e MU="$MU" -e MP="$MP" \
+  -v ~/omni-backups/media:/backup --entrypoint sh minio/mc -c \
+  'mc alias set omni http://host.docker.internal:19000 "$MU" "$MP" && mc mirror --overwrite /backup/omni-media omni/omni-media'
+```
+
+See [`../README.md`](../README.md) → *Data safety & backups* for the PV
+reclaim-policy note that complements these backups.

--- a/deploy/backup/omni-backup.sh
+++ b/deploy/backup/omni-backup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# omni-backup.sh — logical backup of a bundled (self-host) omni stack.
+#
+#   • Postgres (autopg)  -> pg_dump custom-format (+ pg_dumpall globals)
+#   • MinIO media bucket -> incremental mirror
+#
+# Writes to a LOCAL directory (default ~/omni-backups) — point it at a
+# Time Machine / backed-up path. There is NO in-cluster CronJob; run this from
+# the host on a schedule (launchd on macOS, a systemd timer on Linux). See
+# README.md for scheduling + restore.
+#
+# Why throwaway `docker run` images instead of `kubectl exec`:
+#   autopg ships only the Postgres *server* binaries — the in-container pg_dump
+#   is Debian v15 and REFUSES to dump the v18 server. So we run a version-matched
+#   `postgres:18` client over a short-lived port-forward. Media uses `minio/mc`
+#   the same way. Only `docker` + `kubectl` need to be on the host.
+#
+# Config via env (defaults suit an OrbStack dev install):
+#   KCTX=orbstack  NS=omni  RELEASE=omni  OMNI_BACKUP_DIR=~/omni-backups
+#   PG_DB=omni     MEDIA_BUCKET=omni-media
+#   PG_FWD_PORT=15432  MINIO_FWD_PORT=19000  RETENTION_DAYS=14
+# The forwards use NON-standard host ports on purpose: :5432/:9000 are commonly
+# already bound on a dev box (OrbStack exposes its own services there).
+set -euo pipefail
+
+KCTX="${KCTX:-orbstack}"
+NS="${NS:-omni}"
+RELEASE="${RELEASE:-omni}"
+DEST="${OMNI_BACKUP_DIR:-$HOME/omni-backups}"
+PG_DB="${PG_DB:-omni}"
+MEDIA_BUCKET="${MEDIA_BUCKET:-omni-media}"
+PG_FWD_PORT="${PG_FWD_PORT:-15432}"
+MINIO_FWD_PORT="${MINIO_FWD_PORT:-19000}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+PG_SUPERUSER="${PG_SUPERUSER:-postgres}"
+PG_SUPERPASS="${PG_SUPERPASS:-postgres}"   # autopg pins the superuser to postgres/postgres
+
+STAMP="$(date +%Y%m%d-%H%M)"
+kc(){ kubectl --context "$KCTX" -n "$NS" "$@"; }
+log(){ echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+need(){ command -v "$1" >/dev/null || { echo "omni-backup: missing required tool: $1" >&2; exit 1; }; }
+need kubectl; need docker
+mkdir -p "$DEST/postgres" "$DEST/media"
+log "=== omni-backup start ($STAMP) — release=$RELEASE ns=$NS -> $DEST ==="
+
+# --- Postgres: globals + the app DB (custom format) via a v18 client ---------
+kc port-forward --address 127.0.0.1 "svc/${RELEASE}-autopg" "${PG_FWD_PORT}:5432" >/dev/null 2>&1 &
+PF=$!; trap 'kill $PF 2>/dev/null || true' EXIT; sleep 3
+docker run --rm --add-host=host.docker.internal:host-gateway -e PGPASSWORD="$PG_SUPERPASS" postgres:18 \
+  pg_dumpall -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" --globals-only \
+  | gzip > "$DEST/postgres/globals-$STAMP.sql.gz"
+docker run --rm --add-host=host.docker.internal:host-gateway -e PGPASSWORD="$PG_SUPERPASS" postgres:18 \
+  pg_dump -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" -Fc -d "$PG_DB" \
+  > "$DEST/postgres/${PG_DB}-$STAMP.dump"
+kill $PF 2>/dev/null || true; trap - EXIT
+log "postgres dumped -> ${PG_DB}-$STAMP.dump ($(du -h "$DEST/postgres/${PG_DB}-$STAMP.dump" | cut -f1))"
+
+# --- MinIO media: incremental mirror (creds read from the release Secret) ----
+MINIO_SECRET="$(kc get secret \
+  -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=minio" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+if [ -z "$MINIO_SECRET" ]; then
+  log "no bundled MinIO Secret found (external S3?) — skipping media backup"
+  log "=== omni-backup done (postgres only) ==="; exit 0
+fi
+MU="$(kc get secret "$MINIO_SECRET" -o jsonpath='{.data.MINIO_ROOT_USER}' | base64 -d)"
+MP="$(kc get secret "$MINIO_SECRET" -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d)"
+kc port-forward --address 127.0.0.1 "svc/${RELEASE}-minio" "${MINIO_FWD_PORT}:9000" >/dev/null 2>&1 &
+PF=$!; trap 'kill $PF 2>/dev/null || true' EXIT; sleep 3
+# `mc alias set` (not the MC_HOST URL) so passwords with @ : / don't corrupt a URL.
+docker run --rm --add-host=host.docker.internal:host-gateway \
+  -e MU="$MU" -e MP="$MP" -v "$DEST/media:/backup" --entrypoint sh minio/mc -c \
+  "mc alias set omni \"http://host.docker.internal:${MINIO_FWD_PORT}\" \"\$MU\" \"\$MP\" >/dev/null && \
+   mc mirror --overwrite \"omni/${MEDIA_BUCKET}\" \"/backup/${MEDIA_BUCKET}\""
+kill $PF 2>/dev/null || true; trap - EXIT
+log "media mirrored -> media/${MEDIA_BUCKET} ($(du -sh "$DEST/media/${MEDIA_BUCKET}" 2>/dev/null | cut -f1))"
+
+# --- Retention: prune pg dumps older than N days (media mirror kept whole) ---
+find "$DEST/postgres" -type f \( -name '*.dump' -o -name '*.sql.gz' \) -mtime "+$RETENTION_DAYS" -delete
+log "=== omni-backup done ==="

--- a/deploy/backup/omni-restore.sh
+++ b/deploy/backup/omni-restore.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# omni-restore.sh — restore or verify a Postgres dump produced by omni-backup.sh.
+#
+# Modes:
+#   (default)        VERIFY — restore the dump into a throwaway `postgres:18`
+#                    container and print row counts. Touches nothing live; the
+#                    container is removed on exit. Run this regularly to prove
+#                    your backups are actually restorable.
+#   --target <db>    RESTORE into database <db> on the live autopg (requires
+#                    --confirm). Restore into a fresh/empty DB, or pass --clean.
+#
+# Options:
+#   --file <path>    dump to use (default: newest *.dump in $OMNI_BACKUP_DIR/postgres)
+#   --confirm        required for --target (guards against clobbering live data)
+#   --clean          pass pg_restore --clean --if-exists (target mode)
+#
+# Media restore is intentionally NOT scripted (it overwrites the live bucket) —
+# see README.md for the guarded `mc mirror` command.
+#
+# Env: KCTX NS RELEASE OMNI_BACKUP_DIR PG_FWD_PORT PG_SUPERUSER PG_SUPERPASS
+set -euo pipefail
+
+KCTX="${KCTX:-orbstack}"; NS="${NS:-omni}"; RELEASE="${RELEASE:-omni}"
+DEST="${OMNI_BACKUP_DIR:-$HOME/omni-backups}"
+PG_FWD_PORT="${PG_FWD_PORT:-15432}"
+PG_SUPERUSER="${PG_SUPERUSER:-postgres}"; PG_SUPERPASS="${PG_SUPERPASS:-postgres}"
+
+FILE=""; TARGET=""; CONFIRM=0; CLEAN=""
+while [ $# -gt 0 ]; do case "$1" in
+  --file)    FILE="$2"; shift 2;;
+  --target)  TARGET="$2"; shift 2;;
+  --confirm) CONFIRM=1; shift;;
+  --clean)   CLEAN="--clean --if-exists"; shift;;
+  -h|--help) sed -n '2,20p' "$0"; exit 0;;
+  *) echo "omni-restore: unknown arg: $1" >&2; exit 2;;
+esac; done
+
+[ -n "$FILE" ] || FILE="$(ls -t "$DEST"/postgres/*.dump 2>/dev/null | head -1 || true)"
+[ -n "${FILE:-}" ] && [ -f "$FILE" ] || { echo "omni-restore: no dump found (looked in $DEST/postgres)" >&2; exit 1; }
+log(){ echo "[$(date '+%H:%M:%S')] $*"; }
+
+if [ -z "$TARGET" ]; then
+  # ---------- VERIFY: ephemeral postgres:18, restore, count ----------
+  log "verify: restoring $(basename "$FILE") into a throwaway postgres:18 (nothing live is touched)…"
+  CID="omni-restore-verify-$$"
+  docker rm -f "$CID" >/dev/null 2>&1 || true
+  docker run -d --name "$CID" -e POSTGRES_PASSWORD=x -v "$(cd "$(dirname "$FILE")" && pwd):/dumps:ro" postgres:18 >/dev/null
+  trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+  for _ in $(seq 1 30); do docker exec "$CID" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+  docker exec "$CID" createdb -U postgres verify
+  docker exec "$CID" pg_restore -U postgres -d verify --no-owner "/dumps/$(basename "$FILE")" 2>&1 | tail -3 || true
+  docker exec "$CID" psql -U postgres -d verify -qc "ANALYZE;" >/dev/null
+  log "restored OK — top tables by row count:"
+  docker exec "$CID" psql -U postgres -d verify -P pager=off -c \
+    "SELECT relname, n_live_tup AS rows FROM pg_stat_user_tables ORDER BY n_live_tup DESC LIMIT 10;"
+  log "verify PASS"
+  exit 0
+fi
+
+# ---------- TARGET: restore into a live DB (guarded) ----------
+[ "$CONFIRM" = 1 ] || { echo "omni-restore: refusing to write live db '$TARGET' without --confirm" >&2; exit 3; }
+kubectl --context "$KCTX" -n "$NS" port-forward --address 127.0.0.1 "svc/${RELEASE}-autopg" "${PG_FWD_PORT}:5432" >/dev/null 2>&1 &
+PF=$!; trap 'kill $PF 2>/dev/null || true' EXIT; sleep 3
+log "restoring $(basename "$FILE") into LIVE db '$TARGET'…"
+docker run --rm -i --add-host=host.docker.internal:host-gateway -e PGPASSWORD="$PG_SUPERPASS" \
+  -v "$(cd "$(dirname "$FILE")" && pwd):/dumps:ro" postgres:18 \
+  pg_restore -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" -d "$TARGET" --no-owner $CLEAN \
+  "/dumps/$(basename "$FILE")"
+kill $PF 2>/dev/null || true; trap - EXIT
+log "restore into '$TARGET' complete"

--- a/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
+++ b/deploy/helm/omni/charts/autopg/templates/statefulset.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   replicas: 1
   serviceName: {{ include "autopg.headlessServiceName" . }}
+  {{- with .Values.persistentVolumeClaimRetentionPolicy }}
+  # Self-host data safety: control the data PVC's fate when this StatefulSet is
+  # deleted (e.g. `helm uninstall`) or scaled down. Rendered ONLY when set —
+  # realms that omit it keep the Kubernetes default (Retain/Retain), so cloud
+  # manifests are unchanged.
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "autopg.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/omni/charts/autopg/values.yaml
+++ b/deploy/helm/omni/charts/autopg/values.yaml
@@ -146,6 +146,11 @@ persistence:
   accessModes:
     - ReadWriteOnce
 
+# StatefulSet PVC retention. Empty {} => omit the field (Kubernetes default
+# Retain/Retain). Self-host overlays can make data-safety explicit with:
+#   persistentVolumeClaimRetentionPolicy: {whenDeleted: Retain, whenScaled: Retain}
+persistentVolumeClaimRetentionPolicy: {}
+
 resources:
   requests:
     cpu: 250m

--- a/deploy/helm/omni/templates/minio.yaml
+++ b/deploy/helm/omni/templates/minio.yaml
@@ -81,6 +81,12 @@ metadata:
 spec:
   serviceName: {{ include "omni.minio.fullname" . }}
   replicas: 1
+  {{- with .Values.minio.persistentVolumeClaimRetentionPolicy }}
+  # Self-host data safety: keep the media PVC when this StatefulSet is deleted/
+  # scaled. Rendered only when set, so cloud realms (minio disabled) are unaffected.
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "omni.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/omni/templates/nats.yaml
+++ b/deploy/helm/omni/templates/nats.yaml
@@ -80,6 +80,13 @@ metadata:
 spec:
   serviceName: {{ include "omni.nats.fullname" . }}
   replicas: 1
+  {{- with .Values.nats.persistentVolumeClaimRetentionPolicy }}
+  # Self-host data safety: keep the JetStream PVC when this StatefulSet is
+  # deleted/scaled. Rendered only when set — realms that omit it (incl. prod,
+  # where nats is enabled) keep the Kubernetes default, so their output is unchanged.
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "omni.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/omni/values-dev.yaml
+++ b/deploy/helm/omni/values-dev.yaml
@@ -47,15 +47,21 @@ database:
 resources:
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 384Mi
   limits:
     cpu: "1"
-    memory: 768Mi
+    # Bumped 768Mi -> 1536Mi: media processing (image decode + gemini calls)
+    # spikes; a live baseline of ~467Mi was already 61% of the old limit.
+    memory: 1536Mi
 
 nats:
   enabled: true
   persistence:
     size: 512Mi
+  # Keep the JetStream data PVC if the StatefulSet is deleted (self-host safety).
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
   # Expose the client port (:4222) on an OrbStack LoadBalancer so a
   # `genie omni serve` bridge running on a sibling VM can subscribe to
   # omni.message.* and reply on omni.reply.*. Trusted host-net only.
@@ -83,6 +89,11 @@ minio:
     # media corpus (~15Gi) + growth. Applies to fresh installs only
     # (volumeClaimTemplates are immutable on an existing StatefulSet).
     size: 30Gi
+  # Keep the media PVC if the StatefulSet is deleted (self-host safety). Note the
+  # local-path PV reclaimPolicy is still Delete — see deploy/backup/README.md.
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
   resources:
     requests:
       memory: 256Mi
@@ -105,6 +116,10 @@ autopg:
       password: "omni-dev-password"
   persistence:
     size: 2Gi
+  # Keep the Postgres data PVC if the StatefulSet is deleted (self-host safety).
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
 
 # Expose the api to the host (OrbStack assigns a LoadBalancer IP reachable
 # from the Mac) — the omni CLI on the host points at this endpoint.

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -233,6 +233,10 @@ nats:
   persistence:
     storageClass: ""
     size: 1Gi
+  # StatefulSet PVC retention (JetStream data). Empty {} => omit the field
+  # (k8s default Retain/Retain). Self-host overlays may set
+  # {whenDeleted: Retain, whenScaled: Retain}.
+  persistentVolumeClaimRetentionPolicy: {}
   resources:
     requests:
       cpu: 50m
@@ -306,6 +310,10 @@ minio:
   persistence:
     storageClass: ""
     size: 10Gi
+  # StatefulSet PVC retention. Empty {} => omit the field (k8s default
+  # Retain/Retain). Self-host overlays may set {whenDeleted: Retain,
+  # whenScaled: Retain} to make media data-safety explicit.
+  persistentVolumeClaimRetentionPolicy: {}
   # mc (MinIO client) image for the bucket bootstrap Job + omni-api initContainer.
   mc:
     image: minio/mc:RELEASE.2024-01-16T16-06-34Z


### PR DESCRIPTION
## What

Make the **bundled self-host path** (`values-dev.yaml` — in-cluster autopg + MinIO + NATS) safe and ergonomic. **Zero changes to the AWS cloud realms.**

## Why

Running the self-host stack for real surfaced gaps that hit every self-hoster:
- **No backup story at all** — nothing dumps Postgres (WhatsApp/Baileys session state + messages) or mirrors the MinIO media.
- Footguns — `local-path` PV reclaim is `Delete`; rebuilding the fixed `:dev` image doesn't roll the pod; the dev omni-api memory limit (768Mi) is tight under media processing.

## Changes

- **`deploy/backup/`** — host-side `omni-backup.sh` (Postgres via a version-matched `postgres:18` client + MinIO `mc mirror`; **MinIO creds read from the cluster at runtime, no committed secrets**) and `omni-restore.sh` (verify a dump into a throwaway container, or restore into a live DB with a `--confirm` guard), plus a README with the traps, Time Machine note, launchd/systemd scheduling, and a restore runbook. Backups stay local; **no in-cluster CronJob**.
- **PVC retention knob** — `persistentVolumeClaimRetentionPolicy` on the bundled autopg/minio/nats StatefulSets, **rendered only when set**; `values-dev.yaml` opts into `Retain`.
- **`make redeploy`** — rebuild the image + `rollout restart` (a plain `deploy` won't roll the pod because the `:dev` tag is fixed with `pullPolicy: Never`).
- **omni-api memory** `768Mi → 1536Mi` in `values-dev.yaml` only.
- **docs** — `deploy/README.md` "Data safety & backups" (incl. the `local-path` PV `reclaim=Delete` note + the `Retain` one-liner); gitignore the per-machine `values-local.yaml` overlay.

## Cloud safety (the important bit)

The retention field renders **only when the value is set**, and only the self-host overlay sets it — so `helm template` for **prod / homolog / hml-alb is byte-identical to `origin/dev`** (verified with a before/after diff). Untouched: `values-{homolog,prod,hml-alb}.yaml`, `deploy/k8s/omni-hml/*`, `templates/deployment.yaml`, `_helpers.tpl`, `templates/ingress.yaml`, and `Chart.yaml`'s `appVersion`.

## Verification

- `helm lint` clean; `template REALM=dev` shows the 3 retention blocks + `memory: 1536Mi`.
- `make deploy-smoke` green — fresh k3d cluster, every pod Ready + `/health` 200.
- prod / homolog / hml-alb renders **diff-empty** vs `origin/dev`.
- `omni-backup.sh` + `omni-restore.sh` run end-to-end against a live install — restore verified into a throwaway `postgres:18` with row-count parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
