### PR TITLE
fix(gupshup): suppress cross-id duplicate deliveries (relay redelivery + media URL echo)

### DIFF
--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -11,10 +11,10 @@
  * - Reply context extraction
  */
 
-import { describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { GupshupSimplifiedWebhookSchema, handleGupshupWebhook, parseSimplifiedWebhook } from '../handlers/webhooks';
+import { GupshupSimplifiedWebhookSchema, handleGupshupWebhook, parseSimplifiedWebhook, resetCrossIdDedupeState } from '../handlers/webhooks';
 import { GUPSHUP_WEBHOOK_METRIC } from '../observability';
 import type { GupshupPlugin } from '../plugin';
 
@@ -828,5 +828,103 @@ describe('handleGupshupWebhook — simplified payload dispatches like native', (
     expect(received).toHaveLength(1);
     expect(received[0]?.content.text).toBe('oi quero plano');
     expect(logs.filter((l) => l.level === 'warn' && l.message.includes('unrecognized shape'))).toHaveLength(0);
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────
+// Cross-id duplicate suppression
+// ─────────────────────────────────────────────────────────────
+
+describe('Gupshup cross-id duplicate suppression', () => {
+  beforeEach(() => {
+    resetCrossIdDedupeState();
+  });
+
+  function textPayload(id: string, text: string) {
+    return makePayload({
+      type: 'text',
+      text,
+      from: BASE.sender,
+      timestamp: 1776273477,
+      id,
+      raw: { payload: { text } },
+    });
+  }
+
+  it('drops a same-text redelivery under a different external id within the window', async () => {
+    const { plugin, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('gs-entry-1776273477001', 'my daughter is 3 years old')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('wamid.NATIVE_REDELIVERY_001', 'my daughter is 3 years old')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('gs-entry-1776273477001');
+  });
+
+  it('keeps short quick answers even when repeated', async () => {
+    const { plugin, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    await handleGupshupWebhook(makeWebhookRequest(textPayload('gs-entry-1776273477002', 'ok')), plugin, 'inst-gs-xid', undefined, dedupeCache);
+    await handleGupshupWebhook(makeWebhookRequest(textPayload('wamid.SHORT_002', 'ok')), plugin, 'inst-gs-xid', undefined, dedupeCache);
+
+    expect(received).toHaveLength(2);
+  });
+
+  it('keeps different texts from the same chat', async () => {
+    const { plugin, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    await handleGupshupWebhook(makeWebhookRequest(textPayload('gs-entry-1776273477003', 'first message here')), plugin, 'inst-gs-xid', undefined, dedupeCache);
+    await handleGupshupWebhook(makeWebhookRequest(textPayload('wamid.OTHER_003', 'a different message')), plugin, 'inst-gs-xid', undefined, dedupeCache);
+
+    expect(received).toHaveLength(2);
+  });
+
+  it('drops a relay media-URL echo right after a native media message', async () => {
+    const { plugin, received } = makeHandlerHarness();
+    const dedupeCache = createInboundDedupeCache();
+
+    await handleGupshupWebhook(
+      makeWebhookRequest(
+        makePayload({
+          type: 'image',
+          url: 'https://filemanager.gupshup.io/wa/media/972665975453585?download=false',
+          contentType: 'image/jpeg',
+          from: BASE.sender,
+          timestamp: 1776273929,
+          id: 'wamid.MEDIA_NATIVE_004',
+          mediaId: '972665975453585',
+        }),
+      ),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('gs-entry-1776273930111', 'https://filemanager.gupshup.io/wa/media/972665975453585?download=false&fileName=Doc.pdf')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.externalId).toBe('wamid.MEDIA_NATIVE_004');
   });
 });

--- a/packages/channel-gupshup/src/__tests__/webhooks.test.ts
+++ b/packages/channel-gupshup/src/__tests__/webhooks.test.ts
@@ -14,7 +14,12 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { GupshupSimplifiedWebhookSchema, handleGupshupWebhook, parseSimplifiedWebhook, resetCrossIdDedupeState } from '../handlers/webhooks';
+import {
+  GupshupSimplifiedWebhookSchema,
+  handleGupshupWebhook,
+  parseSimplifiedWebhook,
+  resetCrossIdDedupeState,
+} from '../handlers/webhooks';
 import { GUPSHUP_WEBHOOK_METRIC } from '../observability';
 import type { GupshupPlugin } from '../plugin';
 
@@ -831,7 +836,6 @@ describe('handleGupshupWebhook — simplified payload dispatches like native', (
   });
 });
 
-
 // ─────────────────────────────────────────────────────────────
 // Cross-id duplicate suppression
 // ─────────────────────────────────────────────────────────────
@@ -879,8 +883,20 @@ describe('Gupshup cross-id duplicate suppression', () => {
     const { plugin, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
 
-    await handleGupshupWebhook(makeWebhookRequest(textPayload('gs-entry-1776273477002', 'ok')), plugin, 'inst-gs-xid', undefined, dedupeCache);
-    await handleGupshupWebhook(makeWebhookRequest(textPayload('wamid.SHORT_002', 'ok')), plugin, 'inst-gs-xid', undefined, dedupeCache);
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('gs-entry-1776273477002', 'ok')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('wamid.SHORT_002', 'ok')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
 
     expect(received).toHaveLength(2);
   });
@@ -889,8 +905,20 @@ describe('Gupshup cross-id duplicate suppression', () => {
     const { plugin, received } = makeHandlerHarness();
     const dedupeCache = createInboundDedupeCache();
 
-    await handleGupshupWebhook(makeWebhookRequest(textPayload('gs-entry-1776273477003', 'first message here')), plugin, 'inst-gs-xid', undefined, dedupeCache);
-    await handleGupshupWebhook(makeWebhookRequest(textPayload('wamid.OTHER_003', 'a different message')), plugin, 'inst-gs-xid', undefined, dedupeCache);
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('gs-entry-1776273477003', 'first message here')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
+    await handleGupshupWebhook(
+      makeWebhookRequest(textPayload('wamid.OTHER_003', 'a different message')),
+      plugin,
+      'inst-gs-xid',
+      undefined,
+      dedupeCache,
+    );
 
     expect(received).toHaveLength(2);
   });
@@ -917,7 +945,12 @@ describe('Gupshup cross-id duplicate suppression', () => {
       dedupeCache,
     );
     await handleGupshupWebhook(
-      makeWebhookRequest(textPayload('gs-entry-1776273930111', 'https://filemanager.gupshup.io/wa/media/972665975453585?download=false&fileName=Doc.pdf')),
+      makeWebhookRequest(
+        textPayload(
+          'gs-entry-1776273930111',
+          'https://filemanager.gupshup.io/wa/media/972665975453585?download=false&fileName=Doc.pdf',
+        ),
+      ),
       plugin,
       'inst-gs-xid',
       undefined,

--- a/packages/channel-gupshup/src/handlers/webhooks.ts
+++ b/packages/channel-gupshup/src/handlers/webhooks.ts
@@ -460,6 +460,102 @@ export async function handleGupshupWebhook(
 // Inbound message
 // ─────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────
+// Cross-id duplicate suppression
+// ─────────────────────────────────────────────────────────────
+//
+// Some Gupshup routings deliver the same user message twice: once as the
+// native event (wamid external id) and once re-posted by an entry-flow relay
+// under a synthetic id (`gs-entry-<ms>`), typically seconds apart. The
+// id-based dedupe below cannot catch that pair (the ids differ), so the
+// duplicate becomes a second inbound — re-triggering agent processing and
+// superseding a reply still in flight for the first delivery (the first
+// reply is discarded and never reaches the user). Two suppression rules,
+// both scoped to a short window and failing open:
+//
+//   1. Same chat + same normalized text under a different external id.
+//      Texts of <= 3 chars are exempt ("ok"/"yes"-style quick answers repeat
+//      legitimately).
+//   2. A relay text that is just a filemanager media URL arriving right
+//      after a native media message from the same chat (the relay's
+//      "media echo" of an already-delivered attachment).
+
+const CROSS_ID_WINDOW_MS = 60_000;
+const FILEMANAGER_URL_RE = /^https:\/\/filemanager\.gupshup\.io\/\S+$/;
+const recentTextByChat = new Map<string, { ts: number; id: string }>();
+const recentMediaByChat = new Map<string, { ts: number; id: string }>();
+
+/** Test-only: clears the cross-id suppression state between test cases. */
+export function resetCrossIdDedupeState(): void {
+  recentTextByChat.clear();
+  recentMediaByChat.clear();
+}
+
+function pruneExpiredCrossIdEntries(now: number): void {
+  for (const map of [recentTextByChat, recentMediaByChat]) {
+    for (const [key, value] of map) {
+      if (now - value.ts > CROSS_ID_WINDOW_MS * 1.5) map.delete(key);
+    }
+  }
+}
+
+function isRelayMediaEcho(chatKey: string, messageId: string, bodyText: string, now: number): string | null {
+  if (!messageId.startsWith('gs-entry-') || !FILEMANAGER_URL_RE.test(bodyText)) return null;
+  const lastMedia = recentMediaByChat.get(chatKey);
+  if (lastMedia && now - lastMedia.ts <= CROSS_ID_WINDOW_MS) return lastMedia.id;
+  return null;
+}
+
+function isDuplicateTextRedelivery(chatKey: string, messageId: string, bodyText: string, now: number): string | null {
+  const normalized = bodyText.toLowerCase().replace(/\s+/g, ' ');
+  if (normalized.length <= 3) return null; // "ok"/"yes"-style quick answers legitimately repeat
+  const textKey = `${chatKey}:${normalized}`;
+  const prev = recentTextByChat.get(textKey);
+  if (prev && prev.id !== messageId && now - prev.ts <= CROSS_ID_WINDOW_MS) return prev.id;
+  if (!prev || prev.id === messageId) recentTextByChat.set(textKey, { ts: now, id: messageId });
+  return null;
+}
+
+function isCrossIdDuplicate(
+  instanceId: string,
+  msg: { id: string; text?: string; type?: string; raw?: { type?: string } },
+  from: string,
+  logger: import('@omni/core').Logger,
+): boolean {
+  const now = Date.now();
+  pruneExpiredCrossIdEntries(now);
+
+  const chatKey = `${instanceId}:${from.trim()}`;
+  const rawType = msg.type ?? msg.raw?.type ?? '';
+  const bodyText = (msg.text ?? '').trim();
+
+  if (rawType !== 'text' || !bodyText) {
+    if (rawType && rawType !== 'text') recentMediaByChat.set(chatKey, { ts: now, id: msg.id });
+    return false;
+  }
+
+  const echoOf = isRelayMediaEcho(chatKey, msg.id, bodyText, now);
+  if (echoOf) {
+    logger.info('gupshup cross-id dedupe: relay media echo dropped', {
+      instanceId,
+      messageId: msg.id,
+      mediaMessageId: echoOf,
+    });
+    return true;
+  }
+
+  const duplicateOf = isDuplicateTextRedelivery(chatKey, msg.id, bodyText, now);
+  if (duplicateOf) {
+    logger.info('gupshup cross-id dedupe: duplicate content dropped', {
+      instanceId,
+      messageId: msg.id,
+      firstMessageId: duplicateOf,
+    });
+    return true;
+  }
+  return false;
+}
+
 async function processInboundMessage(
   plugin: GupshupPlugin,
   instanceId: string,
@@ -473,6 +569,11 @@ async function processInboundMessage(
   // Dedupe by sender phone + message ID
   const dedupeKey = `${from.trim()}:${msg.id}`;
   if (dedupeCache.isDuplicate(instanceId, dedupeKey, 'gupshup', plugin.getLogger() as import('@omni/core').Logger)) {
+    return false;
+  }
+
+  // Cross-id duplicate suppression (relay redeliveries under synthetic ids).
+  if (isCrossIdDuplicate(instanceId, msg, from, plugin.getLogger() as import('@omni/core').Logger)) {
     return false;
   }
 


### PR DESCRIPTION
Some Gupshup routings deliver the same user message twice: once as the native event (wamid external id) and once re-posted by an entry-flow relay under a synthetic id (`gs-entry-<ms>`), typically a few seconds apart. The id-based dedupe can't catch that pair (the ids differ), so the duplicate becomes a second inbound — re-triggering agent processing and superseding a reply still in flight for the first delivery: the first reply is discarded and never reaches the user, while the agent's history believes it was sent.

This adds a cross-id suppression step in `processInboundMessage`, right after the id-based dedupe. Two rules, both scoped to a 60s window, first-delivery-wins, failing open:

1. **Same-content redelivery** — same chat + same normalized text under a different external id. Texts of ≤3 chars are exempt ("ok"/"yes"-style quick answers legitimately repeat).
2. **Relay media echo** — a synthetic-id (`gs-entry-*`) text that is *only* a filemanager media URL, arriving right after a native media message from the same chat.

State is in-memory per process (two small Maps with TTL pruning), keyed by `instanceId:chat`, with a test-only reset helper.

Tests: 4 new cases in `webhooks.test.ts` (suppression, short-text exemption, distinct texts, media echo). Package suite: 110 pass / 0 fail. `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
