### PR TITLE
fix(messages): quoted-reply fallback returns null on same-burst score tie

### DIFF
--- a/packages/api/src/__tests__/unified-messages.test.ts
+++ b/packages/api/src/__tests__/unified-messages.test.ts
@@ -348,6 +348,43 @@ describeWithDb('Unified Messages', () => {
       expect(result?.textContent).toContain('R$ 182,47');
     });
 
+    test('findRecentOutboundBefore returns null when two option cards from the same burst tie', async () => {
+      const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-gupshup-tie-${Date.now()}@g.us`, {
+        chatType: 'dm',
+        channel: 'gupshup',
+      });
+
+      // Two option cards delivered ~1s apart in the same burst: equal scores,
+      // no reliable way to tell which one the customer quoted.
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `card-a-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Opção 1 — Plano Essencial R$ 150,00/mês com coparticipação',
+        platformTimestamp: new Date('2026-06-09T17:51:50.319Z'),
+        isFromMe: true,
+      });
+      await messageService.create({
+        chatId: chat.id,
+        externalId: `card-b-${Date.now()}`,
+        source: 'realtime',
+        messageType: 'text',
+        textContent: 'Opção 2 — Plano Completo R$ 260,00/mês com coparticipação',
+        platformTimestamp: new Date('2026-06-09T17:51:51.646Z'),
+        isFromMe: true,
+      });
+
+      const result = await messageService.findRecentOutboundBefore(
+        chat.id,
+        new Date('2026-06-09T17:56:00.000Z'),
+        'quero esse',
+      );
+
+      // A guessed quote would corrupt the reply context; null lets the agent ask.
+      expect(result).toBeNull();
+    });
+
     test('should filter list by exact externalId only', async () => {
       const externalId = `BAE5EXACT${Date.now()}`;
       const { chat } = await chatService.findOrCreate(testInstanceId, `test-msg-external-${Date.now()}@g.us`, {

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -375,13 +375,34 @@ export class MessageService {
       return value;
     };
 
-    return (
-      rows
-        .map((message) => ({ message, score: score(message) }))
-        .sort(
-          (a, b) => b.score - a.score || b.message.platformTimestamp.getTime() - a.message.platformTimestamp.getTime(),
-        )[0]?.message ?? null
-    );
+    const ranked = rows
+      .map((message) => ({ message, score: score(message) }))
+      .sort(
+        (a, b) => b.score - a.score || b.message.platformTimestamp.getTime() - a.message.platformTimestamp.getTime(),
+      );
+
+    // Ambiguity guard: when two or more candidates tie at the top score AND
+    // were sent moments apart (same burst — e.g. two product cards delivered
+    // back to back), picking the newest is a coin flip: quoting the WRONG card
+    // silently corrupts the reply context downstream (the agent locks onto an
+    // option the customer never chose). Returning null is strictly safer — the
+    // agent sees no quote and asks which option was meant. Ties against much
+    // OLDER messages keep the recency preference (an hours-old duplicate is
+    // almost never the quote target; see the second-precision grace test).
+    const AMBIGUOUS_TIE_WINDOW_MS = 5 * 60_000;
+    const top = ranked[0];
+    if (!top) return null;
+    const ambiguousTie =
+      top.score > 0 &&
+      ranked.some(
+        (entry, index) =>
+          index > 0 &&
+          entry.score === top.score &&
+          Math.abs(top.message.platformTimestamp.getTime() - entry.message.platformTimestamp.getTime()) <=
+            AMBIGUOUS_TIE_WINDOW_MS,
+      );
+    if (ambiguousTie) return null;
+    return top.message;
   }
 
   /** Get multiple messages by external IDs in a single query */


### PR DESCRIPTION
## Problem

When a channel provider's reply payload does not carry a resolvable message id (some providers return empty message-id lists on send, so outbound ids can never be matched), `findRecentOutboundBefore` falls back to ranking recent outbound messages by a content-based score to guess the quoted message.

If two option cards are delivered in the same burst (~1s apart), they tie at the top score and the newest-first tiebreak becomes a coin flip. The resolver then attaches the **wrong card's text** as the quoted context — silently corrupting the reply downstream: the agent locks onto an option the customer never chose. Observed in real testing with two product cards sent back to back; the customer replied to card A and the resolved quote carried card B's text.

## Fix

If the top score ties with another candidate sent within a 5-minute window (same burst), return `null` instead of guessing. No quote context is strictly safer than a wrong one — the agent simply asks which option the customer meant.

Ties against much older messages keep the recency preference (an hours-old duplicate is almost never the quote target — covered by the existing second-precision grace test).

## Tests

- New regression test: two option cards from the same burst tie → resolver returns `null`.
- Existing grace test (old duplicate vs fresh card, 19h apart) still passes — recency preference preserved.
- Full suite: 4242 pass / 0 fail + typecheck clean (pre-push gate).

## Notes

- Follow-up worth considering (separate change): persist provider-side message ids from delivery/status callbacks when available, so id-based resolution works and this fallback is needed less often.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ambiguous outbound message matches.
  * The system now avoids selecting a message when equally relevant options were sent within a short time window, preventing potentially incorrect quoted responses.

* **Tests**
  * Added coverage for closely timed outbound option messages with tied relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->