### PR TITLE
fix(auth): fail closed when host verifier is unavailable

### DIFF
--- a/packages/api/src/lib/signed-host-scope-context.ts
+++ b/packages/api/src/lib/signed-host-scope-context.ts
@@ -6,6 +6,12 @@ export type SignedHostScopeContext =
   | { kind: 'valid'; hostId: string; scopes: string[] }
   | { kind: 'invalid'; hostId: string };
 
+const GENIE_SIGNATURE_HEADERS = ['x-genie-host-id', 'x-genie-timestamp', 'x-genie-signature'] as const;
+
+function hasAnyGenieSignatureHeader(c: Context<{ Variables: AppVariables }>): boolean {
+  return GENIE_SIGNATURE_HEADERS.some((header) => c.req.header(header) !== undefined);
+}
+
 /**
  * Parse optional Hono context into a strict authorization state.
  *
@@ -15,7 +21,17 @@ export type SignedHostScopeContext =
  */
 export function readSignedHostScopeContext(c: Context<{ Variables: AppVariables }>): SignedHostScopeContext {
   const hostId = c.get('signedBy');
-  if (!hostId) return { kind: 'unsigned' };
+  if (!hostId) {
+    // Signature headers assert a signed-host identity. If upstream signature
+    // verification did not produce `signedBy`, never downgrade that request
+    // to the bearer-only path — verification may have been unavailable or the
+    // middleware chain may have drifted. The signature middleware normally
+    // rejects first; this is the downstream authorization backstop.
+    if (hasAnyGenieSignatureHeader(c)) {
+      return { kind: 'invalid', hostId: c.req.header('x-genie-host-id') ?? 'unknown' };
+    }
+    return { kind: 'unsigned' };
+  }
 
   const scopes: unknown = c.get('signedByScopes');
   if (!Array.isArray(scopes) || !scopes.every((scope) => typeof scope === 'string')) {

--- a/packages/api/src/middleware/__tests__/genie-signature-service-unavailable.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature-service-unavailable.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../types';
+import { genieSignatureMiddleware } from '../genie-signature';
+
+function mountWithoutGenieHosts(): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {} as AppVariables['services']);
+    await next();
+  });
+  app.use('*', genieSignatureMiddleware);
+  app.get('/protected', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('genie-signature middleware — verifier service availability', () => {
+  test('bearer-only request without signature headers still passes through', async () => {
+    const res = await mountWithoutGenieHosts().request('/protected');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test('request with X-Genie signature headers fails closed when genieHosts is unavailable', async () => {
+    const res = await mountWithoutGenieHosts().request('/protected', {
+      headers: {
+        'x-genie-host-id': 'unverified-host',
+        'x-genie-timestamp': '2026-07-17T00:00:00.000Z',
+        'x-genie-signature': 'unverified-signature',
+      },
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('GENIE_SIGNATURE_SERVICE_UNAVAILABLE');
+  });
+
+  test('partial X-Genie signature headers also fail closed when genieHosts is unavailable', async () => {
+    const res = await mountWithoutGenieHosts().request('/protected', {
+      headers: { 'x-genie-host-id': 'unverified-host' },
+    });
+
+    expect(res.status).toBe(503);
+  });
+});

--- a/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
+++ b/packages/api/src/middleware/__tests__/scope-enforcer-host-scopes.test.ts
@@ -84,6 +84,21 @@ describe('scope-enforcer — bearer-only path (no signature)', () => {
     const res = await app.request('/api/v2/agents');
     expect(res.status).toBe(403);
   });
+
+  test('signature headers without a verified signedBy context fail closed instead of degrading to bearer-only', async () => {
+    const app = mountWithCtx({ bearerScopes: ['*'] });
+    const res = await app.request('/api/v2/agents', {
+      headers: {
+        'x-genie-host-id': 'unverified-host',
+        'x-genie-timestamp': '2026-07-17T00:00:00.000Z',
+        'x-genie-signature': 'unverified-signature',
+      },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; host?: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.host).toBe('unverified-host');
+  });
 });
 
 describe('scope-enforcer — signed request, host wildcard (back-compat default)', () => {

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -205,14 +205,6 @@ function pathFromRequest(url: URL): string {
  * `c.req.text()` returns the same string the signer hashed.
  */
 export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
-  const services = c.get('services');
-  if (!services?.genieHosts) {
-    // Service registry not initialized — let the request through; bearer
-    // auth will reject if needed. Don't fail closed for an internal-config
-    // hiccup.
-    return next();
-  }
-
   const hostIdHeader = c.req.header(HEADER_HOST_ID);
   const timestampHeader = c.req.header(HEADER_TIMESTAMP);
   const signatureHeader = c.req.header(HEADER_SIGNATURE);
@@ -220,6 +212,29 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
   // Fast-path: no signature headers → skip work, fall through.
   if (!hostIdHeader && !timestampHeader && !signatureHeader) {
     return next();
+  }
+
+  const services = c.get('services');
+  if (!services?.genieHosts) {
+    // A request carrying any signature header asserts signed-host authority.
+    // If the verifier dependency is unavailable, rejecting is the only safe
+    // behavior: falling through would make the scope enforcer treat it as a
+    // bearer-only request and bypass host narrowing. Unsigned bearer requests
+    // already took the fast path above and retain their existing behavior.
+    log.warn('genie signature verification service unavailable', {
+      hostId: hostIdHeader,
+      method: c.req.method,
+      path: new URL(c.req.url).pathname,
+    });
+    return c.json(
+      {
+        error: {
+          code: 'GENIE_SIGNATURE_SERVICE_UNAVAILABLE',
+          message: 'Genie host signature verification is temporarily unavailable.',
+        },
+      },
+      503,
+    );
   }
 
   // Read the request body ONCE so we hash the same bytes the signer did.


### PR DESCRIPTION
## Security fix

Promotion PR #844 exposed a fail-open path in the signed-host authorization chain:

- `genieSignatureMiddleware` returned `next()` whenever `services.genieHosts` was unavailable, before inspecting `X-Genie-*` headers.
- A request carrying signed-host headers therefore reached the scope enforcer without verified `signedBy`/`signedByScopes` context.
- The scope helper classified it as bearer-only, so a broad bearer token could bypass host narrowing during verifier-service unavailability.

This PR fixes the lowest affected source branch (`dev`) before promotion resumes.

## Behavior

- Unsigned bearer-only requests retain the existing pass-through behavior.
- Any request carrying one or more `X-Genie-*` signature headers now returns fail-closed `503 GENIE_SIGNATURE_SERVICE_UNAVAILABLE` when `genieHosts` is unavailable.
- The signed-host scope reader also treats signature headers without a verified `signedBy` context as invalid, adding a downstream authorization backstop against middleware-chain drift.

## TDD evidence

Before the implementation, the new regression tests failed exactly on the vulnerable behavior:

- expected 503, received 200 (complete signature headers);
- expected 503, received 200 (partial signature headers);
- expected 403, received 200 (scope-enforcer backstop).

After the fix:

- focused authorization suites: **73 passed / 0 failed**;
- full suite: **4,285 passed / 326 skipped / 0 failed**;
- typecheck: **21/21 tasks successful**;
- Biome lint: **1,364 files checked**;
- build: **5/5 tasks successful**;
- Knip and `git diff --check`: passed;
- pre-push hook repeated typecheck + full suite successfully.

## Scope

Four files only: middleware behavior, scope-context backstop, and non-vacuous Hono/scope-enforcer regression tests. No schema, dependency, migration, or secret changes.

## Release consequence

After merge and the automatic dev version/release settlement, close stale promotion #844 and build a fresh exact-tree `dev → homolog` promotion from the new immutable dev release. No deployment should use `v2.260717.5`.
