### PR TITLE
chore: promote dev to homolog (2.260717.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -259,6 +259,7 @@
       },
       "devDependencies": {
         "@omni/api": "workspace:*",
+        "@omni/channel-a2a": "workspace:*",
         "@omni/channel-discord": "workspace:*",
         "@omni/channel-gupshup": "workspace:*",
         "@omni/channel-sdk": "workspace:*",
@@ -274,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -290,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -304,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -323,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -331,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -345,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260717.6",
+      "version": "2.260717.7",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260717.7",
+      "version": "2.260717.8",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260717.6"
+appVersion: "2.260717.7"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260717.7"
+appVersion: "2.260717.8"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/middleware/__tests__/genie-signature-service-unavailable.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature-service-unavailable.test.ts
@@ -42,4 +42,19 @@ describe('genie-signature middleware — verifier service availability', () => {
 
     expect(res.status).toBe(503);
   });
+
+  for (const headerName of ['x-genie-host-id', 'x-genie-timestamp', 'x-genie-signature']) {
+    test(`present-but-empty ${headerName} fails closed when genieHosts is unavailable`, async () => {
+      const headers = new Headers();
+      headers.set(headerName, '');
+      expect(headers.has(headerName)).toBe(true);
+      expect(headers.get(headerName)).toBe('');
+
+      const res = await mountWithoutGenieHosts().request('/protected', { headers });
+
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe('GENIE_SIGNATURE_SERVICE_UNAVAILABLE');
+    });
+  }
 });

--- a/packages/api/src/middleware/__tests__/genie-signature.test.ts
+++ b/packages/api/src/middleware/__tests__/genie-signature.test.ts
@@ -196,6 +196,26 @@ describe('verifySignature — header presence', () => {
     expect(outcome.status).toBe('no-signature');
   });
 
+  for (const [headerName, headers] of [
+    ['host-id', { hostIdHeader: '', timestampHeader: undefined, signatureHeader: undefined }],
+    ['timestamp', { hostIdHeader: undefined, timestampHeader: '', signatureHeader: undefined }],
+    ['signature', { hostIdHeader: undefined, timestampHeader: undefined, signatureHeader: '' }],
+  ] as const) {
+    test(`present-but-empty ${headerName} → status=invalid`, async () => {
+      const outcome = await verifySignature({
+        ...headers,
+        method: 'GET',
+        path: '/x',
+        body: '',
+        now: NOW,
+        findHost: async () => null,
+      });
+
+      expect(outcome.status).toBe('invalid');
+      expect(outcome.reason).toContain('partial');
+    });
+  }
+
   test('only host-id present → status=invalid (forge attempt)', async () => {
     const outcome = await verifySignature({
       hostIdHeader: 'host-1',

--- a/packages/api/src/middleware/genie-signature.ts
+++ b/packages/api/src/middleware/genie-signature.ts
@@ -131,7 +131,9 @@ export async function verifySignature(opts: {
   const { hostIdHeader, timestampHeader, signatureHeader, method, path, body, now, findHost } = opts;
 
   // No signature headers at all → bearer-only path; not our concern.
-  if (!hostIdHeader && !timestampHeader && !signatureHeader) {
+  // Header presence is independent from value truthiness: an empty-valued
+  // X-Genie header is still a signed-request attempt and must fail closed.
+  if (hostIdHeader === undefined && timestampHeader === undefined && signatureHeader === undefined) {
     return { status: 'no-signature' };
   }
 
@@ -209,8 +211,9 @@ export const genieSignatureMiddleware = createMiddleware<{ Variables: AppVariabl
   const timestampHeader = c.req.header(HEADER_TIMESTAMP);
   const signatureHeader = c.req.header(HEADER_SIGNATURE);
 
-  // Fast-path: no signature headers → skip work, fall through.
-  if (!hostIdHeader && !timestampHeader && !signatureHeader) {
+  // Fast-path only when all signature headers are truly absent. Fetch/Hono
+  // preserves present-but-empty headers as '', so truthiness would fail open.
+  if (hostIdHeader === undefined && timestampHeader === undefined && signatureHeader === undefined) {
     return next();
   }
 

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@omni/api": "workspace:*",
+    "@omni/channel-a2a": "workspace:*",
     "@omni/channel-discord": "workspace:*",
     "@omni/channel-gupshup": "workspace:*",
     "@omni/channel-sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/src/bundled-server-entry.ts
+++ b/packages/cli/src/bundled-server-entry.ts
@@ -21,6 +21,16 @@ for (const plugin of [telegramPlugin, discordPlugin, whatsappPlugin, slackPlugin
   channelRegistry.register(plugin);
 }
 
+// A2A is opt-in — gated by the same A2A_ENABLED flag that mounts the JSON-RPC
+// route in @omni/api. Without this the route returns "A2A channel not available"
+// (channelRegistry.get('a2a') is empty) and a2a instances fail to (re)connect,
+// since the bundled distribution never registered the plugin. Dynamic import so
+// it's excluded from the registry when A2A is disabled.
+if (process.env.A2A_ENABLED === 'true') {
+  const { default: a2aPlugin } = await import('@omni/channel-a2a');
+  channelRegistry.register(a2aPlugin as ChannelPlugin);
+}
+
 // Start the API server — must be a dynamic import to guarantee
 // registration happens before the server reads the registry
 await import('@omni/api');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260717.6",
+  "version": "2.260717.7",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260717.7",
+  "version": "2.260717.8",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Exact-tree promotion

Carries the corrected `dev` snapshot into `homolog` without rewriting either protected branch. This supersedes homolog `v2.260717.7`, which is held because it lacks the present-but-empty `X-Genie-*` fail-closed correction.

### Immutable invariants

- Promotion commit: `e0172ce06edceb5341da638f2315e13152e0c710`
- Parent 1 (current homolog): `e0a9f8ebe8f85b795e8ca0bcff0e73c00eac8499`
- Parent 2 (dev v2.260717.8): `6de5e7392644cceebce79a74928146e05dbca2fc`
- Promotion tree: `64242dee4886de2f569e9bacc593511dc21ff702`
- Dev tree: `64242dee4886de2f569e9bacc593511dc21ff702`
- `git diff e0172ce0 origin/dev`: empty

### Security correction included

PR #847 landed source-first on dev. Only all three `X-Genie-*` values exactly `undefined` are unsigned; partial or present-but-empty sets are invalid/fail-closed. Real Hono tests cover each empty header and the ordinary no-header bearer path.

### Gates and release provenance

- Focused security boundary suite: **79 passed, 0 failed**
- Canonical full/pre-push suite: **4,291 passed, 326 skipped, 0 failed**
- Typecheck: **21/21**
- Lint: **1,364 files clean**
- Build: **5/5**
- Knip and diff checks: passed
- v2.260717.8 release run: **success** (`29620473508`)
- Four platform tarballs: cosign keyless signatures, SLSA provenance, GitHub native attestations, and tamper-rejection self-tests passed
- npm `next`: `2.260717.8`

After merge, homolog auto-versioning will stamp and publish the immutable homolog image. Do not deploy until that image digest and provenance are verified.