### PR TITLE
ci(rolling-pr): retarget rolling PR to homolog→main (dev→homolog)

### DIFF
--- a/.github/workflows/rolling-pr.yml
+++ b/.github/workflows/rolling-pr.yml
@@ -24,18 +24,20 @@ jobs:
           # Use a PAT with contents:read + pull-requests:write scopes.
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          # Check if open PR exists (dev -> main)
-          PR=$(gh pr list --repo ${{ github.repository }} --base main --head dev --state open --json number --jq '.[0].number')
+          # Check if open PR exists (homolog -> main)
+          PR=$(gh pr list --repo ${{ github.repository }} --base main --head homolog --state open --json number --jq '.[0].number')
 
           if [ -z "$PR" ]; then
             # Create new rolling PR
             gh pr create --repo ${{ github.repository }} \
-              --base main --head dev \
-              --title "chore: rolling promotion dev -> main" \
+              --base main --head homolog \
+              --title "chore: rolling promotion homolog -> main" \
               --body "$(cat <<'BODY'
           ## Rolling Promotion PR
 
-          Auto-maintained rolling promotion PR from `dev` to `main`.
+          Auto-maintained rolling promotion PR from `homolog` to `main` — the
+          final hop of the two-hop `dev → homolog → main` flow. (`dev → homolog`
+          is opened per-promotion; this keeps the production gate always open.)
 
           **Process:**
           - This PR is automatically created and kept open


### PR DESCRIPTION
## Promote `dev → homolog` — rolling-pr workflow retarget

Carries `ci(rolling-pr): retarget rolling promotion PR to homolog -> main` into homolog so it folds into the in-flight [#823](https://github.com/automagik-dev/omni/pull/823) (homolog→main) and reaches production in the same wave.

Fixes the root cause of the recurring wrong-hop `dev→main` PR (#820): the hourly `rolling-pr.yml` cron predated the homolog branch. Now it maintains the `homolog→main` production gate instead.

Clean fast-forward (only the one CI-file commit over homolog). After merge, #823 will carry admin-ui **+** this retarget to main.
