### PR TITLE
fix(api): guard all API key updates

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -30,6 +30,15 @@ export default {
     // Source commits passed commitlint before merge; ignore this exact accepted merge commit
     // so environment promotions can preserve dev ancestry without rewriting history.
     (message: string) => message.startsWith('fix(api): enforce effective instance authority ceiling (#852)'),
+    // PR #858 merge body was supplied through the GitHub merge API as one immutable
+    // over-100-character line. Match the complete accepted message only.
+    (message: string) =>
+      message.trimEnd() ===
+      [
+        'fix(api): require strict instance authority inputs (#858)',
+        '',
+        'Make authority-helper inputs non-undefined and validate the broad runtime caller context before enforcement.',
+      ].join('\n'),
     // Immutable khal-ui promotion commits with >100-char headers/body lines.
     (message: string) => message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -891,8 +891,20 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     expect(updated).toEqual([{ id: 'target', scopes: ['*'] }]);
   });
 
-  test('metadata-only updates remain allowed for an instance-restricted keys:write caller', async () => {
+  test('restricted caller cannot metadata-only update an unrestricted target key', async () => {
     const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('metadata-only updates remain allowed when the target is within the caller instance authority', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      targetInstanceIds: [INSTANCE_A],
+    });
 
     const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
 

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -490,39 +490,29 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   };
 
   try {
-    if (data.instanceIds !== undefined || data.scopes !== undefined) {
-      let authorityDenied: Response | null | undefined;
-      const result = await services.apiKeys.updateWithAuthorityGuard(id, updateOptions, (_current, next) => {
-        authorityDenied = enforceScopeCeiling(c, next.scopes);
-        if (authorityDenied) return false;
+    let authorityDenied: Response | null | undefined;
+    const result = await services.apiKeys.updateWithAuthorityGuard(id, updateOptions, (_current, next) => {
+      authorityDenied = enforceScopeCeiling(c, next.scopes);
+      if (authorityDenied) return false;
 
-        authorityDenied = enforceInstanceCeiling(c, {
-          instanceIds: next.instanceIds,
-          profile: next.profile,
-          instanceAllowlist: next.instanceAllowlist,
-        });
-        return authorityDenied == null;
+      authorityDenied = enforceInstanceCeiling(c, {
+        instanceIds: next.instanceIds,
+        profile: next.profile,
+        instanceAllowlist: next.instanceAllowlist,
       });
+      return authorityDenied == null;
+    });
 
-      if (result.status === 'denied') {
-        return (
-          authorityDenied ??
-          c.json({ error: { code: 'FORBIDDEN', message: 'API key authority exceeds caller authority' } }, 403)
-        );
-      }
-      if (result.status === 'not_found') {
-        return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
-      }
-      return c.json({ data: result.key });
+    if (result.status === 'denied') {
+      return (
+        authorityDenied ??
+        c.json({ error: { code: 'FORBIDDEN', message: 'API key authority exceeds caller authority' } }, 403)
+      );
     }
-
-    const updated = await services.apiKeys.update(id, updateOptions);
-
-    if (!updated) {
+    if (result.status === 'not_found') {
       return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
     }
-
-    return c.json({ data: updated });
+    return c.json({ data: result.key });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     if (message.includes('Cannot rename primary')) {


### PR DESCRIPTION
## Summary

- route every `PATCH /keys/:id` update through `updateWithAuthorityGuard`
- deny metadata-only changes when the target key exceeds the caller's scope or instance authority
- preserve metadata-only changes when the target is within the caller's authority
- narrowly ignore the exact immutable PR #858 merge message so environment promotions retain ancestry without weakening unrelated commitlint checks

## Security regression

Before the route fix, a restricted caller could omit `scopes` and `instanceIds` and update metadata on an unrestricted key. The new regression test proved the vulnerable behavior first:

- **RED:** expected 403, received 200
- **GREEN:** restricted caller receives 403 and no update is recorded
- in-authority metadata-only update remains 200

## Verification

- focused authority tests: **56 passed, 0 failed**
- full canonical tests: **4,318 passed, 327 skipped, 0 failed**
- typecheck: **21/21**
- lint: **1,364 files clean**
- build: **5/5**
- knip: clean
- version consistency: **22/22**
- `git diff --check`: clean
- commitlint `origin/homolog..HEAD`: clean, including immutable #858 message
- exception boundary: exact #858 message matched once; altered message matched zero ignores; unrelated overlong body still failed
- frozen security diff SHA-256: `94b08e0c829b25f1193e294a911b00839a8294edc8949d78957c304ec730f16a`

## Promotion safety

This PR targets `dev`. The stale homolog promotion #859 was closed and must not be merged. A fresh exact-tree promotion will be created only after this repair lands and its version workflow settles.
