### PR TITLE
fix(api): enforce scope ceiling on key updates

### DIFF
--- a/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
@@ -43,8 +43,8 @@ function mountKeysRoutes(): { app: Hono<{ Variables: AppVariables }>; created: C
         }),
       },
     } as never);
-    // Caller is the platform primary/minting key (`*`). The mint ceiling
-    // (keys.ts `enforceMintCeiling`) requires the requested scopes to be a
+    // Caller is the platform primary/minting key (`*`). The scope ceiling
+    // (keys.ts `enforceScopeCeiling`) requires the requested scopes to be a
     // subset of the caller's own, and console profiles resolve to broad scope
     // sets — so the minter must legitimately hold those scopes. In production
     // the khal-ui BFF mints per-user console keys with the platform primary

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -1,20 +1,22 @@
 /**
- * Mint scope-ceiling enforcement (WISH omni-appkit-gap, Group 2 — HIGH-1).
+ * API-key scope-ceiling enforcement (WISH omni-appkit-gap, Group 2 — HIGH-1).
  *
  * Threat: `console-admin` holds `keys:write`, so the scope-enforcer admits its
- * `POST /keys` calls. Without a ceiling it could mint a `scopes: ['*']` key and
- * use it → a one-hop god key, defeating the wish's core promise that
- * `console-admin` is BOUNDED and is NOT the god key.
+ * key-management writes. Without a ceiling it could create or update a key to
+ * `scopes: ['*']` and use it → a one-hop god key, defeating the wish's core
+ * promise that `console-admin` is BOUNDED and is NOT the god key.
  *
  * Contract:
- *   - A caller may only mint a key whose scopes are a SUBSET of its own.
+ *   - A caller may only create or update a key whose scopes are a SUBSET of
+ *     its own. For signed requests the grant must be covered by BOTH the bearer
+ *     and signing-host scopes (their effective authorization intersection).
  *   - A concrete-scoped caller (e.g. `console-admin`) requesting `*`, a
  *     `namespace:*` super-scope it lacks, or any scope it does not hold → 403.
- *   - A `*`-scoped caller (real god key / `admin` profile) may still mint
+ *   - A `*`-scoped caller (real god key / `admin` profile) may still grant
  *     anything → 2xx (god-key / agent-provisioning unbroken).
- *   - The ceiling applies to BOTH the non-profile branch (raw `scopes`) and the
- *     profile branch (resolved profile scopes), so a bounded caller can't
- *     escalate by requesting a broader profile than it holds.
+ *   - The ceiling applies to the non-profile create branch (raw `scopes`), the
+ *     profile create branch (resolved profile scopes), and PATCH updates, so a
+ *     bounded caller cannot escalate through any key-management write path.
  *
  * These tests mount the REAL `scopeEnforcerMiddleware` in front of the REAL
  * keys routes (the existing mint tests omit it — reviewer LOW-2), so the proof
@@ -34,13 +36,27 @@ interface CreatedKey {
   profile?: string | null;
 }
 
+interface UpdatedKey {
+  id: string;
+  name?: string;
+  scopes?: string[];
+}
+
 /**
  * Mount the real scope enforcer + real keys routes behind a caller key with the
  * given scopes. `profile: null` + empty allowlists means the enforcer's
  * profile-aware locks are inactive, so only scope + ceiling checks decide.
  */
-function mount(callerScopes: string[]): { app: Hono<{ Variables: AppVariables }>; created: CreatedKey[] } {
+function mount(
+  callerScopes: string[],
+  signedByScopes?: string[],
+): {
+  app: Hono<{ Variables: AppVariables }>;
+  created: CreatedKey[];
+  updated: UpdatedKey[];
+} {
   const created: CreatedKey[] = [];
+  const updated: UpdatedKey[] = [];
   const app = new Hono<{ Variables: AppVariables }>();
 
   app.use('*', async (c, next) => {
@@ -49,6 +65,11 @@ function mount(callerScopes: string[]): { app: Hono<{ Variables: AppVariables }>
         create: mock(async (options: CreatedKey) => {
           created.push(options);
           return { key: { id: 'k_1', ...options }, plainTextKey: 'omni_test_key' };
+        }),
+        update: mock(async (id: string, options: Omit<UpdatedKey, 'id'>) => {
+          const row = { id, ...options };
+          updated.push(row);
+          return row;
         }),
       },
     } as never);
@@ -63,12 +84,16 @@ function mount(callerScopes: string[]): { app: Hono<{ Variables: AppVariables }>
       instanceAllowlist: [],
       outboundRecipientAllowlist: [],
     } as never);
+    if (signedByScopes) {
+      c.set('signedBy', 'test-host');
+      c.set('signedByScopes', signedByScopes);
+    }
     await next();
   });
   app.use('*', scopeEnforcerMiddleware);
   app.route('/keys', keysRoutes);
 
