### PR TITLE
fix(cli): register the a2a channel plugin in the bundled server

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@omni/api": "workspace:*",
+    "@omni/channel-a2a": "workspace:*",
     "@omni/channel-discord": "workspace:*",
     "@omni/channel-gupshup": "workspace:*",
     "@omni/channel-sdk": "workspace:*",

--- a/packages/cli/src/bundled-server-entry.ts
+++ b/packages/cli/src/bundled-server-entry.ts
@@ -21,6 +21,16 @@ for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin
   channelRegistry.register(plugin);
 }
 
+// A2A is opt-in — gated by the same A2A_ENABLED flag that mounts the JSON-RPC
+// route in @omni/api. Without this the route returns "A2A channel not available"
+// (channelRegistry.get('a2a') is empty) and a2a instances fail to (re)connect,
+// since the bundled distribution never registered the plugin. Dynamic import so
+// it's excluded from the registry when A2A is disabled.
+if (process.env.A2A_ENABLED === 'true') {
+  const { default: a2aPlugin } = await import('@omni/channel-a2a');
+  channelRegistry.register(a2aPlugin as ChannelPlugin);
+}
+
 // Start the API server — must be a dynamic import to guarantee
 // registration happens before the server reads the registry
 await import('@omni/api');


### PR DESCRIPTION
## Problem

The bundled server entry (`packages/cli/src/bundled-server-entry.ts`, shipped in the `omni-api` image and the npm/bun global install) pre-registers only **telegram, discord, whatsapp, slack, gupshup**. `@omni/channel-a2a` was never a dependency of the CLI package nor imported here, so the a2a plugin never entered the `channelRegistry`.

Effect: with `A2A_ENABLED=true` the JSON-RPC route mounts, but every call returns:
```
{"error":"A2A channel not available"}
```
because `channelRegistry.get('a2a')` is empty — and a2a instances fail to (re)connect at startup:
```
instance-monitor: No plugin for channel: a2a
```
The a2a code is bundled transitively; only the **registration** was missing. Reproduced on both the published `omni-api:v2.260713.3` image and the bun global install.

## Fix

- Add `@omni/channel-a2a` as a CLI dependency.
- Register the a2a plugin in the bundle, **gated by the same `A2A_ENABLED` flag** that mounts the route in `@omni/api` (dynamic import so it stays out of the registry when A2A is disabled).

## Notes

Found while wiring an Agno AgentOS agent to Omni via a2a for an end-to-end test. Happy to adjust the gating (always-on vs `A2A_ENABLED`) to match your intent. CI should validate the monorepo build/typecheck.