### PR TITLE
test(api): harden MinIO harness cleanup

### DIFF
--- a/packages/api/src/__tests__/minio-harness-cleanup.test.ts
+++ b/packages/api/src/__tests__/minio-harness-cleanup.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  MinioContainerLifecycle,
+  type SharedMinioHarnessDependencies,
+  createSharedMinioHarness,
+} from './minio-harness';
+
+type HarnessSignal = 'SIGINT' | 'SIGTERM' | 'SIGHUP';
+type HarnessEvent = 'exit' | HarnessSignal;
+
+class FakeProcessHooks {
+  readonly pid = 4242;
+  readonly signals: Array<{ pid: number; signal: HarnessSignal; listenerCount: number; nativeExitCode: number }> = [];
+  private readonly listeners = new Map<HarnessEvent, Set<() => void>>();
+
+  constructor(private readonly events: string[]) {}
+
+  once(event: HarnessEvent, listener: () => void): void {
+    const listeners = this.listeners.get(event) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(event, listeners);
+  }
+
+  removeListener(event: HarnessSignal, listener: () => void): void {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  kill(pid: number, signal: HarnessSignal): boolean {
+    const nativeExitCode = 128 + { SIGHUP: 1, SIGINT: 2, SIGTERM: 15 }[signal];
+    this.signals.push({ pid, signal, listenerCount: this.listeners.get(signal)?.size ?? 0, nativeExitCode });
+    this.events.push(`kill:${signal}`);
+    return true;
+  }
+
+  emit(event: HarnessEvent): void {
+    const listeners = [...(this.listeners.get(event) ?? [])];
+    this.listeners.delete(event);
+    for (const listener of listeners) listener();
+  }
+
+  listenerCount(event: HarnessEvent): number {
+    return this.listeners.get(event)?.size ?? 0;
+  }
+}
+
+class FakeDocker {
+  readonly calls: string[][] = [];
+  readonly events: string[];
+  beforeCommand: ((command: string[]) => void) | undefined;
+  private readonly containerIds: string[];
+  private readonly stopFailures: Map<string, number>;
+  private readonly stopThrows: Map<string, number>;
+
+  constructor(
+    containerIds: string[],
+    options: { stopFailures?: Record<string, number>; stopThrows?: Record<string, number>; events?: string[] } = {},
+  ) {
+    this.containerIds = [...containerIds];
+    this.stopFailures = new Map(Object.entries(options.stopFailures ?? {}));
+    this.stopThrows = new Map(Object.entries(options.stopThrows ?? {}));
+    this.events = options.events ?? [];
+  }
+
+  runSync = (command: string[]): { exitCode: number; stdout: string; stderr: string } => {
+    this.calls.push([...command]);
+    this.beforeCommand?.(command);
+    const operation = command[1];
+    if (operation === 'pull') return { exitCode: 0, stdout: '', stderr: '' };
+    if (operation === 'run') {
+      const containerId = this.containerIds.shift();
+      return containerId
+        ? { exitCode: 0, stdout: `${containerId}\n`, stderr: '' }
+        : { exitCode: 1, stdout: '', stderr: 'no fake container ID available' };
+    }
+    if (operation === 'inspect') return { exitCode: 0, stdout: 'running exit=0\n', stderr: '' };
+    if (operation === 'logs') return { exitCode: 0, stdout: 'fake MinIO log\n', stderr: '' };
+    if (operation === 'stop') {
+      const containerId = command.at(-1)!;
+      this.events.push(`stop:${containerId}`);
+      const throwsRemaining = this.stopThrows.get(containerId) ?? 0;
+      if (throwsRemaining > 0) {
+        this.stopThrows.set(containerId, throwsRemaining - 1);
+        throw new Error('thrown fake stop failure');
+      }
+      const failuresRemaining = this.stopFailures.get(containerId) ?? 0;
+      if (failuresRemaining > 0) {
+        this.stopFailures.set(containerId, failuresRemaining - 1);
+        return { exitCode: 1, stdout: '', stderr: 'temporary fake stop failure' };
+      }
+      return { exitCode: 0, stdout: `${containerId}\n`, stderr: '' };
+    }
+    throw new Error(`Unexpected fake Docker command: ${command.join(' ')}`);
+  };
+
+  operations(operation: string): string[][] {
+    return this.calls.filter((command) => command[1] === operation);
+  }
+}
+
+function setup(
+  containerIds: string[],
+  options: {
+    ready?: boolean;
+    stopFailures?: Record<string, number>;
+    stopThrows?: Record<string, number>;
+  } = {},
+): {
+  docker: FakeDocker;
+  process: FakeProcessHooks;
+  dependencies: SharedMinioHarnessDependencies;
+  cleanupFailures: string[];
+  events: string[];
+  setReady(ready: boolean): void;
+  getSharedMinio: ReturnType<typeof createSharedMinioHarness>['getSharedMinio'];
+} {
+  let clock = 0;
+  let ready = options.ready ?? true;
+  const events: string[] = [];
+  const docker = new FakeDocker(containerIds, {
+    stopFailures: options.stopFailures,
+    stopThrows: options.stopThrows,
+    events,
+  });
+  const fakeProcess = new FakeProcessHooks(events);
+  const cleanupFailures: string[] = [];
+  const dependencies: SharedMinioHarnessDependencies = {
+    runSync: docker.runSync,
+    process: fakeProcess,
+    readyFetch: async () => {
+      if (!ready) throw new Error('fake MinIO is not ready');
+      return { ok: true };
+    },
+    now: () => clock,
+    sleep: async (ms) => {
+      clock += ms;
+    },
+    random: () => 0.5,
+    sessionId: 'session-123',
+    readinessTimeoutMs: 1_000,
+    reportCleanupFailure: (message) => cleanupFailures.push(message),
+  };
+  const harness = createSharedMinioHarness(dependencies);
+  return {
+    docker,
+    process: fakeProcess,
+    dependencies,
+    cleanupFailures,
+    events,
+    setReady(value) {
+      ready = value;
+    },
+    getSharedMinio: harness.getSharedMinio,
+  };
+}
+
+describe('shared MinIO harness cleanup', () => {
+  test('labels and bounds the container, then synchronously stops its exact ID on normal exit', async () => {
+    const fake = setup(['container-normal']);
+
+    await fake.getSharedMinio();
+
+    expect(fake.docker.operations('run')).toEqual([
+      [
+        'docker',
+        'run',
+        '--rm',
+        '-d',
+        '--label',
+        'com.automagik.omni.test-harness=minio',
+        '--label',
+        'com.automagik.omni.test-session=session-123',
+        '--cpus',
+        '1',
+        '--memory',
+        '512m',
+        '--pids-limit',
+        '256',
+        '--tmpfs',
+        '/data:rw,noexec,nosuid,size=256m',
+        '-p',
+        '30000:9000',
+        '-e',
+        'MINIO_ROOT_USER=minioadmin',
+        '-e',
+        'MINIO_ROOT_PASSWORD=minioadmin',
+        'minio/minio',
+        'server',
+        '/data',
+      ],
+    ]);
+
+    fake.process.emit('exit');
+
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-normal']]);
+    expect(fake.docker.calls.some((command) => command.includes('prune') || command[1] === 'ps')).toBe(false);
+  });
+
+  test('registers handlers before launch and closes a SIGTERM race around the blocking run command', async () => {
+    const fake = setup(['container-launch-race']);
+    let sigtermListenersAtLaunch = 0;
+    fake.docker.beforeCommand = (command) => {
+      if (command[1] !== 'run') return;
+      sigtermListenersAtLaunch = fake.process.listenerCount('SIGTERM');
+      fake.process.emit('SIGTERM');
+    };
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('MinIO launch interrupted by SIGTERM');
+
+    expect(sigtermListenersAtLaunch).toBe(1);
+    expect(fake.events).toEqual(['stop:container-launch-race', 'kill:SIGTERM']);
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-launch-race']]);
+    expect(fake.process.signals).toEqual([{ pid: 4242, signal: 'SIGTERM', listenerCount: 0, nativeExitCode: 143 }]);
+  });
+
+  test('stops a failed-readiness container before a fresh retry', async () => {
+    const fake = setup(['container-failed', 'container-retry'], { ready: false });
+
+    await expect(fake.getSharedMinio()).rejects.toThrow(
+      'MinIO did not become ready within 1s\ncontainer state: running exit=0\ncontainer logs:\nfake MinIO log',
+    );
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-failed']]);
+
+    fake.setReady(true);
+    await expect(fake.getSharedMinio()).resolves.toMatchObject({ endpoint: 'http://127.0.0.1:30000' });
+    expect(fake.docker.operations('run')).toHaveLength(2);
+
+    fake.process.emit('exit');
+    expect(fake.docker.operations('stop')).toEqual([
+      ['docker', 'stop', '--time', '10', 'container-failed'],
+      ['docker', 'stop', '--time', '10', 'container-retry'],
+    ]);
+  });
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    test(`stops the exact container and re-raises ${signal}`, async () => {
+      const fake = setup([`container-${signal.toLowerCase()}`]);
+      await fake.getSharedMinio();
+
+      fake.process.emit(signal);
+
+      expect(fake.docker.operations('stop')).toEqual([
+        ['docker', 'stop', '--time', '10', `container-${signal.toLowerCase()}`],
+      ]);
+      expect(fake.process.signals).toEqual([
+        { pid: 4242, signal, listenerCount: 0, nativeExitCode: signal === 'SIGINT' ? 130 : 143 },
+      ]);
+    });
+  }
+
+  test('uses the same native signal cleanup semantics for SIGHUP', async () => {
+    const fake = setup(['container-sighup']);
+    await fake.getSharedMinio();
+
+    fake.process.emit('SIGHUP');
+
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-sighup']]);
+    expect(fake.process.signals).toEqual([{ pid: 4242, signal: 'SIGHUP', listenerCount: 0, nativeExitCode: 129 }]);
+  });
+
+  test('blocks retry launches until every previously tracked ID is successfully stopped', async () => {
+    const fake = setup(['container-first', 'container-second'], {
+      ready: false,
+      stopFailures: { 'container-first': 2 },
+    });
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('MinIO did not become ready within 1s');
+    fake.setReady(true);
+
+    await expect(fake.getSharedMinio()).rejects.toThrow(
+      'Refusing to launch MinIO while 1 tracked container(s) still require cleanup',
+    );
+    expect(fake.docker.operations('run')).toHaveLength(1);
+
+    await fake.getSharedMinio();
+    expect(fake.docker.operations('run')).toHaveLength(2);
+
+    fake.process.emit('exit');
+
+    expect(fake.docker.operations('stop')).toEqual([
+      ['docker', 'stop', '--time', '10', 'container-first'],
+      ['docker', 'stop', '--time', '10', 'container-first'],
+      ['docker', 'stop', '--time', '10', 'container-first'],
+      ['docker', 'stop', '--time', '10', 'container-second'],
+    ]);
+    expect(fake.cleanupFailures).toEqual([
+      'Failed to stop tracked MinIO test container container-first: temporary fake stop failure',
+      'Failed to stop tracked MinIO test container container-first: temporary fake stop failure',
+    ]);
+    expect(fake.docker.calls.some((command) => command.includes('prune') || command[1] === 'ps')).toBe(false);
+  });
+
+  test('attempts every tracked ID and preserves native 143 when one SIGTERM stop throws', () => {
+    const fake = setup([], { stopThrows: { 'container-throws': 1 } });
+    const lifecycle = new MinioContainerLifecycle(fake.dependencies);
+    lifecycle.prepareForLaunch();
+    lifecycle.track('container-throws');
+    lifecycle.track('container-after-throw');
+
+    fake.process.emit('SIGTERM');
+
+    expect(fake.docker.operations('stop')).toEqual([
+      ['docker', 'stop', '--time', '10', 'container-throws'],
+      ['docker', 'stop', '--time', '10', 'container-after-throw'],
+    ]);
+    expect(fake.events).toEqual(['stop:container-throws', 'stop:container-after-throw', 'kill:SIGTERM']);
+    expect(fake.cleanupFailures).toEqual([
+      'Failed to stop tracked MinIO test container container-throws: thrown fake stop failure',
+    ]);
+    expect(fake.process.signals).toEqual([{ pid: 4242, signal: 'SIGTERM', listenerCount: 0, nativeExitCode: 143 }]);
+  });
+});

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -12,7 +12,7 @@
  * exactly once on process exit — no per-file teardown races.
  */
 
