### PR TITLE
ci(commitlint): ignore immutable khal-ui long-header commit

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -19,5 +19,8 @@ export default {
       message.startsWith(
         'ci(test): execute S3/MinIO integration suites in CI; ungate dispatcher local tests (PR #770 H8, MED-4) (#778)',
       ),
+    // Immutable khal-ui promotion commits with >100-char headers/body lines.
+    (message: string) =>
+      message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],
 };


### PR DESCRIPTION
Fixes the recurring commitlint failure on the dev→main rolling PR (#811): the khal-ui `fix(deps): pin @types/react 18...` commit has a >100-char header/body and is immutable on dev. Added to commitlint `ignores` following the PR #778 precedent.