### PR TITLE
fix(api): require strict instance authority inputs

### DIFF
--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -225,12 +225,9 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
 
 /** `null` is unrestricted; an empty Set is an active deny-all restriction. */
 interface InstanceAuthorityInput {
-  /** Required property; runtime `undefined` is malformed and fails closed. */
-  instanceIds: readonly string[] | null | undefined;
-  /** Required property; runtime `undefined` is malformed and fails closed. */
-  profile: ApiKeyData['profile'];
-  /** Required property; runtime `undefined` is malformed and fails closed. */
-  instanceAllowlist: readonly string[] | undefined;
+  instanceIds: readonly string[] | null;
+  profile: Exclude<ApiKeyData['profile'], undefined>;
+  instanceAllowlist: readonly string[];
 }
 
 type InstanceAuthority = ReadonlySet<string> | null;
@@ -304,7 +301,7 @@ function enforceInstanceCeiling(
   requestedAuthority: InstanceAuthorityInput,
 ): Response | null {
   const apiKey = c.get('apiKey');
-  if (!apiKey) {
+  if (!apiKey || apiKey.profile === undefined || !isStringArray(apiKey.instanceAllowlist)) {
     return c.json(
       {
         error: {


### PR DESCRIPTION
## Summary

- make every `InstanceAuthorityInput` field required and non-`undefined` at compile time
- retain semantic `null` only where it means unrestricted (`instanceIds`, `profile`)
- explicitly validate/narrow the broad authenticated runtime context before invoking the helper
- preserve the existing runtime fail-closed checks for malformed values

## RED → GREEN

After tightening the interface alone, `bun run typecheck` failed exactly at the caller boundary because `profile` and `instanceAllowlist` could be undefined in the broad runtime type. The explicit guard narrows both or returns 403.

## Verification

- authority regression suite: 55/55
- canonical: 4317 passed, 327 skipped, 0 failed
- typecheck: 21/21
- lint: 1364 files clean
- build: 5/5
- knip: clean
- versions: 22/22 at 2.260719.2
- pre-push repeated typecheck + all 4644 tests successfully

## Promotion context

Resolves the unresolved strict non-nullability thread on superseded promotion #857. Merge to dev, settle Auto Version, then cut a new exact-tree dev→homolog promotion.