-  return { app, created };
+  return { app, created, updated };
 }
 
 async function postKey(
@@ -77,6 +102,19 @@ async function postKey(
 ): Promise<{ status: number; json: unknown }> {
   const res = await app.request('/keys', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, json: await res.json().catch(() => null) };
+}
+
+async function patchKey(
+  app: Hono<{ Variables: AppVariables }>,
+  id: string,
+  body: unknown,
+): Promise<{ status: number; json: unknown }> {
+  const res = await app.request(`/keys/${id}`, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -109,6 +147,15 @@ describe('POST /keys — mint scope ceiling', () => {
       const { app, created } = mount(['keys:write', 'chats:read']);
 
       const { status } = await postKey(app, { name: 'over-reach', scopes: ['chats:read', 'instances:write'] });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('narrow signing-host scopes cap a wildcard bearer during create', async () => {
+      const { app, created } = mount(['*'], ['keys:write']);
+
+      const { status } = await postKey(app, { name: 'host-escalation', scopes: ['*'] });
 
       expect(status).toBe(403);
       expect(created).toHaveLength(0);
@@ -177,5 +224,71 @@ describe('POST /keys — mint scope ceiling', () => {
       expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
       expect(created).toHaveLength(0);
     });
+  });
+});
+
+describe('PATCH /keys/:id — update scope ceiling', () => {
+  test('console-admin cannot update its own key to scopes: ["*"]', async () => {
+    const { app, updated } = mount([...CONSOLE_ADMIN_SCOPES]);
+
+    const { status, json } = await patchKey(app, 'minter', { scopes: ['*'] });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+    expect(updated).toHaveLength(0);
+  });
+
+  test('narrow signing-host scopes cap a wildcard bearer during update', async () => {
+    const { app, updated } = mount(['*'], ['keys:write']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['*'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('bounded caller cannot update another key to a namespace super-scope it lacks', async () => {
+    const { app, updated } = mount(['keys:write', 'instances:read']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['instances:*'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('bounded caller can update a key to a subset of its own scopes', async () => {
+    const { app, updated } = mount(['keys:write', 'chats:read', 'chats:write']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['chats:read'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('wildcard bearer can grant a scope covered by its narrowed signing host', async () => {
+    const { app, updated } = mount(['*'], ['keys:write', 'chats:read']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['chats:read'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('god key can update a key to scopes: ["*"]', async () => {
+    const { app, updated } = mount(['*']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['*'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['*'] }]);
+  });
+
+  test('metadata-only updates remain allowed for a keys:write caller', async () => {
+    const { app, updated } = mount(['keys:write']);
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', name: 'renamed-key' }]);
   });
 });

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -168,31 +168,37 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
 }
 
 /**
- * Least-privilege mint ceiling.
+ * Least-privilege scope ceiling for key-management writes.
  *
- * A caller may only mint a key whose scopes are a SUBSET of its OWN scopes.
- * `ApiKeyService.scopeAllows(callerScopes, requested)` is exactly the covering
- * relation we need:
- *   - a `*` caller (the real god-key / `admin` profile) covers every requested
- *     scope, so god-key minting and internal agent-provisioning keep working
- *     unchanged;
- *   - a concrete-scoped caller (e.g. `console-admin`) covers a requested scope
- *     it holds — or one under a `ns:*` it holds — but does NOT cover `*` or a
- *     `ns:*` super-scope it lacks. So a bounded caller can never escalate to a
- *     god key or a whole-namespace grant, even by minting a broader profile.
+ * A caller may only create or update a key whose scopes are a SUBSET of its
+ * OWN scopes. Signed requests are authorized by the intersection of the bearer
+ * and signing-host scopes, so the requested grant must be covered by BOTH.
+ * `ApiKeyService.scopeAllows(authorizerScopes, requested)` is exactly the
+ * covering relation we need:
+ *   - a `*` authorizer (the real god-key / `admin` profile) covers every
+ *     requested scope, so god-key minting and internal agent-provisioning keep
+ *     working unchanged;
+ *   - a concrete-scoped authorizer (e.g. `console-admin` or a narrowed signing
+ *     host) covers a requested scope it holds — or one under a `ns:*` it holds
+ *     — but does NOT cover `*` or a `ns:*` super-scope it lacks. So a bounded
+ *     authority can never escalate to a god key or a whole-namespace grant.
  *
  * Returns a 403 `Response` listing the disallowed scopes, or `null` when every
- * requested scope is within the caller's ceiling.
+ * requested scope is within every active authorizer's ceiling.
  */
-function enforceMintCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
+function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
   const callerScopes = c.get('apiKey')?.scopes ?? [];
-  const exceeding = requestedScopes.filter((scope) => !ApiKeyService.scopeAllows(callerScopes, scope));
+  const signedByScopes = c.get('signedBy') ? c.get('signedByScopes') : undefined;
+  const authorizerScopeSets = signedByScopes ? [callerScopes, signedByScopes] : [callerScopes];
+  const exceeding = requestedScopes.filter((scope) =>
+    authorizerScopeSets.some((authorizerScopes) => !ApiKeyService.scopeAllows(authorizerScopes, scope)),
+  );
   if (exceeding.length === 0) return null;
   return c.json(
     {
       error: {
         code: 'FORBIDDEN',
-        message: `Cannot mint a key whose scopes exceed the caller's own. Disallowed: ${exceeding.join(', ')}`,
+        message: `Cannot grant scopes that exceed the caller's own. Disallowed: ${exceeding.join(', ')}`,
       },
     },
     403,
@@ -217,7 +223,7 @@ async function handleProfileCreate(
 
     // Enforce the mint ceiling on the RESOLVED profile scopes so a bounded
     // caller can't escalate by requesting a broader profile than it holds.
-    const ceilingDenied = enforceMintCeiling(c, resolved.scopes);
+    const ceilingDenied = enforceScopeCeiling(c, resolved.scopes);
     if (ceilingDenied) return ceilingDenied;
 
     const result = await services.apiKeys.create({
@@ -268,7 +274,7 @@ async function handleLegacyCreate(
   // Enforce the mint ceiling: the requested scopes must be a subset of the
   // caller's own. Blocks a `console-admin` (or any concrete-scoped) caller from
   // minting `['*']` / a `ns:*` super-scope and using it as a one-hop god key.
-  const ceilingDenied = enforceMintCeiling(c, data.scopes);
+  const ceilingDenied = enforceScopeCeiling(c, data.scopes);
   if (ceilingDenied) return ceilingDenied;
 
   const result = await services.apiKeys.create({
@@ -329,6 +335,14 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   const id = c.req.param('id');
   const data = c.req.valid('json');
   const services = c.get('services');
+
+  // Updating an existing key is another scope-grant path. Apply the same
+  // least-privilege ceiling as creation so a bounded keys:write caller cannot
+  // PATCH its own (or another) key into a wildcard or broader namespace grant.
+  if (data.scopes) {
+    const ceilingDenied = enforceScopeCeiling(c, data.scopes);
+    if (ceilingDenied) return ceilingDenied;
+  }
 
   try {
     const updated = await services.apiKeys.update(id, {


### PR DESCRIPTION
## Summary

- enforce the caller scope ceiling on `PATCH /keys/:id`
- bound signed key grants by both bearer and signing-host scopes
- preserve valid subset, god-key, and metadata-only updates
- add route-level regressions through the real scope middleware

## Security impact

Closes two privilege-escalation paths:

1. a bounded `keys:write` caller could update an existing key to `scopes: ["*"]`
2. a signed request with a wildcard bearer and narrowed host could grant scopes outside the host ceiling

The effective grant ceiling now mirrors authorization semantics: every requested scope must be covered by every active authorizer.

## TDD evidence

- RED 1: PATCH wildcard and uncovered namespace updates returned `200` instead of `403`
- GREEN 1: focused suite passed after applying the PATCH ceiling
- RED 2: narrowed signing-host create returned `201` and update returned `200`
- GREEN 2: final focused suite passed `17/17`

## Validation

- `bun test packages apps/ui --env-file=.env`: 4,266 passed, 326 skipped, 0 failed
- `bun run typecheck`: 21/21 tasks passed
- `bun run lint`: passed
- `bunx knip`: passed
- `bun run build`: passed
- Codex final read-only review: no critical/high findings
- added-line secret/injection scan: clean

## Scope boundary

No schema migration, deployment mutation, tenant creation, credential minting, or runtime mutation.

The rolling `homolog -> main` PR remains draft until this fix is merged and promoted through `homolog`.
