### PR TITLE
chore: promote dev to homolog (2.260717.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260717.3",
+      "version": "2.260717.4",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260717.1",
+      "version": "2.260717.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +290,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +304,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +331,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +345,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260717.4",
+      "version": "2.260717.5",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260717.1"
+appVersion: "2.260717.3"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260717.4"
+appVersion: "2.260717.5"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260717.3"
+appVersion: "2.260717.4"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/lib/signed-host-scope-context.ts
+++ b/packages/api/src/lib/signed-host-scope-context.ts
@@ -1,0 +1,26 @@
+import type { Context } from 'hono';
+import type { AppVariables } from '../types';
+
+export type SignedHostScopeContext =
+  | { kind: 'unsigned' }
+  | { kind: 'valid'; hostId: string; scopes: string[] }
+  | { kind: 'invalid'; hostId: string };
+
+/**
+ * Parse optional Hono context into a strict authorization state.
+ *
+ * `signedBy` is absent for bearer-only requests. Once it is present, host
+ * scopes are mandatory and must be a string array; missing or malformed scope
+ * context is an invalid state that downstream authorization must deny.
+ */
+export function readSignedHostScopeContext(c: Context<{ Variables: AppVariables }>): SignedHostScopeContext {
+  const hostId = c.get('signedBy');
+  if (!hostId) return { kind: 'unsigned' };
+
+  const scopes: unknown = c.get('signedByScopes');
+  if (!Array.isArray(scopes) || !scopes.every((scope) => typeof scope === 'string')) {
+    return { kind: 'invalid', hostId };
+  }
+
+  return { kind: 'valid', hostId, scopes };
+}

--- a/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
@@ -212,17 +212,19 @@ describe('scope-enforcer — signed request, host narrowed (Group 5 intersection
 });
 
 describe('scope-enforcer — signed request without scopes set on context', () => {
-  test('signedBy set but signedByScopes absent → bearer-only behavior (no host gate)', async () => {
-    // Defensive: if some upstream sets `signedBy` without `signedByScopes`
-    // (shouldn't happen in production but the type allows it), we fall back
-    // to bearer-only enforcement rather than failing closed on a missing
-    // signal.
+  test('signedBy set but signedByScopes absent → fail closed', async () => {
+    // A verified signing identity without its authorization context must never
+    // degrade to bearer-only permissions. Otherwise a wildcard bearer can
+    // bypass host narrowing when upstream context population drifts.
     const app = mountWithCtx({
       bearerScopes: ['*'],
       signedBy: 'host-uuid',
       // signedByScopes intentionally omitted
     });
     const res = await app.request('/api/v2/agents');
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.host).toBe('host-uuid');
   });
 });

--- a/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
@@ -29,7 +29,8 @@ import { scopeEnforcerMiddleware } from '../scope-enforcer';
 interface CtxOverrides {
   bearerScopes: string[];
   signedBy?: string;
-  signedByScopes?: string[];
+  /** `null` simulates malformed runtime context despite the production type. */
+  signedByScopes?: string[] | null;
 }
 
 /**
@@ -53,7 +54,7 @@ function mountWithCtx(overrides: CtxOverrides): Hono<{ Variables: AppVariables }
     };
     c.set('apiKey', apiKey);
     if (overrides.signedBy) c.set('signedBy', overrides.signedBy);
-    if (overrides.signedByScopes) c.set('signedByScopes', overrides.signedByScopes);
+    if (overrides.signedByScopes !== undefined) c.set('signedByScopes', overrides.signedByScopes as never);
     await next();
   });
   app.use('*', scopeEnforcerMiddleware);
@@ -220,6 +221,19 @@ describe('scope-enforcer — signed request without scopes set on context', () =
       bearerScopes: ['*'],
       signedBy: 'host-uuid',
       // signedByScopes intentionally omitted
+    });
+    const res = await app.request('/api/v2/agents');
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.host).toBe('host-uuid');
+  });
+
+  test('signedBy set but signedByScopes is null at runtime → fail closed', async () => {
+    const app = mountWithCtx({
+      bearerScopes: ['*'],
+      signedBy: 'host-uuid',
+      signedByScopes: null,
     });
     const res = await app.request('/api/v2/agents');
     expect(res.status).toBe(403);

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -101,18 +101,21 @@ function loadPubkey(pubkeyB64Url: string): KeyObject {
   return createPublicKey({ key: spki, format: 'der', type: 'spki' });
 }
 
-interface VerificationOutcome {
-  status: 'verified' | 'no-signature' | 'invalid';
-  hostId?: string;
-  /**
-   * Per-host scopes from `genie_hosts.scopes`. Defaults to `['*']` on first
-   * handshake (backward compat with the bearer-only model). The scope-enforcer
-   * intersects this with the bearer key's scopes — both must allow the route.
-   * Empty array = "no permissions" → every scoped route denied.
-   */
-  hostScopes?: string[];
-  reason?: string;
-}
+type VerificationOutcome =
+  | {
+      status: 'verified';
+      hostId: string;
+      reason?: never;
+      /**
+       * Per-host scopes from `genie_hosts.scopes`. Defaults to `['*']` on first
+       * handshake (backward compat with the bearer-only model). The scope-enforcer
+       * intersects this with the bearer key's scopes — both must allow the route.
+       * Empty array = "no permissions" → every scoped route denied.
+       */
+      hostScopes: string[];
+    }
+  | { status: 'no-signature'; hostId?: never; hostScopes?: never; reason?: never }
+  | { status: 'invalid'; hostId?: never; hostScopes?: never; reason: string };
 
 /** Pure verifier — no I/O beyond the host lookup. Tested directly. */
 export async function verifySignature(opts: {
@@ -262,16 +265,14 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
     );
   }
 
