### PR TITLE
fix(ci): harden MinIO readiness and action pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.4.1'
 
@@ -257,7 +257,7 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.4.1'
 

--- a/packages/api/src/__tests__/minio-harness-cleanup.test.ts
+++ b/packages/api/src/__tests__/minio-harness-cleanup.test.ts
@@ -137,6 +137,7 @@ function setup(
     random: () => 0.5,
     sessionId: 'session-123',
     readinessTimeoutMs: 1_000,
+    readyRequestTimeoutMs: 100,
     reportCleanupFailure: (message) => cleanupFailures.push(message),
   };
   const harness = createSharedMinioHarness(dependencies);
@@ -308,4 +309,30 @@ describe('shared MinIO harness cleanup', () => {
     ]);
     expect(fake.process.signals).toEqual([{ pid: 4242, signal: 'SIGTERM', listenerCount: 0, nativeExitCode: 143 }]);
   });
+
+  test('stops the failed container even when collecting readiness diagnostics throws', async () => {
+    const fake = setup(['container-diagnostics-throw'], { ready: false });
+    fake.docker.beforeCommand = (command) => {
+      if (command[1] === 'inspect') throw new Error('fake inspect failure');
+    };
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('container diagnostics unavailable: fake inspect failure');
+
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-diagnostics-throw']]);
+  });
+
+  test('bounds and aborts a readiness request that never settles', async () => {
+    const fake = setup(['container-hung-probe'], { ready: false });
+    let observedSignal: AbortSignal | undefined;
+    fake.dependencies.readyRequestTimeoutMs = 10;
+    fake.dependencies.readyFetch = (_url, options) => {
+      observedSignal = options?.signal;
+      return new Promise(() => {});
+    };
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('MinIO did not become ready within 1s');
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-hung-probe']]);
+  }, 250);
 });

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -119,12 +119,13 @@ interface ProcessHooks {
 export interface SharedMinioHarnessDependencies {
   runSync(command: string[]): SyncCommandResult;
   process: ProcessHooks;
-  readyFetch(url: string): Promise<{ ok: boolean }>;
+  readyFetch(url: string, options: { signal: AbortSignal }): Promise<{ ok: boolean }>;
   now(): number;
   sleep(ms: number): Promise<void>;
   random(): number;
   sessionId: string;
   readinessTimeoutMs: number;
+  readyRequestTimeoutMs: number;
   reportCleanupFailure(message: string): void;
 }
 
@@ -152,6 +153,30 @@ const processHooks: ProcessHooks = {
   },
 };
 
+async function fetchReadyWithTimeout(
+  url: string,
+  timeoutMs: number,
+  dependencies: SharedMinioHarnessDependencies,
+): Promise<{ ok: boolean }> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      dependencies.readyFetch(url, { signal: controller.signal }),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          controller.abort();
+          reject(new Error(`MinIO readiness request timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    controller.abort();
+  }
+}
+
 async function waitForReady(port: number, dependencies: SharedMinioHarnessDependencies): Promise<void> {
   // Single wait for the shared container. Generous deadline: on a loaded CI
   // runner (Blacksmith 4vcpu, full suite hammering the box) MinIO has been
@@ -159,7 +184,13 @@ async function waitForReady(port: number, dependencies: SharedMinioHarnessDepend
   const deadline = dependencies.now() + dependencies.readinessTimeoutMs;
   while (dependencies.now() < deadline) {
     try {
-      const res = await dependencies.readyFetch(`http://127.0.0.1:${port}/minio/health/ready`);
+      const remainingMs = Math.max(1, deadline - dependencies.now());
+      const requestTimeoutMs = Math.min(dependencies.readyRequestTimeoutMs, remainingMs);
+      const res = await fetchReadyWithTimeout(
+        `http://127.0.0.1:${port}/minio/health/ready`,
+        requestTimeoutMs,
+        dependencies,
+      );
       if (res.ok) return;
     } catch {
       // not up yet
@@ -382,8 +413,16 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
     } catch (error) {
       // Capture diagnostics before `--rm` deletes the failed container, then
       // synchronously stop it before another suite is allowed to retry.
-      const failure = describeContainerFailure(containerId, dependencies.runSync);
-      lifecycle.stop(containerId);
+      let failure: string;
+      try {
+        failure = describeContainerFailure(containerId, dependencies.runSync);
+      } catch (diagnosticError) {
+        failure = `container diagnostics unavailable: ${
+          diagnosticError instanceof Error ? diagnosticError.message : String(diagnosticError)
+        }`;
+      } finally {
+        lifecycle.stop(containerId);
+      }
       throw new Error(`${error instanceof Error ? error.message : String(error)}\n${failure}`);
     }
     return { endpoint: `http://127.0.0.1:${port}`, accessKey: ACCESS_KEY, secretKey: SECRET_KEY, region: REGION };
@@ -403,12 +442,13 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
 const sharedMinioHarness = createSharedMinioHarness({
   runSync,
   process: processHooks,
-  readyFetch: (url) => harnessFetch(url),
+  readyFetch: (url, options) => harnessFetch(url, options),
   now: Date.now,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   random: Math.random,
   sessionId: `${process.pid}-${randomUUID()}`,
   readinessTimeoutMs: 120_000,
+  readyRequestTimeoutMs: 5_000,
   reportCleanupFailure: (message) => console.error(message),
 });
 


### PR DESCRIPTION
## Summary

Hardens the promotion path after the bounded review of #839:

- pins both newly introduced `sigstore/cosign-installer` CI uses to the immutable v3 commit `398d4b0eeef1380460a10c8013a76f728fb906ac`
- bounds every MinIO readiness request with an abort signal and per-request timeout, so a fetch that never settles cannot hang the CI job past the overall deadline
- guarantees exact-container cleanup in `finally` even if Docker diagnostics throw
- adds regression coverage for the never-settling readiness probe and diagnostics-failure cleanup paths

The separate `AgentRunResult` review comment was verified as not applicable: `AgentRunnerService.run()` has a non-null `Promise<AgentRunResult>` contract and either returns `{ parts, metadata }` or throws. Optional chaining there would hide a contract violation rather than prevent a valid runtime state.

## TDD evidence

RED on the pre-fix tree:

- diagnostics failure surfaced raw `fake inspect failure` and skipped the stop call
- a readiness probe that returned a permanently pending promise caused the test command itself to time out

GREEN on this exact commit:

- `bun test packages/api/src/__tests__/minio-harness-cleanup.test.ts` — **10 passed, 0 failed**
- `bun run build` — pass
- `bun test packages apps/ui` — **4,293 passed, 326 skipped, 0 failed**
- `bun run typecheck` — **21/21 tasks passed**
- `bun run lint` — **1,364 files checked, no errors**
- `bunx knip` — pass
- pre-push gates repeated typecheck + full canonical suite — pass

## Promotion note

Merge this into `dev` with a merge commit, then promote the exact resulting dev tree to `homolog` before marking #839 ready. Do not merge #839 from the pre-fix homolog head.
