### PR TITLE
fix(api): discard superseded agent replies when newer inbound arrives mid-run

### DIFF
--- a/packages/api/src/plugins/__tests__/message-debouncer.test.ts
+++ b/packages/api/src/plugins/__tests__/message-debouncer.test.ts
@@ -579,4 +579,49 @@ describe('MessageDebouncer', () => {
       expect(byKey['inst-2:chat-1']).toBe(1);
     });
   });
+
+  describe('hasPending — stale-reply detection', () => {
+    it('reports pending messages buffered while a flush is in flight', async () => {
+      const pendingObservedDuringFlush: boolean[] = [];
+      let release: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+        if (messages[0]?.payload.content?.text === 'first') {
+          // Hold the flush open so a second message lands in the buffer.
+          await gate;
+          pendingObservedDuringFlush.push(debouncer.hasPending('inst-1', 'chat-1'));
+        }
+      });
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('first'), disabledConfig);
+      await wait(20); // flush for 'first' is now in flight, awaiting the gate
+
+      expect(debouncer.hasPending('inst-1', 'chat-1')).toBe(false);
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('second'), disabledConfig);
+      expect(debouncer.hasPending('inst-1', 'chat-1')).toBe(true);
+
+      release?.();
+      await wait(30); // in-flight flush completes + finally re-flush drains 'second'
+
+      expect(pendingObservedDuringFlush).toEqual([true]);
+      expect(debouncer.hasPending('inst-1', 'chat-1')).toBe(false);
+    });
+
+    it('is scoped per instanceId:chatId', async () => {
+      debouncer = new MessageDebouncer(async (_chatKey, _messages) => {});
+
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('a'), fixedConfig);
+
+      expect(debouncer.hasPending('inst-1', 'chat-1')).toBe(true);
+      expect(debouncer.hasPending('inst-1', 'chat-2')).toBe(false);
+      expect(debouncer.hasPending('inst-2', 'chat-1')).toBe(false);
+
+      await wait(150); // fixed window elapses, buffer drains
+
+      expect(debouncer.hasPending('inst-1', 'chat-1')).toBe(false);
+    });
+  });
 });

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -390,6 +390,31 @@ class ReactionDedup {
 const PRESENCE_DEFAULT_MIN_MS = 5_000; // quiet window after the user stops typing
 const PRESENCE_DEFAULT_MAX_WAIT_MS = 30_000; // hard cap under continuous typing
 
+/**
+ * Module-level handle to the message debouncer created in the plugin setup.
+ * Lets the dispatch paths ask, right before delivering an agent reply, whether
+ * newer inbound messages are already buffered for the chat (i.e. the reply was
+ * generated from a stale snapshot).
+ */
+let activeMessageDebouncer: MessageDebouncer | null = null;
+
+/** True when newer inbound messages are buffered for this chat than the batch that produced the current reply. */
+function hasPendingInbound(instanceId: string, chatId: string): boolean {
+  return activeMessageDebouncer?.hasPending(instanceId, chatId) ?? false;
+}
+
+/**
+ * Stale-reply gate (per-instance, default 'off'): with `messageSupersedeMode`
+ * set to 'discard', a reply that was generated while newer inbound arrived is
+ * dropped — the debouncer's finally-block re-flush dispatches the buffered
+ * messages immediately, so the follow-up run answers everything with full
+ * context instead of the user receiving an out-of-date reply first.
+ */
+function isReplySuperseded(instance: Instance | DispatchInstance, chatId: string): boolean {
+  const mode = (instance as { messageSupersedeMode?: string | null }).messageSupersedeMode ?? 'off';
+  return mode === 'discard' && hasPendingInbound(instance.id, chatId);
+}
+
 function getDebounceConfig(instance: Instance): DebounceConfig {
   const mode = instance.messageDebounceMode ?? 'disabled';
   const isPresence = mode === 'presence';
@@ -692,6 +717,24 @@ export async function triggerErrorHandoff(
  * native-handoff channels (Gupshup — special message + agent pause), otherwise
  * the plain {@link resolveDispatchErrorMessage} reply.
  */
+/**
+ * Trigger the customer-error handoff when the provider blocked a leaked error
+ * and substituted the customer-safe fallback — unless a handoff already fired
+ * during the run. Extracted from dispatchViaProvider to keep its complexity down.
+ */
+async function maybeTriggerErrorHandoff(
+  services: Services,
+  db: Database,
+  channel: ChannelType,
+  instance: DispatchInstance,
+  chatId: string,
+  customerErrorBlocked: boolean,
+  handoffTriggered: boolean,
+): Promise<boolean> {
+  if (!customerErrorBlocked || handoffTriggered) return false;
+  return triggerErrorHandoff(services, db, channel, instance, chatId, resolveErrorHandoffMessage());
+}
+
 async function handleDispatchFailure(
   services: Services,
   db: Database,
@@ -2677,23 +2720,28 @@ async function dispatchViaProvider(
       const chatAfterRun = await services.chats.findByExternalIdSmart(instance.id, chatId);
       const handoffTriggered = (chatAfterRun?.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
 
+      // If newer inbound arrived while the agent was running, this reply was
+      // generated from a stale snapshot. With messageSupersedeMode='discard',
+      // drop it — the debouncer's finally-block re-flush dispatches the
+      // buffered messages right away, producing one reply with full context.
+      // Never discard when a handoff fired: that announcement must go out.
+      const supersededByNewerInbound = !handoffTriggered && isReplySuperseded(instance, chatId);
+
       // When the provider blocked a leaked error and substituted the customer-safe
       // fallback, route to a human on native-handoff channels (Gupshup) instead of
       // forwarding the generic fallback text. Non-handoff channels fall through and
       // send the fallback parts as before.
-      let errorHandoffDone = false;
-      if (result?.metadata.customerErrorBlocked === true && !handoffTriggered) {
-        errorHandoffDone = await triggerErrorHandoff(
-          services,
-          db,
-          channel,
-          instance,
-          chatId,
-          resolveErrorHandoffMessage(),
-        );
-      }
+      const errorHandoffDone = await maybeTriggerErrorHandoff(
+        services,
+        db,
+        channel,
+        instance,
+        chatId,
+        result?.metadata.customerErrorBlocked === true,
+        handoffTriggered,
+      );
 
-      if (result && result.parts.length > 0 && !handoffTriggered && !errorHandoffDone) {
+      if (result && result.parts.length > 0 && !handoffTriggered && !errorHandoffDone && !supersededByNewerInbound) {
         const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
         const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
         // Apply before_message_write hooks to each response part before sending
@@ -2737,6 +2785,13 @@ async function dispatchViaProvider(
         log.info('Agent response suppressed — handoff triggered during run', {
           instanceId: instance.id,
           chatId,
+        });
+      } else if (supersededByNewerInbound) {
+        log.info('Agent response discarded — superseded by newer inbound', {
+          instanceId: instance.id,
+          chatId,
+          parts: result?.parts.length ?? 0,
+          traceId,
         });
       }
 
@@ -2868,6 +2923,20 @@ async function dispatchViaLegacy(
   );
 
   const correlationId = messages[0]?.metadata.correlationId;
+
+  // Stale-reply gate — same semantics as the provider path: when newer inbound
+  // arrived during the run and messageSupersedeMode='discard', drop this reply
+  // and let the debouncer re-flush answer with full context.
+  if (isReplySuperseded(instance, chatId)) {
+    log.info('Agent response discarded — superseded by newer inbound', {
+      instanceId: instance.id,
+      chatId,
+      parts: result.parts.length,
+      traceId,
+    });
+    return;
+  }
+
   const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
   const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
 
@@ -5130,6 +5199,8 @@ export async function setupAgentDispatcher(
   }, 60_000);
 
   // Create debouncer for message events
+  // (registered module-wide so dispatch paths can consult pending buffers
+  //  for the stale-reply gate — see isReplySuperseded)
   const debouncer = new MessageDebouncer(async (_chatKey, messages) => {
     const firstMsg = messages[0];
     if (!firstMsg) return;
@@ -5173,6 +5244,7 @@ export async function setupAgentDispatcher(
 
     await processAgentResponse(services, instance, messages, triggerType, db, eventBus);
   });
+  activeMessageDebouncer = debouncer;
 
   try {
     // ========================================

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -91,6 +91,17 @@ export class MessageDebouncer {
     this.restartTimer(chatKey, config);
   }
 
+  /**
+   * Whether messages are currently buffered for this chat — typically ones
+   * that arrived while a flush was in flight. The dispatcher uses this to
+   * detect that a reply it is about to deliver was generated from a stale
+   * snapshot (newer inbound exists) and may discard it; the finally-block
+   * re-flush then answers everything with full context.
+   */
+  hasPending(instanceId: string, chatId: string): boolean {
+    return (this.buffers.get(this.getChatKey(instanceId, chatId))?.length ?? 0) > 0;
+  }
+
   onUserTyping(instanceId: string, chatId: string, config: DebounceConfig): void {
     const chatKey = this.getChatKey(instanceId, chatId);
     // Don't restart the timer if this chat is currently being flushed — the

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -115,6 +115,12 @@ const createInstanceSchema = z.object({
     .describe(
       'Presence-mode hard cap in milliseconds — flush at firstBuffered + this even under continuous typing (null = no cap)',
     ),
+  messageSupersedeMode: z
+    .enum(['off', 'discard'])
+    .default('off')
+    .describe(
+      "Stale-reply policy: 'discard' drops an agent reply when newer inbound arrived while the agent was running (the debounced re-flush answers with full context); 'off' keeps legacy behavior",
+    ),
   messageSplitDelayMode: z
     .enum(['disabled', 'fixed', 'randomized'])
     .default('randomized')

--- a/packages/core/src/schemas/instance.ts
+++ b/packages/core/src/schemas/instance.ts
@@ -16,6 +16,14 @@ export const DebounceModeSchema = z.enum(['disabled', 'fixed', 'randomized']);
 export const SplitDelayModeSchema = z.enum(['disabled', 'fixed', 'randomized']);
 
 /**
+ * Stale-reply (supersede) mode enum — what to do with an agent reply when
+ * newer inbound arrived while the agent was still running: 'off' delivers it
+ * (legacy behavior), 'discard' drops it so the debounced re-flush answers
+ * with full context.
+ */
+export const SupersedeModeSchema = z.enum(['off', 'discard']);
+
+/**
  * Agent type enum
  */
 export const AgentTypeSchema = z.enum(['agent', 'team', 'workflow']);
@@ -125,6 +133,9 @@ export const InstanceSchema = z.object({
   messageDebounceMode: DebounceModeSchema,
   messageDebounceMinMs: z.number().int().min(0),
   messageDebounceMaxMs: z.number().int().min(0),
+
+  // Stale-reply policy (see SupersedeModeSchema)
+  messageSupersedeMode: SupersedeModeSchema,
 
   // Split delay
   messageSplitDelayMode: SplitDelayModeSchema,

--- a/packages/db/drizzle/0039_instances_message_supersede_mode.sql
+++ b/packages/db/drizzle/0039_instances_message_supersede_mode.sql
@@ -1,0 +1,19 @@
+-- Per-instance stale-reply policy for the agent dispatcher.
+--
+-- Adds `instances.message_supersede_mode` ('off' | 'discard', default 'off').
+-- When 'discard', an agent reply whose input snapshot is already stale — i.e.
+-- newer inbound arrived for the chat while the agent was still running — is
+-- dropped instead of delivered. The message debouncer's finally-block re-flush
+-- then dispatches the buffered messages immediately, so the follow-up run
+-- answers everything with full context and the user never receives an
+-- out-of-date reply (e.g. a question they already answered).
+--
+-- Default 'off' preserves current delivery behavior for every existing
+-- instance. See `isReplySuperseded` and the gates in
+-- packages/api/src/plugins/agent-dispatcher.ts.
+--
+-- Hand-written (not `drizzle-kit generate`) to avoid the gupshup column
+-- rename prompts that block non-interactive runs in this repo.
+
+ALTER TABLE "instances"
+  ADD COLUMN IF NOT EXISTS "message_supersede_mode" varchar(20) DEFAULT 'off' NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1778040000000,
       "tag": "0038_instances_allow_first_party",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1783900800000,
+      "tag": "0039_instances_message_supersede_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -63,6 +63,12 @@ export type DebounceMode = (typeof debounceMode)[number];
 export const splitDelayMode = ['disabled', 'fixed', 'randomized'] as const;
 export type SplitDelayMode = (typeof splitDelayMode)[number];
 
+// Policy for agent replies whose input snapshot is stale (newer inbound arrived
+// while the agent was running): 'off' delivers them (legacy behavior), 'discard'
+// drops them so the debouncer re-flush answers with full context.
+export const supersedeMode = ['off', 'discard'] as const;
+export type SupersedeMode = (typeof supersedeMode)[number];
+
 export const replyFilterMode = ['all', 'filtered'] as const;
 export type ReplyFilterMode = (typeof replyFilterMode)[number];
 
@@ -760,6 +766,16 @@ export const instances = pgTable(
     messageDebounceRestartOnTyping: boolean('message_debounce_restart_on_typing').notNull().default(false),
     /** Hard cap (ms) for 'presence' mode — flush at firstBuffered + this even under continuous typing. NULL = no cap. */
     messageDebounceMaxWaitMs: integer('message_debounce_max_wait_ms'),
+    /**
+     * Stale-reply policy: what to do when newer inbound arrived while the agent
+     * was still processing the previous batch. 'off' delivers the (stale) reply
+     * as before; 'discard' drops it — the debouncer's re-flush then dispatches
+     * the buffered messages and produces one reply with full context.
+     */
+    messageSupersedeMode: varchar('message_supersede_mode', { length: 20 })
+      .notNull()
+      .default('off')
+      .$type<SupersedeMode>(),
 
     // ---- Smart Response Gate ----
     agentGateEnabled: boolean('agent_gate_enabled').notNull().default(false),


### PR DESCRIPTION
## Problem

When a user sends a message while the agent is still processing the previous batch, the in-flight reply is generated from a stale snapshot. The user experience is:

1. User sends message A → debounce window closes → agent run starts with A only
2. User sends message B seconds later → it lands in the debouncer's in-flight buffer (by design)
3. The reply to A is delivered anyway — often **re-asking exactly what B just answered**
4. The finally-block re-flush dispatches B → a second reply lands moments later

The longer the agent run (tool calls, slow upstreams), the wider the race window — with a ~60s run, the reply to B arrives over a minute late and reads as the agent "answering out of nowhere". Measured on a production instance over 14 days, this two-reply signature appeared in ~23% of active chats (median gap between the two user messages: ~10s, i.e. beyond any reasonable debounce window — a longer window alone cannot fix this, and it taxes every turn with extra latency).

## Change

Opt-in, per-instance stale-reply policy — `messageSupersedeMode: 'off' | 'discard'` (default `'off'`, existing behavior unchanged):

- **`MessageDebouncer.hasPending(instanceId, chatId)`** — exposes whether newer inbound is buffered for the chat (accumulated while a flush is in flight).
- **Delivery gate** in `dispatchViaProvider` and `dispatchViaLegacy`, mirroring the existing handoff suppression: right before sending, if newer inbound is pending and the mode is `'discard'`, the stale reply is dropped and logged (`Agent response discarded — superseded by newer inbound`). The debouncer's finally-block re-flush then dispatches the buffered messages immediately, so the follow-up run answers everything with full context — the user sees **one coherent reply** instead of a stale one plus a correction.
- A reply that accompanies a handoff (`agentPaused` flipped during the run) is **never** discarded — that announcement must reach the user.
- `maybeTriggerErrorHandoff` extracted from `dispatchViaProvider` (keeps cognitive complexity within the lint budget).

### Why discard is safe

The provider has already persisted the turn on its side; discarding only skips **delivery**. The immediate re-flush run sees the full history (including the undelivered turn) plus the new message, so its reply is consistent with everything the user actually said. Conversation-wise the visible thread reads: A, B → one reply covering both.

## Config

```
PATCH /api/v2/instances/:id { "messageSupersedeMode": "discard" }
```

New column `instances.message_supersede_mode` (varchar(20), NOT NULL, default `'off'`) — migration `0039_instances_message_supersede_mode.sql` (hand-written ADD COLUMN, following the 0038 precedent to avoid the interactive rename prompts from `drizzle-kit generate`).

## Out of scope

- **Streaming dispatch**: delivery is progressive; there is no single pre-send point to gate. Documented in the commit.
- **Reaction triggers**: not routed through the message debouncer.
- Route-level override of the new setting (instance-level only for now; trivial follow-up if needed).

## Tests

- `message-debouncer.test.ts`: `hasPending` reports messages buffered during an in-flight flush and is scoped per `instanceId:chatId` (21 pass).
- Existing dispatcher suites unaffected (97 pass across `agent-dispatcher`, `agent-dispatch-error-handoff`, `agent-dispatcher-retry`).
- `turbo typecheck` green for `@omni/api`, `@omni/core`, `@omni/db`; `biome check` clean.

## Rollout

Ship with default `'off'`; enable per instance on a staging environment first, observe the `superseded by newer inbound` log line and reply coherence, then opt in production instances. If validation holds, a follow-up can discuss making `'discard'` the default, since delivering a knowingly-stale reply is arguably always wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uGa7nFuraP8ymBoVcBLTZ
