### PR TITLE
chore(release): promote dev v2.260719.4 to homolog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "author": {
         "name": "Automagik"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260718.4",
+      "version": "2.260718.6",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260719.1",
+      "version": "2.260719.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260719.3",
+      "version": "2.260719.4",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260718.6",
+      "version": "2.260719.1",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260719.2",
+      "version": "2.260719.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -30,6 +30,15 @@ export default {
     // Source commits passed commitlint before merge; ignore this exact accepted merge commit
     // so environment promotions can preserve dev ancestry without rewriting history.
     (message: string) => message.startsWith('fix(api): enforce effective instance authority ceiling (#852)'),
+    // PR #858 merge body was supplied through the GitHub merge API as one immutable
+    // over-100-character line. Match the complete accepted message only.
+    (message: string) =>
+      message.trimEnd() ===
+      [
+        'fix(api): require strict instance authority inputs (#858)',
+        '',
+        'Make authority-helper inputs non-undefined and validate the broad runtime caller context before enforcement.',
+      ].join('\n'),
     // Immutable khal-ui promotion commits with >100-char headers/body lines.
     (message: string) => message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -26,6 +26,10 @@ export default {
       message.startsWith(
         'feat(api): console-viewer/operator/admin key profiles + mint scope ceiling (OSS backend of #829) (#831)',
       ),
+    // PR #852 merge body: GitHub generated an immutable 135-character line.
+    // Source commits passed commitlint before merge; ignore this exact accepted merge commit
+    // so environment promotions can preserve dev ancestry without rewriting history.
+    (message: string) => message.startsWith('fix(api): enforce effective instance authority ceiling (#852)'),
     // Immutable khal-ui promotion commits with >100-char headers/body lines.
     (message: string) => message.startsWith('fix(deps): pin @types/react 18 hoist fallback'),
   ],

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260719.3"
+appVersion: "2.260719.4"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260719.2"
+appVersion: "2.260719.3"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260718.6"
+appVersion: "2.260719.1"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260719.1"
+appVersion: "2.260719.2"
 keywords:
   - omni
   - messaging

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260718.4"
+appVersion: "2.260718.6"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/__tests__/api-key-enforcement.test.ts
+++ b/packages/api/src/__tests__/api-key-enforcement.test.ts
@@ -246,6 +246,68 @@ describeWithDb('API Key Enforcement', () => {
   });
 
   // ============================================================================
+  // Atomic authority-bearing updates
+  // ============================================================================
+
+  describe('ApiKeyService.updateWithAuthorityGuard()', () => {
+    test('serializes concurrent partial authority updates on the same key', async () => {
+      const created = await apiKeyService.create({
+        name: `authority-race-${Date.now()}`,
+        scopes: ['keys:write'],
+        instanceIds: ['11111111-1111-4111-8111-111111111111'],
+      });
+      cleanupIds.keys.push(created.key.id);
+
+      let releaseFirst!: () => void;
+      const firstMayCommit = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let firstGuardEntered!: () => void;
+      const firstIsLocked = new Promise<void>((resolve) => {
+        firstGuardEntered = resolve;
+      });
+
+      const firstUpdate = apiKeyService.updateWithAuthorityGuard(
+        created.key.id,
+        { scopes: ['messages:send'] },
+        async () => {
+          firstGuardEntered();
+          await firstMayCommit;
+          return true;
+        },
+      );
+
+      await firstIsLocked;
+
+      let secondGuardScopes: string[] | undefined;
+      const secondUpdate = apiKeyService.updateWithAuthorityGuard(
+        created.key.id,
+        { instanceIds: ['22222222-2222-4222-8222-222222222222'] },
+        (_current, next) => {
+          secondGuardScopes = next.scopes;
+          return !next.scopes.includes('messages:send');
+        },
+      );
+
+      // The second guard must not run against the stale row while the first
+      // transaction holds its lock.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(secondGuardScopes).toBeUndefined();
+
+      releaseFirst();
+      const [firstResult, secondResult] = await Promise.all([firstUpdate, secondUpdate]);
+
+      expect(firstResult.status).toBe('updated');
+      expect(secondResult.status).toBe('denied');
+      expect(secondGuardScopes).toEqual(['messages:send']);
+
+      const final = await apiKeyService.getById(created.key.id);
+      expect(final?.scopes).toEqual(['messages:send']);
+      expect(final?.instanceIds).toEqual(['11111111-1111-4111-8111-111111111111']);
+    });
+  });
+
+  // ============================================================================
   // API Key validation with IP
   // ============================================================================
 

--- a/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-console-profiles.test.ts
@@ -57,6 +57,10 @@ function mountKeysRoutes(): { app: Hono<{ Variables: AppVariables }>; created: C
       scopes: ['*'],
       instanceIds: null,
       expiresAt: null,
+      profile: null,
+      chatAllowlist: [],
+      instanceAllowlist: [],
+      outboundRecipientAllowlist: [],
     } as never);
     await next();
   });

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -891,8 +891,20 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     expect(updated).toEqual([{ id: 'target', scopes: ['*'] }]);
   });
 