-import { createHash, createHmac } from 'node:crypto';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
 
 /**
  * Real `fetch`, captured at module-load time — before any test body runs.
@@ -101,90 +101,316 @@ export function uniqueBucket(prefix: string): string {
   return `${prefix}-${Math.random().toString(36).slice(2, 10)}`.toLowerCase();
 }
 
-async function waitForReady(port: number): Promise<void> {
+type HarnessSignal = 'SIGINT' | 'SIGTERM' | 'SIGHUP';
+
+interface SyncCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface ProcessHooks {
+  readonly pid: number;
+  once(event: 'exit' | HarnessSignal, listener: () => void): void;
+  removeListener(event: HarnessSignal, listener: () => void): void;
+  kill(pid: number, signal: HarnessSignal): boolean;
+}
+
+export interface SharedMinioHarnessDependencies {
+  runSync(command: string[]): SyncCommandResult;
+  process: ProcessHooks;
+  readyFetch(url: string): Promise<{ ok: boolean }>;
+  now(): number;
+  sleep(ms: number): Promise<void>;
+  random(): number;
+  sessionId: string;
+  readinessTimeoutMs: number;
+  reportCleanupFailure(message: string): void;
+}
+
+function runSync(command: string[]): SyncCommandResult {
+  const result = Bun.spawnSync(command);
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+const processHooks: ProcessHooks = {
+  get pid() {
+    return process.pid;
+  },
+  once(event, listener) {
+    process.once(event, listener);
+  },
+  removeListener(event, listener) {
+    process.removeListener(event, listener);
+  },
+  kill(pid, signal) {
+    return process.kill(pid, signal);
+  },
+};
+
+async function waitForReady(port: number, dependencies: SharedMinioHarnessDependencies): Promise<void> {
   // Single wait for the shared container. Generous deadline: on a loaded CI
   // runner (Blacksmith 4vcpu, full suite hammering the box) MinIO has been
   // observed to need well over 45s to serve its readiness probe.
-  const deadline = Date.now() + 120_000;
-  while (Date.now() < deadline) {
+  const deadline = dependencies.now() + dependencies.readinessTimeoutMs;
+  while (dependencies.now() < deadline) {
     try {
-      const res = await harnessFetch(`http://127.0.0.1:${port}/minio/health/ready`);
+      const res = await dependencies.readyFetch(`http://127.0.0.1:${port}/minio/health/ready`);
       if (res.ok) return;
     } catch {
       // not up yet
     }
-    await new Promise((r) => setTimeout(r, 500));
+    await dependencies.sleep(500);
   }
-  throw new Error('MinIO did not become ready within 120s');
+  throw new Error(`MinIO did not become ready within ${dependencies.readinessTimeoutMs / 1000}s`);
 }
 
 /** Container state + log tail for actionable CI failure messages. */
