### PR TITLE
fix(api): enforce effective instance authority ceiling

### DIFF
--- a/packages/api/src/__tests__/api-key-enforcement.test.ts
+++ b/packages/api/src/__tests__/api-key-enforcement.test.ts
@@ -246,6 +246,68 @@ describeWithDb('API Key Enforcement', () => {
   });
 
   // ============================================================================
+  // Atomic authority-bearing updates
+  // ============================================================================
+
+  describe('ApiKeyService.updateWithAuthorityGuard()', () => {
+    test('serializes concurrent partial authority updates on the same key', async () => {
+      const created = await apiKeyService.create({
+        name: `authority-race-${Date.now()}`,
+        scopes: ['keys:write'],
+        instanceIds: ['11111111-1111-4111-8111-111111111111'],
+      });
+      cleanupIds.keys.push(created.key.id);
+
+      let releaseFirst!: () => void;
+      const firstMayCommit = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let firstGuardEntered!: () => void;
+      const firstIsLocked = new Promise<void>((resolve) => {
+        firstGuardEntered = resolve;
+      });
+
+      const firstUpdate = apiKeyService.updateWithAuthorityGuard(
+        created.key.id,
+        { scopes: ['messages:send'] },
+        async () => {
+          firstGuardEntered();
+          await firstMayCommit;
+          return true;
+        },
+      );
+
+      await firstIsLocked;
+
+      let secondGuardScopes: string[] | undefined;
+      const secondUpdate = apiKeyService.updateWithAuthorityGuard(
+        created.key.id,
+        { instanceIds: ['22222222-2222-4222-8222-222222222222'] },
+        (_current, next) => {
+          secondGuardScopes = next.scopes;
+          return !next.scopes.includes('messages:send');
+        },
+      );
+
+      // The second guard must not run against the stale row while the first
+      // transaction holds its lock.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(secondGuardScopes).toBeUndefined();
+
+      releaseFirst();
+      const [firstResult, secondResult] = await Promise.all([firstUpdate, secondUpdate]);
+
+      expect(firstResult.status).toBe('updated');
+      expect(secondResult.status).toBe('denied');
+      expect(secondGuardScopes).toEqual(['messages:send']);
+
+      const final = await apiKeyService.getById(created.key.id);
+      expect(final?.scopes).toEqual(['messages:send']);
+      expect(final?.instanceIds).toEqual(['11111111-1111-4111-8111-111111111111']);
+    });
+  });
+
+  // ============================================================================
   // API Key validation with IP
   // ============================================================================
 

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -30,9 +30,11 @@
  */
 
 import { describe, expect, mock, test } from 'bun:test';
+import type { ApiKey } from '@omni/db';
 import { Hono } from 'hono';
 import { CONSOLE_ADMIN_SCOPES } from '../../../constants/profiles';
 import { scopeEnforcerMiddleware } from '../../../middleware/scope-enforcer';
+import type { ApiKeyAuthorityGuard, UpdateApiKeyOptions } from '../../../services/api-keys';
 import type { ApiKeyData, AppVariables } from '../../../types';
 import { keysRoutes } from '../keys';
 
@@ -66,6 +68,8 @@ interface MountOptions {
   callerProfile?: ApiKeyData['profile'];
   /** Profile-aware instance ceiling carried by the authenticated caller. */
   callerInstanceAllowlist?: string[];
+  /** Persisted target scopes retained when PATCH omits scopes. */
+  targetScopes?: string[];
   /** Persisted target profile used to derive post-PATCH effective authority. */
   targetProfile?: ApiKeyData['profile'];
   /** Persisted target legacy restriction used when PATCH omits instanceIds. */
@@ -104,10 +108,28 @@ function mount(
           updated.push(row);
           return row;
         }),
