### PR TITLE
ci: refresh setup-bun action pin

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -145,7 +145,7 @@ jobs:
           # must NOT use the PAT: see "Commit and tag" below.
           token: ${{ secrets.VERSION_BUMP_PAT || github.token }}
 
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: 1.3.14
 


### PR DESCRIPTION
## Summary

- refreshes the SHA-pinned `oven-sh/setup-bun` action from the older v2 implementation to the current v2 commit
- keeps Bun itself pinned to `1.3.14`
- removes the remaining tag-list lookup from the Version workflow

## Root cause

PR #835 correctly pinned `bun-version: 1.3.14`, but Version run `29542874665` proved the older action commit `3d267786...` still queried `repos/oven-sh/bun/git/refs/tags` and failed on GitHub's `503` response.

The current `v2` tag resolves to `0c5077e51419868618aeaa5fe8019c62421857d6`; this is the same action generation used by the green CI jobs, while retaining immutable SHA pinning.

## Validation

- `version.yml` YAML syntax parses
- `git diff --check` passes
- `git ls-remote` confirms the pinned SHA is the current `oven-sh/setup-bun` `v2` tag target

## Scope

One-line CI action-pin refresh. No application, schema, runtime, tenant, credential, or production mutation.