-  if (outcome.status === 'verified' && outcome.hostId) {
+  if (outcome.status === 'verified') {
     c.set('signedBy', outcome.hostId);
     // Per-host scopes consumed by scope-enforcer (Group 5). Always set so the
     // enforcer can distinguish "signed and unrestricted" (['*']) from "signed
     // and unscoped" — the former is the back-compat default; the latter
     // doesn't happen today but the enforcer needs the source of truth either
     // way.
-    if (outcome.hostScopes) {
-      c.set('signedByScopes', outcome.hostScopes);
-    }
+    c.set('signedByScopes', outcome.hostScopes);
     // Best-effort last-seen update; never blocks the request.
     services.genieHosts.touchLastSeen(outcome.hostId).catch((err: unknown) => {
       log.warn('touchLastSeen failed (non-fatal)', { hostId: outcome.hostId, err: String(err) });

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -25,6 +25,7 @@ import { createMiddleware } from 'hono/factory';
 import type { LockRequirement, ProfileName } from '../constants/profiles';
 import { PROFILES } from '../constants/profiles';
 import { SCOPE_MAP } from '../constants/scopes';
+import { readSignedHostScopeContext } from '../lib/signed-host-scope-context';
 import { ApiKeyService } from '../services/api-keys';
 import type { ApiKeyData, AppVariables } from '../types';
 
@@ -354,19 +355,14 @@ function lockDenyResponse(c: Context<{ Variables: AppVariables }>, lock: LockNam
   );
 }
 
-function rejectMissingSignedHostScopeContext(
-  c: Context<{ Variables: AppVariables }>,
-  signedBy: string | undefined,
-  signedByScopes: string[] | undefined,
-): Response | null {
-  if (!signedBy || (signedByScopes !== undefined && signedByScopes !== null)) return null;
-  log.warn(`DENIED: signedBy=${signedBy} route=${c.req.method.toUpperCase()} ${c.req.path} host-scopes=MISSING`);
+function invalidSignedHostScopeContextResponse(c: Context<{ Variables: AppVariables }>, hostId: string): Response {
+  log.warn(`DENIED: signedBy=${hostId} route=${c.req.method.toUpperCase()} ${c.req.path} host-scopes=INVALID`);
   return c.json(
     {
       error: {
         code: 'FORBIDDEN',
         message: 'Signing host scope context is missing.',
-        host: signedBy,
+        host: hostId,
       },
     },
     403,
@@ -392,15 +388,12 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   const method = c.req.method.toUpperCase();
   const path = c.req.path;
 
-  const signedBy = c.get('signedBy');
-  const signedByScopes = c.get('signedByScopes');
-
   // A verified signing identity without its authorization context is an
   // invalid state. Never degrade to bearer-only permissions: a wildcard
   // bearer would otherwise bypass per-host narrowing if upstream context
   // population drifts or is reordered.
-  const missingHostScopeDenied = rejectMissingSignedHostScopeContext(c, signedBy, signedByScopes);
-  if (missingHostScopeDenied) return missingHostScopeDenied;
+  const signedHost = readSignedHostScopeContext(c);
+  if (signedHost.kind === 'invalid') return invalidSignedHostScopeContextResponse(c, signedHost.hostId);
 
   const wildcard = ApiKeyService.scopeAllows(apiKey.scopes, '*');
 
@@ -455,9 +448,8 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   //
   // The bearer's wildcard does NOT bypass this — wildcard means "the bearer
   // is unrestricted", but the signing host may still be locked down.
-  if (signedBy) {
-    // The fail-closed guard above proves this context exists for signed requests.
-    const hostScopes = signedByScopes as string[];
+  if (signedHost.kind === 'valid') {
+    const { hostId: signedBy, scopes: hostScopes } = signedHost;
     const hostWildcard = ApiKeyService.scopeAllows(hostScopes, '*');
     if (!hostWildcard) {
       // Resolve the route's required scope if we haven't already (wildcard

--- a/packages/api/src/middleware/scope-enforcer.ts
+++ b/packages/api/src/middleware/scope-enforcer.ts
@@ -354,6 +354,25 @@ function lockDenyResponse(c: Context<{ Variables: AppVariables }>, lock: LockNam
   );
 }
 
+function rejectMissingSignedHostScopeContext(
+  c: Context<{ Variables: AppVariables }>,
+  signedBy: string | undefined,
+  signedByScopes: string[] | undefined,
+): Response | null {
+  if (!signedBy || (signedByScopes !== undefined && signedByScopes !== null)) return null;
+  log.warn(`DENIED: signedBy=${signedBy} route=${c.req.method.toUpperCase()} ${c.req.path} host-scopes=MISSING`);
+  return c.json(
+    {
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Signing host scope context is missing.',
+        host: signedBy,
+      },
+    },
+    403,
+  );
+}
+
 export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
   const apiKey = c.get('apiKey');
 
@@ -375,6 +394,13 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
 
   const signedBy = c.get('signedBy');
   const signedByScopes = c.get('signedByScopes');
+
+  // A verified signing identity without its authorization context is an
+  // invalid state. Never degrade to bearer-only permissions: a wildcard
+  // bearer would otherwise bypass per-host narrowing if upstream context
+  // population drifts or is reordered.
+  const missingHostScopeDenied = rejectMissingSignedHostScopeContext(c, signedBy, signedByScopes);
+  if (missingHostScopeDenied) return missingHostScopeDenied;
 
   const wildcard = ApiKeyService.scopeAllows(apiKey.scopes, '*');
 
@@ -429,8 +455,10 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
   //
   // The bearer's wildcard does NOT bypass this — wildcard means "the bearer
   // is unrestricted", but the signing host may still be locked down.
-  if (signedBy && signedByScopes) {
-    const hostWildcard = ApiKeyService.scopeAllows(signedByScopes, '*');
+  if (signedBy) {
+    // The fail-closed guard above proves this context exists for signed requests.
+    const hostScopes = signedByScopes as string[];
+    const hostWildcard = ApiKeyService.scopeAllows(hostScopes, '*');
     if (!hostWildcard) {
       // Resolve the route's required scope if we haven't already (wildcard
       // bearer skipped that step above).
@@ -452,9 +480,9 @@ export const scopeEnforcerMiddleware = createMiddleware<{ Variables: AppVariable
         );
       }
 
-      if (!ApiKeyService.scopeAllows(signedByScopes, needed)) {
+      if (!ApiKeyService.scopeAllows(hostScopes, needed)) {
         log.warn(
-          `DENIED: signedBy=${signedBy} route=${method} ${path} required=${needed} host-scopes=${signedByScopes.join(',')}`,
+          `DENIED: signedBy=${signedBy} route=${method} ${path} required=${needed} host-scopes=${hostScopes.join(',')}`,
         );
         return c.json(
           {

--- a/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
@@ -43,8 +43,8 @@ function mountKeysRoutes(): { app: Hono<{ Variables: AppVariables }>; created: C
         }),
       },
     } as never);
-    // Caller is the platform primary/minting key (`*`). The mint ceiling
-    // (keys.ts `enforceMintCeiling`) requires the requested scopes to be a
+    // Caller is the platform primary/minting key (`*`). The scope ceiling
+    // (keys.ts `enforceScopeCeiling`) requires the requested scopes to be a
     // subset of the caller's own, and console profiles resolve to broad scope
     // sets — so the minter must legitimately hold those scopes. In production
     // the khal-ui BFF mints per-user console keys with the platform primary

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -42,6 +42,13 @@ interface UpdatedKey {
   scopes?: string[];
 }
 
+interface MountOptions {
+  /** Simulate a verified signing host even when its scope context is missing. */
+  signedBy?: string;
+  /** Disable the general scope enforcer to exercise the route ceiling directly. */
+  withScopeEnforcer?: boolean;
+}
+
 /**
  * Mount the real scope enforcer + real keys routes behind a caller key with the
  * given scopes. `profile: null` + empty allowlists means the enforcer's
@@ -50,6 +57,7 @@ interface UpdatedKey {
 function mount(
   callerScopes: string[],
   signedByScopes?: string[],
+  options: MountOptions = {},
 ): {
   app: Hono<{ Variables: AppVariables }>;
   created: CreatedKey[];
@@ -84,13 +92,18 @@ function mount(
       instanceAllowlist: [],
       outboundRecipientAllowlist: [],
     } as never);
-    if (signedByScopes) {
-      c.set('signedBy', 'test-host');
+    const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
+    if (signedBy) {
+      c.set('signedBy', signedBy);
+    }
+    if (signedByScopes !== undefined) {
       c.set('signedByScopes', signedByScopes);
     }
     await next();
   });
-  app.use('*', scopeEnforcerMiddleware);
+  if (options.withScopeEnforcer !== false) {
+    app.use('*', scopeEnforcerMiddleware);
+  }
   app.route('/keys', keysRoutes);
 
   return { app, created, updated };
@@ -158,6 +171,19 @@ describe('POST /keys — mint scope ceiling', () => {
       const { status } = await postKey(app, { name: 'host-escalation', scopes: ['*'] });
 
       expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing signing-host scope context fails closed in the route ceiling during create', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        signedBy: 'test-host',
+        withScopeEnforcer: false,
+      });
+
+      const { status, json } = await postKey(app, { name: 'missing-host-scopes', scopes: ['*'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
       expect(created).toHaveLength(0);
     });
 
@@ -244,6 +270,19 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     const { status } = await patchKey(app, 'target', { scopes: ['*'] });
 
     expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('missing signing-host scope context fails closed in the route ceiling during update', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      signedBy: 'test-host',
+      withScopeEnforcer: false,
+    });
+
+    const { status, json } = await patchKey(app, 'target', { scopes: ['*'] });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
     expect(updated).toHaveLength(0);
   });
 

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -1,20 +1,22 @@
 /**
- * Mint scope-ceiling enforcement (WISH omni-appkit-gap, Group 2 — HIGH-1).
+ * API-key scope-ceiling enforcement (WISH omni-appkit-gap, Group 2 — HIGH-1).
  *
  * Threat: `console-admin` holds `keys:write`, so the scope-enforcer admits its
- * `POST /keys` calls. Without a ceiling it could mint a `scopes: ['*']` key and
- * use it → a one-hop god key, defeating the wish's core promise that
- * `console-admin` is BOUNDED and is NOT the god key.
+ * key-management writes. Without a ceiling it could create or update a key to
+ * `scopes: ['*']` and use it → a one-hop god key, defeating the wish's core
+ * promise that `console-admin` is BOUNDED and is NOT the god key.
  *
  * Contract:
- *   - A caller may only mint a key whose scopes are a SUBSET of its own.
+ *   - A caller may only create or update a key whose scopes are a SUBSET of
+ *     its own. For signed requests the grant must be covered by BOTH the bearer
+ *     and signing-host scopes (their effective authorization intersection).
  *   - A concrete-scoped caller (e.g. `console-admin`) requesting `*`, a
  *     `namespace:*` super-scope it lacks, or any scope it does not hold → 403.
- *   - A `*`-scoped caller (real god key / `admin` profile) may still mint
+ *   - A `*`-scoped caller (real god key / `admin` profile) may still grant
  *     anything → 2xx (god-key / agent-provisioning unbroken).
- *   - The ceiling applies to BOTH the non-profile branch (raw `scopes`) and the
- *     profile branch (resolved profile scopes), so a bounded caller can't
- *     escalate by requesting a broader profile than it holds.
+ *   - The ceiling applies to the non-profile create branch (raw `scopes`), the
+ *     profile create branch (resolved profile scopes), and PATCH updates, so a
+ *     bounded caller cannot escalate through any key-management write path.
  *
  * These tests mount the REAL `scopeEnforcerMiddleware` in front of the REAL
  * keys routes (the existing mint tests omit it — reviewer LOW-2), so the proof
@@ -34,13 +36,27 @@ interface CreatedKey {
   profile?: string | null;
 }
 
+interface UpdatedKey {
+  id: string;
+  name?: string;
+  scopes?: string[];
+}
+
 /**
  * Mount the real scope enforcer + real keys routes behind a caller key with the
  * given scopes. `profile: null` + empty allowlists means the enforcer's
  * profile-aware locks are inactive, so only scope + ceiling checks decide.
  */
-function mount(callerScopes: string[]): { app: Hono<{ Variables: AppVariables }>; created: CreatedKey[] } {
+function mount(
+  callerScopes: string[],
+  signedByScopes?: string[],
+): {
+  app: Hono<{ Variables: AppVariables }>;
+  created: CreatedKey[];
+  updated: UpdatedKey[];
+} {
   const created: CreatedKey[] = [];
+  const updated: UpdatedKey[] = [];
   const app = new Hono<{ Variables: AppVariables }>();
 
   app.use('*', async (c, next) => {
@@ -49,6 +65,11 @@ function mount(callerScopes: string[]): { app: Hono<{ Variables: AppVariables }>
         create: mock(async (options: CreatedKey) => {
           created.push(options);
           return { key: { id: 'k_1', ...options }, plainTextKey: 'omni_test_key' };
+        }),
+        update: mock(async (id: string, options: Omit<UpdatedKey, 'id'>) => {
+          const row = { id, ...options };
+          updated.push(row);
+          return row;
         }),
       },
     } as never);
@@ -63,12 +84,16 @@ function mount(callerScopes: string[]): { app: Hono<{ Variables: AppVariables }>
       instanceAllowlist: [],
       outboundRecipientAllowlist: [],
     } as never);
+    if (signedByScopes) {
+      c.set('signedBy', 'test-host');
+      c.set('signedByScopes', signedByScopes);
+    }
     await next();
   });
   app.use('*', scopeEnforcerMiddleware);
   app.route('/keys', keysRoutes);
 
-  return { app, created };
+  return { app, created, updated };
 }
 
 async function postKey(
@@ -77,6 +102,19 @@ async function postKey(
 ): Promise<{ status: number; json: unknown }> {
   const res = await app.request('/keys', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, json: await res.json().catch(() => null) };
+}
+
+async function patchKey(
+  app: Hono<{ Variables: AppVariables }>,
+  id: string,
+  body: unknown,
+): Promise<{ status: number; json: unknown }> {
+  const res = await app.request(`/keys/${id}`, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -109,6 +147,15 @@ describe('POST /keys — mint scope ceiling', () => {
       const { app, created } = mount(['keys:write', 'chats:read']);
 
       const { status } = await postKey(app, { name: 'over-reach', scopes: ['chats:read', 'instances:write'] });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('narrow signing-host scopes cap a wildcard bearer during create', async () => {
+      const { app, created } = mount(['*'], ['keys:write']);
+
+      const { status } = await postKey(app, { name: 'host-escalation', scopes: ['*'] });
 
       expect(status).toBe(403);
       expect(created).toHaveLength(0);
@@ -177,5 +224,71 @@ describe('POST /keys — mint scope ceiling', () => {
       expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
       expect(created).toHaveLength(0);
     });
+  });
+});
+
+describe('PATCH /keys/:id — update scope ceiling', () => {
+  test('console-admin cannot update its own key to scopes: ["*"]', async () => {
+    const { app, updated } = mount([...CONSOLE_ADMIN_SCOPES]);
+
+    const { status, json } = await patchKey(app, 'minter', { scopes: ['*'] });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+    expect(updated).toHaveLength(0);
+  });
+
+  test('narrow signing-host scopes cap a wildcard bearer during update', async () => {
+    const { app, updated } = mount(['*'], ['keys:write']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['*'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('bounded caller cannot update another key to a namespace super-scope it lacks', async () => {
+    const { app, updated } = mount(['keys:write', 'instances:read']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['instances:*'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('bounded caller can update a key to a subset of its own scopes', async () => {
+    const { app, updated } = mount(['keys:write', 'chats:read', 'chats:write']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['chats:read'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('wildcard bearer can grant a scope covered by its narrowed signing host', async () => {
+    const { app, updated } = mount(['*'], ['keys:write', 'chats:read']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['chats:read'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('god key can update a key to scopes: ["*"]', async () => {
+    const { app, updated } = mount(['*']);
+
+    const { status } = await patchKey(app, 'target', { scopes: ['*'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['*'] }]);
+  });
+
+  test('metadata-only updates remain allowed for a keys:write caller', async () => {
+    const { app, updated } = mount(['keys:write']);
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', name: 'renamed-key' }]);
   });
 });

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -56,7 +56,7 @@ interface MountOptions {
  */
 function mount(
   callerScopes: string[],
-  signedByScopes?: string[],
+  signedByScopes?: string[] | null,
   options: MountOptions = {},
 ): {
   app: Hono<{ Variables: AppVariables }>;
@@ -97,7 +97,7 @@ function mount(
       c.set('signedBy', signedBy);
     }
     if (signedByScopes !== undefined) {
-      c.set('signedByScopes', signedByScopes);
+      c.set('signedByScopes', signedByScopes as never);
     }
     await next();
   });
@@ -181,6 +181,19 @@ describe('POST /keys — mint scope ceiling', () => {
       });
 
       const { status, json } = await postKey(app, { name: 'missing-host-scopes', scopes: ['*'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+      expect(created).toHaveLength(0);
+    });
+
+    test('null signing-host scope context fails closed in the route ceiling during create', async () => {
+      const { app, created } = mount(['*'], null, {
+        signedBy: 'test-host',
+        withScopeEnforcer: false,
+      });
+
+      const { status, json } = await postKey(app, { name: 'null-host-scopes', scopes: ['*'] });
 
       expect(status).toBe(403);
       expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -1,5 +1,5 @@
 /**
- * API-key scope-ceiling enforcement (WISH omni-appkit-gap, Group 2 — HIGH-1).
+ * API-key authority-ceiling enforcement (WISH omni-appkit-gap, Group 2 — HIGH-1).
  *
  * Threat: `console-admin` holds `keys:write`, so the scope-enforcer admits its
  * key-management writes. Without a ceiling it could create or update a key to
@@ -17,6 +17,9 @@
  *   - The ceiling applies to the non-profile create branch (raw `scopes`), the
  *     profile create branch (resolved profile scopes), and PATCH updates, so a
  *     bounded caller cannot escalate through any key-management write path.
+ *   - Instance access is bounded independently: an unrestricted caller may
+ *     grant any `instanceIds`, while a restricted caller may grant only a
+ *     subset and may not use create omission or explicit `null` to grant all.
  *
  * These tests mount the REAL `scopeEnforcerMiddleware` in front of the REAL
  * keys routes (the existing mint tests omit it — reviewer LOW-2), so the proof
@@ -30,16 +33,21 @@ import { scopeEnforcerMiddleware } from '../../../middleware/scope-enforcer';
 import type { AppVariables } from '../../../types';
 import { keysRoutes } from '../keys';
 
+const INSTANCE_A = '11111111-1111-4111-8111-111111111111';
+const INSTANCE_B = '22222222-2222-4222-8222-222222222222';
+
 interface CreatedKey {
   name: string;
   scopes: string[];
   profile?: string | null;
+  instanceIds?: string[];
 }
 
 interface UpdatedKey {
   id: string;
   name?: string;
   scopes?: string[];
+  instanceIds?: string[] | null;
 }
 
 interface MountOptions {
@@ -47,6 +55,8 @@ interface MountOptions {
   signedBy?: string;
   /** Disable the general scope enforcer to exercise the route ceiling directly. */
   withScopeEnforcer?: boolean;
+  /** Legacy instance-access ceiling carried by the authenticated caller. */
+  callerInstanceIds?: string[] | null;
 }
 
 /**
@@ -85,7 +95,7 @@ function mount(
       id: 'minter',
       name: 'minter',
       scopes: callerScopes,
-      instanceIds: null,
+      instanceIds: options.callerInstanceIds ?? null,
       expiresAt: null,
       profile: null,
       chatAllowlist: [],
@@ -264,6 +274,82 @@ describe('POST /keys — mint scope ceiling', () => {
       expect(created).toHaveLength(0);
     });
   });
+
+  describe('instance access ceiling', () => {
+    test('restricted caller cannot omit instanceIds and mint an unrestricted legacy key', async () => {
+      const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+      const { status, json } = await postKey(app, { name: 'unrestricted-child', scopes: ['keys:write'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+      expect(created).toHaveLength(0);
+    });
+
+    test('restricted caller cannot mint a key for an instance it cannot access', async () => {
+      const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+      const { status } = await postKey(app, {
+        name: 'outside-instance',
+        scopes: ['keys:write'],
+        instanceIds: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('restricted caller cannot omit instanceIds through the profile create branch', async () => {
+      const { app, created } = mount([...CONSOLE_ADMIN_SCOPES], undefined, {
+        callerInstanceIds: [INSTANCE_A],
+      });
+
+      const { status } = await postKey(app, { name: 'profile-unrestricted', profile: 'console-admin' });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('restricted caller can mint a key for a subset of its own instances', async () => {
+      const { app, created } = mount(['keys:write'], undefined, {
+        callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+      });
+
+      const { status } = await postKey(app, {
+        name: 'bounded-instance',
+        scopes: ['keys:write'],
+        instanceIds: [INSTANCE_A],
+      });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+      expect(created[0]?.instanceIds).toEqual([INSTANCE_A]);
+    });
+
+    test('deny-all caller can mint only a deny-all instance subset', async () => {
+      const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [] });
+
+      const { status } = await postKey(app, {
+        name: 'deny-all-child',
+        scopes: ['keys:write'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+      expect(created[0]?.instanceIds).toEqual([]);
+    });
+
+    test('unrestricted caller can still omit instanceIds when minting a key', async () => {
+      const { app, created } = mount(['keys:write']);
+
+      const { status } = await postKey(app, { name: 'unrestricted-ok', scopes: ['keys:write'] });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+      expect(created[0]?.instanceIds).toBeUndefined();
+    });
+  });
 });
 
 describe('PATCH /keys/:id — update scope ceiling', () => {
@@ -317,6 +403,54 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
   });
 
+  test('restricted caller cannot update a key to unrestricted instance access', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+    const { status, json } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+    expect(updated).toHaveLength(0);
+  });
+
+  test('restricted caller cannot update a key to an instance it cannot access', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_B] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('restricted caller can update a key to a subset of its own instances', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', instanceIds: [INSTANCE_A] }]);
+  });
+
+  test('deny-all caller can update a key only to deny-all instance access', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [] });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', instanceIds: [] }]);
+  });
+
+  test('unrestricted caller can update a key to unrestricted instance access', async () => {
+    const { app, updated } = mount(['keys:write']);
+
+    const { status } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', instanceIds: null }]);
+  });
+
   test('wildcard bearer can grant a scope covered by its narrowed signing host', async () => {
     const { app, updated } = mount(['*'], ['keys:write', 'chats:read']);
 
@@ -335,8 +469,8 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     expect(updated).toEqual([{ id: 'target', scopes: ['*'] }]);
   });
 
-  test('metadata-only updates remain allowed for a keys:write caller', async () => {
-    const { app, updated } = mount(['keys:write']);
+  test('metadata-only updates remain allowed for an instance-restricted keys:write caller', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
 
     const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
 

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -9,6 +9,7 @@ import { zValidator } from '@hono/zod-validator';
 import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 import { ProfileResolutionError, type ResolveProfileInput, resolveProfile } from '../../lib/resolve-profile';
+import { readSignedHostScopeContext } from '../../lib/signed-host-scope-context';
 import { optionalDateParam } from '../../schemas/date-query';
 import { ApiKeyService } from '../../services/api-keys';
 import type { AppVariables } from '../../types';
@@ -167,6 +168,20 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
   };
 }
 
+/** Return the common fail-closed response for malformed signed-host context. */
+function invalidSignedHostScopeContextResponse(c: Context<{ Variables: AppVariables }>, hostId: string): Response {
+  return c.json(
+    {
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Signing host scope context is missing.',
+        host: hostId,
+      },
+    },
+    403,
+  );
+}
+
 /**
  * Least-privilege scope ceiling for key-management writes.
  *
@@ -187,25 +202,10 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
  * requested scope is within every active authorizer's ceiling.
  */
 function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
-  const callerScopes = c.get('apiKey')?.scopes ?? [];
-  const signedBy = c.get('signedBy');
-  const signedByScopes = c.get('signedByScopes');
-  const authorizerScopeSets: string[][] = [callerScopes];
-  if (signedBy) {
-    if (signedByScopes === undefined || signedByScopes === null) {
-      return c.json(
-        {
-          error: {
-            code: 'FORBIDDEN',
-            message: 'Signing host scope context is missing.',
-            host: signedBy,
-          },
-        },
-        403,
-      );
-    }
-    authorizerScopeSets.push(signedByScopes);
-  }
+  const authorizerScopeSets: string[][] = [c.get('apiKey')?.scopes ?? []];
+  const signedHost = readSignedHostScopeContext(c);
+  if (signedHost.kind === 'invalid') return invalidSignedHostScopeContextResponse(c, signedHost.hostId);
+  if (signedHost.kind === 'valid') authorizerScopeSets.push(signedHost.scopes);
   const exceeding = requestedScopes.filter((scope) =>
     authorizerScopeSets.some((authorizerScopes) => !ApiKeyService.scopeAllows(authorizerScopes, scope)),
   );

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -221,6 +221,39 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
   );
 }
 
+/**
+ * Least-privilege ceiling for legacy instance access on key-management writes.
+ *
+ * `instanceIds: null` means unrestricted access. A restricted caller may only
+ * grant a subset of its own instance IDs; it may not grant `null`, omit the
+ * field during creation (which persists as unrestricted), or name an instance
+ * outside its own restriction. Missing caller context is denied fail-closed.
+ */
+function enforceInstanceCeiling(
+  c: Context<{ Variables: AppVariables }>,
+  requestedInstanceIds: string[] | null,
+): Response | null {
+  const apiKey = c.get('apiKey');
+  if (apiKey?.instanceIds === null) return null;
+
+  const exceedsCaller =
+    !apiKey ||
+    !Array.isArray(apiKey.instanceIds) ||
+    requestedInstanceIds === null ||
+    requestedInstanceIds.some((instanceId) => !apiKey.instanceIds?.includes(instanceId));
+  if (!exceedsCaller) return null;
+
+  return c.json(
+    {
+      error: {
+        code: 'FORBIDDEN',
+        message: "Cannot grant instance access that exceeds the caller's own.",
+      },
+    },
+    403,
+  );
+}
+
 async function handleProfileCreate(
   c: Context<{ Variables: AppVariables }>,
   data: CreateKeyData,
@@ -241,6 +274,9 @@ async function handleProfileCreate(
     // caller can't escalate by requesting a broader profile than it holds.
     const ceilingDenied = enforceScopeCeiling(c, resolved.scopes);
     if (ceilingDenied) return ceilingDenied;
+
+    const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds ?? null);
+    if (instanceCeilingDenied) return instanceCeilingDenied;
 
     const result = await services.apiKeys.create({
       name: data.name,
@@ -292,6 +328,9 @@ async function handleLegacyCreate(
   // minting `['*']` / a `ns:*` super-scope and using it as a one-hop god key.
   const ceilingDenied = enforceScopeCeiling(c, data.scopes);
   if (ceilingDenied) return ceilingDenied;
+
+  const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds ?? null);
+  if (instanceCeilingDenied) return instanceCeilingDenied;
 
   const result = await services.apiKeys.create({
     name: data.name,
@@ -358,6 +397,10 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   if (data.scopes) {
     const ceilingDenied = enforceScopeCeiling(c, data.scopes);
     if (ceilingDenied) return ceilingDenied;
+  }
+  if (data.instanceIds !== undefined) {
+    const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds);
+    if (instanceCeilingDenied) return instanceCeilingDenied;
   }
 
   try {

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -188,8 +188,24 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
  */
 function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
   const callerScopes = c.get('apiKey')?.scopes ?? [];
-  const signedByScopes = c.get('signedBy') ? c.get('signedByScopes') : undefined;
-  const authorizerScopeSets = signedByScopes ? [callerScopes, signedByScopes] : [callerScopes];
+  const signedBy = c.get('signedBy');
+  const signedByScopes = c.get('signedByScopes');
+  const authorizerScopeSets: string[][] = [callerScopes];
+  if (signedBy) {
+    if (signedByScopes === undefined || signedByScopes === null) {
+      return c.json(
+        {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'Signing host scope context is missing.',
+            host: signedBy,
+          },
+        },
+        403,
+      );
+    }
+    authorizerScopeSets.push(signedByScopes);
+  }
   const exceeding = requestedScopes.filter((scope) =>
     authorizerScopeSets.some((authorizerScopes) => !ApiKeyService.scopeAllows(authorizerScopes, scope)),
   );

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -168,31 +168,37 @@ function normalizeOverrides(overrides: CreateKeyData['overrides']): ResolveProfi
 }
 
 /**
- * Least-privilege mint ceiling.
+ * Least-privilege scope ceiling for key-management writes.
  *
- * A caller may only mint a key whose scopes are a SUBSET of its OWN scopes.
- * `ApiKeyService.scopeAllows(callerScopes, requested)` is exactly the covering
- * relation we need:
- *   - a `*` caller (the real god-key / `admin` profile) covers every requested
- *     scope, so god-key minting and internal agent-provisioning keep working
- *     unchanged;
- *   - a concrete-scoped caller (e.g. `console-admin`) covers a requested scope
- *     it holds — or one under a `ns:*` it holds — but does NOT cover `*` or a
- *     `ns:*` super-scope it lacks. So a bounded caller can never escalate to a
- *     god key or a whole-namespace grant, even by minting a broader profile.
+ * A caller may only create or update a key whose scopes are a SUBSET of its
+ * OWN scopes. Signed requests are authorized by the intersection of the bearer
+ * and signing-host scopes, so the requested grant must be covered by BOTH.
+ * `ApiKeyService.scopeAllows(authorizerScopes, requested)` is exactly the
+ * covering relation we need:
+ *   - a `*` authorizer (the real god-key / `admin` profile) covers every
+ *     requested scope, so god-key minting and internal agent-provisioning keep
+ *     working unchanged;
+ *   - a concrete-scoped authorizer (e.g. `console-admin` or a narrowed signing
+ *     host) covers a requested scope it holds — or one under a `ns:*` it holds
+ *     — but does NOT cover `*` or a `ns:*` super-scope it lacks. So a bounded
+ *     authority can never escalate to a god key or a whole-namespace grant.
  *
  * Returns a 403 `Response` listing the disallowed scopes, or `null` when every
- * requested scope is within the caller's ceiling.
+ * requested scope is within every active authorizer's ceiling.
  */
-function enforceMintCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
+function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedScopes: string[]): Response | null {
   const callerScopes = c.get('apiKey')?.scopes ?? [];
-  const exceeding = requestedScopes.filter((scope) => !ApiKeyService.scopeAllows(callerScopes, scope));
+  const signedByScopes = c.get('signedBy') ? c.get('signedByScopes') : undefined;
+  const authorizerScopeSets = signedByScopes ? [callerScopes, signedByScopes] : [callerScopes];
+  const exceeding = requestedScopes.filter((scope) =>
+    authorizerScopeSets.some((authorizerScopes) => !ApiKeyService.scopeAllows(authorizerScopes, scope)),
+  );
   if (exceeding.length === 0) return null;
   return c.json(
     {
       error: {
         code: 'FORBIDDEN',
-        message: `Cannot mint a key whose scopes exceed the caller's own. Disallowed: ${exceeding.join(', ')}`,
+        message: `Cannot grant scopes that exceed the caller's own. Disallowed: ${exceeding.join(', ')}`,
       },
     },
     403,
@@ -217,7 +223,7 @@ async function handleProfileCreate(
 
     // Enforce the mint ceiling on the RESOLVED profile scopes so a bounded
     // caller can't escalate by requesting a broader profile than it holds.
-    const ceilingDenied = enforceMintCeiling(c, resolved.scopes);
+    const ceilingDenied = enforceScopeCeiling(c, resolved.scopes);
     if (ceilingDenied) return ceilingDenied;
 
     const result = await services.apiKeys.create({
@@ -268,7 +274,7 @@ async function handleLegacyCreate(
   // Enforce the mint ceiling: the requested scopes must be a subset of the
   // caller's own. Blocks a `console-admin` (or any concrete-scoped) caller from
   // minting `['*']` / a `ns:*` super-scope and using it as a one-hop god key.
-  const ceilingDenied = enforceMintCeiling(c, data.scopes);
+  const ceilingDenied = enforceScopeCeiling(c, data.scopes);
   if (ceilingDenied) return ceilingDenied;
 
   const result = await services.apiKeys.create({
@@ -329,6 +335,14 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   const id = c.req.param('id');
   const data = c.req.valid('json');
   const services = c.get('services');
+
+  // Updating an existing key is another scope-grant path. Apply the same
+  // least-privilege ceiling as creation so a bounded keys:write caller cannot
+  // PATCH its own (or another) key into a wildcard or broader namespace grant.
+  if (data.scopes) {
+    const ceilingDenied = enforceScopeCeiling(c, data.scopes);
+    if (ceilingDenied) return ceilingDenied;
+  }
 
   try {
     const updated = await services.apiKeys.update(id, {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260717.4",
+  "version": "2.260717.5",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260717.1",
+  "version": "2.260717.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260717.3",
+  "version": "2.260717.4",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Summary

Promotes the settled `dev` snapshot `v2.260717.5` into `homolog` with an exact-tree, two-parent carry commit.

This replaces stale promotion PR #841, whose head still carries `v2.260717.4` and predates the instance-authority escalation fix merged in #843.

## Immutable promotion identity

- Source: `dev@4162ffba3583199bf6de8d6615304832aa23f001`
- Source tag/version: `v2.260717.5` / `2.260717.5`
- Target base: `homolog@6f531d89bc2824925669f5df43e58b6ccaea58d2`
- Carry commit: `5b4ea8a3ff26f5055a3165066cca6be22e56378d`
- Parent 1: `6f531d89bc2824925669f5df43e58b6ccaea58d2` (`homolog`)
- Parent 2: `4162ffba3583199bf6de8d6615304832aa23f001` (`dev`)
- Exact tree: `a062b0891353711a49248aba2b3eb633013c60b9`
- Diff from settled `dev`: zero files

## Security fixes carried

- #840 — scope ceiling foundation
- #842 — signed-host authority ceiling
- #843 — API-key `instanceIds` authority ceiling

The #843 fix prevents restricted `keys:write` callers from omitting or nulling `instanceIds` to mint/update unrestricted keys, while preserving unrestricted-admin and metadata-only update behavior.

## Fresh local verification on this exact promotion tree

- Focused authorization suites: **45 passed / 0 failed**
- Full pre-push suite: **4,281 passed / 326 skipped / 0 failed**
- Typecheck: **21/21 tasks successful**
- Biome lint: passed, 1,363 files checked
- Build: **5/5 tasks successful**
- Knip: passed
- `git diff --check`: passed
- Promotion invariants: two parents in homolog/dev order, exact source tree, zero source diff

## Source release evidence

- Version workflow: https://github.com/automagik-dev/omni/actions/runs/29596482978
- Signed Release workflow: https://github.com/automagik-dev/omni/actions/runs/29596827840
- Signed prerelease: https://github.com/automagik-dev/omni/releases/tag/v2.260717.5

## Merge gate

Keep this PR draft until:

- [ ] all checks bind to carry commit `5b4ea8a3ff26f5055a3165066cca6be22e56378d` and pass;
- [ ] fresh independent review confirms exact-tree ancestry and no Critical/High/Medium authorization or release blockers;
- [ ] `dev` and `homolog` remain at the recorded source/base refs;
- [ ] no unresolved review threads remain.

Merge with a **merge commit**. Do not squash or rebase; the two-parent promotion ancestry is intentional.

After merge, verify the final post-automation `homolog` SHA, image digest/provenance, branch/tag/version coherence, and deploy the immutable image to the approved Kubernetes HML target only after backup and rollout preflight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key creation and updates now enforce scope and instance-access limits based on effective authorization.
  * Signed requests support host-specific scope enforcement for more precise access control.

* **Bug Fixes**
  * Malformed or missing signed-host authorization details now fail closed with a 403 response.
  * Prevents requests from exceeding permitted scopes or instance access.

* **Chores**
  * Updated the application, plugin, and package release version to 2.260717.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->