### PR TITLE
ci(commitlint): allow immutable PR 852 merge message

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -26,6 +26,10 @@ export default {
       message.startsWith(
         'feat(api): console-viewer/operator/admin key profiles + mint scope ceiling (OSS backend of #829) (#831)',
       ),
+    // PR #852 merge body: GitHub generated an immutable 135-character line.
+    // Source commits passed commitlint before merge; ignore this exact accepted merge commit
+    // so environment promotions can preserve dev ancestry without rewriting history.
+    (message: string) => message.startsWith('fix(api): enforce effective instance authority ceiling (#852)'),
     // Immutable khal-ui promotion commits with >100-char headers/body lines.
     (message: string) => message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],


### PR DESCRIPTION
## Summary

Allow commitlint to ignore the exact immutable GitHub merge message generated for PR #852.

## Why

The source commits passed commitlint before merge, but the accepted GitHub merge commit contains a 135-character body line. The dev→homolog promotion correctly preserves dev ancestry, so the promotion check sees that immutable accepted commit and fails.

Rewriting `dev`, dropping ancestry, or bypassing the required check would violate release safety. The repository already uses exact documented exceptions for the same class of immutable accepted commits (#778 and #831).

## Scope

Exactly one policy file:

- `commitlint.config.ts`

The exception matches only:

`fix(api): enforce effective instance authority ceiling (#852)`

## Verification

- Exact immutable PR #852 merge message: passes.
- Unrelated commit with the same 135-character body: still rejected by `body-max-line-length`.
- `bunx biome check commitlint.config.ts`: clean.
- `git diff --check`: clean.

After this merges to dev, the failed promotion PR #853 will be superseded by a new exact-tree promotion from the updated dev tip. No history will be rewritten.
