### PR TITLE
chore: promote dev to homolog (2.260718.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "author": {
         "name": "Automagik"
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.4.1'
 
@@ -257,7 +257,7 @@ jobs:
         run: ./scripts/ensure-nats.sh
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.4.1'
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260717.8",
+      "version": "2.260718.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260717.8"
+appVersion: "2.260718.2"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/__tests__/minio-harness-cleanup.test.ts
+++ b/packages/api/src/__tests__/minio-harness-cleanup.test.ts
@@ -137,6 +137,7 @@ function setup(
     random: () => 0.5,
     sessionId: 'session-123',
     readinessTimeoutMs: 1_000,
+    readyRequestTimeoutMs: 100,
     reportCleanupFailure: (message) => cleanupFailures.push(message),
   };
   const harness = createSharedMinioHarness(dependencies);
@@ -308,4 +309,30 @@ describe('shared MinIO harness cleanup', () => {
     ]);
     expect(fake.process.signals).toEqual([{ pid: 4242, signal: 'SIGTERM', listenerCount: 0, nativeExitCode: 143 }]);
   });
+
+  test('stops the failed container even when collecting readiness diagnostics throws', async () => {
+    const fake = setup(['container-diagnostics-throw'], { ready: false });
+    fake.docker.beforeCommand = (command) => {
+      if (command[1] === 'inspect') throw new Error('fake inspect failure');
+    };
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('container diagnostics unavailable: fake inspect failure');
+
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-diagnostics-throw']]);
+  });
+
+  test('bounds and aborts a readiness request that never settles', async () => {
+    const fake = setup(['container-hung-probe'], { ready: false });
+    let observedSignal: AbortSignal | undefined;
+    fake.dependencies.readyRequestTimeoutMs = 10;
+    fake.dependencies.readyFetch = (_url, options) => {
+      observedSignal = options?.signal;
+      return new Promise(() => {});
+    };
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('MinIO did not become ready within 1s');
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-hung-probe']]);
+  }, 250);
 });

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -119,12 +119,13 @@ interface ProcessHooks {
 export interface SharedMinioHarnessDependencies {
   runSync(command: string[]): SyncCommandResult;
   process: ProcessHooks;
-  readyFetch(url: string): Promise<{ ok: boolean }>;
+  readyFetch(url: string, options: { signal: AbortSignal }): Promise<{ ok: boolean }>;
   now(): number;
   sleep(ms: number): Promise<void>;
   random(): number;
   sessionId: string;
   readinessTimeoutMs: number;
+  readyRequestTimeoutMs: number;
   reportCleanupFailure(message: string): void;
 }
 
@@ -152,6 +153,30 @@ const processHooks: ProcessHooks = {
   },
 };
 
+async function fetchReadyWithTimeout(
+  url: string,
+  timeoutMs: number,
+  dependencies: SharedMinioHarnessDependencies,
+): Promise<{ ok: boolean }> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      dependencies.readyFetch(url, { signal: controller.signal }),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          controller.abort();
+          reject(new Error(`MinIO readiness request timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    controller.abort();
+  }
+}
+
 async function waitForReady(port: number, dependencies: SharedMinioHarnessDependencies): Promise<void> {
   // Single wait for the shared container. Generous deadline: on a loaded CI
   // runner (Blacksmith 4vcpu, full suite hammering the box) MinIO has been
@@ -159,7 +184,13 @@ async function waitForReady(port: number, dependencies: SharedMinioHarnessDepend
   const deadline = dependencies.now() + dependencies.readinessTimeoutMs;
   while (dependencies.now() < deadline) {
     try {
-      const res = await dependencies.readyFetch(`http://127.0.0.1:${port}/minio/health/ready`);
+      const remainingMs = Math.max(1, deadline - dependencies.now());
+      const requestTimeoutMs = Math.min(dependencies.readyRequestTimeoutMs, remainingMs);
+      const res = await fetchReadyWithTimeout(
+        `http://127.0.0.1:${port}/minio/health/ready`,
+        requestTimeoutMs,
+        dependencies,
+      );
       if (res.ok) return;
     } catch {
       // not up yet
@@ -382,8 +413,16 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
     } catch (error) {
       // Capture diagnostics before `--rm` deletes the failed container, then
       // synchronously stop it before another suite is allowed to retry.
-      const failure = describeContainerFailure(containerId, dependencies.runSync);
-      lifecycle.stop(containerId);
+      let failure: string;
+      try {
+        failure = describeContainerFailure(containerId, dependencies.runSync);
+      } catch (diagnosticError) {
+        failure = `container diagnostics unavailable: ${
+          diagnosticError instanceof Error ? diagnosticError.message : String(diagnosticError)
+        }`;
+      } finally {
+        lifecycle.stop(containerId);
+      }
       throw new Error(`${error instanceof Error ? error.message : String(error)}\n${failure}`);
     }
     return { endpoint: `http://127.0.0.1:${port}`, accessKey: ACCESS_KEY, secretKey: SECRET_KEY, region: REGION };
@@ -403,12 +442,13 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
 const sharedMinioHarness = createSharedMinioHarness({
   runSync,
   process: processHooks,
-  readyFetch: (url) => harnessFetch(url),
+  readyFetch: (url, options) => harnessFetch(url, options),
   now: Date.now,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   random: Math.random,
   sessionId: `${process.pid}-${randomUUID()}`,
   readinessTimeoutMs: 120_000,
+  readyRequestTimeoutMs: 5_000,
   reportCleanupFailure: (message) => console.error(message),
 });
 

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260717.8",
+  "version": "2.260718.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Exact-tree promotion: dev → homolog

Promotes the reviewed `dev` release **v2.260718.2** to `homolog` while preserving both branch histories.

### Provenance

| Ref | SHA | Tree |
|---|---|---|
| `homolog` base | `33f956ec90ccd5d5a88d177e113a796b49173d13` | `2bf65606f7280881df84f4271c5ea591dd6f66c6` |
| tested `dev` | `fb970c3eb0a4ebba638980ee9a6518ece6477cd5` | `f66ed2fbeb78bdff166df69d2fb05b2aa236102e` |
| promotion head | `81769b6a9005a6835e891e01c824c1aafdba09d3` | `f66ed2fbeb78bdff166df69d2fb05b2aa236102e` |

The promotion commit has exactly two parents (`homolog`, then `dev`) and its tree is byte-for-byte identical to the tested dev tree. `git diff promotion..dev` is empty.

### Review-hardening included

- present-but-empty `X-Genie-*` headers remain fail-closed
- MinIO readiness probes are individually bounded and aborted
- readiness-failure cleanup stops the exact container even if diagnostics throw
- newly introduced cosign-installer CI uses are pinned to immutable SHA `398d4b0eeef1380460a10c8013a76f728fb906ac`

### Verification on exact dev tree

- `bun install --frozen-lockfile` — pass
- `bun run build` — pass
- `bun test packages apps/ui` — **4,293 passed, 326 skipped, 0 failed**
- `bun run typecheck` — **21/21 tasks passed**
- `bun run lint` — **1,364 files checked, no errors**
- `bun run verify:versions` — **22/22 files at 2.260718.2**
- `bunx knip` — pass
- pre-push typecheck + full suite repeated — pass

### Merge instruction

Merge with a **merge commit** only. Do not squash or rebase: the audited two-parent promotion ancestry and exact-tree proof must be preserved.
