### PR TITLE
fix(api): fail closed on missing signing host scopes

### DIFF
--- a/packages/api/src/lib/signed-host-scope-context.ts
+++ b/packages/api/src/lib/signed-host-scope-context.ts
@@ -1,0 +1,26 @@
+import type { Context } from 'hono';
+import type { AppVariables } from '../types';
+
+export type SignedHostScopeContext =
+  | { kind: 'unsigned' }
+  | { kind: 'valid'; hostId: string; scopes: string[] }
+  | { kind: 'invalid'; hostId: string };
+
+/**
+ * Parse optional Hono context into a strict authorization state.
+ *
+ * `signedBy` is absent for bearer-only requests. Once it is present, host
+ * scopes are mandatory and must be a string array; missing or malformed scope
+ * context is an invalid state that downstream authorization must deny.
+ */
+export function readSignedHostScopeContext(c: Context<{ Variables: AppVariables }>): SignedHostScopeContext {
+  const hostId = c.get('signedBy');
+  if (!hostId) return { kind: 'unsigned' };
+
+  const scopes: unknown = c.get('signedByScopes');
+  if (!Array.isArray(scopes) || !scopes.every((scope) => typeof scope === 'string')) {
+    return { kind: 'invalid', hostId };
+  }
+
+  return { kind: 'valid', hostId, scopes };
+}

--- a/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
@@ -212,17 +212,19 @@ describe('scope-enforcer — signed request, host narrowed (Group 5 intersection
 });
 
 describe('scope-enforcer — signed request without scopes set on context', () => {
-  test('signedBy set but signedByScopes absent → bearer-only behavior (no host gate)', async () => {
-    // Defensive: if some upstream sets `signedBy` without `signedByScopes`
-    // (shouldn't happen in production but the type allows it), we fall back
-    // to bearer-only enforcement rather than failing closed on a missing
-    // signal.
+  test('signedBy set but signedByScopes absent → fail closed', async () => {
+    // A verified signing identity without its authorization context must never
+    // degrade to bearer-only permissions. Otherwise a wildcard bearer can
+    // bypass host narrowing when upstream context population drifts.
     const app = mountWithCtx({
       bearerScopes: ['*'],
       signedBy: 'host-uuid',
       // signedByScopes intentionally omitted
     });
     const res = await app.request('/api/v2/agents');
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.host).toBe('host-uuid');
   });
 });

--- a/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
@@ -29,7 +29,8 @@ import { scopeEnforcerMiddleware } from '../scope-enforcer';
 interface CtxOverrides {
   bearerScopes: string[];
   signedBy?: string;
-  signedByScopes?: string[];
+  /** `null` simulates malformed runtime context despite the production type. */
+  signedByScopes?: string[] | null;
 }
 
 /**
@@ -53,7 +54,7 @@ function mountWithCtx(overrides: CtxOverrides): Hono<{ Variables: AppVariables }
     };
     c.set('apiKey', apiKey);
     if (overrides.signedBy) c.set('signedBy', overrides.signedBy);
-    if (overrides.signedByScopes) c.set('signedByScopes', overrides.signedByScopes);
+    if (overrides.signedByScopes !== undefined) c.set('signedByScopes', overrides.signedByScopes as never);
     await next();
   });
   app.use('*', scopeEnforcerMiddleware);
@@ -220,6 +221,19 @@ describe('scope-enforcer — signed request without scopes set on context', () =
       bearerScopes: ['*'],
       signedBy: 'host-uuid',
       // signedByScopes intentionally omitted
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.host).toBe('host-uuid');
+  });
+
+  test('signedBy set but signedByScopes is null at runtime → fail closed', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: null,
     });
     const res = await app.request('/api/v2/agents');
     expect(res.status).toBe(403);

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -101,18 +101,21 @@ function loadPubkey(pubkeyB64Url: string): KeyObject {
   return createPublicKey({ key: spki, format: 'der', type: 'spki' });
 }
 
-interface VerificationOutcome {
-  status: 'verified' | 'no-signature' | 'invalid';
-  hostId?: string;
-  /**
-   * Per-host scopes from `genie_hosts.scopes`. Defaults to `['*']` on first
-   * handshake (backward compat with the bearer-only model). The scope-enforcer
-   * intersects this with the bearer key's scopes — both must allow the route.
-   * Empty array = "no permissions" → every scoped route denied.
-   */
-  hostScopes?: string[];
-  reason?: string;
-}
+type VerificationOutcome =
+  | {
+      status: 'verified';
+      hostId: string;
+      reason?: never;
+      /**
+       * Per-host scopes from `genie_hosts.scopes`. Defaults to `['*']` on first
+       * handshake (backward compat with the bearer-only model). The scope-enforcer
+       * intersects this with the bearer key's scopes — both must allow the route.
+       * Empty array = "no permissions" → every scoped route denied.
+       */
+      hostScopes: string[];
+    }
+  | { status: 'no-signature'; hostId?: never; hostScopes?: never; reason?: never }
+  | { status: 'invalid'; hostId?: never; hostScopes?: never; reason: string };
 
 /** Pure verifier — no I/O beyond the host lookup. Tested directly. */
 export async function verifySignature(opts: {
@@ -262,16 +265,14 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
     );
   }
 
