### PR TITLE
fix(deploy): second-round review nits on backup tooling

### DIFF
--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -140,7 +140,7 @@ deploy/backup/omni-restore.sh --target omni --clean --confirm
 
 ```bash
 kubectl -n omni port-forward --address 127.0.0.1 svc/omni-minio 19000:9000 &
-# --decode works on both GNU (Linux) and BSD (macOS) base64
+# --decode works on GNU (Linux) and modern BSD/macOS base64 (use -D on old macOS)
 MU=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_USER}' | base64 --decode)
 MP=$(kubectl -n omni get secret -l app.kubernetes.io/component=minio -o jsonpath='{.items[0].data.MINIO_ROOT_PASSWORD}' | base64 --decode)
 docker run --rm --add-host=host.docker.internal:host-gateway -e MU="$MU" -e MP="$MP" \

--- a/deploy/backup/omni-backup.sh
+++ b/deploy/backup/omni-backup.sh
@@ -43,9 +43,13 @@ STAMP="$(date +%Y%m%d-%H%M)"
 kc(){ kubectl --context "$KCTX" -n "$NS" "$@"; }
 log(){ echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 need(){ command -v "$1" >/dev/null || { echo "omni-backup: missing required tool: $1" >&2; exit 1; }; }
-# base64 decode across GNU (-d/--decode), BSD/macOS (-D/--decode), busybox (-d).
-b64d(){ base64 --decode 2>/dev/null || base64 -d 2>/dev/null || base64 -D; }
 need kubectl; need docker
+# Detect the base64 decode flag ONCE at startup — GNU (-d/--decode),
+# BSD/macOS (-D/--decode), busybox (-d) — instead of a per-call fallback chain.
+if   printf 'eA==' | base64 --decode >/dev/null 2>&1; then b64d(){ base64 --decode; }
+elif printf 'eA==' | base64 -d       >/dev/null 2>&1; then b64d(){ base64 -d; }
+elif printf 'eA==' | base64 -D       >/dev/null 2>&1; then b64d(){ base64 -D; }
+else echo "omni-backup: no working 'base64' decode flag found" >&2; exit 1; fi
 
 # Centralized cleanup so a premature exit never leaks a background port-forward.
 PF_PG=""; PF_MINIO=""

--- a/deploy/backup/omni-restore.sh
+++ b/deploy/backup/omni-restore.sh
@@ -43,7 +43,9 @@ while [ $# -gt 0 ]; do case "$1" in
   --target)  TARGET="$2"; shift 2;;
   --confirm) CONFIRM=1; shift;;
   --clean)   CLEAN="--clean --if-exists"; shift;;
-  -h|--help) sed -n '2,22p' "$0"; exit 0;;
+  # Print the leading comment block (after the shebang) up to the first
+  # non-comment line — immune to header edits shifting line numbers.
+  -h|--help) sed -e '1d' -e '/^[^#]/,$d' "$0"; exit 0;;
   *) echo "omni-restore: unknown arg: $1" >&2; exit 2;;
 esac; done
 

--- a/deploy/backup/omni-restore.sh
+++ b/deploy/backup/omni-restore.sh
@@ -43,7 +43,7 @@ while [ $# -gt 0 ]; do case "$1" in
   --target)  TARGET="$2"; shift 2;;
   --confirm) CONFIRM=1; shift;;
   --clean)   CLEAN="--clean --if-exists"; shift;;
-  -h|--help) sed -n '2,23p' "$0"; exit 0;;
+  -h|--help) sed -n '2,22p' "$0"; exit 0;;
   *) echo "omni-restore: unknown arg: $1" >&2; exit 2;;
 esac; done
 


### PR DESCRIPTION
Tiny follow-up — #809 was merged minutes before this commit was pushed, so it stranded on the branch (same race as #808→#809). Delta is just the 3 second-round bot nits:

- detect the base64 decode flag once at startup (no per-call fallback chain)
- `--help` no longer leaks `set -euo pipefail` (sed range off-by-one)
- README: keep `--decode` (verified on modern macOS + GNU; bot's `-d`-only suggestion is less portable), note `-D` for old macOS

8 insertions / 4 deletions across the 3 backup files; backup e2e re-verified PASS with the detect-once decoder, zero leaked forwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)