### PR TITLE
fix(api): sanitize media text before Postgres write (null bytes)

### DIFF
--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -24,6 +24,21 @@ import {
 } from '@omni/db';
 import { and, count, desc, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm';
 
+import { sanitizeText } from '../utils/utf8';
+
+// Pre-processed media text (extraction / vision / transcription) can carry NUL
+// bytes; Postgres text columns reject 0x00, so strip them before any write.
+function sanitizeMediaText(data: Partial<NewMessage>): Partial<NewMessage> {
+  const out: Partial<NewMessage> = { ...data };
+  if (typeof out.transcription === 'string') out.transcription = sanitizeText(out.transcription) ?? '';
+  if (typeof out.imageDescription === 'string') out.imageDescription = sanitizeText(out.imageDescription) ?? '';
+  if (typeof out.videoDescription === 'string') out.videoDescription = sanitizeText(out.videoDescription) ?? '';
+  if (typeof out.documentExtraction === 'string') {
+    out.documentExtraction = sanitizeText(out.documentExtraction) ?? '';
+  }
+  return out;
+}
+
 export interface ListMessagesOptions {
   chatId?: string;
   instanceIds?: string[];
@@ -422,10 +437,10 @@ export class MessageService {
           mediaLocalPath: options.mediaLocalPath,
           mediaMetadata: options.mediaMetadata,
           // Pre-processed content
-          transcription: options.transcription,
-          imageDescription: options.imageDescription,
-          videoDescription: options.videoDescription,
-          documentExtraction: options.documentExtraction,
+          transcription: sanitizeText(options.transcription),
+          imageDescription: sanitizeText(options.imageDescription),
+          videoDescription: sanitizeText(options.videoDescription),
+          documentExtraction: sanitizeText(options.documentExtraction),
           // Reply/Forward
           replyToMessageId: options.replyToMessageId,
           replyToExternalId: options.replyToExternalId,
@@ -545,7 +560,7 @@ export class MessageService {
   async update(id: string, data: Partial<NewMessage>): Promise<Message> {
     const [updated] = await this.db
       .update(messages)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...sanitizeMediaText(data), updatedAt: new Date() })
       .where(eq(messages.id, id))
       .returning();
 
@@ -755,7 +770,7 @@ export class MessageService {
   async updateTranscription(id: string, transcription: string): Promise<Message> {
     const [updated] = await this.db
       .update(messages)
-      .set({ transcription, updatedAt: new Date() })
+      .set({ transcription: sanitizeText(transcription) ?? '', updatedAt: new Date() })
       .where(eq(messages.id, id))
       .returning();
 
@@ -772,7 +787,7 @@ export class MessageService {
   async updateImageDescription(id: string, description: string): Promise<Message> {
     const [updated] = await this.db
       .update(messages)
-      .set({ imageDescription: description, updatedAt: new Date() })
+      .set({ imageDescription: sanitizeText(description) ?? '', updatedAt: new Date() })
       .where(eq(messages.id, id))
       .returning();
 
@@ -789,7 +804,7 @@ export class MessageService {
   async updateVideoDescription(id: string, description: string): Promise<Message> {
     const [updated] = await this.db
       .update(messages)
-      .set({ videoDescription: description, updatedAt: new Date() })
+      .set({ videoDescription: sanitizeText(description) ?? '', updatedAt: new Date() })
       .where(eq(messages.id, id))
       .returning();
 
@@ -806,7 +821,7 @@ export class MessageService {
   async updateDocumentExtraction(id: string, extraction: string): Promise<Message> {
     const [updated] = await this.db
       .update(messages)
-      .set({ documentExtraction: extraction, updatedAt: new Date() })
+      .set({ documentExtraction: sanitizeText(extraction) ?? '', updatedAt: new Date() })
       .where(eq(messages.id, id))
       .returning();
 


### PR DESCRIPTION
## Problem

Processed media content — transcription (Whisper), image/video description (vision), document extraction (pdf-parse) — is written straight to Postgres text columns by `MessageService`. When the extracted text contains a **NUL byte (0x00)** — common in PDF text extraction — the write fails:

```
invalid byte sequence for encoding "UTF8": 0x00
```

`awaitMediaProcessing` then reads the column state as `error`, and the agent-dispatcher hands the agent **`[media processing unavailable]`** instead of the real content. The agent silently never sees the document/image (it replies "I can't view images / media unavailable"), even though vision/extraction succeeded.

The codebase already ships `sanitizeText()` (utils/utf8.ts — it strips NUL bytes because PostgreSQL text columns reject them), but the four media-update methods do not use it.

## Fix

Apply `sanitizeText()` in `updateTranscription`, `updateImageDescription`, `updateVideoDescription`, `updateDocumentExtraction` before the `.set(...)`.

## Verification (built + tested locally, both images)

`PATCH /messages/:id/transcription` with a JSON NUL escape in the body:

| image | HTTP | stored column |
|---|---|---|
| v2.260720.1 (current release) | 500 (invalid byte sequence 0x00) | NULL (write failed) |
| this fix | 200 | "AAABBB" — NUL stripped, no null byte in column |

So media content now reaches the agent instead of the placeholder.

Found while wiring an Agno AgentOS agent to Omni: a PDF whose extracted text contained a NUL byte produced `[media processing unavailable]` despite successful extraction.