-  if (outcome.status === 'verified' && outcome.hostId) {
+  if (outcome.status === 'verified') {
     c.set('signedBy', outcome.hostId);
     // Per-host scopes consumed by scope-enforcer (Group 5). Always set so the
     // enforcer can distinguish "signed and unrestricted" (['*']) from "signed
     // and unscoped" — the former is the back-compat default; the latter
     // doesn't happen today but the enforcer needs the source of truth either
     // way.
-    if (outcome.hostScopes) {
-      c.set('signedByScopes', outcome.hostScopes);
-    }
+    c.set('signedByScopes', outcome.hostScopes);
     // Best-effort last-seen update; never blocks the request.
     services.genieHosts.touchLastSeen(outcome.hostId).catch((err: unknown) => {
       log.warn('touchLastSeen failed (non-fatal)', { hostId: outcome.hostId, err: String(err) });

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -25,6 +25,7 @@ import { createMiddleware } from 'hono/factory';
 import type { LockRequirement, ProfileName } from '../constants/profiles';
 import { PROFILES } from '../constants/profiles';
 import { SCOPE_MAP } from '../constants/scopes';
+import { readSignedHostScopeContext } from '../lib/signed-host-scope-context';
 import { ApiKeyService } from '../services/api-keys';
 import type { ApiKeyData, AppVariables } from '../types';
 
@@ -354,19 +355,14 @@ function lockDenyResponse(c: Context<{ Variables: AppVariables }>, lock: LockNam
   );
 }
 
-function rejectMissingSignedHostScopeContext(
-  c: Context<{ Variables: AppVariables }>,
-  signedBy: string | undefined,
-  signedByScopes: string[] | undefined,
-): Response | null {
-  if (!signedBy || (signedByScopes !== undefined && signedByScopes !== null)) return null;
-  log.warn(`DENIED: signedBy=${signedBy} route=${c.req.method.toUpperCase()} ${c.req.path} host-scopes=MISSING`);
+function invalidSignedHostScopeContextResponse(c: Context<{ Variables: AppVariables }>, hostId: string): Response {
+  log.warn(`DENIED: signedBy=${hostId} route=${c.req.method.toUpperCase()} ${c.req.path} host-scopes=INVALID`);
   return c.json(
     {
       error: {
         code: 'FORBIDDEN',
         message: 'Signing host scope context is missing.',
-        host: signedBy,
+        host: hostId,
       },
     },
     403,
@@ -392,15 +388,12 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   const method = c.req.method.toUpperCase();
   const path = c.req.path;
 
-  const signedBy = c.get('signedBy');
-  const signedByScopes = c.get('signedByScopes');
-
   // A verified signing identity without its authorization context is an
   // invalid state. Never degrade to bearer-only permissions: a wildcard
   // bearer would otherwise bypass per-host narrowing if upstream context
   // population drifts or is reordered.
-  const missingHostScopeDenied = rejectMissingSignedHostScopeContext(c, signedBy, signedByScopes);
-  if (missingHostScopeDenied) return missingHostScopeDenied;
+  const signedHost = readSignedHostScopeContext(c);
+  if (signedHost.kind === 'invalid') return invalidSignedHostScopeContextResponse(c, signedHost.hostId);
 
   const wildcard = ApiKeyService.scopeAllows(apiKey.scopes, '*');
 
@@ -455,9 +448,8 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   //
   // The bearer's wildcard does NOT bypass this — wildcard means "the bearer
   // is unrestricted", but the signing host may still be locked down.
-  if (signedBy) {
-    // The fail-closed guard above proves this context exists for signed requests.
-    const hostScopes = signedByScopes as string[];
+  if (signedHost.kind === 'valid') {
+    const { hostId: signedBy, scopes: hostScopes } = signedHost;
     const hostWildcard = ApiKeyService.scopeAllows(hostScopes, '*');
     if (!hostWildcard) {
       // Resolve the route's required scope if we haven't already (wildcard

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -354,6 +354,25 @@ function lockDenyResponse(c: Context<{ Variables: AppVariables }>, lock: LockNam
   );
 }
 
+function rejectMissingSignedHostScopeContext(
+  c: Context<{ Variables: AppVariables }>,
+  signedBy: string | undefined,
+  signedByScopes: string[] | undefined,
+): Response | null {
+  if (!signedBy || (signedByScopes !== undefined && signedByScopes !== null)) return null;
+  log.warn(`DENIED: signedBy=${signedBy} route=${c.req.method.toUpperCase()} ${c.req.path} host-scopes=MISSING`);
+  return c.json(
+    {
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Signing host scope context is missing.',
+        host: signedBy,
+      },
+    },
+    403,
+  );
+}
+
 export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
   const apiKey = c.get('apiKey');
 
@@ -375,6 +394,13 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
 
   const signedBy = c.get('signedBy');
   const signedByScopes = c.get('signedByScopes');
+
+  // A verified signing identity without its authorization context is an
+  // invalid state. Never degrade to bearer-only permissions: a wildcard
+  // bearer would otherwise bypass per-host narrowing if upstream context
+  // population drifts or is reordered.
+  const missingHostScopeDenied = rejectMissingSignedHostScopeContext(c, signedBy, signedByScopes);
+  if (missingHostScopeDenied) return missingHostScopeDenied;
 
   const wildcard = ApiKeyService.scopeAllows(apiKey.scopes, '*');
 
@@ -429,8 +455,10 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   //
   // The bearer's wildcard does NOT bypass this — wildcard means "the bearer
   // is unrestricted", but the signing host may still be locked down.
-  if (signedBy && signedByScopes) {
-    const hostWildcard = ApiKeyService.scopeAllows(signedByScopes, '*');
+  if (signedBy) {
+    // The fail-closed guard above proves this context exists for signed requests.
+    const hostScopes = signedByScopes as string[];
+    const hostWildcard = ApiKeyService.scopeAllows(hostScopes, '*');
     if (!hostWildcard) {
       // Resolve the route's required scope if we haven't already (wildcard
       // bearer skipped that step above).
@@ -452,9 +480,9 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
         );
       }
 
-      if (!ApiKeyService.scopeAllows(signedByScopes, needed)) {
+      if (!ApiKeyService.scopeAllows(hostScopes, needed)) {
         log.warn(
-          `DENIED: signedBy=${signedBy} route=${method} ${path} required=${needed} host-scopes=${signedByScopes.join(',')}`,
+          `DENIED: signedBy=${signedBy} route=${method} ${path} required=${needed} host-scopes=${hostScopes.join(',')}`,
         );
         return c.json(
           {

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -42,6 +42,13 @@ interface UpdatedKey {
   scopes?: string[];
 }
 
+interface MountOptions {
+  /** Simulate a verified signing host even when its scope context is missing. */
+  signedBy?: string;
+  /** Disable the general scope enforcer to exercise the route ceiling directly. */
+  withScopeEnforcer?: boolean;
+}
+
 /**
  * Mount the real scope enforcer + real keys routes behind a caller key with the
  * given scopes. `profile: null` + empty allowlists means the enforcer's
@@ -50,6 +57,7 @@ interface UpdatedKey {
 function mount(
   callerScopes: string[],
   signedByScopes?: string[],
+  options: MountOptions = {},
 ): {
   app: Hono<{ Variables: AppVariables }>;
   created: CreatedKey[];
@@ -84,13 +92,18 @@ function mount(
       instanceAllowlist: [],
       outboundRecipientAllowlist: [],
     } as never);
-    if (signedByScopes) {
-      c.set('signedBy', 'test-host');
+    const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
+    if (signedBy) {
+      c.set('signedBy', signedBy);
+    }
+    if (signedByScopes !== undefined) {
       c.set('signedByScopes', signedByScopes);
     }
     await next();
   });
-  app.use('*', scopeEnforcerMiddleware);
+  if (options.withScopeEnforcer !== false) {
+    app.use('*', scopeEnforcerMiddleware);
+  }
   app.route('/keys', keysRoutes);
 
   return { app, created, updated };
@@ -158,6 +171,19 @@ describe('POST /keys — mint scope ceiling', () => {
       const { status } = await postKey(app, { name: 'host-escalation', scopes: ['*'] });
 
       expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing signing-host scope context fails closed in the route ceiling during create', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        signedBy: 'test-host',
+        withScopeEnforcer: false,
+      });
+
+      const { status, json } = await postKey(app, { name: 'missing-host-scopes', scopes: ['*'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
       expect(created).toHaveLength(0);
     });
 
@@ -244,6 +270,19 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     const { status } = await patchKey(app, 'target', { scopes: ['*'] });
 
     expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('missing signing-host scope context fails closed in the route ceiling during update', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      signedBy: 'test-host',
+      withScopeEnforcer: false,
+    });
+
+    const { status, json } = await patchKey(app, 'target', { scopes: ['*'] });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
     expect(updated).toHaveLength(0);
   });
 

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -56,7 +56,7 @@ interface MountOptions {
  */
 function mount(
   callerScopes: string[],
-  signedByScopes?: string[],
+  signedByScopes?: string[] | null,
   options: MountOptions = {},
 ): {
   app: Hono<{ Variables: AppVariables }>;
@@ -97,7 +97,7 @@ function mount(
       c.set('signedBy', signedBy);
     }
     if (signedByScopes !== undefined) {
-      c.set('signedByScopes', signedByScopes);
+      c.set('signedByScopes', signedByScopes as never);
     }
     await next();
   });
@@ -181,6 +181,19 @@ describe('POST /keys — mint scope ceiling', () => {
       });
 
       const { status, json } = await postKey(app, { name: 'missing-host-scopes', scopes: ['*'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+      expect(created).toHaveLength(0);
+    });
+
+    test('null signing-host scope context fails closed in the route ceiling during create', async () => {
+      const { app, created } = mount(['*'], null, {
+        signedBy: 'test-host',
+        withScopeEnforcer: false,
+      });
+
+      const { status, json } = await postKey(app, { name: 'null-host-scopes', scopes: ['*'] });
 
       expect(status).toBe(403);
       expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -9,6 +9,7 @@ import { zValidator } from '@hono/zod-validator';
 import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 import { ProfileResolutionError, type ResolveProfileInput, resolveProfile } from '../../lib/resolve-profile';
+import { readSignedHostScopeContext } from '../../lib/signed-host-scope-context';
 import { optionalDateParam } from '../../schemas/date-query';
 import { ApiKeyService } from '../../services/api-keys';
 import type { AppVariables } from '../../types';
@@ -167,6 +168,20 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
   };
 }
 
+/** Return the common fail-closed response for malformed signed-host context. */
+function invalidSignedHostScopeContextResponse(c: Context<{ Variables: AppVariables }>, hostId: string): Response {
+  return c.json(
+    {
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Signing host scope context is missing.',
+        host: hostId,
+      },
+    },
+    403,
+  );
+}
+
 /**
  * Least-privilege scope ceiling for key-management writes.
  *
@@ -187,25 +202,10 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
  * requested scope is within every active authorizer's ceiling.
  */
 function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
-  const callerScopes = c.get('apiKey')?.scopes ?? [];
-  const signedBy = c.get('signedBy');
-  const signedByScopes = c.get('signedByScopes');
-  const authorizerScopeSets: string[][] = [callerScopes];
-  if (signedBy) {
-    if (signedByScopes === undefined || signedByScopes === null) {
-      return c.json(
-        {
-          error: {
-            code: 'FORBIDDEN',
-            message: 'Signing host scope context is missing.',
-            host: signedBy,
-          },
-        },
-        403,
-      );
-    }
-    authorizerScopeSets.push(signedByScopes);
-  }
+  const authorizerScopeSets: string[][] = [c.get('apiKey')?.scopes ?? []];
+  const signedHost = readSignedHostScopeContext(c);
+  if (signedHost.kind === 'invalid') return invalidSignedHostScopeContextResponse(c, signedHost.hostId);
+  if (signedHost.kind === 'valid') authorizerScopeSets.push(signedHost.scopes);
   const exceeding = requestedScopes.filter((scope) =>
     authorizerScopeSets.some((authorizerScopes) => !ApiKeyService.scopeAllows(authorizerScopes, scope)),
   );

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -188,8 +188,24 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
  */
 function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
   const callerScopes = c.get('apiKey')?.scopes ?? [];
-  const signedByScopes = c.get('signedBy') ? c.get('signedByScopes') : undefined;
-  const authorizerScopeSets = signedByScopes ? [callerScopes, signedByScopes] : [callerScopes];
+  const signedBy = c.get('signedBy');
+  const signedByScopes = c.get('signedByScopes');
+  const authorizerScopeSets: string[][] = [callerScopes];
+  if (signedBy) {
+    if (signedByScopes === undefined || signedByScopes === null) {
+      return c.json(
+        {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'Signing host scope context is missing.',
+            host: signedBy,
+          },
+        },
+        403,
+      );
+    }
+    authorizerScopeSets.push(signedByScopes);
+  }
   const exceeding = requestedScopes.filter((scope) =>
     authorizerScopeSets.some((authorizerScopes) => !ApiKeyService.scopeAllows(authorizerScopes, scope)),
   );


### PR DESCRIPTION
## Summary

Fail closed when a verified signing identity (`signedBy`) is present but its authorization context (`signedByScopes`) is missing or malformed.

This closes the HIGH defense-in-depth gap found during homolog promotion review: invalid host scope context previously degraded to bearer-only authority, allowing a wildcard bearer to bypass per-host narrowing.

## Changes

- parse optional signed-host Hono context once into a strict discriminated state
- reject missing, `null`, non-array, or non-string-array host scope context
- general scope middleware returns 403 for invalid signed-host context
- POST/PATCH key grant ceiling independently returns 403 for the same invalid context
- downstream authorization receives only non-nullable `string[]` host scopes; no assertion or empty-array fallback
- verified signature outcomes require both `hostId` and `hostScopes`
- signature middleware sets verified host scopes unconditionally
- explicit empty host scopes (`[]`) remain valid and deny all scoped routes
- bearer-only requests remain unchanged

## TDD evidence

RED before the original production patch:

- general middleware: expected 403, received 200
- direct POST route ceiling: expected 403, received 201
- direct PATCH route ceiling: expected 403, received 200

GREEN on final head `c4add7f1`:

- focused signature/scope/key suites: 58 passed / 0 failed
- canonical CI test scope: 4,270 passed / 326 skipped / 0 failed
- typecheck: 21/21 tasks passed
- lint: 1,363 files checked, no findings
- build: passed
- knip: passed
- diff check: passed
- production added-line security scan: 88 added lines / 0 findings
- mandatory pre-push hook independently repeated typecheck + canonical suite successfully

The bare repository-wide `bun test` also enters the decoupled `apps/khal-ui` subproject and reports its 8 known harness errors. The authoritative workflow explicitly excludes that subproject and runs `NODE_ENV=test bun test packages apps/ui --env-file=.env`; that exact command is green above.

## Scope

Six files only:

- `packages/api/src/lib/signed-host-scope-context.ts`
- `packages/api/src/middleware/genie-signature.ts`
- `packages/api/src/middleware/scope-enforcer.ts`
- `packages/api/src/routes/v2/keys.ts`
- `packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts`
- `packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts`

No schema, credential, tenant, deployment, or runtime mutation.

## Promotion hold

- Draft homolog promotion PR #841 remains blocked until this PR is reviewed, merged to dev, and the new dev version/release settles.
- Draft homolog → main PR #839 remains blocked.
