### PR TITLE
fix(auth): reject present-but-empty Genie headers

### DIFF
--- a/packages/api/src/middleware/__tests__/genie-signature-service-unavailable.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature-service-unavailable.test.ts
@@ -42,4 +42,19 @@ describe('genie-signature middleware — verifier service availability', () => {
 
     expect(res.status).toBe(503);
   });
+
+  for (const headerName of ['x-genie-host-id', 'x-genie-timestamp', 'x-genie-signature']) {
+    test(`present-but-empty ${headerName} fails closed when genieHosts is unavailable`, async () => {
+      const headers = new Headers();
+      headers.set(headerName, '');
+      expect(headers.has(headerName)).toBe(true);
+      expect(headers.get(headerName)).toBe('');
+
+      const res = await mountWithoutGenieHosts().request('/protected', { headers });
+
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe('GENIE_SIGNATURE_SERVICE_UNAVAILABLE');
+    });
+  }
 });

--- a/packages/api/src/middleware/__tests__/genie-signature.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature.test.ts
@@ -196,6 +196,26 @@ describe('verifySignature — header presence', () => {
     expect(outcome.status).toBe('no-signature');
   });
 
+  for (const [headerName, headers] of [
+    ['host-id', { hostIdHeader: '', timestampHeader: undefined, signatureHeader: undefined }],
+    ['timestamp', { hostIdHeader: undefined, timestampHeader: '', signatureHeader: undefined }],
+    ['signature', { hostIdHeader: undefined, timestampHeader: undefined, signatureHeader: '' }],
+  ] as const) {
+    test(`present-but-empty ${headerName} → status=invalid`, async () => {
+      const outcome = await verifySignature({
+        ...headers,
+        method: 'GET',
+        path: '/x',
+        body: '',
+        now: NOW,
+        findHost: async () => null,
+      });
+
+      expect(outcome.status).toBe('invalid');
+      expect(outcome.reason).toContain('partial');
+    });
+  }
+
   test('only host-id present → status=invalid (forge attempt)', async () => {
     const outcome = await verifySignature({
       hostIdHeader: 'host-1',

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -131,7 +131,9 @@ export async function verifySignature(opts: {
   const { hostIdHeader, timestampHeader, signatureHeader, method, path, body, now, findHost } = opts;
 
   // No signature headers at all → bearer-only path; not our concern.
-  if (!hostIdHeader && !timestampHeader && !signatureHeader) {
+  // Header presence is independent from value truthiness: an empty-valued
+  // X-Genie header is still a signed-request attempt and must fail closed.
+  if (hostIdHeader === undefined && timestampHeader === undefined && signatureHeader === undefined) {
     return { status: 'no-signature' };
   }
 
@@ -209,8 +211,9 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
   const timestampHeader = c.req.header(HEADER_TIMESTAMP);
   const signatureHeader = c.req.header(HEADER_SIGNATURE);
 
-  // Fast-path: no signature headers → skip work, fall through.
-  if (!hostIdHeader && !timestampHeader && !signatureHeader) {
+  // Fast-path only when all signature headers are truly absent. Fetch/Hono
+  // preserves present-but-empty headers as '', so truthiness would fail open.
+  if (hostIdHeader === undefined && timestampHeader === undefined && signatureHeader === undefined) {
     return next();
   }
 


### PR DESCRIPTION
## Security boundary

Fetch/Hono preserves present-but-empty `X-Genie-*` headers as empty strings. Truthiness checks therefore classified a signed-request attempt as ordinary bearer-only traffic and could fail open.

This patch makes header presence explicit in both the pure verifier and production Hono middleware: only all three values being exactly `undefined` is unsigned. Any present-but-empty or partial set is invalid/fail-closed. The ordinary no-header bearer path remains unchanged.

## Tests

- Added real Hono middleware regressions for each present-but-empty header with verifier service unavailable: all return `503 GENIE_SIGNATURE_SERVICE_UNAVAILABLE`.
- Added pure verifier regressions for each empty value: all return `invalid`.
- Focused boundary suite: **79 passed, 0 failed**.
- Canonical full suite: **4,291 passed, 326 skipped, 0 failed**.
- Typecheck: **21/21**.
- Lint: **1,364 files clean**.
- Build: **5/5**.
- Knip and `git diff --check`: passed.
- Pre-push gates: passed.

## Review/provenance

- Independent strict security review: **APPROVE**, no Critical/High/Medium/Low findings.
- Exact patch hash (`git diff --binary HEAD^ HEAD | sha256sum`): `cea6c39ce333f7ea353f82decaac2c72921e7f51f0bb0a256ff6b45c57ceb299`.
- Base: `dev@aff1bc278c2e776a8d6d987ccc34dc3ab5788d4b`.
- Commit: `9a2a4b8dfc03b5d2fdea853d1e470b3d8fce37d9`.

This is source-first. Do not promote/deploy homolog/main until this fix lands and the corrected immutable release is published.