### PR TITLE
chore(release): promote dev v2.260719.6 to homolog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260719.4",
+      "version": "2.260719.6",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260719.4"
+appVersion: "2.260719.6"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
+++ b/packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts
@@ -23,6 +23,10 @@
  *     routes that treat an empty legacy list as inactive. Unrestricted
  *     authority, contradictory restrictions, malformed context, and UUID case
  *     differences must not bypass any ceiling.
+ *   - Profile-aware `chatAllowlist` and `outboundRecipientAllowlist` grants are
+ *     independently bounded to the caller. A restricted caller cannot mint an
+ *     unrestricted/legacy child or mutate an out-of-authority target through a
+ *     metadata-only PATCH; malformed caller allowlist context fails closed.
  *
  * These tests mount the REAL `scopeEnforcerMiddleware` in front of the REAL
  * keys routes (the existing mint tests omit it — reviewer LOW-2), so the proof
@@ -47,7 +51,9 @@ interface CreatedKey {
   scopes: string[];
   profile?: string | null;
   instanceIds?: string[];
+  chatAllowlist?: string[];
   instanceAllowlist?: string[];
+  outboundRecipientAllowlist?: string[];
 }
 
 interface UpdatedKey {
@@ -68,10 +74,18 @@ interface MountOptions {
   callerProfile?: ApiKeyData['profile'];
   /** Profile-aware instance ceiling carried by the authenticated caller. */
   callerInstanceAllowlist?: string[];
+  /** Chat ceiling carried by the authenticated caller. */
+  callerChatAllowlist?: string[];
+  /** Outbound-recipient ceiling carried by the authenticated caller. */
+  callerOutboundRecipientAllowlist?: string[];
   /** Simulate malformed runtime context with the caller profile missing. */
   omitCallerProfile?: boolean;
+  /** Simulate malformed runtime context with the caller chat allowlist missing. */
+  omitCallerChatAllowlist?: boolean;
   /** Simulate malformed runtime context with the caller instance allowlist missing. */
   omitCallerInstanceAllowlist?: boolean;
+  /** Simulate malformed runtime context with the caller outbound allowlist missing. */
+  omitCallerOutboundRecipientAllowlist?: boolean;
   /** Persisted target scopes retained when PATCH omits scopes. */
   targetScopes?: string[];
   /** Persisted target profile used to derive post-PATCH effective authority. */
@@ -80,6 +94,10 @@ interface MountOptions {
   targetInstanceIds?: string[] | null;
   /** Persisted target profile-aware restriction retained across PATCH. */
   targetInstanceAllowlist?: string[];
+  /** Persisted target chat restriction retained across PATCH. */
+  targetChatAllowlist?: string[];
+  /** Persisted target outbound-recipient restriction retained across PATCH. */
+  targetOutboundRecipientAllowlist?: string[];
 }
 
 /**
@@ -120,7 +138,9 @@ function mount(
               scopes: options.targetScopes ?? ['keys:write'],
               instanceIds: options.targetInstanceIds ?? null,
               profile: options.targetProfile ?? null,
+              chatAllowlist: options.targetChatAllowlist ?? [],
               instanceAllowlist: options.targetInstanceAllowlist ?? [],
+              outboundRecipientAllowlist: options.targetOutboundRecipientAllowlist ?? [],
             } as ApiKey;
             const next = { ...current, ...updateOptions } as ApiKey;
             if (!(await guard(current, next))) return { status: 'denied' as const };
@@ -137,9 +157,9 @@ function mount(
           instanceIds: options.targetInstanceIds ?? null,
           expiresAt: null,
           profile: options.targetProfile ?? null,
-          chatAllowlist: [],
+          chatAllowlist: options.targetChatAllowlist ?? [],
           instanceAllowlist: options.targetInstanceAllowlist ?? [],
-          outboundRecipientAllowlist: [],
+          outboundRecipientAllowlist: options.targetOutboundRecipientAllowlist ?? [],
         })),
       },
     } as never);
@@ -150,9 +170,11 @@ function mount(
       instanceIds: options.callerInstanceIds ?? null,
       expiresAt: null,
       profile: options.omitCallerProfile ? undefined : (options.callerProfile ?? null),
-      chatAllowlist: [],
+      chatAllowlist: options.omitCallerChatAllowlist ? undefined : (options.callerChatAllowlist ?? []),
       instanceAllowlist: options.omitCallerInstanceAllowlist ? undefined : (options.callerInstanceAllowlist ?? []),
-      outboundRecipientAllowlist: [],
+      outboundRecipientAllowlist: options.omitCallerOutboundRecipientAllowlist
+        ? undefined
+        : (options.callerOutboundRecipientAllowlist ?? []),
     } as never);
     const signedBy = options.signedBy ?? (signedByScopes !== undefined ? 'test-host' : undefined);
     if (signedBy) {
@@ -602,6 +624,177 @@ describe('POST /keys — mint scope ceiling', () => {
       expect(created[0]?.instanceIds).toBeUndefined();
     });
   });
+
+  describe('chat and outbound-recipient ceilings', () => {
+    test('chat-restricted caller cannot mint a child key for another chat', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'cs',
+        callerChatAllowlist: ['chat-a'],
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'cross-chat',
+        profile: 'cs',
+        chatAllowlist: ['chat-b'],
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('chat-restricted caller can mint a child key for a subset of its chats', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'cs',
+        callerChatAllowlist: ['chat-a', 'chat-b'],
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'chat-subset',
+        profile: 'cs',
+        chatAllowlist: ['chat-a'],
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(201);
+      expect(created[0]?.chatAllowlist).toEqual(['chat-a']);
+    });
+
+    test('chat-restricted caller cannot mint a child whose chat lock is inactive', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'cs',
+        callerChatAllowlist: ['chat-a'],
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'unrestricted-chat',
+        profile: 'personal',
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('chat-restricted caller cannot mint an unrestricted legacy child key', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'cs',
+        callerChatAllowlist: ['chat-a'],
+        callerInstanceAllowlist: [INSTANCE_A],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'legacy-chat-escape',
+        scopes: ['keys:write'],
+        instanceIds: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('outbound-restricted caller cannot mint a child key for another recipient', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'scout',
+        callerOutboundRecipientAllowlist: ['owner-a@example.test'],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'cross-recipient',
+        profile: 'scout',
+        owner: 'owner-b@example.test',
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('outbound-restricted caller can mint a child key for its own recipient', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'scout',
+        callerOutboundRecipientAllowlist: ['owner-a@example.test'],
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'recipient-subset',
+        profile: 'scout',
+        owner: 'owner-a@example.test',
+      });
+
+      expect(status).toBe(201);
+      expect(created[0]?.outboundRecipientAllowlist).toEqual(['owner-a@example.test']);
+    });
+
+    test('missing caller chat allowlist fails closed', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'cs',
+        callerInstanceAllowlist: [INSTANCE_A],
+        omitCallerChatAllowlist: true,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'missing-caller-chat-context',
+        profile: 'cs',
+        chatAllowlist: ['chat-a'],
+        instanceAllowlist: [INSTANCE_A],
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('missing caller outbound allowlist fails closed', async () => {
+      const { app, created } = mount(['*'], undefined, {
+        callerProfile: 'scout',
+        omitCallerOutboundRecipientAllowlist: true,
+        withScopeEnforcer: false,
+      });
+
+      const { status } = await postKey(app, {
+        name: 'missing-caller-outbound-context',
+        profile: 'scout',
+        owner: 'owner-a@example.test',
+      });
+
+      expect(status).toBe(403);
+      expect(created).toHaveLength(0);
+    });
+
+    test('unrestricted caller can still mint chat- and recipient-locked profiles', async () => {
+      const { app, created } = mount(['*']);
+
+      expect(
+        (
+          await postKey(app, {
+            name: 'unrestricted-chat-authorizer',
+            profile: 'cs',
+            chatAllowlist: ['chat-a'],
+            instanceAllowlist: [INSTANCE_A],
+          })
+        ).status,
+      ).toBe(201);
+      expect(
+        (
+          await postKey(app, {
+            name: 'unrestricted-recipient-authorizer',
+            profile: 'scout',
+            owner: 'owner-a@example.test',
+          })
+        ).status,
+      ).toBe(201);
+      expect(created).toHaveLength(2);
+    });
+  });
 });
 
 describe('PATCH /keys/:id — update scope ceiling', () => {
@@ -904,6 +1097,57 @@ describe('PATCH /keys/:id — update scope ceiling', () => {
     const { app, updated } = mount(['keys:write'], undefined, {
       callerInstanceIds: [INSTANCE_A],
       targetInstanceIds: [INSTANCE_A],
+    });
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(200);
+    expect(updated).toEqual([{ id: 'target', name: 'renamed-key' }]);
+  });
+
+  test('chat-restricted caller cannot metadata-only update a target outside its chat authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'cs',
+      callerChatAllowlist: ['chat-a'],
+      callerInstanceAllowlist: [INSTANCE_A],
+      targetProfile: 'cs',
+      targetChatAllowlist: ['chat-b'],
+      targetInstanceAllowlist: [INSTANCE_A],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('outbound-restricted caller cannot metadata-only update a target outside its recipient authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'scout',
+      callerOutboundRecipientAllowlist: ['owner-a@example.test'],
+      targetProfile: 'scout',
+      targetOutboundRecipientAllowlist: ['owner-b@example.test'],
+      withScopeEnforcer: false,
+    });
+
+    const { status } = await patchKey(app, 'target', { name: 'renamed-key' });
+
+    expect(status).toBe(403);
+    expect(updated).toHaveLength(0);
+  });
+
+  test('metadata-only update remains allowed when chat and recipient targets are within caller authority', async () => {
+    const { app, updated } = mount(['*'], undefined, {
+      callerProfile: 'cs',
+      callerChatAllowlist: ['chat-a', 'chat-b'],
+      callerInstanceAllowlist: [INSTANCE_A],
+      callerOutboundRecipientAllowlist: ['owner-a@example.test'],
+      targetProfile: 'cs',
+      targetChatAllowlist: ['chat-a'],
+      targetInstanceAllowlist: [INSTANCE_A],
+      targetOutboundRecipientAllowlist: ['owner-a@example.test'],
+      withScopeEnforcer: false,
     });
 
     const { status } = await patchKey(app, 'target', { name: 'renamed-key' });

--- a/packages/api/src/routes/v2/keys.ts
+++ b/packages/api/src/routes/v2/keys.ts
@@ -288,6 +288,78 @@ function isAuthoritySubset(requested: InstanceAuthority, allowed: InstanceAuthor
   return [...requested].every((instanceId) => allowed.has(instanceId));
 }
 
+interface ProfileAllowlistAuthorityInput {
+  profile: Exclude<ApiKeyData['profile'], undefined>;
+  chatAllowlist: readonly string[];
+  outboundRecipientAllowlist: readonly string[];
+}
+
+interface ProfileAllowlistAuthorities {
+  chat: InstanceAuthority;
+  outboundRecipient: InstanceAuthority;
+}
+
+function deriveProfileAllowlistAuthorities(input: ProfileAllowlistAuthorityInput): ProfileAllowlistAuthorities | null {
+  if (!isStringArray(input.chatAllowlist) || !isStringArray(input.outboundRecipientAllowlist)) return null;
+  if (input.profile !== null && (typeof input.profile !== 'string' || !KNOWN_API_KEY_PROFILES.has(input.profile))) {
+    return null;
+  }
+
+  return {
+    chat: isLockActive(input.profile, 'chatAllowlist', input.chatAllowlist) ? new Set(input.chatAllowlist) : null,
+    outboundRecipient: isLockActive(input.profile, 'outboundRecipientAllowlist', input.outboundRecipientAllowlist)
+      ? new Set(input.outboundRecipientAllowlist)
+      : null,
+  };
+}
+
+/** Bound profile-aware chat and outbound-recipient reach on every key write. */
+function enforceProfileAllowlistCeilings(
+  c: Context<{ Variables: AppVariables }>,
+  requestedAuthority: ProfileAllowlistAuthorityInput,
+): Response | null {
+  const apiKey = c.get('apiKey');
+  if (
+    !apiKey ||
+    apiKey.profile === undefined ||
+    !isStringArray(apiKey.chatAllowlist) ||
+    !isStringArray(apiKey.outboundRecipientAllowlist)
+  ) {
+    return c.json(
+      {
+        error: {
+          code: 'FORBIDDEN',
+          message: "Cannot grant chat or recipient access that exceeds the caller's own.",
+        },
+      },
+      403,
+    );
+  }
+
+  const callerAuthorities = deriveProfileAllowlistAuthorities({
+    profile: apiKey.profile,
+    chatAllowlist: apiKey.chatAllowlist,
+    outboundRecipientAllowlist: apiKey.outboundRecipientAllowlist,
+  });
+  const childAuthorities = deriveProfileAllowlistAuthorities(requestedAuthority);
+  const exceedsCaller =
+    callerAuthorities === null ||
+    childAuthorities === null ||
+    !isAuthoritySubset(childAuthorities.chat, callerAuthorities.chat) ||
+    !isAuthoritySubset(childAuthorities.outboundRecipient, callerAuthorities.outboundRecipient);
+
+  if (!exceedsCaller) return null;
+  return c.json(
+    {
+      error: {
+        code: 'FORBIDDEN',
+        message: "Cannot grant chat or recipient access that exceeds the caller's own.",
+      },
+    },
+    403,
+  );
+}
+
 /**
  * Least-privilege ceiling for instance access on key-management writes.
  *
@@ -367,6 +439,13 @@ async function handleProfileCreate(
     });
     if (instanceCeilingDenied) return instanceCeilingDenied;
 
+    const allowlistCeilingDenied = enforceProfileAllowlistCeilings(c, {
+      profile: resolved.profile,
+      chatAllowlist: resolved.chatAllowlist,
+      outboundRecipientAllowlist: resolved.outboundRecipientAllowlist,
+    });
+    if (allowlistCeilingDenied) return allowlistCeilingDenied;
+
     const result = await services.apiKeys.create({
       name: data.name,
       description: data.description,
@@ -424,6 +503,13 @@ async function handleLegacyCreate(
     instanceAllowlist: [],
   });
   if (instanceCeilingDenied) return instanceCeilingDenied;
+
+  const allowlistCeilingDenied = enforceProfileAllowlistCeilings(c, {
+    profile: null,
+    chatAllowlist: [],
+    outboundRecipientAllowlist: [],
+  });
+  if (allowlistCeilingDenied) return allowlistCeilingDenied;
 
   const result = await services.apiKeys.create({
     name: data.name,
@@ -499,6 +585,13 @@ keysRoutes.patch('/:id', zValidator('json', updateKeySchema), async (c) => {
         instanceIds: next.instanceIds,
         profile: next.profile,
         instanceAllowlist: next.instanceAllowlist,
+      });
+      if (authorityDenied) return false;
+
+      authorityDenied = enforceProfileAllowlistCeilings(c, {
+        profile: next.profile,
+        chatAllowlist: next.chatAllowlist,
+        outboundRecipientAllowlist: next.outboundRecipientAllowlist,
       });
       return authorityDenied == null;
     });

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260719.4",
+  "version": "2.260719.6",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Promotion contract

- Source release: `dev` / `v2.260719.6` (`40d41115c66d7cdbd17e6f86affc20d4a1e5c400`)
- Destination base: `homolog` / `v2.260719.5` (`2fa41d0db4fe512e98e0d59ab7709d32decf87fe`)
- Immutable promotion merge: `92f441f382481fdf61843df64b0c2f66aacbbe3b`
- Exact source tree: `0c6c1889e8dec376bc3a1917ce29a2a5d1db165d`
- Parent 1 = homolog base; parent 2 = released dev source
- `git diff HEAD^2 HEAD` is empty; no conflict-side edits

## Included repair

- Closes the API-key delegation escalation gap for `chatAllowlist` and `outboundRecipientAllowlist` across profile create, legacy create, and atomic partial/metadata-only PATCH.
- Malformed caller authority context fails closed.
- Two independent frozen-commit security reviews approved the repair before merge to dev.

## Verification

- `bun install --frozen-lockfile`
- `bun test packages/api/src/routes/v2/__tests__/keys-mint-ceiling.test.ts` — 68 pass, 0 fail
- `bun test packages apps/ui` — 4,330 pass, 327 skip, 0 fail
- `bun run typecheck`
- `bun run lint` — 1,364 files clean
- `bun run build`
- `bun run verify:versions` — 22/22 at 2.260719.6
- `bunx knip`
- `bunx commitlint --from origin/homolog --to HEAD --verbose`
- `git diff --check origin/homolog HEAD`

## Release evidence

- npm `@next`: `2.260719.6`
- Signed GitHub prerelease: 12 assets
- Source release workflow: https://github.com/automagik-dev/omni/actions/runs/29673177704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted API-key creation and updates so chat and outbound-recipient permissions cannot exceed the caller’s authority.
  - Malformed or missing permission context now fails closed with a forbidden response.
  - Legacy key operations are subject to the same permission safeguards.

- **Tests**
  - Expanded coverage for profile-aware permission limits, update scenarios, and authority-escape attempts.

- **Release**
  - Updated the application, plugin, package, and deployment versions to `2.260719.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->