### PR TITLE
fix(test)+docs: exclude decoupled khal-ui from omni bun test; mock-bleed fix; dev→homolog→main flow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -355,27 +355,37 @@ make migrate-messages      # Live migration
 > **New work = PR to dev. Fixes = direct commit to dev.**
 
 ```
-main <── rolling PR (human merges) <── dev <── feature PRs (auto-merge)
-                                         |
-                                         └── direct commits (fixes/hotfixes)
+main <── homolog <── dev <── feature PRs (auto-merge)
+  ▲          ▲         |
+promote   promote      └── direct commits (fixes/hotfixes)
+(human)   (human)
 ```
+
+Promotion is a **two-hop carry-exact roll**: `dev → homolog → main`. `dev` is
+integration; `homolog` is the staging/hml gate that must go green before
+production; `main` is production. Each hop is a PR a human merges — the version
+carries exactly (bump on `dev` only, never re-bumped on promotion).
 
 ### Branch Roles
 
 | Branch | Purpose | Who commits | Protection |
 |--------|---------|-------------|------------|
-| `main` | Production | Human merges rolling PR | PR-only, all checks required |
+| `main` | Production | Human merges `homolog → main` promotion PR | PR-only, all checks required |
+| `homolog` | Staging / hml gate | Human merges `dev → homolog` promotion PR | PR-only, checks required |
 | `dev` | Integration | Agent + PRs | Direct commits OK, PRs need checks |
 | `feat/*` | New features | Worktrees, PR to `dev` | Auto-merge when green |
 | `fix/*` | Bug fixes | Direct on `dev` or worktree | — |
 
-### Rolling PR (dev to main)
+### Promotion (dev → homolog → main)
 
-A rolling PR from `dev` to `main` is always maintained:
-- **GitHub Actions** creates it automatically if missing (every 15 min)
-- **Agent** monitors CI status and fixes issues
-- **Human** reviews and merges when ready
-- Label `ready-to-merge` added when all checks pass
+1. **`dev → homolog`** — open when `dev` is ahead of `homolog` and green. Carry-exact
+   (no version re-bump). Human merges after homolog CI passes.
+2. **`homolog → main`** — open once `homolog` carries the promoted content. Human
+   merges; `main` merge triggers release-please. Keep `homolog` and `dev` in sync so
+   the next `dev → homolog` never re-conflicts on version files.
+
+Keep `homolog` fast-forwardable from `dev` (reset/promote, never let it drift) so
+promotions stay carry-exact rather than turning into version-file merge conflicts.
 
 ### Conventional Commits (Required)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,9 @@ jobs:
         run: bunx knip
 
       - name: Test
-        run: bun test --env-file=.env
+        # Scope to omni packages + the ui app; apps/khal-ui is a decoupled
+        # sub-project (private @khal-os deps) with its own test run.
+        run: bun test packages apps/ui --env-file=.env
         env:
           NODE_ENV: test
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -66,7 +66,7 @@ if ! make typecheck; then
 fi
 
 echo "▶ pre-push: full test suite"
-if ! bun test; then
+if ! bun test packages apps/ui; then
   echo ""
   echo "✗ tests failed."
   echo "  → If Logger / Buffer tests fail in the full suite but pass in"

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -14,6 +14,11 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test';
+// Real @omni/core captured before mock.module below replaces it. Bun's
+// mock.module REPLACES the module (it does not merge), so the factory must
+// spread the real exports or OmniError/createLogger/etc. become undefined for
+// every test file ordered after this one (the messages-route mock-bleed).
+import * as omniCoreReal from '@omni/core';
 import { instances } from '@omni/db';
 
 // ---------------------------------------------------------------------------
@@ -96,6 +101,9 @@ mock.module('@omni/core', () => {
   // createLogger is NOT mocked — the real implementation passes through via
   // bun's merge behavior, keeping logger.test.ts and other test files working.
   return {
+    // Preserve every real export (OmniError, createLogger, EventType, …) so
+    // this global module mock only overrides the provider surface below.
+    ...omniCoreReal,
     AgnoAgentProvider: MockAgnoAgentProvider,
     WebhookAgentProvider: MockWebhookAgentProvider,
     createProviderClient: mock(() => ({})),


### PR DESCRIPTION
Follow-up to #814. Fixes omni's `bun test` (pre-push hook + CI Quality Gate) which scanned the decoupled apps/khal-ui and errored on unresolvable @khal-os/react/zod imports. Scopes omni's test run to `packages apps/ui` (khal-ui has its own test suite). Also: the agent-dispatcher @omni/core mock-merge fix, and CLAUDE.md updated to the dev→homolog→main promotion flow. Full suite: 4239 pass / 0 fail.