-  test('metadata-only updates remain allowed for an instance-restricted keys:write caller', async () => {
+  test('restricted caller cannot metadata-only update an unrestricted target key', async () => {
     const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('metadata-only updates remain allowed when the target is within the caller instance authority', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      targetInstanceIds: [INSTANCE_A],
+    });
 
     const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
 

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -68,6 +68,10 @@ interface MountOptions {
   callerProfile?: ApiKeyData['profile'];
   /** Profile-aware instance ceiling carried by the authenticated caller. */
   callerInstanceAllowlist?: string[];
+  /** Simulate malformed runtime context with the caller profile missing. */
+  omitCallerProfile?: boolean;
+  /** Simulate malformed runtime context with the caller instance allowlist missing. */
+  omitCallerInstanceAllowlist?: boolean;
   /** Persisted target scopes retained when PATCH omits scopes. */
   targetScopes?: string[];
   /** Persisted target profile used to derive post-PATCH effective authority. */
@@ -145,9 +149,9 @@ function mount(
       scopes: callerScopes,
       instanceIds: options.callerInstanceIds ?? null,
       expiresAt: null,
-      profile: options.callerProfile ?? null,
+      profile: options.omitCallerProfile ? undefined : (options.callerProfile ?? null),
       chatAllowlist: [],
-      instanceAllowlist: options.callerInstanceAllowlist ?? [],
+      instanceAllowlist: options.omitCallerInstanceAllowlist ? undefined : (options.callerInstanceAllowlist ?? []),
       outboundRecipientAllowlist: [],
     } as never);
     const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
@@ -471,6 +475,38 @@ describe('POST /keys — mint scope ceiling', () => {
 
       const { status } = await postKey(app, {
         name: 'deny-all-child-from-malformed-caller',
+        scopes: ['*'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing caller profile fails closed instead of becoming unrestricted', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        omitCallerProfile: true,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'child-from-missing-profile-context',
+        scopes: ['*'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing caller instance allowlist fails closed instead of becoming unrestricted', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        omitCallerInstanceAllowlist: true,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'child-from-missing-allowlist-context',
         scopes: ['*'],
         instanceIds: [],
       });

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -30,9 +30,11 @@
  */
 
 import { describe, expect, mock, test } from 'bun:test';
+import type { ApiKey } from '@omni/db';
 import { Hono } from 'hono';
 import { CONSOLE_ADMIN_SCOPES } from '../../../constants/profiles';
 import { scopeEnforcerMiddleware } from '../../../middleware/scope-enforcer';
+import type { ApiKeyAuthorityGuard, UpdateApiKeyOptions } from '../../../services/api-keys';
 import type { ApiKeyData, AppVariables } from '../../../types';
 import { keysRoutes } from '../keys';
 
@@ -66,6 +68,8 @@ interface MountOptions {
   callerProfile?: ApiKeyData['profile'];
   /** Profile-aware instance ceiling carried by the authenticated caller. */
   callerInstanceAllowlist?: string[];
+  /** Persisted target scopes retained when PATCH omits scopes. */
+  targetScopes?: string[];
   /** Persisted target profile used to derive post-PATCH effective authority. */
   targetProfile?: ApiKeyData['profile'];
   /** Persisted target legacy restriction used when PATCH omits instanceIds. */
@@ -104,10 +108,28 @@ function mount(
           updated.push(row);
           return row;
         }),
+        updateWithAuthorityGuard: mock(
+          async (id: string, updateOptions: UpdateApiKeyOptions, guard: ApiKeyAuthorityGuard) => {
+            const current = {
+              id,
+              name: 'target',
+              scopes: options.targetScopes ?? ['keys:write'],
+              instanceIds: options.targetInstanceIds ?? null,
+              profile: options.targetProfile ?? null,
+              instanceAllowlist: options.targetInstanceAllowlist ?? [],
+            } as ApiKey;
+            const next = { ...current, ...updateOptions } as ApiKey;
+            if (!(await guard(current, next))) return { status: 'denied' as const };
+
+            const row = { id, ...updateOptions } as UpdatedKey;
+            updated.push(row);
+            return { status: 'updated' as const, key: next };
+          },
+        ),
         getById: mock(async (id: string) => ({
           id,
           name: 'target',
-          scopes: ['keys:write'],
+          scopes: options.targetScopes ?? ['keys:write'],
           instanceIds: options.targetInstanceIds ?? null,
           expiresAt: null,
           profile: options.targetProfile ?? null,
@@ -595,6 +617,76 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
 
     expect(status).toBe(200);
     expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('legacy-restricted caller cannot change scopes on an unrestricted target key', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      targetInstanceIds: null,
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['keys:write'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('profile-restricted caller cannot change scopes on a target outside its instance authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_B],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['keys:write'] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('instance-only PATCH cannot activate retained scopes the caller does not hold', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      targetScopes: ['messages:send'],
+      targetInstanceIds: [],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('legacy-restricted caller can change scopes on a target within its instance authority', async () => {
+    const { app, updated } = mount(['keys:write', 'chats:read'], undefined, {
+      callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+      targetInstanceIds: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['chats:read'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['chats:read'] }]);
+  });
+
+  test('profile-restricted caller can change scopes on a target within its instance authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { scopes: ['keys:write'] });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', scopes: ['keys:write'] }]);
   });
 
   test('restricted caller cannot update a key to unrestricted instance access', async () => {

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -17,9 +17,12 @@
  *   - The ceiling applies to the non-profile create branch (raw `scopes`), the
  *     profile create branch (resolved profile scopes), and PATCH updates, so a
  *     bounded caller cannot escalate through any key-management write path.
- *   - Instance access is bounded independently: an unrestricted caller may
- *     grant any `instanceIds`, while a restricted caller may grant only a
- *     subset and may not use create omission or explicit `null` to grant all.
+ *   - Instance access is bounded on every enforcement surface: route-specific
+ *     legacy `instanceIds`, profile-aware `instanceAllowlist`, and routes where
+ *     both restrictions intersect. The ceiling also accounts for historical
+ *     routes that treat an empty legacy list as inactive. Unrestricted
+ *     authority, contradictory restrictions, malformed context, and UUID case
+ *     differences must not bypass any ceiling.
  *
  * These tests mount the REAL `scopeEnforcerMiddleware` in front of the REAL
  * keys routes (the existing mint tests omit it — reviewer LOW-2), so the proof
@@ -30,17 +33,19 @@ import { describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import { CONSOLE_ADMIN_SCOPES } from '../../../constants/profiles';
 import { scopeEnforcerMiddleware } from '../../../middleware/scope-enforcer';
-import type { AppVariables } from '../../../types';
+import type { ApiKeyData, AppVariables } from '../../../types';
 import { keysRoutes } from '../keys';
 
 const INSTANCE_A = '11111111-1111-4111-8111-111111111111';
 const INSTANCE_B = '22222222-2222-4222-8222-222222222222';
+const INSTANCE_CASED = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 interface CreatedKey {
   name: string;
   scopes: string[];
   profile?: string | null;
   instanceIds?: string[];
+  instanceAllowlist?: string[];
 }
 
 interface UpdatedKey {
@@ -57,6 +62,16 @@ interface MountOptions {
   withScopeEnforcer?: boolean;
   /** Legacy instance-access ceiling carried by the authenticated caller. */
   callerInstanceIds?: string[] | null;
+  /** Profile whose lock semantics apply to the authenticated caller. */
+  callerProfile?: ApiKeyData['profile'];
+  /** Profile-aware instance ceiling carried by the authenticated caller. */
+  callerInstanceAllowlist?: string[];
+  /** Persisted target profile used to derive post-PATCH effective authority. */
+  targetProfile?: ApiKeyData['profile'];
+  /** Persisted target legacy restriction used when PATCH omits instanceIds. */
+  targetInstanceIds?: string[] | null;
+  /** Persisted target profile-aware restriction retained across PATCH. */
+  targetInstanceAllowlist?: string[];
 }
 
 /**
@@ -89,6 +104,17 @@ function mount(
           updated.push(row);
           return row;
         }),
+        getById: mock(async (id: string) => ({
+          id,
+          name: 'target',
+          scopes: ['keys:write'],
+          instanceIds: options.targetInstanceIds ?? null,
+          expiresAt: null,
+          profile: options.targetProfile ?? null,
+          chatAllowlist: [],
+          instanceAllowlist: options.targetInstanceAllowlist ?? [],
+          outboundRecipientAllowlist: [],
+        })),
       },
     } as never);
     c.set('apiKey', {
@@ -97,9 +123,9 @@ function mount(
       scopes: callerScopes,
       instanceIds: options.callerInstanceIds ?? null,
       expiresAt: null,
-      profile: null,
+      profile: options.callerProfile ?? null,
       chatAllowlist: [],
-      instanceAllowlist: [],
+      instanceAllowlist: options.callerInstanceAllowlist ?? [],
       outboundRecipientAllowlist: [],
     } as never);
     const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
@@ -276,6 +302,161 @@ describe('POST /keys — mint scope ceiling', () => {
   });
 
   describe('instance access ceiling', () => {
+    test('instanceAllowlist-restricted caller cannot mint an unrestricted legacy key', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status, json } = await postKey(app, { name: 'unrestricted-child', scopes: ['*'] });
+
+      expect(status).toBe(403);
+      expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+      expect(created).toHaveLength(0);
+    });
+
+    test('instanceAllowlist-restricted caller cannot mint a profile key for another instance', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'cross-instance-child',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('instanceAllowlist-restricted caller can mint a profile key for its own instance', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'same-instance-child',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+      expect(created[0]?.instanceAllowlist).toEqual([INSTANCE_A]);
+    });
+
+    test('caller authority is the intersection of instanceIds and instanceAllowlist', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'outside-effective-intersection',
+        scopes: ['*'],
+        instanceIds: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('contradictory child restrictions cannot hide broader profile authority behind an empty intersection', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'split-authority-child',
+        profile: 'personal',
+        instanceIds: [INSTANCE_A],
+        instanceAllowlist: [INSTANCE_B],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('contradictory child restrictions cannot hide broader legacy authority behind an empty intersection', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: [INSTANCE_A],
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'split-legacy-authority-child',
+        profile: 'personal',
+        instanceIds: [INSTANCE_B],
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('profile-locked caller cannot delegate through legacy instanceIds alone', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'legacy-only-child',
+        scopes: ['*'],
+        instanceIds: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('UUID case differences are normalized before authority comparison', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'personal',
+        callerInstanceAllowlist: [INSTANCE_CASED.toUpperCase()],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'same-instance-different-case-child',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_CASED],
+      });
+
+      expect(status).toBe(201);
+      expect(created).toHaveLength(1);
+    });
+
+    test('malformed caller instance context fails closed even for a deny-all child', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerInstanceIds: 'malformed' as never,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'deny-all-child-from-malformed-caller',
+        scopes: ['*'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
     test('restricted caller cannot omit instanceIds and mint an unrestricted legacy key', async () => {
       const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
 
@@ -338,6 +519,19 @@ describe('POST /keys — mint scope ceiling', () => {
       expect(status).toBe(201);
       expect(created).toHaveLength(1);
       expect(created[0]?.instanceIds).toEqual([]);
+    });
+
+    test('restricted caller cannot mint an empty legacy grant that historical routes treat as unrestricted', async () => {
+      const { app, created } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+      const { status } = await postKey(app, {
+        name: 'empty-legacy-compatibility-child',
+        scopes: ['keys:write'],
+        instanceIds: [],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
     });
 
     test('unrestricted caller can still omit instanceIds when minting a key', async () => {
@@ -413,6 +607,97 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     expect(updated).toHaveLength(0);
   });
 
+  test('instanceAllowlist-restricted caller cannot make a legacy target unrestricted', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status, json } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(403);
+    expect((json as { error?: { code?: string } }).error?.code).toBe('FORBIDDEN');
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH retains the target profile lock when deriving its effective authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', instanceIds: null }]);
+  });
+
+  test('PATCH rejects a target profile lock outside the caller effective authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_B],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: null });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH cannot hide an outside profile lock behind a contradictory legacy restriction', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerInstanceIds: [INSTANCE_A, INSTANCE_B],
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_B],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH cannot hide an outside legacy grant behind the caller profile lock', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerInstanceIds: [INSTANCE_A],
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'personal',
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_B] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('PATCH cannot replace a required profile lock with legacy restriction alone', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'personal',
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: null,
+      targetInstanceAllowlist: [],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [INSTANCE_A] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
   test('restricted caller cannot update a key to an instance it cannot access', async () => {
     const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
 
@@ -440,6 +725,15 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
 
     expect(status).toBe(200);
     expect(updated).toEqual([{ id: 'target', instanceIds: [] }]);
+  });
+
+  test('restricted caller cannot PATCH an empty legacy grant that historical routes treat as unrestricted', async () => {
+    const { app, updated } = mount(['keys:write'], undefined, { callerInstanceIds: [INSTANCE_A] });
+
+    const { status } = await patchKey(app, 'target', { instanceIds: [] });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
   });
 
   test('unrestricted caller can update a key to unrestricted instance access', async () => {

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -10,9 +10,10 @@ import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 import { ProfileResolutionError, type ResolveProfileInput, resolveProfile } from '../../lib/resolve-profile';
 import { readSignedHostScopeContext } from '../../lib/signed-host-scope-context';
+import { isLockActive } from '../../middleware/scope-enforcer';
 import { optionalDateParam } from '../../schemas/date-query';
 import { ApiKeyService } from '../../services/api-keys';
-import type { AppVariables } from '../../types';
+import type { ApiKeyData, AppVariables } from '../../types';
 
 export const keysRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -37,6 +38,7 @@ const NON_ADMIN_PROFILES = [
   'console-admin',
 ] as const;
 type NonAdminProfile = (typeof NON_ADMIN_PROFILES)[number];
+const KNOWN_API_KEY_PROFILES = new Set<string>(['admin', ...NON_ADMIN_PROFILES]);
 
 // ============================================================================
 // SCHEMAS
@@ -221,26 +223,114 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
   );
 }
 
+/** `null` is unrestricted; an empty Set is an active deny-all restriction. */
+interface InstanceAuthorityInput {
+  instanceIds: readonly string[] | null;
+  profile?: ApiKeyData['profile'];
+  instanceAllowlist?: readonly string[];
+}
+
+type InstanceAuthority = ReadonlySet<string> | null;
+
+interface DerivedInstanceAuthorities {
+  /** Authority on routes guarded only by the route-specific legacy guard. */
+  legacy: InstanceAuthority;
+  /** Authority on historical legacy routes that skip checks for an empty list. */
+  legacyEmptyInactive: InstanceAuthority;
+  /** Authority on routes where both legacy and profile-aware guards apply. */
+  effective: InstanceAuthority;
+  /** Authority on routes guarded only by the global profile-aware enforcer. */
+  profileAware: InstanceAuthority;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function normalizeInstanceIds(values: readonly string[]): ReadonlySet<string> {
+  // PostgreSQL uuid/uuid[] values are case-insensitive and persist in canonical
+  // lowercase form. Compare the same canonical representation before writing.
+  return new Set(values.map((value) => value.toLowerCase()));
+}
+
+function intersectAuthorities(left: InstanceAuthority, right: InstanceAuthority): InstanceAuthority {
+  if (left === null) return right;
+  if (right === null) return left;
+  return new Set([...left].filter((instanceId) => right.has(instanceId)));
+}
+
+function deriveInstanceAuthorities(input: InstanceAuthorityInput): DerivedInstanceAuthorities | null {
+  // Context is runtime data despite its TypeScript type. Any malformed field is
+  // invalid rather than unrestricted so the write path fails closed.
+  if (input.instanceIds !== null && !isStringArray(input.instanceIds)) return null;
+  if (input.instanceAllowlist !== undefined && !isStringArray(input.instanceAllowlist)) return null;
+  if (
+    input.profile !== undefined &&
+    input.profile !== null &&
+    (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))
+  ) {
+    return null;
+  }
+
+  const legacy = input.instanceIds === null ? null : normalizeInstanceIds(input.instanceIds);
+  const legacyEmptyInactive = input.instanceIds === null || input.instanceIds.length === 0 ? null : legacy;
+  const instanceAllowlist = input.instanceAllowlist ?? [];
+  const profileAware = isLockActive(input.profile, 'instanceAllowlist', instanceAllowlist)
+    ? normalizeInstanceIds(instanceAllowlist)
+    : null;
+
+  return {
+    legacy,
+    legacyEmptyInactive,
+    effective: intersectAuthorities(legacy, profileAware),
+    profileAware,
+  };
+}
+
+function isAuthoritySubset(requested: InstanceAuthority, allowed: InstanceAuthority): boolean {
+  if (allowed === null) return true;
+  if (requested === null) return false;
+  return [...requested].every((instanceId) => allowed.has(instanceId));
+}
+
 /**
- * Least-privilege ceiling for legacy instance access on key-management writes.
+ * Least-privilege ceiling for instance access on key-management writes.
  *
- * `instanceIds: null` means unrestricted access. A restricted caller may only
- * grant a subset of its own instance IDs; it may not grant `null`, omit the
- * field during creation (which persists as unrestricted), or name an instance
- * outside its own restriction. Missing caller context is denied fail-closed.
+ * Legacy-only, profile-aware-only, and combined guard surfaces all exist. Some
+ * historical legacy routes also skip checks for `instanceIds: []`, while the
+ * canonical helper treats it as deny-all. A single intersection comparison is
+ * therefore insufficient: bound every enforcement interpretation separately.
  */
 function enforceInstanceCeiling(
   c: Context<{ Variables: AppVariables }>,
-  requestedInstanceIds: string[] | null,
+  requestedAuthority: InstanceAuthorityInput,
 ): Response | null {
   const apiKey = c.get('apiKey');
-  if (apiKey?.instanceIds === null) return null;
+  if (!apiKey) {
+    return c.json(
+      {
+        error: {
+          code: 'FORBIDDEN',
+          message: "Cannot grant instance access that exceeds the caller's own.",
+        },
+      },
+      403,
+    );
+  }
+  const callerAuthorities = deriveInstanceAuthorities({
+    instanceIds: apiKey.instanceIds,
+    profile: apiKey.profile,
+    instanceAllowlist: apiKey.instanceAllowlist,
+  });
+  const childAuthorities = deriveInstanceAuthorities(requestedAuthority);
 
   const exceedsCaller =
-    !apiKey ||
-    !Array.isArray(apiKey.instanceIds) ||
-    requestedInstanceIds === null ||
-    requestedInstanceIds.some((instanceId) => !apiKey.instanceIds?.includes(instanceId));
+    callerAuthorities === null ||
+    childAuthorities === null ||
+    !isAuthoritySubset(childAuthorities.legacy, callerAuthorities.legacy) ||
+    !isAuthoritySubset(childAuthorities.legacyEmptyInactive, callerAuthorities.legacyEmptyInactive) ||
+    !isAuthoritySubset(childAuthorities.profileAware, callerAuthorities.profileAware) ||
+    !isAuthoritySubset(childAuthorities.effective, callerAuthorities.effective);
   if (!exceedsCaller) return null;
 
   return c.json(
@@ -275,7 +365,11 @@ async function handleProfileCreate(
     const ceilingDenied = enforceScopeCeiling(c, resolved.scopes);
     if (ceilingDenied) return ceilingDenied;
 
-    const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds ?? null);
+    const instanceCeilingDenied = enforceInstanceCeiling(c, {
+      instanceIds: data.instanceIds ?? null,
+      profile: resolved.profile,
+      instanceAllowlist: resolved.instanceAllowlist,
+    });
     if (instanceCeilingDenied) return instanceCeilingDenied;
 
     const result = await services.apiKeys.create({
@@ -329,7 +423,11 @@ async function handleLegacyCreate(
   const ceilingDenied = enforceScopeCeiling(c, data.scopes);
   if (ceilingDenied) return ceilingDenied;
 
-  const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds ?? null);
+  const instanceCeilingDenied = enforceInstanceCeiling(c, {
+    instanceIds: data.instanceIds ?? null,
+    profile: null,
+    instanceAllowlist: [],
+  });
   if (instanceCeilingDenied) return instanceCeilingDenied;
 
   const result = await services.apiKeys.create({
@@ -399,7 +497,18 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
     if (ceilingDenied) return ceilingDenied;
   }
   if (data.instanceIds !== undefined) {
-    const instanceCeilingDenied = enforceInstanceCeiling(c, data.instanceIds);
+    // instanceAllowlist/profile are immutable through this PATCH route, so read
+    // the target once and derive the authority it will have after applying the
+    // requested legacy restriction.
+    const current = await services.apiKeys.getById(id);
+    if (!current) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+    }
+    const instanceCeilingDenied = enforceInstanceCeiling(c, {
+      instanceIds: data.instanceIds,
+      profile: current.profile,
+      instanceAllowlist: current.instanceAllowlist,
+    });
     if (instanceCeilingDenied) return instanceCeilingDenied;
   }
 

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -225,12 +225,9 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
 
 /** `null` is unrestricted; an empty Set is an active deny-all restriction. */
 interface InstanceAuthorityInput {
-  /** Required property; runtime `undefined` is malformed and fails closed. */
-  instanceIds: readonly string[] | null | undefined;
-  /** Required property; runtime `undefined` is malformed and fails closed. */
-  profile: ApiKeyData['profile'];
-  /** Required property; runtime `undefined` is malformed and fails closed. */
-  instanceAllowlist: readonly string[] | undefined;
+  instanceIds: readonly string[] | null;
+  profile: Exclude<ApiKeyData['profile'], undefined>;
+  instanceAllowlist: readonly string[];
 }
 
 type InstanceAuthority = ReadonlySet<string> | null;
@@ -304,7 +301,7 @@ function enforceInstanceCeiling(
   requestedAuthority: InstanceAuthorityInput,
 ): Response | null {
   const apiKey = c.get('apiKey');
-  if (!apiKey) {
+  if (!apiKey || apiKey.profile === undefined || !isStringArray(apiKey.instanceAllowlist)) {
     return c.json(
       {
         error: {

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -489,34 +489,39 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   const data = c.req.valid('json');
   const services = c.get('services');
 
-  // Updating an existing key is another scope-grant path. Apply the same
-  // least-privilege ceiling as creation so a bounded keys:write caller cannot
-  // PATCH its own (or another) key into a wildcard or broader namespace grant.
-  if (data.scopes) {
-    const ceilingDenied = enforceScopeCeiling(c, data.scopes);
-    if (ceilingDenied) return ceilingDenied;
-  }
-  if (data.instanceIds !== undefined) {
-    // instanceAllowlist/profile are immutable through this PATCH route, so read
-    // the target once and derive the authority it will have after applying the
-    // requested legacy restriction.
-    const current = await services.apiKeys.getById(id);
-    if (!current) {
-      return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
-    }
-    const instanceCeilingDenied = enforceInstanceCeiling(c, {
-      instanceIds: data.instanceIds,
-      profile: current.profile,
-      instanceAllowlist: current.instanceAllowlist,
-    });
-    if (instanceCeilingDenied) return instanceCeilingDenied;
-  }
+  const updateOptions = {
+    ...data,
+    expiresAt: data.expiresAt === null ? null : data.expiresAt ? new Date(data.expiresAt) : undefined,
+  };
 
   try {
-    const updated = await services.apiKeys.update(id, {
-      ...data,
-      expiresAt: data.expiresAt === null ? null : data.expiresAt ? new Date(data.expiresAt) : undefined,
-    });
+    if (data.instanceIds !== undefined || data.scopes !== undefined) {
+      let authorityDenied: Response | null | undefined;
+      const result = await services.apiKeys.updateWithAuthorityGuard(id, updateOptions, (_current, next) => {
+        authorityDenied = enforceScopeCeiling(c, next.scopes);
+        if (authorityDenied) return false;
+
+        authorityDenied = enforceInstanceCeiling(c, {
+          instanceIds: next.instanceIds,
+          profile: next.profile,
+          instanceAllowlist: next.instanceAllowlist,
+        });
+        return authorityDenied == null;
+      });
+
+      if (result.status === 'denied') {
+        return (
+          authorityDenied ??
+          c.json({ error: { code: 'FORBIDDEN', message: 'API key authority exceeds caller authority' } }, 403)
+        );
+      }
+      if (result.status === 'not_found') {
+        return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
+      }
+      return c.json({ data: result.key });
+    }
+
+    const updated = await services.apiKeys.update(id, updateOptions);
 
     if (!updated) {
       return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -225,9 +225,12 @@ function enforceScopeCeiling(c: Context<{ Variables: AppVariables }>, requestedS
 
 /** `null` is unrestricted; an empty Set is an active deny-all restriction. */
 interface InstanceAuthorityInput {
-  instanceIds: readonly string[] | null;
-  profile?: ApiKeyData['profile'];
-  instanceAllowlist?: readonly string[];
+  /** Required property; runtime `undefined` is malformed and fails closed. */
+  instanceIds: readonly string[] | null | undefined;
+  /** Required property; runtime `undefined` is malformed and fails closed. */
+  profile: ApiKeyData['profile'];
+  /** Required property; runtime `undefined` is malformed and fails closed. */
+  instanceAllowlist: readonly string[] | undefined;
 }
 
 type InstanceAuthority = ReadonlySet<string> | null;
@@ -260,23 +263,18 @@ function intersectAuthorities(left: InstanceAuthority, right: InstanceAuthority)
 }
 
 function deriveInstanceAuthorities(input: InstanceAuthorityInput): DerivedInstanceAuthorities | null {
-  // Context is runtime data despite its TypeScript type. Any malformed field is
-  // invalid rather than unrestricted so the write path fails closed.
+  // Context is runtime data despite its TypeScript type. Any missing or
+  // malformed field is invalid rather than unrestricted, so writes fail closed.
   if (input.instanceIds !== null && !isStringArray(input.instanceIds)) return null;
-  if (input.instanceAllowlist !== undefined && !isStringArray(input.instanceAllowlist)) return null;
-  if (
-    input.profile !== undefined &&
-    input.profile !== null &&
-    (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))
-  ) {
+  if (!isStringArray(input.instanceAllowlist)) return null;
+  if (input.profile !== null && (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))) {
     return null;
   }
 
   const legacy = input.instanceIds === null ? null : normalizeInstanceIds(input.instanceIds);
   const legacyEmptyInactive = input.instanceIds === null || input.instanceIds.length === 0 ? null : legacy;
-  const instanceAllowlist = input.instanceAllowlist ?? [];
-  const profileAware = isLockActive(input.profile, 'instanceAllowlist', instanceAllowlist)
-    ? normalizeInstanceIds(instanceAllowlist)
+  const profileAware = isLockActive(input.profile, 'instanceAllowlist', input.instanceAllowlist)
+    ? normalizeInstanceIds(input.instanceAllowlist)
     : null;
 
   return {

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -490,39 +490,29 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
   };
 
   try {
-    if (data.instanceIds !== undefined || data.scopes !== undefined) {
-      let authorityDenied: Response | null | undefined;
-      const result = await services.apiKeys.updateWithAuthorityGuard(id, updateOptions, (_current, next) => {
-        authorityDenied = enforceScopeCeiling(c, next.scopes);
-        if (authorityDenied) return false;
+    let authorityDenied: Response | null | undefined;
+    const result = await services.apiKeys.updateWithAuthorityGuard(id, updateOptions, (_current, next) => {
+      authorityDenied = enforceScopeCeiling(c, next.scopes);
+      if (authorityDenied) return false;
 
-        authorityDenied = enforceInstanceCeiling(c, {
-          instanceIds: next.instanceIds,
-          profile: next.profile,
-          instanceAllowlist: next.instanceAllowlist,
-        });
-        return authorityDenied == null;
+      authorityDenied = enforceInstanceCeiling(c, {
+        instanceIds: next.instanceIds,
+        profile: next.profile,
+        instanceAllowlist: next.instanceAllowlist,
       });
+      return authorityDenied == null;
+    });
 
-      if (result.status === 'denied') {
-        return (
-          authorityDenied ??
-          c.json({ error: { code: 'FORBIDDEN', message: 'API key authority exceeds caller authority' } }, 403)
-        );
-      }
-      if (result.status === 'not_found') {
-        return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
-      }
-      return c.json({ data: result.key });
+    if (result.status === 'denied') {
+      return (
+        authorityDenied ??
+        c.json({ error: { code: 'FORBIDDEN', message: 'API key authority exceeds caller authority' } }, 403)
+      );
     }
-
-    const updated = await services.apiKeys.update(id, updateOptions);
-
-    if (!updated) {
+    if (result.status === 'not_found') {
       return c.json({ error: { code: 'NOT_FOUND', message: 'API key not found' } }, 404);
     }
-
-    return c.json({ data: updated });
+    return c.json({ data: result.key });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     if (message.includes('Cannot rename primary')) {

--- a/packages/api/src/services/api-keys.ts
+++ b/packages/api/src/services/api-keys.ts
@@ -90,6 +90,13 @@ export interface UpdateApiKeyOptions {
   contextMessageId?: string | null;
 }
 
+export type ApiKeyAuthorityGuard = (current: ApiKey, next: ApiKey) => boolean | Promise<boolean>;
+
+export type GuardedApiKeyUpdateResult =
+  | { status: 'updated'; key: ApiKey }
+  | { status: 'not_found' }
+  | { status: 'denied' };
+
 export class ApiKeyService {
   constructor(private db: Database) {}
 
@@ -308,6 +315,57 @@ export class ApiKeyService {
       throw new Error('Cannot rename primary API key');
     }
 
+    const updates = this.buildUpdateValues(options);
+
+    const [updated] = await this.db.update(apiKeys).set(updates).where(eq(apiKeys.id, id)).returning();
+
+    if (updated) {
+      await apiKeyCache.delete(CacheKeys.apiKey(updated.keyHash));
+      log.info('API key updated', { id, fields: Object.keys(options) });
+    }
+
+    return updated ?? null;
+  }
+
+  /**
+   * Atomically update an API key after validating its complete post-update
+   * authority. The target row remains locked from the initial read through the
+   * guard and write, so concurrent partial authority PATCHes cannot compose
+   * against the same stale snapshot.
+   */
+  async updateWithAuthorityGuard(
+    id: string,
+    options: UpdateApiKeyOptions,
+    guard: ApiKeyAuthorityGuard,
+  ): Promise<GuardedApiKeyUpdateResult> {
+    const result = await this.db.transaction(async (tx): Promise<GuardedApiKeyUpdateResult> => {
+      const [current] = await tx.select().from(apiKeys).where(eq(apiKeys.id, id)).limit(1).for('update');
+
+      if (!current) return { status: 'not_found' };
+
+      if (options.name !== undefined && current.name === PRIMARY_KEY_NAME) {
+        throw new Error('Cannot rename primary API key');
+      }
+
+      const updates = this.buildUpdateValues(options);
+      const next = { ...current, ...updates } as ApiKey;
+      if (!(await guard(current, next))) return { status: 'denied' };
+
+      const [updated] = await tx.update(apiKeys).set(updates).where(eq(apiKeys.id, id)).returning();
+      if (!updated) return { status: 'not_found' };
+
+      return { status: 'updated', key: updated };
+    });
+
+    if (result.status === 'updated') {
+      await apiKeyCache.delete(CacheKeys.apiKey(result.key.keyHash));
+      log.info('API key updated', { id, fields: Object.keys(options) });
+    }
+
+    return result;
+  }
+
+  private buildUpdateValues(options: UpdateApiKeyOptions): Record<string, unknown> {
     const updates: Record<string, unknown> = { updatedAt: new Date() };
     if (options.name !== undefined) updates.name = options.name;
     if (options.description !== undefined) updates.description = options.description;
@@ -325,15 +383,7 @@ export class ApiKeyService {
     ) {
       updates.contextUpdatedAt = new Date();
     }
-
-    const [updated] = await this.db.update(apiKeys).set(updates).where(eq(apiKeys.id, id)).returning();
-
-    if (updated) {
-      await apiKeyCache.delete(CacheKeys.apiKey(updated.keyHash));
-      log.info('API key updated', { id, fields: Object.keys(options) });
-    }
-
-    return updated ?? null;
+    return updates;
   }
 
   /**

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260719.3",
+  "version": "2.260719.4",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260718.4",
+  "version": "2.260718.6",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260719.2",
+  "version": "2.260719.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260719.1",
+  "version": "2.260719.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260718.6",
+  "version": "2.260719.1",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Exact-tree promotion

Promote the settled dev release `v2.260719.4` to `homolog` without conflict-side edits.

- **parent 1 (homolog):** `5a639092beae17d0888a4e4fe4bf003b7c70f55d`
- **parent 2 (dev):** `b4b64e0d5de1f7c2e529aade8cd07570fbaf5f0a`
- **promotion commit:** `cd74c00e9d1fa7bbfffa3ff13f17837e1611e431`
- **promotion tree:** `1fa0f6ca2c2bb88ee1292a2fe86cf0308170e71a`
- **dev tree:** `1fa0f6ca2c2bb88ee1292a2fe86cf0308170e71a`
- `git diff HEAD^2 HEAD`: empty

## Included security repair

- all `PATCH /keys/:id` updates use the atomic scope and instance authority guard
- metadata/lifecycle/rate-limit-only requests cannot bypass target authority checks
- required runtime authority context fails closed
- strict non-undefined helper inputs remain enforced
- the exact immutable PR #858 merge message is narrowly exempted from commitlint without weakening unrelated messages

## Verification

- independent frozen-diff reviews: **APPROVED / APPROVED**
- local pre-push typecheck: **21/21**
- local pre-push full suite: **4,318 passed, 327 skipped, 0 failed**
- complete `origin/homolog..HEAD` commitlint range: clean
- exact released dev tree: proven identical

Stale promotion PRs #855, #857, and #859 remain closed and must not be merged.
