### PR TITLE
fix(api): refuse unrecognised API keys on the voice WebSocket upgrade

### DIFF
--- a/packages/api/src/__tests__/ws-voice-auth.test.ts
+++ b/packages/api/src/__tests__/ws-voice-auth.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for the voice WebSocket upgrade auth decision.
+ *
+ * BUG BEING FIXED: the upgrade handler awaited `ApiKeyService.validate(apiKey)`
+ * inside a try/catch and refused only when the call THREW. But `validate` is
+ * typed `Promise<ValidatedApiKey | null>` and *returns null* — it does not throw
+ * — for an unknown, malformed, expired, or revoked key. An unrecognised key
+ * therefore reached the voice WebSocket and streamed audio. The whole check was
+ * additionally wrapped in `if (globalDbRef)`, so a process with no database ref
+ * skipped authentication entirely.
+ *
+ * These tests pin the refusal contract: only a key that RESOLVES to a live
+ * credential is admitted. Everything else refuses.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { authorizeVoiceApiKey } from '../ws/voice';
+
+describe('authorizeVoiceApiKey', () => {
+  test('admits a key that resolves to a live credential', async () => {
+    const validate = async () => ({ id: 'key-1', name: 'primary', scopes: ['voice'] });
+    expect(await authorizeVoiceApiKey(validate, 'omni_sk_live')).toBe(true);
+  });
+
+  test('REFUSES a key that resolves to null (the original bug — unknown/expired/revoked)', async () => {
+    const validate = async () => null;
+    expect(await authorizeVoiceApiKey(validate, 'omni_sk_unknown')).toBe(false);
+  });
+
+  test('REFUSES when there is no database to consult (validate absent)', async () => {
+    expect(await authorizeVoiceApiKey(null, 'omni_sk_live')).toBe(false);
+  });
+
+  test('refuses when the credential lookup throws', async () => {
+    const validate = async () => {
+      throw new Error('auth store unreachable');
+    };
+    expect(await authorizeVoiceApiKey(validate, 'omni_sk_live')).toBe(false);
+  });
+
+  test('refuses a malformed key — validate returns null on bad prefix, it does not throw', async () => {
+    // Mirrors ApiKeyService.validate's real contract: a key without the
+    // `omni_sk_` prefix short-circuits to null before any hashing or lookup.
+    const validate = async (apiKey: string) => (apiKey.startsWith('omni_sk_') ? { id: 'key-1' } : null);
+    expect(await authorizeVoiceApiKey(validate, 'not-a-real-key')).toBe(false);
+    expect(await authorizeVoiceApiKey(validate, 'omni_sk_good')).toBe(true);
+  });
+
+  test('passes the api key through unmodified to the validator', async () => {
+    const seen: string[] = [];
+    const validate = async (apiKey: string) => {
+      seen.push(apiKey);
+      return { id: 'key-1' };
+    };
+    await authorizeVoiceApiKey(validate, 'omni_sk_exact_value');
+    expect(seen).toEqual(['omni_sk_exact_value']);
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -89,7 +89,7 @@ const PORT = Number.parseInt(process.env.API_PORT ?? '8882', 10);
 const HOST = process.env.API_HOST ?? '0.0.0.0';
 const NATS_URL = process.env.NATS_URL ?? 'nats://localhost:4222';
 
-import { VoiceStreamRegistry, parseVoiceStreamParams, transcodeAudioFrame } from './ws/voice';
+import { VoiceStreamRegistry, authorizeVoiceApiKey, parseVoiceStreamParams, transcodeAudioFrame } from './ws/voice';
 import type { VoiceStreamClient } from './ws/voice';
 
 // Voice stream WebSocket registry (global singleton)
@@ -248,15 +248,18 @@ function startBunServer(app: App) {
           return;
         }
 
-        // Validate API key against the database
-        if (globalDbRef) {
-          try {
-            const apiKeyService = new ApiKeyService(globalDbRef);
-            await apiKeyService.validate(params.apiKey);
-          } catch {
-            ws.close(4004, 'Invalid API key');
-            return;
-          }
+        // Validate API key against the database. The refusal logic lives in
+        // authorizeVoiceApiKey: an invalid key makes ApiKeyService.validate
+        // RESOLVE NULL rather than throw, so the result must be inspected — and
+        // an absent db ref must refuse rather than skip the check entirely.
+        const db = globalDbRef;
+        const authorized = await authorizeVoiceApiKey(
+          db ? (key: string) => new ApiKeyService(db).validate(key) : null,
+          params.apiKey,
+        );
+        if (!authorized) {
+          ws.close(4004, 'Invalid API key');
+          return;
         }
 
         // Validate session exists via VoiceCapable interface

--- a/packages/api/src/ws/voice.ts
+++ b/packages/api/src/ws/voice.ts
@@ -222,3 +222,30 @@ export function parseVoiceStreamParams(url: URL): VoiceStreamParams | null {
 
   return { sessionId, apiKey, format: format === 'pcm' ? 'pcm' : 'opus', filterUserId };
 }
+
+/**
+ * Authorize an API key for a voice WebSocket upgrade.
+ *
+ * `ApiKeyService.validate` resolves to `ValidatedApiKey | null`: it returns
+ * **null** — it does not throw — for an unknown, malformed, expired, or revoked
+ * key, and only throws when the lookup itself fails. Awaiting it without
+ * inspecting the result therefore admits every key that fails politely and
+ * refuses only the ones that fail loudly, which is the opposite of the intent.
+ *
+ * Every unresolvable outcome refuses:
+ * - `validate` absent (no database to consult) — we cannot authenticate, so we
+ *   do not admit. This is a partially-initialized process, not a deployment shape.
+ * - `validate` resolves null — the key is not a live credential.
+ * - `validate` throws — an auth store we cannot consult is not evidence of authority.
+ */
+export async function authorizeVoiceApiKey(
+  validate: ((apiKey: string) => Promise<unknown>) | null,
+  apiKey: string,
+): Promise<boolean> {
+  if (!validate) return false;
+  try {
+    return (await validate(apiKey)) != null;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## The bug

The voice stream WebSocket upgrade authenticated like this:

```ts
if (globalDbRef) {
  try { await apiKeyService.validate(params.apiKey); }
  catch { ws.close(4004, 'Invalid API key'); return; }
}
```

`ApiKeyService.validate` is typed `Promise<ValidatedApiKey | null>` and **resolves null — it does not throw** — for a key that is unknown, malformed, expired, or revoked (`packages/api/src/services/api-keys.ts:140`). Awaiting it without inspecting the result admits every key that fails *politely* and refuses only the ones that fail *loudly*. That inverts the intent: an unrecognised API key reached the voice WebSocket and streamed audio.

There was a **second fail-open path** stacked above it. The whole check sat inside `if (globalDbRef)`, so a process with no database ref skipped authentication entirely. `globalDbRef` is assigned during startup *before* the server accepts connections, so a null there means a partially-initialized process — not a supported deployment shape. It must refuse, not wave the connection through.

## The fix

Both paths now route through `authorizeVoiceApiKey` (`packages/api/src/ws/voice.ts`), which admits only a key that resolves to a live credential and refuses on null, on throw, and on an absent validator.

The close code and message are unchanged (`4004` / `Invalid API key`), so the client contract is untouched and the refusal does not become an existence oracle.

## Why this is standalone rather than part of the multitenancy wish

Found during the `omni-full-multitenancy` G5 review (run10). It ships separately on purpose: the wish's multitenancy enforcement is feature-flagged and **production runs flag-off**, so the wish does not close this for the deployed world.

> [!IMPORTANT]
> **Integration note for the wish merge.** G5 refactors this block into `ws/voice-upgrade-authorization.ts`, whose flag-off branch *intentionally* reproduces the old behaviour (session-existence check only, no credential resolution) to honour its byte-identical invariant — see its own comment at `:48-51`. Merging G5 on top of this commit would therefore **re-open the hole in the flag-off world**. G5's flag-off branch must adopt this refusal at merge time: the legacy baseline it is measured against has changed.

## Verification

**RED→GREEN, mutation-verified.** Reverting `authorizeVoiceApiKey` to the original semantics fails 3 of the 6 new tests (null-resolve, absent-validator, malformed-key); the fix passes 6/6.

| Gate | Result |
|---|---|
| New suite `ws-voice-auth.test.ts` | 6 pass / 0 fail |
| Existing voice suites (`ws-voice`, `voice-routes`) | 21 pass / 0 fail |
| `turbo typecheck --filter=@omni/api` | 9/9 successful |
| `biome check` | clean |
| `knip` | clean |
| `git diff --check` | clean |

Rebased onto `dev` after #866 merged; all gates re-run green on the new base.