### PR TITLE
fix(follow-up): stale-event gate drops legitimate first deliveries

### DIFF
--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -493,11 +493,17 @@ export class FollowUpLifecycleService {
     if (row?.disarmReason) {
       return { skip: true, reason: `disarmed_${row.disarmReason}` };
     }
+    // The sweeper publishes the event carrying the PRE-increment index and then
+    // immediately advances the row (publish(N) → recordFired(N+1)). By the time a
+    // consumer handles the event the row is legitimately one step ahead, so
+    // `row > event` also matches every healthy first-delivery — dropping real
+    // follow-ups in a publish/consume race. Only a gap of 2+ indicates an actual
+    // replay of a historical event, which is what this gate exists to stop.
     if (
       row !== null &&
       typeof eventSequenceIndex === 'number' &&
       typeof row.sequenceIndex === 'number' &&
-      row.sequenceIndex > eventSequenceIndex
+      row.sequenceIndex > eventSequenceIndex + 1
     ) {
       return {
         skip: true,


### PR DESCRIPTION
## Problem

`shouldSkipStaleIdleTimeout` guards against NATS replay of historical `chat.idle_timeout` events by skipping when the row's sequence index is ahead of the event's:

```ts
row.sequenceIndex > eventSequenceIndex
```

But the sweeper publishes the event carrying the **pre-increment** index and then advances the row:

```
publish(chat.idle_timeout, { sequenceIndex: N })  ->  recordFired(N + 1)
```

So by the time the consumer handles the event, the row is legitimately **one step ahead** — and the guard matches every healthy first delivery, not just replays. Under a publish/consume race the follow-up is silently dropped: the counter still advances (the sequence can even reach `sequence_complete`) while no message is ever generated or sent.

## Impact

Observed in a production deployment: **~14% of chats with an armed sequence received zero follow-up messages**. The skip reasons always showed a gap of exactly one:

```
sequence_advanced_row_at_1_event_0: 21
sequence_advanced_row_at_2_event_1: 19
sequence_advanced_row_at_3_event_2: 12
sequence_advanced_row_at_4_event_3:  9
```

## Fix

Only a gap of **2 or more** indicates an actual replay of a historical event, which is what this gate exists to stop. A gap of exactly one is the normal publish/consume ordering.

After applying this in production: race-condition skips dropped to zero, follow-ups resumed being delivered end-to-end, and legitimate skips (`disarmed_*`, `chat_closed`) still work as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)