+        updateWithAuthorityGuard: mock(
+          async (id: string, updateOptions: UpdateApiKeyOptions, guard: ApiKeyAuthorityGuard) => {
+            const current = {
+              id,
+              name: 'target',
+              scopes: options.targetScopes ?? ['keys:write'],
+              instanceIds: options.targetInstanceIds ?? null,
+              profile: options.targetProfile ?? null,
+              instanceAllowlist: options.targetInstanceAllowlist ?? [],
+            } as ApiKey;
+            const next = { ...current, ...updateOptions } as ApiKey;
+            if (!(await guard(current, next))) return { status: 'denied' as const };
+
+            const row = { id, ...updateOptions } as UpdatedKey;
+            updated.push(row);
+            return { status: 'updated' as const, key: next };
+          },
+        ),
         getById: mock(async (id: string) => ({
           id,
           name: 'target',
-          scopes: ['keys:write'],
+          scopes: options.targetScopes ?? ['keys:write'],
           instanceIds: options.targetInstanceIds ?? null,
           expiresAt: null,
           profile: options.targetProfile ?? null,
@@ -595,6 +617,76 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
 
     expect(status).toBe(200);
     expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('legacy-restricted caller cannot change scopes on an unrestricted target key', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      targetInstanceIds: null,
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['keys:write'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('profile-restricted caller cannot change scopes on a target outside its instance authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_B],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['keys:write'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('instance-only PATCH cannot activate retained scopes the caller does not hold', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      targetScopes: ['messages:send'],
+      targetInstanceIds: [],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('legacy-restricted caller can change scopes on a target within its instance authority', async () => {
+    const { app, updated } = mount(['keys:write', 'chats:read'], undefined, {
+      callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+      targetInstanceIds: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['chats:read'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('profile-restricted caller can change scopes on a target within its instance authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['keys:write'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['keys:write'] }]);
   });
 
   test('restricted caller cannot update a key to unrestricted instance access', async () => {

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -17,9 +17,12 @@
  *   - The ceiling applies to the non-profile create branch (raw `scopes`), the
  *     profile create branch (resolved profile scopes), and PATCH updates, so a
  *     bounded caller cannot escalate through any key-management write path.
- *   - Instance access is bounded independently: an unrestricted caller may
- *     grant any `instanceIds`, while a restricted caller may grant only a
- *     subset and may not use create omission or explicit `null` to grant all.
+ *   - Instance access is bounded on every enforcement surface: route-specific
+ *     legacy `instanceIds`, profile-aware `instanceAllowlist`, and routes where
+ *     both restrictions intersect. The ceiling also accounts for historical
+ *     routes that treat an empty legacy list as inactive. Unrestricted
+ *     authority, contradictory restrictions, malformed context, and UUID case
+ *     differences must not bypass any ceiling.
  *
  * These tests mount the REAL `scopeEnforcerMiddleware` in front of the REAL
  * keys routes (the existing mint tests omit it — reviewer LOW-2), so the proof
@@ -30,17 +33,19 @@ import { describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import { CONSOLE_ADMIN_SCOPES } from '../../../constants/profiles';
 import { scopeEnforcerMiddleware } from '../../../middleware/scope-enforcer';
-import type { AppVariables } from '../../../types';
+import type { ApiKeyData, AppVariables } from '../../../types';
 import { keysRoutes } from '../keys';
 
 const INSTANCE_A = '11111111-1111-4111-8111-111111111111';
 const INSTANCE_B = '22222222-2222-4222-8222-222222222222';
+const INSTANCE_CASED = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 interface CreatedKey {
   name: string;
   scopes: string[];
   profile?: string | null;
   instanceIds?: string[];
+  instanceAllowlist?: string[];
 }
 
 interface UpdatedKey {
@@ -57,6 +62,16 @@ interface MountOptions {
   withScopeEnforcer?: boolean;
   /** Legacy instance-access ceiling carried by the authenticated caller. */
   callerInstanceIds?: string[] | null;
+  /** Profile whose lock semantics apply to the authenticated caller. */
+  callerProfile?: ApiKeyData['profile'];
+  /** Profile-aware instance ceiling carried by the authenticated caller. */
+  callerInstanceAllowlist?: string[];
+  /** Persisted target profile used to derive post-PATCH effective authority. */
+  targetProfile?: ApiKeyData['profile'];
+  /** Persisted target legacy restriction used when PATCH omits instanceIds. */
+  targetInstanceIds?: string[] | null;
+  /** Persisted target profile-aware restriction retained across PATCH. */
+  targetInstanceAllowlist?: string[];
 }
 
 /**
@@ -89,6 +104,17 @@ function mount(
           updated.push(row);
           return row;
         }),
+        getById: mock(async (id: string) => ({
+          id,
+          name: 'target',
+          scopes: ['keys:write'],
+          instanceIds: options.targetInstanceIds ?? null,
+          expiresAt: null,
+          profile: options.targetProfile ?? null,
+          chatAllowlist: [],
+          instanceAllowlist: options.targetInstanceAllowlist ?? [],
+          outboundRecipientAllowlist: [],
+        })),
       },
     } as never);
     c.set('apiKey', {
@@ -97,9 +123,9 @@ function mount(
       scopes: callerScopes,
       instanceIds: options.callerInstanceIds ?? null,
       expiresAt: null,
-      profile: null,
+      profile: options.callerProfile ?? null,
       chatAllowlist: [],
-      instanceAllowlist: [],
+      instanceAllowlist: options.callerInstanceAllowlist ?? [],
       outboundRecipientAllowlist: [],
     } as never);
     const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
@@ -276,6 +302,161 @@ describe('POST /keys — mint scope ceiling', () => {
   });
 
   describe('instance access ceiling', () => {
+    test('instanceAllowlist-restricted caller cannot mint an unrestricted legacy key', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status, json } = await postKey(app, { name: 'unrestricted-child', scopes: ['*'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+      expect(created).toHaveLength(0);
+    });
+
+    test('instanceAllowlist-restricted caller cannot mint a profile key for another instance', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'cross-instance-child',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('instanceAllowlist-restricted caller can mint a profile key for its own instance', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'same-instance-child',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+      expect(created[0]?.instanceAllowlist).toEqual([INSTANCE_A]);
+    });
+
+    test('caller authority is the intersection of instanceIds and instanceAllowlist', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'outside-effective-intersection',
+        scopes: ['*'],
+        instanceIds: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('contradictory child restrictions cannot hide broader profile authority behind an empty intersection', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'split-authority-child',
+        profile: 'personal',
+        instanceIds: [INSTANCE_A],
+        instanceAllowlist: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('contradictory child restrictions cannot hide broader legacy authority behind an empty intersection', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: [INSTANCE_A],
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'split-legacy-authority-child',
+        profile: 'personal',
+        instanceIds: [INSTANCE_B],
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('profile-locked caller cannot delegate through legacy instanceIds alone', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'legacy-only-child',
+        scopes: ['*'],
+        instanceIds: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('UUID case differences are normalized before authority comparison', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_CASED.toUpperCase()],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'same-instance-different-case-child',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_CASED],
+      });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+    });
+
+    test('malformed caller instance context fails closed even for a deny-all child', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: 'malformed' as never,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'deny-all-child-from-malformed-caller',
+        scopes: ['*'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
     test('restricted caller cannot omit instanceIds and mint an unrestricted legacy key', async () => {
       const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
 
@@ -338,6 +519,19 @@ describe('POST /keys — mint scope ceiling', () => {
       expect(status).toBe(201);
       expect(created).toHaveLength(1);
       expect(created[0]?.instanceIds).toEqual([]);
+    });
+
+    test('restricted caller cannot mint an empty legacy grant that historical routes treat as unrestricted', async () => {
+      const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+      const { status } = await postKey(app, {
+        name: 'empty-legacy-compatibility-child',
+        scopes: ['keys:write'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
     });
 
     test('unrestricted caller can still omit instanceIds when minting a key', async () => {
@@ -413,6 +607,97 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     expect(updated).toHaveLength(0);
   });
 
+  test('instanceAllowlist-restricted caller cannot make a legacy target unrestricted', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status, json } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH retains the target profile lock when deriving its effective authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', instanceIds: null }]);
+  });
+
+  test('PATCH rejects a target profile lock outside the caller effective authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_B],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH cannot hide an outside profile lock behind a contradictory legacy restriction', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_B],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH cannot hide an outside legacy grant behind the caller profile lock', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_B] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH cannot replace a required profile lock with legacy restriction alone', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: null,
+      targetInstanceAllowlist: [],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
   test('restricted caller cannot update a key to an instance it cannot access', async () => {
     const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
 
@@ -440,6 +725,15 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
 
     expect(status).toBe(200);
     expect(updated).toEqual([{ id: 'target', instanceIds: [] }]);
+  });
+
+  test('restricted caller cannot PATCH an empty legacy grant that historical routes treat as unrestricted', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
   });
 
   test('unrestricted caller can update a key to unrestricted instance access', async () => {

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -10,9 +10,10 @@ import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 import { ProfileResolutionError, type ResolveProfileInput, resolveProfile } from '../../lib/resolve-profile';
 import { readSignedHostScopeContext } from '../../lib/signed-host-scope-context';
+import { isLockActive } from '../../middleware/scope-enforcer';
 import { optionalDateParam } from '../../schemas/date-query';
 import { ApiKeyService } from '../../services/api-keys';
-import type { AppVariables } from '../../types';
+import type { ApiKeyData, AppVariables } from '../../types';
 
 export const keysRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -37,6 +38,7 @@ const NON_ADMIN_PROFILES = [
   'console-admin',
 ] as const;
 type NonAdminProfile = (typeof NON_ADMIN_PROFILES)[number];
+const KNOWN_API_KEY_PROFILES = new Set<string>(['admin', ...NON_ADMIN_PROFILES]);
 
 // ============================================================================
 // SCHEMAS
@@ -221,26 +223,114 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
   );
 }
 
+/** `null` is unrestricted; an empty Set is an active deny-all restriction. */
+interface InstanceAuthorityInput {
+  instanceIds: readonly string[] | null;
+  profile?: ApiKeyData['profile'];
+  instanceAllowlist?: readonly string[];
+}
+
+type InstanceAuthority = ReadonlySet<string> | null;
+
+interface DerivedInstanceAuthorities {
+  /** Authority on routes guarded only by the route-specific legacy guard. */
+  legacy: InstanceAuthority;
+  /** Authority on historical legacy routes that skip checks for an empty list. */
+  legacyEmptyInactive: InstanceAuthority;
+  /** Authority on routes where both legacy and profile-aware guards apply. */
+  effective: InstanceAuthority;
+  /** Authority on routes guarded only by the global profile-aware enforcer. */
+  profileAware: InstanceAuthority;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function normalizeInstanceIds(values: readonly string[]): ReadonlySet<string> {
+  // PostgreSQL uuid/uuid[] values are case-insensitive and persist in canonical
+  // lowercase form. Compare the same canonical representation before writing.
+  return new Set(values.map((value) => value.toLowerCase()));
+}
+
+function intersectAuthorities(left: InstanceAuthority, right: InstanceAuthority): InstanceAuthority {
+  if (left === null) return right;
+  if (right === null) return left;
+  return new Set([...left].filter((instanceId) => right.has(instanceId)));
+}
+
+function deriveInstanceAuthorities(input: InstanceAuthorityInput): DerivedInstanceAuthorities | null {
+  // Context is runtime data despite its TypeScript type. Any malformed field is
+  // invalid rather than unrestricted so the write path fails closed.
+  if (input.instanceIds !== null && !isStringArray(input.instanceIds)) return null;
+  if (input.instanceAllowlist !== undefined && !isStringArray(input.instanceAllowlist)) return null;
+  if (
+    input.profile !== undefined &&
+    input.profile !== null &&
+    (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))
+  ) {
+    return null;
+  }
+
+  const legacy = input.instanceIds === null ? null : normalizeInstanceIds(input.instanceIds);
+  const legacyEmptyInactive = input.instanceIds === null || input.instanceIds.length === 0 ? null : legacy;
+  const instanceAllowlist = input.instanceAllowlist ?? [];
+  const profileAware = isLockActive(input.profile, 'instanceAllowlist', instanceAllowlist)
+    ? normalizeInstanceIds(instanceAllowlist)
+    : null;
+
+  return {
+    legacy,
+    legacyEmptyInactive,
+    effective: intersectAuthorities(legacy, profileAware),
+    profileAware,
+  };
+}
+
+function isAuthoritySubset(requested: InstanceAuthority, allowed: InstanceAuthority): boolean {
+  if (allowed === null) return true;
+  if (requested === null) return false;
+  return [...requested].every((instanceId) => allowed.has(instanceId));
+}
+
 /**
- * Least-privilege ceiling for legacy instance access on key-management writes.
+ * Least-privilege ceiling for instance access on key-management writes.
  *
- * `instanceIds: null` means unrestricted access. A restricted caller may only
- * grant a subset of its own instance IDs; it may not grant `null`, omit the
- * field during creation (which persists as unrestricted), or name an instance
- * outside its own restriction. Missing caller context is denied fail-closed.
+ * Legacy-only, profile-aware-only, and combined guard surfaces all exist. Some
+ * historical legacy routes also skip checks for `instanceIds: []`, while the
+ * canonical helper treats it as deny-all. A single intersection comparison is
+ * therefore insufficient: bound every enforcement interpretation separately.
  */
 function enforceInstanceCeiling(
   c: Context<{ Variables: AppVariables }>,
-  requestedInstanceIds: string[] | null,
+  requestedAuthority: InstanceAuthorityInput,
 ): Response | null {
   const apiKey = c.get('apiKey');
-  if (apiKey?.instanceIds === null) return null;
+  if (!apiKey) {
+    return c.json(
+      {
+        error: {
+          code: 'FORBIDDEN',
+          message: "Cannot grant instance access that exceeds the caller's own.",
+        },
+      },
+      403,
+    );
+  }
+  const callerAuthorities = deriveInstanceAuthorities({
+    instanceIds: apiKey.instanceIds,
+    profile: apiKey.profile,
+    instanceAllowlist: apiKey.instanceAllowlist,
+  });
+  const childAuthorities = deriveInstanceAuthorities(requestedAuthority);
 
   const exceedsCaller =
-    !apiKey ||
-    !Array.isArray(apiKey.instanceIds) ||
-    requestedInstanceIds === null ||
-    requestedInstanceIds.some((instanceId) => !apiKey.instanceIds?.includes(instanceId));
+    callerAuthorities === null ||
+    childAuthorities === null ||
+    !isAuthoritySubset(childAuthorities.legacy, callerAuthorities.legacy) ||
+    !isAuthoritySubset(childAuthorities.legacyEmptyInactive, callerAuthorities.legacyEmptyInactive) ||
+    !isAuthoritySubset(childAuthorities.profileAware, callerAuthorities.profileAware) ||
+    !isAuthoritySubset(childAuthorities.effective, callerAuthorities.effective);
   if (!exceedsCaller) return null;
 
   return c.json(
@@ -275,7 +365,11 @@ async function handleProfileCreate(
     const ceilingDenied = enforceScopeCeiling(c, resolved.scopes);
     if (ceilingDenied) return ceilingDenied;
 
-    const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds ?? null);
+    const instanceCeilingDenied = enforceInstanceCeiling(c, {
+      instanceIds: data.instanceIds ?? null,
+      profile: resolved.profile,
+      instanceAllowlist: resolved.instanceAllowlist,
+    });
     if (instanceCeilingDenied) return instanceCeilingDenied;
 
     const result = await services.apiKeys.create({
@@ -329,7 +423,11 @@ async function handleLegacyCreate(
   const ceilingDenied = enforceScopeCeiling(c, data.scopes);
   if (ceilingDenied) return ceilingDenied;
 
-  const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds ?? null);
+  const instanceCeilingDenied = enforceInstanceCeiling(c, {
+    instanceIds: data.instanceIds ?? null,
+    profile: null,
+    instanceAllowlist: [],
+  });
   if (instanceCeilingDenied) return instanceCeilingDenied;
 
   const result = await services.apiKeys.create({
@@ -399,7 +497,18 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
     if (ceilingDenied) return ceilingDenied;
   }
   if (data.instanceIds !== undefined) {
-    const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds);
+    // instanceAllowlist/profile are immutable through this PATCH route, so read
+    // the target once and derive the authority it will have after applying the
+    // requested legacy restriction.
+    const current = await services.apiKeys.getById(id);
+    if (!current) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+    }
+    const instanceCeilingDenied = enforceInstanceCeiling(c, {
+      instanceIds: data.instanceIds,
+      profile: current.profile,
+      instanceAllowlist: current.instanceAllowlist,
+    });
     if (instanceCeilingDenied) return instanceCeilingDenied;
   }
 

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -489,34 +489,39 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   const data = c.req.valid('json');
   const services = c.get('services');
 
-  // Updating an existing key is another scope-grant path. Apply the same
-  // least-privilege ceiling as creation so a bounded keys:write caller cannot
-  // PATCH its own (or another) key into a wildcard or broader namespace grant.
-  if (data.scopes) {
-    const ceilingDenied = enforceScopeCeiling(c, data.scopes);
-    if (ceilingDenied) return ceilingDenied;
-  }
-  if (data.instanceIds !== undefined) {
-    // instanceAllowlist/profile are immutable through this PATCH route, so read
-    // the target once and derive the authority it will have after applying the
-    // requested legacy restriction.
-    const current = await services.apiKeys.getById(id);
-    if (!current) {
-      return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
-    }
-    const instanceCeilingDenied = enforceInstanceCeiling(c, {
-      instanceIds: data.instanceIds,
-      profile: current.profile,
-      instanceAllowlist: current.instanceAllowlist,
-    });
-    if (instanceCeilingDenied) return instanceCeilingDenied;
-  }
+  const updateOptions = {
+    ...data,
+    expiresAt: data.expiresAt === null ? null : data.expiresAt ? new Date(data.expiresAt) : undefined,
+  };
 
   try {
-    const updated = await services.apiKeys.update(id, {
-      ...data,
-      expiresAt: data.expiresAt === null ? null : data.expiresAt ? new Date(data.expiresAt) : undefined,
-    });
+    if (data.instanceIds !== undefined || data.scopes !== undefined) {
+      let authorityDenied: Response | null | undefined;
+      const result = await services.apiKeys.updateWithAuthorityGuard(id, updateOptions, (_current, next) => {
+        authorityDenied = enforceScopeCeiling(c, next.scopes);
+        if (authorityDenied) return false;
+
+        authorityDenied = enforceInstanceCeiling(c, {
+          instanceIds: next.instanceIds,
+          profile: next.profile,
+          instanceAllowlist: next.instanceAllowlist,
+        });
+        return authorityDenied == null;
+      });
+
+      if (result.status === 'denied') {
+        return (
+          authorityDenied ??
+          c.json({ error: { code: 'FORBIDDEN', message: 'API key authority exceeds caller authority' } }, 403)
+        );
+      }
+      if (result.status === 'not_found') {
+        return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+      }
+      return c.json({ data: result.key });
+    }
+
+    const updated = await services.apiKeys.update(id, updateOptions);
 
     if (!updated) {
       return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);

--- a/packages/api/src/services/api-keys.ts
+++ b/packages/api/src/services/api-keys.ts
@@ -90,6 +90,13 @@ export interface UpdateApiKeyOptions {
   contextMessageId?: string | null;
 }
 
+export type ApiKeyAuthorityGuard = (current: ApiKey, next: ApiKey) => boolean | Promise<boolean>;
+
+export type GuardedApiKeyUpdateResult =
+  | { status: 'updated'; key: ApiKey }
+  | { status: 'not_found' }
+  | { status: 'denied' };
+
 export class ApiKeyService {
   constructor(private db: Database) {}
 
@@ -308,6 +315,57 @@ export class ApiKeyService {
       throw new Error('Cannot rename primary API key');
     }
 
+    const updates = this.buildUpdateValues(options);
+
+    const [updated] = await this.db.update(apiKeys).set(updates).where(eq(apiKeys.id, id)).returning();
+
+    if (updated) {
+      await apiKeyCache.delete(CacheKeys.apiKey(updated.keyHash));
+      log.info('API key updated', { id, fields: Object.keys(options) });
+    }
+
+    return updated ?? null;
+  }
+
+  /**
+   * Atomically update an API key after validating its complete post-update
+   * authority. The target row remains locked from the initial read through the
+   * guard and write, so concurrent partial authority PATCHes cannot compose
+   * against the same stale snapshot.
+   */
+  async updateWithAuthorityGuard(
+    id: string,
+    options: UpdateApiKeyOptions,
+    guard: ApiKeyAuthorityGuard,
+  ): Promise<GuardedApiKeyUpdateResult> {
+    const result = await this.db.transaction(async (tx): Promise<GuardedApiKeyUpdateResult> => {
+      const [current] = await tx.select().from(apiKeys).where(eq(apiKeys.id, id)).limit(1).for('update');
+
+      if (!current) return { status: 'not_found' };
+
+      if (options.name !== undefined && current.name === PRIMARY_KEY_NAME) {
+        throw new Error('Cannot rename primary API key');
+      }
+
+      const updates = this.buildUpdateValues(options);
+      const next = { ...current, ...updates } as ApiKey;
+      if (!(await guard(current, next))) return { status: 'denied' };
+
+      const [updated] = await tx.update(apiKeys).set(updates).where(eq(apiKeys.id, id)).returning();
+      if (!updated) return { status: 'not_found' };
+
+      return { status: 'updated', key: updated };
+    });
+
+    if (result.status === 'updated') {
+      await apiKeyCache.delete(CacheKeys.apiKey(result.key.keyHash));
+      log.info('API key updated', { id, fields: Object.keys(options) });
+    }
+
+    return result;
+  }
+
+  private buildUpdateValues(options: UpdateApiKeyOptions): Record<string, unknown> {
     const updates: Record<string, unknown> = { updatedAt: new Date() };
     if (options.name !== undefined) updates.name = options.name;
     if (options.description !== undefined) updates.description = options.description;
@@ -325,15 +383,7 @@ export class ApiKeyService {
     ) {
       updates.contextUpdatedAt = new Date();
     }
-
-    const [updated] = await this.db.update(apiKeys).set(updates).where(eq(apiKeys.id, id)).returning();
-
-    if (updated) {
-      await apiKeyCache.delete(CacheKeys.apiKey(updated.keyHash));
-      log.info('API key updated', { id, fields: Object.keys(options) });
-    }
-
-    return updated ?? null;
+    return updates;
   }
 
   /**


### PR DESCRIPTION
## Security fix

Closes the effective instance-authority delegation gap reported on rolling production PR #839 and the partial-PATCH race found during review of this PR.

A key-management caller can now grant authority only when the child remains a subset under every enforcement interpretation currently present in the API:

1. canonical legacy `instanceIds` (`null` unrestricted, `[]` deny-all),
2. historical legacy routes where an empty list is treated as inactive,
3. profile-aware `instanceAllowlist` using `isLockActive`, and
4. routes where legacy and profile-aware restrictions intersect.

For authority-bearing PATCHes (`scopes` or `instanceIds`), `ApiKeyService.updateWithAuthorityGuard()` now:

- starts a PostgreSQL transaction;
- locks the target key row with `SELECT ... FOR UPDATE`;
- constructs the complete post-update record using persisted values for omitted fields;
- validates the complete scope and instance authority while the lock is held;
- updates the row in the same transaction.

This prevents:

- profile-only or legacy-only substitution;
- contradictory restrictions hiding broader authority behind an empty intersection;
- `instanceIds: []` acting as a hidden unrestricted grant on historical routes;
- scope-only PATCHes granting authority to a broader target;
- instance-only PATCHes activating retained scopes the caller does not hold;
- concurrent partial PATCHes composing from the same stale snapshot.

Metadata-only PATCHes retain the existing lightweight update path.

Additional hardening:

- malformed runtime key context fails closed;
- profile names are validated before lock derivation;
- UUIDs are canonicalized before set comparisons;
- primary-key rename protection is preserved inside the locked update path.

## Scope

Exactly four files:

- `packages/api/src/routes/v2/keys.ts`
- `packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts`
- `packages/api/src/services/api-keys.ts`
- `packages/api/src/__tests__/api-key-enforcement.test.ts`

No schema, migration, package, dependency, Helm, or workflow changes.

## TDD evidence

Observed RED before implementation:

- profile-only caller could mint broader authority;
- contradictory legacy/profile restrictions could bypass a single-intersection check;
- restricted callers could grant an empty legacy array consumed as unrestricted by historical routes;
- scope-only PATCH against a broader target returned `200` instead of `403`;
- instance-only PATCH activating retained scopes returned `200` instead of `403`;
- the atomic service method did not exist at the type boundary.

Final focused route result: **53 passed, 0 failed**.

## PostgreSQL concurrency proof

A disposable PostgreSQL 18 cluster was initialized locally, all **40/40 migrations** were applied, and the DB-backed API-key suite passed **17/17**.

The concurrency regression holds the first update's row lock, starts a conflicting second partial update, verifies the second guard does not run against stale state, releases the first transaction, then proves the second guard observes the first committed scopes and denies the conflicting update. The final row preserves only the first authorized change.

## Canonical verification

- `bun install --frozen-lockfile`: clean, no changes
- `bun test packages apps/ui`: **4,315 passed, 327 skipped, 0 failed** across 344 files
- `bun run typecheck`: **21/21**
- `bun run lint`: **1,364 files**, clean
- `bun run build`: **5/5**
- `bun run knip`: clean
- `bun run verify:versions`: **22/22**
- `git diff --check`: clean
- added-line static security scan: clean

Reviewed commit: `4459ffc252a86ea06ecbf8d56d2af63882a58866`  
Reviewed tree: `c82a362d2652dc20a0accf90e40b36fa34a4cd03`  
Committed diff SHA-256 against `origin/dev@1fd0061aba3759afcd5449b4a536d825ff7a4cd9`: `7f0115075ac7600ba9df047ed39f877b06b921faefc36bcb8b6df3d2373b1399`.

## Promotion safety

Merge to `dev` with a normal merge commit only after independent review and green CI. Then promote the exact settled dev tree through `homolog`; do not push or merge directly to `main`.
