### PR TITLE
ci: allow immutable PR 831 squash commit

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -19,6 +19,13 @@ export default {
       message.startsWith(
         'ci(test): execute S3/MinIO integration suites in CI; ungate dispatcher local tests (PR #770 H8, MED-4) (#778)',
       ),
+    // PR #831 squash header/body: GitHub generated immutable lines over 100 chars.
+    // The source commits were linted before merge; ignore this exact accepted squash commit
+    // so environment promotion PRs can preserve dev ancestry without rewriting history.
+    (message: string) =>
+      message.startsWith(
+        'feat(api): console-viewer/operator/admin key profiles + mint scope ceiling (OSS backend of #829) (#831)',
+      ),
     // Immutable khal-ui promotion commits with >100-char headers/body lines.
     (message: string) => message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],


### PR DESCRIPTION
## Summary

Add one exact `commitlint` ignore for the immutable GitHub squash commit created by PR #831. GitHub appended `(#831)` to a long accepted PR title and generated body lines over 100 characters, so rolling environment promotions re-linting `dev` history cannot pass without rewriting immutable/tagged history.

This follows the existing narrow exceptions for immutable PR #778 and khal-ui promotion commits. It does **not** relax global commitlint limits.

## Verification

- Exact immutable commit `a078bde5`: accepted
- Unrelated 110-character header negative control: rejected
- `bunx biome check commitlint.config.ts`: pass
- Pre-push typecheck: 21/21 tasks successful
- Pre-push suite: 4,258 passed / 326 skipped / 0 failed

## Safety

- CI configuration only
- No runtime/schema/deployment/credential changes