### PR TITLE
build(deps): drop unused root @types/react pin (knip)

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -20,7 +20,6 @@ export default {
         'ci(test): execute S3/MinIO integration suites in CI; ungate dispatcher local tests (PR #770 H8, MED-4) (#778)',
       ),
     // Immutable khal-ui promotion commits with >100-char headers/body lines.
-    (message: string) =>
-      message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
+    (message: string) => message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],
 };


### PR DESCRIPTION
Fixes the Quality Gate knip failure on the dev→main rolling PR (#811). The root @types/react pin is dead after khal-ui was decoupled (#814) — already dropped on homolog/main, this lands it on dev. Verified: knip, biome, version-sync, build all green.