-function describeContainerFailure(containerId: string): string {
-  const state = Bun.spawnSync(['docker', 'inspect', '-f', '{{.State.Status}} exit={{.State.ExitCode}}', containerId]);
-  const logs = Bun.spawnSync(['docker', 'logs', '--tail', '15', containerId]);
-  const stateText = state.exitCode === 0 ? state.stdout.toString().trim() : 'container gone (--rm removed it)';
-  const logText = logs.exitCode === 0 ? `${logs.stdout.toString()}${logs.stderr.toString()}`.trim() : '(no logs)';
+function describeContainerFailure(containerId: string, run: SharedMinioHarnessDependencies['runSync']): string {
+  const state = run(['docker', 'inspect', '-f', '{{.State.Status}} exit={{.State.ExitCode}}', containerId]);
+  const logs = run(['docker', 'logs', '--tail', '15', containerId]);
+  const stateText = state.exitCode === 0 ? state.stdout.trim() : 'container gone (--rm removed it)';
+  const logText = logs.exitCode === 0 ? `${logs.stdout}${logs.stderr}`.trim() : '(no logs)';
   return `container state: ${stateText}\ncontainer logs:\n${logText}`;
 }
 
-let teardownRegistered = false;
-function registerTeardown(containerId: string): void {
-  if (teardownRegistered) return;
-  teardownRegistered = true;
-  let stopped = false;
-  const stop = () => {
-    if (stopped || !containerId) return;
-    stopped = true;
-    // Synchronous stop so it completes inside the process-exit handler; the
-    // container ran with `--rm`, so this also removes it.
-    Bun.spawnSync(['docker', 'stop', containerId]);
-  };
-  process.once('exit', stop);
-}
+export class MinioContainerLifecycle {
+  private readonly liveContainerIds = new Set<string>();
+  private handlersRegistered = false;
+  private launchInProgress = false;
+  private pendingSignal: HarnessSignal | undefined;
+  private signalReraised = false;
+  private readonly signalHandlers = new Map<HarnessSignal, () => void>();
 
-let sharedMinioPromise: Promise<SharedMinio> | undefined;
+  constructor(private readonly dependencies: SharedMinioHarnessDependencies) {}
 
-async function startSharedMinio(): Promise<SharedMinio> {
-  // Pre-pull explicitly so a cold image cache (fresh CI runner) cannot eat
-  // into the readiness budget or fail the run with an opaque timeout.
-  const pull = Bun.spawnSync(['docker', 'pull', 'minio/minio']);
-  if (pull.exitCode !== 0) {
-    throw new Error(`docker pull minio/minio failed: ${pull.stderr.toString()}`);
+  prepareForLaunch(): void {
+    this.registerHandlers();
+    if (this.pendingSignal) throw new Error(`Refusing to launch MinIO after ${this.pendingSignal}`);
+    if (this.launchInProgress) throw new Error('Refusing to launch MinIO while another launch is pending');
+
+    // A previous readiness failure may have left an exact ID tracked when its
+    // synchronous stop failed. Retry that cleanup, but never start another
+    // container until every previous ID has been successfully stopped.
+    this.cleanup();
+    if (this.liveContainerIds.size > 0) {
+      throw new Error(
+        `Refusing to launch MinIO while ${this.liveContainerIds.size} tracked container(s) still require cleanup`,
+      );
+    }
   }
 
-  // Random high port avoids collisions with a locally running MinIO.
-  const port = 20000 + Math.floor(Math.random() * 20000);
-  const proc = Bun.spawnSync([
-    'docker',
-    'run',
-    '--rm',
-    '-d',
-    '-p',
-    `${port}:9000`,
-    '-e',
-    `MINIO_ROOT_USER=${ACCESS_KEY}`,
-    '-e',
-    `MINIO_ROOT_PASSWORD=${SECRET_KEY}`,
-    'minio/minio',
-    'server',
-    '/data',
-  ]);
-  if (proc.exitCode !== 0) {
-    throw new Error(`docker run failed: ${proc.stderr.toString()}`);
+  beginLaunch(): void {
+    if (this.pendingSignal) throw new Error(`Refusing to launch MinIO after ${this.pendingSignal}`);
+    this.launchInProgress = true;
   }
-  const containerId = proc.stdout.toString().trim();
-  registerTeardown(containerId);
-  try {
-    await waitForReady(port);
-  } catch (error) {
-    // Say WHY readiness failed (crashed container? still booting? port issue?)
-    // instead of a bare timeout — this is what makes a red CI debuggable.
-    throw new Error(
-      `${error instanceof Error ? error.message : String(error)}\n${describeContainerFailure(containerId)}`,
+
+  track(containerId: string): void {
+    this.launchInProgress = false;
+    if (!containerId) {
+      this.reraisePendingSignal();
+      throw new Error('docker run returned an empty container ID');
+    }
+    this.liveContainerIds.add(containerId);
+
+    // Signal callbacks normally run after spawnSync returns. This also closes
+    // the narrower runtime race where a callback fires while the launch is in
+    // progress: defer re-raise until the returned ID is tracked and stopped.
+    if (this.pendingSignal) {
+      try {
+        this.cleanup();
+      } finally {
+        this.reraisePendingSignal();
+      }
+      throw new Error(`MinIO launch interrupted by ${this.pendingSignal}`);
+    }
+  }
+
+  abortLaunch(): void {
+    this.launchInProgress = false;
+    this.reraisePendingSignal();
+  }
+
+  stop(containerId: string): boolean {
+    if (!this.liveContainerIds.has(containerId)) return true;
+
+    // Synchronous stop is intentional: exit and signal handlers cannot await,
+    // and `--rm` removes exactly this tracked container after it stops.
+    let result: SyncCommandResult;
+    try {
+      result = this.dependencies.runSync(['docker', 'stop', '--time', '10', containerId]);
+    } catch (error) {
+      this.reportCleanupFailure(
+        `Failed to stop tracked MinIO test container ${containerId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return false;
+    }
+    if (result.exitCode === 0) {
+      this.liveContainerIds.delete(containerId);
+      return true;
+    }
+
+    this.reportCleanupFailure(
+      `Failed to stop tracked MinIO test container ${containerId}: ${result.stderr.trim() || `exit ${result.exitCode}`}`,
     );
+    return false;
   }
-  return { endpoint: `http://127.0.0.1:${port}`, accessKey: ACCESS_KEY, secretKey: SECRET_KEY, region: REGION };
+
+  private cleanup = (): void => {
+    for (const containerId of [...this.liveContainerIds]) {
+      try {
+        this.stop(containerId);
+      } catch (error) {
+        // Cleanup is best-effort per exact ID. A faulty command adapter or
+        // reporter must not prevent later IDs from being attempted.
+        this.reportCleanupFailure(
+          `Unexpected cleanup failure for tracked MinIO test container ${containerId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+  };
+
+  private reportCleanupFailure(message: string): void {
+    try {
+      this.dependencies.reportCleanupFailure(message);
+    } catch {
+      // Never let diagnostics suppress cleanup or native signal semantics.
+    }
+  }
+
+  private reraisePendingSignal(): void {
+    if (!this.pendingSignal || this.signalReraised) return;
+    this.signalReraised = true;
+    const signal = this.pendingSignal;
+    const handler = this.signalHandlers.get(signal);
+    if (handler) this.dependencies.process.removeListener(signal, handler);
+    this.dependencies.process.kill(this.dependencies.process.pid, signal);
+  }
+
+  private registerHandlers(): void {
+    if (this.handlersRegistered) return;
+    this.handlersRegistered = true;
+    this.dependencies.process.once('exit', this.cleanup);
+
+    for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+      const handler = () => {
+        this.pendingSignal = signal;
+        try {
+          this.cleanup();
+        } finally {
+          // When docker run is still blocking, wait for its exact returned ID
+          // so `track` can stop it before preserving native signal semantics.
+          if (!this.launchInProgress) this.reraisePendingSignal();
+        }
+      };
+      this.signalHandlers.set(signal, handler);
+      this.dependencies.process.once(signal, handler);
+    }
+  }
 }
+
+export function createSharedMinioHarness(dependencies: SharedMinioHarnessDependencies): {
+  getSharedMinio(): Promise<SharedMinio>;
+} {
+  const lifecycle = new MinioContainerLifecycle(dependencies);
+  let sharedMinioPromise: Promise<SharedMinio> | undefined;
+
+  async function startSharedMinio(): Promise<SharedMinio> {
+    // Register signal/exit cleanup before any blocking Docker operation and
+    // fail closed if an earlier container has not been successfully stopped.
+    lifecycle.prepareForLaunch();
+
+    // Pre-pull explicitly so a cold image cache (fresh CI runner) cannot eat
+    // into the readiness budget or fail the run with an opaque timeout.
+    const pull = dependencies.runSync(['docker', 'pull', 'minio/minio']);
+    if (pull.exitCode !== 0) {
+      throw new Error(`docker pull minio/minio failed: ${pull.stderr}`);
+    }
+
+    // Random high port avoids collisions with a locally running MinIO.
+    const port = 20000 + Math.floor(dependencies.random() * 20000);
+    lifecycle.beginLaunch();
+    let proc: SyncCommandResult;
+    try {
+      proc = dependencies.runSync([
+        'docker',
+        'run',
+        '--rm',
+        '-d',
+        '--label',
+        'com.automagik.omni.test-harness=minio',
+        '--label',
+        `com.automagik.omni.test-session=${dependencies.sessionId}`,
+        '--cpus',
+        '1',
+        '--memory',
+        '512m',
+        '--pids-limit',
+        '256',
+        '--tmpfs',
+        '/data:rw,noexec,nosuid,size=256m',
+        '-p',
+        `${port}:9000`,
+        '-e',
+        `MINIO_ROOT_USER=${ACCESS_KEY}`,
+        '-e',
+        `MINIO_ROOT_PASSWORD=${SECRET_KEY}`,
+        'minio/minio',
+        'server',
+        '/data',
+      ]);
+    } catch (error) {
+      lifecycle.abortLaunch();
+      throw error;
+    }
+    if (proc.exitCode !== 0) {
+      lifecycle.abortLaunch();
+      throw new Error(`docker run failed: ${proc.stderr}`);
+    }
+    const containerId = proc.stdout.trim();
+    lifecycle.track(containerId);
+    try {
+      await waitForReady(port, dependencies);
+    } catch (error) {
+      // Capture diagnostics before `--rm` deletes the failed container, then
+      // synchronously stop it before another suite is allowed to retry.
+      const failure = describeContainerFailure(containerId, dependencies.runSync);
+      lifecycle.stop(containerId);
+      throw new Error(`${error instanceof Error ? error.message : String(error)}\n${failure}`);
+    }
+    return { endpoint: `http://127.0.0.1:${port}`, accessKey: ACCESS_KEY, secretKey: SECRET_KEY, region: REGION };
+  }
+
+  return {
+    getSharedMinio() {
+      sharedMinioPromise ??= startSharedMinio().catch((error) => {
+        sharedMinioPromise = undefined;
+        throw error;
+      });
+      return sharedMinioPromise;
+    },
+  };
+}
+
+const sharedMinioHarness = createSharedMinioHarness({
+  runSync,
+  process: processHooks,
+  readyFetch: (url) => harnessFetch(url),
+  now: Date.now,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  random: Math.random,
+  sessionId: `${process.pid}-${randomUUID()}`,
+  readinessTimeoutMs: 120_000,
+  reportCleanupFailure: (message) => console.error(message),
+});
 
 /**
  * Lazily start ONE shared `minio/minio` container for this test process and
@@ -195,9 +421,5 @@ async function startSharedMinio(): Promise<SharedMinio> {
  * cascades into instant failures for every other MinIO suite in the process.
  */
 export function getSharedMinio(): Promise<SharedMinio> {
-  sharedMinioPromise ??= startSharedMinio().catch((error) => {
-    sharedMinioPromise = undefined;
-    throw error;
-  });
-  return sharedMinioPromise;
+  return sharedMinioHarness.getSharedMinio();
 }


### PR DESCRIPTION
## Summary

- register cleanup before any blocking container launch
- track only exact session-labeled MinIO container IDs
- clean up on normal exit, launch/readiness failure, and SIGINT/SIGTERM/SIGHUP
- block retries after incomplete cleanup while still attempting every tracked ID
- bound test containers with CPU, memory, PID, and tmpfs limits

## Validation

- fake-Docker suite: 8 tests, 30 assertions
- launch-race probe: exact returned ID stopped, exit 143
- thrown-stop probe: every tracked ID attempted, exit 143
- API TypeScript check, Biome, and git diff check passed

## Safety

The harness never enumerates or prunes unrelated containers. This change uses no PGlite and does not alter production runtime behavior.
