### PR TITLE
fix(deploy): harden backup scripts per review findings

### DIFF
--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -52,6 +52,8 @@ deploy/backup/omni-restore.sh
 | `MEDIA_BUCKET` | `omni-media` | MinIO bucket to mirror |
 | `PG_FWD_PORT` / `MINIO_FWD_PORT` | `15432` / `19000` | host ports for the forwards |
 | `RETENTION_DAYS` | `14` | prune pg dumps older than this (media mirror kept whole) |
+| `PG_SVC` / `MINIO_SVC` | derived from `RELEASE` | override the Service names for non-default release layouts |
+| `RESTORE_ROLE` | the `--target` db name | restore-only: role that ends up owning restored objects |
 
 ## Keep the backups safe (Time Machine)
 
@@ -138,8 +140,9 @@ deploy/backup/omni-restore.sh --target omni --clean --confirm
 
 ```bash
 kubectl -n omni port-forward --address 127.0.0.1 svc/omni-minio 19000:9000 &
-MU=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_USER}' | base64 -d)
-MP=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_PASSWORD}' | base64 -d)
+# --decode works on both GNU (Linux) and BSD (macOS) base64
+MU=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_USER}' | base64 --decode)
+MP=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_PASSWORD}' | base64 --decode)
 docker run --rm --add-host=host.docker.internal:host-gateway -e MU="$MU" -e MP="$MP" \
   -v ~/omni-backups/media:/backup --entrypoint sh minio/mc -c \
   'mc alias set omni http://host.docker.internal:19000 "$MU" "$MP" && mc mirror --overwrite /backup/omni-media omni/omni-media'

--- a/deploy/backup/omni-backup.sh
+++ b/deploy/backup/omni-backup.sh
@@ -19,6 +19,9 @@
 #   KCTX=orbstack  NS=omni  RELEASE=omni  OMNI_BACKUP_DIR=~/omni-backups
 #   PG_DB=omni     MEDIA_BUCKET=omni-media
 #   PG_FWD_PORT=15432  MINIO_FWD_PORT=19000  RETENTION_DAYS=14
+#   PG_SVC / MINIO_SVC — override the rendered Service names for non-default
+#   release layouts (MINIO_SVC otherwise auto-derives from the release Secret,
+#   which the chart names identically to the Service).
 # The forwards use NON-standard host ports on purpose: :5432/:9000 are commonly
 # already bound on a dev box (OrbStack exposes its own services there).
 set -euo pipefail
@@ -34,25 +37,41 @@ MINIO_FWD_PORT="${MINIO_FWD_PORT:-19000}"
 RETENTION_DAYS="${RETENTION_DAYS:-14}"
 PG_SUPERUSER="${PG_SUPERUSER:-postgres}"
 PG_SUPERPASS="${PG_SUPERPASS:-postgres}"   # autopg pins the superuser to postgres/postgres
+PG_SVC="${PG_SVC:-${RELEASE}-autopg}"
 
 STAMP="$(date +%Y%m%d-%H%M)"
 kc(){ kubectl --context "$KCTX" -n "$NS" "$@"; }
 log(){ echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 need(){ command -v "$1" >/dev/null || { echo "omni-backup: missing required tool: $1" >&2; exit 1; }; }
+# base64 decode across GNU (-d/--decode), BSD/macOS (-D/--decode), busybox (-d).
+b64d(){ base64 --decode 2>/dev/null || base64 -d 2>/dev/null || base64 -D; }
 need kubectl; need docker
+
+# Centralized cleanup so a premature exit never leaks a background port-forward.
+PF_PG=""; PF_MINIO=""
+cleanup(){
+  [ -n "${PF_PG:-}" ] && kill "$PF_PG" 2>/dev/null || true
+  [ -n "${PF_MINIO:-}" ] && kill "$PF_MINIO" 2>/dev/null || true
+}
+trap cleanup EXIT
+
 mkdir -p "$DEST/postgres" "$DEST/media"
 log "=== omni-backup start ($STAMP) — release=$RELEASE ns=$NS -> $DEST ==="
 
 # --- Postgres: globals + the app DB (custom format) via a v18 client ---------
-kc port-forward --address 127.0.0.1 "svc/${RELEASE}-autopg" "${PG_FWD_PORT}:5432" >/dev/null 2>&1 &
-PF=$!; trap 'kill $PF 2>/dev/null || true' EXIT; sleep 3
+# Background kubectl DIRECTLY (not via the kc function): backgrounding a
+# function forks a subshell whose $! is not kubectl's PID, so killing it
+# orphans the actual port-forward.
+kubectl --context "$KCTX" -n "$NS" port-forward --address 127.0.0.1 "svc/${PG_SVC}" "${PG_FWD_PORT}:5432" >/dev/null 2>&1 &
+PF_PG=$!; sleep 3
+kill -0 "$PF_PG" 2>/dev/null || { echo "omni-backup: Postgres port-forward failed (svc/${PG_SVC}, host port ${PG_FWD_PORT} taken?)" >&2; exit 1; }
 docker run --rm --add-host=host.docker.internal:host-gateway -e PGPASSWORD="$PG_SUPERPASS" postgres:18 \
   pg_dumpall -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" --globals-only \
   | gzip > "$DEST/postgres/globals-$STAMP.sql.gz"
 docker run --rm --add-host=host.docker.internal:host-gateway -e PGPASSWORD="$PG_SUPERPASS" postgres:18 \
   pg_dump -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" -Fc -d "$PG_DB" \
   > "$DEST/postgres/${PG_DB}-$STAMP.dump"
-kill $PF 2>/dev/null || true; trap - EXIT
+kill "$PF_PG" 2>/dev/null || true; PF_PG=""
 log "postgres dumped -> ${PG_DB}-$STAMP.dump ($(du -h "$DEST/postgres/${PG_DB}-$STAMP.dump" | cut -f1))"
 
 # --- MinIO media: incremental mirror (creds read from the release Secret) ----
@@ -63,16 +82,20 @@ if [ -z "$MINIO_SECRET" ]; then
   log "no bundled MinIO Secret found (external S3?) — skipping media backup"
   log "=== omni-backup done (postgres only) ==="; exit 0
 fi
-MU="$(kc get secret "$MINIO_SECRET" -o jsonpath='{.data.MINIO_ROOT_USER}' | base64 -d)"
-MP="$(kc get secret "$MINIO_SECRET" -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d)"
-kc port-forward --address 127.0.0.1 "svc/${RELEASE}-minio" "${MINIO_FWD_PORT}:9000" >/dev/null 2>&1 &
-PF=$!; trap 'kill $PF 2>/dev/null || true' EXIT; sleep 3
+# The chart names the MinIO Secret and Service identically (omni.minio.fullname),
+# so the Secret we just found doubles as the Service name for any release name.
+MINIO_SVC="${MINIO_SVC:-$MINIO_SECRET}"
+MU="$(kc get secret "$MINIO_SECRET" -o jsonpath='{.data.MINIO_ROOT_USER}' | b64d)"
+MP="$(kc get secret "$MINIO_SECRET" -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | b64d)"
+kubectl --context "$KCTX" -n "$NS" port-forward --address 127.0.0.1 "svc/${MINIO_SVC}" "${MINIO_FWD_PORT}:9000" >/dev/null 2>&1 &
+PF_MINIO=$!; sleep 3
+kill -0 "$PF_MINIO" 2>/dev/null || { echo "omni-backup: MinIO port-forward failed (svc/${MINIO_SVC}, host port ${MINIO_FWD_PORT} taken?)" >&2; exit 1; }
 # `mc alias set` (not the MC_HOST URL) so passwords with @ : / don't corrupt a URL.
 docker run --rm --add-host=host.docker.internal:host-gateway \
   -e MU="$MU" -e MP="$MP" -v "$DEST/media:/backup" --entrypoint sh minio/mc -c \
   "mc alias set omni \"http://host.docker.internal:${MINIO_FWD_PORT}\" \"\$MU\" \"\$MP\" >/dev/null && \
    mc mirror --overwrite \"omni/${MEDIA_BUCKET}\" \"/backup/${MEDIA_BUCKET}\""
-kill $PF 2>/dev/null || true; trap - EXIT
+kill "$PF_MINIO" 2>/dev/null || true; PF_MINIO=""
 log "media mirrored -> media/${MEDIA_BUCKET} ($(du -sh "$DEST/media/${MEDIA_BUCKET}" 2>/dev/null | cut -f1))"
 
 # --- Retention: prune pg dumps older than N days (media mirror kept whole) ---

--- a/deploy/backup/omni-restore.sh
+++ b/deploy/backup/omni-restore.sh
@@ -5,7 +5,8 @@
 #   (default)        VERIFY — restore the dump into a throwaway `postgres:18`
 #                    container and print row counts. Touches nothing live; the
 #                    container is removed on exit. Run this regularly to prove
-#                    your backups are actually restorable.
+#                    your backups are actually restorable. Exits non-zero if
+#                    pg_restore reports any error (a corrupt dump must FAIL).
 #   --target <db>    RESTORE into database <db> on the live autopg (requires
 #                    --confirm). Restore into a fresh/empty DB, or pass --clean.
 #
@@ -17,13 +18,24 @@
 # Media restore is intentionally NOT scripted (it overwrites the live bucket) —
 # see README.md for the guarded `mc mirror` command.
 #
-# Env: KCTX NS RELEASE OMNI_BACKUP_DIR PG_FWD_PORT PG_SUPERUSER PG_SUPERPASS
+# Env: KCTX NS RELEASE OMNI_BACKUP_DIR PG_FWD_PORT PG_SVC PG_SUPERUSER
+#      PG_SUPERPASS RESTORE_ROLE (target mode; defaults to the target db name)
 set -euo pipefail
 
 KCTX="${KCTX:-orbstack}"; NS="${NS:-omni}"; RELEASE="${RELEASE:-omni}"
 DEST="${OMNI_BACKUP_DIR:-$HOME/omni-backups}"
 PG_FWD_PORT="${PG_FWD_PORT:-15432}"
 PG_SUPERUSER="${PG_SUPERUSER:-postgres}"; PG_SUPERPASS="${PG_SUPERPASS:-postgres}"
+PG_SVC="${PG_SVC:-${RELEASE}-autopg}"
+
+# Centralized cleanup: the throwaway container and any port-forward are removed
+# even on a premature exit.
+CID=""; PF=""
+cleanup(){
+  [ -n "${CID:-}" ] && docker rm -f "$CID" >/dev/null 2>&1 || true
+  [ -n "${PF:-}" ] && kill "$PF" 2>/dev/null || true
+}
+trap cleanup EXIT
 
 FILE=""; TARGET=""; CONFIRM=0; CLEAN=""
 while [ $# -gt 0 ]; do case "$1" in
@@ -31,7 +43,7 @@ while [ $# -gt 0 ]; do case "$1" in
   --target)  TARGET="$2"; shift 2;;
   --confirm) CONFIRM=1; shift;;
   --clean)   CLEAN="--clean --if-exists"; shift;;
-  -h|--help) sed -n '2,20p' "$0"; exit 0;;
+  -h|--help) sed -n '2,23p' "$0"; exit 0;;
   *) echo "omni-restore: unknown arg: $1" >&2; exit 2;;
 esac; done
 
@@ -45,10 +57,15 @@ if [ -z "$TARGET" ]; then
   CID="omni-restore-verify-$$"
   docker rm -f "$CID" >/dev/null 2>&1 || true
   docker run -d --name "$CID" -e POSTGRES_PASSWORD=x -v "$(cd "$(dirname "$FILE")" && pwd):/dumps:ro" postgres:18 >/dev/null
-  trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
-  for _ in $(seq 1 30); do docker exec "$CID" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+  for _ in {1..30}; do docker exec "$CID" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+  docker exec "$CID" pg_isready -U postgres >/dev/null 2>&1 \
+    || { echo "omni-restore: throwaway postgres never became ready" >&2; exit 1; }
   docker exec "$CID" createdb -U postgres verify
-  docker exec "$CID" pg_restore -U postgres -d verify --no-owner "/dumps/$(basename "$FILE")" 2>&1 | tail -3 || true
+  # Preserve pg_restore's exit status — a dump that does not restore cleanly
+  # must FAIL the verify, that is the whole point of this mode.
+  if ! docker exec "$CID" pg_restore -U postgres -d verify --no-owner "/dumps/$(basename "$FILE")"; then
+    log "verify FAIL — pg_restore reported errors (corrupt or partial dump?)"; exit 1
+  fi
   docker exec "$CID" psql -U postgres -d verify -qc "ANALYZE;" >/dev/null
   log "restored OK — top tables by row count:"
   docker exec "$CID" psql -U postgres -d verify -P pager=off -c \
@@ -59,12 +76,19 @@ fi
 
 # ---------- TARGET: restore into a live DB (guarded) ----------
 [ "$CONFIRM" = 1 ] || { echo "omni-restore: refusing to write live db '$TARGET' without --confirm" >&2; exit 3; }
-kubectl --context "$KCTX" -n "$NS" port-forward --address 127.0.0.1 "svc/${RELEASE}-autopg" "${PG_FWD_PORT}:5432" >/dev/null 2>&1 &
-PF=$!; trap 'kill $PF 2>/dev/null || true' EXIT; sleep 3
-log "restoring $(basename "$FILE") into LIVE db '$TARGET'…"
+# Restore AS the app role (SET ROLE via --role) so restored objects stay owned
+# by it — restoring as the superuser with --no-owner would leave everything
+# owned by postgres and break the app's own access/migrations. The role must
+# already exist (globals restore / the chart's provision Job creates it).
+RESTORE_ROLE="${RESTORE_ROLE:-$TARGET}"
+kubectl --context "$KCTX" -n "$NS" port-forward --address 127.0.0.1 "svc/${PG_SVC}" "${PG_FWD_PORT}:5432" >/dev/null 2>&1 &
+PF=$!; sleep 3
+kill -0 "$PF" 2>/dev/null || { echo "omni-restore: port-forward failed (svc/${PG_SVC}, host port ${PG_FWD_PORT} taken?)" >&2; exit 1; }
+log "restoring $(basename "$FILE") into LIVE db '$TARGET' as role '$RESTORE_ROLE'…"
 docker run --rm -i --add-host=host.docker.internal:host-gateway -e PGPASSWORD="$PG_SUPERPASS" \
   -v "$(cd "$(dirname "$FILE")" && pwd):/dumps:ro" postgres:18 \
-  pg_restore -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" -d "$TARGET" --no-owner $CLEAN \
+  pg_restore -h host.docker.internal -p "$PG_FWD_PORT" -U "$PG_SUPERUSER" -d "$TARGET" \
+  --no-owner --role "$RESTORE_ROLE" $CLEAN \
   "/dumps/$(basename "$FILE")"
-kill $PF 2>/dev/null || true; trap - EXIT
+kill "$PF" 2>/dev/null || true; PF=""
 log "restore into '$TARGET' complete"


### PR DESCRIPTION
Follow-up to #808 — the review-hardening commit was pushed minutes after the merge, so it never landed. Cherry-picked onto `dev`.

Addresses every bot finding from #808 (summary: https://github.com/automagik-dev/omni/pull/808#issuecomment-4931474004):
- **codex P1**: verify mode propagates `pg_restore` failures (corrupt dump ⇒ verify FAILS, no more `|| true` masking)
- **codex P1**: live restores run with `--role` so the app role keeps object ownership (`RESTORE_ROLE` env, defaults to target db)
- **codex P2**: MinIO Service name auto-derived from the release Secret; `PG_SVC`/`MINIO_SVC` overrides
- **gemini high**: portable base64 decode (GNU/BSD/busybox)
- **gemini medium ×6**: centralized EXIT cleanup, `kill -0` fail-fast on port-forward bind failure, throwaway-postgres readiness asserted, `{1..30}`
- **bonus (found re-verifying)**: port-forwards leaked because the `kc()` wrapper was backgrounded (subshell $! ≠ kubectl PID) — kubectl is now backgrounded directly; leak reproduced live, then re-verified clean

Verified end-to-end against a live install: hardened backup + restore-verify both PASS, zero leaked forwards/containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)