### PR TITLE
fix(api): fail closed on missing authority context

### DIFF
--- a/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
@@ -57,6 +57,10 @@ function mountKeysRoutes(): { app: Hono<{ Variables: AppVariables }>; created: C
       scopes: ['*'],
       instanceIds: null,
       expiresAt: null,
+      profile: null,
+      chatAllowlist: [],
+      instanceAllowlist: [],
+      outboundRecipientAllowlist: [],
     } as never);
     await next();
   });

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -68,6 +68,10 @@ interface MountOptions {
   callerProfile?: ApiKeyData['profile'];
   /** Profile-aware instance ceiling carried by the authenticated caller. */
   callerInstanceAllowlist?: string[];
+  /** Simulate malformed runtime context with the caller profile missing. */
+  omitCallerProfile?: boolean;
+  /** Simulate malformed runtime context with the caller instance allowlist missing. */
+  omitCallerInstanceAllowlist?: boolean;
   /** Persisted target scopes retained when PATCH omits scopes. */
   targetScopes?: string[];
   /** Persisted target profile used to derive post-PATCH effective authority. */
@@ -145,9 +149,9 @@ function mount(
       scopes: callerScopes,
       instanceIds: options.callerInstanceIds ?? null,
       expiresAt: null,
-      profile: options.callerProfile ?? null,
+      profile: options.omitCallerProfile ? undefined : (options.callerProfile ?? null),
       chatAllowlist: [],
-      instanceAllowlist: options.callerInstanceAllowlist ?? [],
+      instanceAllowlist: options.omitCallerInstanceAllowlist ? undefined : (options.callerInstanceAllowlist ?? []),
       outboundRecipientAllowlist: [],
     } as never);
     const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
@@ -471,6 +475,38 @@ describe('POST /keys — mint scope ceiling', () => {
 
       const { status } = await postKey(app, {
         name: 'deny-all-child-from-malformed-caller',
+        scopes: ['*'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing caller profile fails closed instead of becoming unrestricted', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        omitCallerProfile: true,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'child-from-missing-profile-context',
+        scopes: ['*'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing caller instance allowlist fails closed instead of becoming unrestricted', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        omitCallerInstanceAllowlist: true,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'child-from-missing-allowlist-context',
         scopes: ['*'],
         instanceIds: [],
       });

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -225,9 +225,12 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
 
 /** `null` is unrestricted; an empty Set is an active deny-all restriction. */
 interface InstanceAuthorityInput {
-  instanceIds: readonly string[] | null;
-  profile?: ApiKeyData['profile'];
-  instanceAllowlist?: readonly string[];
+  /** Required property; runtime `undefined` is malformed and fails closed. */
+  instanceIds: readonly string[] | null | undefined;
+  /** Required property; runtime `undefined` is malformed and fails closed. */
+  profile: ApiKeyData['profile'];
+  /** Required property; runtime `undefined` is malformed and fails closed. */
+  instanceAllowlist: readonly string[] | undefined;
 }
 
 type InstanceAuthority = ReadonlySet<string> | null;
@@ -260,23 +263,18 @@ function intersectAuthorities(left: InstanceAuthority, right: InstanceAuthority)
 }
 
 function deriveInstanceAuthorities(input: InstanceAuthorityInput): DerivedInstanceAuthorities | null {
-  // Context is runtime data despite its TypeScript type. Any malformed field is
-  // invalid rather than unrestricted so the write path fails closed.
+  // Context is runtime data despite its TypeScript type. Any missing or
+  // malformed field is invalid rather than unrestricted, so writes fail closed.
   if (input.instanceIds !== null && !isStringArray(input.instanceIds)) return null;
-  if (input.instanceAllowlist !== undefined && !isStringArray(input.instanceAllowlist)) return null;
-  if (
-    input.profile !== undefined &&
-    input.profile !== null &&
-    (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))
-  ) {
+  if (!isStringArray(input.instanceAllowlist)) return null;
+  if (input.profile !== null && (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))) {
     return null;
   }
 
   const legacy = input.instanceIds === null ? null : normalizeInstanceIds(input.instanceIds);
   const legacyEmptyInactive = input.instanceIds === null || input.instanceIds.length === 0 ? null : legacy;
-  const instanceAllowlist = input.instanceAllowlist ?? [];
-  const profileAware = isLockActive(input.profile, 'instanceAllowlist', instanceAllowlist)
-    ? normalizeInstanceIds(instanceAllowlist)
+  const profileAware = isLockActive(input.profile, 'instanceAllowlist', input.instanceAllowlist)
+    ? normalizeInstanceIds(input.instanceAllowlist)
     : null;
 
   return {


### PR DESCRIPTION
## Summary

- make every `InstanceAuthorityInput` authority surface an explicit required property
- reject runtime-missing `profile` and `instanceAllowlist` instead of treating them as unrestricted
- preserve legitimate unrestricted callers through production auth normalization (`profile: null`, empty allowlists)
- add RED→GREEN regressions and normalize the legacy console-profile test fixture to the production auth shape

## Security regression

Before the fix, authenticated runtime context missing `profile` or `instanceAllowlist` reached the `?? []` fallback and a key mint returned **201**. The new regression cases require **403** and verify no key is created.

## Verification

- targeted: 66 passed, 0 failed
- canonical: 4317 passed, 327 skipped, 0 failed (4644 total)
- typecheck: 21/21 tasks
- lint: 1364 files clean
- build: 5/5 tasks
- knip: clean
- versions: 22/22 at 2.260719.1
- diff/check formatting: clean

## Promotion context

This addresses the unresolved fail-open review findings that block exact-tree dev→homolog promotion PR #855. Merge to `dev` first; then replace #855 with a fresh exact-tree promotion.