### PR TITLE
ci: pin Bun in version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -147,7 +147,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary

- pins the Version workflow to Bun `1.3.14`
- removes the live GitHub tag-list lookup performed by `bun-version: latest`
- unblocks the post-merge version bump that failed after PR #834

## Root cause

Version run `29542540569` failed in `oven-sh/setup-bun` before repository code ran because GitHub returned `503 Service Unavailable` for `repos/oven-sh/bun/git/refs/tags`.

The same exact Bun version is already proven by the current green CI workflow.

## Validation

- `version.yml` YAML syntax parses
- `git diff --check` passes
- no remaining `bun-version: latest` entries exist under `.github/workflows`

## Scope

One-line CI reliability fix. No application, schema, runtime, tenant, credential, or production mutation.
