### PR TITLE
feat: omni full multitenancy — G5 (asynchronous surface conversion)

### DIFF
--- a/packages/api/src/__tests__/scheduler-unread-refresh-tenant.test.ts
+++ b/packages/api/src/__tests__/scheduler-unread-refresh-tenant.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The hourly unread-count-refresh cron's tenant fan-out (G5; ADR-0008).
+ *
+ * This cron is the last SCHEDULER caller that reached `instances.listActive()`
+ * on the ambient pool. Its shape is exactly the one `runForEachActiveTenantRow`
+ * was written for and the two daily sync crons already use: a whole-table
+ * `listActive()` read followed by a per-row side effect that is NOT a database
+ * write (here, an in-process call into the WhatsApp plugin). It needs no open
+ * decision — the fan-out is a pure adoption of the existing precedent.
+ *
+ * What is pinned:
+ *   1. FLAG-OFF IS BYTE-IDENTICAL — one ambient `listActive`, zero auth-plane
+ *      queries, and every active WhatsApp instance refreshed exactly as before.
+ *   2. FLAG-ON ENUMERATES — one scoped `listActive` per ACTIVE tenant, each
+ *      inside that tenant's worker scope, so the read is expressible under RLS.
+ *   3. NO CROSS-TENANT BLEED — an instance owned by tenant B is never refreshed
+ *      during tenant A's pass.
+ *   4. THE CHANNEL FILTER SURVIVES — non-WhatsApp instances are still skipped,
+ *      per tenant.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { __refreshUnreadCountsForTest } from '../scheduler';
+import { MULTITENANCY_FLAG_ENV } from '../tenancy/feature-flag';
+import { currentTenantScope } from '../tenancy/tenant-scope';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+const FLAG_ON: NodeJS.ProcessEnv = { [MULTITENANCY_FLAG_ENV]: 'true' };
+const FLAG_OFF: NodeJS.ProcessEnv = {};
+
+interface StubInstance {
+  id: string;
+  channel: string;
+  tenantId: string | null;
+}
+
+function fakeAuthPlaneDb(ids: string[], counter: { selects: number }): Database {
+  return {
+    select: () => {
+      counter.selects += 1;
+      return { from: () => ({ where: async () => ids.map((id) => ({ id })) }) };
+    },
+  } as unknown as Database;
+}
+
+function fakeScopeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({ execute: async () => [] as unknown }),
+  } as unknown as Database;
+}
+
+function harness(opts: { instances: StubInstance[]; tenants: string[]; env: NodeJS.ProcessEnv }) {
+  const counter = { selects: 0 };
+  const listScopes: Array<string | null> = [];
+  const refreshed: string[] = [];
+
+  const services = {
+    db: fakeScopeDb(),
+    authPlane: { db: fakeAuthPlaneDb(opts.tenants, counter) },
+    instances: {
+      listActive: async () => {
+        listScopes.push(currentTenantScope()?.tenantId ?? null);
+        return opts.instances;
+      },
+    },
+  } as never;
+
+  const channelRegistry = {
+    get: () => ({ refreshUnreadCounts: (id: string) => refreshed.push(id) }),
+  } as never;
+
+  return {
+    run: () => __refreshUnreadCountsForTest(services, channelRegistry, opts.env),
+    counter,
+    listScopes,
+    refreshed,
+  };
+}
+
+describe('unread-count-refresh — flag-off is byte-identical', () => {
+  test('one ambient listActive, no auth-plane query, all WhatsApp instances refreshed', async () => {
+    const h = harness({
+      env: FLAG_OFF,
+      tenants: [TENANT_A],
+      instances: [
+        { id: 'wa-1', channel: 'whatsapp-baileys', tenantId: null },
+        { id: 'wa-2', channel: 'whatsapp-baileys', tenantId: null },
+        { id: 'dc-1', channel: 'discord', tenantId: null },
+      ],
+    });
+
+    const count = await h.run();
+
+    expect(h.counter.selects).toBe(0);
+    expect(h.listScopes).toEqual([null]);
+    expect(h.refreshed).toEqual(['wa-1', 'wa-2']);
+    expect(count).toBe(2);
+  });
+});
+
+describe('unread-count-refresh — tenant world', () => {
+  test('one SCOPED listActive per active tenant', async () => {
+    const h = harness({
+      env: FLAG_ON,
+      tenants: [TENANT_A, TENANT_B],
+      instances: [],
+    });
+
+    await h.run();
+
+    expect(h.counter.selects).toBe(1);
+    // Per-tenant scoped reads plus the transitional NULL-tenant pass.
+    expect(h.listScopes).toEqual([TENANT_A, TENANT_B, null]);
+  });
+
+  test('an instance owned by tenant B is not refreshed during tenant A’s pass', async () => {
+    const h = harness({
+      env: FLAG_ON,
+      tenants: [TENANT_A],
+      instances: [
+        { id: 'wa-a', channel: 'whatsapp-baileys', tenantId: TENANT_A },
+        { id: 'wa-b', channel: 'whatsapp-baileys', tenantId: TENANT_B },
+      ],
+    });
+
+    await h.run();
+
+    expect(h.refreshed).toEqual(['wa-a']);
+  });
+
+  test('the WhatsApp channel filter still applies per tenant', async () => {
+    const h = harness({
+      env: FLAG_ON,
+      tenants: [TENANT_A],
+      instances: [
+        { id: 'wa-a', channel: 'whatsapp-baileys', tenantId: TENANT_A },
+        { id: 'dc-a', channel: 'discord', tenantId: TENANT_A },
+      ],
+    });
+
+    await h.run();
+
+    expect(h.refreshed).toEqual(['wa-a']);
+  });
+
+  test('no WhatsApp plugin registered: nothing runs and no query is issued', async () => {
+    const counter = { selects: 0 };
+    const services = {
+      db: fakeScopeDb(),
+      authPlane: { db: fakeAuthPlaneDb([TENANT_A], counter) },
+      instances: { listActive: async () => [] },
+    } as never;
+    const registryWithoutWhatsApp = { get: () => undefined } as never;
+
+    expect(await __refreshUnreadCountsForTest(services, registryWithoutWhatsApp, FLAG_ON)).toBe(0);
+    expect(counter.selects).toBe(0);
+  });
+});

--- a/packages/api/src/__tests__/tenancy-wiring.test.ts
+++ b/packages/api/src/__tests__/tenancy-wiring.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Composition-root wiring safety net (G5; ADR-0008).
+ *
+ * Three of this leg's conversions are opted into the tenant world by ONE line
+ * each in `index.ts`, and `index.ts` is the one composition root no test can
+ * reach: `main()` and `setupEventBusServices` are module-private, the module
+ * self-invokes `main()` and has import-time side effects (`./instrument`,
+ * `./tracing`, module-scope `configureLogging`), and nothing under `packages/`
+ * imports it. The sibling wirings live in `createServices`, which ~40 test files
+ * exercise through `createApp`; these three do not.
+ *
+ * Deleting any of them compiles cleanly — `AgentHeartbeatStartOptions.db` is
+ * optional, and `services.authPlane`/`globalInstanceMonitor` stay used elsewhere
+ * so no unused-symbol diagnostic fires — while silently reverting the sweep to
+ * the pre-G5 whole-table ambient scan and the heartbeat write to the ambient
+ * pool. The db-access guard cannot see it either: it classifies by {file,table}
+ * and merely NARRATES this wiring inside a justification string.
+ *
+ * So this is a source-scan safety net, the same shape and for the same reason as
+ * `consumer-config.test.ts` (which pins `startFrom` policies by reading the
+ * plugin files). It asserts the wiring EXISTS, not what it does — the behaviour
+ * is pinned by the worker-scope probes, which supply the wiring themselves.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const INDEX_SRC = readFileSync(join(import.meta.dir, '../index.ts'), 'utf-8');
+
+/** Source with `//` line comments stripped, so a commented-out wiring cannot pass. */
+const INDEX_CODE = INDEX_SRC.split('\n')
+  .filter(
+    (line) =>
+      !line.trimStart().startsWith('*') && !line.trimStart().startsWith('//') && !line.trimStart().startsWith('/*'),
+  )
+  .join('\n');
+
+describe('index.ts opts the G5 conversions into the tenant world', () => {
+  test('the instance monitor is handed the auth plane after services exist', () => {
+    // Without this the monitor's `authPlaneDb` stays null and `runHealthCheck`
+    // takes its legacy early-return: the pre-G5 single ambient whole-table scan.
+    expect(INDEX_CODE).toContain('setAuthPlane(services.authPlane.db)');
+    expect(INDEX_CODE.match(/setAuthPlane\(services\.authPlane\.db\)/g)?.length).toBe(1);
+  });
+
+  test('the boot reconnect is given an auth-plane handle for its tenant enumeration', () => {
+    // `reconnectWithPool` runs before `createApp`, so `services.authPlane` does
+    // not exist yet; a short-lived handle is resolved for exactly this sweep.
+    expect(INDEX_CODE).toContain('authPlaneDb: bootAuthPlane.db');
+    expect(INDEX_CODE).toContain('resolveAuthPlaneConnection(db)');
+  });
+
+  test('the agent-heartbeat consumer is given a db handle', () => {
+    // `db` is OPTIONAL on `AgentHeartbeatStartOptions`; without it
+    // `recordHeartbeatActivity` short-circuits to the bare ambient
+    // `turnService.recordActivity` — the pre-G5 write.
+    const call = INDEX_CODE.match(/initAgentHeartbeat\(\{[^}]*\}\)/s)?.[0];
+    expect(call).toBeDefined();
+    expect(call).toContain('db: services.db');
+  });
+});

--- a/packages/api/src/__tests__/voice-instance-ownership.test.ts
+++ b/packages/api/src/__tests__/voice-instance-ownership.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The voice upgrade's ownership read — G5 deliverable (e).
+ *
+ * Pins the two properties `authorizeVoiceUpgrade` depends on: the read happens
+ * INSIDE a worker tenant scope for the credential's tenant (so RLS polices it
+ * under enforcement, and it is detached from any inherited request scope), and a
+ * miss resolves to `null` — never to "owned".
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../tenancy/tenant-scope';
+import { resolveInstanceTenantId } from '../ws/voice-instance-ownership';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+/**
+ * A Database whose `transaction` runs the callback against a handle that
+ * answers the select chain from `rows`, recording the tenant scope in force at
+ * the moment of the read.
+ */
+function fakeDb(rows: { tenantId: string }[], observed: { tenantId?: string | null }): Database {
+  const handle = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => {
+            observed.tenantId = currentTenantScope()?.tenantId ?? null;
+            return Promise.resolve(rows);
+          },
+        }),
+      }),
+    }),
+    execute: async () => [] as unknown,
+  };
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(handle),
+    ...handle,
+  } as unknown as Database;
+}
+
+describe('resolveInstanceTenantId', () => {
+  test('reads inside a worker tenant scope for the credential tenant', async () => {
+    const observed: { tenantId?: string | null } = {};
+    const result = await resolveInstanceTenantId(fakeDb([{ tenantId: TENANT_A }], observed), 'inst-1', TENANT_A);
+
+    expect(observed.tenantId).toBe(TENANT_A);
+    expect(result).toBe(TENANT_A);
+  });
+
+  test('a row the scope cannot see resolves to null, never to owned', async () => {
+    const observed: { tenantId?: string | null } = {};
+    const result = await resolveInstanceTenantId(fakeDb([], observed), 'inst-foreign', TENANT_A);
+
+    expect(result).toBeNull();
+  });
+
+  test('a malformed tenant is refused before any transaction opens', async () => {
+    const observed: { tenantId?: string | null } = {};
+    await expect(resolveInstanceTenantId(fakeDb([], observed), 'inst-1', 'not-a-uuid')).rejects.toThrow(
+      /worker-tenant-context/,
+    );
+    expect(observed.tenantId).toBeUndefined();
+  });
+
+  test('the scope closes when the read completes — nothing outlives the work item', async () => {
+    const observed: { tenantId?: string | null } = {};
+    await resolveInstanceTenantId(fakeDb([{ tenantId: TENANT_A }], observed), 'inst-1', TENANT_A);
+    expect(currentTenantScope()).toBeNull();
+  });
+});

--- a/packages/api/src/__tests__/voice-upgrade-authorization.test.ts
+++ b/packages/api/src/__tests__/voice-upgrade-authorization.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Voice WebSocket upgrade authorization — G5 deliverable (e)
+ * (wish: omni-full-multitenancy; ADR-0008, ADR-0003).
+ *
+ * Pre-G5 the upgrade authorized a connection by asking "does ANY loaded plugin
+ * hold a session with this id?" — a resource-UUID-only check across every
+ * tenant's instances. These probes pin the tenant-authorized replacement:
+ *
+ *   * the tenant comes from the CREDENTIAL, never from the URL;
+ *   * the session's instance must be owned by that same tenant;
+ *   * an unknown session, an unresolvable credential, or an unowned instance is
+ *     refused — fail-closed, never "allow because we could not tell";
+ *   * DUAL WORLD: flag-off returns the pre-G5 decision with NO tenant, and
+ *     performs no credential-tenant or ownership lookup at all.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { authorizeVoiceUpgrade } from '../ws/voice-upgrade-authorization';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const FLAG_ON = { OMNI_MULTITENANCY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv;
+const FLAG_OFF = {} as unknown as NodeJS.ProcessEnv;
+
+function deps(overrides: Record<string, unknown> = {}) {
+  const calls = { credential: 0, ownership: 0 };
+  return {
+    calls,
+    deps: {
+      resolveCredentialTenant: async () => {
+        calls.credential += 1;
+        return { tenantId: TENANT_A, revocationEpoch: 3 };
+      },
+      resolveSessionInstanceId: () => 'instance-1',
+      resolveInstanceTenantId: async () => {
+        calls.ownership += 1;
+        return TENANT_A;
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe('flag-on: tenant-authorized upgrade', () => {
+  test('a tenant may open its OWN session, carrying the credential epoch', async () => {
+    const { deps: d } = deps();
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 's1' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: true, tenantId: TENANT_A, revocationEpoch: 3 });
+  });
+
+  test('naming another tenant session is refused — knowledge is not authority', async () => {
+    const { deps: d } = deps({ resolveInstanceTenantId: async () => TENANT_B });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 's1' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: false, reason: 'cross_tenant_resource' });
+  });
+
+  test('an unresolvable credential is refused before any ownership lookup', async () => {
+    const { deps: d, calls } = deps({ resolveCredentialTenant: async () => null });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'bad', sessionId: 's1' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: false, reason: 'unauthenticated' });
+    expect(calls.ownership).toBe(0);
+  });
+
+  test('an unknown session is refused', async () => {
+    const { deps: d } = deps({ resolveSessionInstanceId: () => null });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 'ghost' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: false, reason: 'session_not_found' });
+  });
+
+  test('fail-closed: an instance with no resolvable owner is refused', async () => {
+    const { deps: d } = deps({ resolveInstanceTenantId: async () => null });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 's1' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: false, reason: 'unowned_resource' });
+  });
+
+  test('fail-closed: an ownership lookup that throws refuses, never allows', async () => {
+    const { deps: d } = deps({
+      resolveInstanceTenantId: async () => {
+        throw new Error('rls denied');
+      },
+    });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 's1' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: false, reason: 'unowned_resource' });
+  });
+
+  test('fail-closed: a credential lookup that throws refuses, never allows', async () => {
+    const { deps: d } = deps({
+      resolveCredentialTenant: async () => {
+        throw new Error('auth plane down');
+      },
+    });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 's1' }, d, FLAG_ON);
+    expect(result).toEqual({ ok: false, reason: 'unauthenticated' });
+  });
+});
+
+describe('DUAL WORLD: flag-off is the pre-G5 decision', () => {
+  test('an existing session is admitted with NO tenant and no tenancy lookups', async () => {
+    const { deps: d, calls } = deps();
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 's1' }, d, FLAG_OFF);
+    expect(result).toEqual({ ok: true, tenantId: null, revocationEpoch: 0 });
+    expect(calls.credential).toBe(0);
+    expect(calls.ownership).toBe(0);
+  });
+
+  test('an unknown session is still refused, exactly as pre-G5', async () => {
+    const { deps: d } = deps({ resolveSessionInstanceId: () => null });
+    const result = await authorizeVoiceUpgrade({ apiKey: 'k', sessionId: 'ghost' }, d, FLAG_OFF);
+    expect(result).toEqual({ ok: false, reason: 'session_not_found' });
+  });
+});

--- a/packages/api/src/__tests__/ws-chats-tenant-keying.test.ts
+++ b/packages/api/src/__tests__/ws-chats-tenant-keying.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Chat WebSocket tenant keying — G5 deliverable (e)
+ * (wish: omni-full-multitenancy; ADR-0008).
+ *
+ * `createChatWebSocketHandler` lets a client `subscribe` to any `chatId` it can
+ * name, and `broadcast` delivers to every subscriber whose filter matches. Under
+ * multitenancy that chat id may belong to another tenant, so the filter must be
+ * a tenant-narrowed one. These probes pin:
+ *
+ *   * a tenant-A update never reaches a tenant-B subscriber of the same chat id;
+ *   * the connection's tenant comes from `open()` (the authenticated upgrade),
+ *     never from the `subscribe` socket message — a client that puts a tenant in
+ *     its payload does not change what it receives;
+ *   * DUAL WORLD: with no tenant on the connection and none on the update, the
+ *     pre-G5 filter behaviour is byte-identical.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { createChatWebSocketHandler } from '../ws/chats';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const db = {} as Database;
+
+function socket() {
+  const sent: string[] = [];
+  return { sent, send: (d: string) => sent.push(d) };
+}
+
+describe('chat fan-out is narrowed by tenant', () => {
+  test('tenant A update does not reach a tenant B subscriber of the same chat id', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const a = socket();
+    const b = socket();
+
+    handler.open(a, { tenantId: TENANT_A, revocationEpoch: 1 });
+    handler.open(b, { tenantId: TENANT_B, revocationEpoch: 1 });
+    handler.message(a, JSON.stringify({ type: 'subscribe', chatId: 'chat-shared' }));
+    handler.message(b, JSON.stringify({ type: 'subscribe', chatId: 'chat-shared' }));
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-shared' }, TENANT_A);
+
+    expect(a.sent).toHaveLength(1);
+    expect(b.sent).toHaveLength(0);
+  });
+
+  test('a caller cannot widen its reach by claiming a tenant in the subscribe payload', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const b = socket();
+
+    handler.open(b, { tenantId: TENANT_B, revocationEpoch: 1 });
+    handler.message(b, JSON.stringify({ type: 'subscribe', chatId: 'chat-shared', tenantId: TENANT_A }));
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-shared' }, TENANT_A);
+
+    expect(b.sent).toHaveLength(0);
+  });
+
+  test('a tenant-bound update never reaches a legacy (tenantless) subscriber', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const legacy = socket();
+
+    handler.open(legacy);
+    handler.message(legacy, JSON.stringify({ type: 'subscribe', chatId: 'chat-shared' }));
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-shared' }, TENANT_A);
+
+    expect(legacy.sent).toHaveLength(0);
+  });
+
+  test('DUAL WORLD: a legacy update reaches legacy subscribers exactly as pre-G5', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const one = socket();
+    const two = socket();
+
+    handler.open(one);
+    handler.open(two);
+    handler.message(one, JSON.stringify({ type: 'subscribe', chatId: 'chat-shared' }));
+    handler.message(two, JSON.stringify({ type: 'subscribe' }));
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-shared' });
+
+    expect(one.sent).toHaveLength(1);
+    expect(two.sent).toHaveLength(1);
+  });
+
+  test('a legacy update does not reach a tenant-bound subscriber', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const bound = socket();
+
+    handler.open(bound, { tenantId: TENANT_A, revocationEpoch: 1 });
+    handler.message(bound, JSON.stringify({ type: 'subscribe', chatId: 'chat-shared' }));
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-shared' });
+
+    expect(bound.sent).toHaveLength(0);
+  });
+
+  test('the pre-G5 type filters still apply inside a tenant', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const a = socket();
+
+    handler.open(a, { tenantId: TENANT_A, revocationEpoch: 1 });
+    handler.message(a, JSON.stringify({ type: 'subscribe', chatId: 'chat-1', includeTyping: false }));
+
+    handler.broadcast({ type: 'chat.typing', chatId: 'chat-1' }, TENANT_A);
+    expect(a.sent).toHaveLength(0);
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-1' }, TENANT_A);
+    expect(a.sent).toHaveLength(1);
+  });
+});
+
+describe('revocation terminates chat subscriptions', () => {
+  test('terminateTenant drops only the revoked tenant', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    const a = socket();
+    const b = socket();
+    const closedA: string[] = [];
+
+    handler.open(a, { tenantId: TENANT_A, revocationEpoch: 1, close: (r: string) => closedA.push(r) });
+    handler.open(b, { tenantId: TENANT_B, revocationEpoch: 1 });
+    handler.message(a, JSON.stringify({ type: 'subscribe', chatId: 'chat-1' }));
+    handler.message(b, JSON.stringify({ type: 'subscribe', chatId: 'chat-1' }));
+
+    expect(handler.terminateTenant(TENANT_A, 'tenant_revoked')).toBe(1);
+    expect(closedA).toEqual(['tenant_revoked']);
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-1' }, TENANT_A);
+    expect(a.sent).toHaveLength(0);
+
+    handler.broadcast({ type: 'message.new', chatId: 'chat-1' }, TENANT_B);
+    expect(b.sent).toHaveLength(1);
+  });
+
+  test('the sweep view lists the live tenants', () => {
+    const handler = createChatWebSocketHandler(db, null, 'instance-1');
+    handler.open(socket(), { tenantId: TENANT_A, revocationEpoch: 3 });
+    handler.open(socket());
+
+    expect(handler.streamRegistry.activeTenantIds()).toEqual([TENANT_A]);
+    expect(handler.streamRegistry.size).toBe(2);
+  });
+});

--- a/packages/api/src/__tests__/ws-voice-tenant-keying.test.ts
+++ b/packages/api/src/__tests__/ws-voice-tenant-keying.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Voice WebSocket tenant keying — G5 deliverable (e)
+ * (wish: omni-full-multitenancy; ADR-0008, ADR-0006).
+ *
+ * `VoiceStreamRegistry` fans audio out to every client whose `params.sessionId`
+ * matches. Pre-G5 that is the whole authorization: a client that can NAME a
+ * session receives its audio. These probes pin the tenant-keyed behaviour on top
+ * of it:
+ *
+ *   * a session bound to tenant A never delivers a frame to a tenant-B client,
+ *     even when both clients named the SAME session id;
+ *   * the tenant is never taken from the URL — `parseVoiceStreamParams` has no
+ *     path to a tenant, so a caller cannot assert one;
+ *   * revocation closes a tenant's live voice sockets;
+ *   * DUAL WORLD: an UNBOUND session (flag-off / legacy) fans out by session id
+ *     exactly as pre-G5.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { sweepRevokedStreamSubscriptions } from '../tenancy/tenant-stream-subscriptions';
+import { VoiceStreamRegistry, parseVoiceStreamParams } from '../ws/voice';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+function client() {
+  const frames: (string | ArrayBuffer | Uint8Array)[] = [];
+  const closed: string[] = [];
+  return {
+    frames,
+    closed,
+    send: (d: string | ArrayBuffer | Uint8Array) => frames.push(d),
+    close: (reason: string) => closed.push(reason),
+  };
+}
+
+describe('session→tenant binding narrows the fan-out', () => {
+  test('the SAME session id under two tenants does not cross', () => {
+    const reg = new VoiceStreamRegistry();
+    const a = client();
+    const b = client();
+    const wsA = {};
+    const wsB = {};
+
+    reg.bindSession('shared-session', TENANT_A);
+    reg.add(wsA, {
+      params: { sessionId: 'shared-session', apiKey: 'k', format: 'opus' },
+      tenantId: TENANT_A,
+      revocationEpoch: 1,
+      send: a.send,
+      close: a.close,
+    });
+    reg.add(wsB, {
+      params: { sessionId: 'shared-session', apiKey: 'k', format: 'opus' },
+      tenantId: TENANT_B,
+      revocationEpoch: 1,
+      send: b.send,
+      close: b.close,
+    });
+
+    reg.pushAudio('shared-session', 'user-1', new Uint8Array([1, 2, 3]), 'opus');
+
+    expect(a.frames).toHaveLength(1);
+    expect(b.frames).toHaveLength(0);
+  });
+
+  test('control broadcasts are narrowed by the same binding', () => {
+    const reg = new VoiceStreamRegistry();
+    const a = client();
+    const b = client();
+
+    reg.bindSession('shared-session', TENANT_A);
+    reg.add(
+      {},
+      {
+        params: { sessionId: 'shared-session', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_A,
+        revocationEpoch: 1,
+        send: a.send,
+        close: a.close,
+      },
+    );
+    reg.add(
+      {},
+      {
+        params: { sessionId: 'shared-session', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_B,
+        revocationEpoch: 1,
+        send: b.send,
+        close: b.close,
+      },
+    );
+
+    reg.broadcast('shared-session', { type: 'participant_joined', userId: 'u1' });
+
+    expect(a.frames).toHaveLength(1);
+    expect(b.frames).toHaveLength(0);
+  });
+
+  test('getClientsForSession is narrowed by the binding too', () => {
+    const reg = new VoiceStreamRegistry();
+    reg.bindSession('shared-session', TENANT_A);
+    reg.add(
+      {},
+      {
+        params: { sessionId: 'shared-session', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_A,
+        revocationEpoch: 1,
+        send: () => {},
+      },
+    );
+    reg.add(
+      {},
+      {
+        params: { sessionId: 'shared-session', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_B,
+        revocationEpoch: 1,
+        send: () => {},
+      },
+    );
+
+    expect(reg.getClientsForSession('shared-session')).toHaveLength(1);
+  });
+
+  test('DUAL WORLD: an unbound session fans out by session id, as pre-G5', () => {
+    const reg = new VoiceStreamRegistry();
+    const one = client();
+    const two = client();
+
+    reg.add({}, { params: { sessionId: 'legacy-session', apiKey: 'k', format: 'opus' }, send: one.send });
+    reg.add({}, { params: { sessionId: 'legacy-session', apiKey: 'k', format: 'opus' }, send: two.send });
+
+    reg.pushAudio('legacy-session', 'user-1', new Uint8Array([9]), 'opus');
+
+    expect(one.frames).toHaveLength(1);
+    expect(two.frames).toHaveLength(1);
+  });
+
+  test('unbinding a session restores the legacy resource-only match', () => {
+    const reg = new VoiceStreamRegistry();
+    const b = client();
+    reg.bindSession('sess', TENANT_A);
+    reg.add(
+      {},
+      {
+        params: { sessionId: 'sess', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_B,
+        revocationEpoch: 1,
+        send: b.send,
+      },
+    );
+
+    reg.pushAudio('sess', 'u', new Uint8Array([1]), 'opus');
+    expect(b.frames).toHaveLength(0);
+
+    reg.unbindSession('sess');
+    reg.pushAudio('sess', 'u', new Uint8Array([1]), 'opus');
+    expect(b.frames).toHaveLength(1);
+  });
+});
+
+describe('the tenant is never caller-supplied', () => {
+  test('a `tenant` query parameter is ignored by the URL parser', () => {
+    const url = new URL(
+      `ws://localhost/api/v2/voice/stream/sess?api_key=sk&tenant=${TENANT_B}&tenant_id=${TENANT_B}&tenantId=${TENANT_B}`,
+    );
+    const params = parseVoiceStreamParams(url);
+    expect(params).not.toBeNull();
+    expect(JSON.stringify(params)).not.toContain(TENANT_B);
+  });
+});
+
+describe('revocation terminates live voice sockets', () => {
+  test('terminateTenant closes only the revoked tenant and drops its clients', () => {
+    const reg = new VoiceStreamRegistry();
+    const a = client();
+    const b = client();
+    reg.add(
+      {},
+      {
+        params: { sessionId: 's1', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_A,
+        revocationEpoch: 1,
+        send: a.send,
+        close: a.close,
+      },
+    );
+    reg.add(
+      {},
+      {
+        params: { sessionId: 's2', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_B,
+        revocationEpoch: 1,
+        send: b.send,
+        close: b.close,
+      },
+    );
+
+    const closed = reg.terminateTenant(TENANT_A, 'tenant_revoked');
+
+    expect(closed).toBe(1);
+    expect(a.closed).toEqual(['tenant_revoked']);
+    expect(b.closed).toEqual([]);
+    expect(reg.size).toBe(1);
+  });
+
+  test('a terminated tenant receives no further audio', () => {
+    const reg = new VoiceStreamRegistry();
+    const a = client();
+    reg.bindSession('s1', TENANT_A);
+    reg.add(
+      {},
+      {
+        params: { sessionId: 's1', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_A,
+        revocationEpoch: 1,
+        send: a.send,
+        close: a.close,
+      },
+    );
+
+    reg.terminateTenant(TENANT_A, 'tenant_revoked');
+    reg.pushAudio('s1', 'u', new Uint8Array([1]), 'opus');
+
+    expect(a.frames).toHaveLength(0);
+  });
+
+  test('the sweep view exposes each live client tenancy binding', () => {
+    const reg = new VoiceStreamRegistry();
+    reg.add(
+      {},
+      {
+        params: { sessionId: 's1', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_A,
+        revocationEpoch: 4,
+        send: () => {},
+      },
+    );
+    reg.add({}, { params: { sessionId: 's2', apiKey: 'k', format: 'opus' }, send: () => {} });
+
+    expect(reg.streamRegistry.activeTenantIds()).toEqual([TENANT_A]);
+    expect(reg.streamRegistry.size).toBe(2);
+  });
+
+  test('the revocation SWEEP closes the socket AND stops it being an audio target', async () => {
+    const reg = new VoiceStreamRegistry();
+    const a = client();
+    const legacy = client();
+    reg.bindSession('s1', TENANT_A);
+    reg.add(
+      {},
+      {
+        params: { sessionId: 's1', apiKey: 'k', format: 'opus' },
+        tenantId: TENANT_A,
+        revocationEpoch: 1,
+        send: a.send,
+        close: a.close,
+      },
+    );
+    reg.add({}, { params: { sessionId: 'legacy-s', apiKey: 'k', format: 'opus' }, send: legacy.send });
+
+    const stats = await sweepRevokedStreamSubscriptions(
+      {} as Database,
+      reg.streamRegistry,
+      { OMNI_MULTITENANCY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
+      async () => ({ status: 'suspended', revocationEpoch: 2 }),
+    );
+
+    expect(stats.terminated).toBe(1);
+    expect(a.closed).toEqual(['tenant_revoked']);
+
+    // The swept socket must no longer receive audio…
+    reg.pushAudio('s1', 'u', new Uint8Array([1]), 'opus');
+    expect(a.frames).toHaveLength(0);
+    // …and the legacy socket must be untouched by the sweep.
+    reg.pushAudio('legacy-s', 'u', new Uint8Array([1]), 'opus');
+    expect(legacy.frames).toHaveLength(1);
+    expect(reg.size).toBe(1);
+  });
+});

--- a/packages/api/src/cache/cache-keys.ts
+++ b/packages/api/src/cache/cache-keys.ts
@@ -4,7 +4,31 @@
  * Provides typed cache key generation and domain-specific cache instances.
  */
 
+import { isMultitenancyEnabled } from '../tenancy/feature-flag';
 import { MemoryCache } from './memory-cache';
+
+/**
+ * Auth-cache invalidation ceiling (wish: omni-full-multitenancy, Group G5,
+ * deliverable (c); RELEASE_SLOS
+ * `revocation.auth_cache_invalidation_seconds_max: 15`).
+ *
+ * Any cached AUTHORIZATION fact (a validated API key, an allow/deny access
+ * decision) must die within this window, so an out-of-band revocation — one
+ * that did not pass through the in-process invalidation hooks — still stops
+ * authenticating within the release ceiling. Dual-world: the clamp binds only
+ * when multitenancy is enabled; flag-off keeps the legacy TTLs byte-identical.
+ */
+export const AUTH_CACHE_INVALIDATION_CEILING_SECONDS = 15;
+
+/**
+ * The TTL an AUTH cache write must use: the legacy TTL, clamped to the
+ * revocation ceiling when multitenancy is enabled. A legacy TTL already under
+ * the ceiling is honoured, not raised.
+ */
+export function authCacheTtlMs(legacyTtlMs: number): number {
+  if (!isMultitenancyEnabled()) return legacyTtlMs;
+  return Math.min(legacyTtlMs, AUTH_CACHE_INVALIDATION_CEILING_SECONDS * 1000);
+}
 
 /**
  * Cache key namespace definitions.

--- a/packages/api/src/cache/index.ts
+++ b/packages/api/src/cache/index.ts
@@ -6,7 +6,6 @@
  */
 
 export {
-  AUTH_CACHE_INVALIDATION_CEILING_SECONDS,
   CacheKeys,
   CacheTTL,
   apiKeyCache,

--- a/packages/api/src/cache/index.ts
+++ b/packages/api/src/cache/index.ts
@@ -5,4 +5,11 @@
  * For multi-instance deployments, use a Redis-backed cache implementation.
  */
 
-export { CacheKeys, CacheTTL, apiKeyCache, type CachedApiKey } from './cache-keys';
+export {
+  AUTH_CACHE_INVALIDATION_CEILING_SECONDS,
+  CacheKeys,
+  CacheTTL,
+  apiKeyCache,
+  authCacheTtlMs,
+  type CachedApiKey,
+} from './cache-keys';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -90,7 +90,9 @@ import { ApiKeyService } from './services/api-keys';
 import { closeTurnEvents, getTurnEventsConnection, initTurnEvents } from './services/turn-events';
 import { TurnMonitor } from './services/turn-monitor';
 import { currentTenantScope } from './tenancy/tenant-scope';
+import { startStreamRevocationSweeper } from './tenancy/tenant-stream-subscriptions';
 import { printStartupBanner } from './utils/startup-banner';
+import { resolveInstanceTenantId } from './ws/voice-instance-ownership';
 
 // Configuration
 const PORT = Number.parseInt(process.env.API_PORT ?? '8882', 10);
@@ -99,6 +101,7 @@ const NATS_URL = process.env.NATS_URL ?? 'nats://localhost:4222';
 
 import { VoiceStreamRegistry, parseVoiceStreamParams, transcodeAudioFrame } from './ws/voice';
 import type { VoiceStreamClient } from './ws/voice';
+import { type VoiceUpgradeDeps, authorizeVoiceUpgrade } from './ws/voice-upgrade-authorization';
 
 // Voice stream WebSocket registry (global singleton)
 const voiceStreamRegistry = new VoiceStreamRegistry();
@@ -275,17 +278,31 @@ function startBunServer(app: App) {
           }
         }
 
-        // Validate session exists via VoiceCapable interface
-        const voicePlugin = globalChannelRegistry
-          ?.getAll()
-          .find((p) => isVoiceCapable(p) && p.voiceSession(params.sessionId));
-        if (!voicePlugin) {
-          ws.close(4004, `Voice session ${params.sessionId} not found`);
+        // G5 deliverable (e): tenant-authorized upgrade. Flag-off this is the
+        // pre-G5 "does the session exist" decision, byte-identical and with no
+        // tenancy lookup; flag-on the connection's tenant is derived from the
+        // CREDENTIAL and the session's instance must be owned by it.
+        const decision = await authorizeVoiceUpgrade(
+          { apiKey: params.apiKey, sessionId: params.sessionId },
+          voiceUpgradeDeps(),
+        );
+        if (!decision.ok) {
+          if (decision.reason === 'session_not_found') {
+            ws.close(4004, `Voice session ${params.sessionId} not found`);
+          } else if (decision.reason === 'unauthenticated') {
+            ws.close(4004, 'Invalid API key');
+          } else {
+            // Cross-tenant / unowned: refuse WITHOUT disclosing whether the
+            // session exists — the refusal must not become an existence oracle.
+            ws.close(4004, `Voice session ${params.sessionId} not found`);
+          }
           return;
         }
 
         const client: VoiceStreamClient = {
           params,
+          tenantId: decision.tenantId,
+          revocationEpoch: decision.revocationEpoch,
           send: (data) => {
             try {
               ws.send(data as string | ArrayBuffer | Uint8Array);
@@ -293,7 +310,17 @@ function startBunServer(app: App) {
               // Client slow or disconnected
             }
           },
+          close: (reason) => {
+            try {
+              ws.close(4003, reason);
+            } catch {
+              // Already gone
+            }
+          },
         };
+        // Bind the session to its trusted owner so the audio fan-out is narrowed
+        // to this tenant even if another tenant holds a session with the same id.
+        if (decision.tenantId) voiceStreamRegistry.bindSession(params.sessionId, decision.tenantId);
         voiceStreamRegistry.add(ws, client);
         ws.send(JSON.stringify({ type: 'session_ready', sessionId: params.sessionId }));
       },
@@ -333,7 +360,14 @@ function startBunServer(app: App) {
         }
       },
       close(ws) {
+        const sessionId = voiceStreamRegistry.get(ws)?.params.sessionId;
         voiceStreamRegistry.remove(ws);
+        // Drop the session→tenant binding only once the session itself is gone,
+        // so a reconnecting client is still narrowed to its own tenant.
+        if (sessionId) {
+          const stillLive = globalChannelRegistry?.getAll().some((p) => isVoiceCapable(p) && p.voiceSession(sessionId));
+          if (!stillLive) voiceStreamRegistry.unbindSession(sessionId);
+        }
       },
     },
   });
@@ -341,6 +375,47 @@ function startBunServer(app: App) {
 
 // Database reference for WS auth (set during startup)
 let globalDbRef: Database | null = null;
+
+/**
+ * Services reference for WS tenant authorization (set during startup).
+ *
+ * G5 deliverable (e): the voice upgrade lives in `Bun.serve`'s raw `fetch`,
+ * before Hono, so it cannot reach the tenancy middleware's context. It resolves
+ * the connection's tenant itself, through the SAME auth plane the HTTP edge uses
+ * (`services.authBootstrap`) and the same ownership root (`instances`).
+ */
+let globalServicesRef: ReturnType<typeof createApp>['services'] | null = null;
+
+/** The revocation sweeper for live voice sockets; stopped on shutdown. */
+let globalStreamSweeper: { stop: () => void } | null = null;
+
+/**
+ * The tenancy derivations the voice upgrade needs, all trusted — the credential
+ * index for the tenant, the live plugin session for the instance, and the
+ * `instances` ownership root (read inside the credential tenant's own scope, so
+ * RLS decides visibility) for the resource owner.
+ */
+function voiceUpgradeDeps(): VoiceUpgradeDeps {
+  return {
+    resolveCredentialTenant: async (apiKey) => {
+      const services = globalServicesRef;
+      if (!services) return null;
+      const result = await services.authBootstrap.lookupBySecret(apiKey, `voice-ws-${crypto.randomUUID()}`);
+      if (!result.ok || result.context.credentialClass !== 'tenant') return null;
+      return { tenantId: result.context.tenantId, revocationEpoch: result.context.revocationEpoch };
+    },
+    resolveSessionInstanceId: (sessionId) => {
+      const plugin = globalChannelRegistry?.getAll().find((p) => isVoiceCapable(p) && p.voiceSession(sessionId));
+      if (!plugin || !isVoiceCapable(plugin)) return null;
+      return plugin.voiceSession(sessionId)?.instanceId ?? null;
+    },
+    resolveInstanceTenantId: async (instanceId, tenantId) => {
+      const db = globalDbRef;
+      if (!db) return null;
+      return resolveInstanceTenantId(db, instanceId, tenantId);
+    },
+  };
+}
 
 /**
  * Set up graceful shutdown handlers
@@ -372,6 +447,12 @@ function setupShutdownHandlers(server: ReturnType<typeof Bun.serve>, earlyShutdo
 
       shutdownLog.info('Stopping HTTP server');
       server.stop();
+
+      if (globalStreamSweeper) {
+        shutdownLog.info('Stopping stream revocation sweeper');
+        globalStreamSweeper.stop();
+        globalStreamSweeper = null;
+      }
 
       if (globalDispatcherCleanup) {
         shutdownLog.info('Stopping agent dispatcher');
@@ -889,6 +970,11 @@ async function main() {
 
   // Create app and get services
   const { app, services } = createApp(db, eventBus, globalChannelRegistry);
+  globalServicesRef = services;
+
+  // G5 deliverable (e): terminate a revoked tenant's live voice sockets inside
+  // the RELEASE_SLOS ceiling. Flag-off this starts no timer at all.
+  globalStreamSweeper = startStreamRevocationSweeper(services.authPlane.db, voiceStreamRegistry.streamRegistry);
 
   // Seed default settings
   try {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -89,6 +89,7 @@ import { closeAgentHeartbeat, initAgentHeartbeat } from './services/agent-heartb
 import { ApiKeyService } from './services/api-keys';
 import { closeTurnEvents, getTurnEventsConnection, initTurnEvents } from './services/turn-events';
 import { TurnMonitor } from './services/turn-monitor';
+import { installInstanceOwnerResolver } from './tenancy/instance-owner-registry';
 import { currentTenantScope } from './tenancy/tenant-scope';
 import { startStreamRevocationSweeper } from './tenancy/tenant-stream-subscriptions';
 import { printStartupBanner } from './utils/startup-banner';
@@ -157,6 +158,16 @@ async function connectToNats(db: Database): Promise<EventBus | null> {
     // republish must pass an explicit `metadata.tenantId` — this resolver never
     // lends an ambient tenant across the request→worker boundary.
     setEnvelopeTenantResolver(() => currentTenantScope()?.tenantId ?? null);
+
+    // ...and the PRODUCER-side derivation for publishes that have no request at
+    // all — every channel-plugin emit (`message.received`, `instance.connected`,
+    // `reaction.*`). Those name an instanceId, and `instances` is the ownership
+    // root, so the tenant comes from the instance's PERSISTED row via the
+    // ownership registry the instance-loading paths populate. Without this the
+    // dominant traffic path stamps nothing and every consumer G5 converted stays
+    // on its legacy branch. Flag-off the registry is empty (NULL tenants teach
+    // it nothing), so publishes remain byte-identical.
+    installInstanceOwnerResolver();
 
     // Set up event listeners
     await setupQrCodeListener(eventBus);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -22,7 +22,14 @@ import './tracing';
  */
 
 import { type ChannelRegistry, isVoiceCapable } from '@omni/channel-sdk';
-import { type EventBus, configureLogging, connectEventBus, createLogger, enableDefaultMetrics } from '@omni/core';
+import {
+  type EventBus,
+  configureLogging,
+  connectEventBus,
+  createLogger,
+  enableDefaultMetrics,
+  setEnvelopeTenantResolver,
+} from '@omni/core';
 import type { Database, DbEnforcementMode, EnforcedBootIdentities } from '@omni/db';
 import {
   API_CRITICAL_COLUMNS,
@@ -82,6 +89,7 @@ import { closeAgentHeartbeat, initAgentHeartbeat } from './services/agent-heartb
 import { ApiKeyService } from './services/api-keys';
 import { closeTurnEvents, getTurnEventsConnection, initTurnEvents } from './services/turn-events';
 import { TurnMonitor } from './services/turn-monitor';
+import { currentTenantScope } from './tenancy/tenant-scope';
 import { printStartupBanner } from './utils/startup-banner';
 
 // Configuration
@@ -138,6 +146,14 @@ async function connectToNats(db: Database): Promise<EventBus | null> {
     });
     globalEventBus = eventBus;
     natsLog.info('Connected to NATS');
+
+    // Versioned tenant-aware envelope (G5, ADR-0008): stamp the request's tenant
+    // onto every request-originated publish, so consumers can validate it. Reads
+    // the per-request tenant scope; returns null off-scope (workers, flag-off),
+    // where nothing is stamped and publishes stay legacy/byte-identical. A worker
+    // republish must pass an explicit `metadata.tenantId` — this resolver never
+    // lends an ambient tenant across the request→worker boundary.
+    setEnvelopeTenantResolver(() => currentTenantScope()?.tenantId ?? null);
 
     // Set up event listeners
     await setupQrCodeListener(eventBus);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -88,6 +88,7 @@ import { closeAgentHeartbeat, initAgentHeartbeat } from './services/agent-heartb
 import { ApiKeyService } from './services/api-keys';
 import { closeTurnEvents, getTurnEventsConnection, initTurnEvents } from './services/turn-events';
 import { TurnMonitor } from './services/turn-monitor';
+import { resolveAuthPlaneConnection } from './tenancy/auth-plane-connection';
 import { installInstanceOwnerResolver } from './tenancy/instance-owner-registry';
 import { currentTenantScope } from './tenancy/tenant-scope';
 import { startStreamRevocationSweeper } from './tenancy/tenant-stream-subscriptions';
@@ -212,12 +213,27 @@ async function initializeChannelPlugins(db: Database, eventBus: EventBus): Promi
     pluginLog.warn('Some channel plugins failed to load', { failed: result.failed });
   }
 
-  // Auto-reconnect previously active instances
+  // Auto-reconnect previously active instances.
+  //
+  // G5 (ADR-0008/ADR-0003): the startup reconnect is a whole-table `instances`
+  // sweep, so it needs the auth-plane identity to ENUMERATE tenants. This runs
+  // BEFORE `createApp`, so `services.authPlane` does not exist yet — resolve a
+  // handle for exactly this sweep and close it immediately after. In legacy mode
+  // (and under enforcement without `OMNI_DB_AUTH_PLANE_URL`) this IS the runtime
+  // handle and `close()` is a no-op, so nothing new is opened; the fan-out itself
+  // is flag-gated and stays a single ambient scan when multitenancy is off.
   pluginLog.info('Auto-reconnecting active instances');
-  const reconnectResult = await reconnectWithPool(db, result.registry, {
-    maxConcurrent: 3,
-    delayBetweenMs: 500,
-  });
+  const bootAuthPlane = resolveAuthPlaneConnection(db);
+  let reconnectResult: Awaited<ReturnType<typeof reconnectWithPool>>;
+  try {
+    reconnectResult = await reconnectWithPool(db, result.registry, {
+      maxConcurrent: 3,
+      delayBetweenMs: 500,
+      authPlaneDb: bootAuthPlane.db,
+    });
+  } finally {
+    await bootAuthPlane.close();
+  }
 
   if (reconnectResult.attempted > 0) {
     pluginLog.info('Instance reconnection complete', {
@@ -607,7 +623,11 @@ async function setupEventBusServices(
   try {
     const turnEventsConn = getTurnEventsConnection();
     if (turnEventsConn) {
-      initAgentHeartbeat({ natsConnection: turnEventsConn, turnService: services.turns });
+      // G5 (ADR-0008): `db` opts this consumer into the tenant world — the
+      // activity write then runs in the scope derived from the heartbeat's
+      // instance ownership. Flag-off no instance carries a tenant, so every
+      // heartbeat classifies legacy and the call is byte-identical.
+      initAgentHeartbeat({ natsConnection: turnEventsConn, turnService: services.turns, db: services.db });
     } else {
       log.warn('Skipping agent heartbeat consumer: no NATS connection');
     }
@@ -851,6 +871,12 @@ async function main() {
   // Create app and get services
   const { app, services } = createApp(db, eventBus, globalChannelRegistry);
   globalServicesRef = services;
+
+  // G5 (ADR-0008): opt the instance monitor into the tenant fan-out now that the
+  // long-lived auth-plane connection exists. Its first health check is a full
+  // 30-second interval away, so this always lands before any tick. Flag-off this
+  // changes nothing — `runForEachActiveTenantRow` still runs one ambient pass.
+  globalInstanceMonitor?.setAuthPlane(services.authPlane.db);
 
   // G5 deliverable (e): terminate a revoked tenant's live voice sockets inside
   // the RELEASE_SLOS ceiling. Flag-off this starts no timer at all.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -595,8 +595,13 @@ async function setupEventBusServices(
       // sweeper published the event, or whose chat is in active close-contact
       // state. Fail-open on errors so a flaky DB doesn't drop legitimate
       // events.
-      staleIdleTimeoutGate: async (chatId, instanceId, eventSequenceIndex) => {
-        return services.followUpLifecycle.evaluateIdleTimeoutFreshness(chatId, instanceId, eventSequenceIndex);
+      staleIdleTimeoutGate: async (chatId, instanceId, eventSequenceIndex, trustedTenantId) => {
+        return services.followUpLifecycle.evaluateIdleTimeoutFreshness(
+          chatId,
+          instanceId,
+          eventSequenceIndex,
+          trustedTenantId,
+        );
       },
     });
   } catch (error) {
@@ -612,7 +617,7 @@ async function setupEventBusServices(
 
   // Follow-up lifecycle hooks (arm on outbound agent msg, disarm on reply/handoff/archive)
   try {
-    await setupFollowUpHooks(eventBus, services);
+    await setupFollowUpHooks(eventBus, services, db);
   } catch (error) {
     log.error('Failed to set up follow-up hooks', { error: String(error) });
   }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -620,6 +620,12 @@ async function setupEventBusServices(
     globalTurnMonitor = new TurnMonitor({
       turnService: services.turns,
       instanceService: services.instances,
+      // G5 (ADR-0008): the pools the per-tenant worker scopes need. Wiring them
+      // does NOT change flag-off behaviour — `runForEachActiveTenantRow` runs
+      // the single ambient pass, and the auth-plane enumeration is gated on the
+      // multitenancy flag.
+      db: services.db,
+      authPlaneDb: services.authPlane.db,
     });
     globalTurnMonitor.start();
     log.info('Turn monitor started');

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -33,7 +33,6 @@ import {
 import type { Database, DbEnforcementMode, EnforcedBootIdentities } from '@omni/db';
 import {
   API_CRITICAL_COLUMNS,
-  agents,
   applyMigrations,
   assertEnforcedRuntimeIdentity,
   closeDb,
@@ -48,7 +47,7 @@ import {
   verifyCriticalColumns,
 } from '@omni/db';
 import * as Sentry from '@sentry/bun';
-import { eq, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 
 // Configure logging at startup
 configureLogging({
@@ -83,7 +82,7 @@ import {
   setupSessionCleaner,
   setupSyncWorker,
 } from './plugins';
-import { getPlugin } from './plugins/loader';
+import { buildAutomationEngineDeps } from './plugins/automation-actions';
 import { setupScheduler, stopScheduler } from './scheduler';
 import { closeAgentHeartbeat, initAgentHeartbeat } from './services/agent-heartbeat';
 import { ApiKeyService } from './services/api-keys';
@@ -518,46 +517,6 @@ function setupShutdownHandlers(server: ReturnType<typeof Bun.serve>, earlyShutdo
   process.on('SIGTERM', shutdown);
 }
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * Resolve chat UUID → channel-native external_id for a call_agent invocation.
- *
- * Symmetric with the send_message action (above) which already auto-resolves
- * UUIDs for the same reason: system-initiated events (chat.idle_timeout) emit
- * payload.chatId as the internal chats.id UUID, but the seller dispatch path
- * carries the external_id (e.g. WA phone). Without resolution, the agent
- * runner's computeSessionId produces session_ids that diverge from sessions
- * created by the seller path.
- *
- * Also resolves senderId — extractAgentCallContext falls back senderId=chatId
- * when payload.from/senderId are absent (follow-up events).
- *
- * On missing chat row, logs a warning and falls through with the raw UUID so
- * the call still runs (avoids hard-failing the automation action).
- */
-async function resolveCallAgentChatIds(
-  services: ReturnType<typeof createApp>['services'],
-  ctx: { chatId: string; senderId: string; instanceId: string },
-): Promise<{ chatId: string; senderId: string }> {
-  if (!UUID_RE.test(ctx.chatId)) {
-    return { chatId: ctx.chatId, senderId: ctx.senderId };
-  }
-  try {
-    const chat = await services.chats.getById(ctx.chatId, { includeHidden: true });
-    return {
-      chatId: chat.externalId,
-      senderId: ctx.senderId === ctx.chatId ? chat.externalId : ctx.senderId,
-    };
-  } catch {
-    log.warn('call_agent: chat UUID not resolvable, using raw value (session may diverge)', {
-      chatId: ctx.chatId,
-      instanceId: ctx.instanceId,
-    });
-    return { chatId: ctx.chatId, senderId: ctx.senderId };
-  }
-}
-
 /**
  * Setup event bus related services (plugins, persistence, workers)
  * Extracted to reduce main() complexity
@@ -593,109 +552,13 @@ async function setupEventBusServices(
     log.error('Failed to set up agent dispatcher', { error: String(error) });
   }
 
-  // Automation engine (subscribes to NATS events and evaluates rules)
+  // Automation engine (subscribes to NATS events and evaluates rules).
+  // The action callbacks live in `plugins/automation-actions.ts` — a worker
+  // surface (G5, ADR-0008): the engine threads each consumed envelope's
+  // trusted tenant into them, and their DB blocks scope themselves with
+  // `runTenantWorkDb` (legacy envelopes run ambient, byte-identically).
   try {
-    await services.automations.startEngine({
-      sendMessage: async (instanceId, to, content) => {
-        const instance = await services.instances.getById(instanceId);
-        if (!instance) throw new Error(`Instance not found: ${instanceId}`);
-        const plugin = await getPlugin(instance.channel);
-        if (!plugin) throw new Error(`No plugin for channel: ${instance.channel}`);
-        // Resolve internal chat UUID → channel-native external_id (e.g. WA JID).
-        // Automation payloads carry chat UUIDs; plugins expect channel JIDs.
-        let recipient = to;
-        if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(to)) {
-          try {
-            const chat = await services.chats.getById(to, { includeHidden: true });
-            recipient = chat.externalId;
-          } catch {
-            throw new Error(`Chat not found for UUID: ${to}`);
-          }
-        }
-        await plugin.sendMessage(instanceId, { to: recipient, content: { type: 'text', text: content } });
-      },
-      callAgent: async (ctx, cfg) => {
-        const instance = await services.instances.getById(ctx.instanceId);
-        if (!instance) throw new Error(`Instance not found: ${ctx.instanceId}`);
-
-        // System-initiated events (chat.idle_timeout) emit payload.chatId as
-        // the internal chats.id UUID; the seller dispatch path carries the
-        // channel-native external_id. Resolve UUID → external_id so the
-        // computed session_id matches sessions created by the seller path.
-        const { chatId: resolvedChatId, senderId: resolvedSenderId } = await resolveCallAgentChatIds(services, ctx);
-
-        const agentFkId = ctx.agentId ?? instance.agentId;
-        if (!agentFkId) throw new Error(`No agent configured for instance ${instance.id}`);
-
-        const [agentRow] = await db
-          .select({
-            name: agents.name,
-            agentProviderId: agents.agentProviderId,
-            agentType: agents.agentType,
-            metadata: agents.metadata,
-            configPath: agents.configPath,
-          })
-          .from(agents)
-          .where(eq(agents.id, agentFkId))
-          .limit(1);
-        if (!agentRow) throw new Error(`Agent not found: ${agentFkId}`);
-
-        const typeMap: Record<string, 'agent' | 'team' | 'workflow'> = {
-          assistant: 'agent',
-          tool: 'agent',
-          workflow: 'workflow',
-          team: 'team',
-        };
-        const providerAgentId =
-          ((agentRow.metadata as Record<string, unknown> | null)?.providerAgentId as string | undefined) ??
-          agentRow.configPath ??
-          agentRow.name;
-
-        const runInstance = {
-          ...instance,
-          agentProviderId: agentRow.agentProviderId ?? null,
-          agentType: cfg.agentType ?? typeMap[agentRow.agentType] ?? 'agent',
-          agentInternalId: providerAgentId,
-          agentSessionStrategy: cfg.sessionStrategy ?? instance.agentSessionStrategy,
-          agentPrefixSenderName: cfg.prefixSenderName ?? instance.agentPrefixSenderName,
-          agentTimeout: cfg.timeoutMs ? Math.ceil(cfg.timeoutMs / 1000) : instance.agentTimeout,
-        };
-
-        // Honor instance.agentStreamMode — sync mode waits for the full agent run
-        // before sending anything (11-14s on some providers); stream mode returns
-        // progressively. See issue #410.
-        const result = await services.agentRunner.runOrStream({
-          instance: runInstance,
-          chatId: resolvedChatId,
-          senderId: resolvedSenderId,
-          senderName: ctx.senderName,
-          chatType: 'dm',
-          messages: ctx.messages,
-        });
-        return {
-          parts: result.parts,
-          fullResponse: result.parts.join('\n'),
-          metadata: {
-            runId: result.metadata.runId,
-            sessionId: result.metadata.sessionId,
-            status: result.metadata.status,
-          },
-        };
-      },
-      // Consumer-side stale-event gate — see engine.handleEvent comment.
-      // Skips chat.idle_timeout events whose row has been disarmed since the
-      // sweeper published the event, or whose chat is in active close-contact
-      // state. Fail-open on errors so a flaky DB doesn't drop legitimate
-      // events.
-      staleIdleTimeoutGate: async (chatId, instanceId, eventSequenceIndex, trustedTenantId) => {
-        return services.followUpLifecycle.evaluateIdleTimeoutFreshness(
-          chatId,
-          instanceId,
-          eventSequenceIndex,
-          trustedTenantId,
-        );
-      },
-    });
+    await services.automations.startEngine(buildAutomationEngineDeps(services, db));
   } catch (error) {
     log.error('Failed to start automation engine', { error: String(error) });
   }

--- a/packages/api/src/instrument.ts
+++ b/packages/api/src/instrument.ts
@@ -13,7 +13,12 @@ import { scrubBreadcrumb, scrubEvent, scrubSpan, scrubTransaction } from './lib/
 const OMNI_SENTRY_DSN =
   'https://2b2ca6f407e3d13409aa7dd8d12483f2@o4509714066571264.ingest.us.sentry.io/4510982636371968';
 
-const dsn = process.env.SENTRY_DSN ?? OMNI_SENTRY_DSN;
+// Never under `bun test`: this module is a transitive import of anything that
+// touches the API entry, and its client is PROCESS-GLOBAL — one test file
+// importing it flips `sentryEnabled()` for every file that runs after it
+// (order-dependent, CI-only failures) and ships test telemetry to the
+// production DSN. Tests that need a client init one explicitly.
+const dsn = process.env.NODE_ENV === 'test' ? '' : (process.env.SENTRY_DSN ?? OMNI_SENTRY_DSN);
 
 if (dsn) {
   const tracesSampleRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1');

--- a/packages/api/src/lib/__tests__/instrument.test.ts
+++ b/packages/api/src/lib/__tests__/instrument.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
 import * as Sentry from '@sentry/bun';
 
 /**
@@ -10,6 +10,19 @@ import * as Sentry from '@sentry/bun';
  * verify option wiring.
  */
 describe('Sentry instrument', () => {
+  afterAll(async () => {
+    // The init above installs a PROCESS-GLOBAL client. `bun test` runs every
+    // test file in one process, so without this teardown each file that runs
+    // after this one sees `sentryEnabled() === true` and takes Sentry-gated
+    // code paths (e.g. the connection gauge) it never takes locally — which
+    // files run "after" depends on filesystem readdir order, so the leak
+    // shows up as CI-only, order-dependent failures. `close()` flushes but
+    // does NOT detach the client; only setClient(undefined) does.
+    await Sentry.close();
+    Sentry.getCurrentScope().setClient(undefined);
+    Sentry.getIsolationScope().setClient(undefined);
+  });
+
   test('does not initialise client when SENTRY_DSN is empty string', async () => {
     // SENTRY_DSN="" is the opt-out escape hatch (DSN is hardcoded by default)
     const savedDsn = process.env.SENTRY_DSN;

--- a/packages/api/src/middleware/__tests__/auth-turn-activity-scope.test.ts
+++ b/packages/api/src/middleware/__tests__/auth-turn-activity-scope.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `middleware/auth.ts` turn-activity tracking — the G4 leg-2 use-after-commit
+ * trap, closed (G5; ADR-0008).
+ *
+ * THE DEFECT. The middleware started a FIRE-AND-FORGET from inside a request:
+ *
+ *     services.turns.getOpenByApiKey(id).then((turn) => {
+ *       if (turn) services.turns.recordActivity(turn.id).catch(() => {});
+ *     }).catch(() => {});
+ *
+ * Nothing detached it and nothing scoped it. Its continuations resolve on a
+ * later microtask, so they can run AFTER the request's tenant transaction has
+ * committed and its pooled connection has been released — and `scopedHandle`
+ * would still hand them that transaction through the ALS. That is exactly the
+ * leg-2 trap `runDetachedFromTenantScope` exists for.
+ *
+ * REACHABILITY, STATED HONESTLY. Today the tenant world does not reach this
+ * block: `tenancyMiddleware` runs first, sets `authContext`, and the very first
+ * line of `authMiddleware` returns early when it is set — so under flag-on the
+ * fire-and-forget never starts, and under flag-off there is no transaction to
+ * outlive. The trap is LATENT, not live: `authMiddleware` is also mounted
+ * standalone (`app.post('/a2a/:instanceId', authMiddleware, …)`), and any future
+ * mount inside a scope would make it live with no other code change. The
+ * structural test below therefore constructs the scope explicitly and says so;
+ * the byte-identity test uses the shape production actually produces.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { Hono } from 'hono';
+import { currentTenantScope, runInTenantScope } from '../../tenancy/tenant-scope';
+import { authMiddleware } from '../auth';
+
+const REQUEST_TENANT = '33333333-3333-4333-8333-33333333333c';
+
+function scope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+function fakePool(counters: { transactions: number }): Database {
+  const db = {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counters.transactions += 1;
+      return cb({ execute: async () => [] });
+    },
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+interface Observed {
+  helper: string;
+  scope: string | null;
+}
+
+function makeServices(observed: Observed[], counters: { transactions: number }) {
+  return {
+    db: fakePool(counters),
+    apiKeys: {
+      validate: async () => ({
+        id: 'key-1',
+        name: 'k',
+        scopes: ['*'],
+        instanceIds: null,
+        profile: null,
+        chatAllowlist: [],
+        instanceAllowlist: [],
+        outboundRecipientAllowlist: [],
+        profileOverrides: null,
+      }),
+    },
+    turns: {
+      getOpenByApiKey: async () => {
+        observed.push({ helper: 'getOpenByApiKey', scope: scope() });
+        return { id: 'turn-1' };
+      },
+      recordActivity: async () => {
+        observed.push({ helper: 'recordActivity', scope: scope() });
+      },
+    },
+  };
+}
+
+/** Drive the middleware exactly as the router does. */
+async function runMiddleware(services: unknown, wrap?: (fn: () => Promise<unknown>) => Promise<unknown>) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('services' as never, services as never);
+    await next();
+  });
+  app.use('*', authMiddleware as never);
+  app.get('/x', (c) => c.text('ok'));
+
+  const call = () => app.request('/x', { headers: { 'x-api-key': 'secret' } });
+  const res = (await (wrap ? wrap(call as () => Promise<unknown>) : call())) as Response;
+  // The fire-and-forget resolves on later microtasks; let them drain.
+  await new Promise((r) => setTimeout(r, 5));
+  return res;
+}
+
+describe('auth middleware turn tracking — legacy world is byte-identical', () => {
+  test('no scope active: the same two calls, on the ambient pool, no worker transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+
+    const res = await runMiddleware(makeServices(observed, counters));
+
+    expect(res.status).toBe(200);
+    expect(observed.map((o) => o.helper)).toEqual(['getOpenByApiKey', 'recordActivity']);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+    expect(counters.transactions).toBe(0);
+  });
+});
+
+describe('auth middleware turn tracking — the latent leg-2 trap is closed', () => {
+  test('STRUCTURAL: started inside a scope, the continuations never inherit that transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const services = makeServices(observed, counters);
+
+    await runMiddleware(services, (call) =>
+      runInTenantScope(
+        services.db,
+        {
+          credentialClass: 'tenant',
+          requestId: 'req-1',
+          principalId: 'p',
+          credentialId: 'c',
+          tenantId: REQUEST_TENANT,
+          tenantSlug: null,
+          actorRole: 'tenant-admin',
+          scopes: [],
+          membershipId: 'm',
+          resourceConstraints: {},
+          expiresAt: null,
+          rateLimit: null,
+          budget: null,
+          delegationDepth: 0,
+          rootKeyId: 'r',
+          policyVersion: 0,
+          revocationEpoch: 0,
+          tenantKeyLineageId: 'l',
+        } as never,
+        call as () => Promise<unknown>,
+      ),
+    );
+
+    expect(observed.map((o) => o.helper)).toEqual(['getOpenByApiKey', 'recordActivity']);
+    // Both continuations ran in a FRESH worker transaction for the captured
+    // tenant — never the request's, which by then may have committed.
+    for (const entry of observed) expect(entry.scope).toBe(REQUEST_TENANT);
+    // The request scope opened one; the detached worker opened its own.
+    expect(counters.transactions).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -5,6 +5,8 @@
 import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { ApiKeyService } from '../services/api-keys';
+import { currentTenantScope, runDetachedFromTenantScope } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import type { ApiKeyData, AppVariables } from '../types';
 
 /**
@@ -92,15 +94,34 @@ export const authMiddleware = createMiddleware<{ Variables: AppVariables }>(asyn
 
   // Fire-and-forget: track turn activity if this key has an open turn.
   // Any API call from a scoped key automatically extends the turn's activity timer.
+  //
+  // G5 (ADR-0008) — the G4 leg-2 use-after-commit trap, closed. This is started
+  // from a REQUEST and its continuations resolve on later microtasks, so they can
+  // run after the request's tenant transaction has committed and its pooled
+  // connection has been released. Left attached, `scopedHandle` would still hand
+  // them that transaction through the ALS.
+  //
+  // The fix is the `batch-jobs.create` shape: CAPTURE the trusted tenant as a
+  // VALUE first — the edge-derived `authContext`, or the active scope read for
+  // its identity only — then run the whole thing DETACHED, opening its own short
+  // worker transaction for the tenant it captured.
+  //
+  // Reachability, stated plainly: under flag-on this block is not reached at all
+  // (the `authContext` early-return at the top of this middleware fires first),
+  // and flag-off there is no transaction to outlive — `runTenantWorkDb(pool,
+  // null, …)` runs `fn()` directly and `runDetachedFromTenantScope` is a no-op on
+  // an empty ALS, so the two queries issued are byte-for-byte the pre-G5 ones.
+  // The trap is latent, and this is what keeps it that way.
   if (services.turns) {
-    services.turns
-      .getOpenByApiKey(validatedKey.id)
-      .then((turn) => {
-        if (turn) {
-          services.turns.recordActivity(turn.id).catch(() => {});
-        }
-      })
-      .catch(() => {});
+    const turnsService = services.turns;
+    const activityTenantId = c.get('authContext')?.tenantId ?? currentTenantScope()?.tenantId ?? null;
+    const pool = services.db;
+    void runDetachedFromTenantScope(async () =>
+      runTenantWorkDb(pool, activityTenantId, async () => {
+        const turn = await turnsService.getOpenByApiKey(validatedKey.id);
+        if (turn) await turnsService.recordActivity(turn.id);
+      }),
+    ).catch(() => {});
   }
 
   await next();

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-access-callsite-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-access-callsite-scope.test.ts
@@ -1,0 +1,207 @@
+/**
+ * The ACCESS CALL SITES thread the envelope-derived tenant (G5; ADR-0008).
+ *
+ * `services/__tests__/access-worker-scope.test.ts` proves `AccessService` HONOURS
+ * a threaded tenant — it invokes `checkAccess`/`requestPairing` with a literal
+ * tenant and asserts the rule read lands in that scope. What it cannot prove is
+ * that any real caller threads one, and that is the whole conversion: the
+ * db-access-guard justification for `access.ts::access_rules` names the two
+ * consumer callers as scoped and names that probe as the pin.
+ *
+ * The gap was mechanically invisible. Dropping the trailing `trustedTenantId`
+ * argument at the two `checkAccessWithFallback` call sites left `tsc` at exit 0
+ * (the parameter is optional), biome clean, and the whole suite green — while
+ * every inbound message's ALLOW/DENY decision silently returned to the ambient
+ * pool: cross-boundary before enforcement, and after it a fail-CLOSED read for
+ * allowlist instances but a fail-OPEN one for the default blocklist mode, where
+ * an empty rule read means "allowed".
+ *
+ * So these probes drive the GUARDS — `shouldProcessMessage` and
+ * `shouldProcessReaction` — and assert the value that reaches `checkAccess`.
+ * They fail if the argument is dropped at either call site.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { __test__ } from '../agent-dispatcher';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+interface AccessCall {
+  senderId: string;
+  tenantId: string | undefined;
+  /** The scope observed AT the call — the service scopes its own block. */
+  scope: string | null;
+}
+
+/** Chainable drizzle stub: builders return self, awaiting yields `rows`. */
+function chain<T>(rows: T): T {
+  const self: unknown = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (onOk: (v: T) => unknown, onErr?: (e: unknown) => unknown) => Promise.resolve(rows).then(onOk, onErr);
+        }
+        return () => self;
+      },
+    },
+  );
+  return self as T;
+}
+
+function fakeDb(): Database {
+  const db = {
+    select: () => chain([{ ownerIdentifier: 'owner-x' }]),
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({ execute: async () => [] as unknown, select: () => chain([{ ownerIdentifier: 'owner-x' }]) }),
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+function fakeInstance(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'inst-1',
+    channel: 'whatsapp-baileys',
+    agentId: 'agent-1',
+    ownerIdentifier: 'owner-self',
+    allowFirstParty: true,
+    agentReplyFilter: null,
+    inboundMaxAgeMinutes: null,
+    accessMode: 'blocklist',
+    ...overrides,
+  };
+}
+
+function harness(instanceOverrides: Record<string, unknown> = {}) {
+  const calls: AccessCall[] = [];
+  const accessService = {
+    checkAccess: async (_instance: unknown, senderId: string, _channel: string, tenantId?: string) => {
+      calls.push({ senderId, tenantId, scope: currentTenantScope()?.tenantId ?? null });
+      return { allowed: true, reason: 'ok' };
+    },
+    requestPairing: async () => {},
+  } as never;
+
+  const agentRunner = {
+    getInstanceWithProvider: async () => fakeInstance(instanceOverrides),
+  } as never;
+
+  const chatsService = {
+    getById: async () => null,
+    findOrCreate: async () => ({ chat: { id: 'chat-1' } }),
+    findByExternalIdSmart: async () => null,
+    getAllExternalIds: async () => [],
+  } as never;
+  const messagesService = { getByExternalId: async () => null } as never;
+  const routeResolver = { resolve: async () => null } as never;
+
+  return { calls, accessService, agentRunner, chatsService, messagesService, routeResolver };
+}
+
+const PAYLOAD = {
+  externalId: 'ext-1',
+  chatId: '5511999999999@s.whatsapp.net',
+  from: '5511999999999',
+  content: { type: 'text', text: 'hi' },
+  rawPayload: {},
+} as never;
+
+const METADATA = { instanceId: 'inst-1', channelType: 'whatsapp-baileys' };
+
+describe('shouldProcessMessage threads the envelope tenant into the access read', () => {
+  test('tenant envelope: checkAccess receives the envelope-derived tenant', async () => {
+    const h = harness();
+
+    const instance = await __test__.shouldProcessMessage(
+      h.agentRunner,
+      h.accessService,
+      h.chatsService,
+      h.messagesService,
+      h.routeResolver,
+      fakeDb(),
+      PAYLOAD,
+      METADATA,
+      TENANT_A,
+    );
+
+    expect(instance).not.toBeNull();
+    expect(h.calls.length).toBeGreaterThan(0);
+    // The threading is the assertion. `undefined` here is the unconverted world:
+    // the ALLOW/DENY rules would be read on the ambient pool.
+    for (const call of h.calls) expect(call.tenantId).toBe(TENANT_A);
+    // Threaded, NOT wrapped: the service scopes its own block because it
+    // publishes `access.allowed`/`access.denied` between blocks.
+    for (const call of h.calls) expect(call.scope).toBeNull();
+  });
+
+  test('legacy envelope: nothing is threaded — byte-identical to pre-G5', async () => {
+    const h = harness();
+
+    await __test__.shouldProcessMessage(
+      h.agentRunner,
+      h.accessService,
+      h.chatsService,
+      h.messagesService,
+      h.routeResolver,
+      fakeDb(),
+      PAYLOAD,
+      METADATA,
+      undefined,
+    );
+
+    expect(h.calls.length).toBeGreaterThan(0);
+    for (const call of h.calls) expect(call.tenantId).toBeUndefined();
+  });
+});
+
+describe('shouldProcessReaction threads the envelope tenant into the access read', () => {
+  const reactionPayload = {
+    messageId: 'msg-1',
+    emoji: '👍',
+    from: '5511999999999',
+    chatId: '5511999999999@s.whatsapp.net',
+    rawPayload: {},
+  } as never;
+
+  const dedup = { isDuplicate: () => false } as never;
+
+  test('tenant envelope: checkAccess receives the envelope-derived tenant', async () => {
+    const h = harness({ triggerEvents: ['reaction.received'] });
+
+    const instance = await __test__.shouldProcessReaction(
+      h.agentRunner,
+      h.accessService,
+      dedup,
+      reactionPayload,
+      METADATA,
+      'reaction.received',
+      fakeDb(),
+      TENANT_A,
+    );
+
+    expect(instance).not.toBeNull();
+    expect(h.calls.length).toBeGreaterThan(0);
+    for (const call of h.calls) expect(call.tenantId).toBe(TENANT_A);
+  });
+
+  test('legacy envelope: nothing is threaded', async () => {
+    const h = harness({ triggerEvents: ['reaction.received'] });
+
+    await __test__.shouldProcessReaction(
+      h.agentRunner,
+      h.accessService,
+      dedup,
+      reactionPayload,
+      METADATA,
+      'reaction.received',
+      fakeDb(),
+      undefined,
+    );
+
+    expect(h.calls.length).toBeGreaterThan(0);
+    for (const call of h.calls) expect(call.tenantId).toBeUndefined();
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-media-tenant.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-media-tenant.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tenant-bound presigning at agent dispatch (wish: omni-full-multitenancy, G5
+ * leg D; ADR-0008).
+ *
+ * The dispatcher consumes `message.received` envelopes. When the envelope is
+ * TENANT world (versioned + trusted producer-stamped tenant), every presign it
+ * mints for the agent must carry that trusted tenant so `MediaStorageService`
+ * can bind tenant + object + expiry. When the envelope is LEGACY world, the
+ * presign call is byte-identical to pre-G5 (no tenant argument at all).
+ *
+ * The tenant travels producer → envelope → `DispatchMetadata.trustedTenantId`
+ * (stamped by the subscription handler from `classifyEnvelope`, NEVER from the
+ * caller-facing payload) → the media-resolution helpers under test here.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { EventMetadata } from '@omni/core';
+import type { MediaStorageService } from '../../services/media-storage';
+import { __test__ } from '../agent-dispatcher';
+
+const { resolveDispatchMediaPath, extractMediaFiles, trustedDispatchTenant } = __test__;
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_KEY = `tenants/${TENANT_A}/instances/inst-1/2026-07/img-1.png`;
+const LEGACY_KEY = 'inst-1/2026-07/img-1.png';
+
+/** Remote-mode MediaStorageService stub recording every presign call. */
+function stubMediaStorage(opts?: { presignError?: boolean }) {
+  const calls: Array<{ ref: string; ttl: number | undefined; tenant: string | undefined }> = [];
+  const stub = {
+    getStorageMode: () => 'remote' as const,
+    presignedUrl: async (ref: string, ttl?: number, tenant?: string) => {
+      calls.push({ ref, ttl, tenant });
+      if (opts?.presignError) throw new Error('media-storage: refusing to presign');
+      return `https://s3.example/${ref}`;
+    },
+  } as unknown as MediaStorageService;
+  return { stub, calls };
+}
+
+type BufferedLike = Parameters<typeof extractMediaFiles>[0][number];
+function bufferedMessage(opts: { mediaLocalPath?: string; trustedTenantId?: string }): BufferedLike {
+  return {
+    payload: {
+      externalId: 'ext-1',
+      chatId: 'chat-1',
+      from: 'user-1',
+      content: { type: 'image', mimeType: 'image/png', mediaUrl: '/api/v2/media/x.png' },
+      rawPayload: opts.mediaLocalPath ? { mediaLocalPath: opts.mediaLocalPath } : undefined,
+    },
+    metadata: { instanceId: 'inst-1', traceId: 'trace-1', trustedTenantId: opts.trustedTenantId },
+    timestamp: Date.now(),
+  } as unknown as BufferedLike;
+}
+
+describe('trustedDispatchTenant (envelope → dispatch tenant derivation)', () => {
+  it('derives the trusted tenant from a versioned tenant envelope', () => {
+    const metadata = { envelopeVersion: 1, tenantId: TENANT_A } as unknown as EventMetadata;
+    expect(trustedDispatchTenant(metadata)).toBe(TENANT_A);
+  });
+
+  it('legacy envelope (no version, no tenant) derives undefined — byte-identical world', () => {
+    expect(trustedDispatchTenant({} as EventMetadata)).toBeUndefined();
+  });
+
+  it('refuses a quarantined envelope instead of falling back to global processing', () => {
+    // Defence in depth: the subscription layer terms quarantined envelopes
+    // before handlers run; if one slips through, deriving "no tenant" would
+    // process it globally — exactly the fallback ADR-0008 forbids.
+    const forged = { tenantId: TENANT_A } as unknown as EventMetadata; // tenant claim, no version
+    expect(() => trustedDispatchTenant(forged)).toThrow(/quarantin/i);
+    const unknownVersion = { envelopeVersion: 999, tenantId: TENANT_A } as unknown as EventMetadata;
+    expect(() => trustedDispatchTenant(unknownVersion)).toThrow(/quarantin/i);
+  });
+});
+
+describe('resolveDispatchMediaPath tenant binding (remote mode)', () => {
+  it('threads the trusted tenant into the presign call', async () => {
+    const { stub, calls } = stubMediaStorage();
+    const url = await resolveDispatchMediaPath(stub, TENANT_KEY, TENANT_A);
+    expect(url).toBe(`https://s3.example/${TENANT_KEY}`);
+    expect(calls).toEqual([{ ref: TENANT_KEY, ttl: undefined, tenant: TENANT_A }]);
+  });
+
+  it('legacy world presigns with NO tenant argument (byte-identical to pre-G5)', async () => {
+    const { stub, calls } = stubMediaStorage();
+    await resolveDispatchMediaPath(stub, LEGACY_KEY);
+    expect(calls).toEqual([{ ref: LEGACY_KEY, ttl: undefined, tenant: undefined }]);
+  });
+
+  it('returns null (no URL) when the tenant-bound presign is refused', async () => {
+    // e.g. a legacy-keyed object under a tenant context: fail closed, degrade
+    // gracefully — the dispatch continues without a media URL rather than
+    // minting an unbound one.
+    const { stub } = stubMediaStorage({ presignError: true });
+    expect(await resolveDispatchMediaPath(stub, LEGACY_KEY, TENANT_A)).toBeNull();
+  });
+});
+
+describe('extractMediaFiles tenant binding (remote mode)', () => {
+  it('presigns each message with its own envelope-derived trusted tenant', async () => {
+    const { stub, calls } = stubMediaStorage();
+    const files = await extractMediaFiles(
+      [bufferedMessage({ mediaLocalPath: TENANT_KEY, trustedTenantId: TENANT_A })],
+      true,
+      stub,
+      null,
+    );
+    expect(files).toEqual([{ url: `https://s3.example/${TENANT_KEY}`, mimeType: 'image/png' }]);
+    expect(calls).toEqual([{ ref: TENANT_KEY, ttl: undefined, tenant: TENANT_A }]);
+  });
+
+  it('legacy message presigns with NO tenant argument (byte-identical)', async () => {
+    const { stub, calls } = stubMediaStorage();
+    await extractMediaFiles([bufferedMessage({ mediaLocalPath: LEGACY_KEY })], true, stub, null);
+    expect(calls).toEqual([{ ref: LEGACY_KEY, ttl: undefined, tenant: undefined }]);
+  });
+
+  it('drops the file (no URL) when the tenant-bound presign is refused', async () => {
+    const { stub } = stubMediaStorage({ presignError: true });
+    const files = await extractMediaFiles(
+      [bufferedMessage({ mediaLocalPath: LEGACY_KEY, trustedTenantId: TENANT_A })],
+      true,
+      stub,
+      null,
+    );
+    expect(files).toEqual([]);
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-two-tenant-postgres.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Two-tenant AGENT-DISPATCHER containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * The dispatcher is a NATS consumer whose four direct tenant-table accesses
+ * were `pending-G5-conversion` sites:
+ *   - `agent_sessions` — the per-thread init marker (check/mark pair);
+ *   - `agents`         — the FK-override read (`applyAgentFkOverrides`) and the
+ *                        turn-based agent lookup;
+ *   - `handoff_logs`   — the error-handoff audit insert;
+ *   - `instances`      — the self-send-guard owner-identifier enumeration,
+ *                        which also keeps an in-memory CACHE that must be
+ *                        tenant-keyed (a global cache would serve tenant A's
+ *                        identifiers to tenant B — the namespace deliverable).
+ *
+ * Each conversion threads the envelope-derived `trustedTenantId` (stamped into
+ * `DispatchMetadata` by the subscription handlers, never read from payloads)
+ * into a SHORT worker tenant scope around the discrete DB block. This suite
+ * proves each converted seam — the exact functions the dispatch path calls —
+ * stays inside the work item's tenant, and that aiming one tenant's scope at
+ * another tenant's rows buys nothing.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  agentSessions,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+  handoffLogs,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { RouteResolver } from '../../services/route-resolver';
+import { scopedHandle } from '../../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { applyAgentFkOverrides, __test__ as dispatcherTest } from '../agent-dispatcher';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+const TENANT_B = '22222222-2222-4222-8222-2222222222ab';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555aa';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555ab';
+const CHAT_A = '66666666-6666-4666-8666-6666666666aa';
+const AGENT_A = '99999999-9999-4999-8999-9999999999aa';
+const ROUTE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const JID = '5511999990000@s.whatsapp.net';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-dispatcher-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+postgresDescribe('two-tenant agent-dispatcher containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_dispatcher_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  const sessionKeysForTenant = (tenantId: string, instanceId: string): Promise<{ sessionKey: string }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ sessionKey: agentSessions.sessionKey })
+        .from(agentSessions)
+        .where(eq(agentSessions.instanceId, instanceId)),
+    );
+
+  const handoffsForTenant = (tenantId: string, chatUuid: string): Promise<{ id: string }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: handoffLogs.id })
+        .from(handoffLogs)
+        .where(eq(handoffLogs.chatUuid, chatUuid)),
+    );
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, is_active, owner_identifier, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', true, 'owner-a', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', true, 'owner-b', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', '${JID}', '${JID}', 'direct', 'whatsapp-baileys', 'Chat A',
+         '${TENANT_A}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO agents (id, name, provider, agent_type, config_path) VALUES
+        ('${AGENT_A}', 'agent-a', 'claude-code', 'assistant', 'agents/a.yaml');
+      -- The BEFORE INSERT derivation trigger forces agents.tenant_id to NULL
+      -- (agents derives its tenant via owner_id -> persons, and persons is
+      -- G2-unowned until the G6 backfill). Stamp it directly as superuser to
+      -- model the POST-G6-backfill state this conversion targets — exactly the
+      -- write the G6 ledger tooling will perform.
+      UPDATE agents SET tenant_id = '${TENANT_A}' WHERE id = '${AGENT_A}';
+
+      -- A chat-scoped route on A's chat; the derivation trigger stamps its
+      -- tenant from the (required) owning instance.
+      INSERT INTO agent_routes (id, instance_id, scope, chat_id, is_active, priority) VALUES
+        ('${ROUTE_A}', '${INSTANCE_A}', 'chat', '${CHAT_A}', true, 0);
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // ONE physical connection shared by both tenants' workers: any bleed shows here.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 1);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('per-thread init marker lands under A and is invisible to B', async () => {
+    await dispatcherTest.markPerThreadSessionInitialized(runtimeDb, INSTANCE_A, 'thread-1', TENANT_A);
+
+    expect(await dispatcherTest.checkPerThreadSessionExists(runtimeDb, INSTANCE_A, 'thread-1', TENANT_A)).toBe(true);
+    // B's worker scope cannot see A's marker — the lazy-init check refuses to
+    // be satisfied by a foreign tenant's row.
+    expect(await dispatcherTest.checkPerThreadSessionExists(runtimeDb, INSTANCE_A, 'thread-1', TENANT_B)).toBe(false);
+    expect((await sessionKeysForTenant(TENANT_A, INSTANCE_A)).length).toBe(1);
+    expect((await sessionKeysForTenant(TENANT_B, INSTANCE_A)).length).toBe(0);
+  });
+
+  test("a B worker cannot mark a session on A's instance", async () => {
+    // The derivation trigger stamps the tenant from the instance (A); under B's
+    // scope the WITH CHECK refuses the row rather than trusting the caller.
+    await expect(
+      dispatcherTest.markPerThreadSessionInitialized(runtimeDb, INSTANCE_A, 'thread-forged', TENANT_B),
+    ).rejects.toThrow();
+    expect((await sessionKeysForTenant(TENANT_A, INSTANCE_A)).length).toBe(1); // only the legit marker
+  });
+
+  test("applyAgentFkOverrides reads A's agent under A and refuses to see it under B", async () => {
+    const effectiveA = { agentId: AGENT_A } as Parameters<typeof applyAgentFkOverrides>[2];
+    await applyAgentFkOverrides(runtimeDb, AGENT_A, effectiveA, TENANT_A);
+    expect(effectiveA.agentInternalId).toBe('agents/a.yaml');
+
+    // Under B's scope A's agent row is invisible: nothing is stamped, so a
+    // forged cross-tenant agentId cannot leak another tenant's agent config.
+    const effectiveB = { agentId: AGENT_A } as Parameters<typeof applyAgentFkOverrides>[2];
+    await applyAgentFkOverrides(runtimeDb, AGENT_A, effectiveB, TENANT_B);
+    expect(effectiveB.agentInternalId).toBeUndefined();
+  });
+
+  test('the self-send-guard enumeration and its cache are tenant-keyed', async () => {
+    dispatcherTest.resetActiveOwnerIdentifiersCache();
+
+    // A sees only its own owner identifiers…
+    expect(await dispatcherTest.listActiveOwnerIdentifiers(runtimeDb, TENANT_A)).toEqual(['owner-a']);
+    // …and B, asking IMMEDIATELY afterwards (inside any cache TTL), must not be
+    // served A's cached list — the cache key includes the tenant. With the old
+    // global cache this returns ['owner-a'] and the guard would treat A's
+    // instance as B's own (cross-tenant identifier leak + wrong gating).
+    expect(await dispatcherTest.listActiveOwnerIdentifiers(runtimeDb, TENANT_B)).toEqual(['owner-b']);
+    // Repeat A from cache: still A's list.
+    expect(await dispatcherTest.listActiveOwnerIdentifiers(runtimeDb, TENANT_A)).toEqual(['owner-a']);
+  });
+
+  test('route resolution is tenant-scoped and its negative cache is tenant-keyed', async () => {
+    const resolver = new RouteResolver(runtimeDb);
+
+    // A foreign (B) worker scope aiming at A's instance/chat resolves NOTHING —
+    // RLS hides the route — and caches its own negative entry…
+    expect(await resolver.resolve(INSTANCE_A, CHAT_A, undefined, TENANT_B)).toBeNull();
+
+    // …which must NOT poison A's lookup: with a tenant-less cache key, B's
+    // NO_ROUTE sentinel would short-circuit this call and A's routing (and
+    // every per-route override) would silently fall back to instance defaults
+    // for the TTL. The tenant-keyed cache keeps the worlds apart.
+    const route = await resolver.resolve(INSTANCE_A, CHAT_A, undefined, TENANT_A);
+    expect(route?.id).toBe(ROUTE_A);
+  });
+
+  test("the error-handoff audit insert lands under A; a B worker aiming at A's chat writes nothing", async () => {
+    // Minimal services stub: the chat row is supplied directly (the chats
+    // service's own containment is its own site's test); the REAL
+    // handoff_logs insert below is the probe.
+    const services = {
+      chats: {
+        findByExternalIdSmart: async () => ({ id: CHAT_A, settings: {} }),
+        update: async () => undefined,
+      },
+      followUpLifecycle: { disarm: async () => undefined },
+    } as unknown as Parameters<typeof dispatcherTest.persistErrorHandoffSideEffects>[0];
+    const instanceA = { id: INSTANCE_A, agentId: null } as Parameters<
+      typeof dispatcherTest.persistErrorHandoffSideEffects
+    >[3];
+
+    await dispatcherTest.persistErrorHandoffSideEffects(
+      services,
+      runtimeDb,
+      'whatsapp-baileys',
+      instanceA,
+      JID,
+      'handoff message',
+      'ext-msg-1',
+      TENANT_A,
+    );
+    expect((await handoffsForTenant(TENANT_A, CHAT_A)).length).toBe(1);
+    expect((await handoffsForTenant(TENANT_B, CHAT_A)).length).toBe(0);
+
+    // A B worker aiming at A's chat/instance: the derivation trigger stamps
+    // tenant A from the instance, B's WITH CHECK refuses, and the side-effect
+    // block's best-effort catch swallows it — nothing lands anywhere.
+    await dispatcherTest.persistErrorHandoffSideEffects(
+      services,
+      runtimeDb,
+      'whatsapp-baileys',
+      instanceA,
+      JID,
+      'forged handoff',
+      'ext-msg-2',
+      TENANT_B,
+    );
+    expect((await handoffsForTenant(TENANT_A, CHAT_A)).length).toBe(1);
+    expect((await handoffsForTenant(TENANT_B, CHAT_A)).length).toBe(0);
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-worker-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-worker-scope.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Agent-dispatcher read-path worker scope (wish: omni-full-multitenancy, Group
+ * G5; ADR-0008).
+ *
+ * The dispatcher already ran its WRITE blocks through `runDispatchDb` (leg A/E).
+ * Its READ helpers did not: `resolveQuotedMessage`, `resolveContactName`,
+ * `resolvePersonId`, `resolveCustomerContext`, `fetchSenderMetadata`,
+ * `fetchChatMetadata`, `buildContextMessages` and the media-wait recovery all
+ * called `services.chats` / `services.messages` / `services.persons` bare, so
+ * they reached the ambient pool even for a tenant-world envelope. That kept
+ * `services/chats.ts::chat_id_mappings`, `services/messages.ts::{messages,chats}`
+ * and `services/persons.ts::platform_identities` at `pending-G5-conversion`
+ * however well the consumers around them were converted — a site is only as
+ * scoped as its least-scoped caller.
+ *
+ * Two of these helpers POLL for another consumer's commit (`resolvePersonId`
+ * waits for message-persistence to create the identity; `awaitMediaProcessing`
+ * waits for the media row). A single transaction spanning the poll could never
+ * observe those commits — REPEATABLE READ would pin the snapshot — and it would
+ * also outlive its work item. So the contract asserted here is per-READ scoping:
+ * each attempt opens and closes its own short worker transaction.
+ *
+ * Probes: for each helper, a trusted tenant scopes every service read to that
+ * tenant, and no trusted tenant (the legacy world) leaves the read completely
+ * unscoped — byte-identical to pre-G5.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { __test__ } from '../agent-dispatcher';
+
+const {
+  resolveQuotedMessage,
+  resolveContactName,
+  resolvePersonId,
+  resolveCustomerContext,
+  resolveLidMentionBot,
+  resolveEffectiveReplyFilter,
+  resolveSlackThreadReply,
+  fetchSenderMetadata,
+  fetchChatMetadata,
+  buildContextMessages,
+  applyCloseContactGate,
+} = __test__;
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+/** A db fake that records the tenant each worker scope stamps. */
+function fakeDb(stamped: string[]): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({
+        execute: async (q: unknown) => {
+          const text = JSON.stringify(q);
+          const match = /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i.exec(text);
+          if (match) stamped.push(match[0]);
+          return [] as unknown;
+        },
+      }),
+  } as unknown as Database;
+}
+
+interface Harness {
+  services: never;
+  scopes: (string | null)[];
+  stamped: string[];
+}
+
+/**
+ * A services fake whose every db-backed method records the tenant scope active
+ * at the moment it runs.
+ */
+function harness(): Harness {
+  const stamped: string[] = [];
+  const scopes: (string | null)[] = [];
+  const db = fakeDb(stamped);
+  const observe = () => {
+    scopes.push(currentTenantScope()?.tenantId ?? null);
+  };
+  const chat = {
+    id: 'chat-uuid',
+    name: 'Group Name',
+    participantCount: 3,
+    chatType: 'group',
+    settings: {},
+  };
+  const services = {
+    db,
+    chats: {
+      findByExternalIdSmart: async () => {
+        observe();
+        return chat;
+      },
+      update: async () => {
+        observe();
+        return chat;
+      },
+      findLidMapping: async () => {
+        observe();
+        return '5511999999999@s.whatsapp.net';
+      },
+    },
+    messages: {
+      getByExternalId: async () => {
+        observe();
+        return {
+          id: 'message-uuid',
+          textContent: 'quoted body',
+          senderDisplayName: 'Someone',
+          isFromMe: false,
+          platformTimestamp: new Date('2026-01-01T00:00:00Z'),
+        };
+      },
+      list: async () => {
+        observe();
+        return { messages: [], total: 0 };
+      },
+      hasBotRepliedInThread: async () => {
+        observe();
+        return true;
+      },
+    },
+    // routeResolver manages its own scope via the trustedTenantId it is passed;
+    // it must NOT observe here, so the only reads these probes record are the
+    // chat/message reads under test.
+    routeResolver: {
+      resolve: async () => null,
+    },
+    persons: {
+      getIdentityByPlatformId: async () => {
+        observe();
+        return { personId: 'person-uuid', profilePicUrl: 'https://x/y.png', platformUsername: 'someone' };
+      },
+      getById: async () => {
+        observe();
+        return { id: 'person-uuid', metadata: {} };
+      },
+    },
+  } as never;
+  return { services, scopes, stamped };
+}
+
+/**
+ * A structural view of the harness's service fakes. The harness types `services`
+ * as `never` so it stays assignable to the full `Services` param of the 8
+ * whole-`services` probes; these three helpers take individual services, so we
+ * project the pieces back out with their exact param types.
+ */
+function pieces(h: Harness): {
+  db: Parameters<typeof resolveEffectiveReplyFilter>[5];
+  chats: Parameters<typeof resolveEffectiveReplyFilter>[0];
+  messages: Parameters<typeof resolveSlackThreadReply>[1];
+  routeResolver: Parameters<typeof resolveEffectiveReplyFilter>[1];
+} {
+  return h.services as unknown as {
+    db: Parameters<typeof resolveEffectiveReplyFilter>[5];
+    chats: Parameters<typeof resolveEffectiveReplyFilter>[0];
+    messages: Parameters<typeof resolveSlackThreadReply>[1];
+    routeResolver: Parameters<typeof resolveEffectiveReplyFilter>[1];
+  };
+}
+
+/** Every recorded read saw the same expectation. */
+function expectAllScopes(scopes: (string | null)[], expected: string | null) {
+  expect(scopes.length).toBeGreaterThan(0);
+  for (const s of scopes) expect(s).toBe(expected);
+}
+
+describe('agent-dispatcher read helpers scope their db reads (G5, ADR-0008)', () => {
+  test('resolveQuotedMessage: tenant world scopes the chat + message reads', async () => {
+    const h = harness();
+    await resolveQuotedMessage(h.services, 'inst-1', 'chat-ext', 'reply-ext', [], { trustedTenantId: TENANT_A });
+    expectAllScopes(h.scopes, TENANT_A);
+    expect(h.stamped.every((t) => t === TENANT_A)).toBe(true);
+  });
+
+  test('resolveQuotedMessage: legacy world leaves the reads unscoped', async () => {
+    const h = harness();
+    await resolveQuotedMessage(h.services, 'inst-1', 'chat-ext', 'reply-ext', [], {});
+    expectAllScopes(h.scopes, null);
+    expect(h.stamped).toEqual([]);
+  });
+
+  test('resolveContactName: tenant world scopes the chat read; legacy does not', async () => {
+    const tenant = harness();
+    await resolveContactName(tenant.services, 'inst-1', 'jid-1', new Map(), TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    await resolveContactName(legacy.services, 'inst-1', 'jid-1', new Map());
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('resolvePersonId: each poll attempt gets its OWN short scope', async () => {
+    const tenant = harness();
+    await resolvePersonId(tenant.services, 'whatsapp-baileys', 'inst-1', 'sender-1', undefined, TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+    // One transaction per attempt — never one spanning the poll.
+    expect(tenant.stamped.length).toBe(tenant.scopes.length);
+
+    const legacy = harness();
+    await resolvePersonId(legacy.services, 'whatsapp-baileys', 'inst-1', 'sender-1');
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('resolveCustomerContext: tenant world scopes the person read; legacy does not', async () => {
+    const tenant = harness();
+    await resolveCustomerContext(tenant.services, 'person-uuid', undefined, TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    await resolveCustomerContext(legacy.services, 'person-uuid', undefined);
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('fetchSenderMetadata: tenant world scopes the identity read; legacy does not', async () => {
+    const tenant = harness();
+    await fetchSenderMetadata(tenant.services, 'whatsapp-baileys', 'inst-1', 'sender-1', TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    await fetchSenderMetadata(legacy.services, 'whatsapp-baileys', 'inst-1', 'sender-1');
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('fetchChatMetadata: tenant world scopes the chat read; legacy does not', async () => {
+    const tenant = harness();
+    await fetchChatMetadata(tenant.services, 'inst-1', 'chat-ext', 'group', TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    await fetchChatMetadata(legacy.services, 'inst-1', 'chat-ext', 'group');
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('buildContextMessages: tenant world scopes the chat + history reads; legacy does not', async () => {
+    const instance = { id: 'inst-1', config: {} } as never;
+    const tenant = harness();
+    await buildContextMessages(tenant.services, instance, 'chat-ext', [], TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    await buildContextMessages(legacy.services, instance, 'chat-ext', []);
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('resolveLidMentionBot: tenant world scopes the LID mapping read; legacy does not', async () => {
+    // Phone-JID owner (not a LID) forces the DB-resolution branch — the direct
+    // LID compare is skipped, so `findLidMapping` (chat_id_mappings) must run.
+    const owner = '5511999999999@s.whatsapp.net';
+    const mentionedJids = ['888888888888@lid'];
+
+    const tenant = harness();
+    const ts = pieces(tenant);
+    await resolveLidMentionBot(
+      ts.chats,
+      'inst-1',
+      owner,
+      mentionedJids,
+      { mentionsBot: false } as never,
+      ts.db,
+      TENANT_A,
+    );
+    expectAllScopes(tenant.scopes, TENANT_A);
+    expect(tenant.stamped.every((t) => t === TENANT_A)).toBe(true);
+
+    const legacy = harness();
+    const ls = pieces(legacy);
+    await resolveLidMentionBot(ls.chats, 'inst-1', owner, mentionedJids, { mentionsBot: false } as never, ls.db);
+    expectAllScopes(legacy.scopes, null);
+    expect(legacy.stamped).toEqual([]);
+  });
+
+  test('resolveEffectiveReplyFilter: tenant world scopes the chat read; legacy does not', async () => {
+    const tenant = harness();
+    const ts = pieces(tenant);
+    await resolveEffectiveReplyFilter(
+      ts.chats,
+      ts.routeResolver,
+      'inst-1',
+      'chat-ext',
+      'all' as never,
+      ts.db,
+      TENANT_A,
+    );
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    const ls = pieces(legacy);
+    await resolveEffectiveReplyFilter(ls.chats, ls.routeResolver, 'inst-1', 'chat-ext', 'all' as never, ls.db);
+    expectAllScopes(legacy.scopes, null);
+  });
+
+  test('resolveSlackThreadReply: tenant world scopes the chat + thread reads; legacy does not', async () => {
+    const instance = { id: 'inst-1', channel: 'slack' } as never;
+    const payload = { chatId: 'chat-ext', rawPayload: { isThreadReply: true, threadTs: '123.456' } } as never;
+
+    const tenant = harness();
+    const ts = pieces(tenant);
+    await resolveSlackThreadReply(
+      ts.chats,
+      ts.messages,
+      instance,
+      payload,
+      { isReplyToBot: false } as never,
+      ts.db,
+      TENANT_A,
+    );
+    expectAllScopes(tenant.scopes, TENANT_A);
+    expect(tenant.stamped.every((t) => t === TENANT_A)).toBe(true);
+
+    const legacy = harness();
+    const ls = pieces(legacy);
+    await resolveSlackThreadReply(ls.chats, ls.messages, instance, payload, { isReplyToBot: false } as never, ls.db);
+    expectAllScopes(legacy.scopes, null);
+    expect(legacy.stamped).toEqual([]);
+  });
+
+  test('applyCloseContactGate: tenant world scopes its chat write; legacy does not', async () => {
+    // A soft close whose cooldown has expired: the gate clears `closeUntil`,
+    // which is the only write path in this function.
+    const settings = { closeUntil: '2020-01-01T00:00:00.000Z' } as never;
+    const tenant = harness();
+    await applyCloseContactGate(tenant.services, 'chat-uuid', 'inst-1', 'chat-ext', settings, TENANT_A);
+    expectAllScopes(tenant.scopes, TENANT_A);
+
+    const legacy = harness();
+    await applyCloseContactGate(legacy.services, 'chat-uuid', 'inst-1', 'chat-ext', settings);
+    expectAllScopes(legacy.scopes, null);
+  });
+});

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -2276,6 +2276,12 @@ describe('agent-dispatcher', () => {
     // CURRENT_OWNER. Returns the agentRunner so callers can assert whether
     // dispatch proceeded (getSenderName is only reached past the gate).
     async function fireFirstPartyMessage(allowFirstParty: boolean) {
+      // The active-owner list is memoized in a module-level cache with a 10s
+      // TTL. Any dispatch by an earlier test (this file or another file in the
+      // same process) inside that window leaves a stale owner list that does
+      // NOT contain OTHER_OWNER, and the gate then dispatches instead of
+      // dropping — order- and timing-dependent, so it only shows on CI.
+      __test__.resetActiveOwnerIdentifiersCache();
       const eventBus = createMockEventBus();
       const agentRunner = {
         getInstanceWithProvider: mock(async () =>

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -605,8 +605,13 @@ describe('agent-dispatcher', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Should have been called 3 times: once for LID, once fallback (no participantAlt), once for resolvedSenderPhone
-      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '100000001', expect.anything());
-      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '5511999000001', expect.anything());
+      // G5 run15: `checkAccess` gained a 4th `trustedTenantId` parameter so the
+      // consumer path can scope its rule read. These legacy-envelope events
+      // classify `legacy`, so the dispatcher threads `undefined` — the same value
+      // the parameter defaults to, i.e. identical behaviour. Only the recorded
+      // ARITY changed, which `toHaveBeenCalledWith` compares exactly.
+      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '100000001', expect.anything(), undefined);
+      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '5511999000001', expect.anything(), undefined);
       // Message should have reached agent (allowed via phone number)
       expect(services.agentRunner.getSenderName).toHaveBeenCalled();
     });
@@ -662,7 +667,12 @@ describe('agent-dispatcher', () => {
       await eventBus.fire('message.received', event);
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '5511999000003', expect.anything());
+      // G5 run15: `checkAccess` gained a 4th `trustedTenantId` parameter so the
+      // consumer path can scope its rule read. These legacy-envelope events
+      // classify `legacy`, so the dispatcher threads `undefined` — the same value
+      // the parameter defaults to, i.e. identical behaviour. Only the recorded
+      // ARITY changed, which `toHaveBeenCalledWith` compares exactly.
+      expect(checkAccess).toHaveBeenCalledWith(expect.anything(), '5511999000003', expect.anything(), undefined);
       expect(services.agentRunner.getSenderName).toHaveBeenCalled();
     });
 

--- a/packages/api/src/plugins/__tests__/automation-actions-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/automation-actions-two-tenant-postgres.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Two-tenant AUTOMATION-ACTIONS containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * The automation engine executes tenant-controlled actions from a NATS
+ * consumer callback. This suite drives the REAL callback factory
+ * (`buildAutomationEngineDeps` — exactly what `index.ts` hands
+ * `startEngine`) with real `Services` over the enforced runtime role, so the
+ * resolution reads (`instances.getById`, `chats.getById`, the direct `agents`
+ * lookup) run precisely the scoped path production runs.
+ *
+ * Probes:
+ *   1. tenant A's callback resolves A's own chat UUID to its external id;
+ *   2. tenant A's callback CANNOT resolve tenant B's chat UUID — RLS turns the
+ *      cross-tenant reference into not-found, and no send happens;
+ *   3. tenant A's callback CANNOT see tenant B's instance;
+ *   4. the `agents` G6 gate, fail-closed: `agents` derives its tenant via
+ *      owner_id → persons (G2-`unowned`), so every row is NULL-tenant until
+ *      the G6 backfill and a SCOPED read finds nothing — `call_agent` refuses
+ *      with "Agent not found" rather than reading another tenant's (or a
+ *      global) agent. Named degradation, mirrors the session-cleaner finding.
+ *   5. under enforcement a LEGACY (tenantless) invocation reads through the
+ *      runtime role with no tenant GUC and the policies match no rows — the
+ *      dual world is data, not a code branch (flag-off byte-identity is
+ *      asserted by the unit worker-scope probes).
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+} from '@omni/db';
+import { createServices } from '../../services';
+import { buildAutomationEngineDeps } from '../automation-actions';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+const TENANT_B = '22222222-2222-4222-8222-2222222222bb';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555aa';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555bb';
+const CHAT_A = '66666666-6666-4666-8666-6666666666aa';
+const CHAT_B = '66666666-6666-4666-8666-6666666666bb';
+const AGENT_ID = '77777777-7777-4777-8777-7777777777aa';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-autoactions-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+postgresDescribe('two-tenant automation-actions containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_autoactions_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let deps: ReturnType<typeof buildAutomationEngineDeps>;
+  let sent: Array<{ instanceId: string; to: string }>;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    // Seed: both tenants own an instance and a chat. The agent row is
+    // deliberately NULL-tenant — that IS production's shape until the G6
+    // persons backfill (agents derives owner_id → persons, G2-`unowned`).
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}');
+
+      INSERT INTO chats (id, instance_id, external_id, chat_type, channel, tenant_id) VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', 'chat-a@s.whatsapp.net', 'dm', 'whatsapp-baileys', '${TENANT_A}'),
+        ('${CHAT_B}', '${INSTANCE_B}', 'chat-b@s.whatsapp.net', 'dm', 'whatsapp-baileys', '${TENANT_B}');
+
+      INSERT INTO agents (id, name, provider, agent_type) VALUES
+        ('${AGENT_ID}', 'null-tenant-agent', 'agno', 'assistant');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // ONE physical connection shared by every probe: any bleed shows here.
+    const runtimeDb = openDb(
+      urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }),
+      1,
+    );
+
+    sent = [];
+    const capture = sent;
+    deps = buildAutomationEngineDeps(createServices(runtimeDb, null), runtimeDb, {
+      resolvePlugin: async () =>
+        ({
+          sendMessage: async (instanceId: string, msg: { to: string }) => {
+            capture.push({ instanceId, to: msg.to });
+          },
+        }) as never,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test("tenant A's callback resolves A's own chat UUID to its external id", async () => {
+    await deps.sendMessage(INSTANCE_A, CHAT_A, 'hello', TENANT_A);
+    expect(sent).toEqual([{ instanceId: INSTANCE_A, to: 'chat-a@s.whatsapp.net' }]);
+    sent.length = 0;
+  }, 30_000);
+
+  test("tenant A's callback cannot resolve tenant B's chat UUID — not found, nothing sent", async () => {
+    await expect(deps.sendMessage(INSTANCE_A, CHAT_B, 'leak?', TENANT_A)).rejects.toThrow(
+      `Chat not found for UUID: ${CHAT_B}`,
+    );
+    expect(sent).toEqual([]);
+  }, 30_000);
+
+  test("tenant A's callback cannot see tenant B's instance", async () => {
+    await expect(deps.sendMessage(INSTANCE_B, CHAT_B, 'leak?', TENANT_A)).rejects.toThrow(/not found/i);
+    expect(sent).toEqual([]);
+  }, 30_000);
+
+  test('call_agent under a tenant scope refuses the NULL-tenant agent row (G6 gate, fail-closed)', async () => {
+    await expect(
+      deps.callAgent(
+        { instanceId: INSTANCE_A, agentId: AGENT_ID, chatId: CHAT_A, senderId: 'sender-1', messages: ['hi'] },
+        { agentId: '' },
+        TENANT_A,
+      ),
+    ).rejects.toThrow(`Agent not found: ${AGENT_ID}`);
+  }, 30_000);
+
+  test('a legacy invocation under enforcement is refused outright — the dual world is data, not a branch', async () => {
+    // No tenant threaded: the read runs on the ambient (runtime-role) pool with
+    // no tenant GUC, and the enforced `omni_current_tenant_id()` guard refuses
+    // the transaction rather than silently matching rows. Flag-off
+    // byte-identity for the legacy world is asserted by the unit worker-scope
+    // probes; under enforcement a scope-less read cannot succeed.
+    await expect(deps.sendMessage(INSTANCE_A, CHAT_A, 'legacy', undefined)).rejects.toThrow(
+      /app\.tenant_id is not set|not found/i,
+    );
+    expect(sent).toEqual([]);
+  }, 30_000);
+});

--- a/packages/api/src/plugins/__tests__/automation-actions-worker-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/automation-actions-worker-scope.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Automation-engine action callbacks worker scope (wish: omni-full-multitenancy,
+ * Group G5; ADR-0008).
+ *
+ * The engine invokes `sendMessage` / `callAgent` from a NATS consumer callback,
+ * so until this leg their DB reads — `services.instances.getById`,
+ * `services.chats.getById` and the DIRECT `agents` lookup — reached the ambient
+ * pool even for a tenant-world envelope. That kept `services/chats.ts::chats`
+ * and `services/instances.ts::instances` at `pending-G5-conversion` however
+ * converted the services themselves were: a site is only as scoped as its
+ * least-scoped caller (the run12 lesson).
+ *
+ * Contract probed here, per callback:
+ *   * tenant world (engine threads the envelope's trusted tenant) — every DB
+ *     read runs inside a short worker tenant scope for that tenant, one
+ *     transaction per discrete read block (never one spanning the outbound side
+ *     effect), and the direct `agents` read goes through `scopedHandle` so it
+ *     lands on the scope's TRANSACTION, not the pool;
+ *   * legacy world (nothing threaded) — zero transactions, every read on the
+ *     ambient pool, byte-identical to the pre-extraction inline callbacks;
+ *   * the outbound side effect (`plugin.sendMessage`, `agentRunner.runOrStream`)
+ *     always executes AFTER the resolution scopes closed — a worker transaction
+ *     must not outlive its work item (G4 leg-2 trap).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { buildAutomationEngineDeps } from '../automation-actions';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+const CHAT_UUID = '99999999-9999-4999-8999-999999999999';
+
+const AGENT_ROW = {
+  name: 'agent-name',
+  agentProviderId: 'prov-1',
+  agentType: 'assistant',
+  metadata: {},
+  configPath: null,
+};
+
+interface Harness {
+  services: Parameters<typeof buildAutomationEngineDeps>[0];
+  db: Database;
+  /** tenant scope observed by each service-mediated DB read, in order */
+  scopes: (string | null)[];
+  /** tenant stamped by each worker transaction that opened */
+  stamped: string[];
+  /** which handle the DIRECT `agents` read ran on: scope tx or ambient pool */
+  agentReadHandles: ('tx' | 'pool')[];
+  /** tenant scope active at the moment the outbound side effect ran */
+  sideEffectScopes: (string | null)[];
+  /** what the plugin was asked to send */
+  sent: Array<{ instanceId: string; to: string }>;
+  /** the runOrStream context the agent runner received */
+  runContexts: Array<Record<string, unknown>>;
+  /** args the stale gate forwarded to the lifecycle service */
+  gateArgs: Array<unknown[]>;
+  deps: ReturnType<typeof buildAutomationEngineDeps>;
+}
+
+/** A chainable `select().from().where().limit()` that resolves to the agent row. */
+function selectChain(onResolve: () => void) {
+  return () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => {
+          onResolve();
+          return [AGENT_ROW];
+        },
+      }),
+    }),
+  });
+}
+
+function harness(): Harness {
+  const scopes: (string | null)[] = [];
+  const stamped: string[] = [];
+  const agentReadHandles: ('tx' | 'pool')[] = [];
+  const sideEffectScopes: (string | null)[] = [];
+  const sent: Array<{ instanceId: string; to: string }> = [];
+  const runContexts: Array<Record<string, unknown>> = [];
+  const gateArgs: Array<unknown[]> = [];
+
+  const db = {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({
+        execute: async (q: unknown) => {
+          const text = JSON.stringify(q);
+          const match = /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i.exec(text);
+          if (match) stamped.push(match[0]);
+          return [] as unknown;
+        },
+        select: selectChain(() => agentReadHandles.push('tx')),
+      }),
+    select: selectChain(() => agentReadHandles.push('pool')),
+  } as unknown as Database;
+
+  const observe = () => {
+    scopes.push(currentTenantScope()?.tenantId ?? null);
+  };
+
+  const services = {
+    instances: {
+      getById: async (id: string) => {
+        observe();
+        return {
+          id,
+          channel: 'test-channel',
+          agentId: 'agent-fk-uuid',
+          agentSessionStrategy: 'per_chat',
+          agentPrefixSenderName: true,
+          agentTimeout: 600,
+          agentStreamMode: false,
+        };
+      },
+    },
+    chats: {
+      getById: async () => {
+        observe();
+        return { externalId: 'ext-5511999@s.whatsapp.net' };
+      },
+    },
+    agentRunner: {
+      runOrStream: async (context: Record<string, unknown>) => {
+        sideEffectScopes.push(currentTenantScope()?.tenantId ?? null);
+        runContexts.push(context);
+        return { parts: ['ok'], metadata: { runId: 'run-1', sessionId: 'sess-1', status: 'completed' as const } };
+      },
+    },
+    followUpLifecycle: {
+      evaluateIdleTimeoutFreshness: async (...args: unknown[]) => {
+        gateArgs.push(args);
+        return { skip: false };
+      },
+    },
+  } as unknown as Parameters<typeof buildAutomationEngineDeps>[0];
+
+  const plugin = {
+    sendMessage: async (instanceId: string, msg: { to: string }) => {
+      sideEffectScopes.push(currentTenantScope()?.tenantId ?? null);
+      sent.push({ instanceId, to: msg.to });
+    },
+  };
+
+  const deps = buildAutomationEngineDeps(services, db, {
+    resolvePlugin: async () => plugin as never,
+  });
+
+  return { services, db, scopes, stamped, agentReadHandles, sideEffectScopes, sent, runContexts, gateArgs, deps };
+}
+
+function expectAllScopes(scopes: (string | null)[], expected: string | null) {
+  expect(scopes.length).toBeGreaterThan(0);
+  for (const s of scopes) expect(s).toBe(expected);
+}
+
+describe('automation-actions callbacks scope their db reads (G5, ADR-0008)', () => {
+  test('sendMessage: tenant world scopes the instance + chat reads, one tx per read block', async () => {
+    const h = harness();
+    await h.deps.sendMessage('inst-1', CHAT_UUID, 'hello', TENANT_A);
+
+    expectAllScopes(h.scopes, TENANT_A);
+    expect(h.scopes.length).toBe(2); // instance read + chat read
+    expect(h.stamped).toEqual([TENANT_A, TENANT_A]); // one short tx each, never one spanning the send
+    expect(h.sent).toEqual([{ instanceId: 'inst-1', to: 'ext-5511999@s.whatsapp.net' }]);
+  });
+
+  test('sendMessage: the outbound plugin call runs OUTSIDE any worker scope', async () => {
+    const h = harness();
+    await h.deps.sendMessage('inst-1', CHAT_UUID, 'hello', TENANT_A);
+    expect(h.sideEffectScopes).toEqual([null]);
+  });
+
+  test('sendMessage: non-UUID recipient skips the chat read — a single tx', async () => {
+    const h = harness();
+    await h.deps.sendMessage('inst-1', '5511988887777@s.whatsapp.net', 'hello', TENANT_A);
+    expect(h.scopes).toEqual([TENANT_A]); // instance read only
+    expect(h.stamped).toEqual([TENANT_A]);
+    expect(h.sent).toEqual([{ instanceId: 'inst-1', to: '5511988887777@s.whatsapp.net' }]);
+  });
+
+  test('sendMessage: legacy world leaves every read unscoped — zero transactions', async () => {
+    const h = harness();
+    await h.deps.sendMessage('inst-1', CHAT_UUID, 'hello');
+    expectAllScopes(h.scopes, null);
+    expect(h.stamped).toEqual([]);
+    expect(h.sent).toEqual([{ instanceId: 'inst-1', to: 'ext-5511999@s.whatsapp.net' }]);
+  });
+
+  test('callAgent: tenant world scopes instance + chat + direct agents reads', async () => {
+    const h = harness();
+    const result = await h.deps.callAgent(
+      { instanceId: 'inst-1', chatId: CHAT_UUID, senderId: CHAT_UUID, messages: ['hi'] },
+      { agentId: '' },
+      TENANT_A,
+    );
+
+    expectAllScopes(h.scopes, TENANT_A); // instance read + chat resolve
+    expect(h.scopes.length).toBe(2);
+    // The DIRECT agents lookup must land on the scope's TRANSACTION, not the pool.
+    expect(h.agentReadHandles).toEqual(['tx']);
+    expect(h.stamped).toEqual([TENANT_A, TENANT_A, TENANT_A]); // one short tx per read block
+    expect(result.metadata.status).toBe('completed');
+  });
+
+  test('callAgent: the agent run executes OUTSIDE any worker scope', async () => {
+    const h = harness();
+    await h.deps.callAgent(
+      { instanceId: 'inst-1', chatId: CHAT_UUID, senderId: CHAT_UUID, messages: ['hi'] },
+      { agentId: '' },
+      TENANT_A,
+    );
+    expect(h.sideEffectScopes).toEqual([null]);
+  });
+
+  test('callAgent: legacy world leaves every read unscoped on the pool — zero transactions', async () => {
+    const h = harness();
+    await h.deps.callAgent(
+      { instanceId: 'inst-1', chatId: CHAT_UUID, senderId: CHAT_UUID, messages: ['hi'] },
+      { agentId: '' },
+    );
+    expectAllScopes(h.scopes, null);
+    expect(h.agentReadHandles).toEqual(['pool']);
+    expect(h.stamped).toEqual([]);
+  });
+
+  test('callAgent: the run context handed to the agent runner is world-independent', async () => {
+    const tenant = harness();
+    await tenant.deps.callAgent(
+      { instanceId: 'inst-1', chatId: CHAT_UUID, senderId: 'sender-9', senderName: 'S', messages: ['hi'] },
+      { agentId: '', agentType: 'team' },
+      TENANT_A,
+    );
+    const legacy = harness();
+    await legacy.deps.callAgent(
+      { instanceId: 'inst-1', chatId: CHAT_UUID, senderId: 'sender-9', senderName: 'S', messages: ['hi'] },
+      { agentId: '', agentType: 'team' },
+    );
+    expect(tenant.runContexts).toEqual(legacy.runContexts);
+  });
+
+  test('staleIdleTimeoutGate: forwards the trusted tenant to the lifecycle gate', async () => {
+    const h = harness();
+    await h.deps.staleIdleTimeoutGate('chat-1', 'inst-1', 3, TENANT_A);
+    expect(h.gateArgs).toEqual([['chat-1', 'inst-1', 3, TENANT_A]]);
+
+    await h.deps.staleIdleTimeoutGate('chat-1', 'inst-1', null, null);
+    expect(h.gateArgs[1]).toEqual(['chat-1', 'inst-1', null, null]);
+  });
+});

--- a/packages/api/src/plugins/__tests__/event-listeners-replay-callsite-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/event-listeners-replay-callsite-scope.test.ts
@@ -123,6 +123,11 @@ describe('event-listeners threads the envelope tenant into the replay', () => {
     const reads = observed.filter((o) => o.op === 'select');
     expect(reads.length).toBeGreaterThan(0);
     for (const read of reads) {
+      // The full observation sequence goes in the failure text — a bare
+      // "Received: null" from a CI-only run is undiagnosable without it.
+      if (read.scope !== TENANT_A || read.handle !== 'TX') {
+        throw new Error(`unscoped read observed; sequence=${JSON.stringify(observed)}`);
+      }
       expect(read.scope).toBe(TENANT_A);
       expect(read.handle).toBe('TX');
     }

--- a/packages/api/src/plugins/__tests__/event-listeners-replay-callsite-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/event-listeners-replay-callsite-scope.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The REPLAY call sites thread the envelope tenant (G5; ADR-0008).
+ *
+ * `services/__tests__/agent-replay-worker-scope.test.ts` proves
+ * `AgentReplayService` honours a threaded tenant. It cannot prove that
+ * `plugins/event-listeners.ts` threads one — and the guard justification for
+ * `agent-replay.ts::{instances,messages}` rests on exactly that: "the two
+ * fire-and-forget event-listener callers detached and threaded".
+ *
+ * Dropping `trustedEnvelopeTenant(event)` at either call site left the whole
+ * suite green: the replay is fire-and-forget behind `.catch(log)`, and the only
+ * test that fires an envelope through this handler asserts on the SEPARATE
+ * `runConsumerInTenantContext` write. So this probe drives the real handler and
+ * asserts the tenant scope the replay's own read observed — including which
+ * HANDLE issued it, since a scope that is opened but not used is the same defect
+ * one class over.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { setupConnectionListener } from '../event-listeners';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+interface Observed {
+  op: string;
+  scope: string | null;
+  handle: 'POOL' | 'TX';
+}
+
+function chain<T>(rows: T): T {
+  const self: unknown = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (onOk: (v: T) => unknown, onErr?: (e: unknown) => unknown) => Promise.resolve(rows).then(onOk, onErr);
+        }
+        return () => self;
+      },
+    },
+  );
+  return self as T;
+}
+
+/**
+ * The replay's instance read is the observation point. The row has no `agentId`,
+ * so the handler stops right after it — one read, deterministic.
+ */
+function makeDb(observed: Observed[]): Database {
+  const row = { id: 'inst-1', channel: 'telegram', replayEnabled: false, lastSeenAt: null, agentId: null };
+  const record = (op: string, handle: 'POOL' | 'TX') =>
+    observed.push({ op, scope: currentTenantScope()?.tenantId ?? null, handle });
+  const tx = {
+    select: () => {
+      record('select', 'TX');
+      return chain([row]);
+    },
+    update: () => {
+      record('update', 'TX');
+      return chain([]);
+    },
+    execute: async () => [],
+  };
+  const db = {
+    select: () => {
+      record('select', 'POOL');
+      return chain([row]);
+    },
+    update: () => {
+      record('update', 'POOL');
+      return chain([]);
+    },
+    transaction: async <T>(cb: (handle: unknown) => Promise<T>): Promise<T> => cb(tx),
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+function harness(observed: Observed[]) {
+  const handlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: async (eventType: string, cb: (event: unknown) => Promise<void>) => {
+      handlers.set(eventType, cb);
+      return { unsubscribe: async () => {} };
+    },
+    subscribePattern: async () => ({ unsubscribe: async () => {} }),
+    publish: async () => ({ id: 'evt-1' }),
+  } as unknown as EventBus;
+
+  const fire = async (eventType: string, metadata: Record<string, unknown>) => {
+    const handler = handlers.get(eventType);
+    if (!handler) throw new Error(`no handler for ${eventType}`);
+    await handler({
+      payload: { instanceId: 'inst-1', channelType: 'telegram', reason: 'network' },
+      metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
+    });
+    // The replay is fire-and-forget; let its detached chain run.
+    await new Promise((r) => setTimeout(r, 5));
+  };
+
+  return { bus, fire, db: makeDb(observed) };
+}
+
+describe('event-listeners threads the envelope tenant into the replay', () => {
+  test('instance.connected, tenant envelope: the replay read runs in that tenant’s scope', async () => {
+    const observed: Observed[] = [];
+    const h = harness(observed);
+    await setupConnectionListener(h.bus, h.db);
+
+    await h.fire('instance.connected', { envelopeVersion: 1, tenantId: TENANT_A });
+
+    // The connect handler's own `instances` update, then the replay's read.
+    const reads = observed.filter((o) => o.op === 'select');
+    expect(reads.length).toBeGreaterThan(0);
+    for (const read of reads) {
+      expect(read.scope).toBe(TENANT_A);
+      expect(read.handle).toBe('TX');
+    }
+  });
+
+  test('instance.connected, legacy envelope: the replay read stays ambient', async () => {
+    const observed: Observed[] = [];
+    const h = harness(observed);
+    await setupConnectionListener(h.bus, h.db);
+
+    await h.fire('instance.connected', {});
+
+    const reads = observed.filter((o) => o.op === 'select');
+    expect(reads.length).toBeGreaterThan(0);
+    for (const read of reads) {
+      expect(read.scope).toBeNull();
+      expect(read.handle).toBe('POOL');
+    }
+  });
+
+  test('instance.disconnected, tenant envelope: the lastSeenAt write is scoped too', async () => {
+    const observed: Observed[] = [];
+    const h = harness(observed);
+    await setupConnectionListener(h.bus, h.db);
+
+    await h.fire('instance.disconnected', { envelopeVersion: 1, tenantId: TENANT_A });
+
+    const writes = observed.filter((o) => o.op === 'update');
+    expect(writes.length).toBeGreaterThan(0);
+    for (const write of writes) {
+      expect(write.scope).toBe(TENANT_A);
+      expect(write.handle).toBe('TX');
+    }
+  });
+});

--- a/packages/api/src/plugins/__tests__/event-listeners-replay-callsite-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/event-listeners-replay-callsite-scope.test.ts
@@ -97,8 +97,15 @@ function harness(observed: Observed[]) {
       payload: { instanceId: 'inst-1', channelType: 'telegram', reason: 'network' },
       metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
     });
-    // The replay is fire-and-forget; let its detached chain run.
-    await new Promise((r) => setTimeout(r, 5));
+    // The replay is fire-and-forget; wait for its detached chain to reach the
+    // db rather than sleeping a fixed slice — a loaded CI runner can stall the
+    // detached continuation past any fixed number of milliseconds.
+    const deadline = Date.now() + 2000;
+    while (observed.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    // One more macrotask so everything downstream of the first db call lands.
+    await new Promise((r) => setTimeout(r, 10));
   };
 
   return { bus, fire, db: makeDb(observed) };

--- a/packages/api/src/plugins/__tests__/event-listeners-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/event-listeners-two-tenant-postgres.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Two-tenant EVENT-LISTENERS containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * `event-listeners.ts` registers small NATS/eventBus consumers that update
+ * connection state on `instances`, persist LID→phone mappings to
+ * `chat_id_mappings`, and write contact names / unread counts to `chats`.
+ * Before G5 all of them ran on the ambient pool — the `pending-G5-conversion`
+ * sites for this file.
+ *
+ * This suite exercises the REAL registered handlers (captured through a fake
+ * eventBus, exactly as `setup*Listener` wires them) against a disposable
+ * RLS-enforced database:
+ *
+ *   * a tenant-world envelope runs the handler's DB work inside the worker
+ *     tenant scope and lands only under that tenant;
+ *   * an envelope forged for the OTHER tenant's resource writes nothing —
+ *     RLS row visibility + the WITH CHECK derivation refuse it rather than
+ *     trusting the payload;
+ *   * a malformed envelope (tenant claim without a version) is refused
+ *     outright — no global-processing fallback.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { EventBus } from '@omni/core';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  chatIdMappings,
+  chats,
+  createDbHandle,
+  instances,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { scopedHandle } from '../../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import {
+  setupChatUnreadListener,
+  setupConnectionListener,
+  setupContactNamesListener,
+  setupLidMappingListener,
+} from '../event-listeners';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111ea';
+const TENANT_B = '22222222-2222-4222-8222-2222222222eb';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555ea';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555eb';
+const CHAT_A = '66666666-6666-4666-8666-6666666666ea';
+const CHAT_B = '66666666-6666-4666-8666-6666666666eb';
+
+const JID = '5511999990000@s.whatsapp.net';
+const LID = '123456789@lid';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-listeners-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+/** Capture the handlers `setup*Listener` registers, exactly as wired. */
+function captureBus() {
+  const handlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: async (type: string, handler: (event: never) => Promise<void>) => {
+      handlers.set(type, handler as unknown as (event: unknown) => Promise<void>);
+    },
+    subscribePattern: async (type: string, handler: (event: never) => Promise<void>) => {
+      handlers.set(type, handler as unknown as (event: unknown) => Promise<void>);
+    },
+  } as unknown as EventBus;
+  const fire = (type: string, event: unknown): Promise<void> => {
+    const handler = handlers.get(type);
+    if (!handler) throw new Error(`no handler registered for ${type}`);
+    return handler(event);
+  };
+  return { bus, fire };
+}
+
+/** A consumer-side event: tenant world, legacy world, or a malformed forgery. */
+function eventWith(
+  tenantId: string | null | 'malformed',
+  payload: Record<string, unknown>,
+  extraMetadata: Record<string, unknown> = {},
+): { id: string; payload: Record<string, unknown>; metadata: Record<string, unknown>; timestamp: number } {
+  const metadata: Record<string, unknown> = { correlationId: `evt-${crypto.randomUUID()}`, ...extraMetadata };
+  if (tenantId === 'malformed') {
+    metadata.tenantId = TENANT_A; // a tenant claim with NO envelope version
+  } else if (tenantId) {
+    metadata.envelopeVersion = 1;
+    metadata.tenantId = tenantId;
+  }
+  return { id: crypto.randomUUID(), payload, metadata, timestamp: Date.now() };
+}
+
+postgresDescribe('two-tenant event-listeners containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_listeners_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let fire: (type: string, event: unknown) => Promise<void>;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  const instanceForTenant = (tenantId: string, instanceId: string): Promise<{ isActive: boolean | null }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ isActive: instances.isActive })
+        .from(instances)
+        .where(eq(instances.id, instanceId)),
+    );
+
+  const mappingsForTenant = (tenantId: string, instanceId: string): Promise<{ lidId: string }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ lidId: chatIdMappings.lidId })
+        .from(chatIdMappings)
+        .where(eq(chatIdMappings.instanceId, instanceId)),
+    );
+
+  const chatForTenant = (
+    tenantId: string,
+    chatId: string,
+  ): Promise<{ name: string | null; unreadCount: number | null }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ name: chats.name, unreadCount: chats.unreadCount })
+        .from(chats)
+        .where(eq(chats.id, chatId)),
+    );
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, is_active, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', false, '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', false, '${SHARED_TIMESTAMP}');
+
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', '${JID}', '${JID}', 'direct', 'whatsapp-baileys', NULL,
+         '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${INSTANCE_B}', '${JID}', '${JID}', 'direct', 'whatsapp-baileys', NULL,
+         '${TENANT_B}', '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // ONE physical connection shared by both tenants' workers: any bleed shows here.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 1);
+
+    // Register the REAL handlers against the runtime handle.
+    const captured = captureBus();
+    fire = captured.fire;
+    await setupConnectionListener(captured.bus, runtimeDb);
+    await setupLidMappingListener(captured.bus, runtimeDb);
+    await setupContactNamesListener(captured.bus, runtimeDb);
+    await setupChatUnreadListener(captured.bus, runtimeDb);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test("instance.connected under A's envelope activates A's instance (and only A's)", async () => {
+    await fire(
+      'instance.connected',
+      eventWith(TENANT_A, { instanceId: INSTANCE_A, channelType: 'whatsapp-baileys', profileName: 'A' }),
+    );
+
+    expect(await instanceForTenant(TENANT_A, INSTANCE_A)).toEqual([{ isActive: true }]);
+    expect(await instanceForTenant(TENANT_B, INSTANCE_B)).toEqual([{ isActive: false }]);
+  });
+
+  test("an A-envelope aiming at B's instanceId updates nothing (payload is not trusted)", async () => {
+    await fire(
+      'instance.connected',
+      eventWith(TENANT_A, { instanceId: INSTANCE_B, channelType: 'whatsapp-baileys', profileName: 'forged' }),
+    );
+
+    // B's instance is invisible to A's scope — the update matched zero rows.
+    expect(await instanceForTenant(TENANT_B, INSTANCE_B)).toEqual([{ isActive: false }]);
+  });
+
+  test("instance.disconnected (logged out) under A deactivates only A's instance", async () => {
+    await fire(
+      'instance.disconnected',
+      eventWith(TENANT_A, {
+        instanceId: INSTANCE_A,
+        channelType: 'whatsapp-baileys',
+        willReconnect: false,
+        reason: 'Connection logged out',
+      }),
+    );
+
+    expect(await instanceForTenant(TENANT_A, INSTANCE_A)).toEqual([{ isActive: false }]);
+  });
+
+  test("lid-mapping batch under A persists only under A; a B-envelope aiming at A's instance persists nothing", async () => {
+    await fire(
+      'custom.lid-mapping.batch',
+      eventWith(TENANT_A, { mappings: [{ lidJid: LID, phoneJid: JID }] }, { instanceId: INSTANCE_A }),
+    );
+
+    expect((await mappingsForTenant(TENANT_A, INSTANCE_A)).map((m) => m.lidId)).toEqual([LID]);
+    expect(await mappingsForTenant(TENANT_B, INSTANCE_A)).toEqual([]);
+
+    // B's worker envelope aiming at A's instance: the derivation/WITH CHECK
+    // refuses the cross-tenant insert; the handler's per-item skip swallows it.
+    await fire(
+      'custom.lid-mapping.batch',
+      eventWith(TENANT_B, { mappings: [{ lidJid: '987654321@lid', phoneJid: JID }] }, { instanceId: INSTANCE_A }),
+    );
+
+    expect((await mappingsForTenant(TENANT_A, INSTANCE_A)).map((m) => m.lidId)).toEqual([LID]);
+    expect(await mappingsForTenant(TENANT_B, INSTANCE_A)).toEqual([]);
+  });
+
+  test("contact names under A rename only A's chat; a B-envelope cannot rename A's chat", async () => {
+    await fire(
+      'custom.contacts.names',
+      eventWith(TENANT_A, { names: [{ jid: JID, name: 'Alice' }] }, { instanceId: INSTANCE_A }),
+    );
+
+    expect((await chatForTenant(TENANT_A, CHAT_A))[0]?.name).toBe('Alice');
+    expect((await chatForTenant(TENANT_B, CHAT_B))[0]?.name).toBeNull();
+
+    // A B-envelope aiming at A's instance/chat sees no rows to update.
+    await fire(
+      'custom.contacts.names',
+      eventWith(TENANT_B, { names: [{ jid: JID, name: 'Mallory' }] }, { instanceId: INSTANCE_A }),
+    );
+    expect((await chatForTenant(TENANT_A, CHAT_A))[0]?.name).toBe('Alice');
+  });
+
+  test("unread-updated under A updates A's chat; a B-envelope aiming at A's chat writes nothing", async () => {
+    await fire(
+      'custom.chat.unread-updated',
+      eventWith(TENANT_A, { chatId: JID, unreadCount: 7 }, { instanceId: INSTANCE_A }),
+    );
+
+    expect((await chatForTenant(TENANT_A, CHAT_A))[0]?.unreadCount).toBe(7);
+    expect((await chatForTenant(TENANT_B, CHAT_B))[0]?.unreadCount).toBe(0);
+
+    await fire(
+      'custom.chat.unread-updated',
+      eventWith(TENANT_B, { chatId: JID, unreadCount: 99 }, { instanceId: INSTANCE_A }),
+    );
+    expect((await chatForTenant(TENANT_A, CHAT_A))[0]?.unreadCount).toBe(7);
+  });
+
+  test('a malformed envelope (tenant claim, no version) is refused — nothing is written', async () => {
+    await fire(
+      'instance.connected',
+      eventWith('malformed', { instanceId: INSTANCE_A, channelType: 'whatsapp-baileys', profileName: 'X' }),
+    );
+
+    // Still inactive from the disconnect test above — the forged envelope was
+    // quarantine-refused, not processed globally.
+    expect(await instanceForTenant(TENANT_A, INSTANCE_A)).toEqual([{ isActive: false }]);
+  });
+});

--- a/packages/api/src/plugins/__tests__/follow-up-hooks-tenant.test.ts
+++ b/packages/api/src/plugins/__tests__/follow-up-hooks-tenant.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Follow-up-hooks worker-tenant boundary (wish: omni-full-multitenancy, Group
+ * G5; ADR-0008).
+ *
+ * The five follow-up-hooks consumers classify their envelope ONCE and thread
+ * the trusted tenant into every service call. These probes assert the THREADING
+ * contract with fakes (no DB, no NATS):
+ *
+ *   1. a tenant-world envelope threads its trusted tenant to `resolveChatId`'s
+ *      DB block AND to the lifecycle service call;
+ *   2. a legacy envelope threads `null` — every call runs unscoped;
+ *   3. a malformed envelope (tenant claim, no version) is refused — no service
+ *      call happens (never processed globally);
+ *   4. the tenant is taken from the ENVELOPE metadata, never a payload field
+ *      named `tenantId`.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { setupFollowUpHooks } from '../follow-up-hooks';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+/** Capture the handlers `setupFollowUpHooks` registers. */
+function captureBus() {
+  const handlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: async (type: string, handler: (event: never) => Promise<void>) => {
+      handlers.set(type, handler as unknown as (event: unknown) => Promise<void>);
+    },
+  } as unknown as EventBus;
+  const fire = (type: string, event: unknown): Promise<void> => {
+    const handler = handlers.get(type);
+    if (!handler) throw new Error(`no handler for ${type}`);
+    return handler(event);
+  };
+  return { bus, fire };
+}
+
+/**
+ * A db fake whose `transaction` records the tenant stamped by the worker scope.
+ * `runInWorkerTenantScope` → `withTenantTransaction` runs
+ * `set_config('app.tenant_id', <tenant>, true)`; we capture that argument.
+ */
+function fakeDb(stamped: string[]) {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({
+        execute: async (q: unknown) => {
+          const text = JSON.stringify(q);
+          const match = /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i.exec(text);
+          if (match) stamped.push(match[0]);
+          return [] as unknown;
+        },
+      }),
+  } as never;
+}
+
+function servicesWith(calls: { chatTenantScope: (string | null)[]; disarm: unknown[] }) {
+  return {
+    chats: {
+      findByExternalIdSmart: mock(async () => {
+        // Record whether a worker scope is active when the chat read runs.
+        calls.chatTenantScope.push(currentTenantScope()?.tenantId ?? null);
+        return { id: 'chat-uuid', settings: {} };
+      }),
+    },
+    followUpLifecycle: {
+      armForOutbound: mock(async (input: unknown) => {
+        calls.disarm.push(input);
+      }),
+      disarm: mock(async (input: unknown) => {
+        calls.disarm.push(input);
+      }),
+      touchInboundTimestamp: mock(async () => undefined),
+    },
+  } as never;
+}
+
+function messageSent(tenant: 'tenant' | 'legacy' | 'malformed') {
+  const metadata: Record<string, unknown> = { instanceId: 'inst-1' };
+  if (tenant === 'tenant') {
+    metadata.envelopeVersion = 1;
+    metadata.tenantId = TENANT_A;
+  } else if (tenant === 'malformed') {
+    metadata.tenantId = TENANT_A; // claim with NO version
+  }
+  return {
+    id: crypto.randomUUID(),
+    // A payload tenantId must NEVER be trusted — put a decoy here.
+    payload: { chatId: 'ext-chat', senderAgentId: 'agent-1', tenantId: 'ffffffff-ffff-4fff-8fff-ffffffffffff' },
+    metadata,
+    timestamp: Date.now(),
+  };
+}
+
+describe('follow-up-hooks worker-tenant threading', () => {
+  test('a tenant envelope threads the trusted tenant into the chat read and the arm call', async () => {
+    const stamped: string[] = [];
+    const calls = { chatTenantScope: [] as (string | null)[], disarm: [] as unknown[] };
+    const { bus, fire } = captureBus();
+    await setupFollowUpHooks(bus, servicesWith(calls), fakeDb(stamped));
+
+    await fire('message.sent', messageSent('tenant'));
+
+    // The chat read ran inside a worker scope stamped with the ENVELOPE tenant.
+    expect(calls.chatTenantScope).toEqual([TENANT_A]);
+    expect(stamped).toContain(TENANT_A);
+    // The arm call was threaded the same trusted tenant — not the payload decoy.
+    expect((calls.disarm[0] as { tenantId?: unknown }).tenantId).toBe(TENANT_A);
+  });
+
+  test('a legacy envelope threads null — the chat read runs unscoped', async () => {
+    const stamped: string[] = [];
+    const calls = { chatTenantScope: [] as (string | null)[], disarm: [] as unknown[] };
+    const { bus, fire } = captureBus();
+    await setupFollowUpHooks(bus, servicesWith(calls), fakeDb(stamped));
+
+    await fire('message.sent', messageSent('legacy'));
+
+    expect(calls.chatTenantScope).toEqual([null]);
+    expect(stamped).toEqual([]);
+    expect((calls.disarm[0] as { tenantId?: unknown }).tenantId).toBeNull();
+  });
+
+  test('a malformed envelope is refused — no chat read, no arm call', async () => {
+    const stamped: string[] = [];
+    const calls = { chatTenantScope: [] as (string | null)[], disarm: [] as unknown[] };
+    const { bus, fire } = captureBus();
+    await setupFollowUpHooks(bus, servicesWith(calls), fakeDb(stamped));
+
+    // The handler swallows nothing here — trustedTenantOf throws before any
+    // service call. The subscription layer would term it; assert defense in
+    // depth: no work happened.
+    await expect(fire('message.sent', messageSent('malformed'))).rejects.toThrow(/quarantined/);
+    expect(calls.chatTenantScope).toEqual([]);
+    expect(calls.disarm).toEqual([]);
+  });
+});

--- a/packages/api/src/plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts
@@ -1,0 +1,237 @@
+/**
+ * The instance monitor's converted sweeps over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0003).
+ *
+ * WHY A REAL-POSTGRES SUITE FOR THIS FILE SPECIFICALLY
+ * ----------------------------------------------------
+ * The in-memory probes fake `select()` with a stub that returns the seeded rows
+ * regardless of scope and never raises. They therefore cannot test the premise
+ * the whole `runForEachActiveTenantRow` shape rests on: that under RLS
+ * enforcement a whole-table scan is NOT EXPRESSIBLE, so a cron must enumerate.
+ * Against a stub, an implementation that opens a tenant scope and then queries
+ * the ambient pool is indistinguishable from one that queries the tenant
+ * transaction — and that was exactly the state of this file: it never called
+ * `scopedHandle`, so every "scoped" read went to a different pooled connection
+ * that never saw `set_config('app.tenant_id', …, true)`. Under enforcement each
+ * pass would have RAISED `insufficient_privilege`, been swallowed by the
+ * fan-out's per-tenant catch, and instance health monitoring plus auto-reconnect
+ * would have stopped for EVERY tenant with all unit tests green.
+ *
+ * So these tests are the counter-evidence: the same sweeps, run by the runtime
+ * (NOBYPASSRLS) role against FORCE RLS, asserting that each tenant's pass sees
+ * its OWN instances and only those.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ChannelRegistry } from '@omni/channel-sdk';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+  instances,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
+import { __resetInstanceOwnerRegistry, rememberInstanceOwners } from '../../tenancy/instance-owner-registry';
+import { InstanceMonitor, reconnectWithPool } from '../instance-monitor';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const INSTANCE_A = '55555555-5555-4555-8555-55555555555a';
+const INSTANCE_B = '55555555-5555-4555-8555-55555555555b';
+const SEED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+/** Flag ON and enforcement ON. `'on'` is the only value `resolveEnforcementMode` accepts. */
+const ENFORCED_ENV: NodeJS.ProcessEnv = { [MULTITENANCY_FLAG_ENV]: 'true', OMNI_DB_ENFORCEMENT: 'on' };
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-im-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+/** A registry that reports every instance healthy and records what it was asked about. */
+function makeRegistry(probed: string[], connected: string[]): ChannelRegistry {
+  return {
+    get: () => ({
+      getStatus: async (instanceId: string) => {
+        probed.push(instanceId);
+        return { state: 'connected' as const };
+      },
+      connect: async (instanceId: string) => {
+        connected.push(instanceId);
+      },
+    }),
+  } as unknown as ChannelRegistry;
+}
+
+postgresDescribe('instance-monitor sweeps under real RLS enforcement', () => {
+  const dbName = `omni_g5_im_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let authPlaneDb: Database;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, is_active, owner_identifier, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', true, 'owner-a', '${SEED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', true, 'owner-b', '${SEED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // More than one connection deliberately: a regression that queries the
+    // ambient pool from INSIDE a worker transaction would deadlock on a
+    // single-connection pool (waiting for the connection the transaction holds)
+    // instead of failing, and a hang is a much worse gate than an assertion.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 5);
+    // ADR-0003: the auth plane is the only runtime-process identity that may
+    // enumerate `tenants`, which is what the fan-out needs.
+    authPlaneDb = openDb(
+      urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.authPlane, password: passwords.authPlane }),
+      2,
+    );
+  }, 180_000);
+
+  afterEach(() => __resetInstanceOwnerRegistry());
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('the CONTROL: an unscoped whole-table instances read is refused, not empty', async () => {
+    // This is the premise the enumeration exists for. `omni_current_tenant_id()`
+    // RAISES with no transaction context, so the pre-G5 ambient scan is not
+    // expressible at all under enforcement — it is an ERROR, not a silent [].
+    // Awaited inside an async thunk: a drizzle query builder is thenable but not
+    // a Promise, and `expect(...).rejects` requires a real one.
+    await expect(
+      (async () => runtimeDb.select().from(instances).where(eq(instances.isActive, true)))(),
+    ).rejects.toThrow(/app\.tenant_id/);
+  });
+
+  test('the 30s health sweep probes EVERY tenant’s instances, and only its own per pass', async () => {
+    const probed: string[] = [];
+    const monitor = new InstanceMonitor(runtimeDb, makeRegistry(probed, []));
+    monitor.setAuthPlane(authPlaneDb, ENFORCED_ENV);
+
+    await monitor.runHealthCheck();
+
+    // Both tenants were enumerated and each pass's scoped read succeeded. A
+    // read issued on the ambient pool inside the scope would have raised, the
+    // fan-out would have swallowed it as `periodic tenant pass failed`, and this
+    // would be `[]` — health monitoring silently dead for every tenant.
+    expect(probed.sort()).toEqual([INSTANCE_A, INSTANCE_B].sort());
+  });
+
+  test('the once-per-boot reconnect sweep reconnects every tenant’s instances', async () => {
+    const connected: string[] = [];
+
+    const results = await reconnectWithPool(runtimeDb, makeRegistry([], connected), {
+      delayBetweenMs: 0,
+      authPlaneDb,
+      env: ENFORCED_ENV,
+    });
+
+    expect(results.attempted).toBe(2);
+    expect(results.failed).toBe(0);
+    expect(connected.sort()).toEqual([INSTANCE_A, INSTANCE_B].sort());
+  });
+
+  test('the single-row read runs in the INSTANCE’s own tenant scope', async () => {
+    // The registry is the trusted instance→tenant derivation; a boot/health
+    // sweep seeds it from the rows it loaded, exactly as here.
+    rememberInstanceOwners([{ id: INSTANCE_A, tenantId: TENANT_A }]);
+    const connected: string[] = [];
+    const monitor = new InstanceMonitor(runtimeDb, makeRegistry([], connected), {
+      backoffBaseMs: 1,
+      maxReconnectAttempts: 5,
+    });
+    monitor.setAuthPlane(authPlaneDb, ENFORCED_ENV);
+
+    // `forceReconnect` → `fetchInstanceById`: it must find the row (its scope is
+    // the instance's own tenant) rather than fail closed.
+    await expect(monitor.forceReconnect(INSTANCE_A)).resolves.toBeUndefined();
+  });
+
+  test('an instance whose ownership was never observed fails closed rather than reading globally', async () => {
+    // No `rememberInstanceOwners` for B: `tenantOf` yields null, the block stays
+    // ambient, and under enforcement an ambient `instances` read is refused —
+    // the correct posture, and emphatically not a global read.
+    const monitor = new InstanceMonitor(runtimeDb, makeRegistry([], []));
+    monitor.setAuthPlane(authPlaneDb, ENFORCED_ENV);
+
+    await expect(monitor.forceReconnect(INSTANCE_B)).rejects.toThrow(/app\.tenant_id/);
+  });
+});

--- a/packages/api/src/plugins/__tests__/instance-monitor-worker-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/instance-monitor-worker-scope.test.ts
@@ -1,0 +1,460 @@
+/**
+ * `plugins/instance-monitor.ts::instances` worker-context boundary
+ * (G5; ADR-0008).
+ *
+ * The monitor is a 30-second INTERVAL plus a 5-second reconnect drain: no
+ * request, no credential, no envelope. Before this conversion every tick read
+ * the WHOLE `instances` table (`fetchActiveInstances`), and the reconnect queue
+ * then re-read single rows (`fetchInstanceById`) and DEACTIVATED instances
+ * (`markInstanceInactive`) — all on the ambient pool. Under RLS enforcement the
+ * whole-table scan is not even expressible, so a cron must ENUMERATE whose work
+ * exists rather than scan and sort out ownership afterwards.
+ *
+ * The tick adopts `runForEachActiveTenantRow` (the daily-sync / turn-monitor
+ * precedent): only the discrete `listActive` READ is scoped, and the per-row
+ * plugin `getStatus`/`connect` calls — network work — run outside it. The
+ * single-row paths derive their tenant from the instance-owner registry, the
+ * same trusted persisted-ownership derivation the publish path uses.
+ *
+ * This file is the enforcement the static guard cannot provide (run12's
+ * FIX-FIRST lesson: the guard sees the FILE, never the CALL SITE).
+ *
+ * WHY THE FAKE TRANSACTION IS A DISTINCT OBJECT
+ * ---------------------------------------------
+ * An earlier revision of this probe had `transaction: (cb) => cb(db)`, so the
+ * transaction handle and the ambient pool were the SAME object. Every assertion
+ * then read `currentTenantScope()` — AsyncLocalStorage presence — which is set
+ * whether the query was issued on the tenant transaction or on the pool. A
+ * converted site that opens the scope and then queries the raw pool was
+ * indistinguishable from one that queries the transaction, and that is exactly
+ * the defect this file exists to catch: only `scopedHandle(db)` returns the
+ * transaction that carries `set_config('app.tenant_id', …, true)`, so a raw-pool
+ * query inside a worker scope runs on a DIFFERENT pooled connection — unstamped
+ * before enforcement, fail-closed under RLS.
+ *
+ * So the fake `transaction` yields its OWN handle and every observation records
+ * WHICH handle issued the statement. `scope` alone is not evidence; `handle` is.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { ChannelRegistry } from '@omni/channel-sdk';
+import type { Database } from '@omni/db';
+import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
+import {
+  __resetInstanceOwnerRegistry,
+  lookupInstanceOwner,
+  rememberInstanceOwners,
+} from '../../tenancy/instance-owner-registry';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { InstanceMonitor, reconnectWithPool } from '../instance-monitor';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+const FLAG_ON: NodeJS.ProcessEnv = { [MULTITENANCY_FLAG_ENV]: 'true' };
+const FLAG_OFF: NodeJS.ProcessEnv = {};
+
+function scope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+/** Drizzle-shaped chain stub: builder methods return self; awaiting yields `result`. */
+function chain<T>(result: T): T {
+  const self: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') {
+          return (onOk: (v: T) => unknown, onErr?: (e: unknown) => unknown) =>
+            Promise.resolve(result).then(onOk, onErr);
+        }
+        return () => self;
+      },
+    },
+  );
+  return self as T;
+}
+
+interface Observed {
+  op: string;
+  scope: string | null;
+  /** Which handle issued the statement: the ambient pool or the tenant tx. */
+  handle: 'POOL' | 'TX';
+}
+
+function fakeAuthPlaneDb(ids: string[], counter: { selects: number }): Database {
+  return {
+    select: () => {
+      counter.selects += 1;
+      return { from: () => ({ where: async () => ids.map((id) => ({ id })) }) };
+    },
+  } as unknown as Database;
+}
+
+function makeDb(observed: Observed[], rows: unknown[], counters: { transactions: number }): Database {
+  const record = (op: string, handle: 'POOL' | 'TX') => {
+    observed.push({ op, scope: scope(), handle });
+  };
+  // The tenant transaction is its OWN object — see the header. `withTenantTransaction`
+  // hands this to `runInTenantScope`, so `scopedHandle(db)` returns THIS and a
+  // site that queries the injected pool instead is visible as `handle: 'POOL'`.
+  const tx = {
+    select: () => {
+      record('select', 'TX');
+      return chain(rows);
+    },
+    update: () => {
+      record('update', 'TX');
+      return chain([]);
+    },
+    execute: async () => [],
+  };
+  const db = {
+    select: () => {
+      record('select', 'POOL');
+      return chain(rows);
+    },
+    update: () => {
+      record('update', 'POOL');
+      return chain([]);
+    },
+    transaction: async <T>(cb: (handle: unknown) => Promise<T>): Promise<T> => {
+      counters.transactions += 1;
+      return cb(tx);
+    },
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+function makeRegistry(statusScopes: Array<string | null>): ChannelRegistry {
+  return {
+    get: () => ({
+      getStatus: async () => {
+        statusScopes.push(scope());
+        return { state: 'disconnected' as const };
+      },
+      connect: async () => {},
+    }),
+  } as unknown as ChannelRegistry;
+}
+
+/**
+ * A registry whose `connect` records the tenant scope it observed and an
+ * ordered start/end log, so the boot reconnect's concurrency shape is
+ * observable rather than asserted.
+ */
+function makeConnectRegistry(connects: {
+  scopes: Array<string | null>;
+  events: string[];
+}): ChannelRegistry {
+  return {
+    get: () => ({
+      getStatus: async () => ({ state: 'disconnected' as const }),
+      connect: async (instanceId: string) => {
+        connects.scopes.push(scope());
+        connects.events.push(`start:${instanceId}`);
+        await new Promise((r) => setTimeout(r, 1));
+        connects.events.push(`end:${instanceId}`);
+      },
+    }),
+  } as unknown as ChannelRegistry;
+}
+
+function instanceRow(id: string, tenantId: string | null) {
+  return { id, name: id, channel: 'telegram', ownerIdentifier: 'owner', tenantId, isActive: true };
+}
+
+afterEach(() => {
+  __resetInstanceOwnerRegistry();
+});
+
+describe('instance-monitor — legacy world is byte-identical', () => {
+  test('no auth plane wired: one ambient scan, no enumeration, no transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const statusScopes: Array<string | null> = [];
+    const monitor = new InstanceMonitor(
+      makeDb(observed, [instanceRow('i1', null)], counters),
+      makeRegistry(statusScopes),
+    );
+
+    await monitor.runHealthCheck();
+
+    expect(observed.filter((o) => o.op === 'select').length).toBe(1);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+    // Byte-identical to pre-G5: the ambient pool issued it, not a transaction.
+    expect(observed.every((o) => o.handle === 'POOL')).toBe(true);
+    expect(counters.transactions).toBe(0);
+    expect(authCounter.selects).toBe(0);
+    // The per-instance health probe still ran — this is behaviour-preserving.
+    expect(statusScopes.length).toBe(1);
+  });
+
+  test('auth plane wired but flag OFF: still one ambient pass and NO auth-plane query', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const monitor = new InstanceMonitor(makeDb(observed, [instanceRow('i1', null)], counters), makeRegistry([]));
+    monitor.setAuthPlane(fakeAuthPlaneDb([TENANT_A], authCounter), FLAG_OFF);
+
+    await monitor.runHealthCheck();
+
+    expect(observed.filter((o) => o.op === 'select').length).toBe(1);
+    expect(authCounter.selects).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+    expect(observed.every((o) => o.handle === 'POOL')).toBe(true);
+    expect(counters.transactions).toBe(0);
+  });
+});
+
+describe('instance-monitor — tenant world', () => {
+  test('the active-instance read is ENUMERATED per tenant and runs inside that tenant scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const monitor = new InstanceMonitor(makeDb(observed, [], counters), makeRegistry([]));
+    monitor.setAuthPlane(fakeAuthPlaneDb([TENANT_A, TENANT_B], authCounter), FLAG_ON);
+
+    await monitor.runHealthCheck();
+
+    expect(authCounter.selects).toBe(1);
+    // One scoped read per tenant plus the transitional NULL-tenant pass, which
+    // only exists outside enforcement.
+    const selects = observed.filter((o) => o.op === 'select');
+    expect(selects.map((o) => o.scope)).toEqual([TENANT_A, TENANT_B, null]);
+    // …and each scoped read is issued ON that tenant's transaction. Asserting
+    // the ALS scope alone would pass for a site that opens the scope and then
+    // queries the ambient pool — the connection that never sees `app.tenant_id`.
+    expect(selects.map((o) => o.handle)).toEqual(['TX', 'TX', 'POOL']);
+  });
+
+  test('the plugin health probe runs OUTSIDE the scope — no transaction spans a network call', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const statusScopes: Array<string | null> = [];
+    const monitor = new InstanceMonitor(
+      makeDb(observed, [instanceRow('i1', TENANT_A)], counters),
+      makeRegistry(statusScopes),
+    );
+    monitor.setAuthPlane(fakeAuthPlaneDb([TENANT_A], { selects: 0 }), FLAG_ON);
+
+    await monitor.runHealthCheck();
+
+    expect(statusScopes.length).toBeGreaterThan(0);
+    expect(statusScopes.every((s) => s === null)).toBe(true);
+  });
+
+  test('an instance owned by tenant B is never probed in tenant A’s pass', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const statusScopes: Array<string | null> = [];
+    const monitor = new InstanceMonitor(
+      makeDb(observed, [instanceRow('i-b', TENANT_B)], counters),
+      makeRegistry(statusScopes),
+    );
+    // Flag on AND enforced, so the transitional NULL-tenant pass is skipped and
+    // tenant A's pass is the only one that could see the row. `'on'` is the
+    // literal `resolveEnforcementMode` accepts — any other value resolves to the
+    // NON-enforced mode and this test would pass for the wrong reason.
+    monitor.setAuthPlane(fakeAuthPlaneDb([TENANT_A], { selects: 0 }), {
+      ...FLAG_ON,
+      OMNI_DB_ENFORCEMENT: 'on',
+    });
+
+    await monitor.runHealthCheck();
+
+    expect(statusScopes.length).toBe(0);
+  });
+
+  test('the single-row reconnect read and the DEACTIVATION run in the instance’s own tenant scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const monitor = new InstanceMonitor(makeDb(observed, [instanceRow('i1', TENANT_A)], counters), makeRegistry([]), {
+      maxReconnectAttempts: 1,
+      backoffBaseMs: 1,
+    });
+    monitor.setAuthPlane(fakeAuthPlaneDb([TENANT_A], { selects: 0 }), FLAG_ON);
+    // The registry is the trusted instance→tenant derivation; the sweep seeds it
+    // from loaded rows exactly like this.
+    rememberInstanceOwners([{ id: 'i1', tenantId: TENANT_A }]);
+
+    // `forceReconnect` → `fetchInstanceById`: the single-row READ.
+    await monitor.forceReconnect('i1');
+    const reads = observed.filter((o) => o.op === 'select');
+    expect(reads.length).toBe(1);
+    expect(reads[0]?.scope).toBe(TENANT_A);
+    expect(reads[0]?.handle).toBe('TX');
+
+    observed.length = 0;
+
+    // Drive the queue past the retry ceiling so the DEACTIVATION write fires.
+    await new Promise((r) => setTimeout(r, 5));
+    monitor.scheduleReconnect('i1', 'telegram', 'boom');
+    await new Promise((r) => setTimeout(r, 5));
+
+    const writes = observed.filter((o) => o.op === 'update');
+    expect(writes.length).toBeGreaterThan(0);
+    for (const write of writes) {
+      expect(write.scope).toBe(TENANT_A);
+      // The DEACTIVATION is the sweep's only write; it must land on the
+      // tenant-stamped transaction, never on the ambient pool.
+      expect(write.handle).toBe('TX');
+    }
+  });
+
+  test('an instance the registry never observed stays ambient (fail-closed under enforcement)', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const monitor = new InstanceMonitor(makeDb(observed, [instanceRow('i9', TENANT_A)], counters), makeRegistry([]));
+    monitor.setAuthPlane(fakeAuthPlaneDb([TENANT_A], { selects: 0 }), FLAG_ON);
+
+    await monitor.forceReconnect('i9');
+
+    // No ownership was ever loaded for `i9`, so no tenant could be derived and
+    // the read is NOT smuggled into some other tenant's scope.
+    expect(observed.filter((o) => o.op === 'select').map((o) => o.scope)).toEqual([null]);
+    expect(observed.filter((o) => o.op === 'select').map((o) => o.handle)).toEqual(['POOL']);
+    expect(counters.transactions).toBe(0);
+  });
+});
+
+/**
+ * The ONCE-PER-BOOT sweep (`reconnectWithPool`).
+ *
+ * It is a module-level function, not a monitor method, and until this block it
+ * had no executable coverage anywhere in the repository — while the db-access
+ * guard's `instance-monitor.ts::instances` justification named this file as
+ * what pins its flag-off behaviour. These probes make that citation true and
+ * pin the three things the health-check probes above cannot reach: the boot
+ * read's handle, the registry seeding that precedes any plugin emit, and the
+ * batching/accounting the tenant fan-out feeds.
+ */
+describe('reconnectWithPool — the once-per-boot sweep', () => {
+  test('no auth plane: ONE ambient scan, no transaction, pre-G5 results', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const connects = { scopes: [] as Array<string | null>, events: [] as string[] };
+    const db = makeDb(observed, [instanceRow('i1', null), instanceRow('i2', null)], counters);
+
+    const results = await reconnectWithPool(db, makeConnectRegistry(connects), { delayBetweenMs: 0 });
+
+    expect(results).toEqual({ attempted: 2, succeeded: 2, failed: 0, errors: [] });
+    const selects = observed.filter((o) => o.op === 'select');
+    expect(selects.length).toBe(1);
+    expect(selects.map((o) => o.handle)).toEqual(['POOL']);
+    expect(selects.every((o) => o.scope === null)).toBe(true);
+    expect(counters.transactions).toBe(0);
+  });
+
+  test('auth plane wired but flag OFF: still one ambient pass and NO auth-plane query', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const connects = { scopes: [] as Array<string | null>, events: [] as string[] };
+    const db = makeDb(observed, [instanceRow('i1', null), instanceRow('i2', null)], counters);
+
+    const results = await reconnectWithPool(db, makeConnectRegistry(connects), {
+      delayBetweenMs: 0,
+      authPlaneDb: fakeAuthPlaneDb([TENANT_A], authCounter),
+      env: FLAG_OFF,
+    });
+
+    // Byte-identical to the no-auth-plane world above: same statements, same
+    // handle, same results. The auth plane is never consulted.
+    expect(results).toEqual({ attempted: 2, succeeded: 2, failed: 0, errors: [] });
+    expect(authCounter.selects).toBe(0);
+    const selects = observed.filter((o) => o.op === 'select');
+    expect(selects.length).toBe(1);
+    expect(selects.map((o) => o.handle)).toEqual(['POOL']);
+    expect(counters.transactions).toBe(0);
+  });
+
+  test('tenant world: the row READ is enumerated per tenant and issued ON that tenant transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const connects = { scopes: [] as Array<string | null>, events: [] as string[] };
+    const db = makeDb(observed, [instanceRow('a1', TENANT_A), instanceRow('b1', TENANT_B)], counters);
+
+    const results = await reconnectWithPool(db, makeConnectRegistry(connects), {
+      delayBetweenMs: 0,
+      authPlaneDb: fakeAuthPlaneDb([TENANT_A, TENANT_B], authCounter),
+      env: FLAG_ON,
+    });
+
+    expect(authCounter.selects).toBe(1);
+    const selects = observed.filter((o) => o.op === 'select');
+    // One scoped read per tenant, then the transitional NULL-tenant pass.
+    expect(selects.map((o) => o.scope)).toEqual([TENANT_A, TENANT_B, null]);
+    expect(selects.map((o) => o.handle)).toEqual(['TX', 'TX', 'POOL']);
+    // `attempted` is the fan-out's own row count: each tenant contributed its
+    // own row and neither saw the other's.
+    expect(results.attempted).toBe(2);
+    expect(results.succeeded).toBe(2);
+  });
+
+  test('every plugin.connect runs OUTSIDE the scope — no transaction spans the network call', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const connects = { scopes: [] as Array<string | null>, events: [] as string[] };
+    const db = makeDb(observed, [instanceRow('a1', TENANT_A)], counters);
+
+    await reconnectWithPool(db, makeConnectRegistry(connects), {
+      delayBetweenMs: 0,
+      authPlaneDb: fakeAuthPlaneDb([TENANT_A], { selects: 0 }),
+      env: FLAG_ON,
+    });
+
+    expect(connects.scopes.length).toBeGreaterThan(0);
+    expect(connects.scopes.every((s) => s === null)).toBe(true);
+  });
+
+  test('the boot read SEEDS the instance-owner registry before any plugin can emit', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const connects = { scopes: [] as Array<string | null>, events: [] as string[] };
+    const db = makeDb(observed, [instanceRow('a1', TENANT_A)], counters);
+
+    expect(lookupInstanceOwner('a1')).toBeNull();
+    await reconnectWithPool(db, makeConnectRegistry(connects), {
+      delayBetweenMs: 0,
+      authPlaneDb: fakeAuthPlaneDb([TENANT_A], { selects: 0 }),
+      env: FLAG_ON,
+    });
+    // This is what makes the very first `message.received` of a boot carry a
+    // trusted tenant rather than a legacy envelope.
+    expect(lookupInstanceOwner('a1')).toBe(TENANT_A);
+  });
+
+  test('the concurrency ceiling is GLOBAL across the enumerated tenants, not per tenant', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const connects = { scopes: [] as Array<string | null>, events: [] as string[] };
+    const db = makeDb(
+      observed,
+      [
+        instanceRow('a1', TENANT_A),
+        instanceRow('a2', TENANT_A),
+        instanceRow('b1', TENANT_B),
+        instanceRow('b2', TENANT_B),
+      ],
+      counters,
+    );
+
+    const results = await reconnectWithPool(db, makeConnectRegistry(connects), {
+      maxConcurrent: 3,
+      delayBetweenMs: 0,
+      authPlaneDb: fakeAuthPlaneDb([TENANT_A, TENANT_B], { selects: 0 }),
+      env: FLAG_ON,
+    });
+
+    expect(results.attempted).toBe(4);
+    // The fan-out collects every tenant's rows into ONE pending list and batches
+    // that list, so the first wave is tenant-MIXED and `maxConcurrent` is the
+    // process-wide ceiling. Pinned deliberately: the function's own comment once
+    // claimed a per-tenant ceiling, which the code has never implemented.
+    expect(connects.events.slice(0, 3)).toEqual(['start:a1', 'start:a2', 'start:b1']);
+  });
+});

--- a/packages/api/src/plugins/__tests__/media-processor-remote.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-remote.test.ts
@@ -156,7 +156,12 @@ describe.skipIf(!hasDocker)('media-processor remote read (MinIO)', () => {
       published,
     });
 
-    await processMessageMedia(ctx, audioPayload, { instanceId: 'inst-1', channelType: 'whatsapp-baileys' });
+    await processMessageMedia(
+      ctx,
+      audioPayload,
+      { instanceId: 'inst-1', channelType: 'whatsapp-baileys' },
+      { metadata: { correlationId: 'legacy' } },
+    );
 
     // The processor received a real, readable temp path — not the S3 key and not
     // a path under the local media base dir.
@@ -190,7 +195,12 @@ describe.skipIf(!hasDocker)('media-processor remote read (MinIO)', () => {
     });
 
     await expect(
-      processMessageMedia(ctx, audioPayload, { instanceId: 'inst-1', channelType: 'whatsapp-baileys' }),
+      processMessageMedia(
+        ctx,
+        audioPayload,
+        { instanceId: 'inst-1', channelType: 'whatsapp-baileys' },
+        { metadata: { correlationId: 'legacy' } },
+      ),
     ).rejects.toThrow('synthetic processing failure');
 
     // The temp file existed (bytes were read) but was removed by the finally block.
@@ -234,7 +244,12 @@ describe('media-processor local read (no MinIO)', () => {
       published,
     });
 
-    await processMessageMedia(ctx, audioPayload, { instanceId: 'inst-local', channelType: 'whatsapp-baileys' });
+    await processMessageMedia(
+      ctx,
+      audioPayload,
+      { instanceId: 'inst-local', channelType: 'whatsapp-baileys' },
+      { metadata: { correlationId: 'legacy' } },
+    );
 
     // Local mode hands the processor the canonical on-disk path (byte-for-byte
     // the pre-remote behavior), never a temp file.

--- a/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
@@ -52,6 +52,10 @@ const CHAT_A = '66666666-6666-4666-8666-6666666666ca';
 const CHAT_B = '66666666-6666-4666-8666-6666666666cb';
 const MESSAGE_A = '77777777-7777-4777-8777-7777777777ca';
 const MESSAGE_B = '77777777-7777-4777-8777-7777777777cb';
+// A dedicated A-owned message for the savepoint protective-path test, so it is
+// independent of the ordering of the two containment tests above (which mutate
+// MESSAGE_A).
+const MESSAGE_PROT = '77777777-7777-4777-8777-7777777777cc';
 const EVENT_A = '88888888-8888-4888-8888-8888888888ca';
 const EVENT_B = '88888888-8888-4888-8888-8888888888cb';
 
@@ -172,7 +176,8 @@ postgresDescribe('two-tenant media-processor containment (real PostgreSQL)', () 
       INSERT INTO messages (id, chat_id, external_id, source, message_type, platform_timestamp, tenant_id)
       VALUES
         ('${MESSAGE_A}', '${CHAT_A}', 'msg-a', 'realtime', 'audio', '${SHARED_TIMESTAMP}', '${TENANT_A}'),
-        ('${MESSAGE_B}', '${CHAT_B}', 'msg-b', 'realtime', 'audio', '${SHARED_TIMESTAMP}', '${TENANT_B}');
+        ('${MESSAGE_B}', '${CHAT_B}', 'msg-b', 'realtime', 'audio', '${SHARED_TIMESTAMP}', '${TENANT_B}'),
+        ('${MESSAGE_PROT}', '${CHAT_A}', 'msg-prot', 'realtime', 'audio', '${SHARED_TIMESTAMP}', '${TENANT_A}');
 
       INSERT INTO omni_events (id, instance_id, channel, event_type, external_id, tenant_id)
       VALUES
@@ -227,5 +232,37 @@ postgresDescribe('two-tenant media-processor containment (real PostgreSQL)', () 
     expect(await transcriptionForTenant(TENANT_A, MESSAGE_A)).toEqual(['hello from A']);
     expect((await mediaForTenant(TENANT_A, MESSAGE_A)).length).toBe(1);
     expect((await mediaForTenant(TENANT_B, MESSAGE_A)).length).toBe(0);
+  });
+
+  test('a NON-tenant failure of the audit insert does not roll back the committed message write (savepoint)', async () => {
+    // The protective-path proof the two containment tests above do NOT give.
+    //
+    // Under A's OWN scope, force ONLY the non-critical `media_content` insert to
+    // fail for a reason that has nothing to do with tenancy — a `language` code
+    // longer than its `varchar(10)` column — while the CRITICAL
+    // `messages.transcription` update succeeds. `persistProcessingResult`
+    // isolates that insert in a SAVEPOINT (`tx.transaction()`), so the failure
+    // must roll back only the audit row and leave the message write committed.
+    //
+    // Without the savepoint the value-too-long error would abort the whole worker
+    // transaction and the transcription would be lost. That regression is
+    // otherwise invisible (the aborted-commit-throws behaviour is
+    // postgres.js-driver-dependent), so this is the test that catches it.
+    // eventId is left undefined so the ONLY failing statement is the audit
+    // insert, not an FK resolution.
+    const poisoned = transcription('committed under A despite a failed audit row');
+    (poisoned as { language?: string }).language = 'pt-BR-this-code-is-far-too-long'; // > varchar(10)
+
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      mediaProcessorTest.persistProcessingResult(ctx, MESSAGE_PROT, undefined, poisoned, 'audio'),
+    );
+
+    // The critical write COMMITTED under A.
+    expect(await transcriptionForTenant(TENANT_A, MESSAGE_PROT)).toEqual([
+      'committed under A despite a failed audit row',
+    ]);
+    // The failed audit insert left NO media_content row — the savepoint rolled it
+    // back without poisoning the surrounding transaction.
+    expect((await mediaForTenant(TENANT_A, MESSAGE_PROT)).length).toBe(0);
   });
 });

--- a/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
@@ -234,6 +234,43 @@ postgresDescribe('two-tenant media-processor containment (real PostgreSQL)', () 
     expect((await mediaForTenant(TENANT_B, MESSAGE_A)).length).toBe(0);
   });
 
+  test('CF#2: the media_content FK resolves inside a worker tenant scope — A resolves, B sees nothing', async () => {
+    // The FK existence check reads `omni_events` through `scopedHandle` inside
+    // `runConsumerInTenantContext`. Under A's envelope the RLS-visible row
+    // resolves; under B's envelope the SAME id is invisible, so the poll
+    // expires and the FK is refused (null) instead of resolved cross-tenant.
+    // This is also the load-bearing probe for the scope itself: an ambient
+    // (unscoped) read under the runtime role sees NO rows at all, so reverting
+    // the conversion turns the A case null and fails this test.
+    const envelopeA = { metadata: { correlationId: 'cf2-a', envelopeVersion: 1, tenantId: TENANT_A } };
+    const envelopeB = { metadata: { correlationId: 'cf2-b', envelopeVersion: 1, tenantId: TENANT_B } };
+
+    expect(await mediaProcessorTest.resolveSafeMediaContentEventId(ctx, envelopeA, EVENT_A)).toBe(EVENT_A);
+    expect(await mediaProcessorTest.resolveSafeMediaContentEventId(ctx, envelopeB, EVENT_A)).toBeNull();
+  }, 10_000);
+
+  test('CF#2 choreography: the FK poll never holds a transaction across its sleeps', async () => {
+    // `runtimeDb` has a POOL OF ONE connection. If the <=250ms poll wrapped its
+    // sleeps inside one open transaction, that connection would stay reserved
+    // for the whole window and a concurrent worker write could not even BEGIN
+    // until the poll finished — so the poll would win this race. With each
+    // existence check in its OWN short scope (the CF#2 contract), the
+    // connection frees during the first sleep and the write finishes in
+    // milliseconds, far inside the poll's 250ms floor.
+    const envelopeB = { metadata: { correlationId: 'cf2-b', envelopeVersion: 1, tenantId: TENANT_B } };
+    // B polling for A's (invisible) event runs the full window.
+    const poll = mediaProcessorTest.resolveSafeMediaContentEventId(ctx, envelopeB, EVENT_A).then(() => 'poll' as const);
+    const write = runInWorkerTenantScope(runtimeDb, TENANT_A, async () => {
+      await scopedHandle(runtimeDb)
+        .update(messages)
+        .set({ transcription: 'hello from A' })
+        .where(eq(messages.id, MESSAGE_A));
+    }).then(() => 'write' as const);
+
+    expect(await Promise.race([poll, write])).toBe('write');
+    expect(await poll).toBe('poll'); // and the poll still terminates cleanly
+  }, 10_000);
+
   test('a NON-tenant failure of the audit insert does not roll back the committed message write (savepoint)', async () => {
     // The protective-path proof the two containment tests above do NOT give.
     //

--- a/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Two-tenant MEDIA-PROCESSOR containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * The `media-processor` plugin is a NATS consumer: it downloads a message's
+ * media, runs it through the AI processing service, then writes the result back
+ * to `messages` and an audit row to `media_content`. Those two writes are the
+ * only tenant-table access the plugin owns, and before G5 they ran on the
+ * ambient pool with no tenant context — the `pending-G5-conversion` sites.
+ *
+ * This proves the converted persistence path (`__test__.persistProcessingResult`,
+ * the exact code the consumer calls) stays inside the worker's tenant when it is
+ * run under `runInWorkerTenantScope`, and that a write aimed at ANOTHER tenant's
+ * message buys nothing — the ambient derivation + RLS WITH CHECK reject it rather
+ * than trusting the caller.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+  mediaContent,
+  messages,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { scopedHandle } from '../../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { __test__ as mediaProcessorTest } from '../media-processor';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111ca';
+const TENANT_B = '22222222-2222-4222-8222-2222222222cb';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555ca';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555cb';
+const CHAT_A = '66666666-6666-4666-8666-6666666666ca';
+const CHAT_B = '66666666-6666-4666-8666-6666666666cb';
+const MESSAGE_A = '77777777-7777-4777-8777-7777777777ca';
+const MESSAGE_B = '77777777-7777-4777-8777-7777777777cb';
+const EVENT_A = '88888888-8888-4888-8888-8888888888ca';
+const EVENT_B = '88888888-8888-4888-8888-8888888888cb';
+
+const SHARED_JID = '5511999990000@s.whatsapp.net';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+type PersistResult = Parameters<typeof mediaProcessorTest.persistProcessingResult>[3];
+
+/** A minimal successful transcription result. */
+function transcription(text: string): PersistResult {
+  return {
+    success: true,
+    processingType: 'transcription',
+    content: text,
+    model: 'test-model',
+    provider: 'test-provider',
+    language: 'en',
+    duration: 1,
+    processingTimeMs: 5,
+  } as unknown as PersistResult;
+}
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-media-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+postgresDescribe('two-tenant media-processor containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_media_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  // The plugin only reads `ctx.db` in the persistence path; a minimal ctx suffices.
+  let ctx: Parameters<typeof mediaProcessorTest.persistProcessingResult>[0];
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  /** Count this tenant's media_content rows for a mediaId, as a worker would. */
+  const mediaForTenant = (tenantId: string, mediaId: string): Promise<{ id: string }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: mediaContent.id })
+        .from(mediaContent)
+        .where(eq(mediaContent.mediaId, mediaId)),
+    );
+
+  /** Read a message's transcription under a tenant scope. */
+  const transcriptionForTenant = (tenantId: string, messageId: string): Promise<(string | null)[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ t: messages.transcription })
+        .from(messages)
+        .where(eq(messages.id, messageId))
+        .then((rows) => rows.map((r) => r.t)),
+    );
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', '${SHARED_JID}', '${SHARED_JID}', 'direct', 'whatsapp-baileys', 'Chat',
+         '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${INSTANCE_B}', '${SHARED_JID}', '${SHARED_JID}', 'direct', 'whatsapp-baileys', 'Chat',
+         '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO messages (id, chat_id, external_id, source, message_type, platform_timestamp, tenant_id)
+      VALUES
+        ('${MESSAGE_A}', '${CHAT_A}', 'msg-a', 'realtime', 'audio', '${SHARED_TIMESTAMP}', '${TENANT_A}'),
+        ('${MESSAGE_B}', '${CHAT_B}', 'msg-b', 'realtime', 'audio', '${SHARED_TIMESTAMP}', '${TENANT_B}');
+
+      INSERT INTO omni_events (id, instance_id, channel, event_type, external_id, tenant_id)
+      VALUES
+        ('${EVENT_A}', '${INSTANCE_A}', 'whatsapp-baileys', 'message.received', 'msg-a', '${TENANT_A}'),
+        ('${EVENT_B}', '${INSTANCE_B}', 'whatsapp-baileys', 'message.received', 'msg-b', '${TENANT_B}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // ONE physical connection shared by both tenants' workers: any bleed shows here.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 1);
+    ctx = { db: runtimeDb } as Parameters<typeof mediaProcessorTest.persistProcessingResult>[0];
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('A worker persists media only under A; B cannot see it', async () => {
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      mediaProcessorTest.persistProcessingResult(ctx, MESSAGE_A, EVENT_A, transcription('hello from A'), 'audio'),
+    );
+
+    // The message transcription landed under A and only A.
+    expect(await transcriptionForTenant(TENANT_A, MESSAGE_A)).toEqual(['hello from A']);
+    // The audit row is visible to A, invisible to B.
+    expect((await mediaForTenant(TENANT_A, MESSAGE_A)).length).toBe(1);
+    expect((await mediaForTenant(TENANT_B, MESSAGE_A)).length).toBe(0);
+  });
+
+  test("a B worker aiming at A's message writes nothing under either tenant", async () => {
+    // A B-scoped worker tries to persist for A's message + A's event. RLS hides
+    // A's message from B's UPDATE (0 rows), and the media_content WITH CHECK
+    // rejects the A-derived tenant under B's scope — the insert is swallowed as
+    // non-critical. Nothing lands, and A's earlier legit row is untouched.
+    await runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
+      mediaProcessorTest.persistProcessingResult(
+        ctx,
+        MESSAGE_A,
+        EVENT_A,
+        transcription('B overwrite attempt'),
+        'audio',
+      ),
+    );
+
+    // A still sees exactly its own single row and original transcription.
+    expect(await transcriptionForTenant(TENANT_A, MESSAGE_A)).toEqual(['hello from A']);
+    expect((await mediaForTenant(TENANT_A, MESSAGE_A)).length).toBe(1);
+    expect((await mediaForTenant(TENANT_B, MESSAGE_A)).length).toBe(0);
+  });
+});

--- a/packages/api/src/plugins/__tests__/media-storage-worker-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/media-storage-worker-scope.test.ts
@@ -1,0 +1,140 @@
+/**
+ * `services/media-storage.ts::messages` worker-context boundary (G5; ADR-0008).
+ *
+ * That registry site is ONE query — `updateMessageLocalPath`'s
+ * `update(messages)`. Three callers reach it:
+ *
+ *   * `routes/v2/messages.ts` (request path — inside the edge tenant transaction);
+ *   * `services/batch-jobs.ts` `resolveFilePath` (already `runTenantWorkDb`);
+ *   * `plugins/media-processor.ts` `downloadMediaFromUrl` — the CONSUMER path,
+ *     which threaded its envelope tenant into `storeFromUrl` (for the egress
+ *     broker and the tenant-prefixed object key) but left the message write on
+ *     whatever handle `scopedHandle` happened to return. Inside a converted
+ *     consumer that is the ambient pool, so the write escaped the tenant
+ *     transaction the rest of the item ran in.
+ *
+ * This file is the enforcement the static guard cannot provide (run12's
+ * FIX-FIRST lesson: the guard sees the SERVICE file, never the CALL SITE).
+ * It probes the real caller shape — `downloadMediaFromUrl` is invoked by
+ * `resolveMediaPath` with the envelope-derived `trustedTenantId` and nothing
+ * else — never a hand-built input production cannot produce.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { __test__ } from '../media-processor';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+/** Worker-scope fake: `transaction` runs the callback, counting openings. */
+function fakeScopeDb(counter: { transactions: number }): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counter.transactions += 1;
+      return cb({ execute: async () => [] as unknown });
+    },
+  } as unknown as Database;
+}
+
+type Observed = Array<{ step: string; scope: string | null }>;
+
+function makeCtx(observed: Observed, counter: { transactions: number }) {
+  return {
+    db: fakeScopeDb(counter),
+    mediaStorage: {
+      storeFromUrl: async (
+        _instanceId: string,
+        _messageId: string,
+        _url: string,
+        _mime: string,
+        _ts: Date | undefined,
+        _fetchOptions: RequestInit | undefined,
+        tenantId: string | undefined,
+      ) => {
+        observed.push({ step: `storeFromUrl:${tenantId ?? 'none'}`, scope: currentScope() });
+        return { localPath: 'tenants/x/obj.ogg', size: 1 };
+      },
+      updateMessageLocalPath: async () => {
+        observed.push({ step: 'updateMessageLocalPath', scope: currentScope() });
+      },
+    },
+    // Slack is the only channel that triggers the instance lookup; keep it out
+    // of the probe so the only DB block observed is the one under test.
+    services: { instances: { getById: async () => ({}) } },
+  } as unknown as Parameters<typeof __test__.downloadMediaFromUrl>[0];
+}
+
+function currentScope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+describe('media-storage::messages — consumer caller (media-processor)', () => {
+  test('the message write runs INSIDE the envelope tenant scope', async () => {
+    const observed: Observed = [];
+    const counter = { transactions: 0 };
+    const ctx = makeCtx(observed, counter);
+
+    const path = await __test__.downloadMediaFromUrl(
+      ctx,
+      'instance-1',
+      'message-1',
+      'https://example.invalid/a.ogg',
+      'audio/ogg',
+      undefined,
+      'whatsapp-baileys',
+      TENANT_A,
+    );
+
+    expect(path).toBe('tenants/x/obj.ogg');
+    const write = observed.find((o) => o.step === 'updateMessageLocalPath');
+    expect(write).toBeDefined();
+    expect(write?.scope).toBe(TENANT_A);
+  });
+
+  test('the DOWNLOAD stays outside the scope — a worker transaction never spans network work', async () => {
+    const observed: Observed = [];
+    const counter = { transactions: 0 };
+    const ctx = makeCtx(observed, counter);
+
+    await __test__.downloadMediaFromUrl(
+      ctx,
+      'instance-1',
+      'message-1',
+      'https://example.invalid/a.ogg',
+      'audio/ogg',
+      undefined,
+      'whatsapp-baileys',
+      TENANT_A,
+    );
+
+    const download = observed.find((o) => o.step.startsWith('storeFromUrl:'));
+    expect(download?.scope).toBeNull();
+    // …and the tenant still reached the storage layer as a threaded VALUE, which
+    // is what binds the object key and the egress policy.
+    expect(download?.step).toBe(`storeFromUrl:${TENANT_A}`);
+    // Exactly one worker transaction: the message write, nothing else.
+    expect(counter.transactions).toBe(1);
+  });
+
+  test('legacy envelope: no scope, no transaction, byte-identical to pre-G5', async () => {
+    const observed: Observed = [];
+    const counter = { transactions: 0 };
+    const ctx = makeCtx(observed, counter);
+
+    await __test__.downloadMediaFromUrl(
+      ctx,
+      'instance-1',
+      'message-1',
+      'https://example.invalid/a.ogg',
+      'audio/ogg',
+      undefined,
+      'whatsapp-baileys',
+      undefined,
+    );
+
+    expect(counter.transactions).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+    expect(observed.map((o) => o.step)).toEqual(['storeFromUrl:none', 'updateMessageLocalPath']);
+  });
+});

--- a/packages/api/src/plugins/__tests__/message-persistence-tenant.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-tenant.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Message-persistence worker-tenant boundary (wish: omni-full-multitenancy,
+ * Group G5; ADR-0008).
+ *
+ * `message-persistence` is the dominant inbound consumer: every `message.received`
+ * / `message.sent` event on every channel lands here and writes `chats`,
+ * `messages`, `chat_participants`, `chat_id_mappings`, `platform_identities` and
+ * `instances`. Until this leg it was the last big unconverted consumer, which is
+ * why nine db-access-guard sites across `services/chats.ts`, `services/messages.ts`,
+ * `services/persons.ts` and `services/instances.ts` stayed `pending-G5-conversion`
+ * even though their route callers had been scoped since G4: a site is only as
+ * scoped as its least-scoped caller.
+ *
+ * These probes assert the conversion contract with fakes (no DB, no NATS):
+ *
+ *   1. a tenant-world envelope runs every awaited service call inside ONE worker
+ *      tenant transaction stamped with the envelope's trusted tenant;
+ *   2. a legacy envelope (no version, no tenant) runs the same body with NO scope
+ *      — byte-identical to pre-G5, the dual-world contract;
+ *   3. a malformed envelope (tenant claim, no version) is refused before any
+ *      service call — quarantine, never a global-processing fallback;
+ *   4. the tenant comes from producer-stamped envelope metadata, NEVER from a
+ *      payload field named `tenantId`;
+ *   5. THE TRAP (G4 leg-2): the fire-and-forget writes this handler spawns
+ *      (`chats.updateLastMessage`, `instances.updateLastMessageAt`,
+ *      `chats.upsertLidMapping`, the profile fetch) must run in their OWN worker
+ *      transaction, not the handler's. Inheriting it would be a use-after-commit
+ *      on a released connection the moment the handler returns.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import { CURRENT_ENVELOPE_VERSION } from '@omni/core';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { setupMessagePersistence } from '../message-persistence';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+const TENANT_B = '22222222-2222-4222-8222-2222222222bb';
+const INSTANCE = 'instance-1';
+
+/** Capture the handlers `setupMessagePersistence` registers. */
+function captureBus() {
+  const handlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: async (type: string, handler: (event: never) => Promise<void>) => {
+      handlers.set(type, handler as unknown as (event: unknown) => Promise<void>);
+    },
+    publish: async () => undefined,
+  } as unknown as EventBus;
+  const fire = (type: string, event: unknown): Promise<void> => {
+    const handler = handlers.get(type);
+    if (!handler) throw new Error(`no handler for ${type}`);
+    return handler(event);
+  };
+  return { bus, fire };
+}
+
+/**
+ * A db fake whose `transaction` hands back a FRESH tx object per call, so a test
+ * can tell one worker transaction from another by identity, and which records the
+ * tenant each scope stamps (`set_config('app.tenant_id', …)`).
+ */
+function fakeDb(stamped: string[]) {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({
+        execute: async (q: unknown) => {
+          const text = JSON.stringify(q);
+          const match = /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i.exec(text);
+          if (match) stamped.push(match[0]);
+          return [] as unknown;
+        },
+      }),
+  } as never;
+}
+
+interface Observation {
+  readonly call: string;
+  readonly tenantId: string | null;
+  readonly tx: unknown;
+}
+
+/**
+ * A services fake that records, for every call message-persistence makes, which
+ * tenant scope (if any) was active and WHICH transaction object it was.
+ */
+function servicesWith(db: unknown, seen: Observation[]) {
+  const observe = (call: string) => {
+    const scope = currentTenantScope();
+    seen.push({ call, tenantId: scope?.tenantId ?? null, tx: scope?.tx ?? null });
+  };
+  const chat = { id: 'chat-uuid', canonicalId: null as string | null, name: null as string | null };
+  return {
+    db,
+    chats: {
+      findByExternalIdSmart: async () => {
+        observe('chats.findByExternalIdSmart');
+        return null;
+      },
+      findOrCreate: async () => {
+        observe('chats.findOrCreate');
+        return { chat, created: true };
+      },
+      update: async () => {
+        observe('chats.update');
+        return chat;
+      },
+      upsertLidMapping: async () => {
+        observe('chats.upsertLidMapping');
+        return undefined;
+      },
+      findOrCreateParticipant: async () => {
+        observe('chats.findOrCreateParticipant');
+        return { participant: { displayName: null } };
+      },
+      recordParticipantActivity: async () => {
+        observe('chats.recordParticipantActivity');
+        return undefined;
+      },
+      updateLastMessage: async () => {
+        observe('chats.updateLastMessage');
+        return undefined;
+      },
+    },
+    messages: {
+      findOrCreate: async () => {
+        observe('messages.findOrCreate');
+        return { message: { id: 'message-uuid' }, created: true };
+      },
+      getByExternalId: async () => {
+        observe('messages.getByExternalId');
+        return null;
+      },
+      recordEdit: async () => {
+        observe('messages.recordEdit');
+        return undefined;
+      },
+      updateDeliveryStatus: async () => {
+        observe('messages.updateDeliveryStatus');
+        return undefined;
+      },
+    },
+    persons: {
+      findOrCreateIdentity: async () => {
+        observe('persons.findOrCreateIdentity');
+        return { identity: { id: 'identity-uuid' }, person: { id: 'person-uuid' }, isNew: false };
+      },
+      updateIdentityProfile: async () => {
+        observe('persons.updateIdentityProfile');
+        return undefined;
+      },
+    },
+    instances: {
+      updateLastMessageAt: async () => {
+        observe('instances.updateLastMessageAt');
+        return undefined;
+      },
+      getLastMessageAt: async () => {
+        observe('instances.getLastMessageAt');
+        return null;
+      },
+    },
+    consumerOffsets: {
+      updateOffset: async () => undefined,
+    },
+  } as never;
+}
+
+/** A `message.received` event whose rawPayload triggers the LID fire-and-forget path. */
+function receivedEvent(metadata: Record<string, unknown>, payloadExtras: Record<string, unknown> = {}) {
+  return {
+    id: 'event-1',
+    timestamp: 1_700_000_000_000,
+    payload: {
+      externalId: 'ext-1',
+      chatId: '5511999999999@lid',
+      from: '5511999999999@lid',
+      senderName: 'Sender',
+      content: { type: 'text', text: 'hello' },
+      rawPayload: { resolvedPhoneJid: '5511999999999@s.whatsapp.net' },
+      ...payloadExtras,
+    },
+    metadata: { instanceId: INSTANCE, channelType: 'whatsapp', ...metadata },
+  };
+}
+
+/** Let the handler's fire-and-forget continuations settle. */
+async function drain(): Promise<void> {
+  for (let i = 0; i < 8; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('message-persistence worker-tenant boundary (G5, ADR-0008)', () => {
+  test('a tenant envelope runs the awaited path in ONE worker transaction stamped with the envelope tenant', async () => {
+    const stamped: string[] = [];
+    const db = fakeDb(stamped);
+    const seen: Observation[] = [];
+    const { bus, fire } = captureBus();
+    await setupMessagePersistence(bus, servicesWith(db, seen));
+
+    await fire('message.received', receivedEvent({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: TENANT_A }));
+    await drain();
+
+    // Every service call the handler AWAITS is inside the tenant scope.
+    const awaited = seen.filter(
+      (o) => o.call !== 'chats.updateLastMessage' && o.call !== 'instances.updateLastMessageAt',
+    );
+    expect(awaited.length).toBeGreaterThan(3);
+    for (const o of awaited) expect(o.tenantId).toBe(TENANT_A);
+    expect(stamped.every((t) => t === TENANT_A)).toBe(true);
+
+    // ...and it is ONE transaction for the whole awaited work item, not one per call.
+    const awaitedTxs = new Set(
+      seen.filter((o) => o.call === 'chats.findOrCreate' || o.call === 'messages.findOrCreate').map((o) => o.tx),
+    );
+    expect(awaitedTxs.size).toBe(1);
+  });
+
+  test('THE TRAP: fire-and-forget writes run in their OWN worker transaction, never the handler transaction', async () => {
+    const stamped: string[] = [];
+    const db = fakeDb(stamped);
+    const seen: Observation[] = [];
+    const { bus, fire } = captureBus();
+    await setupMessagePersistence(bus, servicesWith(db, seen));
+
+    await fire('message.received', receivedEvent({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: TENANT_A }));
+    await drain();
+
+    const handlerTx = seen.find((o) => o.call === 'messages.findOrCreate')?.tx;
+    expect(handlerTx).toBeTruthy();
+
+    const detached = seen.filter(
+      (o) =>
+        o.call === 'chats.updateLastMessage' ||
+        o.call === 'instances.updateLastMessageAt' ||
+        o.call === 'chats.upsertLidMapping',
+    );
+    expect(detached.length).toBeGreaterThan(0);
+    for (const o of detached) {
+      // Still tenant-scoped (the write is RLS-policed)...
+      expect(o.tenantId).toBe(TENANT_A);
+      // ...but NOT on the handler's transaction, which is committed and released
+      // by the time these continuations run.
+      expect(o.tx).not.toBe(handlerTx);
+    }
+  });
+
+  test('a legacy envelope runs the same body with no scope at all (dual world)', async () => {
+    const stamped: string[] = [];
+    const db = fakeDb(stamped);
+    const seen: Observation[] = [];
+    const { bus, fire } = captureBus();
+    await setupMessagePersistence(bus, servicesWith(db, seen));
+
+    await fire('message.received', receivedEvent({}));
+    await drain();
+
+    expect(seen.length).toBeGreaterThan(3);
+    for (const o of seen) expect(o.tenantId).toBeNull();
+    expect(stamped).toEqual([]);
+  });
+
+  test('a malformed envelope (tenant claim, no version) is refused before any service call', async () => {
+    const stamped: string[] = [];
+    const db = fakeDb(stamped);
+    const seen: Observation[] = [];
+    const { bus, fire } = captureBus();
+    await setupMessagePersistence(bus, servicesWith(db, seen));
+
+    await expect(fire('message.received', receivedEvent({ tenantId: TENANT_A }))).rejects.toThrow(
+      /quarantin|worker-tenant-context/i,
+    );
+    await drain();
+
+    expect(seen).toEqual([]);
+    expect(stamped).toEqual([]);
+  });
+
+  test('an unknown envelope version is refused, never processed', async () => {
+    const stamped: string[] = [];
+    const db = fakeDb(stamped);
+    const seen: Observation[] = [];
+    const { bus, fire } = captureBus();
+    await setupMessagePersistence(bus, servicesWith(db, seen));
+
+    await expect(
+      fire('message.received', receivedEvent({ envelopeVersion: 9999, tenantId: TENANT_A })),
+    ).rejects.toThrow(/quarantin|worker-tenant-context/i);
+    await drain();
+
+    expect(seen).toEqual([]);
+  });
+
+  test('the tenant comes from envelope metadata, never from a caller-claimed payload field', async () => {
+    const stamped: string[] = [];
+    const db = fakeDb(stamped);
+    const seen: Observation[] = [];
+    const { bus, fire } = captureBus();
+    await setupMessagePersistence(bus, servicesWith(db, seen));
+
+    // Payload claims tenant B; the producer-stamped envelope says tenant A.
+    await fire(
+      'message.received',
+      receivedEvent({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: TENANT_A }, { tenantId: TENANT_B }),
+    );
+    await drain();
+
+    for (const o of seen) expect(o.tenantId).toBe(TENANT_A);
+    expect(stamped.includes(TENANT_B)).toBe(false);
+  });
+});

--- a/packages/api/src/plugins/__tests__/message-persistence-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-two-tenant-postgres.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Two-tenant MESSAGE-PERSISTENCE containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * `message-persistence` is the dominant inbound consumer — every message on
+ * every channel lands here — and until the G5 read-path leg it was wholly
+ * unconverted: its `chats`, `messages`, `chat_participants`, `chat_id_mappings`,
+ * `platform_identities` and `instances` writes all reached the ambient pool with
+ * no tenant context. This suite drives the REAL registered NATS handler (through
+ * a capture bus and a real `Services` container over the runtime role) against a
+ * real RLS-enforced database, so it exercises the code the consumer actually
+ * runs rather than a re-implementation.
+ *
+ * The seed is deliberately adversarial: both tenants own an instance, and BOTH
+ * inbound events carry the SAME external chat JID and the SAME external message
+ * id. Nothing but the tenant distinguishes them, so any leak — a lookup that
+ * crosses tenants, a find-or-create that latches onto the other tenant's row —
+ * shows up as a wrong row count rather than as a subtle field difference.
+ *
+ * Probes:
+ *   1. tenant A's envelope creates A's chat + message, invisible to B;
+ *   2. tenant B's envelope creates its OWN rows for the same external ids —
+ *      neither tenant's row is reused or overwritten;
+ *   3. a B-scoped envelope naming A's instance writes nothing under either
+ *      tenant (the derivation trigger + RLS WITH CHECK refuse it — the caller's
+ *      claim buys nothing);
+ *   4. a malformed envelope (tenant claim, no version) is quarantined before any
+ *      write — never processed globally.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { EventBus } from '@omni/core';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  chats,
+  createDbHandle,
+  messages,
+} from '@omni/db';
+import { and, eq } from 'drizzle-orm';
+import { createServices } from '../../services';
+import { scopedHandle } from '../../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { setupMessagePersistence } from '../message-persistence';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111da';
+const TENANT_B = '22222222-2222-4222-8222-2222222222db';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555da';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555db';
+
+/** The whole point of the seed: identical external identity, different tenants. */
+const SHARED_JID = '5511999990000@s.whatsapp.net';
+const SHARED_EXTERNAL_ID = 'shared-external-message-id';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-msgpersist-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+/** Capture the handlers `setupMessagePersistence` registers on the bus. */
+function captureBus() {
+  const handlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: async (type: string, handler: (event: never) => Promise<void>) => {
+      handlers.set(type, handler as unknown as (event: unknown) => Promise<void>);
+    },
+    publish: async () => undefined,
+  } as unknown as EventBus;
+  const fire = (type: string, event: unknown): Promise<void> => {
+    const handler = handlers.get(type);
+    if (!handler) throw new Error(`no handler for ${type}`);
+    return handler(event);
+  };
+  return { bus, fire };
+}
+
+/**
+ * A `message.received` envelope. `metadata` is the ONLY place a tenant may come
+ * from — `envelopeVersion`/`tenantId` are producer-stamped (G5, ADR-0008).
+ */
+function receivedEvent(opts: {
+  instanceId: string;
+  envelopeVersion?: number;
+  tenantId?: string;
+  text: string;
+}): unknown {
+  return {
+    id: crypto.randomUUID(),
+    timestamp: Date.parse('2026-01-01T00:00:00Z'),
+    payload: {
+      externalId: SHARED_EXTERNAL_ID,
+      chatId: SHARED_JID,
+      from: SHARED_JID,
+      senderName: 'Sender',
+      content: { type: 'text', text: opts.text },
+      rawPayload: {},
+    },
+    metadata: {
+      instanceId: opts.instanceId,
+      channelType: 'whatsapp-baileys',
+      ...(opts.envelopeVersion === undefined ? {} : { envelopeVersion: opts.envelopeVersion }),
+      ...(opts.tenantId === undefined ? {} : { tenantId: opts.tenantId }),
+    },
+  };
+}
+
+/** Let the handler's fire-and-forget continuations settle. */
+async function drain(): Promise<void> {
+  for (let i = 0; i < 20; i++) await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+postgresDescribe('two-tenant message-persistence containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_msgpersist_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let fire: (type: string, event: unknown) => Promise<void>;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  /** Chats this tenant can see for the shared JID, read as a worker would. */
+  const chatsForTenant = (tenantId: string): Promise<{ id: string; instanceId: string | null }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: chats.id, instanceId: chats.instanceId })
+        .from(chats)
+        .where(eq(chats.externalId, SHARED_JID)),
+    );
+
+  /** Messages this tenant can see for the shared external id. */
+  const messagesForTenant = (tenantId: string): Promise<{ id: string; textContent: string | null }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: messages.id, textContent: messages.textContent })
+        .from(messages)
+        .where(eq(messages.externalId, SHARED_EXTERNAL_ID)),
+    );
+
+  /** Total rows regardless of tenant — the check that "nothing landed" is real. */
+  const totalChats = (): { chats: number; messages: number } => {
+    const out = Bun.spawnSync({
+      cmd: [
+        psqlBin,
+        '-X',
+        '--no-psqlrc',
+        '-A',
+        '-t',
+        '--dbname',
+        urlFor(superUrl, dbName),
+        '-c',
+        `SELECT (SELECT count(*) FROM chats WHERE external_id = '${SHARED_JID}') || ' ' ||
+                (SELECT count(*) FROM messages WHERE external_id = '${SHARED_EXTERNAL_ID}')`,
+      ],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [c, m] = out.stdout.toString().trim().split(/\s+/).map(Number);
+    return { chats: c ?? -1, messages: m ?? -1 };
+  };
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    // Only the tenants and their instances are seeded. The chats, messages,
+    // participants and identities under test are created BY the consumer.
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // ONE physical connection shared by both tenants' workers: any bleed shows here.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 1);
+
+    const captured = captureBus();
+    fire = captured.fire;
+    await setupMessagePersistence(captured.bus, createServices(runtimeDb, null));
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test("tenant A's envelope creates A's chat + message, invisible to B", async () => {
+    await fire(
+      'message.received',
+      receivedEvent({ instanceId: INSTANCE_A, envelopeVersion: 1, tenantId: TENANT_A, text: 'hello from A' }),
+    );
+    await drain();
+
+    const aChats = await chatsForTenant(TENANT_A);
+    expect(aChats.length).toBe(1);
+    expect(aChats[0]?.instanceId).toBe(INSTANCE_A);
+    expect(await messagesForTenant(TENANT_A)).toEqual([{ id: expect.any(String), textContent: 'hello from A' }]);
+
+    // B sees nothing at all — not the chat, not the message.
+    expect(await chatsForTenant(TENANT_B)).toEqual([]);
+    expect(await messagesForTenant(TENANT_B)).toEqual([]);
+  }, 30_000);
+
+  test("tenant B's envelope creates its OWN rows for the SAME external ids", async () => {
+    await fire(
+      'message.received',
+      receivedEvent({ instanceId: INSTANCE_B, envelopeVersion: 1, tenantId: TENANT_B, text: 'hello from B' }),
+    );
+    await drain();
+
+    const bChats = await chatsForTenant(TENANT_B);
+    expect(bChats.length).toBe(1);
+    expect(bChats[0]?.instanceId).toBe(INSTANCE_B);
+    expect(await messagesForTenant(TENANT_B)).toEqual([{ id: expect.any(String), textContent: 'hello from B' }]);
+
+    // A's row is untouched: same id, same text, still exactly one.
+    const aMessages = await messagesForTenant(TENANT_A);
+    expect(aMessages.length).toBe(1);
+    expect(aMessages[0]?.textContent).toBe('hello from A');
+
+    // Two chats and two messages exist in total — one per tenant, never shared.
+    expect(totalChats()).toEqual({ chats: 2, messages: 2 });
+  }, 30_000);
+
+  test("a B-scoped envelope naming A's instance writes nothing under either tenant", async () => {
+    const before = totalChats();
+
+    // The envelope claims tenant B; the instance it names belongs to A. The
+    // chat insert's derivation trigger computes A from `instance_id` while the
+    // scope is B, so the RLS WITH CHECK refuses it. The handler rethrows (the
+    // consumer's retry/DLQ contract) — what matters is that NOTHING lands.
+    await expect(
+      fire(
+        'message.received',
+        receivedEvent({ instanceId: INSTANCE_A, envelopeVersion: 1, tenantId: TENANT_B, text: 'cross-tenant' }),
+      ),
+    ).rejects.toThrow();
+    await drain();
+
+    expect(totalChats()).toEqual(before);
+    // Neither tenant gained a row, and A's text is still A's.
+    expect((await messagesForTenant(TENANT_A)).map((m) => m.textContent)).toEqual(['hello from A']);
+    expect((await messagesForTenant(TENANT_B)).map((m) => m.textContent)).toEqual(['hello from B']);
+  }, 30_000);
+
+  test('a malformed envelope (tenant claim, no version) is quarantined before any write', async () => {
+    const before = totalChats();
+
+    await expect(
+      fire('message.received', receivedEvent({ instanceId: INSTANCE_A, tenantId: TENANT_A, text: 'quarantine me' })),
+    ).rejects.toThrow(/quarantin|worker-tenant-context/i);
+    await drain();
+
+    // Not processed globally, not processed at all.
+    expect(totalChats()).toEqual(before);
+  }, 30_000);
+
+  test('a legacy envelope writes NOTHING under the runtime role — the dual world is data, not a branch', async () => {
+    // A legacy (unversioned, tenant-less) envelope runs the same handler body on
+    // the ambient pool, exactly as pre-G5. Under RLS enforcement with no scope
+    // set, the runtime role's policies match no rows, so the write is refused
+    // rather than silently landing NULL-tenant. This is the enforcement-mode
+    // shape of the dual world; a flag-off deployment (no RLS) keeps the
+    // byte-identical pre-G5 behaviour, which the unit suite covers.
+    const before = totalChats();
+
+    await expect(fire('message.received', receivedEvent({ instanceId: INSTANCE_A, text: 'legacy' }))).rejects.toThrow();
+    await drain();
+
+    expect(totalChats()).toEqual(before);
+    // And no cross-tenant residue: each tenant still sees exactly its own row.
+    expect((await chatsForTenant(TENANT_A)).length).toBe(1);
+    expect((await chatsForTenant(TENANT_B)).length).toBe(1);
+  }, 30_000);
+
+  test("chat lookups are tenant-scoped: A cannot reach B's chat by its UUID", async () => {
+    const bChat = (await chatsForTenant(TENANT_B))[0];
+    expect(bChat).toBeTruthy();
+    const bChatId = bChat?.id as string;
+
+    const seenByA = await runInWorkerTenantScope(runtimeDb, TENANT_A, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: chats.id })
+        .from(chats)
+        .where(and(eq(chats.id, bChatId), eq(chats.externalId, SHARED_JID))),
+    );
+    expect(seenByA).toEqual([]);
+  }, 30_000);
+});

--- a/packages/api/src/plugins/__tests__/openclaw-client-pool-tenant.test.ts
+++ b/packages/api/src/plugins/__tests__/openclaw-client-pool-tenant.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The shared OpenClaw WS client pool is a CREDENTIAL cache (G5; ADR-0008).
+ *
+ * DEC-3 gave the dispatcher one WS connection per provider, keyed by
+ * `provider.id` alone. That key was written before `agent_providers` carried
+ * tenant-bound secrets. The cached `OpenClawClient` holds the Ed25519
+ * `devicePrivateKey` and the `deviceToken` it was BUILT with, and signs every
+ * connect with them (`@omni/core` `openclaw/client.ts`) — so the pooled object
+ * is the credential, not merely a socket.
+ *
+ * `agent_providers` is a G0-`split` table with no `tenant_id`, so ONE provider
+ * row is reachable from instances of different tenants, and `ProviderService`
+ * binds its secrets to the ACTIVE SCOPE: tenant A opens the device key, every
+ * other context fails closed to null ("fails closed to a null secret rather
+ * than to someone else's key", providers.ts). A pool keyed by provider id alone
+ * short-circuits exactly that null — the reachable path being
+ * `routes/v2/chats.ts` → `session-cleaner.ts` `resolveProvider`, which builds
+ * the client from secrets OPENED inside a tenant scope and then pools it
+ * globally.
+ *
+ * So the key must carry the tenant the secrets were opened under. These probes
+ * pin that, plus the two properties the change must not break: the scope-less
+ * legacy world still shares ONE client per provider, and invalidation still
+ * evicts EVERY tenant's client for a provider.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { __test__, invalidateProviderCache, resolveProvider } from '../agent-dispatcher';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const PROVIDER_ID = '33333333-3333-4333-8333-333333333333';
+
+interface CapturedClient {
+  config: { token?: string; device?: { privateKey: string; token: string } };
+  started: boolean;
+  stopped: boolean;
+}
+
+const built: CapturedClient[] = [];
+
+/** Stand-in for `OpenClawClient` — captures what it was built with, opens nothing. */
+class FakeOpenClawClient {
+  readonly captured: CapturedClient;
+  constructor(config: CapturedClient['config']) {
+    this.captured = { config, started: false, stopped: false };
+    built.push(this.captured);
+  }
+  start(): void {
+    this.captured.started = true;
+  }
+  stop(): void {
+    this.captured.stopped = true;
+  }
+}
+
+/** A provider row as `ProviderService` returns it AFTER opening under `tenant`. */
+function providerOpenedFor(tenant: 'A' | 'foreign') {
+  const owned = tenant === 'A';
+  return {
+    id: PROVIDER_ID,
+    name: 'openclaw-provider',
+    schema: 'openclaw',
+    baseUrl: 'ws://openclaw.invalid',
+    // Fail-closed nulls are exactly what a non-owning tenant sees.
+    apiKey: owned ? 'sk-tenant-a' : null,
+    isActive: true,
+    defaultTimeout: 600,
+    schemaConfig: {
+      deviceId: 'device-1',
+      devicePublicKey: 'ed25519-pub',
+      devicePrivateKey: owned ? 'ed25519-priv-A' : null,
+      deviceToken: owned ? 'device-token-A' : null,
+      origin: 'https://openclaw.invalid',
+      defaultAgentId: 'agent-1',
+    },
+  } as unknown as Parameters<typeof resolveProvider>[0];
+}
+
+function instance(id: string) {
+  return {
+    id,
+    channel: 'discord',
+    agentInternalId: 'agent-1',
+    agentProviderId: PROVIDER_ID,
+  } as unknown as Parameters<typeof resolveProvider>[1];
+}
+
+/** Worker-scope harness: `runInWorkerTenantScope` needs a transaction-capable handle. */
+const db = {
+  transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn({ execute: async () => [] }),
+  execute: async () => undefined,
+} as unknown as Database;
+
+afterEach(() => {
+  built.length = 0;
+  __test__.resetProviderCaches();
+  __test__.resetOpenClawClientClass();
+});
+
+function useFakeClient(): void {
+  __test__.OpenClawClientClass = FakeOpenClawClient as never;
+}
+
+describe('openclaw client pool — one client per (provider, tenant)', () => {
+  test('tenant B never reaches tenant A’s device identity through the pool', async () => {
+    useFakeClient();
+
+    await runInWorkerTenantScope(db, TENANT_A, async () => {
+      resolveProvider(providerOpenedFor('A'), instance('inst-a'), db);
+    });
+    await runInWorkerTenantScope(db, TENANT_B, async () => {
+      // B's read of the same provider row fails closed to null secrets.
+      resolveProvider(providerOpenedFor('foreign'), instance('inst-b'), db);
+    });
+
+    // Two clients, not one: the pool must not hand B the object A's key is in.
+    expect(built.length).toBe(2);
+    const forB = built[1];
+    expect(forB?.config.device).toBeUndefined();
+    expect(JSON.stringify(built[1])).not.toContain('ed25519-priv-A');
+    expect(JSON.stringify(built[1])).not.toContain('device-token-A');
+    expect(JSON.stringify(built[1])).not.toContain('sk-tenant-a');
+    // And the pool says so structurally.
+    expect(__test__.openclawPoolKeys().sort()).toEqual(
+      [`${PROVIDER_ID}::${TENANT_A}`, `${PROVIDER_ID}::${TENANT_B}`].sort(),
+    );
+  });
+
+  test('the NATS-consumer shape (tenant THREADED, no ambient scope) is partitioned too', () => {
+    useFakeClient();
+
+    // `session-cleaner.ts` opens the provider record inside `runTenantWorkDb`
+    // and then resolves the provider OUTSIDE that scope, threading the trusted
+    // tenant — so `currentTenantScope()` is null here for BOTH tenants. Keyed on
+    // the ambient scope alone, A's device key would sit in the legacy bucket and
+    // be handed straight to B.
+    resolveProvider(providerOpenedFor('A'), instance('inst-a'), db, TENANT_A);
+    resolveProvider(providerOpenedFor('foreign'), instance('inst-b'), db, TENANT_B);
+
+    expect(built.length).toBe(2);
+    expect(JSON.stringify(built[1])).not.toContain('ed25519-priv-A');
+    expect(__test__.openclawPoolKeys().sort()).toEqual(
+      [`${PROVIDER_ID}::${TENANT_A}`, `${PROVIDER_ID}::${TENANT_B}`].sort(),
+    );
+  });
+
+  test('the same tenant still reuses ONE connection across its instances (DEC-3)', async () => {
+    useFakeClient();
+
+    await runInWorkerTenantScope(db, TENANT_A, async () => {
+      resolveProvider(providerOpenedFor('A'), instance('inst-a1'), db);
+      resolveProvider(providerOpenedFor('A'), instance('inst-a2'), db);
+    });
+
+    expect(built.length).toBe(1);
+    expect(__test__.openclawPoolKeys()).toEqual([`${PROVIDER_ID}::${TENANT_A}`]);
+  });
+
+  test('the scope-less legacy world is byte-identical: one shared client', () => {
+    useFakeClient();
+
+    resolveProvider(providerOpenedFor('A'), instance('inst-legacy-1'), db);
+    resolveProvider(providerOpenedFor('A'), instance('inst-legacy-2'), db);
+
+    expect(built.length).toBe(1);
+    expect(__test__.openclawPoolKeys()).toEqual([`${PROVIDER_ID}::-`]);
+  });
+
+  test('invalidation evicts EVERY tenant’s client for the provider', async () => {
+    useFakeClient();
+
+    await runInWorkerTenantScope(db, TENANT_A, async () => {
+      resolveProvider(providerOpenedFor('A'), instance('inst-a'), db);
+    });
+    await runInWorkerTenantScope(db, TENANT_B, async () => {
+      resolveProvider(providerOpenedFor('foreign'), instance('inst-b'), db);
+    });
+
+    invalidateProviderCache(PROVIDER_ID);
+
+    expect(__test__.openclawPoolKeys()).toEqual([]);
+    expect(built.every((c) => c.stopped)).toBe(true);
+  });
+});

--- a/packages/api/src/plugins/__tests__/plugin-storage-sealing.test.ts
+++ b/packages/api/src/plugins/__tests__/plugin-storage-sealing.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Deliverable (g) — `plugin_storage.value` sealed at rest (G5; ADR-0008;
+ * OWNERSHIP_MANIFEST `filesystem_session_state`).
+ *
+ * WHAT IS IN THIS COLUMN
+ * ----------------------
+ * The WhatsApp channel keeps its whole Baileys authentication state here:
+ * `auth:<instanceId>:creds` is the credential blob that IS the WhatsApp session
+ * (registration identity, noise key, signed identity key), and
+ * `auth:<instanceId>:keys:<type>:<id>` are the Signal protocol keys. Whoever
+ * reads those rows can impersonate the instance. ADR-0008 puts them squarely in
+ * the tenant-owned secret-material class.
+ *
+ * WHERE THE TENANT COMES FROM
+ * ---------------------------
+ * `plugin_storage` is a G0-`split` table with no `tenant_id`, but every one of
+ * these keys NAMES its instance, and `instances` is the ownership root. So the
+ * binding is: parse the instance id out of the storage key, then ask the
+ * instance-owner registry — the same trusted, DB-loaded derivation the publish
+ * path uses. No payload, no header, no caller hint. A key that names no known
+ * instance seals nothing and reads through as plaintext.
+ *
+ * The registry is empty flag-off (every `instances.tenant_id` is NULL), so this
+ * whole surface is inert there without a single flag check, exactly like
+ * `instance-owner-registry.ts` itself.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { setTenantSecretMasterKey } from '@omni/core';
+import type { Database } from '@omni/db';
+import { __resetInstanceOwnerRegistry, rememberInstanceOwner } from '../../tenancy/instance-owner-registry';
+import { isSealedCredentialField } from '../../tenancy/sealed-credentials';
+import { __createPluginStorageForTest } from '../storage';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const INSTANCE_A = '33333333-3333-4333-8333-33333333333a';
+const INSTANCE_B = '44444444-4444-4444-8444-44444444444b';
+const MASTER_KEY = Buffer.alloc(32, 3);
+
+beforeEach(() => __resetInstanceOwnerRegistry());
+afterEach(() => {
+  setTenantSecretMasterKey(null);
+  __resetInstanceOwnerRegistry();
+});
+
+/** One-table stand-in for `plugin_storage`, keyed exactly as the real one. */
+function makeStorageDb() {
+  const rows = new Map<string, { pluginId: string; key: string; value: string; expiresAt: Date | null }>();
+  let pending: { pluginId: string; key: string; value: string; expiresAt: Date | null } | null = null;
+  let lastWhereKey: string | null = null;
+  const db: Record<string, unknown> = {
+    insert: () => ({
+      values: (v: { pluginId: string; key: string; value: string; expiresAt: Date | null }) => {
+        pending = v;
+        return {
+          onConflictDoUpdate: async () => {
+            if (pending) rows.set(pending.key, pending);
+          },
+        };
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            const row = lastWhereKey ? rows.get(lastWhereKey) : [...rows.values()][0];
+            return row ? [row] : [];
+          },
+        }),
+      }),
+    }),
+    delete: () => ({ where: async () => rows.clear() }),
+  };
+  return {
+    db: db as unknown as Database,
+    rows,
+    /** The fake `where` is opaque, so tests name the row they expect back. */
+    expectKey(key: string) {
+      lastWhereKey = key;
+    },
+  };
+}
+
+describe('(g) plugin_storage.value — dual world', () => {
+  test('no master key: Baileys creds are stored exactly as before (plaintext JSON)', async () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, rows } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set(`auth:${INSTANCE_A}:creds`, { noiseKey: 'nk-secret', registered: true });
+
+    const stored = [...rows.values()][0];
+    expect(stored?.value).toContain('nk-secret');
+    expect(isSealedCredentialField(stored?.value)).toBe(false);
+  });
+
+  test('key configured but the instance has no known tenant: still plaintext', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set(`auth:${INSTANCE_A}:creds`, { noiseKey: 'nk-secret' });
+
+    expect([...rows.values()][0]?.value).toContain('nk-secret');
+  });
+
+  test('a key that names no instance at all is never sealed', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, rows } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set('global:feature-cache', { some: 'value' });
+
+    expect([...rows.values()][0]?.value).toContain('value');
+  });
+});
+
+describe('(g) plugin_storage.value — sealed at rest', () => {
+  test('owned instance + key: creds are sealed, and the same store reads them back', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, rows, expectKey } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set(`auth:${INSTANCE_A}:creds`, { noiseKey: 'nk-secret', registered: true });
+
+    const stored = [...rows.values()][0];
+    expect(isSealedCredentialField(stored?.value)).toBe(true);
+    expect(stored?.value).not.toContain('nk-secret');
+
+    expectKey(`plugin:whatsapp-baileys:auth:${INSTANCE_A}:creds`);
+    const read = await storage.get<{ noiseKey: string; registered: boolean }>(`auth:${INSTANCE_A}:creds`);
+    expect(read).toEqual({ noiseKey: 'nk-secret', registered: true });
+  });
+
+  test('a string value (not an object) round-trips through the seal unchanged', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, expectKey } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set(`auth:${INSTANCE_A}:keys:session:abc`, 'raw-signal-key');
+    expectKey(`plugin:whatsapp-baileys:auth:${INSTANCE_A}:keys:session:abc`);
+    expect(await storage.get<string>(`auth:${INSTANCE_A}:keys:session:abc`)).toBe('raw-signal-key');
+  });
+});
+
+describe('(g) plugin_storage.value — cross-tenant refusal', () => {
+  test('an instance owned by tenant B cannot open a blob sealed for tenant A', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, rows, expectKey } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set(`auth:${INSTANCE_A}:creds`, { noiseKey: 'nk-secret' });
+
+    // Re-file the sealed row under an instance owned by tenant B — the storage
+    // key is the only thing an attacker controls here, and it must not help.
+    const sealed = [...rows.values()][0];
+    if (!sealed) throw new Error('expected a sealed row');
+    const foreignKey = `plugin:whatsapp-baileys:auth:${INSTANCE_B}:creds`;
+    rows.set(foreignKey, { ...sealed, key: foreignKey });
+    rememberInstanceOwner({ id: INSTANCE_B, tenantId: TENANT_B });
+
+    expectKey(foreignKey);
+    expect(await storage.get(`auth:${INSTANCE_B}:creds`)).toBeNull();
+  });
+
+  test('a sealed blob is unreadable once the master key is withdrawn (fails closed to null)', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, expectKey } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    await storage.set(`auth:${INSTANCE_A}:creds`, { noiseKey: 'nk-secret' });
+    setTenantSecretMasterKey(null);
+
+    expectKey(`plugin:whatsapp-baileys:auth:${INSTANCE_A}:creds`);
+    expect(await storage.get(`auth:${INSTANCE_A}:creds`)).toBeNull();
+  });
+});
+
+describe('(g) plugin_storage.value — transitional reads', () => {
+  test('a legacy plaintext row still reads while sealing is enabled', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    const { db, rows, expectKey } = makeStorageDb();
+    const storage = __createPluginStorageForTest(db, 'whatsapp-baileys');
+
+    const legacyKey = `plugin:whatsapp-baileys:auth:${INSTANCE_A}:creds`;
+    rows.set(legacyKey, {
+      pluginId: 'whatsapp-baileys',
+      key: legacyKey,
+      value: JSON.stringify({ noiseKey: 'legacy-plain' }),
+      expiresAt: null,
+    });
+
+    expectKey(legacyKey);
+    expect(await storage.get<{ noiseKey: string }>(`auth:${INSTANCE_A}:creds`)).toEqual({ noiseKey: 'legacy-plain' });
+  });
+});

--- a/packages/api/src/plugins/__tests__/session-cleaner-send-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cleaner-send-scope.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Session-cleaner confirmation-send instance read scope (wish:
+ * omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * `runTrashEmojiCleanup` scopes every cleanup DB block with the envelope
+ * tenant — but the confirmation/error `sendMessage` helper it calls at the end
+ * read `instances` BARE, so a tenant-world cleanup still hit the ambient pool
+ * for that one lookup. That kept `services/instances.ts::instances` held by
+ * this caller (a site is only as scoped as its least-scoped caller — the
+ * run12 lesson).
+ *
+ * Probes drive the REAL `runTrashEmojiCleanup` consumer path into its error
+ * send (the first cleanup read throws a non-skippable error), asserting the
+ * helper's instance read observes the envelope tenant's worker scope in the
+ * tenant world and no scope in the legacy world.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { runTrashEmojiCleanup } from '../session-cleaner';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+function fakeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({
+        execute: async () => [] as unknown,
+      }),
+  } as unknown as Database;
+}
+
+function harness() {
+  const instanceScopes: (string | null)[] = [];
+  const services = {
+    agentRunner: {
+      // The FIRST cleanup read: throw a non-skippable error so the handler
+      // falls through to the error-message send — the path under test.
+      getInstanceWithProvider: mock(async () => {
+        throw new Error('probe: cleanup failed before any session work');
+      }),
+    },
+    instances: {
+      getById: mock(async () => {
+        instanceScopes.push(currentTenantScope()?.tenantId ?? null);
+        // No plugin is registered for this channel in the test process, so the
+        // send helper stops after this read — exactly the read under probe.
+        return { id: 'inst-1', channel: 'probe-channel' };
+      }),
+    },
+  } as never;
+  return { services, instanceScopes };
+}
+
+function trashEvent(metadata: Record<string, unknown>) {
+  return {
+    id: `evt-${crypto.randomUUID()}`,
+    type: 'message.received',
+    payload: { chatId: 'chat-ext-1', from: 'user-1', content: { type: 'text', text: '🗑️' } },
+    metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
+    timestamp: Date.now(),
+  } as never;
+}
+
+describe('session-cleaner send helper scopes its instance read (G5, ADR-0008)', () => {
+  test('tenant envelope: the send-side instance read runs inside the worker tenant scope', async () => {
+    const h = harness();
+    await runTrashEmojiCleanup(h.services, fakeDb(), trashEvent({ envelopeVersion: 1, tenantId: TENANT_A }));
+    expect(h.instanceScopes).toEqual([TENANT_A]);
+  });
+
+  test('legacy envelope: the send-side instance read stays unscoped — byte-identical', async () => {
+    const h = harness();
+    await runTrashEmojiCleanup(h.services, fakeDb(), trashEvent({}));
+    expect(h.instanceScopes).toEqual([null]);
+  });
+});

--- a/packages/api/src/plugins/__tests__/session-cleaner.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cleaner.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { clearAgentSession } from '../session-cleaner';
+import type { TypedOmniEvent } from '@omni/core';
+import type { Database } from '@omni/db';
+import { currentTenantScope, requireTenantScope } from '../../tenancy/tenant-scope';
+import { clearAgentSession, runTrashEmojiCleanup } from '../session-cleaner';
 
 function makeDbWithAgentProvider(providerId: string) {
   return {
@@ -43,5 +46,118 @@ describe('session-cleaner canonical KHAL reset guard', () => {
         rawPayload: { headers: { 'x-khal-env': 'hml' } },
       }),
     ).rejects.toThrow('Canonical KHAL session resolution failed');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// G5 worker tenant boundary (ADR-0008): the cleanup handler must run its DB
+// work in the envelope's world — a tenant envelope opens a worker scope stamped
+// with the trusted tenant, a legacy envelope runs unscoped on the ambient pool
+// byte-identically, and a malformed envelope is refused before any work runs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+/** A Database whose `transaction` runs the callback with a no-op tx handle. */
+function fakeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({ execute: async () => [] as unknown }),
+  } as unknown as Database;
+}
+
+interface CleanupProbe {
+  scopeSeen: string | null | undefined;
+  getInstanceCalls: number;
+  sendMessageCalls: number;
+  disarmTenant: string | null | undefined;
+}
+
+/**
+ * Build a services stub whose `getInstanceWithProvider` records the tenant scope
+ * active while it runs, then returns an agent-less instance so `clearAgentSession`
+ * throws the skippable "No agent configured" — enough to prove the FIRST cleanup
+ * DB block ran in the right world without wiring a full provider.
+ */
+function makeProbeServices(probe: CleanupProbe) {
+  return {
+    agentRunner: {
+      getInstanceWithProvider: async () => {
+        probe.getInstanceCalls += 1;
+        const scope = currentTenantScope();
+        probe.scopeSeen = scope ? requireTenantScope().tenantId : null;
+        // Agent-less → clearAgentSession throws a skippable error (no send).
+        return { id: 'inst-1', agentId: undefined };
+      },
+    },
+    providers: { getById: async () => ({ id: 'p', schema: 'agno' }) },
+    chats: {
+      findByExternalIdSmart: async () => null,
+      update: async () => ({ id: 'chat-1' }),
+    },
+    followUpLifecycle: {
+      disarm: async (input: { tenantId?: string | null }) => {
+        probe.disarmTenant = input.tenantId ?? null;
+      },
+    },
+    instances: { getById: async () => ({ id: 'inst-1', channel: 'whatsapp-gupshup' }) },
+  } as never;
+}
+
+function makeEvent(metadata: Record<string, unknown>): TypedOmniEvent<'message.received'> {
+  return {
+    id: 'evt-1',
+    type: 'message.received',
+    timestamp: new Date().toISOString(),
+    payload: { chatId: 'chat-ext', from: 'user-1', content: { text: '🗑️' }, rawPayload: {} },
+    metadata: { instanceId: 'inst-1', ...metadata },
+  } as unknown as TypedOmniEvent<'message.received'>;
+}
+
+describe('session-cleaner worker tenant boundary (G5)', () => {
+  it('(a) a tenant envelope runs cleanup DB work inside a worker scope stamped with the envelope tenant', async () => {
+    const probe: CleanupProbe = {
+      scopeSeen: undefined,
+      getInstanceCalls: 0,
+      sendMessageCalls: 0,
+      disarmTenant: undefined,
+    };
+    const services = makeProbeServices(probe);
+    const event = makeEvent({ envelopeVersion: 1, tenantId: TENANT_A, correlationId: 'c1' });
+
+    await runTrashEmojiCleanup(services, fakeDb(), event);
+
+    expect(probe.getInstanceCalls).toBe(1);
+    expect(probe.scopeSeen).toBe(TENANT_A);
+  });
+
+  it('(b) a legacy envelope runs cleanup with NO tenant scope (ambient pool)', async () => {
+    const probe: CleanupProbe = {
+      scopeSeen: undefined,
+      getInstanceCalls: 0,
+      sendMessageCalls: 0,
+      disarmTenant: undefined,
+    };
+    const services = makeProbeServices(probe);
+    const event = makeEvent({ correlationId: 'c1' }); // no envelopeVersion / tenantId
+
+    await runTrashEmojiCleanup(services, fakeDb(), event);
+
+    expect(probe.getInstanceCalls).toBe(1);
+    expect(probe.scopeSeen).toBeNull();
+  });
+
+  it('(c) a malformed envelope (tenant without version) is refused and performs no cleanup work', async () => {
+    const probe: CleanupProbe = {
+      scopeSeen: undefined,
+      getInstanceCalls: 0,
+      sendMessageCalls: 0,
+      disarmTenant: undefined,
+    };
+    const services = makeProbeServices(probe);
+    const event = makeEvent({ tenantId: TENANT_A }); // tenant claim, no envelopeVersion → quarantine
+
+    await expect(runTrashEmojiCleanup(services, fakeDb(), event)).rejects.toThrow();
+
+    expect(probe.getInstanceCalls).toBe(0);
   });
 });

--- a/packages/api/src/plugins/__tests__/session-cluster-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cluster-two-tenant-postgres.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Two-tenant SESSION/DISPATCH-BACKEND containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * Three `pending-G5-conversion` sites share one caller graph — the
+ * `message.received` dispatch/session consumers — and are converted together:
+ *
+ *   * `services/agent-runner.ts::instances`  — `getInstanceWithProvider`, the
+ *     instance lookup EVERY dispatch path starts from. Zero HTTP callers.
+ *   * `plugins/session-cleaner.ts::chat_participants` — `resolveCleanupPersonId`'s
+ *     participant read, reached from the `session-cleaner` durable consumer and
+ *     from `routes/v2/chats.ts`.
+ *   * `plugins/session-storage.ts::agent_sessions` — the Claude-Code provider's
+ *     session store, constructed inside the dispatcher and therefore reached only
+ *     from a consumer.
+ *
+ * Before this leg all three ran on the AMBIENT POOL. Under enforcement that is
+ * not merely unscoped, it is fail-closed loud: `omni_current_tenant_id()` RAISES
+ * when no `app.tenant_id` is set, so an ambient read inside a worker scope errors
+ * rather than quietly returning another tenant's row. That is what these tests
+ * pin — each converted seam, run under `runInWorkerTenantScope`, must SUCCEED for
+ * its own tenant and find NOTHING for the other.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+} from '@omni/db';
+import { AgentRunnerService } from '../../services/agent-runner';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { __test__ as sessionCleanerTest } from '../session-cleaner';
+import { createSessionStorage } from '../session-storage';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111ca';
+const TENANT_B = '22222222-2222-4222-8222-2222222222cb';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555ca';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555cb';
+const CHAT_A = '66666666-6666-4666-8666-6666666666ca';
+const CHAT_B = '66666666-6666-4666-8666-6666666666cb';
+
+const JID_A = '5511999990101@s.whatsapp.net';
+const JID_B = '5511999990102@s.whatsapp.net';
+const PARTICIPANT_USER_A = '5511999990901';
+const PARTICIPANT_USER_B = '5511999990902';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stdout: string; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-session-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+postgresDescribe('two-tenant session/dispatch-backend containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_sess_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let superDbUrl: string;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'sess-tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'sess-tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'sess-inst-a', 'whatsapp-baileys', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'sess-inst-b', 'whatsapp-baileys', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', '${JID_A}', '${JID_A}', 'direct', 'whatsapp-baileys', 'Chat A',
+         '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${INSTANCE_B}', '${JID_B}', '${JID_B}', 'direct', 'whatsapp-baileys', 'Chat B',
+         '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      -- Participants carry NO person_id: the tenant derives from chat_id, which
+      -- is the required parent. This is deliberate — it keeps the probe off the
+      -- G6-gated \`persons\` root while still exercising the real read.
+      INSERT INTO chat_participants (chat_id, platform_user_id, tenant_id, created_at) VALUES
+        ('${CHAT_A}', '${PARTICIPANT_USER_A}', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${PARTICIPANT_USER_B}', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO agent_sessions (instance_id, session_key, provider_session_data, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'provider:p1:session:shared-key', '{"sessionId":"sid-A"}', '${TENANT_A}',
+         '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'provider:p1:session:shared-key', '{"sessionId":"sid-B"}', '${TENANT_B}',
+         '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // maxConnections=2: the worker tenant transaction holds one; an ambient
+    // pool access (the un-converted state) takes the OTHER, where no
+    // `app.tenant_id` is set and `omni_current_tenant_id()` RAISES. The pre-G5
+    // failure therefore surfaces as a loud error, not a silent leak.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 2);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  // -------------------------------------------------------------------------
+  // agent-runner.ts::instances — getInstanceWithProvider
+  // -------------------------------------------------------------------------
+
+  test('getInstanceWithProvider resolves inside its worker tenant and finds nothing across tenants', async () => {
+    const runner = new AgentRunnerService(runtimeDb);
+
+    const aSeesA = await runInWorkerTenantScope(runtimeDb, TENANT_A, () => runner.getInstanceWithProvider(INSTANCE_A));
+    expect(aSeesA?.id).toBe(INSTANCE_A);
+
+    // B's scope must not resolve A's instance. Under RLS the row is invisible,
+    // so the dispatch path that starts here simply has no instance to act on.
+    const bSeesA = await runInWorkerTenantScope(runtimeDb, TENANT_B, () => runner.getInstanceWithProvider(INSTANCE_A));
+    expect(bSeesA).toBeNull();
+
+    const bSeesB = await runInWorkerTenantScope(runtimeDb, TENANT_B, () => runner.getInstanceWithProvider(INSTANCE_B));
+    expect(bSeesB?.id).toBe(INSTANCE_B);
+  });
+
+  // -------------------------------------------------------------------------
+  // session-cleaner.ts::chat_participants — resolveCleanupPersonId's read
+  // -------------------------------------------------------------------------
+
+  test('the session-cleaner participant read stays inside the work item’s tenant', async () => {
+    const aOwnParticipant = await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      sessionCleanerTest.readChatParticipant(runtimeDb, CHAT_A, PARTICIPANT_USER_A),
+    );
+    expect(aOwnParticipant).not.toBeUndefined();
+
+    // A's chat is invisible to B, so B's cleanup resolves no participant at all
+    // — it cannot learn that A's chat has one, let alone whose person it is.
+    const bViewOfA = await runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
+      sessionCleanerTest.readChatParticipant(runtimeDb, CHAT_A, PARTICIPANT_USER_A),
+    );
+    expect(bViewOfA).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // session-storage.ts::agent_sessions — the provider session store
+  // -------------------------------------------------------------------------
+
+  test('session storage reads/writes only the resolved tenant’s agent_sessions row', async () => {
+    // The store resolves its tenant from the instance's PERSISTED ownership —
+    // the dispatcher passes `instance.tenantId`, never a payload claim.
+    const storeA = createSessionStorage(runtimeDb, 'p1', undefined, { resolveTenantId: () => TENANT_A });
+    const storeB = createSessionStorage(runtimeDb, 'p1', undefined, { resolveTenantId: () => TENANT_B });
+
+    expect((await storeA.getSession(INSTANCE_A, 'shared-key'))?.sessionId).toBe('sid-A');
+    expect((await storeB.getSession(INSTANCE_B, 'shared-key'))?.sessionId).toBe('sid-B');
+
+    // The session KEY is identical across tenants; only the tenant scope
+    // distinguishes them. B asking for A's instance gets nothing.
+    expect(await storeB.getSession(INSTANCE_A, 'shared-key')).toBeNull();
+
+    // A write under B for A's instance cannot land: `agent_sessions` derives its
+    // tenant from the required `instances` parent, so the WITH CHECK refuses it.
+    await expect(storeB.upsertSession(INSTANCE_A, 'stolen-key', 'sid-forged', null)).rejects.toThrow(
+      /row-level security/i,
+    );
+
+    // A's own write lands and is readable only under A.
+    await storeA.upsertSession(INSTANCE_A, 'fresh-key', 'sid-A2', null);
+    expect((await storeA.getSession(INSTANCE_A, 'fresh-key'))?.sessionId).toBe('sid-A2');
+    expect(await storeB.getSession(INSTANCE_A, 'fresh-key')).toBeNull();
+
+    // And a delete under B cannot remove A's row.
+    await storeB.deleteSession(INSTANCE_A, 'fresh-key');
+    expect((await storeA.getSession(INSTANCE_A, 'fresh-key'))?.sessionId).toBe('sid-A2');
+  });
+
+  test('a store with NO tenant resolver keeps the pre-G5 ambient path (dual world)', async () => {
+    // The legacy shape: no resolver, so no scope is opened and the query runs on
+    // the ambient pool exactly as before. Under enforcement that is fail-closed
+    // LOUD — which is the proof that the converted path above is what carries
+    // the tenant, not some incidental ambient visibility.
+    const legacyStore = createSessionStorage(runtimeDb, 'p1');
+    await expect(legacyStore.getSession(INSTANCE_A, 'shared-key')).rejects.toThrow(/tenant/i);
+  });
+});

--- a/packages/api/src/plugins/__tests__/session-storage-sealing.test.ts
+++ b/packages/api/src/plugins/__tests__/session-storage-sealing.test.ts
@@ -32,11 +32,23 @@ afterEach(() => setTenantSecretMasterKey(null));
  * persisted `providerSessionData` verbatim so a test can inspect the bytes at
  * rest, and serves it back to `getSession` unchanged — exactly the storage
  * fidelity the sealing contract depends on.
+ *
+ * TOUCHED BY THE LATER G5 LEG that scoped this store's DB access. Supplying a
+ * `resolveTenantId` now opens a worker tenant TRANSACTION around each discrete
+ * DB block (ADR-0008), so the stub has to model that boundary or the
+ * resolver-present cases below cannot run at all. The `transaction` here is the
+ * minimum honest model — it hands the same handle to the callback, which is what
+ * a real Drizzle transaction does from the query builder's point of view — and
+ * it does NOT weaken any assertion: the sealing/cross-tenant expectations are
+ * unchanged, and real transactional isolation is proven separately against
+ * PostgreSQL in `session-cluster-two-tenant-postgres.test.ts`.
  */
 function makeFakeDb() {
   const rows = new Map<string, { providerSessionData: unknown; lastUsedAt: Date; expiresAt: Date | null }>();
   let pendingValues: { instanceId: string; sessionKey: string; providerSessionData: unknown } | null = null;
   const db = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
     insert: () => ({
       values: (v: { instanceId: string; sessionKey: string; providerSessionData: unknown }) => {
         pendingValues = v;

--- a/packages/api/src/plugins/__tests__/session-storage-sealing.test.ts
+++ b/packages/api/src/plugins/__tests__/session-storage-sealing.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tenant-bound sealing of session secrets at rest (G5; ADR-0008;
+ * OWNERSHIP_MANIFEST `filesystem_session_state`).
+ *
+ * Proves the deliverable-(g) contract end-to-end at the session-storage layer:
+ *
+ *   * DUAL WORLD — with no tenant resolver (the production default) or no master
+ *     key, the persisted `provider_session_data` is legacy plaintext
+ *     `{ sessionId }`, byte-identical to pre-G5, and round-trips.
+ *   * SEALED AT REST — with a resolver + key, the persisted blob is a
+ *     `SealedSecret` (no plaintext session id in the stored bytes), yet the
+ *     owning tenant reads its session back.
+ *   * CROSS-TENANT REFUSAL — a store whose resolver returns tenant B cannot read
+ *     a session sealed for tenant A; it fails closed to "no session" (null),
+ *     never a plaintext leak or a crash. This is the manifest's verification
+ *     target, "session state cannot be decrypted/exported under another tenant".
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { isSealedSecret, setTenantSecretMasterKey } from '@omni/core';
+import type { Database } from '@omni/db';
+import { createSessionStorage } from '../session-storage';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const MASTER_KEY = Buffer.alloc(32, 9);
+
+afterEach(() => setTenantSecretMasterKey(null));
+
+/**
+ * A one-row in-memory stand-in for the `agent_sessions` table. Captures the
+ * persisted `providerSessionData` verbatim so a test can inspect the bytes at
+ * rest, and serves it back to `getSession` unchanged — exactly the storage
+ * fidelity the sealing contract depends on.
+ */
+function makeFakeDb() {
+  const rows = new Map<string, { providerSessionData: unknown; lastUsedAt: Date; expiresAt: Date | null }>();
+  let pendingValues: { instanceId: string; sessionKey: string; providerSessionData: unknown } | null = null;
+  const db = {
+    insert: () => ({
+      values: (v: { instanceId: string; sessionKey: string; providerSessionData: unknown }) => {
+        pendingValues = v;
+        return {
+          onConflictDoUpdate: async () => {
+            if (pendingValues) {
+              rows.set(`${pendingValues.instanceId}::${pendingValues.sessionKey}`, {
+                providerSessionData: pendingValues.providerSessionData,
+                lastUsedAt: new Date(),
+                expiresAt: null,
+              });
+            }
+          },
+        };
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            const [only] = [...rows.values()];
+            return only ? [only] : [];
+          },
+        }),
+      }),
+    }),
+    delete: () => ({ where: async () => rows.clear() }),
+  };
+  return { db: db as unknown as Database, rows };
+}
+
+describe('session-storage sealing — dual world (default = plaintext)', () => {
+  test('no resolver: provider_session_data is legacy plaintext and round-trips', async () => {
+    const { db, rows } = makeFakeDb();
+    const store = createSessionStorage(db, 'p');
+    await store.upsertSession('inst-1', 'k', 'sess-123', null);
+
+    const stored = [...rows.values()][0];
+    if (!stored) throw new Error('expected a persisted session row');
+    expect(isSealedSecret(stored.providerSessionData)).toBe(false);
+    expect(stored.providerSessionData).toEqual({ sessionId: 'sess-123' });
+
+    const got = await store.getSession('inst-1', 'k');
+    expect(got?.sessionId).toBe('sess-123');
+  });
+
+  test('resolver present but no master key: still plaintext (byte-identical)', async () => {
+    setTenantSecretMasterKey(null);
+    const { db, rows } = makeFakeDb();
+    const store = createSessionStorage(db, 'p', undefined, { resolveTenantId: () => TENANT_A });
+    await store.upsertSession('inst-1', 'k', 'sess-123', null);
+    const stored = [...rows.values()][0];
+    if (!stored) throw new Error('expected a persisted session row');
+    expect(isSealedSecret(stored.providerSessionData)).toBe(false);
+  });
+});
+
+describe('session-storage sealing — sealed at rest', () => {
+  test('resolver + key: blob is sealed (no plaintext session id) and owner reads it back', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeFakeDb();
+    const store = createSessionStorage(db, 'p', undefined, { resolveTenantId: () => TENANT_A });
+    await store.upsertSession('inst-1', 'k', 'sess-abc', null);
+
+    const stored = [...rows.values()][0];
+    if (!stored) throw new Error('expected a persisted session row');
+    expect(isSealedSecret(stored.providerSessionData)).toBe(true);
+    expect(JSON.stringify(stored.providerSessionData)).not.toContain('sess-abc');
+
+    const got = await store.getSession('inst-1', 'k');
+    expect(got?.sessionId).toBe('sess-abc');
+  });
+});
+
+describe('session-storage sealing — cross-tenant refusal', () => {
+  test('tenant B store cannot read a session sealed for tenant A (fails closed to null)', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db } = makeFakeDb();
+    const storeA = createSessionStorage(db, 'p', undefined, { resolveTenantId: () => TENANT_A });
+    await storeA.upsertSession('inst-1', 'k', 'sess-secret', null);
+
+    const storeB = createSessionStorage(db, 'p', undefined, { resolveTenantId: () => TENANT_B });
+    const got = await storeB.getSession('inst-1', 'k');
+    expect(got).toBeNull();
+  });
+
+  test('a sealed row is unreadable when the tenant cannot be resolved', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db } = makeFakeDb();
+    const storeA = createSessionStorage(db, 'p', undefined, { resolveTenantId: () => TENANT_A });
+    await storeA.upsertSession('inst-1', 'k', 'sess-secret', null);
+
+    // A reader with a key but no resolver cannot open a sealed row.
+    const storeNoResolver = createSessionStorage(db, 'p');
+    expect(await storeNoResolver.getSession('inst-1', 'k')).toBeNull();
+  });
+});

--- a/packages/api/src/plugins/__tests__/sync-worker-inflight-revocation.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker-inflight-revocation.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Sync-worker in-flight revocation gate (wish: omni-full-multitenancy, Group
+ * G5, deliverable (c); RELEASE_SLOS
+ * `revocation.inflight_privileged_work_revocation_seconds_max: 30`).
+ *
+ * A message sync is the repository's longest-running consumer work item — a
+ * multi-thousand-message backfill can outlive any dequeue-time check by
+ * minutes. The `createInflightRevocationMonitor` gate gives its loop the
+ * bounded observation the ceiling requires (cadence proven with a synthetic
+ * clock in tenancy/__tests__/inflight-revocation.test.ts); THIS suite proves
+ * the wiring, in all three tenant-gated processors (messages/contacts/groups):
+ *
+ *   * a REVOKED tenant's job performs ZERO side effects — the first gate
+ *     (which doubles as dequeue-time revalidation) refuses before any store,
+ *     and the job is failed, not completed;
+ *   * a MID-FLIGHT revocation (tenant flips after items have started flowing)
+ *     is observed at the recheck cadence: once the gate refuses, later
+ *     onMessage/onContact/onGroup deliveries from the channel plugin are
+ *     dropped without side effects (the sticky-refusal shape), post-flip
+ *     progress writes are suppressed, and the job fails, never completes.
+ *     The cadence tick is driven with `setSystemTime` — the monitor's default
+ *     clock — so no wall-clock waits;
+ *   * an UNREACHABLE auth plane refuses fail-closed: a job whose admissibility
+ *     read throws stores nothing and fails;
+ *   * an ACTIVE tenant's job stores normally;
+ *   * a LEGACY job never consults the auth plane at all — byte-identical.
+ */
+
+import { afterEach, describe, expect, mock, setSystemTime, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import type { Database } from '@omni/db';
+import type { SyncJobType } from '@omni/db';
+import { setupSyncWorker } from '../sync-worker';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+/** One tick past the monitor's recheck cadence (half the 30s ceiling). */
+const PAST_RECHECK_MS = 16_000;
+
+afterEach(() => {
+  setSystemTime(); // restore the real clock after mid-flight cadence tests
+});
+
+function fakeDb(storedGroups: string[]): Database {
+  // The worker-scope transaction handle needs just enough drizzle surface for
+  // `upsertSyncedGroup` (select→from→where→limit, insert→values) plus the
+  // `set_config` execute; everything else in these tests goes through service
+  // mocks. Ambient-pool reads (the legacy world's anchor discovery) resolve to
+  // empty result sets.
+  const tx = {
+    execute: async () => [] as unknown,
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [] as unknown[],
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: async (row: { externalId: string }) => {
+        storedGroups.push(row.externalId);
+      },
+    }),
+  };
+  return {
+    execute: async () => [] as unknown,
+    transaction: async <T>(cb: (t: unknown) => Promise<T>): Promise<T> => cb(tx),
+  } as unknown as Database;
+}
+
+function harness(tenantStatus: 'active' | 'suspended') {
+  let handler: ((event: unknown) => Promise<void>) | null = null;
+  const authPlaneReads = { count: 0 };
+  const progressUpdates = { count: 0 };
+  const storedMessages: string[] = [];
+  const storedContacts: string[] = [];
+  const storedGroups: string[] = [];
+  const jobOutcomes: string[] = [];
+
+  // Mutable auth-plane state: mid-flight tests flip `status` between item
+  // deliveries; `readError` makes every admissibility read throw (the
+  // auth-plane-unreachable shape).
+  const tenantState: { status: 'active' | 'suspended'; readError: Error | null } = {
+    status: tenantStatus,
+    readError: null,
+  };
+
+  // Per-processor feeds. `afterFirstItem` runs after the FIRST delivery of the
+  // fired feed — the mid-flight flip point. `progressAfterFeed` has the plugin
+  // report progress after the last delivery (post-flip in mid-flight tests).
+  const feed = {
+    messages: ['m-1', 'm-2'],
+    contacts: ['c-1', 'c-2'],
+    groups: ['g-1', 'g-2'],
+    afterFirstItem: null as (() => void) | null,
+    progressAfterFeed: false,
+  };
+
+  const bus = {
+    subscribe: mock(async (eventType: string, cb: (event: unknown) => Promise<void>) => {
+      if (eventType === 'sync.started') handler = cb;
+      return { unsubscribe: mock(async () => {}) };
+    }),
+    subscribePattern: mock(async () => ({ unsubscribe: mock(async () => {}) })),
+    publish: mock(async () => ({ id: 'evt-1' })),
+  } as unknown as EventBus;
+
+  const authPlaneDb = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            authPlaneReads.count++;
+            if (tenantState.readError) throw tenantState.readError;
+            return [{ status: tenantState.status }];
+          },
+        }),
+      }),
+    }),
+  } as unknown as Database;
+
+  const services = {
+    authPlane: { db: authPlaneDb },
+    syncJobs: {
+      start: mock(async () => {}),
+      complete: mock(async () => {
+        jobOutcomes.push('complete');
+      }),
+      fail: mock(async (_id: string, error: string) => {
+        jobOutcomes.push(`fail:${error}`);
+      }),
+      updateProgress: mock(async () => {
+        progressUpdates.count++;
+      }),
+    },
+    instances: {
+      getById: mock(async () => ({ id: 'inst-1', channel: 'whatsapp-baileys' })),
+    },
+    chats: {
+      findOrCreate: mock(async () => ({ chat: { id: 'chat-1' }, created: false })),
+      getAllExternalIds: mock(async () => []),
+      findByExternalIdSmart: mock(async () => null),
+      update: mock(async () => ({})),
+    },
+    messages: {
+      getByExternalId: mock(async () => null),
+      create: mock(async (data: { externalId: string }) => {
+        storedMessages.push(data.externalId);
+        return {};
+      }),
+    },
+    persons: {
+      findOrCreateIdentity: mock(async (identity: { platformUserId: string }) => {
+        storedContacts.push(identity.platformUserId);
+        return { isNew: true, wasLinked: false };
+      }),
+    },
+  } as never;
+
+  // A plugin that keeps feeding items regardless of gate state — the worker,
+  // not the channel, owns the revocation boundary.
+  const registry = {
+    get: mock(() => ({
+      fetchHistory: async (
+        _instanceId: string,
+        opts: { onMessage: (m: unknown) => Promise<void>; onProgress?: (count: number) => Promise<void> },
+      ) => {
+        for (const [index, externalId] of feed.messages.entries()) {
+          await opts.onMessage({
+            externalId,
+            chatId: 'chat-ext-1',
+            from: 'user-1',
+            isFromMe: false,
+            timestamp: new Date(),
+            content: { type: 'text', text: externalId },
+            rawPayload: {},
+          });
+          if (index === 0) feed.afterFirstItem?.();
+        }
+        if (feed.progressAfterFeed) await opts.onProgress?.(feed.messages.length);
+      },
+      fetchContacts: async (_instanceId: string, opts: { onContact: (c: unknown) => Promise<void> }) => {
+        for (const [index, platformUserId] of feed.contacts.entries()) {
+          await opts.onContact({
+            platformUserId,
+            name: `name-${platformUserId}`,
+            isGroup: false,
+          });
+          if (index === 0) feed.afterFirstItem?.();
+        }
+      },
+      fetchGroups: async (_instanceId: string, opts: { onGroup: (g: unknown) => Promise<void> }) => {
+        for (const [index, externalId] of feed.groups.entries()) {
+          await opts.onGroup({ externalId, name: `name-${externalId}` });
+          if (index === 0) feed.afterFirstItem?.();
+        }
+      },
+    })),
+  } as never;
+
+  const fire = async (metadata: Record<string, unknown>, type: SyncJobType = 'messages') => {
+    if (!handler) throw new Error('sync.started handler not registered');
+    await handler({
+      payload: { jobId: 'job-1', instanceId: 'inst-1', type, config: {} },
+      metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
+    });
+  };
+
+  return {
+    bus,
+    services,
+    registry,
+    authPlaneReads,
+    progressUpdates,
+    storedMessages,
+    storedContacts,
+    storedGroups,
+    jobOutcomes,
+    tenantState,
+    feed,
+    fire,
+    db: fakeDb(storedGroups),
+  };
+}
+
+/** The mid-flight flip: the tenant is revoked and the recheck cadence elapses. */
+function revokeMidFlight(h: ReturnType<typeof harness>): void {
+  h.tenantState.status = 'suspended';
+  setSystemTime(new Date(Date.now() + PAST_RECHECK_MS));
+}
+
+describe('sync-worker in-flight revocation gate (G5, RELEASE_SLOS inflight ceiling)', () => {
+  test('a revoked tenant’s job stores NOTHING and is failed, not completed', async () => {
+    const h = harness('suspended');
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A });
+
+    expect(h.storedMessages).toEqual([]);
+    expect(h.authPlaneReads.count).toBeGreaterThan(0);
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('a mid-flight revocation stops the message stream: later deliveries drop sticky, progress is suppressed, the job fails', async () => {
+    const h = harness('active');
+    h.feed.messages = ['m-1', 'm-2', 'm-3'];
+    h.feed.afterFirstItem = () => revokeMidFlight(h);
+    h.feed.progressAfterFeed = true; // the plugin reports progress AFTER the flip
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A });
+
+    // m-1 landed before the flip; m-2 observes the revocation at the cadence
+    // tick; m-3 is dropped by the sticky guard without a fresh auth-plane read.
+    expect(h.storedMessages).toEqual(['m-1']);
+    expect(h.authPlaneReads.count).toBe(2); // dequeue gate + the m-2 recheck
+    // The post-flip onProgress and the final progress write are both
+    // suppressed — no durable side effects after the flip.
+    expect(h.progressUpdates.count).toBe(0);
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('an unreachable auth plane refuses fail-closed: the job stores nothing and fails', async () => {
+    const h = harness('active');
+    h.tenantState.readError = new Error('auth plane unreachable');
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A });
+
+    expect(h.storedMessages).toEqual([]);
+    expect(h.authPlaneReads.count).toBeGreaterThan(0);
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('contacts: a revoked tenant’s job ingests NOTHING and is failed, not completed', async () => {
+    const h = harness('suspended');
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A }, 'contacts');
+
+    expect(h.storedContacts).toEqual([]);
+    expect(h.authPlaneReads.count).toBeGreaterThan(0);
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('contacts: a mid-flight revocation drops later deliveries and fails the job', async () => {
+    const h = harness('active');
+    h.feed.contacts = ['c-1', 'c-2', 'c-3'];
+    h.feed.afterFirstItem = () => revokeMidFlight(h);
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A }, 'contacts');
+
+    expect(h.storedContacts).toEqual(['c-1']);
+    expect(h.authPlaneReads.count).toBe(2); // dequeue gate + the c-2 recheck
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('groups: a revoked tenant’s job upserts NOTHING and is failed, not completed', async () => {
+    const h = harness('suspended');
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A }, 'groups');
+
+    expect(h.storedGroups).toEqual([]);
+    expect(h.authPlaneReads.count).toBeGreaterThan(0);
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('groups: a mid-flight revocation drops later deliveries and fails the job', async () => {
+    const h = harness('active');
+    h.feed.groups = ['g-1', 'g-2', 'g-3'];
+    h.feed.afterFirstItem = () => revokeMidFlight(h);
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A }, 'groups');
+
+    expect(h.storedGroups).toEqual(['g-1']);
+    expect(h.authPlaneReads.count).toBe(2); // dequeue gate + the g-2 recheck
+    expect(h.jobOutcomes.length).toBe(1);
+    expect(h.jobOutcomes[0]).toMatch(/^fail:.*no longer admissible/);
+  });
+
+  test('an active tenant’s job stores normally through the gate', async () => {
+    const h = harness('active');
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A });
+
+    expect(h.storedMessages).toEqual(['m-1', 'm-2']);
+    expect(h.jobOutcomes).toEqual(['complete']);
+  });
+
+  test('a legacy job never consults the auth plane — byte-identical', async () => {
+    const h = harness('suspended'); // would refuse if ever consulted
+    await setupSyncWorker(h.bus, h.services, h.registry, h.db);
+    await h.fire({});
+
+    expect(h.authPlaneReads.count).toBe(0);
+    expect(h.storedMessages).toEqual(['m-1', 'm-2']);
+    expect(h.jobOutcomes).toEqual(['complete']);
+  });
+});

--- a/packages/api/src/plugins/__tests__/sync-worker-instance-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker-instance-scope.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Sync-worker `instances` read scope (wish: omni-full-multitenancy, Group G5;
+ * ADR-0008).
+ *
+ * The `sync.started` handler classifies its envelope up front and scopes the
+ * per-item work (`inSyncWorkerScope`) — but the instance lookup that decides
+ * the channel type ran BARE between `syncJobs.start` and the per-item loop, so
+ * a tenant-world job still read `instances` on the ambient pool. That kept
+ * `services/instances.ts::instances` held by this caller (a site is only as
+ * scoped as its least-scoped caller — the run12 lesson).
+ *
+ * Probes: a tenant-stamped `sync.started` envelope runs the instance read
+ * inside a worker scope for the envelope tenant; a legacy envelope leaves it
+ * unscoped, byte-identical.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { setupSyncWorker } from '../sync-worker';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+function fakeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({
+        execute: async () => [] as unknown,
+      }),
+  } as unknown as Database;
+}
+
+function harness() {
+  let handler: ((event: unknown) => Promise<void>) | null = null;
+  const instanceScopes: (string | null)[] = [];
+
+  const bus = {
+    subscribe: mock(async (eventType: string, cb: (event: unknown) => Promise<void>) => {
+      if (eventType === 'sync.started') handler = cb;
+      return { unsubscribe: mock(async () => {}) };
+    }),
+    subscribePattern: mock(async () => ({ unsubscribe: mock(async () => {}) })),
+    publish: mock(async () => ({ id: 'evt-1' })),
+  } as unknown as EventBus;
+
+  const services = {
+    syncJobs: {
+      start: mock(async () => {}),
+      complete: mock(async () => {}),
+      fail: mock(async () => {}),
+    },
+    instances: {
+      getById: mock(async () => {
+        instanceScopes.push(currentTenantScope()?.tenantId ?? null);
+        return { id: 'inst-1', channel: 'whatsapp-baileys' };
+      }),
+    },
+  } as never;
+
+  const registry = { get: mock(() => undefined) } as never;
+
+  const fire = async (metadata: Record<string, unknown>) => {
+    if (!handler) throw new Error('sync.started handler not registered');
+    // An unknown job type: the handler reads the instance, then fails the job —
+    // the cheapest deterministic path through the read under test.
+    await handler({
+      payload: { jobId: 'job-1', instanceId: 'inst-1', type: 'unknown-probe-type', config: {} },
+      metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
+    });
+  };
+
+  return { bus, services, registry, instanceScopes, fire };
+}
+
+describe('sync-worker scopes its instance read (G5, ADR-0008)', () => {
+  test('tenant envelope: the instance read runs inside the worker tenant scope', async () => {
+    const h = harness();
+    await setupSyncWorker(h.bus, h.services, h.registry, fakeDb());
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A });
+    expect(h.instanceScopes).toEqual([TENANT_A]);
+  });
+
+  test('legacy envelope: the instance read stays unscoped — byte-identical', async () => {
+    const h = harness();
+    await setupSyncWorker(h.bus, h.services, h.registry, fakeDb());
+    await h.fire({});
+    expect(h.instanceScopes).toEqual([null]);
+  });
+});

--- a/packages/api/src/plugins/__tests__/sync-worker-media-backfill-scope.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker-media-backfill-scope.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The post-sync media backfill THREADS the job's tenant (G5; ADR-0008).
+ *
+ * `services/batch-jobs.ts` was ratcheted to `tenant-boundary` on a justification
+ * naming two trusted-tenant sources for `create`: `currentTenantScope()` for a
+ * request caller, and "threaded trustedTenantId for the sync-worker's post-sync
+ * backfill". The second half described code that did not exist —
+ * `processMessageSync` held `jobTenantId`, threaded it to `updateProgress` and
+ * `complete`, and then called `queueMediaBackfillAfterSync` without it.
+ *
+ * That call site is OUTSIDE every scope: `inSyncWorkerScope` wraps only the
+ * per-item closures, which have closed by then, and the handler is a NATS
+ * consumer with no ambient scope of its own. So `create` saw
+ * `trustedTenantId === undefined` AND `currentTenantScope() === null` and
+ * enqueued a NULL-tenant row, whose detached executor then read `messages` and
+ * wrote `media_content` for that tenant's instance entirely unscoped — and
+ * `isTenantWorkAdmissible(authPlane, null)` returns true, so the dequeue-time
+ * revocation gate was skipped as well.
+ *
+ * This probe drives the REAL `sync.started` handler, because the threading is a
+ * property of the call site: a probe that invoked the helper directly would stay
+ * green if the argument were dropped again.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import type { Database } from '@omni/db';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { setupSyncWorker } from '../sync-worker';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+function fakeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({ execute: async () => [] as unknown }),
+  } as unknown as Database;
+}
+
+/** Auth plane for the in-flight revocation gate: the tenant is active. */
+function fakeAuthPlaneDb(): Database {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [{ status: 'active' }] }),
+      }),
+    }),
+  } as unknown as Database;
+}
+
+interface CreateCall {
+  instanceId: string;
+  trustedTenantId: string | null | undefined;
+  /** The scope observed AT the call — the backfill enqueues outside every scope. */
+  scope: string | null;
+}
+
+function harness() {
+  let handler: ((event: unknown) => Promise<void>) | null = null;
+  const creates: CreateCall[] = [];
+
+  const bus = {
+    subscribe: mock(async (eventType: string, cb: (event: unknown) => Promise<void>) => {
+      if (eventType === 'sync.started') handler = cb;
+      return { unsubscribe: mock(async () => {}) };
+    }),
+    subscribePattern: mock(async () => ({ unsubscribe: mock(async () => {}) })),
+    publish: mock(async () => ({ id: 'evt-1' })),
+  } as unknown as EventBus;
+
+  const services = {
+    authPlane: { db: fakeAuthPlaneDb() },
+    syncJobs: {
+      start: mock(async () => {}),
+      complete: mock(async () => {}),
+      fail: mock(async () => {}),
+      updateProgress: mock(async () => {}),
+    },
+    instances: {
+      getById: mock(async () => ({ id: 'inst-1', channel: 'telegram' })),
+    },
+    chats: {
+      findOrCreate: mock(async () => ({ chat: { id: 'chat-1' } })),
+    },
+    messages: {
+      getByExternalId: mock(async () => null),
+      create: mock(async () => ({ id: 'msg-1' })),
+    },
+    batchJobs: {
+      create: mock(async (options: { instanceId: string }, trustedTenantId?: string | null) => {
+        creates.push({
+          instanceId: options.instanceId,
+          trustedTenantId,
+          scope: currentTenantScope()?.tenantId ?? null,
+        });
+        return { id: 'batch-1' };
+      }),
+    },
+  } as never;
+
+  // A telegram plugin whose history fetch yields exactly one storable message,
+  // so `stored > 0` and the backfill guard is satisfied.
+  const registry = {
+    get: mock(() => ({
+      fetchHistory: async (
+        _instanceId: string,
+        options: { onMessage: (msg: Record<string, unknown>) => Promise<void> },
+      ) => {
+        await options.onMessage({
+          chatId: 'chat-ext-1',
+          externalId: 'msg-ext-1',
+          content: { type: 'text', text: 'hello' },
+          timestamp: new Date(),
+          from: 'sender-1',
+          isFromMe: false,
+          rawPayload: {},
+        });
+      },
+    })),
+  } as never;
+
+  const fire = async (metadata: Record<string, unknown>) => {
+    if (!handler) throw new Error('sync.started handler not registered');
+    await handler({
+      payload: {
+        jobId: 'job-1',
+        instanceId: 'inst-1',
+        type: 'messages',
+        config: { backfillMedia: true, depth: '7d' },
+      },
+      metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
+    });
+  };
+
+  return { bus, services, registry, creates, fire };
+}
+
+describe('sync-worker post-sync media backfill (G5, ADR-0008)', () => {
+  test('tenant envelope: the backfill batch job is enqueued with the JOB’s tenant', async () => {
+    const h = harness();
+    await setupSyncWorker(h.bus, h.services, h.registry, fakeDb());
+
+    await h.fire({ envelopeVersion: 1, tenantId: TENANT_A });
+
+    expect(h.creates.length).toBe(1);
+    expect(h.creates[0]?.trustedTenantId).toBe(TENANT_A);
+    // …and it is genuinely THREADED, not inherited: the enqueue happens outside
+    // every scope (the per-item scopes closed before this ran), so the value has
+    // to travel as an argument or it is lost.
+    expect(h.creates[0]?.scope).toBeNull();
+  });
+
+  test('legacy envelope: nothing is threaded and the enqueue is byte-identical', async () => {
+    const h = harness();
+    await setupSyncWorker(h.bus, h.services, h.registry, fakeDb());
+
+    await h.fire({});
+
+    expect(h.creates.length).toBe(1);
+    // A legacy job has no tenant to stamp; `null` forces the pre-G5 ambient job
+    // exactly as the unthreaded call produced before.
+    expect(h.creates[0]?.trustedTenantId ?? null).toBeNull();
+    expect(h.creates[0]?.scope).toBeNull();
+  });
+});

--- a/packages/api/src/plugins/__tests__/sync-worker-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker-two-tenant-postgres.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Two-tenant SYNC-WORKER containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * The `sync-worker` plugin is a `sync.started` NATS consumer. Its two tenant-table
+ * access sites were the `pending-G5-conversion` sites:
+ *   - `omni_groups` — the per-group upsert in the `onGroup`/`onGuild` callbacks
+ *     (extracted here as `__test__.upsertSyncedGroup`);
+ *   - `messages`    — the raw-SQL anchor read `__test__.buildWhatsAppAnchors`.
+ *
+ * Before G5 both ran on the ambient pool with no tenant context. This proves the
+ * converted seams — the exact functions the consumer calls — stay inside the
+ * work item's tenant when run under `runInWorkerTenantScope`, and that neither
+ * a read nor a write leaks across to another tenant.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+  omniGroups,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { scopedHandle } from '../../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { __test__ as syncWorkerTest } from '../sync-worker';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111da';
+const TENANT_B = '22222222-2222-4222-8222-2222222222db';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555da';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555db';
+const CHAT_A = '66666666-6666-4666-8666-6666666666da';
+const CHAT_B = '66666666-6666-4666-8666-6666666666db';
+const MESSAGE_A = '77777777-7777-4777-8777-7777777777da';
+const MESSAGE_B = '77777777-7777-4777-8777-7777777777db';
+
+const JID_A = '5511999990001@s.whatsapp.net';
+const JID_B = '5511999990002@s.whatsapp.net';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-sync-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+postgresDescribe('two-tenant sync-worker containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_sync_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  /** Read a tenant's omni_groups rows for an externalId, as a worker would. */
+  const groupsForTenant = (tenantId: string, externalId: string): Promise<{ id: string; name: string | null }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: omniGroups.id, name: omniGroups.name })
+        .from(omniGroups)
+        .where(eq(omniGroups.externalId, externalId)),
+    );
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', '${JID_A}', '${JID_A}', 'direct', 'whatsapp-baileys', 'Chat A',
+         '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${INSTANCE_B}', '${JID_B}', '${JID_B}', 'direct', 'whatsapp-baileys', 'Chat B',
+         '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      INSERT INTO messages (id, chat_id, external_id, source, message_type, platform_timestamp, raw_payload, tenant_id)
+      VALUES
+        ('${MESSAGE_A}', '${CHAT_A}', 'wamid.A', 'sync', 'text', '${SHARED_TIMESTAMP}',
+         '{"key":{"id":"wamid.A","remoteJid":"${JID_A}","fromMe":false}}', '${TENANT_A}'),
+        ('${MESSAGE_B}', '${CHAT_B}', 'wamid.B', 'sync', 'text', '${SHARED_TIMESTAMP}',
+         '{"key":{"id":"wamid.B","remoteJid":"${JID_B}","fromMe":false}}', '${TENANT_B}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // maxConnections=2: the worker tenant transaction holds one; a raw-pool
+    // access (the un-converted state) would take the OTHER, so the pre-G5
+    // failure surfaces as an RLS rejection rather than a single-connection
+    // deadlock — a fast, deterministic RED.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 2);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('upsertSyncedGroup writes a group only under its worker tenant; the other tenant cannot see it', async () => {
+    const outcome = await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      syncWorkerTest.upsertSyncedGroup(runtimeDb, INSTANCE_A, 'whatsapp-baileys', {
+        externalId: 'group-a@g.us',
+        name: 'A group',
+      }),
+    );
+    expect(outcome).toBe('stored');
+
+    // Visible to A, invisible to B.
+    expect((await groupsForTenant(TENANT_A, 'group-a@g.us')).map((r) => r.name)).toEqual(['A group']);
+    expect((await groupsForTenant(TENANT_B, 'group-a@g.us')).length).toBe(0);
+
+    // A second upsert of the same group under A takes the update path (the
+    // select-existing read is itself scoped).
+    const second = await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      syncWorkerTest.upsertSyncedGroup(runtimeDb, INSTANCE_A, 'whatsapp-baileys', {
+        externalId: 'group-a@g.us',
+        name: 'A group renamed',
+      }),
+    );
+    expect(second).toBe('updated');
+    expect((await groupsForTenant(TENANT_A, 'group-a@g.us')).map((r) => r.name)).toEqual(['A group renamed']);
+  });
+
+  test('a B worker cannot write a group on A’s instance — RLS rejects the cross-tenant insert', async () => {
+    // B's select cannot see A's row (RLS), so it takes the INSERT path. The
+    // omni_groups WITH CHECK is derived from instance ownership, and INSTANCE_A
+    // belongs to A, so B's insert is rejected outright rather than landing a
+    // stray B-row. (In the live consumer `onGroup` swallows this and continues.)
+    await expect(
+      runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
+        syncWorkerTest.upsertSyncedGroup(runtimeDb, INSTANCE_A, 'whatsapp-baileys', {
+          externalId: 'group-a@g.us',
+          name: 'B overwrite attempt',
+        }),
+      ),
+    ).rejects.toThrow(/row-level security/i);
+
+    // A's row is untouched; B has no row at all.
+    expect((await groupsForTenant(TENANT_A, 'group-a@g.us')).map((r) => r.name)).toEqual(['A group renamed']);
+    expect((await groupsForTenant(TENANT_B, 'group-a@g.us')).length).toBe(0);
+  });
+
+  test('buildWhatsAppAnchors reads only the worker tenant’s messages', async () => {
+    // Under A's scope, A's seeded message yields exactly one anchor.
+    const aAnchors = await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      syncWorkerTest.buildWhatsAppAnchors(runtimeDb, INSTANCE_A),
+    );
+    expect(aAnchors.map((a) => a.messageKey.id)).toEqual(['wamid.A']);
+
+    // B cannot see A's instance data — RLS hides A's chats/messages entirely.
+    const bViewOfA = await runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
+      syncWorkerTest.buildWhatsAppAnchors(runtimeDb, INSTANCE_A),
+    );
+    expect(bViewOfA.length).toBe(0);
+
+    // And B sees its OWN instance's anchor.
+    const bAnchors = await runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
+      syncWorkerTest.buildWhatsAppAnchors(runtimeDb, INSTANCE_B),
+    );
+    expect(bAnchors.map((a) => a.messageKey.id)).toEqual(['wamid.B']);
+  });
+});

--- a/packages/api/src/plugins/__tests__/sync-worker.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker.test.ts
@@ -118,7 +118,7 @@ describe('setupSyncWorker', () => {
       config: {},
     });
 
-    expect(services.syncJobs.start).toHaveBeenCalledWith('job-1');
+    expect(services.syncJobs.start).toHaveBeenCalledWith('job-1', null);
   });
 
   // -- Type routing ----------------------------------------------------------
@@ -132,8 +132,8 @@ describe('setupSyncWorker', () => {
       config: {},
     });
 
-    expect(services.syncJobs.start).toHaveBeenCalledWith('job-p');
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-p');
+    expect(services.syncJobs.start).toHaveBeenCalledWith('job-p', null);
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-p', null);
     // Plugin should never be looked up for profile sync
     expect(registry.get).not.toHaveBeenCalled();
   });
@@ -159,7 +159,7 @@ describe('setupSyncWorker', () => {
     // First argument is the instanceId
     const histCalls = mockPlugin.fetchHistory.mock.calls as unknown[][];
     expect(histCalls[0]?.[0]).toBe('inst-1');
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-m');
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-m', null);
   });
 
   test('contacts type calls plugin.fetchContacts', async () => {
@@ -182,7 +182,7 @@ describe('setupSyncWorker', () => {
     expect(mockPlugin.fetchContacts).toHaveBeenCalledTimes(1);
     const contactCalls = mockPlugin.fetchContacts.mock.calls as unknown[][];
     expect(contactCalls[0]?.[0]).toBe('inst-1');
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-c');
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-c', null);
   });
 
   test('groups type calls plugin.fetchGroups', async () => {
@@ -203,7 +203,7 @@ describe('setupSyncWorker', () => {
 
     expect(registry.get).toHaveBeenCalledWith('whatsapp-baileys');
     expect(mockPlugin.fetchGroups).toHaveBeenCalledTimes(1);
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-g');
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-g', null);
   });
 
   test('all type calls plugin.fetchHistory (processes message sync)', async () => {
@@ -223,7 +223,7 @@ describe('setupSyncWorker', () => {
     });
 
     expect(mockPlugin.fetchHistory).toHaveBeenCalledTimes(1);
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-a');
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-a', null);
   });
 
   test('history-push type is a no-op after start', async () => {
@@ -235,7 +235,7 @@ describe('setupSyncWorker', () => {
       config: {},
     });
 
-    expect(services.syncJobs.start).toHaveBeenCalledWith('job-hp');
+    expect(services.syncJobs.start).toHaveBeenCalledWith('job-hp', null);
     // Should NOT call complete or fail — progress is driven by tracker subscribers
     expect(services.syncJobs.complete).not.toHaveBeenCalled();
     expect(services.syncJobs.fail).not.toHaveBeenCalled();
@@ -253,7 +253,7 @@ describe('setupSyncWorker', () => {
       config: {},
     });
 
-    expect(services.syncJobs.fail).toHaveBeenCalledWith('job-u', 'Unknown sync type: banana');
+    expect(services.syncJobs.fail).toHaveBeenCalledWith('job-u', 'Unknown sync type: banana', null);
   });
 
   test('fails job when instances.getById returns null', async () => {
@@ -448,7 +448,7 @@ describe('setupSyncWorker', () => {
       '5511999999999@s.whatsapp.net',
     ]);
 
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-gh142');
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-gh142', null);
   });
 
   test('default WhatsApp sync falls back to passive when no prior data (fresh instance)', async () => {
@@ -484,6 +484,6 @@ describe('setupSyncWorker', () => {
     // Fresh instance: no anchors, passive sync
     expect(capturedOptions[0]!.anchors).toBeUndefined();
 
-    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-fresh');
+    expect(services.syncJobs.complete).toHaveBeenCalledWith('job-fresh', null);
   });
 });

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -731,7 +731,15 @@ async function persistErrorHandoffSideEffects(
       return found;
     });
     if (chat) {
-      await services.followUpLifecycle.disarm({ chatId: chat.id, instanceId: instance.id, reason: 'handoff' });
+      // The disarm THREADS the trusted tenant instead of being wrapped: the
+      // lifecycle scopes its own DB blocks from `tenantId` and publishes
+      // between them (G5 conversion of follow-up-lifecycle.ts).
+      await services.followUpLifecycle.disarm({
+        chatId: chat.id,
+        instanceId: instance.id,
+        reason: 'handoff',
+        tenantId: trustedTenantId ?? null,
+      });
       await runDispatchDb(db, trustedTenantId, async () => {
         await scopedHandle(db)
           .insert(handoffLogs)

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -5356,7 +5356,7 @@ async function shouldProcessMessage(
   // messages still reach the debounce buffer. Counting per-inbound-message
   // silently dropped mid-thought messages and corrupted the agent context.
 
-  const accessDenied = await checkAccessWithFallback(accessService, instance, payload, channel);
+  const accessDenied = await checkAccessWithFallback(accessService, instance, payload, channel, trustedTenantId);
   if (accessDenied) return null;
 
   return instance;
@@ -5372,6 +5372,7 @@ async function checkAccessWithFallback(
   instance: Instance,
   payload: { from: string; chatId: string; rawPayload?: unknown },
   channel: ChannelType,
+  trustedTenantId?: string,
 ): Promise<boolean> {
   const rawPayload = payload.rawPayload as Record<string, unknown> | undefined;
   const rawKey = rawPayload?.key as Record<string, unknown> | undefined;
@@ -5384,7 +5385,11 @@ async function checkAccessWithFallback(
   const resolvedSenderPhone = rawResolvedPhone && /^\d{7,15}$/.test(rawResolvedPhone) ? rawResolvedPhone : undefined;
   const primaryId = payload.from ?? '';
 
-  let accessResult = await accessService.checkAccess(instance, primaryId, channel);
+  // G5 (ADR-0008): the ALLOW/DENY decision is evaluated against rules read in
+  // the MESSAGE's world. `trustedTenantId` is the envelope-derived tenant
+  // (`trustedDispatchTenant`), threaded rather than wrapped because the service
+  // publishes `access.allowed`/`access.denied` between blocks.
+  let accessResult = await accessService.checkAccess(instance, primaryId, channel, trustedTenantId);
   if (!accessResult.allowed && participantAlt && participantAlt !== primaryId) {
     log.warn('Access fallback to participantAlt', {
       instanceId: instance.id,
@@ -5392,7 +5397,7 @@ async function checkAccessWithFallback(
       participantAlt,
       chatId: payload.chatId,
     });
-    accessResult = await accessService.checkAccess(instance, participantAlt, channel);
+    accessResult = await accessService.checkAccess(instance, participantAlt, channel, trustedTenantId);
   }
   if (
     !accessResult.allowed &&
@@ -5406,7 +5411,7 @@ async function checkAccessWithFallback(
       resolvedSenderPhone,
       chatId: payload.chatId,
     });
-    accessResult = await accessService.checkAccess(instance, resolvedSenderPhone, channel);
+    accessResult = await accessService.checkAccess(instance, resolvedSenderPhone, channel, trustedTenantId);
   }
   if (accessResult.allowed) return false;
 
@@ -5423,9 +5428,11 @@ async function checkAccessWithFallback(
   // Guard against empty primaryId: a missing payload.from would otherwise create a
   // degenerate pairing entry shared by all anonymous senders.
   if (accessResult.mode === 'allowlist' && !accessResult.rule && primaryId) {
-    accessService.requestPairing(instance.id, primaryId, { channelType: instance.channel }).catch((err) => {
-      log.warn('Failed to create pairing request', { instanceId: instance.id, from: primaryId, error: String(err) });
-    });
+    accessService
+      .requestPairing(instance.id, primaryId, { channelType: instance.channel }, trustedTenantId)
+      .catch((err) => {
+        log.warn('Failed to create pairing request', { instanceId: instance.id, from: primaryId, error: String(err) });
+      });
   }
 
   if (accessResult.rule?.action !== 'silent_block' && accessResult.rule?.blockMessage) {
@@ -5471,7 +5478,7 @@ async function shouldProcessReaction(
   const channel = (metadata.channelType ?? instance.channel) as ChannelType;
 
   // Access check for reactions (reuses LID fallback logic)
-  const accessDenied = await checkAccessWithFallback(accessService, instance, payload, channel);
+  const accessDenied = await checkAccessWithFallback(accessService, instance, payload, channel, trustedTenantId);
   if (accessDenied) return null;
 
   if (reactionDedup.isDuplicate(payload.messageId, payload.emoji, payload.from)) {
@@ -6150,6 +6157,12 @@ export const __test__ = {
   resolveLidMentionBot,
   resolveEffectiveReplyFilter,
   resolveSlackThreadReply,
+  // The two inbound GUARDS. Exported so a probe can prove they THREAD the
+  // envelope-derived tenant into the access read — a property of the call site
+  // that no probe of `AccessService` itself can pin (the run12 lesson).
+  shouldProcessMessage,
+  shouldProcessReaction,
+  checkAccessWithFallback,
   fetchSenderMetadata,
   fetchChatMetadata,
   applyCloseContactGate,

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -89,7 +89,7 @@ import type { MediaStorageService } from '../services/media-storage';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 import { runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
 import { fetchMediaUrl } from '../utils/safe-media-fetch';
 import { AgentDispatchLimiter, loadAgentDispatchLimiterConfig } from './agent-dispatch-limiter';
@@ -4073,8 +4073,42 @@ async function processAgentResponse(
 /** Cache of IAgentProvider instances by "providerId:instanceId" */
 const providerCache = new Map<string, IAgentProvider>();
 
-/** Shared OpenClaw WS clients keyed by provider DB ID (DEC-3: one connection per provider) */
+/**
+ * Shared OpenClaw WS clients (DEC-3: one connection per provider) keyed by
+ * `providerId::tenant`.
+ *
+ * TENANT IN THE KEY (G5; ADR-0008). A pooled `OpenClawClient` HOLDS the Ed25519
+ * `devicePrivateKey` and `deviceToken` it was constructed with and signs every
+ * connect with them, so this map is a credential cache, not merely a connection
+ * cache. `agent_providers` is a G0-`split` table with no `tenant_id`, so one
+ * provider row is reachable from instances of different tenants, and
+ * `ProviderService` binds its secrets to the ACTIVE SCOPE — every other context
+ * fails closed to a null secret "rather than to someone else's key". Keyed by
+ * provider id ALONE, the first tenant to build a client would hand its device
+ * identity to every later tenant and short-circuit exactly that null. The
+ * scope-less legacy world keys on `-` and therefore still shares one client per
+ * provider, byte-identically.
+ */
 const openclawClientPool = new Map<string, OpenClawClient>();
+
+/** Test-only DI hook for the OpenClaw WS client constructor (see `_natsGenieProviderCtor`). */
+let _openClawClientCtor: typeof OpenClawClient = OpenClawClient;
+
+/**
+ * The pool key for `providerId` under the tenant its secrets were OPENED under.
+ *
+ * `openedForTenantId` is the threaded trusted tenant when the caller has one:
+ * `session-cleaner` reads the provider record inside `runTenantWorkDb(...,
+ * trustedTenantId, ...)` and then resolves the provider OUTSIDE that scope (a
+ * worker transaction must not span the provider call), so the ambient scope
+ * alone would key A's opened device key under the legacy `-` bucket and hand it
+ * to the next tenant. Nothing threaded falls back to the active request scope,
+ * and no scope at all is the legacy bucket — which is correct there, because a
+ * scope-less read never opened anything tenant-bound in the first place.
+ */
+function openclawPoolKey(providerId: string, openedForTenantId?: string | null): string {
+  return `${providerId}::${openedForTenantId ?? currentTenantScope()?.tenantId ?? '-'}`;
+}
 
 /**
  * Pick the first non-empty agentId from instance → provider schemaConfig.
@@ -4100,9 +4134,14 @@ function resolveRequiredAgentId(
 }
 
 /** Create an OpenClaw-based agent provider */
-function createOpenClawProviderInstance(provider: AgentProvider, instance: DispatchInstance): IAgentProvider {
-  // DEC-3: Reuse shared WS client per provider ID
-  let client = openclawClientPool.get(provider.id);
+function createOpenClawProviderInstance(
+  provider: AgentProvider,
+  instance: DispatchInstance,
+  openedForTenantId?: string | null,
+): IAgentProvider {
+  // DEC-3: Reuse the shared WS client per provider — within one tenant.
+  const poolKey = openclawPoolKey(provider.id, openedForTenantId);
+  let client = openclawClientPool.get(poolKey);
   if (!client) {
     const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
     // FIX-SCOPE: Pass device credentials from schemaConfig if present.
@@ -4125,9 +4164,9 @@ function createOpenClawProviderInstance(provider: AgentProvider, instance: Dispa
       origin: (schemaConfig.origin as string) ?? undefined,
       device: deviceConfig,
     };
-    client = new OpenClawClient(clientConfig);
+    client = new _openClawClientCtor(clientConfig);
     client.start(); // DEC-14: lazy connect — starts WS in background
-    openclawClientPool.set(provider.id, client);
+    openclawClientPool.set(poolKey, client);
   }
 
   const schemaConfig = (provider.schemaConfig ?? {}) as Record<string, unknown>;
@@ -4366,6 +4405,11 @@ export function resolveProvider(
   provider: AgentProvider,
   instance: DispatchInstance,
   db: Database,
+  /**
+   * The tenant `provider`'s secrets were OPENED under, when the caller threads
+   * one instead of holding a scope across this call (see `openclawPoolKey`).
+   */
+  openedForTenantId?: string | null,
 ): IAgentProvider | null {
   const cacheKey = `${provider.id}:${instance.id}`;
   const cached = providerCache.get(cacheKey);
@@ -4381,7 +4425,7 @@ export function resolveProvider(
       agentProvider = createWebhookProvider(provider);
       break;
     case 'openclaw':
-      agentProvider = createOpenClawProviderInstance(provider, instance);
+      agentProvider = createOpenClawProviderInstance(provider, instance, openedForTenantId);
       break;
     case 'claude-code':
       agentProvider = createClaudeCodeProviderInstance(provider, instance, db);
@@ -4432,8 +4476,11 @@ export function invalidateProviderCache(providerId: string): void {
     }
   }
 
-  const openclawClient = openclawClientPool.get(providerId);
-  if (openclawClient) {
+  // Every TENANT's client for this provider — the pool is keyed
+  // `providerId::tenant`, and a config change invalidates all of them.
+  const poolPrefix = `${providerId}::`;
+  for (const [key, openclawClient] of openclawClientPool.entries()) {
+    if (!key.startsWith(poolPrefix)) continue;
     try {
       openclawClient.stop();
     } catch (err) {
@@ -4442,7 +4489,7 @@ export function invalidateProviderCache(providerId: string): void {
         error: String(err),
       });
     }
-    openclawClientPool.delete(providerId);
+    openclawClientPool.delete(key);
   }
 
   log.debug('Provider cache invalidated', { providerId, removed });
@@ -6136,5 +6183,22 @@ export const __test__ = {
   /** Reset to the real NatsGenieProvider (call in afterEach). */
   resetNatsGenieProviderClass() {
     _natsGenieProviderCtor = NatsGenieProvider;
+  },
+  /** Override the OpenClawClient constructor for tests (no WS is opened). */
+  set OpenClawClientClass(cls: typeof OpenClawClient) {
+    _openClawClientCtor = cls;
+  },
+  /** Reset to the real OpenClawClient (call in afterEach). */
+  resetOpenClawClientClass() {
+    _openClawClientCtor = OpenClawClient;
+  },
+  /** The live pool keys (`providerId::tenant`) — for the pool-partitioning probes. */
+  openclawPoolKeys(): string[] {
+    return [...openclawClientPool.keys()];
+  },
+  /** Drop both provider caches WITHOUT stopping anything (test isolation only). */
+  resetProviderCaches() {
+    providerCache.clear();
+    openclawClientPool.clear();
   },
 };

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -40,6 +40,7 @@ import {
   type BeforeMessageWriteContext,
   ClaudeCodeAgentProvider,
   type EventBus,
+  type EventMetadata,
   type IAgentProvider,
   InMemorySessionActivityStore,
   JOURNEY_STAGES,
@@ -57,6 +58,7 @@ import {
   type StreamDelta,
   WebhookAgentProvider,
   checkSessionReset,
+  classifyEnvelope,
   createLogger,
   createProviderClient,
   executeHooks,
@@ -87,6 +89,8 @@ import type { MediaStorageService } from '../services/media-storage';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
 import { publishTurnOpen } from '../services/turn-events';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
 import { fetchMediaUrl } from '../utils/safe-media-fetch';
 import { AgentDispatchLimiter, loadAgentDispatchLimiterConfig } from './agent-dispatch-limiter';
 import { getPlugin } from './loader';
@@ -646,6 +650,7 @@ export async function triggerErrorHandoff(
   instance: DispatchInstance,
   chatId: string,
   message: string,
+  trustedTenantId?: string,
 ): Promise<boolean> {
   const plugin = await getPlugin(channel);
   if (plugin?.capabilities?.canHandoff !== true) return false;
@@ -677,27 +682,76 @@ export async function triggerErrorHandoff(
     return false;
   }
 
-  // Step 2 — persist side-effects (pause + disarm + audit) best-effort. The
-  // message already reached the user, so a failure here must NOT flip the result
-  // to false — that would make the caller send a SECOND (plain error) message.
+  await persistErrorHandoffSideEffects(
+    services,
+    db,
+    channel,
+    instance,
+    chatId,
+    message,
+    sendResult?.messageId,
+    trustedTenantId,
+  );
+
+  log.info('agent_dispatch_error_handoff', { instanceId: instance.id, chatId, channel });
+  return true;
+}
+
+/**
+ * Step 2 of the error handoff — persist side-effects (pause + disarm + audit)
+ * best-effort. The message already reached the user, so a failure here must
+ * NOT propagate — that would make the caller send a SECOND (plain error)
+ * message.
+ *
+ * Tenant boundary (G5, ADR-0008): the chat lookup + pause write run in one
+ * short worker scope and the audit insert in another, both keyed by the
+ * envelope-derived `trustedTenantId`. The follow-up disarm sits BETWEEN them
+ * un-wrapped: it publishes events through its own service (its scoping is that
+ * service's conversion), and holding a dispatch transaction across an event
+ * publish is exactly what {@link runDispatchDb} forbids. A legacy message
+ * (`trustedTenantId` undefined) runs every step on the ambient pool
+ * byte-identically.
+ */
+async function persistErrorHandoffSideEffects(
+  services: Services,
+  db: Database,
+  channel: ChannelType,
+  instance: DispatchInstance,
+  chatId: string,
+  message: string,
+  sentMessageId: string | null | undefined,
+  trustedTenantId?: string,
+): Promise<void> {
   try {
-    const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
+    const chat = await runDispatchDb(db, trustedTenantId, async () => {
+      const found = await services.chats.findByExternalIdSmart(instance.id, chatId);
+      if (!found) return null;
+      const settings = (found.settings as Record<string, unknown> | null) ?? {};
+      await services.chats.update(found.id, { settings: { ...settings, agentPaused: true } });
+      return found;
+    });
     if (chat) {
-      const settings = (chat.settings as Record<string, unknown> | null) ?? {};
-      await services.chats.update(chat.id, { settings: { ...settings, agentPaused: true } });
       await services.followUpLifecycle.disarm({ chatId: chat.id, instanceId: instance.id, reason: 'handoff' });
-      await db.insert(handoffLogs).values({
-        instanceId: instance.id,
-        chatUuid: chat.id,
-        chatId,
-        toPhone: chatId,
-        text: message,
-        extraInfo: null,
-        agentId: instance.agentId ?? null,
-        externalMessageId: sendResult?.messageId ?? null,
-        handoffFields: null,
-        sentAt: new Date(),
-        metadata: { instanceChannel: channel, channelHandoffSupported: true, motivoHandoff: 'agent_dispatch_error' },
+      await runDispatchDb(db, trustedTenantId, async () => {
+        await scopedHandle(db)
+          .insert(handoffLogs)
+          .values({
+            instanceId: instance.id,
+            chatUuid: chat.id,
+            chatId,
+            toPhone: chatId,
+            text: message,
+            extraInfo: null,
+            agentId: instance.agentId ?? null,
+            externalMessageId: sentMessageId ?? null,
+            handoffFields: null,
+            sentAt: new Date(),
+            metadata: {
+              instanceChannel: channel,
+              channelHandoffSupported: true,
+              motivoHandoff: 'agent_dispatch_error',
+            },
+          });
       });
     }
   } catch (err) {
@@ -707,9 +761,6 @@ export async function triggerErrorHandoff(
       error: String(err),
     });
   }
-
-  log.info('agent_dispatch_error_handoff', { instanceId: instance.id, chatId, channel });
-  return true;
 }
 
 /**
@@ -730,9 +781,10 @@ async function maybeTriggerErrorHandoff(
   chatId: string,
   customerErrorBlocked: boolean,
   handoffTriggered: boolean,
+  trustedTenantId?: string,
 ): Promise<boolean> {
   if (!customerErrorBlocked || handoffTriggered) return false;
-  return triggerErrorHandoff(services, db, channel, instance, chatId, resolveErrorHandoffMessage());
+  return triggerErrorHandoff(services, db, channel, instance, chatId, resolveErrorHandoffMessage(), trustedTenantId);
 }
 
 async function handleDispatchFailure(
@@ -742,8 +794,17 @@ async function handleDispatchFailure(
   instance: DispatchInstance,
   chatId: string,
   error: unknown,
+  trustedTenantId?: string,
 ): Promise<void> {
-  const handedOff = await triggerErrorHandoff(services, db, channel, instance, chatId, resolveErrorHandoffMessage());
+  const handedOff = await triggerErrorHandoff(
+    services,
+    db,
+    channel,
+    instance,
+    chatId,
+    resolveErrorHandoffMessage(),
+    trustedTenantId,
+  );
   if (handedOff) return;
   // Per-instance override tier is null until the `agentErrorMessage` column
   // lands (see resolveDispatchErrorMessage note) — env + default for now.
@@ -927,6 +988,49 @@ function resolveMediaPath(mediaUrl: string): string | null {
 }
 
 /**
+ * Derive the trusted tenant a dispatch runs under from the inbound envelope
+ * (wish: omni-full-multitenancy G5; ADR-0008).
+ *
+ * Classifies the producer-stamped metadata — never the caller-facing payload:
+ *   * `tenant` → the trusted tenant id, threaded through `DispatchMetadata`
+ *     into tenant-bound presigning (and, as conversion proceeds, the worker
+ *     tenant scope);
+ *   * `legacy` → `undefined`: downstream behavior stays byte-identical to
+ *     pre-G5;
+ *   * `quarantine` → throws. The subscription layer terms quarantined
+ *     envelopes before any handler runs, so this is defence in depth — if one
+ *     slips through, deriving "no tenant" would process it globally, exactly
+ *     the fallback ADR-0008 forbids. The handler's catch logs and drops it.
+ */
+function trustedDispatchTenant(metadata: EventMetadata): string | undefined {
+  const classification = classifyEnvelope(metadata);
+  if (classification.world === 'quarantine') {
+    throw new Error(`agent-dispatcher: refusing to dispatch a quarantined envelope (${classification.reason})`);
+  }
+  return classification.world === 'tenant' ? classification.tenantId : undefined;
+}
+
+/**
+ * Run one DISCRETE dispatch DB block in the message's world (G5, ADR-0008).
+ *
+ * `trustedTenantId` is the envelope-derived tenant carried on
+ * `DispatchMetadata` ({@link trustedDispatchTenant} — quarantine was already
+ * refused at the subscription boundary):
+ *   * tenant world → a fresh SHORT worker tenant scope wraps exactly this
+ *     block; `scopedHandle(db)` inside `fn` returns its transaction;
+ *   * legacy world (`undefined`) → `fn` runs directly on the ambient pool,
+ *     byte-identical to pre-G5.
+ *
+ * The dispatch pipeline interleaves DB work with the LONG agent call, media
+ * waits, and channel sends, so a scope must never wrap more than one discrete
+ * DB block — the G4 leg-2 rule that a worker transaction never outlives its
+ * work item, applied at block granularity.
+ */
+function runDispatchDb<T>(db: Database, trustedTenantId: string | undefined, fn: () => Promise<T>): Promise<T> {
+  return trustedTenantId === undefined ? fn() : runInWorkerTenantScope(db, trustedTenantId, fn);
+}
+
+/**
  * Resolve a stored media reference (`messages.mediaLocalPath`) into the string
  * handed to the agent alongside processed text.
  *
@@ -935,17 +1039,25 @@ function resolveMediaPath(mediaUrl: string): string | null {
  * - `remote` mode: the reference is an S3 key, presigned into a time-limited
  *   GET URL at dispatch time (TTL from config) — never a stored expiring URL.
  *
+ * `trustedTenantId` (envelope-derived via {@link trustedDispatchTenant}) binds
+ * the presign to tenant + object + expiry (ADR-0008): `MediaStorageService`
+ * refuses references outside the tenant's own prefix and clamps the TTL to the
+ * 60s ceiling. A refusal degrades gracefully — the dispatch continues without
+ * a media URL rather than minting an unbound one. Undefined (legacy world)
+ * keeps the presign call byte-identical to pre-G5.
+ *
  * `mediaStorage` is optional so unit tests with a partial `services` mock fall
  * back to local resolution.
  */
 async function resolveDispatchMediaPath(
   mediaStorage: MediaStorageService | undefined,
   reference: string | null | undefined,
+  trustedTenantId?: string,
 ): Promise<string | null> {
   if (!reference) return null;
   if (mediaStorage?.getStorageMode?.() === 'remote') {
     try {
-      return await mediaStorage.presignedUrl(reference);
+      return await mediaStorage.presignedUrl(reference, undefined, trustedTenantId);
     } catch (error) {
       log.warn('Failed to presign processed media URL', { error: String(error) });
       return null;
@@ -980,7 +1092,10 @@ async function remoteMediaFile(
   // Audio (and any non-path type) stays URL-less in remote mode.
   if (!key || !type || !allowedTypes.includes(type)) return null;
   try {
-    return { url: await mediaStorage.presignedUrl(key), mimeType };
+    // Tenant-bound presign (ADR-0008): each message carries its own
+    // envelope-derived trusted tenant; legacy messages carry none and the
+    // presign call stays byte-identical to pre-G5.
+    return { url: await mediaStorage.presignedUrl(key, undefined, m.metadata.trustedTenantId), mimeType };
   } catch (error) {
     log.warn('Failed to presign media URL for dispatch', { error: String(error) });
     return null;
@@ -1124,6 +1239,7 @@ async function recoverProcessedMediaAfterTimeout(
   chatRecordId: string,
   externalId: string,
   column: string,
+  trustedTenantId?: string,
 ): Promise<{ content: string; localPath: string | null } | null> {
   const refreshed = await services.messages.getByExternalId(chatRecordId, externalId);
   if (!refreshed) return null;
@@ -1131,7 +1247,11 @@ async function recoverProcessedMediaAfterTimeout(
   if (recovered === 'pending' || recovered === 'error') return null;
   return {
     content: recovered.content,
-    localPath: await resolveDispatchMediaPath(services.mediaStorage, refreshed.mediaLocalPath as string | null),
+    localPath: await resolveDispatchMediaPath(
+      services.mediaStorage,
+      refreshed.mediaLocalPath as string | null,
+      trustedTenantId,
+    ),
   };
 }
 
@@ -1145,6 +1265,7 @@ async function awaitMediaProcessing(
   chatId: string,
   externalId: string,
   contentType: string,
+  trustedTenantId?: string,
 ): Promise<{ content: string | null; localPath: string | null }> {
   const column = getProcessedColumn(contentType);
   if (!column) return MEDIA_WAIT_NULL;
@@ -1173,7 +1294,11 @@ async function awaitMediaProcessing(
   if (existing !== 'pending') {
     return {
       content: existing.content,
-      localPath: await resolveDispatchMediaPath(services.mediaStorage, msg.mediaLocalPath as string | null),
+      localPath: await resolveDispatchMediaPath(
+        services.mediaStorage,
+        msg.mediaLocalPath as string | null,
+        trustedTenantId,
+      ),
     };
   }
 
@@ -1182,7 +1307,11 @@ async function awaitMediaProcessing(
   if (cached) {
     mediaResultCache.delete(msg.id);
     if (!cached.content || cached.error) return MEDIA_WAIT_NULL;
-    const localPath = await resolveDispatchMediaPath(services.mediaStorage, msg.mediaLocalPath as string | null);
+    const localPath = await resolveDispatchMediaPath(
+      services.mediaStorage,
+      msg.mediaLocalPath as string | null,
+      trustedTenantId,
+    );
     return { content: cached.content, localPath };
   }
 
@@ -1200,7 +1329,7 @@ async function awaitMediaProcessing(
       msgId: msg.id,
       error: String(error),
     });
-    const recovered = await recoverProcessedMediaAfterTimeout(services, chat.id, externalId, column);
+    const recovered = await recoverProcessedMediaAfterTimeout(services, chat.id, externalId, column, trustedTenantId);
     if (recovered) return recovered;
     return MEDIA_WAIT_NULL;
   }
@@ -1209,7 +1338,11 @@ async function awaitMediaProcessing(
 
   // Re-read message for localPath (media storage may have updated it)
   const updated = await services.messages.getByExternalId(chat.id, externalId);
-  const localPath = await resolveDispatchMediaPath(services.mediaStorage, updated?.mediaLocalPath as string | null);
+  const localPath = await resolveDispatchMediaPath(
+    services.mediaStorage,
+    updated?.mediaLocalPath as string | null,
+    trustedTenantId,
+  );
   return { content: result.content, localPath };
 }
 
@@ -1442,7 +1575,14 @@ async function collectProcessedMedia(
 
     let result: { content: string | null; localPath: string | null };
     try {
-      result = await awaitMediaProcessing(services, instance.id, m.payload.chatId, m.payload.externalId, contentType);
+      result = await awaitMediaProcessing(
+        services,
+        instance.id,
+        m.payload.chatId,
+        m.payload.externalId,
+        contentType,
+        m.metadata.trustedTenantId,
+      );
     } catch (error) {
       log.warn('Media await failed', { externalId: m.payload.externalId, error: String(error) });
       result = MEDIA_WAIT_NULL;
@@ -2446,14 +2586,19 @@ async function dispatchViaTurnBasedProvider(
 ): Promise<boolean> {
   const messageId = messages[0]?.payload.externalId ?? '';
 
-  // Look up agent record for scoped key name
+  // Look up agent record for scoped key name. Discrete DB block in the
+  // message's world (G5, ADR-0008): tenant envelopes read through a short
+  // worker scope, legacy ones on the ambient pool byte-identically.
   let agentRecord: { id: string; name: string } | undefined;
   if (instance.agentId) {
-    const [row] = await db
-      .select({ id: agents.id, name: agents.name })
-      .from(agents)
-      .where(eq(agents.id, instance.agentId))
-      .limit(1);
+    const agentFkId = instance.agentId;
+    const [row] = await runDispatchDb(db, messages[0]?.metadata.trustedTenantId, () =>
+      scopedHandle(db)
+        .select({ id: agents.id, name: agents.name })
+        .from(agents)
+        .where(eq(agents.id, agentFkId))
+        .limit(1),
+    );
     agentRecord = row;
   }
   if (!agentRecord) {
@@ -2739,6 +2884,7 @@ async function dispatchViaProvider(
         chatId,
         result?.metadata.customerErrorBlocked === true,
         handoffTriggered,
+        messages[0]?.metadata.trustedTenantId,
       );
 
       if (result && result.parts.length > 0 && !handoffTriggered && !errorHandoffDone && !supersededByNewerInbound) {
@@ -3118,13 +3264,22 @@ async function handleSessionReset(
  * Check whether a per_thread session has been initialized for this instance/thread.
  * Uses the agentSessions table with a dedicated 'thread_init:' key prefix.
  */
-async function checkPerThreadSessionExists(db: Database, instanceId: string, sessionId: string): Promise<boolean> {
+async function checkPerThreadSessionExists(
+  db: Database,
+  instanceId: string,
+  sessionId: string,
+  trustedTenantId?: string,
+): Promise<boolean> {
   const initKey = `thread_init:${sessionId}`;
-  const result = await db
-    .select({ instanceId: agentSessions.instanceId })
-    .from(agentSessions)
-    .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, initKey)))
-    .limit(1);
+  // Discrete DB block in the message's world (G5, ADR-0008): under a tenant
+  // envelope the check can only be satisfied by the tenant's OWN marker row.
+  const result = await runDispatchDb(db, trustedTenantId, () =>
+    scopedHandle(db)
+      .select({ instanceId: agentSessions.instanceId })
+      .from(agentSessions)
+      .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, initKey)))
+      .limit(1),
+  );
   return result.length > 0;
 }
 
@@ -3132,22 +3287,32 @@ async function checkPerThreadSessionExists(db: Database, instanceId: string, ses
  * Mark a per_thread session as initialized in the DB.
  * Called after the first lazy-init dispatch so subsequent triggers skip history fetch.
  */
-async function markPerThreadSessionInitialized(db: Database, instanceId: string, sessionId: string): Promise<void> {
+async function markPerThreadSessionInitialized(
+  db: Database,
+  instanceId: string,
+  sessionId: string,
+  trustedTenantId?: string,
+): Promise<void> {
   const initKey = `thread_init:${sessionId}`;
   const now = new Date();
-  await db
-    .insert(agentSessions)
-    .values({
-      instanceId,
-      sessionKey: initKey,
-      providerSessionData: { initialized: true, initializedAt: now.toISOString() },
-      lastUsedAt: now,
-      expiresAt: null,
-    })
-    .onConflictDoUpdate({
-      target: [agentSessions.instanceId, agentSessions.sessionKey],
-      set: { lastUsedAt: now, updatedAt: now },
-    });
+  // Discrete DB block in the message's world (G5, ADR-0008): the derivation
+  // trigger stamps the tenant from the instance, and a scope aimed at another
+  // tenant's instance is refused by the WITH CHECK rather than trusted.
+  await runDispatchDb(db, trustedTenantId, async () => {
+    await scopedHandle(db)
+      .insert(agentSessions)
+      .values({
+        instanceId,
+        sessionKey: initKey,
+        providerSessionData: { initialized: true, initializedAt: now.toISOString() },
+        lastUsedAt: now,
+        expiresAt: null,
+      })
+      .onConflictDoUpdate({
+        target: [agentSessions.instanceId, agentSessions.sessionKey],
+        set: { lastUsedAt: now, updatedAt: now },
+      });
+  });
   log.info('per_thread session initialized', { instanceId, sessionId });
 }
 
@@ -3362,6 +3527,7 @@ async function handlePerThreadLazyInit(
   threadId: string,
   sessionId: string,
   db: Database,
+  trustedTenantId?: string,
 ): Promise<string[]> {
   log.info('per_thread lazy init', {
     instanceId: instance.id,
@@ -3375,7 +3541,7 @@ async function handlePerThreadLazyInit(
 
   // Persist the init marker so subsequent triggers skip history fetch
   try {
-    await markPerThreadSessionInitialized(db, instance.id, sessionId);
+    await markPerThreadSessionInitialized(db, instance.id, sessionId, trustedTenantId);
   } catch (err) {
     log.warn('Failed to mark per_thread session initialized', {
       error: String(err),
@@ -3405,9 +3571,10 @@ async function resolvePerThreadExtraContext(
   const rawThreadId = (firstMessage.payload.rawPayload as Record<string, unknown>)?.threadId as string | undefined;
   if (strategy !== 'per_thread' || !rawThreadId) return undefined;
   const sessionId = computeSessionId('per_thread', senderId, chatId, rawThreadId);
-  const sessionExists = await checkPerThreadSessionExists(db, instance.id, sessionId);
+  const trustedTenantId = firstMessage.metadata.trustedTenantId;
+  const sessionExists = await checkPerThreadSessionExists(db, instance.id, sessionId, trustedTenantId);
   if (sessionExists) return undefined;
-  return handlePerThreadLazyInit(services, instance, channel, chatId, rawThreadId, sessionId, db);
+  return handlePerThreadLazyInit(services, instance, channel, chatId, rawThreadId, sessionId, db, trustedTenantId);
 }
 
 /**
@@ -3765,7 +3932,7 @@ async function processAgentResponse(
       error: String(error),
       traceId,
     });
-    await handleDispatchFailure(services, db, channel, instance, chatId, error);
+    await handleDispatchFailure(services, db, channel, instance, chatId, error, firstMessage.metadata.trustedTenantId);
   } finally {
     ackHandle.remove();
   }
@@ -4184,19 +4351,27 @@ export async function applyAgentFkOverrides(
   db: Database,
   agentFkId: string,
   effectiveInstance: DispatchInstance,
+  trustedTenantId?: string,
 ): Promise<void> {
-  const [agentRow] = await db
-    .select({
-      id: agents.id,
-      name: agents.name,
-      agentProviderId: agents.agentProviderId,
-      agentType: agents.agentType,
-      metadata: agents.metadata,
-      configPath: agents.configPath,
-    })
-    .from(agents)
-    .where(eq(agents.id, agentFkId))
-    .limit(1);
+  // Discrete DB block in the message's world (G5, ADR-0008): a tenant envelope
+  // reads through a short worker scope — a forged cross-tenant agentId then
+  // resolves nothing and stamps nothing — while a legacy caller (including the
+  // still-pending session-cleaner path, which passes no tenant) runs on the
+  // ambient pool byte-identically.
+  const [agentRow] = await runDispatchDb(db, trustedTenantId, () =>
+    scopedHandle(db)
+      .select({
+        id: agents.id,
+        name: agents.name,
+        agentProviderId: agents.agentProviderId,
+        agentType: agents.agentType,
+        metadata: agents.metadata,
+        configPath: agents.configPath,
+      })
+      .from(agents)
+      .where(eq(agents.id, agentFkId))
+      .limit(1),
+  );
 
   if (!agentRow) return;
 
@@ -4259,10 +4434,11 @@ function mergeRouteOverrides(instance: Instance, route: ResolvedRoute): Dispatch
 async function applyInstanceFkAndReturn(
   db: Database,
   instance: Instance,
+  trustedTenantId?: string,
 ): Promise<{ instance: DispatchInstance; routeId: null }> {
   if (!instance.agentId) return { instance, routeId: null };
   const effectiveInstance: DispatchInstance = { ...instance };
-  await applyAgentFkOverrides(db, instance.agentId, effectiveInstance);
+  await applyAgentFkOverrides(db, instance.agentId, effectiveInstance, trustedTenantId);
   return { instance: effectiveInstance, routeId: null };
 }
 
@@ -4278,15 +4454,16 @@ async function resolveEffectiveInstance(
   instance: Instance,
   chatId: string | undefined,
   personId?: string,
+  trustedTenantId?: string,
 ): Promise<{ instance: DispatchInstance; routeId: string | null }> {
   // If chatId is undefined (chat not found in DB), skip chat-scoped route resolution
   // and return instance defaults. This is the safe path for LID-only chats.
   if (!chatId) {
     log.debug('No internal chatId — using instance default agent', { instanceId: instance.id, personId });
-    return applyInstanceFkAndReturn(db, instance);
+    return applyInstanceFkAndReturn(db, instance, trustedTenantId);
   }
   // Resolve route (chat > user > null)
-  const route = await services.routeResolver.resolve(instance.id, chatId, personId);
+  const route = await services.routeResolver.resolve(instance.id, chatId, personId, trustedTenantId);
 
   if (!route) {
     // No route matched - use instance defaults.
@@ -4301,7 +4478,7 @@ async function resolveEffectiveInstance(
   // Route-level agentId takes priority; fall back to instance-level agentId.
   const effectiveAgentFkId = route.agentId ?? instance.agentId;
   if (effectiveAgentFkId) {
-    await applyAgentFkOverrides(db, effectiveAgentFkId, effectiveInstance);
+    await applyAgentFkOverrides(db, effectiveAgentFkId, effectiveInstance, trustedTenantId);
   }
 
   log.debug('Route resolved and merged', {
@@ -4349,6 +4526,7 @@ async function processReactionTrigger(
     baseInstance,
     internalChatId,
     reactionPersonId,
+    metadata.trustedTenantId,
   );
 
   log.info('Dispatching reaction trigger', {
@@ -4621,10 +4799,11 @@ async function resolveEffectiveReplyFilter(
   instanceId: string,
   chatId: string,
   defaultFilter: Instance['agentReplyFilter'],
+  trustedTenantId?: string,
 ): Promise<Instance['agentReplyFilter']> {
   const chat = await chatsService.findByExternalIdSmart(instanceId, chatId);
   if (!chat?.id) return defaultFilter;
-  const route = await routeResolver.resolve(instanceId, chat.id);
+  const route = await routeResolver.resolve(instanceId, chat.id, undefined, trustedTenantId);
   return (route?.agentReplyFilter as Instance['agentReplyFilter']) ?? defaultFilter;
 }
 
@@ -4732,9 +4911,45 @@ export function isFirstPartyInstanceSender(
 const ACTIVE_OWNER_IDENTIFIER_CACHE_TTL_MS = 10_000;
 let cachedActiveOwnerIdentifiers: Array<string | null> | null = null;
 let cachedActiveOwnerIdentifiersAt = 0;
+/**
+ * Tenant-keyed variant of the owner-identifier cache (G5, ADR-0008; WISH
+ * "cache keys include tenant identity"). A GLOBAL cache here would serve
+ * tenant A's identifiers to tenant B inside the TTL — a cross-tenant
+ * identifier leak AND wrong self-send gating. Bounded by the number of active
+ * tenants in the process, entries overwritten on expiry.
+ */
+const tenantCachedActiveOwnerIdentifiers = new Map<string, { ids: Array<string | null>; at: number }>();
 
-async function listActiveOwnerIdentifiers(db: Database): Promise<Array<string | null>> {
+/** @internal test hook — clears both worlds' caches. */
+function resetActiveOwnerIdentifiersCache(): void {
+  cachedActiveOwnerIdentifiers = null;
+  cachedActiveOwnerIdentifiersAt = 0;
+  tenantCachedActiveOwnerIdentifiers.clear();
+}
+
+async function listActiveOwnerIdentifiers(db: Database, trustedTenantId?: string): Promise<Array<string | null>> {
   const now = Date.now();
+
+  // Tenant world (G5): the enumeration runs inside a short worker scope, so it
+  // sees — and the self-send guard therefore considers — only the tenant's own
+  // instances. Cross-tenant "self"-sends are two independent parties, not a
+  // loop, so per-tenant is the CORRECT guard semantics under multitenancy.
+  if (trustedTenantId !== undefined) {
+    const cached = tenantCachedActiveOwnerIdentifiers.get(trustedTenantId);
+    if (cached && now - cached.at < ACTIVE_OWNER_IDENTIFIER_CACHE_TTL_MS) return cached.ids;
+    const rows = await runInWorkerTenantScope(db, trustedTenantId, () =>
+      scopedHandle(db)
+        .select({ ownerIdentifier: instances.ownerIdentifier })
+        .from(instances)
+        .where(eq(instances.isActive, true)),
+    );
+    if (!Array.isArray(rows)) return [];
+    const ids = rows.map((row) => row.ownerIdentifier);
+    tenantCachedActiveOwnerIdentifiers.set(trustedTenantId, { ids, at: now });
+    return ids;
+  }
+
+  // Legacy world: byte-identical pre-G5 path, global cache and ambient read.
   if (cachedActiveOwnerIdentifiers && now - cachedActiveOwnerIdentifiersAt < ACTIVE_OWNER_IDENTIFIER_CACHE_TTL_MS) {
     return cachedActiveOwnerIdentifiers;
   }
@@ -4764,6 +4979,7 @@ async function shouldProcessMessage(
   db: Database,
   payload: MessageReceivedPayload,
   metadata: { instanceId?: string; channelType?: string; platformIdentityId?: string },
+  trustedTenantId?: string,
 ): Promise<Instance | null> {
   if (!metadata.instanceId) {
     log.debug('No instanceId in metadata', { from: payload.from, chatId: payload.chatId });
@@ -4801,7 +5017,7 @@ async function shouldProcessMessage(
   // "assistant" instance can reply to messages from their own personal number
   // (another instance's owner). The separate "message from self" self-skip
   // above is unaffected — an instance still never replies to its own outbound.
-  const activeOwnerIdentifiers = await listActiveOwnerIdentifiers(db);
+  const activeOwnerIdentifiers = await listActiveOwnerIdentifiers(db, trustedTenantId);
   if (
     !instance.allowFirstParty &&
     isFirstPartyInstanceSender(payload, instance.ownerIdentifier, activeOwnerIdentifiers)
@@ -4874,6 +5090,7 @@ async function shouldProcessMessage(
     instance.id,
     payload.chatId,
     instance.agentReplyFilter,
+    trustedTenantId,
   );
 
   // #371: null filter now means "allow all" instead of silently dropping every
@@ -5222,7 +5439,14 @@ export async function setupAgentDispatcher(
       }
       const externalChatId = firstMsg.payload.chatId;
       const chat = await services.chats.findByExternalIdSmart(instanceId, externalChatId);
-      const resolved = await resolveEffectiveInstance(services, db, baseInstance, chat?.id, firstMsg.metadata.personId);
+      const resolved = await resolveEffectiveInstance(
+        services,
+        db,
+        baseInstance,
+        chat?.id,
+        firstMsg.metadata.personId,
+        firstMsg.metadata.trustedTenantId,
+      );
       instance = resolved.instance;
     }
 
@@ -5261,6 +5485,11 @@ export async function setupAgentDispatcher(
         // agent dispatches on the customer side.
         await withIdempotency(db, event.id, 'agent-dispatcher-msg', async () => {
           try {
+            // Envelope-derived trusted tenant (G5, ADR-0008): stamped from
+            // producer metadata, never the payload; undefined for legacy
+            // envelopes (byte-identical world); throws on quarantine — caught
+            // below, so a bad envelope is dropped, never processed globally.
+            const trustedTenantId = trustedDispatchTenant(metadata);
             const instance = await shouldProcessMessage(
               agentRunner,
               accessService,
@@ -5270,6 +5499,7 @@ export async function setupAgentDispatcher(
               db,
               payload,
               metadata,
+              trustedTenantId,
             );
             if (!instance) return;
 
@@ -5296,6 +5526,7 @@ export async function setupAgentDispatcher(
               instance,
               chat?.id,
               earlyPersonId,
+              trustedTenantId,
             );
 
             const debounceConfig = getDebounceConfig(resolved);
@@ -5328,6 +5559,9 @@ export async function setupAgentDispatcher(
                   journeyTracked: metadata.timings != null,
                   resolvedInstance: resolved,
                   routeId,
+                  // Envelope-derived trusted tenant (G5, ADR-0008) — hoisted
+                  // above, before the shouldProcessMessage gate.
+                  trustedTenantId,
                 },
                 timestamp: event.timestamp,
               },
@@ -5382,6 +5616,9 @@ export async function setupAgentDispatcher(
                 personId: metadata.personId,
                 platformIdentityId: metadata.platformIdentityId,
                 traceId,
+                // Envelope-derived trusted tenant (G5, ADR-0008) — producer
+                // metadata only; throws on quarantine, caught below.
+                trustedTenantId: trustedDispatchTenant(metadata),
               },
               event,
               db,
@@ -5439,6 +5676,9 @@ export async function setupAgentDispatcher(
                 personId: metadata.personId,
                 platformIdentityId: metadata.platformIdentityId,
                 traceId,
+                // Envelope-derived trusted tenant (G5, ADR-0008) — producer
+                // metadata only; throws on quarantine, caught below.
+                trustedTenantId: trustedDispatchTenant(metadata),
               },
               event,
               db,
@@ -5490,6 +5730,7 @@ export async function setupAgentDispatcher(
               baseInstance,
               chat?.id,
               typingPersonId,
+              trustedDispatchTenant(metadata),
             );
 
             const debounceConfig = getDebounceConfig(resolved);
@@ -5637,6 +5878,12 @@ export const __test__ = {
   extractMediaFiles,
   formatProcessedMedia,
   resolveDispatchMediaPath,
+  trustedDispatchTenant,
+  checkPerThreadSessionExists,
+  markPerThreadSessionInitialized,
+  listActiveOwnerIdentifiers,
+  resetActiveOwnerIdentifiersCache,
+  persistErrorHandoffSideEffects,
   MEDIA_WAIT_NULL,
   extractA2ACustomerContext,
   resolveCustomerContext,

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -1249,7 +1249,9 @@ async function recoverProcessedMediaAfterTimeout(
   column: string,
   trustedTenantId?: string,
 ): Promise<{ content: string; localPath: string | null } | null> {
-  const refreshed = await services.messages.getByExternalId(chatRecordId, externalId);
+  const refreshed = await runDispatchDb(services.db, trustedTenantId, () =>
+    services.messages.getByExternalId(chatRecordId, externalId),
+  );
   if (!refreshed) return null;
   const recovered = checkProcessedColumn(refreshed, column);
   if (recovered === 'pending' || recovered === 'error') return null;
@@ -1281,13 +1283,20 @@ async function awaitMediaProcessing(
   // Wait briefly for message-persistence to create the DB rows (race condition:
   // both media-processor and agent-dispatcher subscribe to message.received,
   // and the dispatcher's debounce may fire before persistence completes).
-  const chat = await waitForRecord(() => services.chats.findByExternalIdSmart(instanceId, chatId));
+  // Each poll attempt opens and closes its OWN short scope (G5, ADR-0008): this
+  // waits for another consumer's commit, which a single spanning transaction
+  // could never observe.
+  const chat = await waitForRecord(() =>
+    runDispatchDb(services.db, trustedTenantId, () => services.chats.findByExternalIdSmart(instanceId, chatId)),
+  );
   if (!chat) {
     log.warn('Chat not found for media wait', { instanceId, chatId });
     return MEDIA_WAIT_NULL;
   }
 
-  const msg = await waitForRecord(() => services.messages.getByExternalId(chat.id, externalId));
+  const msg = await waitForRecord(() =>
+    runDispatchDb(services.db, trustedTenantId, () => services.messages.getByExternalId(chat.id, externalId)),
+  );
   if (!msg) {
     log.warn('Message not found for media wait after retries', { instanceId, chatId, externalId });
     return MEDIA_WAIT_NULL;
@@ -1345,7 +1354,9 @@ async function awaitMediaProcessing(
   if (!result.content || result.error) return MEDIA_WAIT_NULL;
 
   // Re-read message for localPath (media storage may have updated it)
-  const updated = await services.messages.getByExternalId(chat.id, externalId);
+  const updated = await runDispatchDb(services.db, trustedTenantId, () =>
+    services.messages.getByExternalId(chat.id, externalId),
+  );
   const localPath = await resolveDispatchMediaPath(
     services.mediaStorage,
     updated?.mediaLocalPath as string | null,
@@ -1423,6 +1434,13 @@ type MessageAliasLookup = Services['messages'] & {
 interface QuotedLookupOptions {
   inboundAt?: Date;
   inboundText?: string;
+  /**
+   * Envelope-derived trusted tenant (G5, ADR-0008). Carried in the options bag
+   * rather than as a positional parameter because this function is exported and
+   * called from several places; `undefined` is the legacy world and leaves the
+   * lookup byte-identical to pre-G5.
+   */
+  trustedTenantId?: string;
 }
 
 function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
@@ -1469,10 +1487,14 @@ export async function resolveQuotedMessage(
   options: QuotedLookupOptions = {},
 ): Promise<string | null> {
   try {
-    const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
-    if (!chat) return null;
-
-    const quoted = await lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases, options);
+    // One discrete read block — chat lookup plus the quoted-message lookup — in
+    // the envelope's world (G5, ADR-0008). Pure reads, no publish, so a single
+    // short scope is correct.
+    const quoted = await runDispatchDb(services.db, options.trustedTenantId, async () => {
+      const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+      if (!chat) return null;
+      return lookupQuotedMessage(services.messages, chat.id, replyToId, providerAliases, options);
+    });
     if (!quoted) return null;
 
     const sender = quoted.senderDisplayName ?? quoted.senderPlatformUserId ?? (quoted.isFromMe ? 'You' : 'unknown');
@@ -1662,6 +1684,7 @@ async function prependQuotedContext(
     const quotedText = await resolveQuotedMessage(services, instanceId, chatId, replyToId, providerAliases, {
       inboundAt: extractInboundPlatformDate(rawPayload),
       inboundText: m.payload.content?.text,
+      trustedTenantId: m.metadata.trustedTenantId,
     });
     if (!quotedText) continue;
 
@@ -1684,14 +1707,17 @@ async function resolveContactName(
   instanceId: string,
   jid: string,
   cacheMap: Map<string, string>,
+  trustedTenantId?: string,
 ): Promise<string | null> {
   // Try cache first (fast path)
   const cachedName = cacheMap.get(jid);
   if (cachedName) return cachedName;
 
-  // Cache miss → query database
+  // Cache miss → query database, in the envelope's world (G5, ADR-0008)
   try {
-    const chat = await services.chats.findByExternalIdSmart(instanceId, jid);
+    const chat = await runDispatchDb(services.db, trustedTenantId, () =>
+      services.chats.findByExternalIdSmart(instanceId, jid),
+    );
     if (chat?.name) {
       log.debug('Contact name from DB fallback', { jid, name: chat.name });
       return chat.name;
@@ -1720,6 +1746,7 @@ async function applyJidMentionReplacement(
   jidToName: Map<string, string>,
   text: string,
   stats: MentionStats,
+  trustedTenantId?: string,
 ): Promise<string> {
   // Extract phone number from JID (supports @s.whatsapp.net, @lid, and device IDs like :3@s.whatsapp.net)
   const phoneMatch = jid.match(/^(\d+)(@s\.whatsapp\.net|@lid|:[\d]+@s\.whatsapp\.net)$/);
@@ -1728,7 +1755,7 @@ async function applyJidMentionReplacement(
     return text;
   }
 
-  const contactName = await resolveContactName(services, instanceId, jid, jidToName);
+  const contactName = await resolveContactName(services, instanceId, jid, jidToName, trustedTenantId);
   if (!contactName) {
     stats.unresolved++;
     return text;
@@ -1750,6 +1777,7 @@ async function replaceMentionsWithContactNames(
   text: string,
   mentionedJids: string[] | undefined,
   mentionedContacts: Array<{ jid: string; name?: string }> | undefined,
+  trustedTenantId?: string,
 ): Promise<string> {
   if (!mentionedJids?.length) return text;
 
@@ -1760,7 +1788,15 @@ async function replaceMentionsWithContactNames(
   let replacedText = text;
 
   for (const jid of mentionedJids) {
-    replacedText = await applyJidMentionReplacement(services, instanceId, jid, jidToName, replacedText, stats);
+    replacedText = await applyJidMentionReplacement(
+      services,
+      instanceId,
+      jid,
+      jidToName,
+      replacedText,
+      stats,
+      trustedTenantId,
+    );
   }
 
   log.debug('Mention replacement complete', {
@@ -1821,6 +1857,7 @@ async function prepareAgentContent(
       entry.text,
       mentionData.mentionedJids,
       mentionData.mentionedContacts,
+      messages[0]?.metadata.trustedTenantId,
     );
   }
 
@@ -1856,12 +1893,18 @@ async function resolvePersonId(
   instanceId: string,
   senderId: string,
   metadataPersonId?: string,
+  trustedTenantId?: string,
 ): Promise<string | undefined> {
   if (metadataPersonId) return metadataPersonId;
   if (!senderId) return undefined;
 
   for (let attempt = 0; attempt < 10; attempt++) {
-    const identity = await services.persons.getIdentityByPlatformId(channel, instanceId, senderId);
+    // Each attempt is its OWN short scope: this polls for another consumer's
+    // commit, so one transaction spanning the loop would pin a snapshot that can
+    // never contain the row it is waiting for — and would outlive its work item.
+    const identity = await runDispatchDb(services.db, trustedTenantId, () =>
+      services.persons.getIdentityByPlatformId(channel, instanceId, senderId),
+    );
     if (identity?.personId) return identity.personId;
     await sleep(200);
   }
@@ -1918,12 +1961,13 @@ async function resolveCustomerContext(
   services: Services,
   personId: string | undefined,
   externalContext?: OmniCustomerContext,
+  trustedTenantId?: string,
 ): Promise<OmniCustomerContext | undefined> {
   let storedContext: OmniCustomerContext | undefined;
 
   if (personId) {
     try {
-      const person = await services.persons.getById(personId);
+      const person = await runDispatchDb(services.db, trustedTenantId, () => services.persons.getById(personId));
       if (person && isRecord(person.metadata)) {
         storedContext = customerContextFromRecord(person.metadata);
       }
@@ -1946,9 +1990,12 @@ async function fetchSenderMetadata(
   channel: ChannelType,
   instanceId: string,
   senderId: string,
+  trustedTenantId?: string,
 ): Promise<{ avatarUrl?: string; platformUsername?: string }> {
   try {
-    const identity = await services.persons.getIdentityByPlatformId(channel, instanceId, senderId);
+    const identity = await runDispatchDb(services.db, trustedTenantId, () =>
+      services.persons.getIdentityByPlatformId(channel, instanceId, senderId),
+    );
     return {
       avatarUrl: identity?.profilePicUrl ?? undefined,
       platformUsername: identity?.platformUsername ?? undefined,
@@ -1967,11 +2014,14 @@ async function fetchChatMetadata(
   instanceId: string,
   chatId: string,
   chatType: string,
+  trustedTenantId?: string,
 ): Promise<{ chatName?: string; participantCount?: number }> {
   if (chatType !== 'group') return {};
 
   try {
-    const chat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+    const chat = await runDispatchDb(services.db, trustedTenantId, () =>
+      services.chats.findByExternalIdSmart(instanceId, chatId),
+    );
     return {
       chatName: chat?.name ?? undefined,
       participantCount: chat?.participantCount ?? undefined,
@@ -2320,7 +2370,13 @@ async function dispatchViaStreamingProvider(
   const replyToId = messages[0]?.payload.replyToId ?? messages[0]?.payload.externalId;
 
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
-  const dbContextMessages = await buildContextMessages(services, instance, chatId, currentMessageIds);
+  const dbContextMessages = await buildContextMessages(
+    services,
+    instance,
+    chatId,
+    currentMessageIds,
+    messages[0]?.metadata.trustedTenantId,
+  );
   const allContextMessages = mergeContextMessages(extraContextMessages, dbContextMessages);
   const triggerFiles = toTriggerFiles(mediaFiles);
 
@@ -2344,6 +2400,7 @@ async function dispatchViaStreamingProvider(
     services,
     personId,
     extractA2ACustomerContext(messages, channel),
+    messages[0]?.metadata.trustedTenantId,
   );
   const trigger = buildMessageTrigger(
     traceId,
@@ -2472,27 +2529,35 @@ async function buildContextMessages(
   instance: Instance,
   chatId: string,
   currentMessageIds: string[],
+  trustedTenantId?: string,
 ): Promise<string[]> {
   try {
     // Per-instance configurable limit, capped at 200 (0 = disabled)
     const historyLimit = Math.min(Math.max(instance.groupHistorySize ?? 50, 0), 200);
     if (historyLimit === 0) return [];
 
-    // chatId here is the external JID, not internal UUID
-    const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
-    if (!chat) {
+    // One discrete read block in the envelope's world (G5, ADR-0008): the chat
+    // lookup and the history query it parameterises.
+    const loaded = await runDispatchDb(services.db, trustedTenantId, async () => {
+      // chatId here is the external JID, not internal UUID
+      const chat = await services.chats.findByExternalIdSmart(instance.id, chatId);
+      if (!chat) return null;
+
+      // DMs use a smaller context window (cap at 20) to keep context focused
+      const effectiveLimit = chat.chatType === 'group' ? historyLimit : Math.min(historyLimit, DM_HISTORY_LIMIT);
+
+      // Query recent messages (configurable limit, ordered by timestamp desc by default)
+      // Use the internal chat.id (UUID) for the query
+      const messagesResult = await services.messages.list({
+        chatId: chat.id,
+        limit: effectiveLimit,
+      });
+      return { chat, messagesResult };
+    });
+    if (!loaded) {
       return [];
     }
-
-    // DMs use a smaller context window (cap at 20) to keep context focused
-    const effectiveLimit = chat.chatType === 'group' ? historyLimit : Math.min(historyLimit, DM_HISTORY_LIMIT);
-
-    // Query recent messages (configurable limit, ordered by timestamp desc by default)
-    // Use the internal chat.id (UUID) for the query
-    const messagesResult = await services.messages.list({
-      chatId: chat.id,
-      limit: effectiveLimit,
-    });
+    const { chat, messagesResult } = loaded;
 
     const recentMessages = messagesResult.items;
 
@@ -2623,22 +2688,27 @@ async function dispatchViaTurnBasedProvider(
   }
 
   // Open turn (turns.chat_id is text, accepts external JID)
-  const turn = await services.turns.open({
-    instanceId: instance.id,
-    chatId,
-    messageId,
-    agentId: agentRecord.id,
-    apiKeyId: scopedKey.id,
-  });
+  const turn = await runDispatchDb(db, messages[0]?.metadata.trustedTenantId, () =>
+    services.turns.open({
+      instanceId: instance.id,
+      chatId,
+      messageId,
+      agentId: agentRecord.id,
+      apiKeyId: scopedKey.id,
+    }),
+  );
 
   // Resolve internal UUIDs for the API key context columns (uuid types).
   // chatId is an external JID (e.g. "54958418317348@lid") and messageId is an
   // external WhatsApp ID (e.g. "3BB06F44A03A3AE78E5B") — neither is a valid UUID.
   // The api_keys context columns are uuid-typed, so we must resolve to internal IDs.
-  const contextChat = await services.chats.findByExternalIdSmart(instance.id, chatId);
-  const contextChatId = contextChat?.id ?? null;
-  const contextMsg =
-    contextChat && messageId ? await services.messages.getByExternalId(contextChat.id, messageId) : null;
+  const { contextChatId, contextMsg } = await runDispatchDb(db, messages[0]?.metadata.trustedTenantId, async () => {
+    const contextChat = await services.chats.findByExternalIdSmart(instance.id, chatId);
+    return {
+      contextChatId: contextChat?.id ?? null,
+      contextMsg: contextChat && messageId ? await services.messages.getByExternalId(contextChat.id, messageId) : null,
+    };
+  });
 
   // Set context on the scoped key so verb commands resolve to this chat
   await services.apiKeys.update(scopedKey.id, {
@@ -2763,7 +2833,13 @@ async function dispatchViaProvider(
 
   // Build context messages for group and DM conversations (messages since last bot response)
   const currentMessageIds = messages.map((msg) => msg.payload.externalId).filter((id): id is string => !!id);
-  const dbContextMessages = await buildContextMessages(services, instance, chatId, currentMessageIds);
+  const dbContextMessages = await buildContextMessages(
+    services,
+    instance,
+    chatId,
+    currentMessageIds,
+    messages[0]?.metadata.trustedTenantId,
+  );
   const allContextMessages = mergeContextMessages(extraContextMessages, dbContextMessages);
   const triggerFiles = toTriggerFiles(mediaFiles);
 
@@ -2784,6 +2860,7 @@ async function dispatchViaProvider(
     services,
     personId,
     extractA2ACustomerContext(messages, channel),
+    messages[0]?.metadata.trustedTenantId,
   );
   const trigger = buildMessageTrigger(
     traceId,
@@ -2870,7 +2947,9 @@ async function dispatchViaProvider(
 
       // If the agent triggered a handoff during this run (agentPaused: true),
       // suppress the response — the handoff message already notified the user.
-      const chatAfterRun = await services.chats.findByExternalIdSmart(instance.id, chatId);
+      const chatAfterRun = await runDispatchDb(db, messages[0]?.metadata.trustedTenantId, () =>
+        services.chats.findByExternalIdSmart(instance.id, chatId),
+      );
       const handoffTriggered = (chatAfterRun?.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
 
       // If newer inbound arrived while the agent was running, this reply was
@@ -3008,8 +3087,15 @@ async function dispatchViaLegacy(
     channel,
     instance.id,
     senderId,
+    messages[0]?.metadata.trustedTenantId,
   );
-  const { chatName, participantCount } = await fetchChatMetadata(services, instance.id, chatId, chatType);
+  const { chatName, participantCount } = await fetchChatMetadata(
+    services,
+    instance.id,
+    chatId,
+    chatType,
+    messages[0]?.metadata.trustedTenantId,
+  );
 
   // Fire before_agent_start hooks (observational for v1 — mutations logged but not applied)
   // TODO: wire mutated context values back once DEC-5 allowlist infra (provider/agentId validation) exists
@@ -3740,6 +3826,7 @@ async function applyCloseContactGate(
   instanceId: string,
   chatId: string,
   chatSettings: ChatSettingsForGate | null,
+  trustedTenantId?: string,
 ): Promise<'skip' | 'reopened' | 'pass'> {
   if (chatSettings?.closed === true) {
     log.debug('Chat closed (terminal), skipping dispatch', {
@@ -3771,14 +3858,16 @@ async function applyCloseContactGate(
   // explicitly cleared. Report `reopened` so the handoff gate ignores any
   // stale flag.
   try {
-    await services.chats.update(chatRecordId, {
-      settings: {
-        ...(chatSettings as Record<string, unknown>),
-        agentPaused: false,
-        closeUntil: null,
-        agentResumedAt: new Date().toISOString(),
-      } as Record<string, unknown>,
-    });
+    await runDispatchDb(services.db, trustedTenantId, () =>
+      services.chats.update(chatRecordId, {
+        settings: {
+          ...(chatSettings as Record<string, unknown>),
+          agentPaused: false,
+          closeUntil: null,
+          agentResumedAt: new Date().toISOString(),
+        } as Record<string, unknown>,
+      }),
+    );
     log.info('Close cooldown expired, state cleaned', {
       instanceId,
       chatId,
@@ -3825,8 +3914,19 @@ async function processAgentResponse(
     buildAckConfig(instance),
   );
 
+  // The envelope-derived tenant for this whole dispatch (G5, ADR-0008); every
+  // discrete DB block below runs in its world.
+  const dispatchTenantId = firstMessage.metadata.trustedTenantId;
+
   // Resolve person ID (waits for message-persistence to create identity)
-  const personId = await resolvePersonId(services, channel, instance.id, senderId, firstMessage.metadata.personId);
+  const personId = await resolvePersonId(
+    services,
+    channel,
+    instance.id,
+    senderId,
+    firstMessage.metadata.personId,
+    dispatchTenantId,
+  );
   if (!personId) {
     log.warn('Could not resolve person ID, skipping agent', { instanceId: instance.id, chatId, senderId });
     ackHandle.remove();
@@ -3835,10 +3935,19 @@ async function processAgentResponse(
 
   // ── Close-contact gate — runs BEFORE the handoff/agentPaused gate ──
   // See applyCloseContactGate() for the full semantics.
-  const chatRecord = await services.chats.findByExternalIdSmart(instance.id, chatId);
+  const chatRecord = await runDispatchDb(db, dispatchTenantId, () =>
+    services.chats.findByExternalIdSmart(instance.id, chatId),
+  );
   const chatSettings = chatRecord?.settings as ChatSettingsForGate | null;
 
-  const gateResult = await applyCloseContactGate(services, chatRecord?.id ?? null, instance.id, chatId, chatSettings);
+  const gateResult = await applyCloseContactGate(
+    services,
+    chatRecord?.id ?? null,
+    instance.id,
+    chatId,
+    chatSettings,
+    dispatchTenantId,
+  );
   if (gateResult === 'skip') {
     ackHandle.remove();
     return;
@@ -4536,8 +4645,10 @@ async function processReactionTrigger(
   const channel = (metadata.channelType ?? baseInstance.channel) as ChannelType;
   const externalChatId = payload.chatId;
 
-  // Look up internal chat UUID for route resolution
-  const chat = await services.chats.findByExternalIdSmart(baseInstance.id, externalChatId);
+  // Look up internal chat UUID for route resolution, in the envelope's world
+  const chat = await runDispatchDb(db, metadata.trustedTenantId, () =>
+    services.chats.findByExternalIdSmart(baseInstance.id, externalChatId),
+  );
   const internalChatId = chat?.id; // undefined when chat not in DB (e.g. LID-only chats)
 
   // Resolve person ID for route matching (metadata.personId may not be set yet)
@@ -4582,7 +4693,12 @@ async function processReactionTrigger(
         personId: effectivePersonId,
         rawPayload: payload.rawPayload as Record<string, unknown> | undefined,
       }).sessionId;
-      const customerContext = await resolveCustomerContext(services, effectivePersonId);
+      const customerContext = await resolveCustomerContext(
+        services,
+        effectivePersonId,
+        undefined,
+        metadata.trustedTenantId,
+      );
 
       const trigger: AgentTrigger = {
         traceId: metadata.traceId,
@@ -4654,8 +4770,15 @@ async function processReactionTrigger(
       channel,
       instance.id,
       payload.from,
+      metadata.trustedTenantId,
     );
-    const { chatName, participantCount } = await fetchChatMetadata(services, instance.id, externalChatId, chatType);
+    const { chatName, participantCount } = await fetchChatMetadata(
+      services,
+      instance.id,
+      externalChatId,
+      chatType,
+      metadata.trustedTenantId,
+    );
 
     const result = await services.agentRunner.run({
       instance,
@@ -4757,6 +4880,8 @@ async function isLidMatchingOwner(
   ownerPhone: string,
   ownerIsLid: boolean,
   lidJid: string,
+  db: Database,
+  trustedTenantId?: string,
 ): Promise<boolean> {
   // Direct LID match: when ownerIdentifier is itself a LID, compare directly
   if (ownerIsLid && extractPhoneFromJid(lidJid) === ownerPhone) {
@@ -4764,9 +4889,13 @@ async function isLidMatchingOwner(
     return true;
   }
 
-  // DB resolution: resolve LID -> phone JID, then compare with owner phone
+  // DB resolution: resolve LID -> phone JID, then compare with owner phone.
+  // The chat_id_mappings reads run in the message's world (G5, ADR-0008): a
+  // tenant envelope opens a short worker scope per read; a legacy envelope
+  // (no tenant) stays byte-identical on the ambient pool. The surrounding
+  // try/catch keeps DB-lookup failures non-critical, as before.
   try {
-    const mapping = await chatsService.findLidMapping(instanceId, lidJid);
+    const mapping = await runDispatchDb(db, trustedTenantId, () => chatsService.findLidMapping(instanceId, lidJid));
     if (!mapping) return false;
 
     const resolvedPhone = extractPhoneFromJid(mapping);
@@ -4777,7 +4906,9 @@ async function isLidMatchingOwner(
 
     // Reverse check: when owner is LID, also look up the owner's phone mapping
     if (ownerIsLid) {
-      const ownerMapping = await chatsService.findLidMapping(instanceId, ownerIdentifier);
+      const ownerMapping = await runDispatchDb(db, trustedTenantId, () =>
+        chatsService.findLidMapping(instanceId, ownerIdentifier),
+      );
       if (ownerMapping && extractPhoneFromJid(ownerMapping) === resolvedPhone) {
         log.debug('LID resolved to owner via reverse mapping', { lidJid, resolvedPhone, ownerIdentifier });
         return true;
@@ -4802,6 +4933,8 @@ async function resolveLidMentionBot(
   ownerIdentifier: string,
   mentionedJids: string[],
   messageContext: MessageContext,
+  db: Database,
+  trustedTenantId?: string,
 ): Promise<void> {
   const lidMentions = mentionedJids.filter((jid) => jid.endsWith('@lid'));
   if (lidMentions.length === 0) return;
@@ -4810,7 +4943,18 @@ async function resolveLidMentionBot(
   const ownerPhone = extractPhoneFromJid(ownerIdentifier);
 
   for (const lidJid of lidMentions) {
-    if (await isLidMatchingOwner(chatsService, instanceId, ownerIdentifier, ownerPhone, ownerIsLid, lidJid)) {
+    if (
+      await isLidMatchingOwner(
+        chatsService,
+        instanceId,
+        ownerIdentifier,
+        ownerPhone,
+        ownerIsLid,
+        lidJid,
+        db,
+        trustedTenantId,
+      )
+    ) {
       messageContext.mentionsBot = true;
       break;
     }
@@ -4823,9 +4967,13 @@ async function resolveEffectiveReplyFilter(
   instanceId: string,
   chatId: string,
   defaultFilter: Instance['agentReplyFilter'],
+  db: Database,
   trustedTenantId?: string,
 ): Promise<Instance['agentReplyFilter']> {
-  const chat = await chatsService.findByExternalIdSmart(instanceId, chatId);
+  // chat_id_mappings read in the message's world (G5, ADR-0008): tenant
+  // envelope → short worker scope, legacy → ambient pass-through. routeResolver
+  // threads its own trustedTenantId and manages its own scope.
+  const chat = await runDispatchDb(db, trustedTenantId, () => chatsService.findByExternalIdSmart(instanceId, chatId));
   if (!chat?.id) return defaultFilter;
   const route = await routeResolver.resolve(instanceId, chat.id, undefined, trustedTenantId);
   return (route?.agentReplyFilter as Instance['agentReplyFilter']) ?? defaultFilter;
@@ -4842,13 +4990,22 @@ async function resolveSlackThreadReply(
   instance: Instance,
   payload: MessageReceivedPayload,
   context: MessageContext,
+  db: Database,
+  trustedTenantId?: string,
 ): Promise<void> {
   if (instance.channel !== 'slack') return;
   const raw = payload.rawPayload ?? {};
   if (raw.isThreadReply !== true || !raw.threadTs) return;
-  const chat = await chatsService.findByExternalIdSmart(instance.id, payload.chatId);
-  if (!chat) return;
-  context.isReplyToBot = await messagesService.hasBotRepliedInThread(chat.id, raw.threadTs as string);
+  // chats + messages reads in the message's world (G5, ADR-0008): a tenant
+  // envelope runs the chat lookup and the thread-reply lookup in a short worker
+  // scope; a legacy envelope (no tenant) stays byte-identical on the ambient
+  // pool. When no chat is found, context.isReplyToBot is left unchanged.
+  const isReplyToBot = await runDispatchDb(db, trustedTenantId, async () => {
+    const chat = await chatsService.findByExternalIdSmart(instance.id, payload.chatId);
+    if (!chat) return undefined;
+    return messagesService.hasBotRepliedInThread(chat.id, raw.threadTs as string);
+  });
+  if (isReplyToBot !== undefined) context.isReplyToBot = isReplyToBot;
 }
 
 /** True if the chat is a newsletter or broadcast channel (agent never processes these). */
@@ -5097,10 +5254,12 @@ async function shouldProcessMessage(
       instance.ownerIdentifier as string,
       mentionedJids,
       messageContext,
+      db,
+      trustedTenantId,
     );
   }
 
-  await resolveSlackThreadReply(chatsService, messagesService, instance, payload, messageContext);
+  await resolveSlackThreadReply(chatsService, messagesService, instance, payload, messageContext, db, trustedTenantId);
 
   log.debug('Message context built', {
     instanceId: instance.id,
@@ -5120,6 +5279,7 @@ async function shouldProcessMessage(
     instance.id,
     payload.chatId,
     instance.agentReplyFilter,
+    db,
     trustedTenantId,
   );
 
@@ -5482,7 +5642,9 @@ export async function setupAgentDispatcher(
         return;
       }
       const externalChatId = firstMsg.payload.chatId;
-      const chat = await services.chats.findByExternalIdSmart(instanceId, externalChatId);
+      const chat = await runDispatchDb(db, firstMsg.metadata.trustedTenantId, () =>
+        services.chats.findByExternalIdSmart(instanceId, externalChatId),
+      );
       const resolved = await resolveEffectiveInstance(
         services,
         db,
@@ -5551,7 +5713,9 @@ export async function setupAgentDispatcher(
 
             // Early route resolution: resolve route BEFORE debounce so per-user
             // debounce overrides (e.g. messageDebounceMode: 'disabled') take effect.
-            const chat = await services.chats.findByExternalIdSmart(instance.id, payload.chatId);
+            const chat = await runDispatchDb(db, trustedTenantId, () =>
+              services.chats.findByExternalIdSmart(instance.id, payload.chatId),
+            );
 
             // Resolve person ID for route matching. metadata.personId may not be set yet
             // (message-persistence runs in parallel), so fall back to identity lookup.
@@ -5562,6 +5726,7 @@ export async function setupAgentDispatcher(
               instance.id,
               payload.from,
               metadata.personId,
+              trustedTenantId,
             );
 
             const { instance: resolved, routeId } = await resolveEffectiveInstance(
@@ -5780,7 +5945,9 @@ export async function setupAgentDispatcher(
 
             // Resolve route so per-user debounce overrides (e.g. restartOnTyping) take effect.
             // Use metadata personId directly — don't poll for identity here (typing is latency-sensitive).
-            const chat = await services.chats.findByExternalIdSmart(metadata.instanceId as string, payload.chatId);
+            const chat = await runDispatchDb(db, trustedDispatchTenant(metadata), () =>
+              services.chats.findByExternalIdSmart(metadata.instanceId as string, payload.chatId),
+            );
             const typingPersonId = metadata.personId;
             const { instance: resolved } = await resolveEffectiveInstance(
               services,
@@ -5928,6 +6095,17 @@ export const setupAgentResponder = setupAgentDispatcher;
 export const __test__ = {
   buildContextMessages,
   awaitMediaProcessing,
+  // Read helpers converted in the G5 read-path leg — exported so the
+  // worker-scope probes can assert their threading contract directly.
+  resolveQuotedMessage,
+  resolveContactName,
+  resolvePersonId,
+  resolveLidMentionBot,
+  resolveEffectiveReplyFilter,
+  resolveSlackThreadReply,
+  fetchSenderMetadata,
+  fetchChatMetadata,
+  applyCloseContactGate,
   downloadToTempFile,
   mediaCompletions,
   mediaResultCache,

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3346,12 +3346,16 @@ function mimeToContentType(mimeType: string): 'audio' | 'image' | 'video' | 'doc
  * Download a URL to a temp file and return the local path.
  * Returns null on any error (graceful degradation).
  */
-async function downloadToTempFile(url: string, mimeType: string): Promise<string | null> {
+async function downloadToTempFile(url: string, mimeType: string, trustedTenantId?: string): Promise<string | null> {
   try {
     // SSRF-guarded: rejects private/metadata targets (initial URL and every
     // redirect hop) before connecting — history-sync mediaUrl values originate
-    // from channel payloads, not from operator config.
-    const res = await fetchMediaUrl(url);
+    // from channel payloads, not from operator config. In a tenant context the
+    // `OMNI_MEDIA_URL_GUARD=off` escape hatch is SUBSUMED (G5 deliverable (b),
+    // ADR-0009): this URL is tenant-controlled, so no per-deployment flag may
+    // open private ranges to it. `trustedTenantId` comes from the LOADED
+    // instance's persisted ownership, never a payload claim.
+    const res = await fetchMediaUrl(url, { trustedTenantId });
     if (!res.ok) return null;
 
     const buffer = Buffer.from(await res.arrayBuffer());
@@ -3372,12 +3376,13 @@ async function processMediaFile(
   msg: HistorySyncMessage,
   mimeType: string,
   mediaService: ReturnType<typeof createMediaProcessingService> | null,
+  trustedTenantId?: string,
 ): Promise<string | null> {
   let localPath = msg.content.localPath ?? null;
   let ownedTempFile = false;
 
   if (!localPath && msg.content.mediaUrl && mediaService) {
-    localPath = await downloadToTempFile(msg.content.mediaUrl, mimeType);
+    localPath = await downloadToTempFile(msg.content.mediaUrl, mimeType, trustedTenantId);
     if (localPath) ownedTempFile = true;
   }
 
@@ -3420,6 +3425,7 @@ async function processHistoryMessage(
   mediaService: ReturnType<typeof createMediaProcessingService> | null,
   reactFn: ((msgId: string, emoji: string) => Promise<void>) | null,
   unreactFn: ((msgId: string, emoji: string) => Promise<void>) | null,
+  trustedTenantId?: string,
 ): Promise<string> {
   const timeStr = msg.timestamp.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
   const header = `[${msg.from ?? 'Unknown'} - ${timeStr}]`;
@@ -3435,7 +3441,7 @@ async function processHistoryMessage(
 
   if (reactFn) reactFn(msg.externalId, startEmoji).catch(() => {});
 
-  const processedContent = await processMediaFile(msg, mimeType, mediaService);
+  const processedContent = await processMediaFile(msg, mimeType, mediaService, trustedTenantId);
 
   // Always remove start emoji; add done emoji only on success
   if (unreactFn) unreactFn(msg.externalId, startEmoji).catch(() => {});
@@ -3507,7 +3513,12 @@ async function fetchAndProcessThreadHistory(
   // Process in batches to cap concurrency
   for (let i = 0; i < mediaMessages.length; i += CONCURRENCY) {
     const batch = mediaMessages.slice(i, i + CONCURRENCY);
-    const results = await Promise.all(batch.map((msg) => processHistoryMessage(msg, mediaService, reactFn, unreactFn)));
+    const results = await Promise.all(
+      // The instance row's persisted `tenantId` is the ownership root (G2) — the
+      // trusted derivation that subsumes the media escape hatch for these
+      // tenant-controlled history URLs. Null in the flag-off world.
+      batch.map((msg) => processHistoryMessage(msg, mediaService, reactFn, unreactFn, instance.tenantId ?? undefined)),
+    );
     contextMessages.push(...results);
   }
 
@@ -4081,7 +4092,12 @@ function createClaudeCodeProviderInstance(
       maxTurns: schemaConfig.maxTurns as number | undefined,
       pathToClaudeCodeExecutable: schemaConfig.pathToClaudeCodeExecutable as string | undefined,
     },
-    createSessionStorage(db, provider.id),
+    // G5 (ADR-0008): the session store is reached only from this consumer, so it
+    // establishes its own tenant scope from the LOADED instance's persisted
+    // ownership — `instances.tenantId` is the G2 ownership root, read from the
+    // database, never asserted by a payload. Null in the flag-off world, where
+    // the store keeps its pre-G5 ambient/plaintext path byte-identically.
+    createSessionStorage(db, provider.id, undefined, { resolveTenantId: () => instance.tenantId ?? null }),
     {
       timeoutMs: ((instance.agentTimeout ?? provider.defaultTimeout ?? 600) as number) * 1000,
       enableAutoSplit: instance.enableAutoSplit ?? true,
@@ -5014,7 +5030,13 @@ async function shouldProcessMessage(
     return null;
   }
 
-  const instance = await agentRunner.getInstanceWithProvider(metadata.instanceId);
+  // Discrete DB block in the message's world (G5, ADR-0008): a tenant envelope
+  // reads the instance through a short worker scope, so a forged/foreign
+  // instanceId resolves to nothing and dispatch stops here. A legacy envelope
+  // (no tenant) runs on the ambient pool byte-identically.
+  const instance = await runDispatchDb(db, trustedTenantId, () =>
+    agentRunner.getInstanceWithProvider(metadata.instanceId as string),
+  );
   if (!instance?.agentId) {
     log.debug('Instance has no agentId', { instanceId: metadata.instanceId });
     return null;
@@ -5215,10 +5237,21 @@ async function shouldProcessReaction(
   payload: ReactionReceivedPayload,
   metadata: { instanceId?: string; channelType?: string },
   eventType: 'reaction.received' | 'reaction.removed' = 'reaction.received',
+  db?: Database,
+  trustedTenantId?: string,
 ): Promise<Instance | null> {
   if (!metadata.instanceId) return null;
 
-  const instance = await agentRunner.getInstanceWithProvider(metadata.instanceId);
+  // Discrete DB block in the reaction's world (G5, ADR-0008) — see the sibling
+  // block in `shouldProcessMessage`. `db` is optional only because the unit
+  // tests call this guard directly with no handle; without one there is nothing
+  // to open a scope on and the read stays ambient, exactly as before.
+  const instance =
+    db && trustedTenantId !== undefined
+      ? await runDispatchDb(db, trustedTenantId, () =>
+          agentRunner.getInstanceWithProvider(metadata.instanceId as string),
+        )
+      : await agentRunner.getInstanceWithProvider(metadata.instanceId);
   if (!instance?.agentId) return null;
 
   if (!instanceTriggersOnEvent(instance, eventType)) return null;
@@ -5439,8 +5472,11 @@ export async function setupAgentDispatcher(
     if (firstMsg.metadata.resolvedInstance) {
       instance = firstMsg.metadata.resolvedInstance as DispatchInstance;
     } else {
-      // Fallback: resolve now if metadata doesn't carry it (shouldn't happen in normal flow)
-      const baseInstance = await agentRunner.getInstanceWithProvider(instanceId);
+      // Fallback: resolve now if metadata doesn't carry it (shouldn't happen in normal flow).
+      // Discrete DB block in the buffered message's world (G5, ADR-0008).
+      const baseInstance = await runDispatchDb(db, firstMsg.metadata.trustedTenantId, () =>
+        agentRunner.getInstanceWithProvider(instanceId),
+      );
       if (!baseInstance) {
         log.warn('Instance not found for debounced messages', { instanceId });
         return;
@@ -5609,7 +5645,16 @@ export async function setupAgentDispatcher(
         // for the same reaction event.
         await withIdempotency(db, event.id, 'agent-dispatcher-reaction', async () => {
           try {
-            const instance = await shouldProcessReaction(agentRunner, accessService, reactionDedup, payload, metadata);
+            const instance = await shouldProcessReaction(
+              agentRunner,
+              accessService,
+              reactionDedup,
+              payload,
+              metadata,
+              'reaction.received',
+              db,
+              trustedDispatchTenant(metadata),
+            );
             if (!instance) return;
 
             const traceId = metadata.traceId ?? generateCorrelationId('trc');
@@ -5669,6 +5714,8 @@ export async function setupAgentDispatcher(
               payload,
               metadata,
               'reaction.removed',
+              db,
+              trustedDispatchTenant(metadata),
             );
             if (!instance) return;
 
@@ -5725,7 +5772,10 @@ export async function setupAgentDispatcher(
         // timer on a stale typing event.
         await withIdempotency(db, event.id, 'agent-dispatcher-typing', async () => {
           try {
-            const baseInstance = await agentRunner.getInstanceWithProvider(metadata.instanceId as string);
+            // Discrete DB block in the typing event's world (G5, ADR-0008).
+            const baseInstance = await runDispatchDb(db, trustedDispatchTenant(metadata), () =>
+              agentRunner.getInstanceWithProvider(metadata.instanceId as string),
+            );
             if (!baseInstance?.agentId) return;
 
             // Resolve route so per-user debounce overrides (e.g. restartOnTyping) take effect.

--- a/packages/api/src/plugins/agent-responder.ts
+++ b/packages/api/src/plugins/agent-responder.ts
@@ -30,6 +30,7 @@ import {
   getSplitDelayConfig,
   shouldAgentReply,
 } from '../services/agent-runner';
+import { trustedEnvelopeTenant } from '../tenancy/worker-tenant-context';
 import { getPlugin } from './loader';
 
 const log = createLogger('agent-responder');
@@ -543,6 +544,7 @@ async function processIncomingMessage(
   agentRunner: AgentRunnerService,
   accessService: AccessService,
   debouncer: MessageDebouncer,
+  trustedTenantId?: string,
 ): Promise<void> {
   const instance = await agentRunner.getInstanceWithProvider(metadata.instanceId);
   if (!instance?.agentId) return;
@@ -554,7 +556,11 @@ async function processIncomingMessage(
   }
 
   const channel = (metadata.channelType ?? instance.channel) as ChannelType;
-  const accessResult = await accessService.checkAccess(instance, payload.from ?? '', channel);
+  // G5 (ADR-0008): the ALLOW/DENY decision is evaluated against rules read in
+  // the MESSAGE's world. `trustedTenantId` is the envelope-derived tenant
+  // (`trustedEnvelopeTenant`), threaded rather than wrapped because the service
+  // publishes `access.allowed`/`access.denied` between blocks.
+  const accessResult = await accessService.checkAccess(instance, payload.from ?? '', channel, trustedTenantId);
 
   if (!accessResult.allowed) {
     log.info('Access denied by rule', {
@@ -568,13 +574,15 @@ async function processIncomingMessage(
     // Trigger pairing flow for unknown senders in allowlist mode (no explicit rule matched).
     // Fire-and-forget: pairing request creation must not block message processing.
     if (accessResult.mode === 'allowlist' && !accessResult.rule && payload.from) {
-      accessService.requestPairing(instance.id, payload.from, { channelType: instance.channel }).catch((err) => {
-        log.warn('Failed to create pairing request', {
-          instanceId: instance.id,
-          from: payload.from,
-          error: String(err),
+      accessService
+        .requestPairing(instance.id, payload.from, { channelType: instance.channel }, trustedTenantId)
+        .catch((err) => {
+          log.warn('Failed to create pairing request', {
+            instanceId: instance.id,
+            from: payload.from,
+            error: String(err),
+          });
         });
-      });
     }
 
     await handleAccessDenied(channel, instance.id, payload.chatId, accessResult);
@@ -654,6 +662,7 @@ export async function setupAgentResponder(eventBus: EventBus, services: Services
               agentRunner,
               accessService,
               debouncer,
+              trustedEnvelopeTenant(event),
             );
           } catch (error) {
             log.error('Error processing message for agent response', {

--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -259,6 +259,3 @@ export function buildAutomationEngineDeps(
     releaseIdleTimeoutClaim: (claimToken) => releaseIdleTimeoutClaim(claimToken),
   };
 }
-
-/** Test seam: the worker-scope probes drive exactly what production runs. */
-export const __test__ = { resolveCallAgentChatIds, buildAutomationEngineDeps };

--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -1,0 +1,257 @@
+/**
+ * Automation-engine action callbacks (wish: omni-full-multitenancy, Group G5;
+ * ADR-0008).
+ *
+ * These are the `sendMessage` / `callAgent` / `staleIdleTimeoutGate`
+ * dependencies `AutomationService.startEngine` hands the core engine. They
+ * used to live inline in `index.ts`; they are extracted here because they are
+ * a WORKER surface, not a bootstrap surface: the engine invokes them from a
+ * NATS consumer callback, so every DB read they make runs with no request
+ * scope. Extraction makes them registrable (the direct `agents` read below
+ * gets its own honest db-access-guard site instead of hiding under
+ * `index.ts`'s control-plane startup entry) and testable (the worker-scope
+ * probes drive exactly the functions production runs).
+ *
+ * TENANT BOUNDARY (G5, ADR-0008)
+ * ------------------------------
+ * The engine classifies each consumed envelope (`classifyEnvelope`) and
+ * threads the producer-stamped trusted tenant into every callback — never a
+ * payload claim. Each callback wraps its DISCRETE DB block in
+ * `runTenantWorkDb`:
+ *
+ *   * tenant world  → the block runs in its own short worker tenant scope
+ *     (detached, tenant-stamped, exactly one transaction), and the service
+ *     reads inside (`services.instances` / `services.chats` / the direct
+ *     `agents` lookup via `scopedHandle`) are RLS-policed to that tenant;
+ *   * legacy world  → nothing is threaded and the block runs on the ambient
+ *     pool byte-identically to the pre-G5 inline callbacks.
+ *
+ * The scope NEVER spans the outbound side effect: `plugin.sendMessage` (a
+ * channel network call) and `agentRunner.runOrStream` (an 11-14s agent run)
+ * execute strictly AFTER the resolution scope closes — a worker transaction
+ * must not outlive its work item, and holding one across a network call would
+ * pin a pooled connection for the duration (the G4 leg-2 trap).
+ */
+
+import type { AgentCallContext, AgentRunResult, CallAgentActionConfig } from '@omni/core';
+import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import { agents } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import type { Services } from '../services';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
+import { getPlugin } from './loader';
+
+const log = createLogger('automation-actions');
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve chat UUID → channel-native external_id for a call_agent invocation.
+ *
+ * Symmetric with the send_message action (below) which already auto-resolves
+ * UUIDs for the same reason: system-initiated events (chat.idle_timeout) emit
+ * payload.chatId as the internal chats.id UUID, but the seller dispatch path
+ * carries the external_id (e.g. WA phone). Without resolution, the agent
+ * runner's computeSessionId produces session_ids that diverge from sessions
+ * created by the seller path.
+ *
+ * Also resolves senderId — extractAgentCallContext falls back senderId=chatId
+ * when payload.from/senderId are absent (follow-up events).
+ *
+ * On missing chat row, logs a warning and falls through with the raw UUID so
+ * the call still runs (avoids hard-failing the automation action). The chat
+ * read runs in its own short worker scope for the threaded tenant: a
+ * cross-tenant UUID is simply not found (RLS), which degrades exactly like a
+ * missing row. Legacy (nothing threaded) reads the ambient pool as before.
+ */
+async function resolveCallAgentChatIds(
+  services: Services,
+  db: Database,
+  ctx: { chatId: string; senderId: string; instanceId: string },
+  trustedTenantId: string | null,
+): Promise<{ chatId: string; senderId: string }> {
+  if (!UUID_RE.test(ctx.chatId)) {
+    return { chatId: ctx.chatId, senderId: ctx.senderId };
+  }
+  try {
+    const chat = await runTenantWorkDb(db, trustedTenantId, () =>
+      services.chats.getById(ctx.chatId, { includeHidden: true }),
+    );
+    return {
+      chatId: chat.externalId,
+      senderId: ctx.senderId === ctx.chatId ? chat.externalId : ctx.senderId,
+    };
+  } catch {
+    log.warn('call_agent: chat UUID not resolvable, using raw value (session may diverge)', {
+      chatId: ctx.chatId,
+      instanceId: ctx.instanceId,
+    });
+    return { chatId: ctx.chatId, senderId: ctx.senderId };
+  }
+}
+
+/** The dependency shape `AutomationService.startEngine` accepts. */
+export interface AutomationEngineDeps {
+  sendMessage: (instanceId: string, to: string, content: string, trustedTenantId?: string | null) => Promise<void>;
+  callAgent: (
+    context: AgentCallContext,
+    config: CallAgentActionConfig,
+    trustedTenantId?: string | null,
+  ) => Promise<AgentRunResult>;
+  staleIdleTimeoutGate: (
+    chatId: string,
+    instanceId: string,
+    eventSequenceIndex: number | null,
+    trustedTenantId?: string | null,
+  ) => Promise<{ skip: boolean; reason?: string }>;
+}
+
+/** Injectable seams (tests only — production uses the module defaults). */
+export interface AutomationEngineDepsOptions {
+  resolvePlugin?: typeof getPlugin;
+}
+
+/**
+ * Build the automation-engine action callbacks over the real services.
+ *
+ * `db` is the ambient pool handle; it is only ever used through the tenancy
+ * bridges (`runTenantWorkDb` / `scopedHandle`), so a legacy invocation
+ * reaches it exactly as the inline callbacks did.
+ */
+export function buildAutomationEngineDeps(
+  services: Services,
+  db: Database,
+  options: AutomationEngineDepsOptions = {},
+): AutomationEngineDeps {
+  const resolvePlugin = options.resolvePlugin ?? getPlugin;
+  return {
+    sendMessage: async (instanceId, to, content, trustedTenantId = null) => {
+      // Discrete read block #1: the instance row. One short worker scope in
+      // the tenant world; ambient passthrough in legacy.
+      const instance = await runTenantWorkDb(db, trustedTenantId, () => services.instances.getById(instanceId));
+      if (!instance) throw new Error(`Instance not found: ${instanceId}`);
+      const plugin = await resolvePlugin(instance.channel);
+      if (!plugin) throw new Error(`No plugin for channel: ${instance.channel}`);
+      // Resolve internal chat UUID → channel-native external_id (e.g. WA JID).
+      // Automation payloads carry chat UUIDs; plugins expect channel JIDs.
+      let recipient = to;
+      if (UUID_RE.test(to)) {
+        // Discrete read block #2 — kept a SEPARATE scope so the plugin lookup
+        // between the reads stays outside any transaction and the legacy
+        // error ordering (no-plugin before chat-not-found) is preserved.
+        try {
+          const chat = await runTenantWorkDb(db, trustedTenantId, () =>
+            services.chats.getById(to, { includeHidden: true }),
+          );
+          recipient = chat.externalId;
+        } catch {
+          throw new Error(`Chat not found for UUID: ${to}`);
+        }
+      }
+      // Outbound side effect strictly AFTER the resolution scopes closed — a
+      // worker transaction must never span a channel network call.
+      await plugin.sendMessage(instanceId, { to: recipient, content: { type: 'text', text: content } });
+    },
+
+    callAgent: async (ctx, cfg, trustedTenantId = null) => {
+      // Discrete read block #1: the instance row.
+      const instance = await runTenantWorkDb(db, trustedTenantId, () => services.instances.getById(ctx.instanceId));
+      if (!instance) throw new Error(`Instance not found: ${ctx.instanceId}`);
+
+      // System-initiated events (chat.idle_timeout) emit payload.chatId as
+      // the internal chats.id UUID; the seller dispatch path carries the
+      // channel-native external_id. Resolve UUID → external_id so the
+      // computed session_id matches sessions created by the seller path.
+      // (Discrete read block #2, inside the resolver.)
+      const { chatId: resolvedChatId, senderId: resolvedSenderId } = await resolveCallAgentChatIds(
+        services,
+        db,
+        ctx,
+        trustedTenantId,
+      );
+
+      const agentFkId = ctx.agentId ?? instance.agentId;
+      if (!agentFkId) throw new Error(`No agent configured for instance ${instance.id}`);
+
+      // Discrete read block #3: the DIRECT agents lookup. `scopedHandle` lands
+      // it on the worker scope's transaction in the tenant world and on the
+      // ambient pool (byte-identical) in legacy.
+      const [agentRow] = await runTenantWorkDb(db, trustedTenantId, () =>
+        scopedHandle(db)
+          .select({
+            name: agents.name,
+            agentProviderId: agents.agentProviderId,
+            agentType: agents.agentType,
+            metadata: agents.metadata,
+            configPath: agents.configPath,
+          })
+          .from(agents)
+          .where(eq(agents.id, agentFkId))
+          .limit(1),
+      );
+      if (!agentRow) throw new Error(`Agent not found: ${agentFkId}`);
+
+      const typeMap: Record<string, 'agent' | 'team' | 'workflow'> = {
+        assistant: 'agent',
+        tool: 'agent',
+        workflow: 'workflow',
+        team: 'team',
+      };
+      const providerAgentId =
+        ((agentRow.metadata as Record<string, unknown> | null)?.providerAgentId as string | undefined) ??
+        agentRow.configPath ??
+        agentRow.name;
+
+      const runInstance = {
+        ...instance,
+        agentProviderId: agentRow.agentProviderId ?? null,
+        agentType: cfg.agentType ?? typeMap[agentRow.agentType] ?? 'agent',
+        agentInternalId: providerAgentId,
+        agentSessionStrategy: cfg.sessionStrategy ?? instance.agentSessionStrategy,
+        agentPrefixSenderName: cfg.prefixSenderName ?? instance.agentPrefixSenderName,
+        agentTimeout: cfg.timeoutMs ? Math.ceil(cfg.timeoutMs / 1000) : instance.agentTimeout,
+      };
+
+      // Honor instance.agentStreamMode — sync mode waits for the full agent run
+      // before sending anything (11-14s on some providers); stream mode returns
+      // progressively. See issue #410. Runs strictly OUTSIDE the resolution
+      // scopes: a worker transaction must never span an agent run.
+      const result = await services.agentRunner.runOrStream({
+        instance: runInstance,
+        chatId: resolvedChatId,
+        senderId: resolvedSenderId,
+        senderName: ctx.senderName,
+        chatType: 'dm',
+        messages: ctx.messages,
+      });
+      return {
+        parts: result.parts,
+        fullResponse: result.parts.join('\n'),
+        metadata: {
+          runId: result.metadata.runId,
+          sessionId: result.metadata.sessionId,
+          status: result.metadata.status,
+        },
+      };
+    },
+
+    // Consumer-side stale-event gate — see engine.handleEvent comment.
+    // Skips chat.idle_timeout events whose row has been disarmed since the
+    // sweeper published the event, or whose chat is in active close-contact
+    // state. Fail-open on errors so a flaky DB doesn't drop legitimate
+    // events.
+    staleIdleTimeoutGate: async (chatId, instanceId, eventSequenceIndex, trustedTenantId) => {
+      return services.followUpLifecycle.evaluateIdleTimeoutFreshness(
+        chatId,
+        instanceId,
+        eventSequenceIndex,
+        trustedTenantId,
+      );
+    },
+  };
+}
+
+/** Test seam: the worker-scope probes drive exactly what production runs. */
+export const __test__ = { resolveCallAgentChatIds, buildAutomationEngineDeps };

--- a/packages/api/src/plugins/connection-gauge.ts
+++ b/packages/api/src/plugins/connection-gauge.ts
@@ -1,0 +1,44 @@
+/**
+ * Platform-wide instance-connection gauge (extracted from `event-listeners.ts`
+ * during the G5 consumer conversion — wish: omni-full-multitenancy, G5).
+ *
+ * This is deliberately its OWN module: it is the one access in the connection
+ * listeners that is NOT tenant work. The gauge counts active instances across
+ * ALL tenants (grouped by channel only — no tenant labels, so it satisfies the
+ * WISH "metrics avoid unbounded tenant labels" by carrying no tenant dimension
+ * at all), which a worker tenant scope can by definition not compute.
+ *
+ * It therefore stays on the ambient pool and keeps its own
+ * `pending-G5-conversion` registration in `tenancy-db-access-guard.ts`: under
+ * RLS enforcement an ambient runtime-role read returns no rows, so the gauge
+ * needs an observability-plane read credential (or a per-tenant emission
+ * design) — a decision recorded there as the open question. Splitting it out
+ * lets the tenant-work sites in `event-listeners.ts` convert and ratchet
+ * without hiding this one behind them.
+ */
+
+import type { Database } from '@omni/db';
+import { instances } from '@omni/db';
+import * as Sentry from '@sentry/bun';
+import { eq, sql } from 'drizzle-orm';
+
+/**
+ * Count active instances per channel type and emit Sentry gauge metrics.
+ * Called on connect/disconnect events to keep the gauge current.
+ */
+export async function emitConnectionGauge(db: Database): Promise<void> {
+  const rows = await db
+    .select({
+      channel: instances.channel,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(instances)
+    .where(eq(instances.isActive, true))
+    .groupBy(instances.channel);
+
+  for (const row of rows) {
+    Sentry.metrics.gauge('instance.connections', row.count, {
+      attributes: { channel_type: row.channel },
+    });
+  }
+}

--- a/packages/api/src/plugins/event-listeners.ts
+++ b/packages/api/src/plugins/event-listeners.ts
@@ -8,11 +8,13 @@
 import { type EventBus, createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
 import { chatIdMappings, chats, instances } from '@omni/db';
-import * as Sentry from '@sentry/bun';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { sentryEnabled } from '../lib/sentry-scrub';
 import { AgentReplayService } from '../services/agent-replay';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 import { sanitizeText } from '../utils/utf8';
+import { emitConnectionGauge } from './connection-gauge';
 import { clearQrCode } from './qr-store';
 
 const instanceLog = createLogger('instance');
@@ -37,19 +39,25 @@ export async function setupConnectionListener(eventBus: EventBus, db?: Database)
       // Clear QR code
       clearQrCode(instanceId);
 
-      // Update database with connection info
+      // Update database with connection info. The write runs in the envelope's
+      // world (G5, ADR-0008): a tenant envelope opens a worker tenant scope and
+      // the update goes through `scopedHandle` inside it; a legacy envelope runs
+      // it on the ambient pool byte-identically; a malformed one is refused here
+      // (quarantine — never processed globally) and lands in the catch.
       if (db) {
         try {
-          await db
-            .update(instances)
-            .set({
-              isActive: true,
-              ownerIdentifier: ownerIdentifier || null,
-              profileName: profileName || null,
-              profilePicUrl: profilePicUrl || null,
-              updatedAt: new Date(),
-            })
-            .where(eq(instances.id, instanceId));
+          await runConsumerInTenantContext(db, event, async () => {
+            await scopedHandle(db)
+              .update(instances)
+              .set({
+                isActive: true,
+                ownerIdentifier: ownerIdentifier || null,
+                profileName: profileName || null,
+                profilePicUrl: profilePicUrl || null,
+                updatedAt: new Date(),
+              })
+              .where(eq(instances.id, instanceId));
+          });
         } catch (dbError) {
           instanceLog.error('Failed to update database', { instanceId, error: String(dbError) });
         }
@@ -81,13 +89,16 @@ export async function setupConnectionListener(eventBus: EventBus, db?: Database)
 
       if (db && isLoggedOut) {
         try {
-          await db
-            .update(instances)
-            .set({
-              isActive: false,
-              updatedAt: new Date(),
-            })
-            .where(eq(instances.id, instanceId));
+          // Same worker-tenant boundary as the connect handler above.
+          await runConsumerInTenantContext(db, event, async () => {
+            await scopedHandle(db)
+              .update(instances)
+              .set({
+                isActive: false,
+                updatedAt: new Date(),
+              })
+              .where(eq(instances.id, instanceId));
+          });
           instanceLog.info('Marked inactive (logged out)', { instanceId });
         } catch (dbError) {
           instanceLog.error('Failed to update database', { instanceId, error: String(dbError) });
@@ -115,27 +126,6 @@ export async function setupConnectionListener(eventBus: EventBus, db?: Database)
     });
   } catch (error) {
     instanceLog.warn('Failed to set up connection listener', { error: String(error) });
-  }
-}
-
-/**
- * Count active instances per channel type and emit Sentry gauge metrics.
- * Called on connect/disconnect events to keep the gauge current.
- */
-async function emitConnectionGauge(db: Database): Promise<void> {
-  const rows = await db
-    .select({
-      channel: instances.channel,
-      count: sql<number>`count(*)::int`,
-    })
-    .from(instances)
-    .where(eq(instances.isActive, true))
-    .groupBy(instances.channel);
-
-  for (const row of rows) {
-    Sentry.metrics.gauge('instance.connections', row.count, {
-      attributes: { channel_type: row.channel },
-    });
   }
 }
 
@@ -180,13 +170,21 @@ export async function setupLidMappingListener(eventBus: EventBus, db?: Database)
       let persisted = 0;
       for (const { lidJid, phoneJid } of mappings) {
         try {
-          await db
-            .insert(chatIdMappings)
-            .values({ instanceId, lidId: lidJid, phoneId: phoneJid, discoveredFrom: 'contacts_sync' })
-            .onConflictDoUpdate({
-              target: [chatIdMappings.instanceId, chatIdMappings.lidId],
-              set: { phoneId: phoneJid, discoveredAt: new Date() },
-            });
+          // Per-ITEM worker scope (G5, ADR-0008), mirroring the per-statement
+          // implicit transactions this loop had before the conversion: one bad
+          // mapping aborts only its own short transaction, and the later items
+          // still persist — wrapping the whole loop in one scope would let a
+          // single failure poison the batch. A legacy envelope runs each insert
+          // on the ambient pool byte-identically.
+          await runConsumerInTenantContext(db, event, async () => {
+            await scopedHandle(db)
+              .insert(chatIdMappings)
+              .values({ instanceId, lidId: lidJid, phoneId: phoneJid, discoveredFrom: 'contacts_sync' })
+              .onConflictDoUpdate({
+                target: [chatIdMappings.instanceId, chatIdMappings.lidId],
+                set: { phoneId: phoneJid, discoveredAt: new Date() },
+              });
+          });
           persisted++;
         } catch {
           // Skip individual failures
@@ -255,7 +253,13 @@ export async function setupContactNamesListener(eventBus: EventBus, db?: Databas
       let updated = 0;
       for (const { jid, name } of names) {
         try {
-          if (await updateChatName(db, instanceId, jid, name)) updated++;
+          // Per-item worker scope (G5) — same shape as the LID batch above.
+          // `updateChatName` receives the scope's handle, so its reads and its
+          // write all run inside the same short tenant transaction.
+          if (
+            await runConsumerInTenantContext(db, event, () => updateChatName(scopedHandle(db), instanceId, jid, name))
+          )
+            updated++;
         } catch {
           // Skip individual failures
         }
@@ -286,11 +290,14 @@ export async function setupChatUnreadListener(eventBus: EventBus, db?: Database)
       if (!instanceId || !chatId) return;
 
       try {
-        const result = await db
-          .update(chats)
-          .set({ unreadCount, updatedAt: new Date() })
-          .where(and(eq(chats.instanceId, instanceId), eq(chats.externalId, chatId)))
-          .returning({ id: chats.id });
+        // Worker tenant boundary (G5, ADR-0008) — see the connect handler.
+        const result = await runConsumerInTenantContext(db, event, () =>
+          scopedHandle(db)
+            .update(chats)
+            .set({ unreadCount, updatedAt: new Date() })
+            .where(and(eq(chats.instanceId, instanceId), eq(chats.externalId, chatId)))
+            .returning({ id: chats.id }),
+        );
 
         if (result.length > 0) {
           unreadLog.debug('Synced unread count from platform', { instanceId, chatId, unreadCount });

--- a/packages/api/src/plugins/event-listeners.ts
+++ b/packages/api/src/plugins/event-listeners.ts
@@ -11,8 +11,8 @@ import { chatIdMappings, chats, instances } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
 import { sentryEnabled } from '../lib/sentry-scrub';
 import { AgentReplayService } from '../services/agent-replay';
-import { scopedHandle } from '../tenancy/tenant-scope';
-import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
+import { runDetachedFromTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { runConsumerInTenantContext, trustedEnvelopeTenant } from '../tenancy/worker-tenant-context';
 import { sanitizeText } from '../utils/utf8';
 import { emitConnectionGauge } from './connection-gauge';
 import { clearQrCode } from './qr-store';
@@ -70,9 +70,23 @@ export async function setupConnectionListener(eventBus: EventBus, db?: Database)
         emitConnectionGauge(db).catch(() => {});
       }
 
-      // Trigger agent replay for missed messages (fire-and-forget)
+      // Trigger agent replay for missed messages (fire-and-forget).
+      //
+      // G5 (ADR-0008): replay interleaves DB pages with `message.received`
+      // PUBLISHES, so it cannot be wrapped in one `runConsumerInTenantContext`
+      // scope — the tenant is derived as a VALUE and threaded, and the service
+      // scopes each discrete block itself. A legacy envelope threads `undefined`
+      // and every block stays ambient, byte-identical to pre-G5; a quarantined
+      // envelope throws before the replay starts and is dropped, never replayed
+      // globally.
+      //
+      // The whole fire-and-forget runs DETACHED (G4 leg-2 rule): a background
+      // continuation must never be able to borrow the handler's ALS scope, in
+      // either world.
       if (replayService) {
-        replayService.onInstanceConnect(instanceId).catch((err) => {
+        void runDetachedFromTenantScope(async () =>
+          replayService.onInstanceConnect(instanceId, trustedEnvelopeTenant(event)),
+        ).catch((err) => {
           instanceLog.warn('Agent replay failed', { instanceId, error: String(err) });
         });
       }
@@ -105,9 +119,13 @@ export async function setupConnectionListener(eventBus: EventBus, db?: Database)
         }
       }
 
-      // Update lastSeenAt on any disconnect so the next replay window is accurate
+      // Update lastSeenAt on any disconnect so the next replay window is accurate.
+      // Same threaded-tenant conversion as the connect handler above — one DB
+      // block, in the envelope's world.
       if (replayService) {
-        replayService.updateLastSeenAt(instanceId).catch((err) => {
+        void runDetachedFromTenantScope(async () =>
+          replayService.updateLastSeenAt(instanceId, undefined, trustedEnvelopeTenant(event)),
+        ).catch((err) => {
           instanceLog.warn('Failed to update lastSeenAt on disconnect', { instanceId, error: String(err) });
         });
       }

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -3,6 +3,20 @@
  *
  * Subscribes to message events and persists them to the omni_events table.
  * This provides the data backing for the /events API endpoints.
+ *
+ * TENANT CONTEXT (G5, ADR-0008)
+ * -----------------------------
+ * These are consumer-only handlers — a NATS subscription, no request, no
+ * credential. Each handler's DB work now runs through
+ * `runConsumerInTenantContext(db, event, ...)`, which reads the versioned
+ * envelope and, when it carries a trusted tenant, opens a fresh worker tenant
+ * scope so the `omni_events` insert and the `chats` lookup are RLS-policed to
+ * that tenant. A legacy envelope (no tenant) runs the same body on the ambient
+ * pool exactly as before — the dual-world contract — and a quarantined envelope
+ * never reaches here (the subscription layer rejects it first). All queries go
+ * through `scopedHandle(db)`, which returns the worker transaction in-scope and
+ * the ambient pool otherwise; the `omni_events` tenant_id is set by the
+ * BEFORE INSERT derivation trigger, so no column is added here.
  */
 
 import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
@@ -10,6 +24,8 @@ import { JOURNEY_STAGES, createLogger, getJourneyTracker, isValidUuid } from '@o
 import type { Database, NewOmniEvent } from '@omni/db';
 import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 import { deepSanitize, sanitizeText } from '../utils/utf8';
 
 const log = createLogger('event-persistence');
@@ -93,36 +109,39 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         }
 
         try {
-          const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
+          await runConsumerInTenantContext(db, event, async () => {
+            const sdb = scopedHandle(db);
+            const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
 
-          const newEvent: NewOmniEvent = {
-            ...eventIdInsert(event.id),
-            externalId: payload.externalId,
-            channel: mapChannelType(metadata.channelType),
-            instanceId: metadata.instanceId,
-            personId: metadata.personId,
-            platformIdentityId: metadata.platformIdentityId,
-            eventType: 'message.received',
-            direction: 'inbound',
-            contentType: mapContentType(payload.content.type),
-            textContent: sanitizeText(payload.content.text),
-            mediaUrl: payload.content.mediaUrl,
-            mediaMimeType: payload.content.mimeType,
-            chatId: payload.chatId,
-            replyToExternalId: payload.replyToId,
-            status: 'received',
-            receivedAt: new Date(event.timestamp),
-            rawPayload: payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined,
-            metadata: {
-              correlationId: metadata.correlationId,
-              from: payload.from,
-            },
-            agentId: metadata.agentId ?? null,
-            conversationId: null,
-            chatUuid,
-          };
+            const newEvent: NewOmniEvent = {
+              ...eventIdInsert(event.id),
+              externalId: payload.externalId,
+              channel: mapChannelType(metadata.channelType),
+              instanceId: metadata.instanceId,
+              personId: metadata.personId,
+              platformIdentityId: metadata.platformIdentityId,
+              eventType: 'message.received',
+              direction: 'inbound',
+              contentType: mapContentType(payload.content.type),
+              textContent: sanitizeText(payload.content.text),
+              mediaUrl: payload.content.mediaUrl,
+              mediaMimeType: payload.content.mimeType,
+              chatId: payload.chatId,
+              replyToExternalId: payload.replyToId,
+              status: 'received',
+              receivedAt: new Date(event.timestamp),
+              rawPayload: payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined,
+              metadata: {
+                correlationId: metadata.correlationId,
+                from: payload.from,
+              },
+              agentId: metadata.agentId ?? null,
+              conversationId: null,
+              chatUuid,
+            };
 
-          await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+          });
 
           // T4: Message stored in database — record journey checkpoint
           if (metadata.timings && metadata.correlationId) {
@@ -152,39 +171,42 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         const metadata = event.metadata;
 
         try {
-          const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
+          await runConsumerInTenantContext(db, event, async () => {
+            const sdb = scopedHandle(db);
+            const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
 
-          const newEvent: NewOmniEvent = {
-            ...eventIdInsert(event.id),
-            externalId: payload.externalId,
-            channel: mapChannelType(metadata.channelType),
-            instanceId: metadata.instanceId,
-            personId: metadata.personId,
-            platformIdentityId: metadata.platformIdentityId,
-            eventType: 'message.sent',
-            direction: 'outbound',
-            contentType: mapContentType(payload.content.type),
-            textContent: sanitizeText(payload.content.text ?? payload.content.caption),
-            mediaUrl: payload.content.mediaUrl,
-            mediaMimeType: payload.content.mimeType,
-            chatId: payload.chatId,
-            replyToExternalId: payload.replyToId,
-            status: 'completed',
-            receivedAt: new Date(event.timestamp),
-            processedAt: new Date(),
-            rawPayload: payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined,
-            metadata: {
-              correlationId: metadata.correlationId,
-              to: payload.to,
-              filename: payload.content.filename,
-              voiceNote: payload.content.isVoiceNote,
-            },
-            agentId: metadata.agentId ?? null,
-            conversationId: null,
-            chatUuid,
-          };
+            const newEvent: NewOmniEvent = {
+              ...eventIdInsert(event.id),
+              externalId: payload.externalId,
+              channel: mapChannelType(metadata.channelType),
+              instanceId: metadata.instanceId,
+              personId: metadata.personId,
+              platformIdentityId: metadata.platformIdentityId,
+              eventType: 'message.sent',
+              direction: 'outbound',
+              contentType: mapContentType(payload.content.type),
+              textContent: sanitizeText(payload.content.text ?? payload.content.caption),
+              mediaUrl: payload.content.mediaUrl,
+              mediaMimeType: payload.content.mimeType,
+              chatId: payload.chatId,
+              replyToExternalId: payload.replyToId,
+              status: 'completed',
+              receivedAt: new Date(event.timestamp),
+              processedAt: new Date(),
+              rawPayload: payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined,
+              metadata: {
+                correlationId: metadata.correlationId,
+                to: payload.to,
+                filename: payload.content.filename,
+                voiceNote: payload.content.isVoiceNote,
+              },
+              agentId: metadata.agentId ?? null,
+              conversationId: null,
+              chatUuid,
+            };
 
-          await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+          });
           log.debug('Persisted message.sent', {
             externalId: payload.externalId,
             instanceId: metadata.instanceId,
@@ -207,36 +229,39 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         const metadata = event.metadata;
 
         try {
-          // Try to update existing event, or create new record
-          const updated = await db
-            .update(omniEvents)
-            .set({
-              deliveredAt: new Date(payload.deliveredAt),
-              status: 'completed',
-            })
-            .where(eq(omniEvents.externalId, payload.externalId))
-            .returning();
+          await runConsumerInTenantContext(db, event, async () => {
+            const sdb = scopedHandle(db);
+            // Try to update existing event, or create new record
+            const updated = await sdb
+              .update(omniEvents)
+              .set({
+                deliveredAt: new Date(payload.deliveredAt),
+                status: 'completed',
+              })
+              .where(eq(omniEvents.externalId, payload.externalId))
+              .returning();
 
-          if (updated.length === 0) {
-            // No existing event found, create a new record
-            const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
-            const newEvent: NewOmniEvent = {
-              ...eventIdInsert(event.id),
-              externalId: payload.externalId,
-              channel: mapChannelType(metadata.channelType),
-              instanceId: metadata.instanceId,
-              eventType: 'message.delivered',
-              direction: 'outbound',
-              chatId: payload.chatId,
-              status: 'completed',
-              receivedAt: new Date(event.timestamp),
-              deliveredAt: new Date(payload.deliveredAt),
-              agentId: metadata.agentId ?? null,
-              conversationId: null,
-              chatUuid,
-            };
-            await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
-          }
+            if (updated.length === 0) {
+              // No existing event found, create a new record
+              const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+              const newEvent: NewOmniEvent = {
+                ...eventIdInsert(event.id),
+                externalId: payload.externalId,
+                channel: mapChannelType(metadata.channelType),
+                instanceId: metadata.instanceId,
+                eventType: 'message.delivered',
+                direction: 'outbound',
+                chatId: payload.chatId,
+                status: 'completed',
+                receivedAt: new Date(event.timestamp),
+                deliveredAt: new Date(payload.deliveredAt),
+                agentId: metadata.agentId ?? null,
+                conversationId: null,
+                chatUuid,
+              };
+              await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            }
+          });
 
           log.debug('Persisted message.delivered', {
             externalId: payload.externalId,
@@ -259,34 +284,37 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         const metadata = event.metadata;
 
         try {
-          const updated = await db
-            .update(omniEvents)
-            .set({
-              readAt: new Date(payload.readAt),
-            })
-            .where(eq(omniEvents.externalId, payload.externalId))
-            .returning();
+          await runConsumerInTenantContext(db, event, async () => {
+            const sdb = scopedHandle(db);
+            const updated = await sdb
+              .update(omniEvents)
+              .set({
+                readAt: new Date(payload.readAt),
+              })
+              .where(eq(omniEvents.externalId, payload.externalId))
+              .returning();
 
-          if (updated.length === 0) {
-            // No existing event found, create a new record
-            const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
-            const newEvent: NewOmniEvent = {
-              ...eventIdInsert(event.id),
-              externalId: payload.externalId,
-              channel: mapChannelType(metadata.channelType),
-              instanceId: metadata.instanceId,
-              eventType: 'message.read',
-              direction: 'outbound',
-              chatId: payload.chatId,
-              status: 'completed',
-              receivedAt: new Date(event.timestamp),
-              readAt: new Date(payload.readAt),
-              agentId: metadata.agentId ?? null,
-              conversationId: null,
-              chatUuid,
-            };
-            await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
-          }
+            if (updated.length === 0) {
+              // No existing event found, create a new record
+              const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+              const newEvent: NewOmniEvent = {
+                ...eventIdInsert(event.id),
+                externalId: payload.externalId,
+                channel: mapChannelType(metadata.channelType),
+                instanceId: metadata.instanceId,
+                eventType: 'message.read',
+                direction: 'outbound',
+                chatId: payload.chatId,
+                status: 'completed',
+                receivedAt: new Date(event.timestamp),
+                readAt: new Date(payload.readAt),
+                agentId: metadata.agentId ?? null,
+                conversationId: null,
+                chatUuid,
+              };
+              await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            }
+          });
 
           log.debug('Persisted message.read', {
             externalId: payload.externalId,
@@ -315,63 +343,69 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         const metadata = event.metadata;
 
         try {
-          // Async failures (e.g. WhatsApp PreKeyError surfaced minutes after a
-          // server-ACKed send) arrive AFTER the original message.sent row was
-          // already persisted with status='completed'. Flip the existing row
-          // to 'failed' instead of inserting a parallel record so the audit
-          // trail stays unambiguous. Match on instance+externalId; fall back
-          // to insert when no original row exists (synchronous failures).
-          let updated: { id: string }[] = [];
-          if (payload.externalId && metadata.instanceId) {
-            updated = await db
-              .update(omniEvents)
-              .set({
+          const updatedRows = await runConsumerInTenantContext(db, event, async () => {
+            const sdb = scopedHandle(db);
+            // Async failures (e.g. WhatsApp PreKeyError surfaced minutes after a
+            // server-ACKed send) arrive AFTER the original message.sent row was
+            // already persisted with status='completed'. Flip the existing row
+            // to 'failed' instead of inserting a parallel record so the audit
+            // trail stays unambiguous. Match on instance+externalId; fall back
+            // to insert when no original row exists (synchronous failures).
+            let updated: { id: string }[] = [];
+            if (payload.externalId && metadata.instanceId) {
+              updated = await sdb
+                .update(omniEvents)
+                .set({
+                  status: 'failed',
+                  errorMessage: payload.error,
+                  errorStage: payload.errorCode,
+                  metadata: {
+                    correlationId: metadata.correlationId,
+                    retryable: payload.retryable,
+                  },
+                })
+                .where(
+                  and(eq(omniEvents.instanceId, metadata.instanceId), eq(omniEvents.externalId, payload.externalId)),
+                )
+                .returning({ id: omniEvents.id });
+            }
+
+            if (updated.length === 0) {
+              // No existing message.sent row to flip — synchronous failure path.
+              // Insert a fresh failed row, mirroring the message.read subscriber
+              // pattern (eventIdInsert for replay-safe deterministic id +
+              // onConflictDoNothing on id for idempotency).
+              const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+              const newEvent: NewOmniEvent = {
+                ...eventIdInsert(event.id),
+                externalId: payload.externalId,
+                channel: mapChannelType(metadata.channelType),
+                instanceId: metadata.instanceId,
+                personId: metadata.personId,
+                eventType: 'message.failed',
+                direction: 'outbound',
+                chatId: payload.chatId,
                 status: 'failed',
                 errorMessage: payload.error,
                 errorStage: payload.errorCode,
+                receivedAt: new Date(event.timestamp),
                 metadata: {
                   correlationId: metadata.correlationId,
                   retryable: payload.retryable,
                 },
-              })
-              .where(and(eq(omniEvents.instanceId, metadata.instanceId), eq(omniEvents.externalId, payload.externalId)))
-              .returning({ id: omniEvents.id });
-          }
-
-          if (updated.length === 0) {
-            // No existing message.sent row to flip — synchronous failure path.
-            // Insert a fresh failed row, mirroring the message.read subscriber
-            // pattern (eventIdInsert for replay-safe deterministic id +
-            // onConflictDoNothing on id for idempotency).
-            const chatUuid = await resolveChatUuid(db, metadata.instanceId, payload.chatId);
-            const newEvent: NewOmniEvent = {
-              ...eventIdInsert(event.id),
-              externalId: payload.externalId,
-              channel: mapChannelType(metadata.channelType),
-              instanceId: metadata.instanceId,
-              personId: metadata.personId,
-              eventType: 'message.failed',
-              direction: 'outbound',
-              chatId: payload.chatId,
-              status: 'failed',
-              errorMessage: payload.error,
-              errorStage: payload.errorCode,
-              receivedAt: new Date(event.timestamp),
-              metadata: {
-                correlationId: metadata.correlationId,
-                retryable: payload.retryable,
-              },
-              agentId: metadata.agentId ?? null,
-              conversationId: null,
-              chatUuid,
-            };
-            await db.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
-          }
+                agentId: metadata.agentId ?? null,
+                conversationId: null,
+                chatUuid,
+              };
+              await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            }
+            return updated.length;
+          });
 
           log.debug('Persisted message.failed', {
             chatId: payload.chatId,
             externalId: payload.externalId,
-            updatedRows: updated.length,
+            updatedRows,
             error: payload.error,
           });
         } catch (error) {

--- a/packages/api/src/plugins/follow-up-hooks.ts
+++ b/packages/api/src/plugins/follow-up-hooks.ts
@@ -14,6 +14,16 @@
  * swallow errors — follow-up lifecycle failures must never abort message
  * processing.
  *
+ * Tenant boundary (G5, ADR-0008): each handler classifies its envelope ONCE
+ * and threads the trusted tenant through every service call — the chat-id
+ * resolution runs inside a short worker scope here, and the lifecycle service
+ * scopes its own DB blocks from the threaded `tenantId` (it publishes events
+ * between blocks, so wrapping the whole handler in one scope would hold a
+ * worker transaction across a publish). A legacy envelope threads nothing and
+ * every call runs on the ambient pool byte-identically; a quarantined envelope
+ * is refused here outright (defense in depth — the subscription layer already
+ * terms it before the handler runs).
+ *
  * @see issue #404 — Configurable Idle-Chat Follow-Up Sequences
  */
 
@@ -24,20 +34,44 @@ import type {
   EventBus,
   MessageReceivedPayload,
   MessageSentPayload,
+  OmniEvent,
 } from '@omni/core';
-import { createLogger } from '@omni/core';
+import { classifyEnvelope, createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
 import type { Services } from '../services';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 
 const log = createLogger('follow-up-hooks');
 
 /**
- * Resolve the DB chat UUID from a message event's external chat id.
- * Returns null when the chat has not been persisted yet — the follow-up row
- * can safely be skipped in that case.
+ * Classify the consumed envelope and return the trusted tenant to thread, or
+ * `null` for a legacy envelope. Throws on quarantine — processing globally is
+ * the fallback ADR-0008 forbids.
  */
-async function resolveChatId(services: Services, instanceId: string, externalId: string): Promise<string | null> {
+function trustedTenantOf(event: Pick<OmniEvent, 'metadata'>): string | null {
+  const classification = classifyEnvelope(event.metadata);
+  if (classification.world === 'quarantine') {
+    throw new Error(`follow-up-hooks: refusing quarantined envelope (${classification.reason})`);
+  }
+  return classification.world === 'tenant' ? classification.tenantId : null;
+}
+
+/**
+ * Resolve the DB chat UUID from a message event's external chat id, inside the
+ * work item's world. Returns null when the chat has not been persisted yet —
+ * the follow-up row can safely be skipped in that case.
+ */
+async function resolveChatId(
+  services: Services,
+  db: Database,
+  tenantId: string | null,
+  instanceId: string,
+  externalId: string,
+): Promise<string | null> {
   try {
-    const chat = await services.chats.findByExternalIdSmart(instanceId, externalId);
+    const chat = await runTenantWorkDb(db, tenantId, () =>
+      services.chats.findByExternalIdSmart(instanceId, externalId),
+    );
     return chat?.id ?? null;
   } catch (err) {
     // findByExternalIdSmart returns null for not-found, so anything thrown
@@ -48,7 +82,7 @@ async function resolveChatId(services: Services, instanceId: string, externalId:
   }
 }
 
-export async function setupFollowUpHooks(eventBus: EventBus, services: Services): Promise<void> {
+export async function setupFollowUpHooks(eventBus: EventBus, services: Services, db: Database): Promise<void> {
   try {
     // ── Outbound agent message → arm sequence ──────────────────────────────
     await eventBus.subscribe(
@@ -62,7 +96,8 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
         const senderAgentId = payload.senderAgentId;
         if (!senderAgentId) return; // Only arm on agent-origin messages.
 
-        const chatId = await resolveChatId(services, instanceId, payload.chatId);
+        const tenantId = trustedTenantOf(event);
+        const chatId = await resolveChatId(services, db, tenantId, instanceId, payload.chatId);
         if (!chatId) return;
 
         await services.followUpLifecycle.armForOutbound({
@@ -70,6 +105,7 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
           instanceId,
           agentId: senderAgentId,
           lastAgentMessageAt: new Date(event.timestamp),
+          tenantId,
         });
       },
       {
@@ -94,7 +130,8 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
         const isFromMe = payload.rawPayload?.isFromMe === true;
         if (isFromMe) return; // Only disarm on customer-origin messages.
 
-        const chatId = await resolveChatId(services, instanceId, payload.chatId);
+        const tenantId = trustedTenantOf(event);
+        const chatId = await resolveChatId(services, db, tenantId, instanceId, payload.chatId);
         if (!chatId) return;
 
         const at = new Date(event.timestamp);
@@ -105,13 +142,14 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
         // `lastInboundCustomerMessageAt` would never advance and the
         // terminal-disarm guard in `armForOutbound` would refuse to re-arm
         // even after the customer genuinely returns. See #419.
-        await services.followUpLifecycle.touchInboundTimestamp({ chatId, instanceId, at });
+        await services.followUpLifecycle.touchInboundTimestamp({ chatId, instanceId, at, tenantId });
 
         await services.followUpLifecycle.disarm({
           chatId,
           instanceId,
           reason: 'customer_replied',
           lastInboundCustomerMessageAt: at,
+          tenantId,
         });
       },
       {
@@ -134,6 +172,7 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
           instanceId: payload.instanceId,
           agentId: payload.agentId ?? null,
           reason: 'handoff',
+          tenantId: trustedTenantOf(event),
         });
       },
       {
@@ -154,6 +193,7 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
           chatId: payload.chatId,
           instanceId: payload.instanceId,
           reason: 'archived',
+          tenantId: trustedTenantOf(event),
         });
       },
       {
@@ -175,6 +215,7 @@ export async function setupFollowUpHooks(eventBus: EventBus, services: Services)
           instanceId: payload.instanceId,
           agentId: payload.agentId ?? null,
           reason: 'contact_closed',
+          tenantId: trustedTenantOf(event),
         });
       },
       {

--- a/packages/api/src/plugins/instance-monitor.ts
+++ b/packages/api/src/plugins/instance-monitor.ts
@@ -12,6 +12,7 @@ import type { Database } from '@omni/db';
 import { instances } from '@omni/db';
 import { eq } from 'drizzle-orm';
 
+import { rememberInstanceOwners } from '../tenancy/instance-owner-registry';
 import { createLogger } from './logger';
 
 const logger = createLogger({ module: 'instance-monitor' });
@@ -25,6 +26,8 @@ interface InstanceInfo {
   name: string;
   channel: string;
   ownerIdentifier: string | null;
+  /** Persisted ownership (G2 root), carried so the sweep can seed the registry. */
+  tenantId: string | null;
 }
 
 interface ReconnectState {
@@ -391,15 +394,23 @@ export class InstanceMonitor {
    * Fetch all active instances from database
    */
   private async fetchActiveInstances(): Promise<InstanceInfo[]> {
-    return this.db
+    const rows = await this.db
       .select({
         id: instances.id,
         name: instances.name,
         channel: instances.channel,
         ownerIdentifier: instances.ownerIdentifier,
+        tenantId: instances.tenantId,
       })
       .from(instances)
       .where(eq(instances.isActive, true));
+
+    // G5 (ADR-0008): this health-check sweep is one of the few places the
+    // process loads EVERY active instance row, so it is a natural place to
+    // teach the ownership registry that lets channel-plugin publishes stamp a
+    // trusted tenant. See `tenancy/instance-owner-registry.ts`.
+    rememberInstanceOwners(rows);
+    return rows;
   }
 
   /**
@@ -610,6 +621,7 @@ export class InstanceMonitor {
     twilioValidateSignature?: boolean | null;
   } | null> {
     const [instance] = await this.db.select().from(instances).where(eq(instances.id, instanceId)).limit(1);
+    if (instance) rememberInstanceOwners([instance]);
     return instance ?? null;
   }
 
@@ -678,6 +690,13 @@ export async function reconnectWithPool(
   const { maxConcurrent = 3, delayBetweenMs = 500 } = options;
 
   const activeInstances = await db.select().from(instances).where(eq(instances.isActive, true));
+
+  // G5 (ADR-0008): the startup reconnect is the FIRST bulk load of instance
+  // rows in the process, and it happens before any channel plugin can emit —
+  // so seeding the ownership registry here is what makes the very first
+  // `message.received` of a boot carry a trusted tenant rather than a legacy
+  // envelope.
+  rememberInstanceOwners(activeInstances);
 
   logger.info('Starting pooled reconnection', {
     instanceCount: activeInstances.length,

--- a/packages/api/src/plugins/instance-monitor.ts
+++ b/packages/api/src/plugins/instance-monitor.ts
@@ -5,6 +5,36 @@
  * - Health monitoring with periodic checks
  * - Automatic reconnection with exponential backoff
  * - Connection pooling to limit concurrent operations
+ *
+ * WORKER TENANT CONTEXT (wish: omni-full-multitenancy, G5; ADR-0008)
+ * ------------------------------------------------------------------
+ * This module is periodic work: a 30-second health INTERVAL, a 5-second
+ * reconnect drain, and a once-per-boot pooled reconnect. None of them has a
+ * request, a credential or an envelope, so nothing hands them a tenant. Before
+ * the conversion every path read the WHOLE `instances` table and then re-read /
+ * DEACTIVATED single rows on the ambient pool — the unscoped worker access that
+ * kept `plugins/instance-monitor.ts::instances` in `pending-G5-conversion`.
+ *
+ * Two shapes, both established by earlier legs:
+ *
+ *   * WHOLE-TABLE SWEEPS (`runHealthCheck`, `reconnectWithPool`) adopt
+ *     `runForEachActiveTenantRow` — the daily-sync / turn-monitor precedent. A
+ *     cron must ENUMERATE whose work exists (under RLS enforcement the global
+ *     scan is not expressible at all), and only the discrete `listActive` READ
+ *     is scoped: the per-row plugin `getStatus`/`connect` calls are NETWORK work
+ *     and must never be held inside a worker transaction.
+ *   * SINGLE-ROW PATHS (`fetchInstanceById`, `markInstanceInactive`) derive
+ *     their tenant from the INSTANCE-OWNER REGISTRY — the same trusted
+ *     persisted-ownership derivation the publish path uses, and one this module
+ *     already feeds from every row it loads. The reconnect queue is an in-memory
+ *     structure keyed by instance id with no envelope of its own, so the
+ *     registry is the only non-caller-controlled answer available to it.
+ *
+ * THE DUAL WORLD: with no auth plane wired (`setAuthPlane` never called — the
+ * shape every existing test and every flag-off deployment produces), or with the
+ * flag off, every path is EXACTLY the pre-G5 one: one ambient scan, no
+ * enumeration, not one additional query. The tenant fan-out binds only to the
+ * multitenancy world, where tenants exist at all.
  */
 
 import type { ChannelPlugin, ChannelRegistry } from '@omni/channel-sdk';
@@ -12,7 +42,10 @@ import type { Database } from '@omni/db';
 import { instances } from '@omni/db';
 import { eq } from 'drizzle-orm';
 
-import { rememberInstanceOwners } from '../tenancy/instance-owner-registry';
+import { lookupInstanceOwner, rememberInstanceOwners } from '../tenancy/instance-owner-registry';
+import { runForEachActiveTenantRow } from '../tenancy/periodic-tenant-work';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import { createLogger } from './logger';
 
 const logger = createLogger({ module: 'instance-monitor' });
@@ -324,12 +357,65 @@ export class InstanceMonitor {
   private activeReconnects = 0;
   private isRunning = false;
 
+  /**
+   * The auth-plane read connection, injected after construction by `index.ts`
+   * (mirrors `batchJobs.setAuthPlane` / `followUpSweeper.setAuthPlane`). Per
+   * ADR-0003 it is the only runtime-process identity that may enumerate
+   * `tenants`, and its ABSENCE is the legacy world: without it every sweep is
+   * the pre-G5 single ambient pass.
+   */
+  private authPlaneDb: Database | null = null;
+  /** Environment used for the flag/enforcement decisions. Tests override it. */
+  private env: NodeJS.ProcessEnv | undefined;
+
+  /**
+   * The handle every query in this class uses.
+   *
+   * Opening a worker tenant scope is only half the conversion: the scope carries
+   * the tenant-stamped TRANSACTION, and `set_config('app.tenant_id', …, true)`
+   * is transaction-local. A query issued on the injected pool inside that scope
+   * takes a DIFFERENT pooled connection, which never saw the stamp — unscoped
+   * before enforcement, fail-closed under RLS, and invisible to any probe that
+   * only asserts `currentTenantScope()`. `scopedHandle` is the one bridge, and
+   * it is the same accessor every converted service uses (`services/batch-jobs.ts`,
+   * `services/agent-replay.ts`). Outside a scope it returns the ambient pool, so
+   * the legacy/flag-off statement is byte-for-byte the pre-G5 one.
+   */
+  private get db(): Database {
+    return scopedHandle(this.pool);
+  }
+
   constructor(
-    private readonly db: Database,
+    private readonly pool: Database,
     private readonly registry: ChannelRegistry,
     config: MonitorConfig = {},
   ) {
     this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Opt this monitor into the tenant fan-out (wired by `index.ts` once services
+   * exist). Until it is called the monitor runs its pre-G5 ambient sweep; the
+   * first health check is a full interval away, so wiring during the same
+   * startup tick happens long before any tick fires.
+   */
+  setAuthPlane(authPlaneDb: Database, env?: NodeJS.ProcessEnv): void {
+    this.authPlaneDb = authPlaneDb;
+    this.env = env;
+  }
+
+  /**
+   * The TRUSTED tenant of a single instance, for the paths that hold only an
+   * instance id (the in-memory reconnect queue, `forceReconnect`).
+   *
+   * Read from the instance-owner registry — persisted `instances.tenant_id` this
+   * process already loaded — never from any caller-supplied value. Unknown
+   * instances resolve to `null` and their block runs exactly as it did pre-G5
+   * (and fails closed under enforcement, which is the correct posture for an
+   * instance whose ownership this process has never observed).
+   */
+  private tenantOf(instanceId: string): string | null {
+    return lookupInstanceOwner(instanceId);
   }
 
   /**
@@ -379,15 +465,39 @@ export class InstanceMonitor {
   }
 
   /**
-   * Run health check on all active instances
+   * Run health check on all active instances.
+   *
+   * G5 (ADR-0008): the sweep is fanned out across tenants. Only the discrete
+   * `fetchActiveInstances` READ runs inside a tenant's worker scope; the
+   * per-instance health probe (`checkInstanceHealth` → `plugin.getStatus`) is a
+   * network/in-process plugin call and runs OUTSIDE it, so no pooled connection
+   * is pinned across the round trip.
+   *
+   * Legacy (no auth plane wired, or flag off): the helper runs exactly one
+   * ambient pass with `tenantId === null` — the pre-G5 loop, statement for
+   * statement.
    */
   async runHealthCheck(): Promise<void> {
-    const activeInstances = await this.fetchActiveInstances();
-    if (activeInstances.length === 0) return;
-
-    for (const instance of activeInstances) {
-      await this.checkInstanceHealth(instance);
+    if (!this.authPlaneDb) {
+      const activeInstances = await this.fetchActiveInstances();
+      for (const instance of activeInstances) {
+        await this.checkInstanceHealth(instance);
+      }
+      return;
     }
+
+    await runForEachActiveTenantRow(
+      {
+        // The POOL: the fan-out opens the per-tenant transaction itself. Queries
+        // inside the scope reach it through `this.db` (`scopedHandle`).
+        db: this.pool,
+        authPlaneDb: this.authPlaneDb,
+        jobName: 'instance-health-check',
+        listActive: () => this.fetchActiveInstances(),
+        env: this.env,
+      },
+      (instance) => this.checkInstanceHealth(instance),
+    );
   }
 
   /**
@@ -620,16 +730,27 @@ export class InstanceMonitor {
     twilioWebhookUrl?: string | null;
     twilioValidateSignature?: boolean | null;
   } | null> {
-    const [instance] = await this.db.select().from(instances).where(eq(instances.id, instanceId)).limit(1);
+    // Discrete DB block in the INSTANCE's own world: its tenant comes from the
+    // ownership registry, not from the queue entry that asked for it.
+    const [instance] = await runTenantWorkDb(this.pool, this.tenantOf(instanceId), () =>
+      this.db.select().from(instances).where(eq(instances.id, instanceId)).limit(1),
+    );
     if (instance) rememberInstanceOwners([instance]);
     return instance ?? null;
   }
 
   /**
-   * Mark an instance as inactive in the database
+   * Mark an instance as inactive in the database.
+   *
+   * This is the sweep's only WRITE, and it is a deactivation — exactly the
+   * effect that must never cross a tenant boundary. Same registry-derived
+   * tenant as the read above; ambient (and fail-closed under enforcement) for an
+   * instance whose ownership this process never observed.
    */
   private async markInstanceInactive(instanceId: string): Promise<void> {
-    await this.db.update(instances).set({ isActive: false }).where(eq(instances.id, instanceId));
+    await runTenantWorkDb(this.pool, this.tenantOf(instanceId), () =>
+      this.db.update(instances).set({ isActive: false }).where(eq(instances.id, instanceId)),
+    );
     logger.info('Marked instance as inactive', { instanceId });
   }
 
@@ -680,43 +801,86 @@ export class InstanceMonitor {
 // ============================================================================
 
 /**
- * Reconnect instances with connection pooling
+ * Reconnect instances with connection pooling.
+ *
+ * G5 (ADR-0008): the startup reconnect is a whole-table `instances` scan with no
+ * request and no credential, so it is fanned out across tenants exactly like the
+ * health check. `authPlaneDb` is what opts it in — `index.ts` resolves an
+ * auth-plane handle for the duration of the boot reconnect and closes it right
+ * after, because at that point in startup the long-lived services (and their
+ * `services.authPlane`) do not exist yet. Without it this is the pre-G5 single
+ * ambient scan, byte for byte.
+ *
+ * The connect itself is a NETWORK call per instance and stays outside every
+ * scope: only the row READ is scoped.
  */
 export async function reconnectWithPool(
   db: Database,
   registry: ChannelRegistry,
-  options: { maxConcurrent?: number; delayBetweenMs?: number } = {},
+  options: {
+    maxConcurrent?: number;
+    delayBetweenMs?: number;
+    authPlaneDb?: Database;
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): Promise<ReconnectResults> {
-  const { maxConcurrent = 3, delayBetweenMs = 500 } = options;
+  const { maxConcurrent = 3, delayBetweenMs = 500, authPlaneDb, env } = options;
 
-  const activeInstances = await db.select().from(instances).where(eq(instances.isActive, true));
+  const results: ReconnectResults = { attempted: 0, succeeded: 0, failed: 0, errors: [] };
 
-  // G5 (ADR-0008): the startup reconnect is the FIRST bulk load of instance
-  // rows in the process, and it happens before any channel plugin can emit —
-  // so seeding the ownership registry here is what makes the very first
-  // `message.received` of a boot carry a trusted tenant rather than a legacy
-  // envelope.
-  rememberInstanceOwners(activeInstances);
-
-  logger.info('Starting pooled reconnection', {
-    instanceCount: activeInstances.length,
-    maxConcurrent,
-    delayBetweenMs,
-  });
-
-  const results: ReconnectResults = {
-    attempted: activeInstances.length,
-    succeeded: 0,
-    failed: 0,
-    errors: [],
+  const loadActive = async (): Promise<
+    Array<{ id: string; name: string; channel: string; tenantId: string | null }>
+  > => {
+    // `scopedHandle` for the same reason the class uses it: inside a per-tenant
+    // worker scope this is that tenant's stamped transaction, and outside one it
+    // is `db` itself — the pre-G5 statement, unchanged.
+    const rows = await scopedHandle(db).select().from(instances).where(eq(instances.isActive, true));
+    // G5 (ADR-0008): the startup reconnect is the FIRST bulk load of instance
+    // rows in the process, and it happens before any channel plugin can emit —
+    // so seeding the ownership registry here is what makes the very first
+    // `message.received` of a boot carry a trusted tenant rather than a legacy
+    // envelope.
+    rememberInstanceOwners(rows);
+    return rows as Array<{ id: string; name: string; channel: string; tenantId: string | null }>;
   };
 
-  if (activeInstances.length === 0) {
+  // LEGACY WORLD: one ambient scan, then the pre-G5 batching. Unchanged.
+  if (!authPlaneDb) {
+    const activeInstances = await loadActive();
+    results.attempted = activeInstances.length;
+    logger.info('Starting pooled reconnection', {
+      instanceCount: activeInstances.length,
+      maxConcurrent,
+      delayBetweenMs,
+    });
+    if (activeInstances.length === 0) return results;
+    await processInstanceBatches(activeInstances, registry, db, results, maxConcurrent, delayBetweenMs);
+    logger.info('Pooled reconnection complete', { ...results });
     return results;
   }
 
-  await processInstanceBatches(activeInstances, registry, db, results, maxConcurrent, delayBetweenMs);
+  // TENANT WORLD: the read is scoped per active tenant; the batching (and every
+  // `plugin.connect`) runs outside that scope.
+  //
+  // The enumerated rows are collected into ONE pending list and batched
+  // together, so `maxConcurrent` stays the process-wide ceiling it has always
+  // been and the waves are tenant-MIXED. That is deliberate: the ceiling exists
+  // to protect this process's socket/CPU budget at boot, and making it
+  // per-tenant would multiply the real concurrency by the tenant count. Pinned
+  // by the `concurrency ceiling is GLOBAL` probe in
+  // `plugins/__tests__/instance-monitor-worker-scope.test.ts`.
+  const pending: Array<{ id: string; name: string; channel: string }> = [];
+  await runForEachActiveTenantRow(
+    { db, authPlaneDb, jobName: 'startup-reconnect', listActive: loadActive, env },
+    async (instance) => {
+      pending.push(instance);
+    },
+  );
+  results.attempted = pending.length;
+  logger.info('Starting pooled reconnection', { instanceCount: pending.length, maxConcurrent, delayBetweenMs });
+  if (pending.length === 0) return results;
 
+  await processInstanceBatches(pending, registry, db, results, maxConcurrent, delayBetweenMs);
   logger.info('Pooled reconnection complete', { ...results });
   return results;
 }

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -219,7 +219,14 @@ async function downloadMediaFromUrl(
       fetchOptions,
       trustedTenantId,
     );
-    await ctx.mediaStorage.updateMessageLocalPath(messageId, result.localPath);
+    // The message write is a discrete DB block, so it gets its own short worker
+    // scope (G5, ADR-0008): `storeFromUrl` above is a NETWORK download and must
+    // never be held inside a worker transaction, and this write must not land on
+    // the ambient pool while the rest of the item runs tenant-scoped. This was
+    // the last unscoped caller of `services/media-storage.ts::messages`; a
+    // legacy envelope (`trustedTenantId` undefined) still writes ambient,
+    // byte-identically to pre-G5.
+    await runMediaDb(ctx, trustedTenantId, () => ctx.mediaStorage.updateMessageLocalPath(messageId, result.localPath));
     log.debug('Downloaded media from URL', { messageId, filePath: result.localPath });
     return result.localPath;
   } catch (error) {
@@ -768,6 +775,7 @@ export const __test__ = {
   persistProcessingResult,
   resolveSafeMediaContentEventId,
   processMessageMedia,
+  downloadMediaFromUrl,
 };
 
 export type { MediaProcessorContext };

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -16,7 +16,7 @@
  * @see media-processing-realtime wish
  */
 
-import type { ChannelType, EventBus, MessageReceivedPayload } from '@omni/core';
+import type { ChannelType, EventBus, MessageReceivedPayload, OmniEvent } from '@omni/core';
 import { createLogger, isValidUuid } from '@omni/core';
 import type { Database } from '@omni/db';
 import { mediaContent, messages, omniEvents } from '@omni/db';
@@ -30,6 +30,8 @@ import {
 import { eq } from 'drizzle-orm';
 import type { Services } from '../services';
 import { MediaStorageService } from '../services/media-storage';
+import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 
 const log = createLogger('media-processor');
 
@@ -272,7 +274,7 @@ async function resolveSafeMediaContentEventId(
 
   while (true) {
     try {
-      const [event] = await ctx.db
+      const [event] = await scopedHandle(ctx.db)
         .select({ id: omniEvents.id })
         .from(omniEvents)
         .where(eq(omniEvents.id, eventId))
@@ -307,18 +309,28 @@ async function persistProcessingResult(
   if (result.content) {
     const updateField = getContentFieldForType(result.processingType, contentType);
     if (updateField) {
-      await ctx.db
+      await scopedHandle(ctx.db)
         .update(messages)
         .set({ [updateField]: result.content })
         .where(eq(messages.id, messageId));
     }
   }
 
-  // Store result in media_content table (non-critical analytics/audit record)
+  // Store result in media_content table (non-critical analytics/audit record).
+  //
+  // When this runs inside a worker tenant scope, the message update above and
+  // this insert share ONE transaction, so a failed insert (an RLS/FK rejection,
+  // an ambiguous derivation) would abort the transaction and roll back the
+  // CRITICAL message content write. On the legacy ambient pool each statement is
+  // its own implicit transaction, so a failed audit insert never touched the
+  // already-committed message update. To preserve that priority under a scope we
+  // isolate the insert in a SAVEPOINT (`tx.transaction()` nests as one): a
+  // failure rolls back only the audit row. Outside a scope the insert runs
+  // exactly as before — byte-identical to pre-G5.
   try {
     const safeEventId = await resolveSafeMediaContentEventId(ctx, eventId);
-
-    await ctx.db.insert(mediaContent).values({
+    const sdb = scopedHandle(ctx.db);
+    const row = {
       eventId: safeEventId,
       mediaId: messageId,
       processingType: result.processingType,
@@ -330,7 +342,14 @@ async function persistProcessingResult(
       tokensUsed: result.inputTokens ? result.inputTokens + (result.outputTokens ?? 0) : undefined,
       costUsd: result.costCents != null ? String(Math.round(result.costCents)) : null,
       processingTimeMs: result.processingTimeMs,
-    });
+    };
+    if (currentTenantScope()) {
+      await sdb.transaction(async (sp) => {
+        await sp.insert(mediaContent).values(row);
+      });
+    } else {
+      await sdb.insert(mediaContent).values(row);
+    }
   } catch (error) {
     log.warn('Failed to insert media_content record (non-critical)', {
       messageId,
@@ -357,6 +376,11 @@ async function processMessageMedia(
   ctx: MediaProcessorContext,
   payload: MessageReceivedPayload,
   metadata: { instanceId: string; eventId?: string; channelType?: ChannelType },
+  // The versioned envelope of the message.received event this work item processes.
+  // Its trusted tenant (or `legacy`, flag-off) scopes every DB write below via
+  // `runConsumerInTenantContext`; the media download/AI work stays OUTSIDE the
+  // tenant transaction so no transaction is held across network I/O.
+  envelope: Pick<OmniEvent, 'metadata'>,
 ): Promise<void> {
   const { instanceId, eventId } = metadata;
   const { content, externalId } = payload;
@@ -405,10 +429,12 @@ async function processMessageMedia(
     const errorColumn = getContentFieldForType(processingType, content.type);
     if (errorColumn) {
       const marker = `[error: media processing failed — ${reason}]`;
-      await ctx.db
-        .update(messages)
-        .set({ [errorColumn]: marker })
-        .where(eq(messages.id, media.messageId));
+      await runConsumerInTenantContext(ctx.db, envelope, async () => {
+        await scopedHandle(ctx.db)
+          .update(messages)
+          .set({ [errorColumn]: marker })
+          .where(eq(messages.id, media.messageId));
+      });
     }
 
     // Publish media.processing.failed event (dedicated failure event)
@@ -440,7 +466,9 @@ async function processMessageMedia(
     return;
   }
 
-  await persistProcessingResult(ctx, media.messageId, eventId, result, content.type);
+  await runConsumerInTenantContext(ctx.db, envelope, () =>
+    persistProcessingResult(ctx, media.messageId, eventId, result, content.type),
+  );
 
   log.info('Media processing complete', {
     messageId: media.messageId,
@@ -606,11 +634,16 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
       if (!shouldProcess(payload.content.type)) return;
 
       try {
-        await processMessageMedia(ctx, payload, {
-          instanceId: metadata.instanceId,
-          eventId: event.id,
-          channelType: metadata.channelType,
-        });
+        await processMessageMedia(
+          ctx,
+          payload,
+          {
+            instanceId: metadata.instanceId,
+            eventId: event.id,
+            channelType: metadata.channelType,
+          },
+          event,
+        );
       } catch (error) {
         log.error('Failed to process media', {
           externalId: payload.externalId,

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -17,7 +17,7 @@
  */
 
 import type { ChannelType, EventBus, MessageReceivedPayload, OmniEvent } from '@omni/core';
-import { createLogger, isValidUuid } from '@omni/core';
+import { classifyEnvelope, createLogger, isValidUuid } from '@omni/core';
 import type { Database } from '@omni/db';
 import { mediaContent, messages, omniEvents } from '@omni/db';
 import {
@@ -86,6 +86,18 @@ function shouldProcess(contentType: string | undefined): boolean {
 
 function isUuid(value: string | undefined): value is string {
   return typeof value === 'string' && isValidUuid(value);
+}
+
+/**
+ * The trusted tenant for a tenant-context storage write, or undefined for a
+ * legacy/flag-off (or non-tenant) envelope. Read from the versioned envelope the
+ * producer stamped (never a payload/request field), so a tenant-prefixed object
+ * key is emitted only for a genuine tenant-context write and a legacy envelope
+ * keeps the byte-identical pre-G5 key layout (ADR-0008).
+ */
+function envelopeTenantId(envelope: Pick<OmniEvent, 'metadata'>): string | undefined {
+  const classification = classifyEnvelope(envelope.metadata);
+  return classification.world === 'tenant' ? classification.tenantId : undefined;
 }
 
 /**
@@ -174,6 +186,7 @@ async function downloadMediaFromUrl(
   mimeType: string,
   platformTimestamp: Date | undefined,
   channelType?: ChannelType,
+  trustedTenantId?: string,
 ): Promise<string | null> {
   const fetchOptions = await buildFetchOptions(ctx, instanceId, channelType);
   try {
@@ -184,6 +197,7 @@ async function downloadMediaFromUrl(
       mimeType,
       platformTimestamp,
       fetchOptions,
+      trustedTenantId,
     );
     await ctx.mediaStorage.updateMessageLocalPath(messageId, result.localPath);
     log.debug('Downloaded media from URL', { messageId, filePath: result.localPath });
@@ -206,6 +220,7 @@ async function resolveMediaPath(
   content: MessageReceivedPayload['content'],
   mimeType: string,
   channelType?: ChannelType,
+  trustedTenantId?: string,
 ): Promise<MediaResolution | null> {
   // Wait briefly for message-persistence to create the DB row (race condition:
   // both media-processor and message-persistence subscribe to message.received)
@@ -245,6 +260,7 @@ async function resolveMediaPath(
       mimeType,
       message.platformTimestamp ?? undefined,
       channelType,
+      trustedTenantId,
     );
     if (!filePath) return null;
   }
@@ -262,9 +278,11 @@ async function resolveMediaPath(
 
 async function resolveSafeMediaContentEventId(
   ctx: MediaProcessorContext,
+  envelope: Pick<OmniEvent, 'metadata'>,
   eventId: string | undefined,
 ): Promise<string | null> {
   if (!isUuid(eventId)) return null;
+  const id = eventId;
 
   // media_content is audit/replay metadata, so do not block media.processed for long.
   // Event persistence runs concurrently with this processor and should normally win within milliseconds.
@@ -273,21 +291,32 @@ async function resolveSafeMediaContentEventId(
   const deadline = Date.now() + maxWaitMs;
 
   while (true) {
+    // Carry-forward #2: each existence check runs in its OWN short worker tenant
+    // scope, resolved BEFORE the persist scope opens. The <=250ms poll therefore
+    // never holds the persist transaction open across its `setTimeout` sleeps —
+    // the sleeps happen between scopes, on no open transaction. The `omni_events`
+    // read still runs under a worker scope through `scopedHandle`, so the site
+    // stays a tenant-boundary: a plain ambient read would both regress that
+    // classification AND, under RLS, see nothing (the FK would never resolve).
+    let found: string | null;
     try {
-      const [event] = await scopedHandle(ctx.db)
-        .select({ id: omniEvents.id })
-        .from(omniEvents)
-        .where(eq(omniEvents.id, eventId))
-        .limit(1);
-
-      if (event) return event.id;
+      found = await runConsumerInTenantContext(ctx.db, envelope, async () => {
+        const [event] = await scopedHandle(ctx.db)
+          .select({ id: omniEvents.id })
+          .from(omniEvents)
+          .where(eq(omniEvents.id, id))
+          .limit(1);
+        return event?.id ?? null;
+      });
     } catch (error) {
-      log.debug('Failed to validate media_content event FK', { eventId, error: String(error) });
+      log.debug('Failed to validate media_content event FK', { eventId: id, error: String(error) });
       return null;
     }
 
+    if (found) return found;
+
     if (Date.now() >= deadline) {
-      log.debug('Skipping media_content event FK; omni_event not found', { eventId });
+      log.debug('Skipping media_content event FK; omni_event not found', { eventId: id });
       return null;
     }
 
@@ -301,7 +330,11 @@ async function resolveSafeMediaContentEventId(
 async function persistProcessingResult(
   ctx: MediaProcessorContext,
   messageId: string,
-  eventId: string | undefined,
+  // The media_content FK, already resolved (carry-forward #2) in its OWN short
+  // worker scope BEFORE this persist scope opened — so the <=250ms omni_events
+  // existence poll never holds this transaction open across its sleeps. `null`
+  // means "no safe FK" (missing/unresolvable event); the row is stored FK-less.
+  safeEventId: string | null | undefined,
   result: Awaited<ReturnType<MediaProcessingService['process']>>,
   contentType?: string,
 ): Promise<void> {
@@ -328,10 +361,9 @@ async function persistProcessingResult(
   // failure rolls back only the audit row. Outside a scope the insert runs
   // exactly as before — byte-identical to pre-G5.
   try {
-    const safeEventId = await resolveSafeMediaContentEventId(ctx, eventId);
     const sdb = scopedHandle(ctx.db);
     const row = {
-      eventId: safeEventId,
+      eventId: safeEventId ?? null,
       mediaId: messageId,
       processingType: result.processingType,
       content: result.content ?? '',
@@ -385,6 +417,10 @@ async function processMessageMedia(
   const { instanceId, eventId } = metadata;
   const { content, externalId } = payload;
   const mimeType = getMimeType(content);
+  // The trusted tenant for any object this work item stores (ADR-0008), read
+  // from the versioned envelope — undefined for a legacy envelope, which keeps
+  // the byte-identical pre-G5 key layout.
+  const trustedTenantId = envelopeTenantId(envelope);
 
   if (!mimeType || !ctx.mediaService.canProcess(mimeType)) {
     log.debug('MIME type not processable or missing', { mimeType, externalId });
@@ -399,6 +435,7 @@ async function processMessageMedia(
     content,
     mimeType,
     metadata.channelType,
+    trustedTenantId,
   );
   if (!media) return;
 
@@ -466,8 +503,13 @@ async function processMessageMedia(
     return;
   }
 
+  // Carry-forward #2: resolve the media_content FK in its OWN short worker
+  // scope(s) FIRST — the <=250ms omni_events poll runs and releases here, so the
+  // persist scope below never holds its transaction open across the poll's sleeps.
+  const safeEventId = await resolveSafeMediaContentEventId(ctx, envelope, eventId);
+
   await runConsumerInTenantContext(ctx.db, envelope, () =>
-    persistProcessingResult(ctx, media.messageId, eventId, result, content.type),
+    persistProcessingResult(ctx, media.messageId, safeEventId, result, content.type),
   );
 
   log.info('Media processing complete', {

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -31,7 +31,7 @@ import { eq } from 'drizzle-orm';
 import type { Services } from '../services';
 import { MediaStorageService } from '../services/media-storage';
 import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
-import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
+import { runConsumerInTenantContext, runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
 
 const log = createLogger('media-processor');
 
@@ -101,6 +101,25 @@ function envelopeTenantId(envelope: Pick<OmniEvent, 'metadata'>): string | undef
 }
 
 /**
+ * Run one DISCRETE media-processing DB block in the message's world (G5,
+ * ADR-0008).
+ *
+ * The counterpart of the dispatcher's `runDispatchDb`. Media processing
+ * interleaves DB reads with long downloads, AI transcription and NATS publishes,
+ * so a scope must never wrap more than one discrete block — the G4 leg-2 rule
+ * that a worker transaction never outlives its work item, applied at block
+ * granularity. The chat/message lookups below additionally POLL for
+ * message-persistence's commit, which a single spanning transaction could never
+ * observe; each attempt therefore opens and closes its own scope.
+ *
+ * `undefined` is the legacy world: `fn` runs on the ambient pool, byte-identical
+ * to pre-G5.
+ */
+function runMediaDb<T>(ctx: MediaProcessorContext, trustedTenantId: string | undefined, fn: () => Promise<T>) {
+  return trustedTenantId === undefined ? fn() : runInWorkerTenantScope(ctx.db, trustedTenantId, fn);
+}
+
+/**
  * Get MIME type from content or infer from type
  */
 function getMimeType(content: MessageReceivedPayload['content']): string | undefined {
@@ -160,10 +179,11 @@ async function buildFetchOptions(
   ctx: MediaProcessorContext,
   instanceId: string,
   channelType?: ChannelType,
+  trustedTenantId?: string,
 ): Promise<RequestInit | undefined> {
   if (channelType !== 'slack') return undefined;
   try {
-    const instance = await ctx.services.instances.getById(instanceId);
+    const instance = await runMediaDb(ctx, trustedTenantId, () => ctx.services.instances.getById(instanceId));
     const slackBotToken = (instance as Record<string, unknown>).slackBotToken as string | undefined;
     if (slackBotToken) {
       return { headers: { Authorization: `Bearer ${slackBotToken}` } };
@@ -188,7 +208,7 @@ async function downloadMediaFromUrl(
   channelType?: ChannelType,
   trustedTenantId?: string,
 ): Promise<string | null> {
-  const fetchOptions = await buildFetchOptions(ctx, instanceId, channelType);
+  const fetchOptions = await buildFetchOptions(ctx, instanceId, channelType, trustedTenantId);
   try {
     const result = await ctx.mediaStorage.storeFromUrl(
       instanceId,
@@ -229,20 +249,23 @@ async function resolveMediaPath(
   const deadline = Date.now() + maxWaitMs;
 
   // Use smart lookup to handle LID/phone JID resolution
-  let chat = await ctx.services.chats.findByExternalIdSmart(instanceId, chatId);
+  let chat = await runMediaDb(ctx, trustedTenantId, () => ctx.services.chats.findByExternalIdSmart(instanceId, chatId));
   while (!chat && Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, pollMs));
-    chat = await ctx.services.chats.findByExternalIdSmart(instanceId, chatId);
+    chat = await runMediaDb(ctx, trustedTenantId, () => ctx.services.chats.findByExternalIdSmart(instanceId, chatId));
   }
   if (!chat) {
     log.debug('Chat not found, cannot process media', { chatId, externalId });
     return null;
   }
 
-  let message = await ctx.services.messages.getByExternalId(chat.id, externalId);
+  const chatDbId = chat.id;
+  let message = await runMediaDb(ctx, trustedTenantId, () =>
+    ctx.services.messages.getByExternalId(chatDbId, externalId),
+  );
   while (!message && Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, pollMs));
-    message = await ctx.services.messages.getByExternalId(chat.id, externalId);
+    message = await runMediaDb(ctx, trustedTenantId, () => ctx.services.messages.getByExternalId(chatDbId, externalId));
   }
   if (!message) {
     log.debug('Message not found after waiting, cannot process media', { externalId });
@@ -546,11 +569,12 @@ async function publishMediaCrashEvents(
   payload: MessageReceivedPayload,
   metadata: { instanceId?: string; channelType?: ChannelType },
   error: unknown,
+  trustedTenantId?: string,
 ): Promise<void> {
   try {
     const processingType = inferProcessingType(payload.content.type);
     const reason = `unexpected: ${String(error)}`;
-    const mediaId = await resolveMediaIdForCrash(ctx, metadata.instanceId ?? '', payload);
+    const mediaId = await resolveMediaIdForCrash(ctx, metadata.instanceId ?? '', payload, trustedTenantId);
     const meta = { instanceId: metadata.instanceId, channelType: metadata.channelType };
 
     await ctx.eventBus.publish(
@@ -590,13 +614,15 @@ async function resolveMediaIdForCrash(
   ctx: MediaProcessorContext,
   instanceId: string,
   payload: MessageReceivedPayload,
+  trustedTenantId?: string,
 ): Promise<string> {
   try {
-    const chat = await ctx.services.chats.findByExternalIdSmart(instanceId, payload.chatId);
-    if (chat) {
-      const msg = await ctx.services.messages.getByExternalId(chat.id, payload.externalId);
-      if (msg) return msg.id;
-    }
+    const msg = await runMediaDb(ctx, trustedTenantId, async () => {
+      const chat = await ctx.services.chats.findByExternalIdSmart(instanceId, payload.chatId);
+      if (!chat) return null;
+      return ctx.services.messages.getByExternalId(chat.id, payload.externalId);
+    });
+    if (msg) return msg.id;
   } catch (lookupError) {
     log.debug('Failed to resolve DB message UUID for crash handler, falling back to externalId', {
       error: String(lookupError),
@@ -691,7 +717,7 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
           externalId: payload.externalId,
           error: String(error),
         });
-        await publishMediaCrashEvents(ctx, event.id, payload, metadata, error);
+        await publishMediaCrashEvents(ctx, event.id, payload, metadata, error, envelopeTenantId(event));
       }
     },
     {

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -26,6 +26,15 @@ export interface DispatchMetadata {
   personId?: string;
   platformIdentityId?: string;
   traceId: string;
+  /**
+   * Trusted tenant for this message, derived by the subscription handler from
+   * the versioned envelope (`classifyEnvelope` over producer-stamped metadata —
+   * wish: omni-full-multitenancy G5, ADR-0008), NEVER from the caller-facing
+   * payload. Undefined for legacy-world envelopes, whose downstream handling
+   * stays byte-identical to pre-G5. Consumed by tenant-bound presigning and,
+   * as conversion proceeds, by the dispatcher's worker tenant scope.
+   */
+  trustedTenantId?: string;
   /** Original NATS event correlationId for journey tracking */
   correlationId?: string;
   /** Whether this message is being journey-tracked (has timings) */

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -14,7 +14,7 @@
  */
 
 import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
-import { createLogger } from '@omni/core';
+import { classifyEnvelope, createLogger } from '@omni/core';
 import type { ChannelType, ChatType, MessageType } from '@omni/db';
 import * as Sentry from '@sentry/bun';
 import { sentryEnabled } from '../lib/sentry-scrub';
@@ -1089,7 +1089,12 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
                 gapMinutes,
               });
 
-              // Create a sync job (inserts DB row + publishes sync.started event)
+              // Create a sync job (inserts DB row + publishes sync.started event).
+              // The job is created for the RECONNECTED INSTANCE's tenant, taken
+              // from the `instance.connected` envelope the producer stamped
+              // (G5, ADR-0008) — never from the payload. A legacy envelope
+              // threads null and the create runs ambient, byte-identically.
+              const reconnectClassification = classifyEnvelope(event.metadata);
               const job = await services.syncJobs.create({
                 instanceId,
                 channelType,
@@ -1098,6 +1103,7 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
                   since: lastMessageAt.toISOString(),
                   until: new Date().toISOString(),
                 },
+                tenantId: reconnectClassification.world === 'tenant' ? reconnectClassification.tenantId : null,
               });
 
               log.info('Post-reconnect backfill triggered', {

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -11,6 +11,48 @@
  * - message.delivered/read → update message delivery status
  *
  * @see unified-messages wish
+ *
+ * TENANT CONTEXT (G5, ADR-0008)
+ * -----------------------------
+ * This is the dominant inbound consumer: every message on every channel lands
+ * here and writes `chats`, `messages`, `chat_participants`, `chat_id_mappings`,
+ * `platform_identities` and `instances`. All five handlers are consumer-only —
+ * a NATS subscription, no request, no credential — so until this leg every one
+ * of those writes reached the ambient pool, which is why nine db-access-guard
+ * sites stayed `pending-G5-conversion` long after their route callers were
+ * scoped: a site is only as scoped as its least-scoped caller.
+ *
+ * Each handler now runs its AWAITED db work through
+ * `runConsumerInTenantContext(services.db, event, ...)`: the versioned envelope
+ * is classified once, and a producer-stamped trusted tenant opens one worker
+ * tenant transaction for the whole work item. The services read `scopedHandle`
+ * internally, so the same service code is RLS-policed here and on the routes. A
+ * legacy envelope (no version, no tenant) runs the identical body on the ambient
+ * pool exactly as before — the dual-world contract — and a quarantined envelope
+ * is refused at the top of the handler, before ANY write.
+ *
+ * THE G6 GATE ON `persons`
+ * -----------------------
+ * The sender-identity write is deliberately NOT part of the message transaction.
+ * `persons` is a G2-`unowned` table with no derivation, so under RLS enforcement
+ * its INSERT policy can never be satisfied until the G6 backfill assigns a
+ * `tenant_id`. Keeping that write inside the message transaction would let the
+ * G6 gate destroy the message; nesting a scope for it would hold two pooled
+ * connections at once. It therefore runs first, as its own work item, and
+ * degrades to unset identity FKs (all nullable) with a warning — in the TENANT
+ * world only. See `resolveSenderIdentityForWorkItem`.
+ *
+ * THE FIRE-AND-FORGET TRAP (G4 leg-2)
+ * -----------------------------------
+ * This handler spawns several unawaited writes — the LID mapping upserts, the
+ * chat/instance recency bumps, and the new-identity profile fetch. They outlive
+ * the handler, so they must NOT inherit its transaction: by the time their
+ * continuations run it is committed and its connection is back in the pool, and
+ * a query on it is a use-after-commit. Each therefore takes the trusted tenant
+ * threaded down from the handler and opens its OWN worker scope through
+ * `runTenantWorkDb`, which detaches before it stamps. Threading `null` (the
+ * legacy world) makes `runTenantWorkDb` a pass-through, so flag-off behaviour is
+ * byte-identical down to the call order.
  */
 
 import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
@@ -19,6 +61,11 @@ import type { ChannelType, ChatType, MessageType } from '@omni/db';
 import * as Sentry from '@sentry/bun';
 import { sentryEnabled } from '../lib/sentry-scrub';
 import type { Services } from '../services';
+import {
+  WorkerTenantContextError,
+  runConsumerInTenantContext,
+  runTenantWorkDb,
+} from '../tenancy/worker-tenant-context';
 import { deepSanitize, sanitizeText } from '../utils/utf8';
 import { getPlugin } from './loader';
 
@@ -309,6 +356,7 @@ async function processSenderIdentity(
   payload: MessageReceivedPayload,
   metadata: { instanceId: string; personId?: string; platformIdentityId?: string; channelType?: string },
   channel: ChannelType,
+  trustedTenantId: string | null,
 ): Promise<IdentityResult> {
   // Return existing if already resolved
   if (metadata.platformIdentityId) {
@@ -351,10 +399,69 @@ async function processSenderIdentity(
       identityId: identity.id,
       personId: person?.id,
     });
-    fetchAndUpdateProfile(services, channel, metadata.instanceId, payload.from, identity.id).catch(() => {});
+    // Fire-and-forget: outlives the handler transaction, so it carries the
+    // trusted tenant and opens its own scope for the write (see module header).
+    fetchAndUpdateProfile(services, channel, metadata.instanceId, payload.from, identity.id, trustedTenantId).catch(
+      () => {},
+    );
   }
 
   return { personId: person?.id, platformIdentityId: identity.id };
+}
+
+/**
+ * Resolve the sender's identity as its OWN work item, BEFORE the message's
+ * persistence transaction opens (G5, ADR-0008; G6-gated).
+ *
+ * This is hoisted out of `handleMessageReceived` for one specific reason. The
+ * identity write touches `persons`, and `persons` is a G2-`unowned` table: it
+ * has no derivation, so its `tenant_id` stays NULL until the G6 backfill assigns
+ * one. Under RLS enforcement the `persons` INSERT policy is
+ * `tenant_id = omni_current_tenant_id()`, which a NULL can never satisfy — so a
+ * person cannot be created inside a tenant scope at all yet. (It cannot be
+ * created OUTSIDE one either: unscoped, `omni_current_tenant_id()` raises.)
+ * That is the same G6 gate that keeps `agent-runner.ts::persons` pending.
+ *
+ * Two consequences, both deliberate:
+ *
+ *   1. **Its own scope, never a nested one.** Running it inside the message
+ *      transaction would make its failure abort that transaction and LOSE the
+ *      message; running it as a nested `runInWorkerTenantScope` would hold two
+ *      pooled connections at once and can deadlock under pool pressure. Hoisting
+ *      it gives failure isolation with exactly one connection held at a time.
+ *   2. **Degrade, do not drop — but only in the tenant world.** When a tenant is
+ *      in play and the identity write is refused, the chat/message/participant
+ *      rows still land with the identity FKs left unset (all three are nullable)
+ *      and a warning is logged, rather than the whole message being lost to the
+ *      G6 gate. The LEGACY path is untouched: no tenant means the original call
+ *      with its original error propagation, byte-identical to pre-G5.
+ *
+ * Remove the degradation once G6 lands `persons.tenant_id`; the site is tracked
+ * as `persons.ts`-adjacent debt in the db-access registry.
+ */
+async function resolveSenderIdentityForWorkItem(
+  services: Services,
+  payload: MessageReceivedPayload,
+  metadata: { instanceId: string; personId?: string; platformIdentityId?: string; channelType?: string },
+  channel: ChannelType,
+  trustedTenantId: string | null,
+): Promise<IdentityResult> {
+  // Legacy world: exactly the pre-G5 call, exactly the pre-G5 error behaviour.
+  if (!trustedTenantId) return processSenderIdentity(services, payload, metadata, channel, null);
+
+  try {
+    return await runTenantWorkDb(services.db, trustedTenantId, () =>
+      processSenderIdentity(services, payload, metadata, channel, trustedTenantId),
+    );
+  } catch (error) {
+    log.warn('Sender identity unresolved for this message; persisting without identity links', {
+      instanceId: metadata.instanceId,
+      externalId: payload.externalId,
+      reason: 'persons has no tenant derivation until the G6 backfill (ADR-0008 / G6)',
+      error: String(error),
+    });
+    return { personId: metadata.personId, platformIdentityId: metadata.platformIdentityId };
+  }
 }
 
 /**
@@ -366,6 +473,7 @@ async function fetchAndUpdateProfile(
   instanceId: string,
   userId: string,
   identityId: string,
+  trustedTenantId: string | null,
 ): Promise<void> {
   try {
     const plugin = await getPlugin(channel);
@@ -378,7 +486,9 @@ async function fetchAndUpdateProfile(
 
     const profile = await fetchProfile.call(plugin, instanceId, userId);
     if (profile.avatarUrl || profile.bio || profile.platformData) {
-      await services.persons.updateIdentityProfile(identityId, profile);
+      await runTenantWorkDb(services.db, trustedTenantId, () =>
+        services.persons.updateIdentityProfile(identityId, profile),
+      );
       log.debug('Updated identity with profile data', {
         identityId,
         hasAvatar: !!profile.avatarUrl,
@@ -419,11 +529,15 @@ async function persistLidMappings(
   chatExternalId: string,
   instanceId: string,
   rawPayload: Record<string, unknown> | undefined,
+  trustedTenantId: string | null,
 ): Promise<void> {
   // Legacy path: phone-form chat, LID came from rawPayload.originalLidJid (pre-LID-first messages)
   const originalLidJid = rawPayload?.originalLidJid as string | undefined;
   if (originalLidJid && chatExternalId.endsWith('@s.whatsapp.net')) {
-    services.chats.upsertLidMapping(instanceId, originalLidJid, chatExternalId).catch((err) => {
+    // Unawaited: own worker scope, never the handler's transaction.
+    runTenantWorkDb(services.db, trustedTenantId, () =>
+      services.chats.upsertLidMapping(instanceId, originalLidJid, chatExternalId),
+    ).catch((err) => {
       log.debug('Failed to persist LID mapping (non-critical)', { error: String(err) });
     });
     if (!chat.canonicalId) {
@@ -436,7 +550,10 @@ async function persistLidMappings(
   // Without this, phone-based lookups after restart miss the chat and create duplicate threads.
   const resolvedPhoneJid = rawPayload?.resolvedPhoneJid as string | undefined;
   if (chatExternalId.endsWith('@lid') && resolvedPhoneJid) {
-    services.chats.upsertLidMapping(instanceId, chatExternalId, resolvedPhoneJid).catch((err) => {
+    // Unawaited: own worker scope, never the handler's transaction.
+    runTenantWorkDb(services.db, trustedTenantId, () =>
+      services.chats.upsertLidMapping(instanceId, chatExternalId, resolvedPhoneJid),
+    ).catch((err) => {
       log.debug('Failed to persist LID↔phone mapping for LID-canonical chat (non-critical)', { error: String(err) });
     });
     if (!chat.canonicalId) {
@@ -471,6 +588,7 @@ async function postProcessChat(
   rawPayload: Record<string, unknown> | undefined,
   isFromMe: boolean,
   chatName: string | undefined,
+  trustedTenantId: string | null,
 ): Promise<void> {
   // Populate canonicalId ONLY if not already set
   // (Usually set during creation, but handle legacy chats or edge cases)
@@ -479,7 +597,7 @@ async function postProcessChat(
     chat.canonicalId = chatExternalId;
   }
 
-  await persistLidMappings(services, chat, chatExternalId, instanceId, rawPayload);
+  await persistLidMappings(services, chat, chatExternalId, instanceId, rawPayload, trustedTenantId);
 
   // Update chat name if missing, stale, or changed (e.g. Discord thread/channel renames)
   // For outbound DMs: also resolve from rawPayload (recipientName, verifiedBizName)
@@ -570,17 +688,24 @@ function maybeUpdateRecency(
   rawPayload: Record<string, unknown> | undefined,
   payload: MessageReceivedPayload,
   platformTimestamp: Date,
+  trustedTenantId: string | null,
 ): void {
   // Edits should not bump recency.
   if (rawPayload?.isEdited === true) return;
 
   const preview = sanitizeText(buildChatPreview(payload, rawPayload)) ?? '';
   const isFromMe = rawPayload?.isFromMe === true;
-  services.chats.updateLastMessage(chatId, preview, platformTimestamp, isFromMe).catch((error) => {
+  // Both writes are unawaited and outlive the handler transaction, so each opens
+  // its own worker scope rather than inheriting one that is about to commit.
+  runTenantWorkDb(services.db, trustedTenantId, () =>
+    services.chats.updateLastMessage(chatId, preview, platformTimestamp, isFromMe),
+  ).catch((error) => {
     log.debug('Failed to update chat lastMessage (non-critical)', { error: String(error) });
   });
 
-  services.instances.updateLastMessageAt(instanceId, platformTimestamp).catch((error) => {
+  runTenantWorkDb(services.db, trustedTenantId, () =>
+    services.instances.updateLastMessageAt(instanceId, platformTimestamp),
+  ).catch((error) => {
     log.debug('Failed to update instance lastMessageAt (non-critical)', { error: String(error) });
   });
 }
@@ -604,13 +729,17 @@ async function resolveOrCreateChat(
   effectiveName: string | undefined,
   canonicalId: string | undefined,
   rawPayload: Record<string, unknown> | undefined,
+  trustedTenantId: string | null,
 ): ReturnType<typeof services.chats.findOrCreate> {
   const resolvedPhoneJid = rawPayload?.resolvedPhoneJid as string | undefined;
   if (chatExternalId.endsWith('@lid') && resolvedPhoneJid) {
     return services.chats.findByExternalIdSmart(instanceId, resolvedPhoneJid).then((phoneChat) => {
       if (phoneChat) {
-        // Persist mapping so subsequent LID lookups also route to this phone chat
-        services.chats.upsertLidMapping(instanceId, chatExternalId, resolvedPhoneJid).catch((err) => {
+        // Persist mapping so subsequent LID lookups also route to this phone chat.
+        // Unawaited: own worker scope, never the handler's transaction.
+        runTenantWorkDb(services.db, trustedTenantId, () =>
+          services.chats.upsertLidMapping(instanceId, chatExternalId, resolvedPhoneJid),
+        ).catch((err) => {
           log.debug('Failed to persist LID mapping during chat pre-check (non-critical)', { error: String(err) });
         });
         return { chat: phoneChat, created: false };
@@ -639,6 +768,8 @@ async function handleMessageReceived(
   payload: MessageReceivedPayload,
   metadata: MessageMetadata,
   eventTimestamp: number,
+  trustedTenantId: string | null,
+  identity: IdentityResult,
 ): Promise<void> {
   const channel = (metadata.channelType ?? 'whatsapp') as ChannelType;
   const isHistorySync = metadata.ingestMode === 'history-sync';
@@ -672,6 +803,7 @@ async function handleMessageReceived(
     effectiveName,
     canonicalId,
     rawPayload,
+    trustedTenantId,
   );
 
   // Post-process chat: canonicalId, LID mapping, name updates
@@ -686,10 +818,12 @@ async function handleMessageReceived(
     rawPayload,
     isFromMe,
     chatName,
+    trustedTenantId,
   );
 
-  // Step 2: Process sender identity (before participant, so we have IDs)
-  const { personId, platformIdentityId } = await processSenderIdentity(services, payload, metadata, channel);
+  // Step 2: sender identity, resolved by the caller in its OWN work item before
+  // this transaction opened (see `resolveSenderIdentityForWorkItem`).
+  const { personId, platformIdentityId } = identity;
 
   // Step 3: Find or create participant (with identity links)
   const participantResult = await maybeFindOrCreateParticipant(
@@ -771,6 +905,7 @@ async function handleMessageReceived(
     rawPayload,
     payload,
     platformTimestamp ?? new Date(eventTimestamp),
+    trustedTenantId,
   );
 }
 
@@ -824,12 +959,36 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
           return;
         }
 
+        // The trusted tenant for this work item, read from the producer-stamped
+        // envelope and NEVER from the payload (G5, ADR-0008). It is threaded into
+        // the handler so the fire-and-forget writes it spawns can open their own
+        // scopes; the awaited work is wrapped below.
+        const classification = classifyEnvelope(metadata);
+        // Refused HERE, not merely inside `runConsumerInTenantContext` below:
+        // the identity resolution is hoisted ahead of that call, so the
+        // quarantine check has to come ahead of BOTH or a malformed envelope
+        // would get one write in before being rejected.
+        if (classification.world === 'quarantine') {
+          throw new WorkerTenantContextError(`refusing to process a quarantined envelope (${classification.reason})`);
+        }
+        const trustedTenantId = classification.world === 'tenant' ? classification.tenantId : null;
+        // Captured before the closure below: TypeScript drops the narrowing from
+        // the `!metadata.instanceId` guard across a callback boundary.
+        const instanceId = metadata.instanceId;
+
         try {
-          await handleMessageReceived(
+          const workMetadata = { ...metadata, instanceId };
+          // Resolved BEFORE the persistence transaction opens — its own work
+          // item, its own scope, G6-gated (see the function's header).
+          const identity = await resolveSenderIdentityForWorkItem(
             services,
             payload,
-            { ...metadata, instanceId: metadata.instanceId },
-            event.timestamp,
+            workMetadata,
+            (metadata.channelType ?? 'whatsapp') as ChannelType,
+            trustedTenantId,
+          );
+          await runConsumerInTenantContext(services.db, event, () =>
+            handleMessageReceived(services, payload, workMetadata, event.timestamp, trustedTenantId, identity),
           );
           // Sentry metric: message received count by channel
           if (sentryEnabled()) {
@@ -879,34 +1038,43 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
           const chatExternalId = truncate(payload.chatId, 255) ?? payload.chatId;
           const messageExternalId = truncate(payload.externalId, 255) ?? payload.externalId;
 
-          // Find or create chat
-          const { chat } = await services.chats.findOrCreate(metadata.instanceId, chatExternalId, {
-            chatType: inferChatType(payload.chatId),
-            channel: (metadata.channelType ?? 'whatsapp') as ChannelType,
-          });
+          const sentInstanceId = metadata.instanceId;
+          const sentClassification = classifyEnvelope(metadata);
+          const sentTenantId = sentClassification.world === 'tenant' ? sentClassification.tenantId : null;
 
-          const sentContent = buildSentMessageContentFields(payload);
+          // The chat + message writes are one work item: one worker transaction.
+          const { chat, message, created } = await runConsumerInTenantContext(services.db, event, async () => {
+            // Find or create chat
+            const { chat } = await services.chats.findOrCreate(sentInstanceId, chatExternalId, {
+              chatType: inferChatType(payload.chatId),
+              channel: (metadata.channelType ?? 'whatsapp') as ChannelType,
+            });
 
-          // Create message (sent by us)
-          const { message, created } = await services.messages.findOrCreate(chat.id, messageExternalId, {
-            source: 'realtime',
-            messageType: mapContentType(payload.content.type),
-            textContent: sentContent.textContent,
-            platformTimestamp: new Date(event.timestamp),
-            // Sender info (from us)
-            senderPersonId: metadata.personId,
-            senderPlatformIdentityId: metadata.platformIdentityId,
-            isFromMe: true,
-            senderAgentId: (payload as MessageSentPayload & { senderAgentId?: string }).senderAgentId ?? null,
-            // Media
-            hasMedia: sentContent.hasMedia,
-            mediaMimeType: sentContent.mediaMimeType,
-            mediaUrl: sentContent.mediaUrl,
-            mediaLocalPath: sentContent.mediaLocalPath,
-            mediaMetadata: sentContent.mediaMetadata,
-            rawPayload: sentContent.rawPayload,
-            // Reply info - truncate varchar(255) fields
-            replyToExternalId: truncate(payload.replyToId, 255),
+            const sentContent = buildSentMessageContentFields(payload);
+
+            // Create message (sent by us)
+            const { message, created } = await services.messages.findOrCreate(chat.id, messageExternalId, {
+              source: 'realtime',
+              messageType: mapContentType(payload.content.type),
+              textContent: sentContent.textContent,
+              platformTimestamp: new Date(event.timestamp),
+              // Sender info (from us)
+              senderPersonId: metadata.personId,
+              senderPlatformIdentityId: metadata.platformIdentityId,
+              isFromMe: true,
+              senderAgentId: (payload as MessageSentPayload & { senderAgentId?: string }).senderAgentId ?? null,
+              // Media
+              hasMedia: sentContent.hasMedia,
+              mediaMimeType: sentContent.mediaMimeType,
+              mediaUrl: sentContent.mediaUrl,
+              mediaLocalPath: sentContent.mediaLocalPath,
+              mediaMetadata: sentContent.mediaMetadata,
+              rawPayload: sentContent.rawPayload,
+              // Reply info - truncate varchar(255) fields
+              replyToExternalId: truncate(payload.replyToId, 255),
+            });
+
+            return { chat, message, created };
           });
 
           if (created) {
@@ -919,14 +1087,15 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
 
           // Update chat recency — marks lastMessageFromMe=true so the chat no longer
           // shows as pending/attention-needing after we send a reply.
-          services.chats
-            .updateLastMessage(
+          // Unawaited: own worker scope, never the transaction that just committed.
+          runTenantWorkDb(services.db, sentTenantId, () =>
+            services.chats.updateLastMessage(
               chat.id,
               sanitizeText(buildSentChatPreview(payload)) ?? '',
               new Date(event.timestamp),
               true,
-            )
-            .catch((err: unknown) => log.debug('Failed to update chat recency (sent)', { error: String(err) }));
+            ),
+          ).catch((err: unknown) => log.debug('Failed to update chat recency (sent)', { error: String(err) }));
 
           // Track consumer offset after successful processing
           if (metadata.streamSequence) {
@@ -967,24 +1136,28 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
 
           // Skip internal WhatsApp JIDs (device sync, broadcasts, newsletters)
           if (isInternalWhatsAppJid(payload.chatId)) return;
+          const deliveredInstanceId = metadata.instanceId;
 
-          // Find the chat (use smart lookup to handle LID/phone JID resolution)
-          const chat = await services.chats.findByExternalIdSmart(metadata.instanceId, payload.chatId);
-          if (!chat) {
-            log.debug('Chat not found for message.delivered', { chatId: payload.chatId });
-            return;
-          }
+          // Lookup + status update are one work item: one worker transaction.
+          await runConsumerInTenantContext(services.db, event, async () => {
+            // Find the chat (use smart lookup to handle LID/phone JID resolution)
+            const chat = await services.chats.findByExternalIdSmart(deliveredInstanceId, payload.chatId);
+            if (!chat) {
+              log.debug('Chat not found for message.delivered', { chatId: payload.chatId });
+              return;
+            }
 
-          // Find the message
-          const message = await services.messages.getByExternalId(chat.id, payload.externalId);
-          if (!message) {
-            log.debug('Message not found for message.delivered', { externalId: payload.externalId });
-            return;
-          }
+            // Find the message
+            const message = await services.messages.getByExternalId(chat.id, payload.externalId);
+            if (!message) {
+              log.debug('Message not found for message.delivered', { externalId: payload.externalId });
+              return;
+            }
 
-          // Update delivery status
-          await services.messages.updateDeliveryStatus(message.id, 'delivered');
-          log.debug('Updated message delivery status', { messageId: message.id, status: 'delivered' });
+            // Update delivery status
+            await services.messages.updateDeliveryStatus(message.id, 'delivered');
+            log.debug('Updated message delivery status', { messageId: message.id, status: 'delivered' });
+          });
         } catch (error) {
           log.error('Failed to update delivery status', {
             externalId: payload.externalId,
@@ -1016,24 +1189,28 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
 
           // Skip internal WhatsApp JIDs (device sync, broadcasts, newsletters)
           if (isInternalWhatsAppJid(payload.chatId)) return;
+          const readInstanceId = metadata.instanceId;
 
-          // Find the chat (use smart lookup to handle LID/phone JID resolution)
-          const chat = await services.chats.findByExternalIdSmart(metadata.instanceId, payload.chatId);
-          if (!chat) {
-            log.debug('Chat not found for message.read', { chatId: payload.chatId });
-            return;
-          }
+          // Lookup + status update are one work item: one worker transaction.
+          await runConsumerInTenantContext(services.db, event, async () => {
+            // Find the chat (use smart lookup to handle LID/phone JID resolution)
+            const chat = await services.chats.findByExternalIdSmart(readInstanceId, payload.chatId);
+            if (!chat) {
+              log.debug('Chat not found for message.read', { chatId: payload.chatId });
+              return;
+            }
 
-          // Find the message
-          const message = await services.messages.getByExternalId(chat.id, payload.externalId);
-          if (!message) {
-            log.debug('Message not found for message.read', { externalId: payload.externalId });
-            return;
-          }
+            // Find the message
+            const message = await services.messages.getByExternalId(chat.id, payload.externalId);
+            if (!message) {
+              log.debug('Message not found for message.read', { externalId: payload.externalId });
+              return;
+            }
 
-          // Update delivery status to read
-          await services.messages.updateDeliveryStatus(message.id, 'read');
-          log.debug('Updated message delivery status', { messageId: message.id, status: 'read' });
+            // Update delivery status to read
+            await services.messages.updateDeliveryStatus(message.id, 'read');
+            log.debug('Updated message delivery status', { messageId: message.id, status: 'read' });
+          });
         } catch (error) {
           log.error('Failed to update read status', {
             externalId: payload.externalId,
@@ -1060,8 +1237,22 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
         const instanceId = payload.instanceId;
         if (!instanceId) return;
 
+        // Classified once for the whole handler: the `instances` read below runs
+        // in a worker scope, while `syncJobs.create` (which PUBLISHES) stays
+        // outside it — holding a transaction across a publish would make the
+        // event a pre-commit side effect (a phantom on rollback).
+        const reconnectClassification = classifyEnvelope(event.metadata);
+        const reconnectTenantId = reconnectClassification.world === 'tenant' ? reconnectClassification.tenantId : null;
+        if (reconnectClassification.world === 'quarantine') {
+          throw new Error(
+            `message-persistence: refusing a quarantined instance.connected envelope (${reconnectClassification.reason})`,
+          );
+        }
+
         try {
-          const lastMessageAt = await services.instances.getLastMessageAt(instanceId);
+          const lastMessageAt = await runTenantWorkDb(services.db, reconnectTenantId, () =>
+            services.instances.getLastMessageAt(instanceId),
+          );
           if (!lastMessageAt) return;
 
           const gapMs = Date.now() - lastMessageAt.getTime();
@@ -1094,7 +1285,6 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
               // from the `instance.connected` envelope the producer stamped
               // (G5, ADR-0008) — never from the payload. A legacy envelope
               // threads null and the create runs ambient, byte-identically.
-              const reconnectClassification = classifyEnvelope(event.metadata);
               const job = await services.syncJobs.create({
                 instanceId,
                 channelType,
@@ -1103,7 +1293,7 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
                   since: lastMessageAt.toISOString(),
                   until: new Date().toISOString(),
                 },
-                tenantId: reconnectClassification.world === 'tenant' ? reconnectClassification.tenantId : null,
+                tenantId: reconnectTenantId,
               });
 
               log.info('Post-reconnect backfill triggered', {

--- a/packages/api/src/plugins/session-cleaner.ts
+++ b/packages/api/src/plugins/session-cleaner.ts
@@ -218,7 +218,13 @@ export async function clearAgentSession(
   // applyAgentFkOverrides threads the trusted tenant into its own discrete DB
   // block (via runDispatchDb); no extra wrap here.
   await applyAgentFkOverrides(db, agentId, dispatchInstance, trustedTenantId ?? undefined);
-  const agentProvider = resolveProvider(providerRecord, dispatchInstance, db);
+  // `providerRecord`'s secrets were opened inside the worker scope above; this
+  // resolution deliberately runs OUTSIDE it (a worker transaction must not span
+  // the provider call), so the tenant is threaded rather than read from the
+  // ambient scope — otherwise the shared OpenClaw client built with THIS
+  // tenant's device key would be pooled in the scope-less bucket and reused by
+  // the next tenant (G5; ADR-0008).
+  const agentProvider = resolveProvider(providerRecord, dispatchInstance, db, trustedTenantId ?? null);
   if (agentProvider?.resetSession) {
     await agentProvider.resetSession(sessionId, chatId, instanceId);
     if (legacySessionId !== sessionId) {

--- a/packages/api/src/plugins/session-cleaner.ts
+++ b/packages/api/src/plugins/session-cleaner.ts
@@ -53,10 +53,23 @@ function isTrashEmojiOnly(text: string | undefined): boolean {
 }
 
 /**
- * Send a message via channel plugin
+ * Send a message via channel plugin.
+ *
+ * The instance lookup is one discrete scoped read (G5, ADR-0008): the
+ * consumer caller threads the envelope tenant so a tenant-world cleanup
+ * resolves the channel under a short worker scope; nothing threaded reads the
+ * ambient pool byte-identically. The plugin network call stays OUTSIDE the
+ * scope — a worker transaction must never span a channel send.
  */
-async function sendMessage(services: Services, instanceId: string, chatId: string, text: string): Promise<void> {
-  const instance = await services.instances.getById(instanceId);
+async function sendMessage(
+  services: Services,
+  db: Database,
+  instanceId: string,
+  chatId: string,
+  text: string,
+  trustedTenantId?: string | null,
+): Promise<void> {
+  const instance = await runTenantWorkDb(db, trustedTenantId, () => services.instances.getById(instanceId));
   const channel = instance.channel as ChannelType;
   const plugin = await getPlugin(channel);
   if (plugin) {
@@ -361,7 +374,14 @@ export async function runTrashEmojiCleanup(
 
     // Send confirmation message
     try {
-      await sendMessage(services, instanceId, chatId, '✅ Conversa limpa! Sua sessão com o assistente foi resetada.');
+      await sendMessage(
+        services,
+        db,
+        instanceId,
+        chatId,
+        '✅ Conversa limpa! Sua sessão com o assistente foi resetada.',
+        tenantId,
+      );
       log.info('Sent session cleared confirmation', { instanceId, chatId });
     } catch (sendError) {
       log.error('Failed to send confirmation message', { instanceId, chatId, error: String(sendError) });
@@ -385,7 +405,7 @@ export async function runTrashEmojiCleanup(
 
     // Send error message
     try {
-      await sendMessage(services, instanceId, chatId, '❌ Erro ao limpar sessão. Tente novamente.');
+      await sendMessage(services, db, instanceId, chatId, '❌ Erro ao limpar sessão. Tente novamente.', tenantId);
     } catch (sendError) {
       log.error('Failed to send error message', { instanceId, chatId, error: String(sendError) });
     }

--- a/packages/api/src/plugins/session-cleaner.ts
+++ b/packages/api/src/plugins/session-cleaner.ts
@@ -15,6 +15,7 @@ import { and, eq } from 'drizzle-orm';
 import { withIdempotency } from '../lib/idempotency';
 import type { Services } from '../services';
 import { type ResolvedAgentSessionIdentity, resolveKhalSessionId } from '../services/agent-session-identity';
+import { scopedHandle } from '../tenancy/tenant-scope';
 import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import { applyAgentFkOverrides, resolveProvider } from './agent-dispatcher';
 import { getPlugin } from './loader';
@@ -67,6 +68,24 @@ async function sendMessage(services: Services, instanceId: string, chatId: strin
 }
 
 /**
+ * The `chat_participants` read of the cleanup path, extracted so the two-tenant
+ * probe can exercise the EXACT query the consumer issues rather than a replica
+ * of it. Callers supply the world (see `resolveCleanupPersonId`).
+ */
+async function readChatParticipant(
+  db: Database,
+  chatId: string,
+  platformUserId: string,
+): Promise<{ personId: string | null } | undefined> {
+  const [participant] = await scopedHandle(db)
+    .select({ personId: chatParticipants.personId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.platformUserId, platformUserId)))
+    .limit(1);
+  return participant;
+}
+
+/**
  * Clear agent session for the given user and chat.
  * Tries IAgentProvider.resetSession() first (supports OpenClaw, Webhook, etc.),
  * falls back to direct AgnoOS client for legacy.
@@ -90,16 +109,13 @@ async function resolveCleanupPersonId(
   );
   if (!dbChat?.id) return undefined;
 
-  // The chat_participants read is a registered `pending-G5-conversion` site
-  // (blocked on the G6 persons backfill); the CALLER scope is established here
-  // so it lands in the right world once the query switches to `scopedHandle`.
-  const [participant] = await runTenantWorkDb(db, trustedTenantId, () =>
-    db
-      .select({ personId: chatParticipants.personId })
-      .from(chatParticipants)
-      .where(and(eq(chatParticipants.chatId, dbChat.id), eq(chatParticipants.platformUserId, from)))
-      .limit(1),
-  );
+  // G5-CONVERTED. The participant read runs through `scopedHandle` inside the
+  // same threaded world as the chat lookup above. `chat_participants` derives its
+  // tenant from the REQUIRED `chat_id` parent, so it is owned by the `instances`
+  // root and RLS scopes it — it does NOT need the G6 `persons` backfill, even
+  // though `person_id` is the column being read (the column's VALUE is opaque
+  // here; only the ROW's visibility is at stake).
+  const participant = await runTenantWorkDb(db, trustedTenantId, () => readChatParticipant(db, dbChat.id, from));
 
   return participant?.personId ?? undefined;
 }
@@ -399,3 +415,6 @@ export async function setupSessionCleaner(eventBus: EventBus, services: Services
     throw error;
   }
 }
+
+/** Seams the two-tenant containment probe drives directly. Not a public API. */
+export const __test__ = { readChatParticipant };

--- a/packages/api/src/plugins/session-cleaner.ts
+++ b/packages/api/src/plugins/session-cleaner.ts
@@ -7,18 +7,34 @@
  * Sends a confirmation message and blocks agent response.
  */
 
-import type { EventBus, TypedOmniEvent } from '@omni/core';
-import { createAgnoClient, createLogger } from '@omni/core';
+import type { EventBus, OmniEvent, TypedOmniEvent } from '@omni/core';
+import { classifyEnvelope, createAgnoClient, createLogger } from '@omni/core';
 import type { ChannelType, Database } from '@omni/db';
 import { agents, chatParticipants } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
 import { withIdempotency } from '../lib/idempotency';
 import type { Services } from '../services';
 import { type ResolvedAgentSessionIdentity, resolveKhalSessionId } from '../services/agent-session-identity';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import { applyAgentFkOverrides, resolveProvider } from './agent-dispatcher';
 import { getPlugin } from './loader';
 
 const log = createLogger('session-cleaner');
+
+/**
+ * Classify the consumed envelope once and return the trusted tenant to thread
+ * through the cleanup's DB blocks, or `null` for a legacy envelope. Throws on a
+ * quarantined envelope — processing it globally is the fallback ADR-0008 forbids
+ * (defense in depth: the subscription layer already terms it first). The tenant
+ * is read ONLY from the producer-stamped metadata, never from payload fields.
+ */
+function trustedTenantOf(event: Pick<OmniEvent, 'metadata'>): string | null {
+  const classification = classifyEnvelope(event.metadata);
+  if (classification.world === 'quarantine') {
+    throw new Error(`session-cleaner: refusing quarantined envelope (${classification.reason})`);
+  }
+  return classification.world === 'tenant' ? classification.tenantId : null;
+}
 
 /**
  * Check if message contains only trash emoji
@@ -62,21 +78,45 @@ async function resolveCleanupPersonId(
   chatId: string,
   from: string,
   metadataPersonId?: string,
+  trustedTenantId?: string | null,
 ): Promise<string | undefined> {
   if (metadataPersonId?.trim()) return metadataPersonId.trim();
 
-  const dbChat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+  // Discrete DB block in the caller's world (G5, ADR-0008): threaded a tenant
+  // opens a short worker scope; threaded nothing (legacy consumer / route
+  // request scope) runs byte-identically via `runTenantWorkDb`'s passthrough.
+  const dbChat = await runTenantWorkDb(db, trustedTenantId, () =>
+    services.chats.findByExternalIdSmart(instanceId, chatId),
+  );
   if (!dbChat?.id) return undefined;
 
-  const [participant] = await db
-    .select({ personId: chatParticipants.personId })
-    .from(chatParticipants)
-    .where(and(eq(chatParticipants.chatId, dbChat.id), eq(chatParticipants.platformUserId, from)))
-    .limit(1);
+  // The chat_participants read is a registered `pending-G5-conversion` site
+  // (blocked on the G6 persons backfill); the CALLER scope is established here
+  // so it lands in the right world once the query switches to `scopedHandle`.
+  const [participant] = await runTenantWorkDb(db, trustedTenantId, () =>
+    db
+      .select({ personId: chatParticipants.personId })
+      .from(chatParticipants)
+      .where(and(eq(chatParticipants.chatId, dbChat.id), eq(chatParticipants.platformUserId, from)))
+      .limit(1),
+  );
 
   return participant?.personId ?? undefined;
 }
 
+/**
+ * Clear the agent session for a user/chat.
+ *
+ * Tenant boundary (G5, ADR-0008): each DISCRETE DB block is wrapped in
+ * `runTenantWorkDb(db, trustedTenantId, …)`. The consumer path threads the
+ * envelope-derived tenant so every lookup runs in a short worker scope; the
+ * route caller (routes/v2/chats.ts) threads NOTHING and relies on its own
+ * request scope via `scopedHandle` — `runTenantWorkDb` passes straight through
+ * for an undefined tenant, so that path is byte-identical to pre-G5. The
+ * provider `resetSession` / Agno `deleteSession` calls are EXTERNAL side effects
+ * and are deliberately left outside any scope — a worker transaction must never
+ * span them.
+ */
 export async function clearAgentSession(
   services: Services,
   db: Database,
@@ -84,29 +124,43 @@ export async function clearAgentSession(
   from: string,
   chatId: string,
   options: { personId?: string; rawPayload?: Record<string, unknown> } = {},
+  trustedTenantId?: string | null,
 ): Promise<ResolvedAgentSessionIdentity> {
-  // Get instance with provider
-  const instance = await services.agentRunner.getInstanceWithProvider(instanceId);
+  // Get instance with provider (pure DB lookup → scoped as one block).
+  const instance = await runTenantWorkDb(db, trustedTenantId, () =>
+    services.agentRunner.getInstanceWithProvider(instanceId),
+  );
 
   if (!instance?.agentId) {
     throw new Error('No agent configured for instance');
   }
+  // Narrow the nullable FK to a local BEFORE the closure captures it — TS cannot
+  // carry the `!instance.agentId` guard into an arrow that closes over `instance`.
+  const agentId = instance.agentId;
 
-  // Resolve agent provider from the agent FK
-  const [agentRow] = await db
-    .select({ agentProviderId: agents.agentProviderId })
-    .from(agents)
-    .where(eq(agents.id, instance.agentId))
-    .limit(1);
+  // Resolve agent provider from the agent FK. This `agents` read is a registered
+  // `pending-G5-conversion` site; the caller scope is established around it.
+  const [agentRow] = await runTenantWorkDb(db, trustedTenantId, () =>
+    db.select({ agentProviderId: agents.agentProviderId }).from(agents).where(eq(agents.id, agentId)).limit(1),
+  );
 
   if (!agentRow?.agentProviderId) {
     throw new Error('Agent has no provider configured');
   }
+  const agentProviderId = agentRow.agentProviderId;
 
-  // Get provider record from DB
-  const providerRecord = await services.providers.getById(agentRow.agentProviderId);
+  // Get provider record from DB (pure DB lookup → scoped as one block).
+  const providerRecord = await runTenantWorkDb(db, trustedTenantId, () => services.providers.getById(agentProviderId));
 
-  const personId = await resolveCleanupPersonId(services, db, instanceId, chatId, from, options.personId);
+  const personId = await resolveCleanupPersonId(
+    services,
+    db,
+    instanceId,
+    chatId,
+    from,
+    options.personId,
+    trustedTenantId,
+  );
   const identity = resolveKhalSessionId({
     providerSchema: providerRecord.schema,
     sessionStrategy: instance.agentSessionStrategy ?? 'per_chat',
@@ -132,7 +186,9 @@ export async function clearAgentSession(
   // Agent entity — without it, providers that require a non-empty agentId (post 2.260430)
   // throw "cannot resolve agentId" and the user sees "Erro ao limpar sessão".
   const dispatchInstance = { ...instance, agentProviderId: agentRow.agentProviderId };
-  await applyAgentFkOverrides(db, instance.agentId, dispatchInstance);
+  // applyAgentFkOverrides threads the trusted tenant into its own discrete DB
+  // block (via runDispatchDb); no extra wrap here.
+  await applyAgentFkOverrides(db, agentId, dispatchInstance, trustedTenantId ?? undefined);
   const agentProvider = resolveProvider(providerRecord, dispatchInstance, db);
   if (agentProvider?.resetSession) {
     await agentProvider.resetSession(sessionId, chatId, instanceId);
@@ -203,7 +259,7 @@ async function handleTrashEmojiMessage(
   }
 }
 
-async function runTrashEmojiCleanup(
+export async function runTrashEmojiCleanup(
   services: Services,
   db: Database,
   event: TypedOmniEvent<'message.received'>,
@@ -212,10 +268,23 @@ async function runTrashEmojiCleanup(
   const { instanceId, personId } = event.metadata;
   if (!instanceId) return;
 
+  // Classify the envelope ONCE and refuse quarantine BEFORE any work — the throw
+  // must escape (not be swallowed by the error handler below into an "Erro ao
+  // limpar sessão" message), so a corrupt/forged tenant does no cleanup at all.
+  const tenantId = trustedTenantOf(event);
+
   log.info('Trash emoji detected, clearing session', { instanceId, chatId, from, personId });
 
   try {
-    const identity = await clearAgentSession(services, db, instanceId, from, chatId, { personId, rawPayload });
+    const identity = await clearAgentSession(
+      services,
+      db,
+      instanceId,
+      from,
+      chatId,
+      { personId, rawPayload },
+      tenantId,
+    );
     const { sessionId, legacySessionId, sessionStrategy, source, canonicalSessionId, environment, channelSegment } =
       identity;
 
@@ -237,12 +306,18 @@ async function runTrashEmojiCleanup(
     // Also resume agent if paused (handoff active) — trash emoji from dev/QA
     // is the explicit signal to re-enable the agent and start fresh.
     try {
-      const dbChat = await services.chats.findByExternalIdSmart(instanceId, chatId);
+      const dbChat = await runTenantWorkDb(db, tenantId, () =>
+        services.chats.findByExternalIdSmart(instanceId, chatId),
+      );
       if (dbChat?.id) {
+        // Disarm THREADS the tenant — the lifecycle service scopes its own DB
+        // blocks and publishes between them, so wrapping it in one scope here
+        // would hold a worker transaction across a publish.
         await services.followUpLifecycle.disarm({
           chatId: dbChat.id,
           instanceId,
           reason: 'session_cleared',
+          tenantId,
         });
 
         // Resume agent if handoff had paused it.
@@ -250,9 +325,13 @@ async function runTrashEmojiCleanup(
         // arrived before the resume (NATS redelivery of pre-handoff messages).
         const isAgentPaused = (dbChat.settings as { agentPaused?: boolean } | null)?.agentPaused === true;
         if (isAgentPaused) {
-          await services.chats.update(dbChat.id, {
-            settings: { agentPaused: false, agentResumedAt: new Date().toISOString() },
-          });
+          // Discrete DB block → scoped. This write sets agentPaused:false, so
+          // chats.update's false→true handoff publish never fires here.
+          await runTenantWorkDb(db, tenantId, () =>
+            services.chats.update(dbChat.id, {
+              settings: { agentPaused: false, agentResumedAt: new Date().toISOString() },
+            }),
+          );
           log.info('Agent resumed after session clear (was paused by handoff)', { instanceId, chatId });
         }
       }

--- a/packages/api/src/plugins/session-storage.ts
+++ b/packages/api/src/plugins/session-storage.ts
@@ -1,8 +1,29 @@
 /**
- * Database-backed session storage implementation for ClaudeCodeAgentProvider
+ * Database-backed session storage implementation for ClaudeCodeAgentProvider.
+ *
+ * TENANT-BOUND SECRET SEALING (G5; ADR-0008; OWNERSHIP_MANIFEST
+ * `filesystem_session_state`)
+ * ----------------------------------------------------------------
+ * `agent_sessions.provider_session_data` holds session-secret material (a
+ * provider session id/token). ADR-0008 requires session secrets to be
+ * "non-exportable by default and encrypted with tenant-bound context; plaintext
+ * never appears in ... caches ...". When a caller supplies a tenant resolver AND
+ * a master key is configured (`@omni/core` `setTenantSecretMasterKey`), this
+ * store SEALS the blob with the resolved tenant's key before writing it and
+ * OPENS it under that tenant on read — a session sealed for tenant A cannot be
+ * decrypted under tenant B.
+ *
+ * DUAL WORLD. Sealing is entirely opt-in and gated twice: the caller passes no
+ * `resolveTenantId` (the default), or no master key is configured. In either
+ * case the blob is stored and read as legacy plaintext `{ sessionId }` —
+ * byte-identical to pre-G5. Reads are transitional: a legacy plaintext row and a
+ * sealed row can coexist, and each is handled on its own shape. The single
+ * production caller (`agent-dispatcher`) passes no resolver today, so runtime
+ * behavior is unchanged until the API layer wires a tenant resolver + key.
  */
 
 import type { SessionStorage } from '@omni/core';
+import { isSealedSecret, isTenantSecretSealingEnabled, openTenantSecretJson, sealTenantSecretJson } from '@omni/core';
 import type { Database } from '@omni/db';
 import { agentSessions } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
@@ -14,17 +35,77 @@ function scopeSessionKey(providerId: string, sessionKey: string): string {
 /** Default max session age: 4 hours. Sessions older than this are considered stale and cleared. */
 const DEFAULT_MAX_SESSION_AGE_MS = 4 * 60 * 60 * 1000;
 
+export interface SessionStorageOptions {
+  /**
+   * Optional tenant resolver. When present AND secret-sealing is enabled (a
+   * master key is configured), the session blob is sealed with the resolved
+   * tenant's key before it is written and opened under that tenant on read.
+   * When absent — or when it returns null, or when no master key is configured —
+   * the blob is stored/read as legacy plaintext, byte-identical to pre-G5.
+   *
+   * The tenant MUST be derived from the instance's persisted ownership (the same
+   * trusted derivation G2 defined), never from a caller/payload claim.
+   */
+  resolveTenantId?: (instanceId: string) => string | null | Promise<string | null>;
+}
+
+/** The shape a legacy (unsealed) session blob has always had. */
+interface LegacySessionData {
+  readonly sessionId: string;
+}
+
 export function createSessionStorage(
   db: Database,
   providerId = 'default',
   maxSessionAgeMs = DEFAULT_MAX_SESSION_AGE_MS,
+  options: SessionStorageOptions = {},
 ): SessionStorage {
+  const { resolveTenantId } = options;
+
+  /**
+   * Resolve the tenant for `instanceId` only when sealing could apply. Returns
+   * null (→ legacy plaintext path) when there is no resolver or no key.
+   */
+  async function tenantFor(instanceId: string): Promise<string | null> {
+    if (!resolveTenantId || !isTenantSecretSealingEnabled()) return null;
+    return (await resolveTenantId(instanceId)) ?? null;
+  }
+
+  /**
+   * Turn a stored blob (legacy plaintext OR a sealed envelope) into the session
+   * id. A sealed blob requires the owning tenant; if it cannot be opened
+   * (missing tenant, wrong tenant, or tampering) the session is treated as
+   * absent — fail-closed, never a plaintext leak or a crash.
+   */
+  async function readSessionId(instanceId: string, blob: unknown): Promise<string | null> {
+    if (isSealedSecret(blob)) {
+      const tenantId = await tenantFor(instanceId);
+      if (!tenantId) return null;
+      try {
+        return (openTenantSecretJson(tenantId, blob) as LegacySessionData).sessionId;
+      } catch {
+        return null;
+      }
+    }
+    const legacy = blob as LegacySessionData | null;
+    return legacy?.sessionId ?? null;
+  }
+
+  /** Build the blob to persist: sealed when a tenant is available, else legacy. */
+  async function buildSessionData(instanceId: string, sessionId: string): Promise<Record<string, unknown>> {
+    const tenantId = await tenantFor(instanceId);
+    if (tenantId) {
+      return { ...sealTenantSecretJson(tenantId, { sessionId } satisfies LegacySessionData) };
+    }
+    return { sessionId } satisfies LegacySessionData;
+  }
+
   return {
     async getSession(instanceId: string, sessionKey: string) {
       const scopedSessionKey = scopeSessionKey(providerId, sessionKey);
       const [session] = await db
         .select({
-          sessionId: agentSessions.providerSessionData,
+          providerSessionData: agentSessions.providerSessionData,
           lastUsedAt: agentSessions.lastUsedAt,
           expiresAt: agentSessions.expiresAt,
         })
@@ -53,8 +134,11 @@ export function createSessionStorage(
         return null;
       }
 
+      const sessionId = await readSessionId(instanceId, session.providerSessionData);
+      if (!sessionId) return null;
+
       return {
-        sessionId: (session.sessionId as { sessionId: string }).sessionId,
+        sessionId,
         lastUsedAt: session.lastUsedAt,
       };
     },
@@ -62,20 +146,21 @@ export function createSessionStorage(
     async upsertSession(instanceId: string, sessionKey: string, sessionId: string, expiresAt: Date | null) {
       const scopedSessionKey = scopeSessionKey(providerId, sessionKey);
       const now = new Date();
+      const providerSessionData = await buildSessionData(instanceId, sessionId);
 
       await db
         .insert(agentSessions)
         .values({
           instanceId,
           sessionKey: scopedSessionKey,
-          providerSessionData: { sessionId },
+          providerSessionData,
           lastUsedAt: now,
           expiresAt,
         })
         .onConflictDoUpdate({
           target: [agentSessions.instanceId, agentSessions.sessionKey],
           set: {
-            providerSessionData: { sessionId },
+            providerSessionData,
             lastUsedAt: now,
             expiresAt,
             updatedAt: now,

--- a/packages/api/src/plugins/session-storage.ts
+++ b/packages/api/src/plugins/session-storage.ts
@@ -13,13 +13,31 @@
  * OPENS it under that tenant on read — a session sealed for tenant A cannot be
  * decrypted under tenant B.
  *
- * DUAL WORLD. Sealing is entirely opt-in and gated twice: the caller passes no
- * `resolveTenantId` (the default), or no master key is configured. In either
- * case the blob is stored and read as legacy plaintext `{ sessionId }` —
- * byte-identical to pre-G5. Reads are transitional: a legacy plaintext row and a
- * sealed row can coexist, and each is handled on its own shape. The single
- * production caller (`agent-dispatcher`) passes no resolver today, so runtime
- * behavior is unchanged until the API layer wires a tenant resolver + key.
+ * TENANT-SCOPED DB ACCESS
+ * -----------------------
+ * The store is constructed inside the agent dispatcher and reached only from a
+ * NATS consumer, so it has no request scope to inherit — that is why its
+ * `agent_sessions` site was `pending-G5-conversion`. When a `resolveTenantId` is
+ * supplied, every discrete DB block now runs inside its own short worker tenant
+ * scope (`runTenantWorkDb`) and reads through `scopedHandle`, so RLS decides
+ * visibility: a session key that exists under two tenants resolves to each
+ * tenant's OWN row, and a write aimed at another tenant's instance is refused by
+ * the `agent_sessions` WITH CHECK (its tenant derives from the required
+ * `instances` parent).
+ *
+ * The DB scope is deliberately independent of the sealing key — see `scopeFor`.
+ *
+ * DUAL WORLD. Both behaviors are opt-in on the SAME switch, `resolveTenantId`.
+ * With no resolver (the legacy shape) no scope opens, `scopedHandle` returns the
+ * ambient pool, and the blob is stored and read as legacy plaintext
+ * `{ sessionId }` — byte-identical to pre-G5. Sealing is gated once more, on a
+ * configured master key. Reads are transitional: a legacy plaintext row and a
+ * sealed row can coexist, and each is handled on its own shape.
+ *
+ * The production caller (`agent-dispatcher`) supplies the resolver from the
+ * DISPATCH INSTANCE's persisted `tenantId` — the ownership root G2 defined,
+ * loaded from the database, never a payload claim — which is null in the
+ * flag-off world and therefore changes nothing there.
  */
 
 import type { SessionStorage } from '@omni/core';
@@ -27,6 +45,8 @@ import { isSealedSecret, isTenantSecretSealingEnabled, openTenantSecretJson, sea
 import type { Database } from '@omni/db';
 import { agentSessions } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 
 function scopeSessionKey(providerId: string, sessionKey: string): string {
   return `provider:${providerId}:session:${sessionKey}`;
@@ -63,7 +83,26 @@ export function createSessionStorage(
   const { resolveTenantId } = options;
 
   /**
-   * Resolve the tenant for `instanceId` only when sealing could apply. Returns
+   * The tenant this store's DB work runs under (G5, ADR-0008) — the store is
+   * constructed inside the agent dispatcher and reached only from a consumer, so
+   * it has no request scope to inherit and must establish its own.
+   *
+   * Deliberately NOT gated on `isTenantSecretSealingEnabled()`: the DB boundary
+   * and the secret-sealing boundary are independent decisions. A deployment that
+   * has multitenancy but no session-secret master key still needs its
+   * `agent_sessions` reads scoped; conflating the two would make the tenant
+   * boundary depend on whether a key happens to be configured.
+   *
+   * Returns null when no resolver was supplied — the legacy shape, where no
+   * scope opens and every query runs on the ambient pool byte-identically.
+   */
+  async function scopeFor(instanceId: string): Promise<string | null> {
+    if (!resolveTenantId) return null;
+    return (await resolveTenantId(instanceId)) ?? null;
+  }
+
+  /**
+   * Resolve the tenant for `instanceId` only when SEALING could apply. Returns
    * null (→ legacy plaintext path) when there is no resolver or no key.
    */
   async function tenantFor(instanceId: string): Promise<string | null> {
@@ -103,36 +142,41 @@ export function createSessionStorage(
   return {
     async getSession(instanceId: string, sessionKey: string) {
       const scopedSessionKey = scopeSessionKey(providerId, sessionKey);
-      const [session] = await db
-        .select({
-          providerSessionData: agentSessions.providerSessionData,
-          lastUsedAt: agentSessions.lastUsedAt,
-          expiresAt: agentSessions.expiresAt,
-        })
-        .from(agentSessions)
-        .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey)))
-        .limit(1);
+      const scopeTenant = await scopeFor(instanceId);
+
+      // ONE discrete DB block: the lookup plus the two staleness deletes it may
+      // trigger are a single work item, and the transaction closes before the
+      // (pure, non-DB) unsealing below.
+      const session = await runTenantWorkDb(db, scopeTenant, async () => {
+        const [row] = await scopedHandle(db)
+          .select({
+            providerSessionData: agentSessions.providerSessionData,
+            lastUsedAt: agentSessions.lastUsedAt,
+            expiresAt: agentSessions.expiresAt,
+          })
+          .from(agentSessions)
+          .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey)))
+          .limit(1);
+
+        if (!row) return null;
+
+        const now = new Date();
+        const hardExpired = !!row.expiresAt && row.expiresAt < now;
+        // Sessions older than the threshold are likely zombie/stale. Resuming a
+        // killed or terminal-owned session causes agents to stop mid-reply.
+        const tooOld = !!row.lastUsedAt && now.getTime() - row.lastUsedAt.getTime() > maxSessionAgeMs;
+
+        if (hardExpired || tooOld) {
+          await scopedHandle(db)
+            .delete(agentSessions)
+            .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey)));
+          return null;
+        }
+
+        return row;
+      });
 
       if (!session) return null;
-
-      const now = new Date();
-
-      // Check hard expiry
-      if (session.expiresAt && session.expiresAt < now) {
-        await db
-          .delete(agentSessions)
-          .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey)));
-        return null;
-      }
-
-      // Check max age — sessions older than the threshold are likely zombie/stale.
-      // Resuming a killed or terminal-owned session causes agents to stop mid-reply.
-      if (session.lastUsedAt && now.getTime() - session.lastUsedAt.getTime() > maxSessionAgeMs) {
-        await db
-          .delete(agentSessions)
-          .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey)));
-        return null;
-      }
 
       const sessionId = await readSessionId(instanceId, session.providerSessionData);
       if (!sessionId) return null;
@@ -146,33 +190,41 @@ export function createSessionStorage(
     async upsertSession(instanceId: string, sessionKey: string, sessionId: string, expiresAt: Date | null) {
       const scopedSessionKey = scopeSessionKey(providerId, sessionKey);
       const now = new Date();
+      // Sealing is pure crypto — kept OUTSIDE the transaction so the worker scope
+      // spans nothing but the write itself.
       const providerSessionData = await buildSessionData(instanceId, sessionId);
+      const scopeTenant = await scopeFor(instanceId);
 
-      await db
-        .insert(agentSessions)
-        .values({
-          instanceId,
-          sessionKey: scopedSessionKey,
-          providerSessionData,
-          lastUsedAt: now,
-          expiresAt,
-        })
-        .onConflictDoUpdate({
-          target: [agentSessions.instanceId, agentSessions.sessionKey],
-          set: {
+      await runTenantWorkDb(db, scopeTenant, () =>
+        scopedHandle(db)
+          .insert(agentSessions)
+          .values({
+            instanceId,
+            sessionKey: scopedSessionKey,
             providerSessionData,
             lastUsedAt: now,
             expiresAt,
-            updatedAt: now,
-          },
-        });
+          })
+          .onConflictDoUpdate({
+            target: [agentSessions.instanceId, agentSessions.sessionKey],
+            set: {
+              providerSessionData,
+              lastUsedAt: now,
+              expiresAt,
+              updatedAt: now,
+            },
+          }),
+      );
     },
 
     async deleteSession(instanceId: string, sessionKey: string) {
       const scopedSessionKey = scopeSessionKey(providerId, sessionKey);
-      await db
-        .delete(agentSessions)
-        .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey)));
+      const scopeTenant = await scopeFor(instanceId);
+      await runTenantWorkDb(db, scopeTenant, () =>
+        scopedHandle(db)
+          .delete(agentSessions)
+          .where(and(eq(agentSessions.instanceId, instanceId), eq(agentSessions.sessionKey, scopedSessionKey))),
+      );
     },
   };
 }

--- a/packages/api/src/plugins/storage.ts
+++ b/packages/api/src/plugins/storage.ts
@@ -3,6 +3,35 @@
  *
  * Persists plugin data (auth state, credentials, etc.) to PostgreSQL.
  * Data survives API restarts.
+ *
+ * TENANT-BOUND SEALING OF PLUGIN CREDENTIALS (G5 deliverable (g); ADR-0008;
+ * OWNERSHIP_MANIFEST `filesystem_session_state`)
+ * ---------------------------------------------------------------------------
+ * The doc comment above says "auth state, credentials" and it means it: the
+ * WhatsApp channel stores its entire Baileys session here — `auth:<instanceId>:
+ * creds` is the blob that IS the authenticated WhatsApp identity, and
+ * `auth:<instanceId>:keys:*` are the Signal protocol keys. ADR-0008 requires
+ * this material to be encrypted with tenant-bound context.
+ *
+ * WHERE THE TENANT COMES FROM
+ * ---------------------------
+ * `plugin_storage` is a G0-`split` table and carries no `tenant_id`. But every
+ * credential key NAMES its instance, and `instances` is the G2 ownership root —
+ * so the tenant is derived by parsing the instance id out of the key and asking
+ * the instance-owner registry, which is populated only from `instances` ROWS the
+ * API layer already loaded. That is the same trusted derivation the publish path
+ * uses (`instance-owner-registry.ts`), never a payload or caller hint.
+ *
+ * DUAL WORLD, WITH NO FLAG CHECK. The registry is empty when every
+ * `instances.tenant_id` is NULL, and the codec is the identity function without
+ * a master key — so a flag-off deployment writes byte-identical plaintext and
+ * this module is inert. Reads are transitional: a legacy plaintext row and a
+ * sealed row coexist and each is handled on its own shape, because G5 ships no
+ * credential backfill.
+ *
+ * A key that names no known instance (`global:*`, platform plugin state) seals
+ * nothing — there is no tenant to bind it to, and guessing one would be worse
+ * than leaving it as it is.
  */
 
 import type { PluginStorage } from '@omni/channel-sdk';
@@ -10,8 +39,23 @@ import { createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
 import { pluginStorage } from '@omni/db';
 import { and, eq, gt, isNotNull, isNull, like, lt, or, sql } from 'drizzle-orm';
+import { lookupInstanceOwner } from '../tenancy/instance-owner-registry';
+import { openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
 
 const log = createLogger('api:storage');
+
+/** First UUID appearing in a storage key — the instance it belongs to. */
+const INSTANCE_ID_IN_KEY = /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+
+/**
+ * The tenant a given storage key's value is sealed for, or null when this row
+ * is not tenant-owned secret material (no instance in the key, or an instance
+ * whose ownership this process has never loaded).
+ */
+function tenantForStorageKey(fullKey: string): string | null {
+  const match = INSTANCE_ID_IN_KEY.exec(fullKey);
+  return match ? lookupInstanceOwner(match[0]) : null;
+}
 
 /**
  * Database-backed storage for plugin data
@@ -60,16 +104,25 @@ class DatabasePluginStorage implements PluginStorage {
     const row = result[0];
     if (!row) return null;
 
+    // Unseal BEFORE parsing: a sealed row's `value` is the envelope, and the
+    // plaintext inside it is exactly the string `set` serialized. A row that
+    // cannot be opened (sealed for another tenant, or no key configured) is
+    // treated as ABSENT — fail-closed. Returning the envelope would hand the
+    // caller a blob it would then present to WhatsApp as a session credential.
+    const opened = openCredentialField(tenantForStorageKey(fullKey), row.value);
+    if (opened == null) return null;
+
     try {
-      return JSON.parse(row.value) as T;
+      return JSON.parse(opened) as T;
     } catch {
-      return row.value as unknown as T;
+      return opened as unknown as T;
     }
   }
 
   async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
     const fullKey = this.getFullKey(key);
-    const serializedValue = typeof value === 'string' ? value : JSON.stringify(value);
+    const plainValue = typeof value === 'string' ? value : JSON.stringify(value);
+    const serializedValue = sealCredentialField(tenantForStorageKey(fullKey), plainValue);
     const expiresAt = ttlMs ? new Date(Date.now() + ttlMs) : null;
 
     await this.db
@@ -258,6 +311,18 @@ export function setStorageDatabase(db: Database): void {
  *
  * Uses DatabasePluginStorage if database is available, falls back to InMemory
  */
+/**
+ * Test-only constructor for the database-backed store.
+ *
+ * `getPluginStorage` memoises one instance per plugin id against a module-global
+ * database, which the sealing probes cannot use: each case needs its own fresh
+ * table stand-in. This exposes the class without widening the production API —
+ * `getPluginStorage` remains the only way production code obtains a store.
+ */
+export function __createPluginStorageForTest(db: Database, pluginId: string): PluginStorage {
+  return new DatabasePluginStorage(db, pluginId);
+}
+
 export function getPluginStorage(pluginId: string): PluginStorage {
   let storage = storageInstances.get(pluginId);
   if (!storage) {

--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -359,11 +359,14 @@ async function discoverAnchorsFromPlugin(
   plugin: unknown,
   dbAnchors: WAnchor[],
   services: Services,
+  envelope: SyncEnvelope,
 ): Promise<WAnchor[]> {
   const anchoredJids = new Set(dbAnchors.map((a) => a.chatJid));
 
-  // Query DB for all known chat external IDs (survives restarts)
-  const dbExternalIds = await services.chats.getAllExternalIds(instanceId);
+  // Query DB for all known chat external IDs (survives restarts). Discrete block
+  // in the job envelope's world (G5, ADR-0008) — it reads `chats` AND
+  // `chat_id_mappings`, so an ambient read would leave both sites unscoped.
+  const dbExternalIds = await inSyncWorkerScope(envelope, () => services.chats.getAllExternalIds(instanceId));
 
   // Merge with Baileys volatile cache (newly connected chats not yet in DB)
   const baileysJids = hasKnownChatJids(plugin) ? plugin.getKnownChatJids(instanceId) : [];
@@ -395,6 +398,7 @@ async function resolveWhatsAppAnchors(
   plugin: unknown,
   dbAnchors: WAnchor[],
   services: Services,
+  envelope: SyncEnvelope,
 ): Promise<WAnchor[]> {
   // Explicit chatJids take priority (per-chat active sync)
   if (config.chatJids?.length) {
@@ -402,7 +406,7 @@ async function resolveWhatsAppAnchors(
   }
 
   // Default: use DB anchors + discover chats known to Baileys but not in DB.
-  return [...dbAnchors, ...(await discoverAnchorsFromPlugin(jobId, instanceId, plugin, dbAnchors, services))];
+  return [...dbAnchors, ...(await discoverAnchorsFromPlugin(jobId, instanceId, plugin, dbAnchors, services, envelope))];
 }
 
 /**
@@ -462,13 +466,13 @@ async function processMessageSync(
     // The DB anchor read runs in a per-item worker scope so it only sees the
     // work item's tenant's messages/chats under enforcement.
     const dbAnchors = handle ? await inSyncWorkerScope(envelope, () => buildWhatsAppAnchors(handle, instanceId)) : [];
-    anchors = await resolveWhatsAppAnchors(jobId, instanceId, config, plugin, dbAnchors, services);
+    anchors = await resolveWhatsAppAnchors(jobId, instanceId, config, plugin, dbAnchors, services, envelope);
     log.info('WhatsApp per-chat active sync', { jobId, anchorCount: anchors.length, chatJids: config.chatJids });
   } else if (channelType === 'whatsapp-baileys') {
     // Default sync: discover all known chats from DB + Baileys volatile cache.
     // Using DB ensures chats survive restarts even when Baileys cache is empty.
     const dbAnchors = handle ? await inSyncWorkerScope(envelope, () => buildWhatsAppAnchors(handle, instanceId)) : [];
-    const discoveredAnchors = await discoverAnchorsFromPlugin(jobId, instanceId, plugin, dbAnchors, services);
+    const discoveredAnchors = await discoverAnchorsFromPlugin(jobId, instanceId, plugin, dbAnchors, services, envelope);
     anchors = [...dbAnchors, ...discoveredAnchors];
     if (anchors.length > 0) {
       log.info('WhatsApp default sync with DB+cache discovery', {
@@ -643,15 +647,24 @@ function mapContentType(
 }
 
 /** Update a DM chat's name if it's missing or stale */
-async function updateDmChatName(services: Services, instanceId: string, jid: string, name: string): Promise<void> {
+async function updateDmChatName(
+  services: Services,
+  instanceId: string,
+  jid: string,
+  name: string,
+  envelope: SyncEnvelope,
+): Promise<void> {
   try {
-    // Use smart lookup to handle LID/phone JID resolution
-    const chat = await services.chats.findByExternalIdSmart(instanceId, jid);
-    if (!chat) return;
-    const hasStaleJidName = chat.name?.endsWith('@s.whatsapp.net') || chat.name?.endsWith('@lid');
-    if (!chat.name || hasStaleJidName) {
-      await services.chats.update(chat.id, { name });
-    }
+    // Lookup + conditional rename are one work item, in the envelope's world.
+    await inSyncWorkerScope(envelope, async () => {
+      // Use smart lookup to handle LID/phone JID resolution
+      const chat = await services.chats.findByExternalIdSmart(instanceId, jid);
+      if (!chat) return;
+      const hasStaleJidName = chat.name?.endsWith('@s.whatsapp.net') || chat.name?.endsWith('@lid');
+      if (!chat.name || hasStaleJidName) {
+        await services.chats.update(chat.id, { name });
+      }
+    });
   } catch {
     // Chat may not exist yet — that's fine
   }
@@ -729,20 +742,25 @@ async function processContactsSync(
       if (c.isGroup) return;
 
       try {
-        const result = await services.persons.findOrCreateIdentity(
-          {
-            channel: channelType,
-            instanceId,
-            platformUserId: c.platformUserId,
-            platformUsername: c.name,
-            profilePicUrl: c.profilePicUrl,
-            profileData: c.metadata,
-          },
-          {
-            matchByPhone: validateContactPhone(c.phone, c.platformUserId),
-            createPerson: true,
-            displayName: c.name,
-          },
+        // One work item per contact: the identity/person write runs in the job
+        // envelope's world (G5, ADR-0008), so `platform_identities` and the
+        // `chat_id_mappings` read behind it are RLS-policed.
+        const result = await inSyncWorkerScope(envelope, () =>
+          services.persons.findOrCreateIdentity(
+            {
+              channel: channelType,
+              instanceId,
+              platformUserId: c.platformUserId,
+              platformUsername: c.name,
+              profilePicUrl: c.profilePicUrl,
+              profileData: c.metadata,
+            },
+            {
+              matchByPhone: validateContactPhone(c.phone, c.platformUserId),
+              createPerson: true,
+              displayName: c.name,
+            },
+          ),
         );
 
         if (result.isNew) stored++;
@@ -750,7 +768,7 @@ async function processContactsSync(
 
         // Update DM chat name if missing or stale
         if (c.name && !c.isGroup) {
-          await updateDmChatName(services, instanceId, c.platformUserId, c.name);
+          await updateDmChatName(services, instanceId, c.platformUserId, c.name, envelope);
         }
       } catch (error) {
         log.warn('Failed to store synced contact', {

--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -626,7 +626,7 @@ async function processMessageSync(
     jobTenantId,
   );
 
-  await queueMediaBackfillAfterSync(services, config, instanceId, jobId, stored);
+  await queueMediaBackfillAfterSync(services, config, instanceId, jobId, stored, jobTenantId);
 
   // Complete the job
   await services.syncJobs.complete(jobId, jobTenantId);
@@ -639,12 +639,27 @@ async function processMessageSync(
   });
 }
 
+/**
+ * Enqueue the post-sync media backfill batch job.
+ *
+ * @param trustedTenantId - the sync job's OWN tenant (`trustedSyncTenant`,
+ *   producer-stamped envelope metadata — never payload). This call site sits
+ *   OUTSIDE every scope: `inSyncWorkerScope` wraps only the per-item closures,
+ *   which closed before the fetch returned, and the handler is a NATS consumer
+ *   with no ambient scope. So `BatchJobService.create` cannot recover the tenant
+ *   from `currentTenantScope()` here — unthreaded, it would stamp a NULL-tenant
+ *   row whose detached executor reads `messages` and writes `media_content`
+ *   unscoped, and whose dequeue-time revocation gate is skipped (a null tenant
+ *   is admissible by definition). `null` for a legacy job keeps the pre-G5
+ *   ambient behaviour byte-identically.
+ */
 async function queueMediaBackfillAfterSync(
   services: Services,
   config: SyncJobConfig,
   instanceId: string,
   jobId: string,
   stored: number,
+  trustedTenantId: string | null,
 ): Promise<void> {
   if ((config.backfillMedia !== true && config.processMedia !== true) || stored === 0) return;
 
@@ -659,7 +674,7 @@ async function queueMediaBackfillAfterSync(
       delayMinMs: config.delayMinMs ?? 1000,
       delayMaxMs: config.delayMaxMs ?? 3000,
     };
-    const batch = await services.batchJobs.create(params);
+    const batch = await services.batchJobs.create(params, trustedTenantId);
     log.info('Queued media backfill batch after message sync', { jobId, batchJobId: batch.id, stored });
   } catch (error) {
     log.warn('Failed to queue media backfill batch after message sync', { jobId, error: String(error) });

--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -15,6 +15,8 @@ import type { Database, SyncJobConfig, SyncJobProgress, SyncJobType } from '@omn
 import { omniGroups } from '@omni/db';
 import { and, eq, sql } from 'drizzle-orm';
 import type { Services } from '../services';
+import { InflightRevocationError, createInflightRevocationMonitor } from '../tenancy/inflight-revocation';
+import { isTenantWorkAdmissible } from '../tenancy/periodic-tenant-work';
 import { scopedHandle } from '../tenancy/tenant-scope';
 import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 import { validateContactPhone } from '../utils/phone';
@@ -144,6 +146,21 @@ function trustedSyncTenant(envelope: SyncEnvelope): string | null {
   return classification.world === 'tenant' ? classification.tenantId : null;
 }
 
+/**
+ * The in-flight revocation gate for a sync job (G5, deliverable (c);
+ * RELEASE_SLOS `inflight_privileged_work_revocation_seconds_max`). A message
+ * backfill can run for minutes, so each processor calls the monitor per work
+ * item: the first call doubles as dequeue-time revalidation, later calls
+ * re-check the auth plane at the bounded cadence. Legacy jobs (null tenant)
+ * never check — byte-identical.
+ */
+function jobRevocationMonitor(services: Services, jobTenantId: string | null) {
+  return createInflightRevocationMonitor({
+    tenantId: jobTenantId,
+    check: (tenantId) => isTenantWorkAdmissible(services.authPlane.db, tenantId),
+  });
+}
+
 export async function setupSyncWorker(
   eventBus: EventBus,
   services: Services,
@@ -173,8 +190,13 @@ export async function setupSyncWorker(
           // Start the job
           await services.syncJobs.start(jobId, jobTenantId);
 
-          // Get instance to determine channel type
-          const instance = await services.instances.getById(instanceId);
+          // Get instance to determine channel type. One discrete scoped read
+          // (G5, ADR-0008): a tenant-world job runs it in a short worker scope
+          // via the envelope's classified world; a legacy job reads the
+          // ambient pool byte-identically. Without this wrap the read was the
+          // handler's ONE bare `instances` access between `syncJobs.start`
+          // and the scoped per-item loop.
+          const instance = await inSyncWorkerScope(event, () => services.instances.getById(instanceId));
           if (!instance) {
             throw new Error(`Instance ${instanceId} not found`);
           }
@@ -434,6 +456,14 @@ async function processMessageSync(
   // `trustedSyncTenant`.
   const jobTenantId = trustedSyncTenant(envelope);
 
+  // In-flight revocation gate (RELEASE_SLOS inflight ceiling): the first call
+  // is the dequeue-time revalidation — it runs before ANY anchor read or
+  // message store; per-message calls below observe a mid-flight revocation at
+  // the bounded cadence. Sticky: once refused, the rest of the fetch drops.
+  const revocation = jobRevocationMonitor(services, jobTenantId);
+  await revocation.assertAdmissible();
+  let inflightRevoked: InflightRevocationError | null = null;
+
   // Check if plugin supports fetchHistory
   if (!('fetchHistory' in plugin) || typeof plugin.fetchHistory !== 'function') {
     log.warn('Plugin does not support fetchHistory', { channelType });
@@ -494,6 +524,7 @@ async function processMessageSync(
     count: 100, // Messages per chat (recursive fetching will get more)
     anchors: anchors.length > 0 ? anchors : undefined,
     onProgress: async (count: number, progress?: number) => {
+      if (inflightRevoked) return; // no durable side effects after the flip
       await services.syncJobs.updateProgress(
         jobId,
         {
@@ -506,6 +537,21 @@ async function processMessageSync(
       );
     },
     onMessage: async (msg: HistorySyncMessage) => {
+      // The per-item revocation gate, BEFORE the try below: its refusal must
+      // stop the store, not be swallowed by the per-message error handler. The
+      // channel plugin may keep feeding messages after the flip — they are
+      // dropped here without side effects, and the job fails after the fetch.
+      if (inflightRevoked) return;
+      try {
+        await revocation.assertAdmissible();
+      } catch (error) {
+        if (error instanceof InflightRevocationError) {
+          inflightRevoked = error;
+          return;
+        }
+        throw error;
+      }
+
       // Rate limit — OUTSIDE the worker scope, so no tenant transaction is held
       // across the sleep.
       await rateLimiter.wait();
@@ -565,6 +611,9 @@ async function processMessageSync(
 
   // Call fetchHistory
   await plugin.fetchHistory(instanceId, fetchOptions);
+
+  // A revocation observed mid-flight fails the job — never "completed".
+  if (inflightRevoked) throw inflightRevoked;
 
   // Update final progress
   await services.syncJobs.updateProgress(
@@ -694,6 +743,11 @@ async function processContactsSync(
   // would find nothing. The job table is owned and is scoped.
   const jobTenantId = trustedSyncTenant(envelope);
 
+  // In-flight revocation gate — same contract as processMessageSync.
+  const revocation = jobRevocationMonitor(services, jobTenantId);
+  await revocation.assertAdmissible();
+  let inflightRevoked: InflightRevocationError | null = null;
+
   // Check if plugin supports fetchContacts
   if (!('fetchContacts' in plugin) || typeof plugin.fetchContacts !== 'function') {
     log.warn('Plugin does not support fetchContacts', { channelType });
@@ -725,6 +779,17 @@ async function processContactsSync(
       );
     },
     onContact: async (contact: unknown) => {
+      if (inflightRevoked) return;
+      try {
+        await revocation.assertAdmissible();
+      } catch (error) {
+        if (error instanceof InflightRevocationError) {
+          inflightRevoked = error;
+          return;
+        }
+        throw error;
+      }
+
       fetched++;
 
       const c = contact as {
@@ -786,6 +851,9 @@ async function processContactsSync(
 
   // Call fetchContacts
   await plugin.fetchContacts(instanceId, fetchOptions);
+
+  // A revocation observed mid-flight fails the job — never "completed".
+  if (inflightRevoked) throw inflightRevoked;
 
   // Update final progress
   await services.syncJobs.updateProgress(
@@ -905,6 +973,11 @@ async function processGroupsSync(
   // per-item `inSyncWorkerScope` (leg B pt2).
   const jobTenantId = trustedSyncTenant(envelope);
 
+  // In-flight revocation gate — same contract as processMessageSync.
+  const revocation = jobRevocationMonitor(services, jobTenantId);
+  await revocation.assertAdmissible();
+  let inflightRevoked: InflightRevocationError | null = null;
+
   // Check if plugin supports fetchGroups (WhatsApp) or fetchGuilds (Discord)
   const fetchMethod = channelType === 'discord' ? 'fetchGuilds' : 'fetchGroups';
   if (!(fetchMethod in plugin) || typeof plugin[fetchMethod as keyof typeof plugin] !== 'function') {
@@ -944,6 +1017,16 @@ async function processGroupsSync(
       );
     },
     onGroup: async (group: unknown) => {
+      if (inflightRevoked) return;
+      try {
+        await revocation.assertAdmissible();
+      } catch (error) {
+        if (error instanceof InflightRevocationError) {
+          inflightRevoked = error;
+          return;
+        }
+        throw error;
+      }
       fetched++;
 
       const g = group as SyncedGroupInput;
@@ -1044,6 +1127,9 @@ async function processGroupsSync(
     options: Record<string, unknown>,
   ) => Promise<void>;
   await fetchFn.call(plugin, instanceId, fetchOptions);
+
+  // A revocation observed mid-flight fails the job — never "completed".
+  if (inflightRevoked) throw inflightRevoked;
 
   // Update final progress
   await services.syncJobs.updateProgress(

--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -8,13 +8,15 @@
  */
 
 import type { ChannelRegistry, FetchHistoryOptions, HistorySyncMessage } from '@omni/channel-sdk';
-import type { EventBus } from '@omni/core';
+import type { EventBus, OmniEvent } from '@omni/core';
 import { createLogger } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
 import type { Database, SyncJobConfig, SyncJobProgress, SyncJobType } from '@omni/db';
 import { omniGroups } from '@omni/db';
 import { and, eq, sql } from 'drizzle-orm';
 import type { Services } from '../services';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 import { validateContactPhone } from '../utils/phone';
 
 const log = createLogger('sync-worker');
@@ -99,6 +101,29 @@ function parseSyncDepth(depth?: string): Date | undefined {
  */
 let db: Database | null = null;
 
+/**
+ * The envelope carried by the `sync.started` work item. Its trusted tenant (or
+ * `legacy`, flag-off) scopes each per-item DB block below.
+ */
+type SyncEnvelope = Pick<OmniEvent, 'metadata'>;
+
+/**
+ * Run ONE per-item DB block under the work item's worker tenant scope.
+ *
+ * G5 worker-context boundary (ADR-0008): a converted consumer wraps each DISCRETE
+ * DB block — never the whole `fetchHistory`/`fetchContacts`/`fetchGroups` job,
+ * which awaits long-running channel I/O and must not hold a tenant transaction —
+ * so `scopedHandle(db)` inside the block returns the worker transaction. A legacy
+ * envelope runs the block on the ambient pool byte-identically; a quarantined one
+ * is refused before any DB work. When no `db` handle was injected (unit setups
+ * that never touch tenant tables) the block runs directly, exactly as before.
+ */
+function inSyncWorkerScope<T>(envelope: SyncEnvelope, fn: () => Promise<T>): Promise<T> {
+  const handle = db;
+  if (!handle) return fn();
+  return runConsumerInTenantContext(handle, envelope, fn);
+}
+
 export async function setupSyncWorker(
   eventBus: EventBus,
   services: Services,
@@ -131,24 +156,30 @@ export async function setupSyncWorker(
 
           const channelType = instance.channel;
 
-          // Process based on job type
+          // Process based on job type. The `event` (versioned envelope) threads
+          // through so each processor can scope its per-item DB blocks to the
+          // work item's trusted tenant.
           switch (type) {
             case 'messages':
-              await processMessageSync(jobId, instanceId, channelType, config, services, channelRegistry);
+              await processMessageSync(jobId, instanceId, channelType, config, services, channelRegistry, event);
               break;
             case 'profile':
               // Profile sync is handled by ProfileSyncService, just mark complete
               await services.syncJobs.complete(jobId);
               break;
             case 'contacts':
+              // Not scoped this leg: its only tenant-table write is `persons`,
+              // which G2 classifies `unowned` (tenant_id stays NULL until the G6
+              // backfill), so there is no registered sync-worker site here to
+              // ratchet. Left byte-identical.
               await processContactsSync(jobId, instanceId, channelType, config, services, channelRegistry);
               break;
             case 'groups':
-              await processGroupsSync(jobId, instanceId, channelType, config, services, channelRegistry);
+              await processGroupsSync(jobId, instanceId, channelType, config, services, channelRegistry, event);
               break;
             case 'all':
               // All sync - process each type
-              await processMessageSync(jobId, instanceId, channelType, config, services, channelRegistry);
+              await processMessageSync(jobId, instanceId, channelType, config, services, channelRegistry, event);
               break;
             case 'history-push':
               // Progress/completion is driven by tracker subscribers, not the worker
@@ -182,19 +213,17 @@ export async function setupSyncWorker(
  * Gets the oldest message per chat to use as anchor points
  */
 async function buildWhatsAppAnchors(
+  database: Database,
   instanceId: string,
-  _services: Services,
 ): Promise<
   Array<{ chatJid: string; messageKey: { remoteJid: string; id: string; fromMe: boolean }; timestamp: number }>
 > {
-  if (!db) {
-    log.warn('Database not available for building anchors');
-    return [];
-  }
-
   // Query oldest message per chat that has a raw_payload with key
-  // Using raw SQL for the complex DISTINCT ON query
-  const result = await db.execute(sql`
+  // Using raw SQL for the complex DISTINCT ON query. `scopedHandle` returns the
+  // worker tenant transaction when this read runs inside a per-item worker scope
+  // (see `inSyncWorkerScope`), and the ambient pool otherwise (byte-identical to
+  // pre-G5).
+  const result = await scopedHandle(database).execute(sql`
     WITH oldest_messages AS (
       SELECT DISTINCT ON (c.external_id)
         c.external_id as chat_jid,
@@ -361,11 +390,16 @@ async function processMessageSync(
   config: SyncJobConfig,
   services: Services,
   channelRegistry: ChannelRegistry,
+  envelope: SyncEnvelope,
 ): Promise<void> {
   const plugin = channelRegistry.get(channelType);
   if (!plugin) {
     throw new Error(`No plugin found for channel type: ${channelType}`);
   }
+
+  // Non-null db handle for the per-item worker scopes below. When absent (unit
+  // setups that never touch tenant tables) the blocks run unscoped, as before.
+  const handle = db;
 
   // Check if plugin supports fetchHistory
   if (!('fetchHistory' in plugin) || typeof plugin.fetchHistory !== 'function') {
@@ -395,14 +429,16 @@ async function processMessageSync(
   let anchors: WAnchor[] = [];
 
   if (channelType === 'whatsapp-baileys' && config.chatJids?.length) {
-    // Per-chat active sync: build anchors for the specific requested chats only
-    const dbAnchors = await buildWhatsAppAnchors(instanceId, services);
+    // Per-chat active sync: build anchors for the specific requested chats only.
+    // The DB anchor read runs in a per-item worker scope so it only sees the
+    // work item's tenant's messages/chats under enforcement.
+    const dbAnchors = handle ? await inSyncWorkerScope(envelope, () => buildWhatsAppAnchors(handle, instanceId)) : [];
     anchors = await resolveWhatsAppAnchors(jobId, instanceId, config, plugin, dbAnchors, services);
     log.info('WhatsApp per-chat active sync', { jobId, anchorCount: anchors.length, chatJids: config.chatJids });
   } else if (channelType === 'whatsapp-baileys') {
     // Default sync: discover all known chats from DB + Baileys volatile cache.
     // Using DB ensures chats survive restarts even when Baileys cache is empty.
-    const dbAnchors = await buildWhatsAppAnchors(instanceId, services);
+    const dbAnchors = handle ? await inSyncWorkerScope(envelope, () => buildWhatsAppAnchors(handle, instanceId)) : [];
     const discoveredAnchors = await discoverAnchorsFromPlugin(jobId, instanceId, plugin, dbAnchors, services);
     anchors = [...dbAnchors, ...discoveredAnchors];
     if (anchors.length > 0) {
@@ -433,43 +469,49 @@ async function processMessageSync(
       });
     },
     onMessage: async (msg: HistorySyncMessage) => {
-      // Rate limit
+      // Rate limit — OUTSIDE the worker scope, so no tenant transaction is held
+      // across the sleep.
       await rateLimiter.wait();
 
       fetched++;
 
       try {
-        // Find or create chat
-        const { chat } = await services.chats.findOrCreate(instanceId, msg.chatId, {
-          chatType: 'dm', // Default, will be updated
-          channel: channelType as 'whatsapp-baileys' | 'discord',
+        // Each synced message is one work item: its find-or-create + de-dupe
+        // check + insert run inside a fresh per-item worker tenant scope so the
+        // row lands under the work item's tenant (legacy envelope → ambient pool,
+        // byte-identical). The counters are updated OUTSIDE the scope.
+        const outcome = await inSyncWorkerScope(envelope, async (): Promise<'duplicate' | 'stored'> => {
+          // Find or create chat
+          const { chat } = await services.chats.findOrCreate(instanceId, msg.chatId, {
+            chatType: 'dm', // Default, will be updated
+            channel: channelType as 'whatsapp-baileys' | 'discord',
+          });
+
+          // Check for duplicates
+          const existing = await services.messages.getByExternalId(chat.id, msg.externalId);
+          if (existing) return 'duplicate';
+
+          // Create message
+          await services.messages.create({
+            chatId: chat.id,
+            externalId: msg.externalId,
+            source: 'sync',
+            messageType: mapContentType(msg.content.type),
+            textContent: msg.content.text ?? msg.content.caption,
+            platformTimestamp: msg.timestamp,
+            hasMedia: ['audio', 'image', 'video', 'document', 'sticker'].includes(msg.content.type),
+            mediaMimeType: msg.content.mimeType,
+            mediaUrl: msg.content.mediaUrl,
+            mediaLocalPath: msg.content.localPath,
+            senderPlatformUserId: msg.from,
+            isFromMe: msg.isFromMe,
+            rawPayload: msg.rawPayload as Record<string, unknown>,
+          });
+          return 'stored';
         });
 
-        // Check for duplicates
-        const existing = await services.messages.getByExternalId(chat.id, msg.externalId);
-        if (existing) {
-          duplicates++;
-          return;
-        }
-
-        // Create message
-        await services.messages.create({
-          chatId: chat.id,
-          externalId: msg.externalId,
-          source: 'sync',
-          messageType: mapContentType(msg.content.type),
-          textContent: msg.content.text ?? msg.content.caption,
-          platformTimestamp: msg.timestamp,
-          hasMedia: ['audio', 'image', 'video', 'document', 'sticker'].includes(msg.content.type),
-          mediaMimeType: msg.content.mimeType,
-          mediaUrl: msg.content.mediaUrl,
-          mediaLocalPath: msg.content.localPath,
-          senderPlatformUserId: msg.from,
-          isFromMe: msg.isFromMe,
-          rawPayload: msg.rawPayload as Record<string, unknown>,
-        });
-
-        stored++;
+        if (outcome === 'duplicate') duplicates++;
+        else stored++;
       } catch (error) {
         log.warn('Failed to store synced message', {
           externalId: msg.externalId,
@@ -696,6 +738,80 @@ async function processContactsSync(
   });
 }
 
+/** Shape of a WhatsApp group emitted by the channel plugin's fetchGroups. */
+type SyncedGroupInput = {
+  externalId: string;
+  name?: string;
+  description?: string;
+  memberCount?: number;
+  iconUrl?: string;
+  ownerId?: string;
+  createdBy?: string;
+  createdAt?: Date;
+  isReadOnly?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Upsert ONE synced WhatsApp group. Extracted from the `onGroup` callback so it
+ * is a testable seam: it reads/writes `omni_groups` through `scopedHandle`, so
+ * inside a per-item worker scope it is the worker's tenant transaction and the
+ * insert is RLS-stamped/checked; on the ambient pool it is byte-identical to
+ * pre-G5. Errors propagate to the caller, which keeps the sync-loop's
+ * log-and-continue behaviour.
+ */
+async function upsertSyncedGroup(
+  database: Database,
+  instanceId: string,
+  channelType: ChannelType,
+  g: SyncedGroupInput,
+): Promise<'stored' | 'updated'> {
+  const sdb = scopedHandle(database);
+  // Check if group already exists
+  const [existing] = await sdb
+    .select()
+    .from(omniGroups)
+    .where(and(eq(omniGroups.instanceId, instanceId), eq(omniGroups.externalId, g.externalId)))
+    .limit(1);
+
+  if (existing) {
+    // Update existing group
+    await sdb
+      .update(omniGroups)
+      .set({
+        name: g.name,
+        description: g.description,
+        iconUrl: g.iconUrl,
+        memberCount: g.memberCount,
+        ownerId: g.ownerId,
+        isReadOnly: g.isReadOnly ?? false,
+        platformMetadata: g.metadata,
+        syncedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(omniGroups.id, existing.id));
+    return 'updated';
+  }
+
+  // Create new group
+  await sdb.insert(omniGroups).values({
+    instanceId,
+    externalId: g.externalId,
+    channel: channelType,
+    name: g.name,
+    description: g.description,
+    iconUrl: g.iconUrl,
+    memberCount: g.memberCount,
+    ownerId: g.ownerId,
+    createdBy: g.createdBy,
+    isReadOnly: g.isReadOnly ?? false,
+    isCommunity: false,
+    platformMetadata: g.metadata,
+    syncedAt: new Date(),
+  });
+  return 'stored';
+}
+
 /**
  * Process groups sync
  */
@@ -706,6 +822,7 @@ async function processGroupsSync(
   _config: SyncJobConfig,
   services: Services,
   channelRegistry: ChannelRegistry,
+  envelope: SyncEnvelope,
 ): Promise<void> {
   const plugin = channelRegistry.get(channelType);
   if (!plugin) {
@@ -749,63 +866,16 @@ async function processGroupsSync(
     onGroup: async (group: unknown) => {
       fetched++;
 
-      const g = group as {
-        externalId: string;
-        name?: string;
-        description?: string;
-        memberCount?: number;
-        iconUrl?: string;
-        ownerId?: string;
-        createdBy?: string;
-        createdAt?: Date;
-        isReadOnly?: boolean;
-        metadata?: Record<string, unknown>;
-      };
+      const g = group as SyncedGroupInput;
 
       try {
-        // Check if group already exists
-        const [existing] = await database
-          .select()
-          .from(omniGroups)
-          .where(and(eq(omniGroups.instanceId, instanceId), eq(omniGroups.externalId, g.externalId)))
-          .limit(1);
-
-        if (existing) {
-          // Update existing group
-          await database
-            .update(omniGroups)
-            .set({
-              name: g.name,
-              description: g.description,
-              iconUrl: g.iconUrl,
-              memberCount: g.memberCount,
-              ownerId: g.ownerId,
-              isReadOnly: g.isReadOnly ?? false,
-              platformMetadata: g.metadata,
-              syncedAt: new Date(),
-              updatedAt: new Date(),
-            })
-            .where(eq(omniGroups.id, existing.id));
-          updated++;
-        } else {
-          // Create new group
-          await database.insert(omniGroups).values({
-            instanceId,
-            externalId: g.externalId,
-            channel: channelType,
-            name: g.name,
-            description: g.description,
-            iconUrl: g.iconUrl,
-            memberCount: g.memberCount,
-            ownerId: g.ownerId,
-            createdBy: g.createdBy,
-            isReadOnly: g.isReadOnly ?? false,
-            isCommunity: false,
-            platformMetadata: g.metadata,
-            syncedAt: new Date(),
-          });
-          stored++;
-        }
+        // One group = one work item, upserted inside a fresh per-item worker
+        // tenant scope; counters are updated OUTSIDE the scope.
+        const outcome = await inSyncWorkerScope(envelope, () =>
+          upsertSyncedGroup(database, instanceId, channelType, g),
+        );
+        if (outcome === 'updated') updated++;
+        else stored++;
       } catch (error) {
         log.warn('Failed to store synced group', {
           externalId: g.externalId,
@@ -829,32 +899,39 @@ async function processGroupsSync(
       };
 
       try {
-        // Check if guild already exists
-        const [existing] = await database
-          .select()
-          .from(omniGroups)
-          .where(and(eq(omniGroups.instanceId, instanceId), eq(omniGroups.externalId, g.externalId)))
-          .limit(1);
+        // One guild = one work item, upserted inside a fresh per-item worker
+        // tenant scope; `scopedHandle` returns the worker transaction (ambient
+        // pool when unscoped, byte-identical). Discord's field mapping differs
+        // from WhatsApp groups (no createdBy, isReadOnly always false), so it is
+        // kept inline rather than sharing `upsertSyncedGroup`.
+        const outcome = await inSyncWorkerScope(envelope, async (): Promise<'stored' | 'updated'> => {
+          const sdb = scopedHandle(database);
+          // Check if guild already exists
+          const [existing] = await sdb
+            .select()
+            .from(omniGroups)
+            .where(and(eq(omniGroups.instanceId, instanceId), eq(omniGroups.externalId, g.externalId)))
+            .limit(1);
 
-        if (existing) {
-          // Update existing guild
-          await database
-            .update(omniGroups)
-            .set({
-              name: g.name,
-              description: g.description,
-              iconUrl: g.iconUrl,
-              memberCount: g.memberCount,
-              ownerId: g.ownerId,
-              platformMetadata: g.metadata,
-              syncedAt: new Date(),
-              updatedAt: new Date(),
-            })
-            .where(eq(omniGroups.id, existing.id));
-          updated++;
-        } else {
+          if (existing) {
+            // Update existing guild
+            await sdb
+              .update(omniGroups)
+              .set({
+                name: g.name,
+                description: g.description,
+                iconUrl: g.iconUrl,
+                memberCount: g.memberCount,
+                ownerId: g.ownerId,
+                platformMetadata: g.metadata,
+                syncedAt: new Date(),
+                updatedAt: new Date(),
+              })
+              .where(eq(omniGroups.id, existing.id));
+            return 'updated';
+          }
           // Create new guild
-          await database.insert(omniGroups).values({
+          await sdb.insert(omniGroups).values({
             instanceId,
             externalId: g.externalId,
             channel: channelType,
@@ -868,8 +945,10 @@ async function processGroupsSync(
             platformMetadata: g.metadata,
             syncedAt: new Date(),
           });
-          stored++;
-        }
+          return 'stored';
+        });
+        if (outcome === 'updated') updated++;
+        else stored++;
       } catch (error) {
         log.warn('Failed to store synced guild', {
           externalId: g.externalId,
@@ -1082,3 +1161,13 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
     throw error;
   }
 }
+
+/**
+ * Test-only seams: the two `omni_groups`/`messages` DB-access sites, exposed so
+ * the two-tenant real-PostgreSQL suite can drive them directly under a worker
+ * tenant scope (the same shape the media-processor suite uses).
+ */
+export const __test__ = {
+  buildWhatsAppAnchors,
+  upsertSyncedGroup,
+};

--- a/packages/api/src/plugins/sync-worker.ts
+++ b/packages/api/src/plugins/sync-worker.ts
@@ -9,7 +9,7 @@
 
 import type { ChannelRegistry, FetchHistoryOptions, HistorySyncMessage } from '@omni/channel-sdk';
 import type { EventBus, OmniEvent } from '@omni/core';
-import { createLogger } from '@omni/core';
+import { classifyEnvelope, createLogger } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
 import type { Database, SyncJobConfig, SyncJobProgress, SyncJobType } from '@omni/db';
 import { omniGroups } from '@omni/db';
@@ -124,6 +124,26 @@ function inSyncWorkerScope<T>(envelope: SyncEnvelope, fn: () => Promise<T>): Pro
   return runConsumerInTenantContext(handle, envelope, fn);
 }
 
+/**
+ * The work item's trusted tenant, for the JOB-TABLE writes that cannot be
+ * wrapped in `inSyncWorkerScope` (G5, ADR-0008).
+ *
+ * `SyncJobService` both writes `sync_jobs` AND publishes `sync.*`, so a scope
+ * wrapped around a whole `start`/`complete`/`fail` call would hold a worker
+ * transaction across the publish — a pre-commit side effect. The service instead
+ * takes a THREADED tenant and scopes each of its own discrete DB blocks; this is
+ * what threads it. Read only from producer-stamped envelope metadata, never from
+ * payload. `null` for a legacy envelope (the ambient, byte-identical path);
+ * throws on a quarantined one, which the subscription layer already refused.
+ */
+function trustedSyncTenant(envelope: SyncEnvelope): string | null {
+  const classification = classifyEnvelope(envelope.metadata);
+  if (classification.world === 'quarantine') {
+    throw new Error(`sync-worker: refusing a quarantined envelope (${classification.reason})`);
+  }
+  return classification.world === 'tenant' ? classification.tenantId : null;
+}
+
 export async function setupSyncWorker(
   eventBus: EventBus,
   services: Services,
@@ -144,9 +164,14 @@ export async function setupSyncWorker(
 
         log.info('Processing sync job', { jobId, instanceId, type });
 
+        // Classify ONCE, before any work: a quarantined envelope must do no job
+        // work at all, and the throw must escape rather than be swallowed into a
+        // `syncJobs.fail` below.
+        const jobTenantId = trustedSyncTenant(event);
+
         try {
           // Start the job
-          await services.syncJobs.start(jobId);
+          await services.syncJobs.start(jobId, jobTenantId);
 
           // Get instance to determine channel type
           const instance = await services.instances.getById(instanceId);
@@ -165,14 +190,14 @@ export async function setupSyncWorker(
               break;
             case 'profile':
               // Profile sync is handled by ProfileSyncService, just mark complete
-              await services.syncJobs.complete(jobId);
+              await services.syncJobs.complete(jobId, jobTenantId);
               break;
             case 'contacts':
               // Not scoped this leg: its only tenant-table write is `persons`,
               // which G2 classifies `unowned` (tenant_id stays NULL until the G6
               // backfill), so there is no registered sync-worker site here to
               // ratchet. Left byte-identical.
-              await processContactsSync(jobId, instanceId, channelType, config, services, channelRegistry);
+              await processContactsSync(jobId, instanceId, channelType, config, services, channelRegistry, event);
               break;
             case 'groups':
               await processGroupsSync(jobId, instanceId, channelType, config, services, channelRegistry, event);
@@ -186,12 +211,12 @@ export async function setupSyncWorker(
               break;
             default:
               log.warn('Unknown sync type', { jobId, type });
-              await services.syncJobs.fail(jobId, `Unknown sync type: ${type}`);
+              await services.syncJobs.fail(jobId, `Unknown sync type: ${type}`, jobTenantId);
           }
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           log.error('Sync job failed', { jobId, error: errorMessage });
-          await services.syncJobs.fail(jobId, errorMessage);
+          await services.syncJobs.fail(jobId, errorMessage, jobTenantId);
         }
       },
       {
@@ -401,10 +426,14 @@ async function processMessageSync(
   // setups that never touch tenant tables) the blocks run unscoped, as before.
   const handle = db;
 
+  // The `sync_jobs` writes below are threaded rather than wrapped — see
+  // `trustedSyncTenant`.
+  const jobTenantId = trustedSyncTenant(envelope);
+
   // Check if plugin supports fetchHistory
   if (!('fetchHistory' in plugin) || typeof plugin.fetchHistory !== 'function') {
     log.warn('Plugin does not support fetchHistory', { channelType });
-    await services.syncJobs.complete(jobId);
+    await services.syncJobs.complete(jobId, jobTenantId);
     return;
   }
 
@@ -461,12 +490,16 @@ async function processMessageSync(
     count: 100, // Messages per chat (recursive fetching will get more)
     anchors: anchors.length > 0 ? anchors : undefined,
     onProgress: async (count: number, progress?: number) => {
-      await services.syncJobs.updateProgress(jobId, {
-        fetched: count,
-        stored,
-        duplicates,
-        totalEstimated: progress ? Math.round(count / (progress / 100)) : undefined,
-      });
+      await services.syncJobs.updateProgress(
+        jobId,
+        {
+          fetched: count,
+          stored,
+          duplicates,
+          totalEstimated: progress ? Math.round(count / (progress / 100)) : undefined,
+        },
+        jobTenantId,
+      );
     },
     onMessage: async (msg: HistorySyncMessage) => {
       // Rate limit — OUTSIDE the worker scope, so no tenant transaction is held
@@ -530,16 +563,20 @@ async function processMessageSync(
   await plugin.fetchHistory(instanceId, fetchOptions);
 
   // Update final progress
-  await services.syncJobs.updateProgress(jobId, {
-    fetched,
-    stored,
-    duplicates,
-  });
+  await services.syncJobs.updateProgress(
+    jobId,
+    {
+      fetched,
+      stored,
+      duplicates,
+    },
+    jobTenantId,
+  );
 
   await queueMediaBackfillAfterSync(services, config, instanceId, jobId, stored);
 
   // Complete the job
-  await services.syncJobs.complete(jobId);
+  await services.syncJobs.complete(jobId, jobTenantId);
 
   log.info('Message sync completed', {
     jobId,
@@ -630,16 +667,24 @@ async function processContactsSync(
   config: SyncJobConfig,
   services: Services,
   channelRegistry: ChannelRegistry,
+  envelope: SyncEnvelope,
 ): Promise<void> {
   const plugin = channelRegistry.get(channelType);
   if (!plugin) {
     throw new Error(`No plugin found for channel type: ${channelType}`);
   }
 
+  // The envelope reaches this processor for its `sync_jobs` bookkeeping ONLY.
+  // The contact ingestion itself is deliberately left unscoped: its tenant-table
+  // write is `persons`, which G2 classifies `unowned` (tenant_id stays NULL until
+  // the G6 backfill), so there is no registered site here to convert and a scope
+  // would find nothing. The job table is owned and is scoped.
+  const jobTenantId = trustedSyncTenant(envelope);
+
   // Check if plugin supports fetchContacts
   if (!('fetchContacts' in plugin) || typeof plugin.fetchContacts !== 'function') {
     log.warn('Plugin does not support fetchContacts', { channelType });
-    await services.syncJobs.complete(jobId);
+    await services.syncJobs.complete(jobId, jobTenantId);
     return;
   }
 
@@ -656,11 +701,15 @@ async function processContactsSync(
   // Build fetch options based on channel type
   const fetchOptions: Record<string, unknown> = {
     onProgress: async (count: number) => {
-      await services.syncJobs.updateProgress(jobId, {
-        fetched: count,
-        stored,
-        duplicates: 0,
-      });
+      await services.syncJobs.updateProgress(
+        jobId,
+        {
+          fetched: count,
+          stored,
+          duplicates: 0,
+        },
+        jobTenantId,
+      );
     },
     onContact: async (contact: unknown) => {
       fetched++;
@@ -721,14 +770,18 @@ async function processContactsSync(
   await plugin.fetchContacts(instanceId, fetchOptions);
 
   // Update final progress
-  await services.syncJobs.updateProgress(jobId, {
-    fetched,
-    stored,
-    duplicates: 0,
-  });
+  await services.syncJobs.updateProgress(
+    jobId,
+    {
+      fetched,
+      stored,
+      duplicates: 0,
+    },
+    jobTenantId,
+  );
 
   // Complete the job
-  await services.syncJobs.complete(jobId);
+  await services.syncJobs.complete(jobId, jobTenantId);
 
   log.info('Contacts sync completed', {
     jobId,
@@ -829,11 +882,16 @@ async function processGroupsSync(
     throw new Error(`No plugin found for channel type: ${channelType}`);
   }
 
+  // The `sync_jobs` writes below are threaded rather than wrapped — see
+  // `trustedSyncTenant`. The per-group `omni_groups` upserts keep their own
+  // per-item `inSyncWorkerScope` (leg B pt2).
+  const jobTenantId = trustedSyncTenant(envelope);
+
   // Check if plugin supports fetchGroups (WhatsApp) or fetchGuilds (Discord)
   const fetchMethod = channelType === 'discord' ? 'fetchGuilds' : 'fetchGroups';
   if (!(fetchMethod in plugin) || typeof plugin[fetchMethod as keyof typeof plugin] !== 'function') {
     log.warn(`Plugin does not support ${fetchMethod}`, { channelType });
-    await services.syncJobs.complete(jobId);
+    await services.syncJobs.complete(jobId, jobTenantId);
     return;
   }
 
@@ -857,11 +915,15 @@ async function processGroupsSync(
   // Build fetch options
   const fetchOptions: Record<string, unknown> = {
     onProgress: async (count: number) => {
-      await services.syncJobs.updateProgress(jobId, {
-        fetched: count,
-        stored,
-        duplicates: updated,
-      });
+      await services.syncJobs.updateProgress(
+        jobId,
+        {
+          fetched: count,
+          stored,
+          duplicates: updated,
+        },
+        jobTenantId,
+      );
     },
     onGroup: async (group: unknown) => {
       fetched++;
@@ -966,14 +1028,18 @@ async function processGroupsSync(
   await fetchFn.call(plugin, instanceId, fetchOptions);
 
   // Update final progress
-  await services.syncJobs.updateProgress(jobId, {
-    fetched,
-    stored,
-    duplicates: updated,
-  });
+  await services.syncJobs.updateProgress(
+    jobId,
+    {
+      fetched,
+      stored,
+      duplicates: updated,
+    },
+    jobTenantId,
+  );
 
   // Complete the job
-  await services.syncJobs.complete(jobId);
+  await services.syncJobs.complete(jobId, jobTenantId);
 
   log.info('Groups sync completed', {
     jobId,
@@ -1000,10 +1066,16 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
       async (event) => {
         const { instanceId, channelType } = event.payload;
 
+        // The `instance.connected` envelope's trusted tenant (G5, ADR-0008).
+        // Since the ownership registry seeds channel-plugin publishes, a
+        // plugin-originated reconnect now carries the instance's persisted
+        // tenant here; a legacy envelope threads null and runs ambient.
+        const jobTenantId = trustedSyncTenant(event);
+
         try {
           // Reuse an already-running history-push job for this instance instead of
           // creating a duplicate on every reconnect.
-          if (await services.syncJobs.hasActiveJob(instanceId, 'history-push')) {
+          if (await services.syncJobs.hasActiveJob(instanceId, 'history-push', jobTenantId)) {
             historyPushLog.debug('Active history-push job already exists — skipping create', {
               instanceId,
               channel: channelType,
@@ -1016,10 +1088,11 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
             instanceId,
             channelType,
             type: 'history-push',
+            tenantId: jobTenantId,
           });
 
           // Immediately start the job (set status to running)
-          await services.syncJobs.start(job.id);
+          await services.syncJobs.start(job.id, jobTenantId);
 
           historyPushLog.info('Created history-push sync job', {
             jobId: job.id,
@@ -1053,9 +1126,11 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
         // Only handle history-push progress events (from WhatsApp plugin)
         if (payload.jobType !== 'history-push' || !payload.instanceId) return;
 
+        const jobTenantId = trustedSyncTenant(event);
+
         try {
           // Find the active history-push job for this instance
-          const activeJobs = await services.syncJobs.getActiveForInstance(payload.instanceId);
+          const activeJobs = await services.syncJobs.getActiveForInstance(payload.instanceId, jobTenantId);
           const historyPushJob = activeJobs.find((j) => j.type === 'history-push');
 
           if (!historyPushJob) {
@@ -1080,7 +1155,7 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
 
           if (Object.keys(update).length === 0) return;
 
-          await services.syncJobs.updateProgress(historyPushJob.id, update);
+          await services.syncJobs.updateProgress(historyPushJob.id, update, jobTenantId);
 
           historyPushLog.debug('Updated history-push progress', {
             jobId: historyPushJob.id,
@@ -1114,9 +1189,11 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
         // Only handle history-push completed events (from WhatsApp plugin)
         if (payload.jobType !== 'history-push' || !payload.instanceId) return;
 
+        const jobTenantId = trustedSyncTenant(event);
+
         try {
           // Find the active history-push job for this instance
-          const activeJobs = await services.syncJobs.getActiveForInstance(payload.instanceId);
+          const activeJobs = await services.syncJobs.getActiveForInstance(payload.instanceId, jobTenantId);
           const historyPushJob = activeJobs.find((j) => j.type === 'history-push');
 
           if (!historyPushJob) {
@@ -1127,15 +1204,19 @@ export async function setupHistoryPushTracker(eventBus: EventBus, services: Serv
           }
 
           // Update final progress
-          await services.syncJobs.updateProgress(historyPushJob.id, {
-            fetched: payload.totalFetched ?? 0,
-            stored: 0,
-            duplicates: 0,
-            mediaDownloaded: 0,
-          });
+          await services.syncJobs.updateProgress(
+            historyPushJob.id,
+            {
+              fetched: payload.totalFetched ?? 0,
+              stored: 0,
+              duplicates: 0,
+              mediaDownloaded: 0,
+            },
+            jobTenantId,
+          );
 
           // Mark completed
-          await services.syncJobs.complete(historyPushJob.id);
+          await services.syncJobs.complete(historyPushJob.id, jobTenantId);
 
           historyPushLog.info('History-push sync completed', {
             jobId: historyPushJob.id,

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -53,6 +53,7 @@ import { optionalDateParam } from '../../schemas/date-query';
 import type { Services } from '../../services';
 import { ApiKeyService } from '../../services/api-keys';
 import { type MediaFetchOptions, MediaStorageService } from '../../services/media-storage';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
 import type { ApiKeyData, AppVariables } from '../../types';
 import { isHardTerminalOutcome, resolveCloseContactConfig } from './_close-contact-config';
 
@@ -825,6 +826,12 @@ messagesRoutes.post('/media/download', zValidator('json', messageRefSchema), asy
         message.mediaMimeType ?? undefined,
         message.platformTimestamp ?? undefined,
         buildMediaDownloadFetchOptions(instance as Record<string, unknown>),
+        // `mediaUrl` came off a stored message, i.e. a tenant-controlled
+        // payload, so this download is tenant-controlled egress: pass the
+        // REQUEST's tenant so the `OMNI_MEDIA_URL_GUARD=off` escape hatch is
+        // subsumed here too (G5 deliverable (b), ADR-0009). Null off-scope
+        // (flag-off), where the pre-G5 behavior is kept exactly.
+        currentTenantScope()?.tenantId ?? undefined,
       );
       mediaLocalPath = result.localPath;
       await mediaStorage.updateMessageLocalPath(message.id, result.localPath);

--- a/packages/api/src/scheduler.ts
+++ b/packages/api/src/scheduler.ts
@@ -77,6 +77,69 @@ async function createDailySyncJobs(services: Services, type: 'contacts' | 'group
 }
 
 /**
+ * Re-emit cached unread counts for every active WhatsApp instance, fanned out
+ * across tenants (G5, ADR-0008).
+ *
+ * Structurally identical to `createDailySyncJobs` and converted for the same
+ * reason: a cron has no envelope and no credential, so it must ENUMERATE whose
+ * instances exist rather than scan the table — under RLS enforcement the global
+ * `listActive()` is not expressible at all. This was the last scheduler caller
+ * reaching `services/instances.ts::instances` unscoped.
+ *
+ * The per-row side effect is an IN-PROCESS plugin call, not a database write, so
+ * `runForEachActiveTenantRow` is the right helper: it scopes only the discrete
+ * `listActive` READ and runs `perRow` outside that scope, never pinning a pooled
+ * connection across the plugin call.
+ *
+ * Three worlds, from the helper: flag-off is the pre-G5 single ambient pass,
+ * byte for byte; flag-on runs one scoped pass per ACTIVE tenant (a suspended
+ * tenant stops being refreshed at the next tick); the transitional NULL-tenant
+ * pass is skipped under enforcement.
+ *
+ * Returns the number of instances refreshed — what the job logs.
+ */
+async function refreshUnreadCounts(
+  services: Services,
+  channelRegistry: ChannelRegistry,
+  env?: NodeJS.ProcessEnv,
+): Promise<number> {
+  const waPlugin = channelRegistry.get('whatsapp-baileys') as
+    | { refreshUnreadCounts?: (instanceId: string) => void }
+    | undefined;
+
+  // No plugin: return before any enumeration or query, exactly as the pre-G5
+  // early return did.
+  if (!waPlugin?.refreshUnreadCounts) return 0;
+  const refresh = waPlugin.refreshUnreadCounts.bind(waPlugin);
+
+  let refreshed = 0;
+  await runForEachActiveTenantRow(
+    {
+      db: services.db,
+      authPlaneDb: services.authPlane.db,
+      jobName: 'unread-count-refresh',
+      listActive: () => services.instances.listActive(),
+      env,
+    },
+    async (instance) => {
+      if (instance.channel !== 'whatsapp-baileys') return;
+      refresh(instance.id);
+      refreshed++;
+    },
+  );
+  return refreshed;
+}
+
+/** Test seam for {@link refreshUnreadCounts} — see the tenant fan-out probe. */
+export function __refreshUnreadCountsForTest(
+  services: Services,
+  channelRegistry: ChannelRegistry,
+  env?: NodeJS.ProcessEnv,
+): Promise<number> {
+  return refreshUnreadCounts(services, channelRegistry, env);
+}
+
+/**
  * Wrap a scheduled job handler with Sentry cron monitoring.
  * When Sentry is not configured the handler runs directly.
  */
@@ -266,22 +329,11 @@ export function setupScheduler(services: Services, channelRegistry?: ChannelRegi
       await withCronMonitor('unread-count-refresh', '0 * * * *', 5, 5, async () => {
         const startTime = Date.now();
         try {
-          const waPlugin = channelRegistry.get('whatsapp-baileys') as
-            | { refreshUnreadCounts?: (instanceId: string) => void }
-            | undefined;
-
-          if (!waPlugin?.refreshUnreadCounts) return;
-
-          const instances = await services.instances.listActive();
-          const waInstances = instances.filter((i) => i.channel === 'whatsapp-baileys');
-
-          for (const instance of waInstances) {
-            waPlugin.refreshUnreadCounts(instance.id);
-          }
+          const instanceCount = await refreshUnreadCounts(services, channelRegistry);
 
           const durationSec = (Date.now() - startTime) / 1000;
           recordScheduledJob('unread-count-refresh', 'success', durationSec);
-          log.debug('Refreshed unread counts', { instanceCount: waInstances.length });
+          log.debug('Refreshed unread counts', { instanceCount });
         } catch (err) {
           const durationSec = (Date.now() - startTime) / 1000;
           recordScheduledJob('unread-count-refresh', 'failure', durationSec);

--- a/packages/api/src/scheduler.ts
+++ b/packages/api/src/scheduler.ts
@@ -22,8 +22,59 @@ import {
 import * as Sentry from '@sentry/bun';
 import { sentryEnabled } from './lib/sentry-scrub';
 import type { Services } from './services';
+import { runForEachActiveTenantRow } from './tenancy/periodic-tenant-work';
 
 const log = createLogger('scheduler:setup');
+
+/**
+ * Create one daily per-instance sync job, fanned out across tenants
+ * (G5, ADR-0008).
+ *
+ * This is the exact shape `runForEachActiveTenantRow` was written for: a
+ * whole-table `listActive()` read followed by a per-row side effect that WRITES
+ * a job row and PUBLISHES `sync.started`. A cron has no envelope and no
+ * credential, so it must ENUMERATE whose work exists rather than scan
+ * globally — under RLS enforcement the global scan is not even expressible.
+ *
+ * The three worlds are the helper's: flag-off runs the single pre-G5 ambient
+ * pass byte-identically; flag-on runs one scoped `listActive` per ACTIVE tenant
+ * (so a suspended tenant's daily sync stops at the next tick — dequeue-time
+ * revalidation at cron cadence) and threads that tenant into `syncJobs.create`,
+ * which scopes its own insert and stamps the published envelope; the
+ * transitional NULL-tenant pass is skipped under enforcement.
+ *
+ * `perRow` failures stay per-row: one instance that cannot be synced must not
+ * abort the rest of the tenant's pass, which is what the pre-G5 loop did too.
+ */
+async function createDailySyncJobs(services: Services, type: 'contacts' | 'groups'): Promise<number> {
+  let jobsCreated = 0;
+  await runForEachActiveTenantRow(
+    {
+      db: services.db,
+      authPlaneDb: services.authPlane.db,
+      jobName: `${type}-sync-daily`,
+      listActive: () => services.instances.listActive(),
+    },
+    async (instance, tenantId) => {
+      try {
+        await services.syncJobs.create({
+          instanceId: instance.id,
+          channelType: instance.channel,
+          type,
+          config: {},
+          tenantId,
+        });
+        jobsCreated++;
+      } catch (err) {
+        log.warn(`Failed to create ${type} sync job for instance`, {
+          instanceId: instance.id,
+          error: String(err),
+        });
+      }
+    },
+  );
+  return jobsCreated;
+}
 
 /**
  * Wrap a scheduled job handler with Sentry cron monitoring.
@@ -139,30 +190,11 @@ export function setupScheduler(services: Services, channelRegistry?: ChannelRegi
       await withCronMonitor('contacts-sync-daily', '0 4 * * *', 15, 60, async () => {
         const startTime = Date.now();
         try {
-          // Get all active instances and create sync jobs for each
-          const instances = await services.instances.listActive();
-          let jobsCreated = 0;
-
-          for (const instance of instances) {
-            try {
-              await services.syncJobs.create({
-                instanceId: instance.id,
-                channelType: instance.channel,
-                type: 'contacts',
-                config: {},
-              });
-              jobsCreated++;
-            } catch (err) {
-              log.warn('Failed to create contacts sync job for instance', {
-                instanceId: instance.id,
-                error: String(err),
-              });
-            }
-          }
+          const jobsCreated = await createDailySyncJobs(services, 'contacts');
 
           const durationSec = (Date.now() - startTime) / 1000;
           recordScheduledJob('contacts-sync-daily', 'success', durationSec);
-          log.info('Daily contacts sync jobs created', { jobsCreated, instanceCount: instances.length });
+          log.info('Daily contacts sync jobs created', { jobsCreated });
         } catch (err) {
           const durationSec = (Date.now() - startTime) / 1000;
           recordScheduledJob('contacts-sync-daily', 'failure', durationSec);
@@ -181,30 +213,11 @@ export function setupScheduler(services: Services, channelRegistry?: ChannelRegi
       await withCronMonitor('groups-sync-daily', '0 5 * * *', 15, 60, async () => {
         const startTime = Date.now();
         try {
-          // Get all active instances and create sync jobs for each
-          const instances = await services.instances.listActive();
-          let jobsCreated = 0;
-
-          for (const instance of instances) {
-            try {
-              await services.syncJobs.create({
-                instanceId: instance.id,
-                channelType: instance.channel,
-                type: 'groups',
-                config: {},
-              });
-              jobsCreated++;
-            } catch (err) {
-              log.warn('Failed to create groups sync job for instance', {
-                instanceId: instance.id,
-                error: String(err),
-              });
-            }
-          }
+          const jobsCreated = await createDailySyncJobs(services, 'groups');
 
           const durationSec = (Date.now() - startTime) / 1000;
           recordScheduledJob('groups-sync-daily', 'success', durationSec);
-          log.info('Daily groups sync jobs created', { jobsCreated, instanceCount: instances.length });
+          log.info('Daily groups sync jobs created', { jobsCreated });
         } catch (err) {
           const durationSec = (Date.now() - startTime) / 1000;
           recordScheduledJob('groups-sync-daily', 'failure', durationSec);

--- a/packages/api/src/services/__tests__/access-worker-scope.test.ts
+++ b/packages/api/src/services/__tests__/access-worker-scope.test.ts
@@ -1,0 +1,225 @@
+/**
+ * `services/access.ts` worker-context boundary (G5; ADR-0008).
+ *
+ * Two consumer paths reach this service with no scope of any kind:
+ *
+ *   * `plugins/agent-dispatcher.ts` `checkAccessWithFallback` — up to three
+ *     `checkAccess` calls per inbound message (primary id, Baileys
+ *     `participantAlt`, LID→phone `resolvedSenderPhone`) plus a fire-and-forget
+ *     `requestPairing`;
+ *   * `plugins/agent-responder.ts` `processIncomingMessage` — the same pair.
+ *
+ * Both run inside a converted consumer that already derived the envelope's
+ * trusted tenant, but the access read itself landed on the ambient pool: an
+ * ALLOW/DENY decision — the gate that decides whether a message reaches an agent
+ * at all — was being evaluated against rules read outside any tenant boundary.
+ *
+ * The conversion THREADS that tenant rather than wrapping the call, because
+ * `checkAccess` PUBLISHES `access.allowed`/`access.denied` and `requestPairing`
+ * publishes `access.pairing_requested`; a worker transaction held across a
+ * publish makes the event a pre-commit side effect.
+ *
+ * NOTE ON THE REGISTRY: this closes the ASYNC half of
+ * `access.ts::access_rules`. That entry stays `pending-G5-conversion` because
+ * `trpc/router.ts` — a second synchronous edge with no tenant boundary at all —
+ * also reaches `list`/`getById`/`create`/`checkAccess`. That is the same open
+ * decision that holds `instances.ts::instances` and
+ * `persons.ts::platform_identities`, not G5 async work.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope, runInTenantScope } from '../../tenancy/tenant-scope';
+import { AccessService } from '../access';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+function scope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+function chain<T>(result: T): T {
+  const self: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') {
+          return (onOk: (v: T) => unknown, onErr?: (e: unknown) => unknown) =>
+            Promise.resolve(result).then(onOk, onErr);
+        }
+        return () => self;
+      },
+    },
+  );
+  return self as T;
+}
+
+interface Observed {
+  op: string;
+  scope: string | null;
+}
+
+function makeDb(observed: Observed[], counters: { transactions: number }): Database {
+  const db = {
+    select: () => {
+      observed.push({ op: 'select', scope: scope() });
+      return chain([] as unknown[]);
+    },
+    insert: () => {
+      observed.push({ op: 'insert', scope: scope() });
+      return chain([{ id: 'rule-1', createdAt: new Date() }]);
+    },
+    delete: () => {
+      observed.push({ op: 'delete', scope: scope() });
+      return chain([]);
+    },
+    update: () => {
+      observed.push({ op: 'update', scope: scope() });
+      return chain([]);
+    },
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counters.transactions += 1;
+      return cb(db);
+    },
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+function makeService(observed: Observed[], counters: { transactions: number }) {
+  const publishScopes: Array<string | null> = [];
+  const eventBus = {
+    publish: async () => {
+      publishScopes.push(scope());
+    },
+  } as unknown as ConstructorParameters<typeof AccessService>[1];
+  return { service: new AccessService(makeDb(observed, counters), eventBus, null), publishScopes };
+}
+
+const INSTANCE = { id: 'inst-1', accessMode: 'allowlist' as const };
+
+describe('access — consumer caller threads the envelope tenant', () => {
+  test('checkAccess reads the rules INSIDE the tenant scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service } = makeService(observed, counters);
+
+    await service.checkAccess(INSTANCE, '5511999999999', 'whatsapp-baileys', TENANT_A);
+
+    const reads = observed.filter((o) => o.op === 'select');
+    expect(reads.length).toBeGreaterThan(0);
+    for (const read of reads) expect(read.scope).toBe(TENANT_A);
+  });
+
+  test('the access-decision publish happens OUTSIDE the scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, publishScopes } = makeService(observed, counters);
+
+    // allowlist + no matching rule = default deny, which publishes access.denied.
+    const result = await service.checkAccess(INSTANCE, '5511999999999', 'whatsapp-baileys', TENANT_A);
+
+    expect(result.allowed).toBe(false);
+    expect(publishScopes.length).toBe(1);
+    expect(publishScopes).toEqual([null]);
+  });
+
+  test('requestPairing runs its read-count-insert transaction inside the tenant scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, publishScopes } = makeService(observed, counters);
+
+    await service.requestPairing('inst-1', '5511999999999', {}, TENANT_A);
+
+    const inside = observed.filter((o) => o.op !== 'select' || true);
+    expect(inside.length).toBeGreaterThan(0);
+    for (const entry of inside) expect(entry.scope).toBe(TENANT_A);
+    // …and the pairing publish is outside it.
+    expect(publishScopes).toEqual([null]);
+  });
+});
+
+describe('access — the `instances` half of the file is request-only', () => {
+  test('approvePairingRequest — its channel lookup observes the REQUEST scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const publishScopes: Array<string | null> = [];
+    const eventBus = {
+      publish: async () => {
+        publishScopes.push(scope());
+      },
+    } as unknown as ConstructorParameters<typeof AccessService>[1];
+
+    // `access_rules` reads inside the transaction must return a pending request,
+    // then a consumed row; the trailing `instances` read is the site under test.
+    const db = {
+      select: () => {
+        observed.push({ op: 'select', scope: scope() });
+        return chain([{ id: 'req-1', instanceId: 'inst-1', platformUserId: 'u', metadata: {}, expiresAt: null }]);
+      },
+      update: () => {
+        observed.push({ op: 'update', scope: scope() });
+        return chain([{ id: 'req-1' }]);
+      },
+      insert: () => {
+        observed.push({ op: 'insert', scope: scope() });
+        return chain([{ id: 'rule-1' }]);
+      },
+      delete: () => {
+        observed.push({ op: 'delete', scope: scope() });
+        return chain([]);
+      },
+      transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+        counters.transactions += 1;
+        return cb(db);
+      },
+      execute: async () => [],
+    } as unknown as Database;
+
+    const service = new AccessService(db, eventBus, null);
+
+    await runInTenantScope(
+      db,
+      {
+        credentialClass: 'tenant',
+        requestId: 'req',
+        principalId: 'p',
+        credentialId: 'c',
+        tenantId: TENANT_A,
+        tenantSlug: null,
+        actorRole: 'tenant-admin',
+        scopes: [],
+        membershipId: 'm',
+        resourceConstraints: {},
+        expiresAt: null,
+        rateLimit: null,
+        budget: null,
+        delegationDepth: 0,
+        rootKeyId: 'r',
+        policyVersion: 0,
+        revocationEpoch: 0,
+        tenantKeyLineageId: 'l',
+      } as never,
+      () => service.approvePairingRequest('req-1', 'inst-1'),
+    );
+
+    // Every statement, including the `instances` channel lookup that follows the
+    // transaction, ran on the request's tenant transaction.
+    expect(observed.length).toBeGreaterThan(0);
+    for (const entry of observed) expect(entry.scope).toBe(TENANT_A);
+  });
+});
+
+describe('access — legacy world is byte-identical', () => {
+  test('no threaded tenant: no scope, no worker transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service } = makeService(observed, counters);
+
+    await service.checkAccess(INSTANCE, '5511999999999', 'whatsapp-baileys');
+    const workerTransactions = counters.transactions;
+
+    expect(workerTransactions).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+  });
+});

--- a/packages/api/src/services/__tests__/agent-heartbeat-worker-scope.test.ts
+++ b/packages/api/src/services/__tests__/agent-heartbeat-worker-scope.test.ts
@@ -1,0 +1,227 @@
+/**
+ * `services/agent-heartbeat.ts` worker-context boundary (G5; ADR-0008).
+ *
+ * THE DEFECT. This is a NATS consumer — a raw `omni.agent.heartbeat.>`
+ * subscription, not an eventBus one — and it called
+ * `turnService.recordActivity(turnId)` directly on the ambient pool. It never
+ * went through `classifyEnvelope`, so it had no world at all: no tenant, no
+ * legacy/quarantine distinction, and a write on whatever handle happened to be
+ * ambient. It is one of the two unscoped worker callers named in the
+ * `turns.ts::turns` registry justification.
+ *
+ * THE TRUSTED DERIVATION. A heartbeat is published by an EXTERNAL client (the
+ * genie publisher) as raw JSON, so nothing in its body may be believed: ADR-0008
+ * requires the tenant to come from an authenticated context or a LOADED
+ * resource's persisted ownership. The message names an `instanceId`, and
+ * `instances` is the ownership ROOT, so the instance-owner registry — populated
+ * only from `instances` rows this process already read — is the answer. Any
+ * `tenantId` a publisher tries to put in the payload is dropped by
+ * `parseHeartbeat`, which returns only its four validated fields.
+ *
+ * The derived tenant is then STAMPED onto an envelope and classified, so the
+ * consumer inherits `runConsumerInTenantContext`'s three worlds unchanged.
+ *
+ * NOTE ON THE REGISTRY: `turns.ts::turns` stays `pending-G5-conversion` after
+ * this. It is G6-GATED — `turns.agent_id` is NOT NULL and `agents` derives via
+ * `owner_id -> persons` (G2-`unowned`), so `turns.tenant_id` is stamped NULL for
+ * every row until the G6 backfill. Converting its callers is real work; it does
+ * not license lowering that ceiling.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { __resetInstanceOwnerRegistry, rememberInstanceOwners } from '../../tenancy/instance-owner-registry';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { AgentHeartbeatConsumer } from '../agent-heartbeat';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+
+function scope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+type Msg = { subject: string; data: Uint8Array };
+
+function createFakeNats() {
+  const queue: Msg[] = [];
+  const waiters: Array<(value: IteratorResult<Msg>) => void> = [];
+  let ended = false;
+
+  const drain = () => {
+    while (waiters.length > 0 && queue.length > 0) {
+      const w = waiters.shift();
+      const m = queue.shift();
+      if (w && m) w({ value: m, done: false });
+    }
+    if (ended) {
+      while (waiters.length > 0) {
+        const w = waiters.shift();
+        if (w) w({ value: undefined as never, done: true });
+      }
+    }
+  };
+
+  const subscription = {
+    unsubscribe() {
+      ended = true;
+      drain();
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<Msg>> {
+          const m = queue.shift();
+          if (m) return Promise.resolve({ value: m, done: false });
+          if (ended) return Promise.resolve({ value: undefined as never, done: true });
+          return new Promise<IteratorResult<Msg>>((resolve) => waiters.push(resolve));
+        },
+        return(): Promise<IteratorResult<Msg>> {
+          ended = true;
+          drain();
+          return Promise.resolve({ value: undefined as never, done: true });
+        },
+      };
+    },
+  };
+
+  return {
+    isClosed: () => false,
+    subscribe: () => subscription,
+    __push(payload: unknown) {
+      queue.push({
+        subject: 'omni.agent.heartbeat.inst-1.chat-1',
+        data: new TextEncoder().encode(JSON.stringify(payload)),
+      });
+      drain();
+    },
+    __end() {
+      ended = true;
+      drain();
+    },
+  };
+}
+
+function fakePool(counters: { transactions: number }): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counters.transactions += 1;
+      return cb({ execute: async () => [] });
+    },
+    execute: async () => [],
+  } as unknown as Database;
+}
+
+function heartbeat(overrides: Record<string, unknown> = {}) {
+  return {
+    turnId: 'turn-abc',
+    instanceId: 'inst-1',
+    chatId: 'chat-1',
+    timestamp: '2026-07-25T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function flush() {
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('agent-heartbeat — worker tenant context', () => {
+  let consumer: AgentHeartbeatConsumer;
+  let nats: ReturnType<typeof createFakeNats>;
+
+  beforeEach(() => {
+    consumer = new AgentHeartbeatConsumer();
+    nats = createFakeNats();
+    __resetInstanceOwnerRegistry();
+  });
+
+  afterEach(async () => {
+    nats.__end();
+    await consumer.stop();
+    __resetInstanceOwnerRegistry();
+  });
+
+  test('the activity write runs inside the INSTANCE-derived tenant scope', async () => {
+    const observed: Array<string | null> = [];
+    const counters = { transactions: 0 };
+    rememberInstanceOwners([{ id: 'inst-1', tenantId: TENANT_A }]);
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: {
+        recordActivity: async () => {
+          observed.push(scope());
+        },
+      } as never,
+      db: fakePool(counters),
+    });
+
+    nats.__push(heartbeat());
+    await flush();
+
+    expect(observed).toEqual([TENANT_A]);
+    expect(counters.transactions).toBe(1);
+  });
+
+  test('a payload tenant claim is IGNORED — the registry is the only source', async () => {
+    const observed: Array<string | null> = [];
+    const counters = { transactions: 0 };
+    // The instance is owned by A; the publisher claims a different tenant and a
+    // forged envelope version in the body.
+    rememberInstanceOwners([{ id: 'inst-1', tenantId: TENANT_A }]);
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: {
+        recordActivity: async () => {
+          observed.push(scope());
+        },
+      } as never,
+      db: fakePool(counters),
+    });
+
+    nats.__push(heartbeat({ tenantId: '22222222-2222-4222-8222-22222222222b', envelopeVersion: 99 }));
+    await flush();
+
+    expect(observed).toEqual([TENANT_A]);
+  });
+
+  test('legacy world: no db wired — the pre-G5 ambient call, byte-identical', async () => {
+    const observed: Array<string | null> = [];
+    rememberInstanceOwners([{ id: 'inst-1', tenantId: TENANT_A }]);
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: {
+        recordActivity: async () => {
+          observed.push(scope());
+        },
+      } as never,
+    });
+
+    nats.__push(heartbeat());
+    await flush();
+
+    expect(observed).toEqual([null]);
+  });
+
+  test('an instance with no observed ownership stays legacy (never another tenant)', async () => {
+    const observed: Array<string | null> = [];
+    const counters = { transactions: 0 };
+
+    consumer.start({
+      natsConnection: nats as never,
+      turnService: {
+        recordActivity: async () => {
+          observed.push(scope());
+        },
+      } as never,
+      db: fakePool(counters),
+    });
+
+    nats.__push(heartbeat());
+    await flush();
+
+    expect(observed).toEqual([null]);
+    expect(counters.transactions).toBe(0);
+  });
+});

--- a/packages/api/src/services/__tests__/agent-replay-worker-scope.test.ts
+++ b/packages/api/src/services/__tests__/agent-replay-worker-scope.test.ts
@@ -1,0 +1,207 @@
+/**
+ * `services/agent-replay.ts::{instances,messages}` worker-context boundary
+ * (G5; ADR-0008).
+ *
+ * Two callers reach this service, and only one of them had a tenant:
+ *
+ *   * `routes/v2/instances.ts` — the manual replay endpoint, inside the edge
+ *     tenant transaction (G4). It threads NOTHING and must keep observing the
+ *     REQUEST's scope: that is the shape the real route produces.
+ *   * `plugins/event-listeners.ts` — the `instance.connected` /
+ *     `instance.disconnected` consumers, which call `onInstanceConnect` and
+ *     `updateLastSeenAt` FIRE-AND-FORGET. Those had no scope at all: the
+ *     instance read, the message pages and the `lastSeenAt` write ran on the
+ *     ambient pool while the rest of the consumer ran tenant-scoped.
+ *
+ * The conversion cannot wrap the whole call: `replayMissedMessages` PUBLISHES a
+ * `message.received` per replayed row, and a worker transaction held across a
+ * publish makes the event a pre-commit side effect (a phantom on rollback).
+ * So the tenant is THREADED and each discrete DB block opens its own short
+ * scope — the `runTenantWorkDb` shape turn-monitor uses.
+ *
+ * This file is the enforcement the static guard cannot provide (run12's
+ * FIX-FIRST lesson: the guard sees the SERVICE, never the CALL SITE), probing
+ * every helper that reads/writes under a live tenant.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { currentTenantScope, runInTenantScope } from '../../tenancy/tenant-scope';
+import { AgentReplayService } from '../agent-replay';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const REQUEST_TENANT = '33333333-3333-4333-8333-33333333333c';
+
+function scope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+/** Drizzle-shaped chain stub: every builder method returns itself; awaiting yields `result`. */
+function chain<T>(result: T): T {
+  const self: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') {
+          return (onOk: (v: T) => unknown, onErr?: (e: unknown) => unknown) =>
+            Promise.resolve(result).then(onOk, onErr);
+        }
+        return () => self;
+      },
+    },
+  );
+  return self as T;
+}
+
+interface Observed {
+  op: string;
+  scope: string | null;
+}
+
+function makeDb(observed: Observed[], selects: unknown[], counters: { transactions: number }): Database {
+  const db = {
+    select: () => {
+      observed.push({ op: 'select', scope: scope() });
+      return chain(selects.shift() ?? []);
+    },
+    update: () => {
+      observed.push({ op: 'update', scope: scope() });
+      return chain([]);
+    },
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counters.transactions += 1;
+      return cb(db);
+    },
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+const INSTANCE_ROW = {
+  id: 'instance-1',
+  channel: 'whatsapp-baileys',
+  replayEnabled: true,
+  lastSeenAt: new Date(Date.now() - 60_000),
+  agentId: 'agent-1',
+};
+
+const MESSAGE_ROW = {
+  id: 'msg-1',
+  chatId: 'chat-1',
+  externalId: 'ext-1',
+  messageType: 'text',
+  textContent: 'oi',
+  mediaUrl: null,
+  mediaLocalPath: null,
+  mediaMimeType: null,
+  senderPlatformUserId: '5511999999999',
+  replyToExternalId: null,
+  rawPayload: null,
+  platformTimestamp: new Date(Date.now() - 30_000),
+  isFromMe: false,
+  senderAgentId: null,
+  chatExternalId: '5511999999999@s.whatsapp.net',
+  chatInstanceId: 'instance-1',
+};
+
+function makeService(observed: Observed[], selects: unknown[], counters: { transactions: number }) {
+  const publishScopes: Array<string | null> = [];
+  const eventBus = {
+    publish: async () => {
+      publishScopes.push(scope());
+    },
+  } as unknown as ConstructorParameters<typeof AgentReplayService>[1];
+  const db = makeDb(observed, selects, counters);
+  return { service: new AgentReplayService(db, eventBus), publishScopes, db };
+}
+
+describe('agent-replay — consumer caller threads the envelope tenant', () => {
+  test('onInstanceConnect: instance read, message page and lastSeenAt write all observe the tenant scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service } = makeService(observed, [[INSTANCE_ROW], [MESSAGE_ROW], []], counters);
+
+    await service.onInstanceConnect('instance-1', TENANT_A);
+
+    expect(observed.length).toBeGreaterThanOrEqual(3);
+    for (const entry of observed) {
+      expect(entry.scope).toBe(TENANT_A);
+    }
+    // The lastSeenAt write is the `instances` half of the site.
+    expect(observed.some((o) => o.op === 'update')).toBe(true);
+  });
+
+  test('the worker scope does NOT span the redispatch publish', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, publishScopes } = makeService(observed, [[INSTANCE_ROW], [MESSAGE_ROW], []], counters);
+
+    await service.onInstanceConnect('instance-1', TENANT_A);
+
+    expect(publishScopes.length).toBe(1);
+    expect(publishScopes).toEqual([null]);
+  });
+
+  test('updateLastSeenAt threads its own tenant when called from the disconnect consumer', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service } = makeService(observed, [], counters);
+
+    await service.updateLastSeenAt('instance-1', undefined, TENANT_A);
+
+    expect(observed).toEqual([{ op: 'update', scope: TENANT_A }]);
+    expect(counters.transactions).toBe(1);
+  });
+});
+
+describe('agent-replay — the request caller keeps the REQUEST scope', () => {
+  test('replayMissedMessages threading nothing stays on the edge transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, db } = makeService(observed, [[MESSAGE_ROW], []], counters);
+
+    // The real route shape: inside the edge tenant scope, no threaded tenant.
+    await runInTenantScope(
+      db,
+      {
+        credentialClass: 'tenant',
+        requestId: 'req-1',
+        principalId: 'p',
+        credentialId: 'c',
+        tenantId: REQUEST_TENANT,
+        tenantSlug: null,
+        actorRole: 'tenant-admin',
+        scopes: [],
+        membershipId: 'm',
+        resourceConstraints: {},
+        expiresAt: null,
+        rateLimit: null,
+        budget: null,
+        delegationDepth: 0,
+        rootKeyId: 'r',
+        policyVersion: 0,
+        revocationEpoch: 0,
+        tenantKeyLineageId: 'l',
+      } as never,
+      () => service.replayMissedMessages({ instanceId: 'instance-1', since: new Date(Date.now() - 60_000) }),
+    );
+
+    expect(observed.length).toBeGreaterThan(0);
+    for (const entry of observed) {
+      expect(entry.scope).toBe(REQUEST_TENANT);
+    }
+  });
+});
+
+describe('agent-replay — legacy world is byte-identical', () => {
+  test('no threaded tenant and no active scope: no transaction, no scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service } = makeService(observed, [[INSTANCE_ROW], [MESSAGE_ROW], []], counters);
+
+    await service.onInstanceConnect('instance-1');
+
+    expect(counters.transactions).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+  });
+});

--- a/packages/api/src/services/__tests__/agent-runner-client-cache-tenant.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner-client-cache-tenant.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `AgentRunnerService`'s provider-client cache is a CREDENTIAL cache (G5; ADR-0008).
+ *
+ * The cached `IAgentClient` is built with the provider row's `api_key` and sends
+ * it as that provider's bearer credential on every call. `agent_providers` is a
+ * G0-`split` table with no `tenant_id`, so ONE provider row is reachable from
+ * instances of different tenants — a cache keyed by provider id alone serves the
+ * first caller's client, and its key, to every later tenant.
+ *
+ * These probes pin the partitioning and the two properties it must not break:
+ * one client per provider WITHIN a tenant, and a scope-less legacy world that
+ * still shares exactly one.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { AgentRunnerService } from '../agent-runner';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const PROVIDER_ID = '33333333-3333-4333-8333-333333333333';
+
+/** A db whose only job is to return the one provider row, plus transaction support. */
+function fakeDb(): Database {
+  const row = {
+    id: PROVIDER_ID,
+    name: 'p',
+    schema: 'agno',
+    baseUrl: 'https://agno.invalid',
+    apiKey: 'sk-provider',
+    defaultTimeout: 600,
+    isActive: true,
+  };
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => [row] }) }),
+    }),
+  };
+  return db as unknown as Database;
+}
+
+/** `getClient` is private; the probe is about its CACHE KEY, so reach it directly. */
+function getClient(svc: AgentRunnerService, providerId: string) {
+  return (svc as unknown as { getClient: (id: string) => Promise<unknown> }).getClient(providerId);
+}
+
+function cacheKeys(svc: AgentRunnerService): string[] {
+  return [...(svc as unknown as { clientCache: Map<string, unknown> }).clientCache.keys()];
+}
+
+describe('agent-runner client cache — one client per (provider, tenant)', () => {
+  test('two tenants asking for the same provider do not share a client', async () => {
+    const svc = new AgentRunnerService(fakeDb());
+
+    const asA = await runInWorkerTenantScope(fakeDb(), TENANT_A, () => getClient(svc, PROVIDER_ID));
+    const asB = await runInWorkerTenantScope(fakeDb(), TENANT_B, () => getClient(svc, PROVIDER_ID));
+
+    expect(asA).not.toBe(asB);
+    expect(cacheKeys(svc).sort()).toEqual([`${PROVIDER_ID}::${TENANT_A}`, `${PROVIDER_ID}::${TENANT_B}`].sort());
+  });
+
+  test('the same tenant reuses its client, and the legacy world keeps exactly one', async () => {
+    const svc = new AgentRunnerService(fakeDb());
+
+    const first = await runInWorkerTenantScope(fakeDb(), TENANT_A, () => getClient(svc, PROVIDER_ID));
+    const second = await runInWorkerTenantScope(fakeDb(), TENANT_A, () => getClient(svc, PROVIDER_ID));
+    expect(first).toBe(second);
+
+    const legacySvc = new AgentRunnerService(fakeDb());
+    const legacy1 = await getClient(legacySvc, PROVIDER_ID);
+    const legacy2 = await getClient(legacySvc, PROVIDER_ID);
+    expect(legacy1).toBe(legacy2);
+    expect(cacheKeys(legacySvc)).toEqual([`${PROVIDER_ID}::-`]);
+  });
+
+  test('clearCache(providerId) drops EVERY tenant’s client for that provider', async () => {
+    const svc = new AgentRunnerService(fakeDb());
+
+    await runInWorkerTenantScope(fakeDb(), TENANT_A, () => getClient(svc, PROVIDER_ID));
+    await runInWorkerTenantScope(fakeDb(), TENANT_B, () => getClient(svc, PROVIDER_ID));
+    expect(cacheKeys(svc).length).toBe(2);
+
+    svc.clearCache(PROVIDER_ID);
+    expect(cacheKeys(svc)).toEqual([]);
+  });
+});

--- a/packages/api/src/services/__tests__/agent-runner-sealed-provider.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner-sealed-provider.test.ts
@@ -1,0 +1,190 @@
+/**
+ * `AgentRunnerService.getClient` must OPEN the sealed provider credential
+ * (G5 deliverable (g); ADR-0008).
+ *
+ * `ProviderService` is where `agent_providers.api_key` is sealed and opened, but
+ * it is not the only reader: the legacy dispatch fallback
+ * (`agent-dispatcher.ts` `dispatchViaLegacy` → `services.agentRunner.run`) and
+ * the `call_agent` automation action both reach `getClient`, which loads the row
+ * itself and hands `apiKey` straight to `createProviderClient`.
+ *
+ * With sealing active that value is the AES-GCM ENVELOPE — a JSON string
+ * carrying the ciphertext AND the tenant UUID — and `agno-client.ts` emits it as
+ * `Authorization: Bearer …`. That is verbatim the outcome `sealed-credentials.ts`
+ * says must never happen: ciphertext plus tenant identity in a third party's
+ * request logs, and a 401 whose cause is invisible. Worse, sealing ROUTES
+ * traffic here: when `ProviderService` cannot open the envelope it yields a null
+ * key, the provider dispatch declines, and the fallback path re-reads the row raw.
+ *
+ * Both worlds are asserted. The legacy/plaintext half is the important one: it
+ * is what proves the codec stayed inert, and it fails loudly if a future edit
+ * made opening unconditional.
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as omniCoreReal from '@omni/core';
+import { setTenantSecretMasterKey } from '@omni/core';
+import type { Database } from '@omni/db';
+import { sealCredentialField } from '../../tenancy/sealed-credentials';
+import { runInTenantScope } from '../../tenancy/tenant-scope';
+import { buildWorkerTenantContext } from '../../tenancy/worker-tenant-context';
+import { AgentRunnerService } from '../agent-runner';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const MASTER_KEY = Buffer.alloc(32, 7);
+const PLAINTEXT_KEY = 'sk-agno-live-0123456789';
+
+/**
+ * The credential handed to the provider-client factory — the exact value that
+ * becomes `Authorization: Bearer …`.
+ *
+ * Recorded through a module mock rather than read off the returned client,
+ * because bun's `mock.module` is process-wide and a sibling suite
+ * (`plugins/__tests__/agent-dispatcher.test.ts`) replaces `createProviderClient`
+ * with a stub that returns `{}`. This mock spreads the real module and
+ * DELEGATES to the real factory, so it observes without changing behaviour for
+ * this file or any file ordered after it.
+ */
+const factoryCalls: Array<{ apiKey: string }> = [];
+// Captured BEFORE the mock installs: `omniCoreReal` is a live ESM namespace, so
+// reading `.createProviderClient` off it afterwards would resolve to the wrapper
+// and recurse forever.
+const realCreateProviderClient = omniCoreReal.createProviderClient;
+mock.module('@omni/core', () => ({
+  ...omniCoreReal,
+  createProviderClient: (config: { apiKey: string }) => {
+    factoryCalls.push(config);
+    return realCreateProviderClient(config as never);
+  },
+}));
+
+afterEach(() => {
+  setTenantSecretMasterKey(null);
+  factoryCalls.length = 0;
+});
+
+/** A one-row `agent_providers` stand-in whose `api_key` is whatever we store. */
+function makeDb(apiKey: string | null): Database {
+  const row = {
+    id: 'provider-1',
+    name: 'agno',
+    schema: 'agno',
+    baseUrl: 'https://agno.example',
+    apiKey,
+    defaultTimeout: 600,
+    isActive: true,
+    schemaConfig: null,
+  };
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [row],
+        }),
+      }),
+    }),
+  };
+  return db as unknown as Database;
+}
+
+function inTenantScope<T>(db: Database, tenantId: string, fn: () => Promise<T>): Promise<T> {
+  return runInTenantScope(db, buildWorkerTenantContext(tenantId), fn);
+}
+
+/**
+ * The credential the client was built with — what `AgnoClient` renders as
+ * `Authorization: Bearer ${apiKey}` on every call, i.e. the bytes that would
+ * leave the process.
+ */
+function bearer(): string {
+  const last = factoryCalls.at(-1);
+  if (!last) throw new Error('createProviderClient was never called');
+  return last.apiKey;
+}
+
+/** `getClient` is private; the run path reaches it, and so does this. */
+function getClient(service: AgentRunnerService, providerId: string): Promise<unknown> {
+  return (service as unknown as { getClient: (id: string) => Promise<unknown> }).getClient(providerId);
+}
+
+describe('agent-runner — legacy world is byte-identical', () => {
+  test('no key configured, plaintext row: the exact stored bytes reach the client', async () => {
+    const db = makeDb(PLAINTEXT_KEY);
+    await getClient(new AgentRunnerService(db), 'provider-1');
+    expect(bearer()).toBe(PLAINTEXT_KEY);
+  });
+
+  test('KEY PRESENT but the row is legacy plaintext: still the exact stored bytes', async () => {
+    // The transitional world G5 ships: sealing is enabled, but there is no
+    // credential backfill, so plaintext rows must keep working untouched.
+    setTenantSecretMasterKey(MASTER_KEY);
+    const db = makeDb(PLAINTEXT_KEY);
+    await inTenantScope(db, TENANT_A, () => getClient(new AgentRunnerService(db), 'provider-1'));
+    expect(bearer()).toBe(PLAINTEXT_KEY);
+  });
+
+  test('KEY ABSENT, plaintext row, inside a scope: still the exact stored bytes', async () => {
+    // No key means the codec is the identity function, so a tenant scope cannot
+    // by itself change what a plaintext column produces. Without this probe "no
+    // key" and "no tenant" would be indistinguishable.
+    const db = makeDb(PLAINTEXT_KEY);
+    await inTenantScope(db, TENANT_A, () => getClient(new AgentRunnerService(db), 'provider-1'));
+    expect(bearer()).toBe(PLAINTEXT_KEY);
+  });
+
+  test('KEY WITHDRAWN with a sealed row: fails closed — the envelope is never forwarded', async () => {
+    // Seal with a key, then withdraw it: the column now holds an envelope no
+    // reader can open. `openCredentialField` returns null for exactly this
+    // (sealed + no key), the same posture `ProviderService` takes, and null must
+    // never degrade into "send the envelope".
+    setTenantSecretMasterKey(MASTER_KEY);
+    const sealed = sealCredentialField(TENANT_A, PLAINTEXT_KEY);
+    setTenantSecretMasterKey(null);
+    const db = makeDb(sealed);
+
+    await expect(
+      inTenantScope(db, TENANT_A, () => getClient(new AgentRunnerService(db), 'provider-1')),
+    ).rejects.toThrow(/not available/i);
+  });
+});
+
+describe('agent-runner — the sealed credential is OPENED, never forwarded', () => {
+  test('sealed for the tenant whose scope is active: the client gets the PLAINTEXT', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const sealed = sealCredentialField(TENANT_A, PLAINTEXT_KEY);
+    expect(sealed).not.toBe(PLAINTEXT_KEY);
+    const db = makeDb(sealed);
+
+    await inTenantScope(db, TENANT_A, () => getClient(new AgentRunnerService(db), 'provider-1'));
+
+    expect(bearer()).toBe(PLAINTEXT_KEY);
+    // The envelope carries the tenant UUID; neither it nor the ciphertext may
+    // ever become an `Authorization: Bearer` value.
+    expect(bearer()).not.toContain('"alg"');
+    expect(bearer()).not.toContain(TENANT_A);
+  });
+
+  test('sealed for ANOTHER tenant: fails closed — no client, no envelope on the wire', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const db = makeDb(sealCredentialField(TENANT_A, PLAINTEXT_KEY));
+
+    await expect(
+      inTenantScope(db, TENANT_B, () => getClient(new AgentRunnerService(db), 'provider-1')),
+    ).rejects.toThrow(/not available/i);
+  });
+
+  test('sealed but NO scope (the unscoped worker path): fails closed', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const db = makeDb(sealCredentialField(TENANT_A, PLAINTEXT_KEY));
+
+    await expect(getClient(new AgentRunnerService(db), 'provider-1')).rejects.toThrow(/not available/i);
+  });
+
+  test('an absent key still raises the pre-existing "no API key configured" error', async () => {
+    const db = makeDb(null);
+    await expect(getClient(new AgentRunnerService(db), 'provider-1')).rejects.toThrow(/no API key configured/);
+  });
+});

--- a/packages/api/src/services/__tests__/auth-cache-invalidation-ceiling.test.ts
+++ b/packages/api/src/services/__tests__/auth-cache-invalidation-ceiling.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Auth-cache invalidation ceiling, proven with a SYNTHETIC clock
+ * (wish: omni-full-multitenancy, Group G5, deliverable (c); ADR-0006;
+ * RELEASE_SLOS `revocation.auth_cache_invalidation_seconds_max: 15`).
+ *
+ * The repository holds exactly two caches of AUTHORIZATION state:
+ *
+ *   * `apiKeyCache` — validated API keys (legacy TTL 60s). In-process
+ *     revocation deletes the entry by hash immediately (`revoke()` →
+ *     `apiKeyCache.delete`), so the TTL is the bound ONLY for out-of-band
+ *     revocations (direct DB update from another process) — and 60s exceeds
+ *     the 15s release ceiling.
+ *   * `accessCache` — per-user/per-instance allow/deny decisions (legacy TTL
+ *     5 minutes). Rule mutations clear it in-process; the TTL is again the
+ *     out-of-band bound.
+ *
+ * The conversion is DUAL-WORLD, like every G5 enforcement: with multitenancy
+ * ENABLED the caches write with TTL ≤ the ceiling, so any cached authorization
+ * fact dies within 15s of the state that produced it changing anywhere; with
+ * the flag off the legacy TTLs are byte-identical (60s / 300s — asserted here
+ * so a regression in either direction fails).
+ *
+ * All timing is `setSystemTime` — no wall-clock waits, no production timing
+ * claims. The tenant-plane credential path (G3 `requestAuthenticator`) caches
+ * nothing — every request re-reads the auth plane, which is the
+ * `new_api_or_privileged_action_check: next_authorization_check` shape — so
+ * these two legacy-plane caches are the class's only subjects.
+ */
+
+import { afterEach, describe, expect, setSystemTime, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { CacheTTL, apiKeyCache } from '../../cache';
+import { AUTH_CACHE_INVALIDATION_CEILING_SECONDS, authCacheTtlMs } from '../../cache/cache-keys';
+import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
+import { AccessService } from '../access';
+import { ApiKeyService } from '../api-keys';
+
+const T0 = new Date('2026-07-24T00:00:00.000Z');
+
+/** A thenable that satisfies drizzle's fluent fire-and-forget update chain. */
+function thenable(): { then: (fn?: () => void) => unknown; catch: () => unknown } {
+  const t = {
+    // biome-ignore lint/suspicious/noThenProperty: drizzle chains ARE thenables; the fake must mirror that surface
+    then: (fn?: () => void) => {
+      fn?.();
+      return t;
+    },
+    catch: () => t,
+  };
+  return t;
+}
+
+/** A db whose SELECT returns the given api-key row and counts its reads. */
+function fakeKeyDb(row: Record<string, unknown> | null): { db: Database; reads: { count: number } } {
+  const reads = { count: 0 };
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            reads.count++;
+            return row ? [row] : [];
+          },
+        }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: () => thenable() }) }),
+  } as unknown as Database;
+  return { db, reads };
+}
+
+function keyRow(keyHash: string): Record<string, unknown> {
+  return {
+    id: 'key-1',
+    name: 'probe-key',
+    status: 'active',
+    expiresAt: null,
+    scopes: ['*'],
+    instanceIds: null,
+    profile: null,
+    chatAllowlist: [],
+    instanceAllowlist: [],
+    outboundRecipientAllowlist: [],
+    profileOverrides: null,
+    keyHash,
+  };
+}
+
+afterEach(async () => {
+  setSystemTime();
+  delete process.env[MULTITENANCY_FLAG_ENV];
+  await apiKeyCache.clear();
+});
+
+describe('the ceiling constant (RELEASE_SLOS auth_cache_invalidation_seconds_max)', () => {
+  test('is 15 seconds, and the clamp helper binds it to the tenant world only', () => {
+    expect(AUTH_CACHE_INVALIDATION_CEILING_SECONDS).toBe(15);
+
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    expect(authCacheTtlMs(CacheTTL.API_KEY)).toBe(15_000);
+    expect(authCacheTtlMs(CacheTTL.ACCESS_CHECK)).toBe(15_000);
+    // A legacy TTL already under the ceiling is honoured, not raised.
+    expect(authCacheTtlMs(5_000)).toBe(5_000);
+
+    delete process.env[MULTITENANCY_FLAG_ENV];
+    expect(authCacheTtlMs(CacheTTL.API_KEY)).toBe(CacheTTL.API_KEY);
+    expect(authCacheTtlMs(CacheTTL.ACCESS_CHECK)).toBe(CacheTTL.ACCESS_CHECK);
+  });
+});
+
+describe('apiKeyCache honours the ceiling in the tenant world (synthetic clock)', () => {
+  const KEY = 'omni_sk_probe_auth_cache_ceiling';
+
+  async function primedService(): Promise<{ service: ApiKeyService; reads: { count: number } }> {
+    const service = new ApiKeyService({} as unknown as Database);
+    const hash = await (service as unknown as { hashKey(k: string): Promise<string> }).hashKey(KEY);
+    const { db, reads } = fakeKeyDb(keyRow(hash));
+    (service as unknown as { db: Database }).db = db;
+    return { service, reads };
+  }
+
+  test('flag-on: a cached validation dies within the 15s ceiling', async () => {
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    setSystemTime(T0);
+    const { service, reads } = await primedService();
+
+    expect(await service.validate(KEY)).not.toBeNull();
+    expect(reads.count).toBe(1);
+
+    // Inside the ceiling: still served from cache — the clamp is a maximum,
+    // not an eager expiry.
+    setSystemTime(new Date(T0.getTime() + AUTH_CACHE_INVALIDATION_CEILING_SECONDS * 1000 - 1));
+    expect(await service.validate(KEY)).not.toBeNull();
+    expect(reads.count).toBe(1);
+
+    // One millisecond past the ceiling: the cached authorization is GONE and
+    // the next validation re-reads the database — an out-of-band revocation
+    // becomes visible here, ≤ 15s after it landed.
+    setSystemTime(new Date(T0.getTime() + AUTH_CACHE_INVALIDATION_CEILING_SECONDS * 1000 + 1));
+    expect(await service.validate(KEY)).not.toBeNull();
+    expect(reads.count).toBe(2);
+  });
+
+  test('flag-off: the legacy 60s TTL is byte-identical in both directions', async () => {
+    setSystemTime(T0);
+    const { service, reads } = await primedService();
+
+    expect(await service.validate(KEY)).not.toBeNull();
+    expect(reads.count).toBe(1);
+
+    // Well past the tenant ceiling but inside the legacy TTL: STILL cached —
+    // the clamp must not leak into the flag-off world.
+    setSystemTime(new Date(T0.getTime() + 59_999));
+    expect(await service.validate(KEY)).not.toBeNull();
+    expect(reads.count).toBe(1);
+
+    setSystemTime(new Date(T0.getTime() + 60_001));
+    expect(await service.validate(KEY)).not.toBeNull();
+    expect(reads.count).toBe(2);
+  });
+
+  test('in-process revocation invalidates immediately in BOTH worlds — the TTL is only the out-of-band bound', async () => {
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    setSystemTime(T0);
+    const service = new ApiKeyService({} as unknown as Database);
+    const hash = await (service as unknown as { hashKey(k: string): Promise<string> }).hashKey(KEY);
+    const row = keyRow(hash);
+    const { db } = fakeKeyDb(row);
+    // `revoke` drives update().returning(); `updateUsageAsync` drives the same
+    // chain as a fire-and-forget thenable — the fake serves both.
+    (db as unknown as { update: () => unknown }).update = () => ({
+      set: () => ({
+        where: () => {
+          const chain = {
+            returning: async () => [row],
+            // biome-ignore lint/suspicious/noThenProperty: drizzle chains ARE thenables; the fake must mirror that surface
+            then: (fn?: () => void) => {
+              fn?.();
+              return chain;
+            },
+            catch: () => chain,
+          };
+          return chain;
+        },
+      }),
+    });
+    (service as unknown as { db: Database }).db = db;
+
+    expect(await service.validate(KEY)).not.toBeNull();
+    await service.revoke('key-1', 'probe');
+
+    // No clock advance at all: the cache entry is gone NOW.
+    const { db: emptyDb } = fakeKeyDb(null);
+    (service as unknown as { db: Database }).db = emptyDb;
+    expect(await service.validate(KEY)).toBeNull();
+  });
+});
+
+describe('accessCache honours the ceiling in the tenant world', () => {
+  function accessHarness(): { service: AccessService; ttls: (number | undefined)[] } {
+    const ttls: (number | undefined)[] = [];
+    const cache = {
+      get: async () => null,
+      set: async (_k: string, _v: unknown, ttlMs?: number) => {
+        ttls.push(ttlMs);
+      },
+      delete: async () => {},
+      has: async () => false,
+      clear: async () => {},
+      stats: async () => ({ hits: 0, misses: 0, size: 0, evictions: 0 }),
+      dispose: async () => {},
+    };
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: async () => [],
+            limit: async () => [],
+          }),
+        }),
+      }),
+    } as unknown as Database;
+    const service = new AccessService(db, null, cache as never);
+    return { service, ttls };
+  }
+
+  test('flag-on: allow/deny decisions are cached for at most the ceiling', async () => {
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    const { service, ttls } = accessHarness();
+    await service.checkAccess({ id: 'inst-1', accessMode: 'allowlist' } as never, 'user-1', 'whatsapp-baileys');
+    expect(ttls).toEqual([15_000]);
+  });
+
+  test('flag-off: the legacy 5-minute TTL is passed through unchanged', async () => {
+    const { service, ttls } = accessHarness();
+    await service.checkAccess({ id: 'inst-1', accessMode: 'allowlist' } as never, 'user-1', 'whatsapp-baileys');
+    expect(ttls).toEqual([CacheTTL.ACCESS_CHECK]);
+  });
+});

--- a/packages/api/src/services/__tests__/batch-jobs-dequeue-revalidation.test.ts
+++ b/packages/api/src/services/__tests__/batch-jobs-dequeue-revalidation.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Batch-job dequeue-time tenant revalidation (wish: omni-full-multitenancy,
+ * Group G5; ADR-0008, ADR-0006; RELEASE_SLOS "queued_retry_delayed_dlq_check").
+ *
+ * A batch job is created (or resumed) with a trusted tenant, then sits until a
+ * detached executor runs it — possibly across a process restart. Between
+ * derivation and dequeue the tenant may be suspended/archived. The executor
+ * MUST revalidate the tenant is still admissible BEFORE it begins, and stop the
+ * job with no side effect when it is not.
+ *
+ * Synthetic clock/epoch: the "epoch" here is the auth-plane `tenants.status`
+ * transition active→suspended (suspension bumps the revocation epoch — see
+ * periodic-tenant-work.ts). We flip the fake auth-plane's answer and assert the
+ * executor's behavior changes accordingly. No production timing is claimed.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { BatchJobService } from '../batch-jobs';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111ba';
+
+/**
+ * A pool whose `update(...).set(...).where(...)` records the status written, and
+ * whose `select` (getById) returns a pending job. `transaction` runs the
+ * callback (worker scope opens one). Enough surface for `executeJob`'s stop
+ * path; the processing path is never reached when the tenant is inadmissible.
+ */
+function fakePool(writes: Array<{ status?: string; errorMessage?: string }>): Database {
+  const job = {
+    id: 'job-1',
+    instanceId: 'inst-1',
+    jobType: 'time_based_batch',
+    status: 'pending',
+    requestParams: { daysBack: 1 },
+    tenantId: TENANT_A,
+  };
+  const handle = {
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(handle),
+    execute: async () => [],
+    update: () => ({
+      set: (values: { status?: string; errorMessage?: string }) => ({
+        where: async () => {
+          writes.push({ status: values.status, errorMessage: values.errorMessage });
+          return [];
+        },
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [job] }),
+      }),
+    }),
+  };
+  return handle as unknown as Database;
+}
+
+/** True when a write is the dequeue fail-stop (its message names admissibility). */
+const isDequeueStop = (w: { status?: string; errorMessage?: string }): boolean =>
+  w.status === 'failed' && (w.errorMessage ?? '').includes('not admissible');
+
+/** A fake auth-plane whose tenant status is switchable to simulate suspension. */
+function fakeAuthPlane(status: { value: 'active' | 'suspended' }): Database {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [{ status: status.value }] }),
+      }),
+    }),
+  } as unknown as Database;
+}
+
+interface ExecutorAccess {
+  executeJob(jobId: string, jobTenantId: string | null): Promise<void>;
+}
+
+describe('batch-jobs dequeue-time tenant revalidation', () => {
+  test('a suspended tenant stops the job at dequeue with NO processing side effect', async () => {
+    const writes: Array<{ status?: string; errorMessage?: string }> = [];
+    const service = new BatchJobService(fakePool(writes), null);
+    service.setAuthPlane(fakeAuthPlane({ value: 'suspended' }));
+
+    await (service as unknown as ExecutorAccess).executeJob('job-1', TENANT_A);
+
+    // Exactly one write: the dequeue fail-stop. No 'running', no processing.
+    expect(writes.length).toBe(1);
+    expect(writes[0] && isDequeueStop(writes[0])).toBe(true);
+  });
+
+  test('a legacy (null-tenant) job is always admissible and never stops at dequeue', async () => {
+    const writes: Array<{ status?: string; errorMessage?: string }> = [];
+    const service = new BatchJobService(fakePool(writes), null);
+    // No auth plane injected: a null-tenant job must not need one. It passes the
+    // gate and then fails on the unwired processing path (via handleJobError) —
+    // which is NOT the dequeue fail-stop.
+    await (service as unknown as ExecutorAccess).executeJob('job-1', null);
+    expect(writes.some(isDequeueStop)).toBe(false);
+  });
+
+  test('an active tenant is admissible — the dequeue gate does not stop it', async () => {
+    const writes: Array<{ status?: string; errorMessage?: string }> = [];
+    const service = new BatchJobService(fakePool(writes), null);
+    service.setAuthPlane(fakeAuthPlane({ value: 'active' }));
+    await (service as unknown as ExecutorAccess).executeJob('job-1', TENANT_A);
+    expect(writes.some(isDequeueStop)).toBe(false);
+  });
+});

--- a/packages/api/src/services/__tests__/batch-jobs-resume-worker-scope.test.ts
+++ b/packages/api/src/services/__tests__/batch-jobs-resume-worker-scope.test.ts
@@ -1,0 +1,200 @@
+/**
+ * `services/batch-jobs.ts::{batch_jobs,media_content,messages}` — the LAST
+ * unscoped caller (G5; ADR-0008).
+ *
+ * Earlier legs converted the whole fire-and-forget executor: every discrete DB
+ * block inside `executeJob` runs in `runTenantWorkDb(pool, jobTenantId, …)`,
+ * with the job's TRUSTED tenant captured from the request scope at create time
+ * or threaded by a worker caller. What stayed ambient was `resumeJobs()` — the
+ * restart-recovery path, which scans the WHOLE `batch_jobs` table for
+ * `status = 'running'` with no request, no credential and no envelope. Under RLS
+ * enforcement that global scan is not expressible at all, so recovery must
+ * ENUMERATE whose jobs exist rather than scan and sort out ownership afterwards.
+ *
+ * This probe pins:
+ *   1. LEGACY WORLD IS BYTE-IDENTICAL — no auth plane wired (the shape every
+ *      existing test and every flag-off deployment produces): one ambient scan,
+ *      no enumeration, no transaction.
+ *   2. ENUMERATED, NOT SCANNED — flag-on the scan runs once per ACTIVE tenant
+ *      inside that tenant's worker scope.
+ *   3. THE RESUMED EXECUTOR CARRIES THE ROW'S OWN TENANT — not the pass's, not
+ *      an ambient one: `executeJob` is handed `job.tenantId`, which is what makes
+ *      the dequeue revalidation and every downstream block target the right
+ *      tenant.
+ *   4. NO CROSS-TENANT BLEED — a job owned by tenant B is not resumed in tenant
+ *      A's pass.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import { BatchJobService } from '../batch-jobs';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+const FLAG_ON: NodeJS.ProcessEnv = { [MULTITENANCY_FLAG_ENV]: 'true' };
+const FLAG_OFF: NodeJS.ProcessEnv = {};
+
+function scope(): string | null {
+  return currentTenantScope()?.tenantId ?? null;
+}
+
+function chain<T>(result: T): T {
+  const self: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') {
+          return (onOk: (v: T) => unknown, onErr?: (e: unknown) => unknown) =>
+            Promise.resolve(result).then(onOk, onErr);
+        }
+        return () => self;
+      },
+    },
+  );
+  return self as T;
+}
+
+interface Observed {
+  op: string;
+  scope: string | null;
+}
+
+function fakeAuthPlaneDb(ids: string[], counter: { selects: number }): Database {
+  return {
+    select: () => {
+      counter.selects += 1;
+      return {
+        from: () => ({
+          where: Object.assign(async () => ids.map((id) => ({ id, status: 'active' })), {
+            limit: async () => ids.map((id) => ({ id, status: 'active' })),
+          }),
+        }),
+      };
+    },
+  } as unknown as Database;
+}
+
+function makeDb(observed: Observed[], rows: unknown[], counters: { transactions: number }): Database {
+  const db = {
+    select: () => {
+      observed.push({ op: 'select', scope: scope() });
+      return chain(rows);
+    },
+    update: () => {
+      observed.push({ op: 'update', scope: scope() });
+      return chain([]);
+    },
+    insert: () => {
+      observed.push({ op: 'insert', scope: scope() });
+      return chain([]);
+    },
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counters.transactions += 1;
+      return cb(db);
+    },
+    execute: async () => [],
+  };
+  return db as unknown as Database;
+}
+
+function jobRow(id: string, tenantId: string | null) {
+  return { id, tenantId, status: 'running', instanceId: 'inst-1', jobType: 'time_based_batch' };
+}
+
+/**
+ * Build the service and replace `executeJob` with a recorder. That method is the
+ * already-converted executor; what this file probes is the RESUME path that
+ * feeds it — which tenant each resumed job is dispatched with.
+ */
+function makeService(rows: unknown[], observed: Observed[], counters: { transactions: number }) {
+  const executed: Array<{ jobId: string; tenantId: string | null }> = [];
+  const db = makeDb(observed, rows, counters);
+  const service = new BatchJobService(db, null);
+  (service as unknown as { executeJob: (id: string, t: string | null) => Promise<void> }).executeJob = async (
+    jobId,
+    tenantId,
+  ) => {
+    executed.push({ jobId, tenantId });
+  };
+  return { service, executed };
+}
+
+describe('batch-jobs resumeJobs — legacy world is byte-identical', () => {
+  test('no auth plane wired: one ambient scan, no enumeration, no transaction', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, executed } = makeService([jobRow('job-1', null)], observed, counters);
+
+    await service.resumeJobs();
+
+    expect(observed.filter((o) => o.op === 'select').length).toBe(1);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+    expect(counters.transactions).toBe(0);
+    expect(executed).toEqual([{ jobId: 'job-1', tenantId: null }]);
+  });
+
+  test('auth plane wired but flag OFF: still one ambient pass and NO auth-plane query', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const { service } = makeService([jobRow('job-1', null)], observed, counters);
+    service.setAuthPlane(fakeAuthPlaneDb([TENANT_A], authCounter));
+    service.setResumeEnv(FLAG_OFF);
+
+    await service.resumeJobs();
+
+    expect(observed.filter((o) => o.op === 'select').length).toBe(1);
+    expect(authCounter.selects).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+  });
+});
+
+describe('batch-jobs resumeJobs — tenant world', () => {
+  test('the running-job scan is ENUMERATED per tenant and runs inside that tenant scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const authCounter = { selects: 0 };
+    const { service } = makeService([], observed, counters);
+    service.setAuthPlane(fakeAuthPlaneDb([TENANT_A, TENANT_B], authCounter));
+    service.setResumeEnv(FLAG_ON);
+
+    await service.resumeJobs();
+
+    expect(authCounter.selects).toBe(1);
+    const selects = observed.filter((o) => o.op === 'select').map((o) => o.scope);
+    expect(selects).toEqual([TENANT_A, TENANT_B, null]);
+  });
+
+  test('the resumed executor is handed the ROW’s own tenant, outside the read scope', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, executed } = makeService([jobRow('job-a', TENANT_A)], observed, counters);
+    service.setAuthPlane(fakeAuthPlaneDb([TENANT_A], { selects: 0 }));
+    service.setResumeEnv(FLAG_ON);
+
+    await service.resumeJobs();
+
+    expect(executed).toEqual([{ jobId: 'job-a', tenantId: TENANT_A }]);
+  });
+
+  test('a job owned by tenant B is not resumed in tenant A’s pass', async () => {
+    const observed: Observed[] = [];
+    const counters = { transactions: 0 };
+    const { service, executed } = makeService([jobRow('job-b', TENANT_B)], observed, counters);
+    service.setAuthPlane(fakeAuthPlaneDb([TENANT_A], { selects: 0 }));
+    // Enforced, so the transitional NULL-tenant pass is skipped too. `'on'` is
+    // the ONLY value `resolveEnforcementMode` accepts (tenancy-startup.ts:
+    // deliberately not truthy-ish) — spelling it 'enforced' would resolve to the
+    // legacy mode and this test would pass for the wrong reason.
+    service.setResumeEnv({ ...FLAG_ON, OMNI_DB_ENFORCEMENT: 'on' });
+
+    await service.resumeJobs();
+
+    expect(executed).toEqual([]);
+    // The NULL-tenant pass really was skipped: only tenant A's scoped read ran.
+    expect(observed.filter((o) => o.op === 'select').map((o) => o.scope)).toEqual([TENANT_A]);
+  });
+});

--- a/packages/api/src/services/__tests__/event-ops-multi-effect-revocation.test.ts
+++ b/packages/api/src/services/__tests__/event-ops-multi-effect-revocation.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Multi-effect work revalidates the revocation state between side effects,
+ * proven with a SYNTHETIC epoch (wish: omni-full-multitenancy, Group G5,
+ * deliverable (c); ADR-0006; RELEASE_SLOS
+ * `revocation.multi_effect_work_check: current_revocation_epoch_between_every_side_effect`
+ * and `queued_retry_delayed_dlq_check`).
+ *
+ * The event-replay executor is the repository's canonical multi-effect work
+ * item: one replay session republishes MANY events (durable side effects on
+ * the bus), batch after batch. The contract proven here — pinning the
+ * behavior the leg-E conversion introduced, so no later edit can quietly drop
+ * it:
+ *
+ *   1. DEQUEUE-TIME: a replay whose tenant is already inadmissible when the
+ *      detached executor starts performs ZERO side effects;
+ *   2. BETWEEN-EFFECT: a tenant suspended after the first batch's publishes
+ *      is observed at the next batch boundary — the remaining batches never
+ *      publish, and the session fails rather than completes;
+ *   3. LEGACY: a null-tenant replay never consults the auth plane and
+ *      publishes as before — byte-identical.
+ *
+ * The "epoch" is the tenant's `status` row on the auth plane
+ * (`isTenantWorkAdmissible` — the same trusted, non-caller-controlled read
+ * every revocation-sensitive executor uses), injected as a scripted sequence
+ * of answers: the flip is a STEP in the test, never a wall-clock wait.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ReplayOptions } from '@omni/core';
+import type { Database } from '@omni/db';
+import type { DeadLetterService } from '../dead-letters';
+import { EventOpsService } from '../event-ops';
+import type { PayloadStoreService } from '../payload-store';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+/** One synthetic stored event per publish the batch would perform. */
+function batchEvent(id: string): Record<string, unknown> {
+  return {
+    id,
+    eventType: 'message.received',
+    instanceId: 'inst-1',
+    channel: 'whatsapp-baileys',
+    textContent: `event ${id}`,
+    status: 'pending',
+    receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+/**
+ * A pool serving the two SELECT shapes the replay walks: the count query
+ * (awaited straight off `where()`) and the batch query
+ * (`orderBy().limit().offset()`), yielding the scripted batches in order.
+ */
+function fakePool(batches: Record<string, unknown>[][]): Database {
+  let nextBatch = 0;
+  const where = () => {
+    const chain = {
+      orderBy: () => ({
+        limit: () => ({
+          offset: async () => batches[nextBatch++] ?? [],
+        }),
+      }),
+      // biome-ignore lint/suspicious/noThenProperty: the count query awaits the drizzle chain directly; the fake must be thenable
+      then: (resolve: (rows: unknown[]) => void) => {
+        resolve([{ count: batches.flat().length }]);
+      },
+    };
+    return chain;
+  };
+  const select = () => ({ from: () => ({ where }) });
+  const tx = { execute: async () => [], select };
+  return {
+    select,
+    transaction: async (fn: (t: unknown) => Promise<unknown>) => fn(tx),
+  } as unknown as Database;
+}
+
+/** An auth plane answering the scripted admissibility sequence, then its last value. */
+function fakeAuthPlane(statuses: ('active' | 'suspended')[]): { db: Database; reads: { count: number } } {
+  const reads = { count: 0 };
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            const status = statuses[Math.min(reads.count, statuses.length - 1)];
+            reads.count++;
+            return [{ status }];
+          },
+        }),
+      }),
+    }),
+  } as unknown as Database;
+  return { db, reads };
+}
+
+function harness(batches: Record<string, unknown>[][], statuses: ('active' | 'suspended')[]) {
+  const published: string[] = [];
+  const eventBus = {
+    publishGeneric: async (_type: string, payload: Record<string, unknown>) => {
+      // Count only the REPLAYED events (the durable side effects under test);
+      // the session lifecycle notifications the service also publishes are not
+      // per-event side effects.
+      if (payload._replay === true) published.push(String(payload._originalEventId));
+      return { id: 'pub-1', timestamp: Date.now() };
+    },
+  } as never;
+  const service = new EventOpsService(
+    fakePool(batches),
+    eventBus,
+    {} as unknown as DeadLetterService,
+    {} as unknown as PayloadStoreService,
+  );
+  const authPlane = fakeAuthPlane(statuses);
+  service.setAuthPlane(authPlane.db);
+  return { service, published, authPlaneReads: authPlane.reads };
+}
+
+const OPTIONS: ReplayOptions = { since: new Date('2026-01-01T00:00:00.000Z') };
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 30; i++) await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+describe('event-replay multi-effect revocation (G5, RELEASE_SLOS multi_effect_work_check)', () => {
+  test('dequeue-time: an already-inadmissible tenant performs ZERO side effects', async () => {
+    const h = harness([[batchEvent('e1'), batchEvent('e2')]], ['suspended']);
+    const session = await h.service.startReplay(OPTIONS, TENANT_A);
+    await settle();
+
+    expect(h.published).toEqual([]);
+    const after = h.service.getReplaySession(session.id);
+    expect(after?.status).toBe('failed');
+    expect(after?.error ?? '').toContain('admissible');
+  });
+
+  test('between effects: a mid-replay suspension halts at the NEXT batch boundary', async () => {
+    // Two batches of durable side effects. Admissibility answers, in read
+    // order: dequeue-check OK, batch-1 boundary OK, batch-2 boundary REFUSED.
+    const h = harness(
+      [
+        [batchEvent('e1'), batchEvent('e2')],
+        [batchEvent('e3'), batchEvent('e4')],
+      ],
+      ['active', 'active', 'suspended'],
+    );
+    const session = await h.service.startReplay(OPTIONS, TENANT_A);
+    await settle();
+
+    // Batch 1 published; batch 2 never did — the flip was observed BETWEEN the
+    // two groups of side effects, exactly the ceiling's shape.
+    expect(h.published).toEqual(['e1', 'e2']);
+    expect(h.authPlaneReads.count).toBeGreaterThanOrEqual(3);
+    const after = h.service.getReplaySession(session.id);
+    expect(after?.status).toBe('failed');
+    expect(after?.error ?? '').toContain('inadmissible');
+  });
+
+  test('legacy: a null-tenant replay never consults the auth plane — byte-identical', async () => {
+    const h = harness([[batchEvent('e1'), batchEvent('e2')]], ['suspended']);
+    const session = await h.service.startReplay(OPTIONS, null);
+    await settle();
+
+    expect(h.authPlaneReads.count).toBe(0);
+    expect(h.published).toEqual(['e1', 'e2']);
+    const after = h.service.getReplaySession(session.id);
+    expect(after?.status).toBe('completed');
+  });
+});

--- a/packages/api/src/services/__tests__/follow-up-sweeper-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/follow-up-sweeper-two-tenant-postgres.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Two-tenant FOLLOW-UP SWEEPER fan-out over real PostgreSQL
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0003).
+ *
+ * The sweeper is a CRON path: no envelope, no credential. Its G5 conversion
+ * enumerates active tenants on the auth-plane connection and runs one pass per
+ * tenant, each DB block in its own short worker scope, stamping every fired
+ * event with the row's trusted tenant. This suite proves, against a disposable
+ * database:
+ *
+ *   PHASE 1 (pre-enforcement, flag-on — the transitional mixed state):
+ *   * tenant A's due row fires inside A's pass with an A-stamped envelope,
+ *     tenant B's inside B's with a B-stamped envelope — never crossed;
+ *   * a NULL-tenant legacy row is swept by the transitional legacy pass and
+ *     its envelope stays legacy (no version, no tenant);
+ *
+ *   PHASE 2 (RLS enforcement installed, runtime role):
+ *   * the per-tenant passes still fire their own tenants' rows;
+ *   * the legacy pass is skipped — a NULL-tenant row stays untouched (the
+ *     enforcement state machine forbids that mixed state; nothing ambient
+ *     runs against a policed table);
+ *   * a SUSPENDED tenant drops out of the enumeration — its due row does not
+ *     fire (dequeue-time revalidation for periodic work).
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { EventBus } from '@omni/core';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  chatFollowUpState,
+  createDbHandle,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
+import { scopedHandle } from '../../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { FollowUpSweeperService } from '../follow-up-sweeper';
+
+/** Held in a const so `delete process.env[ENFORCEMENT_ENV]` is a computed
+ * member access (satisfies biome's noDelete + useLiteralKeys). */
+const ENFORCEMENT_ENV = 'OMNI_DB_ENFORCEMENT';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111fa';
+const TENANT_B = '22222222-2222-4222-8222-2222222222fb';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555fa';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555fb';
+const INSTANCE_L = '55555555-5555-4555-8555-5555555555fc';
+const CHAT_A = '66666666-6666-4666-8666-6666666666fa';
+const CHAT_B = '66666666-6666-4666-8666-6666666666fb';
+const CHAT_L = '66666666-6666-4666-8666-6666666666fc';
+const ROW_A = '77777777-7777-4777-8777-7777777777fa';
+const ROW_B = '77777777-7777-4777-8777-7777777777fb';
+const ROW_L = '77777777-7777-4777-8777-7777777777fc';
+
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+/** A fixed 3-step config whose first fire is due immediately when seeded due. */
+const SEQ_CONFIG = JSON.stringify({
+  enabled: true,
+  schedule: { kind: 'fixed', intervalsMinutes: [3, 5, 30] },
+  maxFollowUps: 3,
+  promptTemplate: 'idle {{minutes}}m',
+  stopOutsideMessagingWindow: false,
+  showTypingIndicator: false,
+});
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-sweeper-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+interface PublishedEvent {
+  type: string;
+  payload: Record<string, unknown>;
+  metadata: Record<string, unknown> | undefined;
+}
+
+/** An EventBus fake that records publishes (the sweeper only publishes). */
+function recordingBus(events: PublishedEvent[]): EventBus {
+  return {
+    publish: async (type: string, payload: Record<string, unknown>, metadata?: Record<string, unknown>) => {
+      events.push({ type, payload, metadata });
+      return { ok: true };
+    },
+  } as unknown as EventBus;
+}
+
+/** Re-seed the three follow-up rows as armed and due NOW. */
+function seedDueRows(superDbUrl: string): void {
+  const seeded = runSqlOn(
+    superDbUrl,
+    `
+    DELETE FROM chat_follow_up_state
+      WHERE id IN ('${ROW_A}', '${ROW_B}', '${ROW_L}');
+    INSERT INTO chat_follow_up_state
+      (id, chat_id, instance_id, agent_id, sequence_config, sequence_index,
+       last_agent_message_at, next_fire_at, disarm_reason, tenant_id)
+    VALUES
+      ('${ROW_A}', '${CHAT_A}', '${INSTANCE_A}', NULL, '${SEQ_CONFIG}', 0,
+       now() - interval '10 minutes', now() - interval '1 minute', NULL, '${TENANT_A}'),
+      ('${ROW_B}', '${CHAT_B}', '${INSTANCE_B}', NULL, '${SEQ_CONFIG}', 0,
+       now() - interval '10 minutes', now() - interval '1 minute', NULL, '${TENANT_B}'),
+      ('${ROW_L}', '${CHAT_L}', '${INSTANCE_L}', NULL, '${SEQ_CONFIG}', 0,
+       now() - interval '10 minutes', now() - interval '1 minute', NULL, NULL);
+    `,
+  );
+  if (seeded.exitCode !== 0) throw new Error(`row seed failed: ${seeded.stderr}`);
+}
+
+postgresDescribe('two-tenant follow-up sweeper fan-out (real PostgreSQL)', () => {
+  const dbName = `omni_g5_sweeper_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  const savedEnv: Record<string, string | undefined> = {};
+  let superDbUrl = '';
+  let superDb: Database;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  function sweeperOn(pool: Database, authPlane: Database, events: PublishedEvent[]): FollowUpSweeperService {
+    const sweeper = new FollowUpSweeperService(pool, recordingBus(events));
+    sweeper.setAuthPlane(authPlane);
+    return sweeper;
+  }
+
+  beforeAll(async () => {
+    for (const key of [MULTITENANCY_FLAG_ENV, ENFORCEMENT_ENV]) {
+      savedEnv[key] = process.env[key];
+    }
+
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+    superDbUrl = urlFor(superUrl, dbName);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, is_active, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', true, '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', true, '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_L}', 'inst-legacy', 'whatsapp-baileys', NULL, true, '${SHARED_TIMESTAMP}');
+
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', 'jid-a', 'jid-a', 'direct', 'whatsapp-baileys', 'Chat A',
+         '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${INSTANCE_B}', 'jid-b', 'jid-b', 'direct', 'whatsapp-baileys', 'Chat B',
+         '${TENANT_B}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_L}', '${INSTANCE_L}', 'jid-l', 'jid-l', 'direct', 'whatsapp-baileys', 'Chat L',
+         NULL, '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    superDb = openDb(superDbUrl, 3);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  // ── PHASE 1: flag-on, pre-enforcement (the transitional mixed state) ──────
+
+  test('pre-enforcement: each tenant pass fires its own row with its own stamp; the legacy pass fires the NULL row unstamped', async () => {
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    delete process.env[ENFORCEMENT_ENV];
+    seedDueRows(superDbUrl);
+
+    const events: PublishedEvent[] = [];
+    const stats = await sweeperOn(superDb, superDb, events).sweep();
+
+    expect(stats.fired).toBe(3);
+
+    const fired = events.filter((e) => e.type === 'chat.idle_timeout');
+    const byChat = new Map(fired.map((e) => [e.payload.chatId as string, e]));
+    expect(byChat.get(CHAT_A)?.metadata?.tenantId).toBe(TENANT_A);
+    expect(byChat.get(CHAT_B)?.metadata?.tenantId).toBe(TENANT_B);
+    // The legacy row's envelope carries NO tenant claim at all.
+    expect(byChat.get(CHAT_L)?.metadata && 'tenantId' in (byChat.get(CHAT_L)?.metadata ?? {})).toBe(false);
+
+    // Every row advanced exactly once.
+    const rows = await superDb
+      .select({ id: chatFollowUpState.id, sequenceIndex: chatFollowUpState.sequenceIndex })
+      .from(chatFollowUpState);
+    expect(new Map(rows.map((r) => [r.id, r.sequenceIndex]))).toEqual(
+      new Map([
+        [ROW_A, 1],
+        [ROW_B, 1],
+        [ROW_L, 1],
+      ]),
+    );
+  });
+
+  test('flag-off is the single pre-G5 pass: no enumeration, every row swept ambient, no envelope stamped', async () => {
+    delete process.env[MULTITENANCY_FLAG_ENV];
+    delete process.env[ENFORCEMENT_ENV];
+    seedDueRows(superDbUrl);
+
+    const events: PublishedEvent[] = [];
+    // No auth plane injected on purpose: the flag-off path must never need it.
+    const sweeper = new FollowUpSweeperService(superDb, recordingBus(events));
+    const stats = await sweeper.sweep();
+
+    expect(stats.fired).toBe(3);
+    for (const event of events) {
+      expect(event.metadata && 'tenantId' in event.metadata).toBe(false);
+      expect(event.metadata && 'envelopeVersion' in event.metadata).toBe(false);
+    }
+  });
+
+  // ── PHASE 2: RLS enforcement installed, runtime + auth-plane roles ────────
+
+  test('enforced: per-tenant passes fire their own rows; the NULL-tenant row is untouched (no ambient pass exists)', async () => {
+    // Install enforcement ONCE, then run everything below as the runtime role.
+    await applyTenantRlsEnforcement(superDb);
+    await applyTenancyRoles(superDb, passwords, DEFAULT_ROLE_NAMES, dbName);
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    process.env[ENFORCEMENT_ENV] = 'on';
+    seedDueRows(superDbUrl);
+
+    const runtimeDb = openDb(
+      urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }),
+      1,
+    );
+    const authPlaneDb = openDb(
+      urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.authPlane, password: passwords.authPlane }),
+      1,
+    );
+
+    const events: PublishedEvent[] = [];
+    const stats = await sweeperOn(runtimeDb, authPlaneDb, events).sweep();
+
+    expect(stats.fired).toBe(2);
+    const fired = events.filter((e) => e.type === 'chat.idle_timeout');
+    const byChat = new Map(fired.map((e) => [e.payload.chatId as string, e]));
+    expect(byChat.get(CHAT_A)?.metadata?.tenantId).toBe(TENANT_A);
+    expect(byChat.get(CHAT_B)?.metadata?.tenantId).toBe(TENANT_B);
+    expect(byChat.has(CHAT_L)).toBe(false);
+
+    // A's row is visible inside A's scope and advanced; the NULL-tenant row
+    // never fired (checked via the superuser handle — it is invisible to every
+    // tenant scope, which is the point).
+    const scopedA = await runInWorkerTenantScope(runtimeDb, TENANT_A, async () =>
+      scopedHandle(runtimeDb)
+        .select({ sequenceIndex: chatFollowUpState.sequenceIndex })
+        .from(chatFollowUpState)
+        .where(eq(chatFollowUpState.id, ROW_A)),
+    );
+    expect(scopedA).toEqual([{ sequenceIndex: 1 }]);
+    const legacyRow = await superDb
+      .select({ sequenceIndex: chatFollowUpState.sequenceIndex })
+      .from(chatFollowUpState)
+      .where(eq(chatFollowUpState.id, ROW_L));
+    expect(legacyRow).toEqual([{ sequenceIndex: 0 }]);
+  });
+
+  test('enforced: a suspended tenant drops out of the enumeration — its due row does not fire', async () => {
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    process.env[ENFORCEMENT_ENV] = 'on';
+    seedDueRows(superDbUrl);
+    const suspended = runSqlOn(superDbUrl, `UPDATE tenants SET status = 'suspended' WHERE id = '${TENANT_B}';`);
+    if (suspended.exitCode !== 0) throw new Error(`suspend failed: ${suspended.stderr}`);
+
+    const runtimeDb = openDb(
+      urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }),
+      1,
+    );
+    const authPlaneDb = openDb(
+      urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.authPlane, password: passwords.authPlane }),
+      1,
+    );
+
+    const events: PublishedEvent[] = [];
+    const stats = await sweeperOn(runtimeDb, authPlaneDb, events).sweep();
+
+    expect(stats.fired).toBe(1);
+    const fired = events.filter((e) => e.type === 'chat.idle_timeout');
+    expect(fired.map((e) => e.payload.chatId)).toEqual([CHAT_A]);
+
+    // B's row is exactly where it was seeded — suspended work never dequeues.
+    const rowB = await superDb
+      .select({ sequenceIndex: chatFollowUpState.sequenceIndex })
+      .from(chatFollowUpState)
+      .where(eq(chatFollowUpState.id, ROW_B));
+    expect(rowB).toEqual([{ sequenceIndex: 0 }]);
+  });
+});

--- a/packages/api/src/services/__tests__/media-storage.test.ts
+++ b/packages/api/src/services/__tests__/media-storage.test.ts
@@ -319,6 +319,13 @@ describe('MediaStorageService.presignedUrl tenant binding (G5 ADR-0008)', () => 
   it('tenant-context presign of an own-prefix object clamps TTL to the 60s ceiling', async () => {
     const { backend, presigns } = capturingBackend();
     const service = new MediaStorageService(fakeDb, undefined, backend);
+    // TOUCHED by the later G5 leg that added the revocation gate: a
+    // tenant-context presign now also requires an admissibility check, and fails
+    // CLOSED without one. This test is about the TTL clamp, so it declares the
+    // tenant admissible and leaves every TTL assertion below unchanged. The gate
+    // itself is proven against synthetic epochs in
+    // `presign-revocation-ceiling.test.ts`.
+    service.setTenantAdmissibilityCheck(async () => true);
     await service.presignedUrl(tenantKey(TENANT_A), 3600, TENANT_A); // over ceiling → clamped
     await service.presignedUrl(tenantKey(TENANT_A), undefined, TENANT_A); // default → ceiling
     await service.presignedUrl(tenantKey(TENANT_A), 30, TENANT_A); // under ceiling → kept

--- a/packages/api/src/services/__tests__/media-storage.test.ts
+++ b/packages/api/src/services/__tests__/media-storage.test.ts
@@ -14,7 +14,7 @@ import { join } from 'node:path';
 import type { MediaStorageBackend } from '@omni/channel-sdk';
 import type { Database } from '@omni/db';
 import { UnsafeMediaUrlError } from '../../utils/safe-media-fetch';
-import { MediaStorageService } from '../media-storage';
+import { MediaStorageService, PRESIGNED_URL_TTL_CEILING_SECONDS } from '../media-storage';
 
 const fakeDb = {} as unknown as Database;
 
@@ -217,6 +217,143 @@ describe('MediaStorageService.storeFromUrl (omni#500)', () => {
       UnsafeMediaUrlError,
     );
     expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ── G5 tenant-context storage prefixing + presigned binding (ADR-0008) ─────
+//
+// Two-tenant probes for the leg-D contract: tenant-context writes land under
+// `tenants/<tenantId>/instances/<instanceId>/...`, presigns are bound to
+// tenant + object + expiry (TTL ceiling 60s), and the legacy/flag-off world is
+// byte-identical (no tenant → the pre-G5 key layout and presign call).
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_B = '22222222-2222-4222-8222-222222222222';
+const INSTANCE_ID = '33333333-3333-4333-8333-333333333333';
+const MESSAGE_ID = '44444444-4444-4444-8444-444444444444';
+const APRIL = new Date('2026-04-23T00:00:00Z');
+
+/** Backend stub that records every store/presign call it receives. */
+function capturingBackend() {
+  const stored: Array<{ key: string }> = [];
+  const presigns: Array<{ key: string; ttl: number | undefined }> = [];
+  const backend: MediaStorageBackend = {
+    mode: 'remote' as const,
+    store: async ({ key, buffer, mimeType }) => {
+      stored.push({ key });
+      return { reference: key, size: buffer.length, mimeType };
+    },
+    storeStream: async ({ key, mimeType }) => ({ reference: key, size: 0, mimeType }),
+    read: async () => Buffer.alloc(0),
+    stat: async () => null,
+    readRange: async () => Buffer.alloc(0),
+    readStream: async () => new ReadableStream(),
+    presignedUrl: async (key, ttl) => {
+      presigns.push({ key, ttl });
+      return `https://s3.example/${key}?ttl=${ttl ?? 'default'}`;
+    },
+  };
+  return { backend, stored, presigns };
+}
+
+describe('MediaStorageService tenant-context key layout (G5 ADR-0008)', () => {
+  it('prefixes tenant-context keys with tenants/<tenantId>/instances/<instanceId>/', () => {
+    const service = new MediaStorageService(fakeDb, undefined, capturingBackend().backend);
+    const key = service.buildKey(INSTANCE_ID, MESSAGE_ID, 'image/png', APRIL, TENANT_A);
+    expect(key).toBe(join('tenants', TENANT_A, 'instances', INSTANCE_ID, '2026-04', `${MESSAGE_ID}.png`));
+  });
+
+  it('legacy world (no tenant) keeps the pre-G5 key layout byte-identical', () => {
+    const service = new MediaStorageService(fakeDb, undefined, capturingBackend().backend);
+    const key = service.buildKey(INSTANCE_ID, MESSAGE_ID, 'image/png', APRIL);
+    expect(key).toBe(join(INSTANCE_ID, '2026-04', `${MESSAGE_ID}.png`));
+  });
+
+  it('fails closed on a non-UUID tenant/instance/message segment (traversal-safe)', () => {
+    const service = new MediaStorageService(fakeDb, undefined, capturingBackend().backend);
+    expect(() => service.buildKey(INSTANCE_ID, MESSAGE_ID, 'image/png', APRIL, '../../etc')).toThrow(
+      /non-UUID tenantId/,
+    );
+    expect(() => service.buildKey('..', MESSAGE_ID, 'image/png', APRIL, TENANT_A)).toThrow(/non-UUID instanceId/);
+    expect(() => service.buildKey(INSTANCE_ID, 'msg-1', 'image/png', APRIL, TENANT_A)).toThrow(/non-UUID messageId/);
+  });
+
+  it('storeFromBuffer with a trusted tenant stores under the tenant prefix', async () => {
+    const { backend, stored } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    const result = await service.storeFromBuffer(
+      INSTANCE_ID,
+      MESSAGE_ID,
+      Buffer.from([1, 2, 3]),
+      'image/png',
+      APRIL,
+      TENANT_A,
+    );
+    expect(stored[0]?.key).toBe(join('tenants', TENANT_A, 'instances', INSTANCE_ID, '2026-04', `${MESSAGE_ID}.png`));
+    expect(result.localPath).toStartWith(join('tenants', TENANT_A));
+  });
+
+  it('storeFromBuffer without a tenant stores the legacy key byte-identically', async () => {
+    const { backend, stored } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    await service.storeFromBuffer(INSTANCE_ID, MESSAGE_ID, Buffer.from([1, 2, 3]), 'image/png', APRIL);
+    expect(stored[0]?.key).toBe(join(INSTANCE_ID, '2026-04', `${MESSAGE_ID}.png`));
+  });
+});
+
+describe('MediaStorageService.presignedUrl tenant binding (G5 ADR-0008)', () => {
+  const tenantKey = (tenant: string) =>
+    join('tenants', tenant, 'instances', INSTANCE_ID, '2026-04', `${MESSAGE_ID}.png`);
+
+  it('legacy world passes the caller TTL to the backend verbatim (byte-identical)', async () => {
+    const { backend, presigns } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    await service.presignedUrl('inst-1/2026-04/msg.png', 3600);
+    await service.presignedUrl('inst-1/2026-04/msg.png');
+    expect(presigns).toEqual([
+      { key: 'inst-1/2026-04/msg.png', ttl: 3600 },
+      { key: 'inst-1/2026-04/msg.png', ttl: undefined },
+    ]);
+  });
+
+  it('tenant-context presign of an own-prefix object clamps TTL to the 60s ceiling', async () => {
+    const { backend, presigns } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    await service.presignedUrl(tenantKey(TENANT_A), 3600, TENANT_A); // over ceiling → clamped
+    await service.presignedUrl(tenantKey(TENANT_A), undefined, TENANT_A); // default → ceiling
+    await service.presignedUrl(tenantKey(TENANT_A), 30, TENANT_A); // under ceiling → kept
+    expect(presigns.map((p) => p.ttl)).toEqual([
+      PRESIGNED_URL_TTL_CEILING_SECONDS,
+      PRESIGNED_URL_TTL_CEILING_SECONDS,
+      30,
+    ]);
+  });
+
+  it("two-tenant probe: tenant B cannot presign tenant A's object", async () => {
+    const { backend, presigns } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    await expect(service.presignedUrl(tenantKey(TENANT_A), 30, TENANT_B)).rejects.toThrow(
+      /outside the requesting tenant prefix/,
+    );
+    expect(presigns).toHaveLength(0); // refused before the backend was consulted
+  });
+
+  it('tenant-context presign refuses a legacy-keyed (unprefixed) reference', async () => {
+    const { backend, presigns } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    await expect(service.presignedUrl(`${INSTANCE_ID}/2026-04/${MESSAGE_ID}.png`, 30, TENANT_A)).rejects.toThrow(
+      /outside the requesting tenant prefix/,
+    );
+    expect(presigns).toHaveLength(0);
+  });
+
+  it('refuses a malformed trusted tenant before touching the backend', async () => {
+    const { backend, presigns } = capturingBackend();
+    const service = new MediaStorageService(fakeDb, undefined, backend);
+    await expect(service.presignedUrl(tenantKey(TENANT_A), 30, 'not-a-uuid')).rejects.toThrow(/non-UUID tenantId/);
+    // A prefix-shaped forgery must not smuggle a traversal into the prefix check.
+    await expect(service.presignedUrl('tenants/../secrets/x.png', 30, '..')).rejects.toThrow(/non-UUID tenantId/);
+    expect(presigns).toHaveLength(0);
   });
 });
 

--- a/packages/api/src/services/__tests__/presign-revocation-ceiling.test.ts
+++ b/packages/api/src/services/__tests__/presign-revocation-ceiling.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Presigned-URL revocation ceilings, proven with a SYNTHETIC epoch/clock
+ * (wish: omni-full-multitenancy, Group G5, deliverable (c); ADR-0008, ADR-0006;
+ * RELEASE_SLOS `revocation`).
+ *
+ * Two normative numbers from `RELEASE_SLOS.yaml`, and nothing about production
+ * timing is claimed — both are driven from injected state:
+ *
+ *   * `presigned_url_ttl_seconds_max: 60` — a tenant-bound URL's lifetime is
+ *     clamped, so it self-expires inside the revocation-propagation window even
+ *     if nothing revokes it explicitly. Already enforced when the tenant prefix
+ *     binding landed; pinned here as the other half of the pair.
+ *   * `presigned_url_issue_or_refresh_after_revocation_max: 0` — once the tenant
+ *     is revoked, a presign must be REFUSED. A clamped TTL alone does not
+ *     satisfy this: without a gate, a revoked tenant could keep minting fresh
+ *     60-second URLs indefinitely, and every one of them would be "within the
+ *     ceiling" while the ceiling as written is ZERO issuances.
+ *
+ * The gate is the same trusted, non-caller-controlled read the other
+ * revocation-sensitive executors use (`periodic-tenant-work.ts`
+ * `isTenantWorkAdmissible` — the tenant's own `status` on the auth plane). It is
+ * injected here as a synthetic admissibility function so the epoch transition is
+ * a step in the test, not a wall-clock wait.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { MediaStorageBackend } from '@omni/channel-sdk';
+import type { Database } from '@omni/db';
+import { MediaStorageService, PRESIGNED_URL_TTL_CEILING_SECONDS } from '../media-storage';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111ce1a';
+const TENANT_B = '22222222-2222-4222-8222-22222222ce2b';
+
+/** Records the TTL each presign was actually issued with. */
+function makeBackend(): { backend: MediaStorageBackend; ttls: (number | undefined)[] } {
+  const ttls: (number | undefined)[] = [];
+  const backend = {
+    mode: 'remote',
+    write: async () => '',
+    read: async () => Buffer.alloc(0),
+    delete: async () => {},
+    exists: async () => true,
+    presignedUrl: async (reference: string, ttlSeconds?: number) => {
+      ttls.push(ttlSeconds);
+      return `https://example.invalid/${reference}?ttl=${ttlSeconds ?? 'default'}`;
+    },
+  } as unknown as MediaStorageBackend;
+  return { backend, ttls };
+}
+
+function makeService(backend: MediaStorageBackend): MediaStorageService {
+  return new MediaStorageService({} as unknown as Database, '/tmp/omni-presign-probe', backend);
+}
+
+const keyFor = (tenantId: string) => `tenants/${tenantId}/instances/inst-1/2026-07/msg-1.jpg`;
+
+describe('presigned URL TTL ceiling (RELEASE_SLOS presigned_url_ttl_seconds_max)', () => {
+  test('a tenant-bound presign is clamped to the ceiling even when asked for longer', async () => {
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+    // An admissible tenant — this block is about the TTL, not the gate.
+    service.setTenantAdmissibilityCheck(async () => true);
+
+    await service.presignedUrl(keyFor(TENANT_A), 3600, TENANT_A);
+    expect(ttls.at(-1)).toBe(PRESIGNED_URL_TTL_CEILING_SECONDS);
+    expect(PRESIGNED_URL_TTL_CEILING_SECONDS).toBeLessThanOrEqual(60);
+
+    // A shorter request is honoured — the ceiling is a maximum, not a default
+    // that overrides a caller asking for less exposure.
+    await service.presignedUrl(keyFor(TENANT_A), 5, TENANT_A);
+    expect(ttls.at(-1)).toBe(5);
+  });
+
+  test('a legacy (no-tenant) presign is byte-identical: no clamp, no gate', async () => {
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+
+    await service.presignedUrl('inst-1/2026-07/msg-1.jpg', 3600);
+    expect(ttls.at(-1)).toBe(3600);
+  });
+});
+
+describe('presign after revocation (RELEASE_SLOS presigned_url_issue_or_refresh_after_revocation_max: 0)', () => {
+  test('a revoked tenant cannot issue a NEW presign, and cannot refresh an old one', async () => {
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+
+    // Synthetic epoch: the tenant is admissible until the test revokes it. No
+    // wall clock, no production timing claim.
+    let revoked = false;
+    service.setTenantAdmissibilityCheck(async (tenantId) => tenantId === TENANT_A && !revoked);
+
+    // Before revocation: issuance works.
+    await service.presignedUrl(keyFor(TENANT_A), 30, TENANT_A);
+    expect(ttls.length).toBe(1);
+
+    // The epoch advances — the tenant is suspended/archived.
+    revoked = true;
+
+    // Issue AND refresh are both refused, and neither reaches the backend, so
+    // the count of post-revocation issuances is exactly zero.
+    await expect(service.presignedUrl(keyFor(TENANT_A), 30, TENANT_A)).rejects.toThrow(/revoked|not admissible/i);
+    await expect(service.presignedUrl(keyFor(TENANT_A), 5, TENANT_A)).rejects.toThrow(/revoked|not admissible/i);
+    expect(ttls.length).toBe(1);
+  });
+
+  test('a tenant that was never admissible is refused from the first call', async () => {
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+    service.setTenantAdmissibilityCheck(async () => false);
+
+    await expect(service.presignedUrl(keyFor(TENANT_B), 30, TENANT_B)).rejects.toThrow(/revoked|not admissible/i);
+    expect(ttls.length).toBe(0);
+  });
+
+  test('the prefix binding is checked too — a revoked tenant cannot reach another tenant’s object', async () => {
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+    service.setTenantAdmissibilityCheck(async () => true);
+
+    await expect(service.presignedUrl(keyFor(TENANT_B), 30, TENANT_A)).rejects.toThrow(
+      /outside the requesting tenant/i,
+    );
+    expect(ttls.length).toBe(0);
+  });
+
+  test('with NO check wired, a tenant presign FAILS CLOSED rather than minting unguarded URLs', async () => {
+    // The multitenancy world always wires the check (services/index.ts). Its
+    // absence under a tenant-context presign is a misconfiguration, and the same
+    // fail-closed stance `batch-jobs.ts` takes for a tenant job with no auth
+    // plane applies here: refuse, do not mint.
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+
+    await expect(service.presignedUrl(keyFor(TENANT_A), 30, TENANT_A)).rejects.toThrow(/revocation check/i);
+    expect(ttls.length).toBe(0);
+  });
+
+  test('the legacy path never consults the check and never fails closed', async () => {
+    // Flag-off has no tenants to revoke, so the pre-G5 presign must keep working
+    // with no admissibility wiring at all.
+    const { backend, ttls } = makeBackend();
+    const service = makeService(backend);
+
+    await service.presignedUrl('inst-1/2026-07/msg-1.jpg');
+    expect(ttls.length).toBe(1);
+  });
+});

--- a/packages/api/src/services/__tests__/sealed-credential-surfaces.test.ts
+++ b/packages/api/src/services/__tests__/sealed-credential-surfaces.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Deliverable (g) — the remaining credential surfaces sealed at rest
+ * (G5; ADR-0008; WISH "Async and storage enforcement").
+ *
+ * Run9 sealed `agent_sessions.provider_session_data`. The credential material
+ * that survived that leg lives in three more places, and this file is their
+ * contract:
+ *
+ *   * `instances.*` channel tokens — the Discord/Slack/Telegram/Gupshup/Twilio
+ *     bot tokens and signing secrets. The tenant is the instance row's OWN
+ *     persisted `tenant_id` (the G2 ownership root), so the binding needs no
+ *     resolver seam at all.
+ *   * `agent_providers.api_key` + the OpenClaw Ed25519 device key material in
+ *     `schema_config` (`devicePrivateKey`, `deviceToken`). `agent_providers` is
+ *     a G0-`split` table with no `tenant_id` yet, so the binding is the ACTIVE
+ *     tenant scope — a provider configured inside tenant A's context is sealed
+ *     for A and fails closed everywhere else.
+ *   * `global_settings.value` where `is_secret` — same split-table situation,
+ *     same active-scope binding. Sealing here also stops the plaintext from
+ *     being copied into `setting_change_history`, which ADR-0008 names
+ *     explicitly ("plaintext never appears in ... migration receipts").
+ *
+ * Every case below is asserted in BOTH worlds. The flag-off/key-absent
+ * assertions are the important half: they are what proves the deliverable is
+ * inert, and they would fail loudly if a future edit made sealing
+ * unconditional.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { setTenantSecretMasterKey } from '@omni/core';
+import type { Database } from '@omni/db';
+import { settingChangeHistory } from '@omni/db';
+import { isSealedCredentialField } from '../../tenancy/sealed-credentials';
+import { runInTenantScope } from '../../tenancy/tenant-scope';
+import { buildWorkerTenantContext } from '../../tenancy/worker-tenant-context';
+import { InstanceService } from '../instances';
+import { ProviderService } from '../providers';
+import { SettingsService } from '../settings';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const MASTER_KEY = Buffer.alloc(32, 5);
+
+afterEach(() => setTenantSecretMasterKey(null));
+
+/**
+ * Run `fn` inside a real tenant scope for `tenantId`.
+ *
+ * `runInTenantScope` opens `withTenantTransaction`, so the fake db must model
+ * `transaction()` — it hands back the same handle, which is what a Drizzle
+ * transaction looks like from the query builder's side. Real transactional
+ * isolation is proven against PostgreSQL in the two-tenant PG suites; what this
+ * harness needs is only that `scopedHandle()` resolves and that the scope's
+ * tenant is observable by the service.
+ */
+function inTenantScope<T>(db: Database, tenantId: string, fn: () => Promise<T>): Promise<T> {
+  return runInTenantScope(db, buildWorkerTenantContext(tenantId), fn);
+}
+
+// ---------------------------------------------------------------------------
+// instances.* channel tokens
+// ---------------------------------------------------------------------------
+
+/** One-row stand-in for `instances`; stores whatever the service writes. */
+function makeInstancesDb() {
+  const rows: Array<Record<string, unknown>> = [];
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    insert: () => ({
+      values: (v: Record<string, unknown>) => ({
+        returning: async () => {
+          const row = { id: 'inst-1', channel: 'discord', ...v };
+          rows.push(row);
+          return [row];
+        },
+      }),
+    }),
+    update: () => ({
+      set: (v: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            const row = rows[0];
+            if (!row) return [];
+            Object.assign(row, v);
+            return [row];
+          },
+        }),
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (rows[0] ? [rows[0]] : []),
+        }),
+      }),
+    }),
+  };
+  return { db: db as unknown as Database, rows };
+}
+
+describe('(g) instances.* channel tokens', () => {
+  test('flag-off (no scope, no key): the token is stored as plaintext, byte-identical', async () => {
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    await svc.create({ name: 'i', channel: 'discord', discordBotToken: 'MTIz.bot.token' } as never);
+    expect(rows[0]?.discordBotToken).toBe('MTIz.bot.token');
+  });
+
+  test('KEY PRESENT but NO tenant scope (the legacy/worker/CLI write): still plaintext', async () => {
+    // The risk-carrying half of the dual world. With no key, "no tenant" and "no
+    // key" are indistinguishable — both collapse to the identity function — so a
+    // no-key probe cannot attribute the inertness to the tenant guard at all.
+    // Only this combination can, and a future edit that gave the write path a
+    // fallback tenant would seal under a tenant no reader ever presents.
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    const created = await svc.create({ name: 'i', channel: 'discord', discordBotToken: 'MTIz.bot.token' } as never);
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(false);
+    expect(rows[0]?.discordBotToken).toBe('MTIz.bot.token');
+    expect(created.discordBotToken).toBe('MTIz.bot.token');
+  });
+
+  test('tenant scope but NO master key: still plaintext (the deliverable is inert)', async () => {
+    setTenantSecretMasterKey(null);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'i', channel: 'discord', discordBotToken: 'MTIz.bot.token', tenantId: TENANT_A } as never),
+    );
+    expect(rows[0]?.discordBotToken).toBe('MTIz.bot.token');
+  });
+
+  test('tenant scope + key: sealed at rest, and the owner reads the plaintext back', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+
+    const created = await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'i', channel: 'discord', discordBotToken: 'MTIz.bot.token', tenantId: TENANT_A } as never),
+    );
+
+    // At rest: no plaintext anywhere in the row.
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(true);
+    expect(JSON.stringify(rows[0])).not.toContain('MTIz.bot.token');
+    // Returned to the caller: plaintext, so route/plugin callers are unchanged.
+    expect(created.discordBotToken).toBe('MTIz.bot.token');
+
+    const read = await inTenantScope(db, TENANT_A, () => svc.getById('inst-1'));
+    expect(read.discordBotToken).toBe('MTIz.bot.token');
+  });
+
+  test('every declared channel-credential column is sealed, not just the first', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({
+        name: 'i',
+        channel: 'slack',
+        tenantId: TENANT_A,
+        slackBotToken: 'xoxb-A',
+        slackAppToken: 'xapp-A',
+        slackSigningSecret: 'sign-A',
+        telegramBotToken: 'tg-A',
+        gupshupAuthToken: 'gup-A',
+        webhookVerifyToken: 'hook-A',
+        twilioAuthToken: 'tw-A',
+      } as never),
+    );
+    const at = JSON.stringify(rows[0]);
+    for (const secret of ['xoxb-A', 'xapp-A', 'sign-A', 'tg-A', 'gup-A', 'hook-A', 'tw-A']) {
+      expect(at).not.toContain(secret);
+    }
+  });
+
+  test('a NON-credential column is never reshaped (profileName stays plaintext)', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'i', channel: 'discord', tenantId: TENANT_A, profileName: 'Support Bot' } as never),
+    );
+    expect(rows[0]?.profileName).toBe('Support Bot');
+  });
+
+  test('tenant B cannot read tenant A’s sealed token — it fails closed to null', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'i', channel: 'discord', discordBotToken: 'MTIz.bot.token', tenantId: TENANT_A } as never),
+    );
+
+    // The row is served back under B's scope; only the seal stands between them.
+    const row = rows[0];
+    if (row) row.tenantId = TENANT_B;
+    const read = await inTenantScope(db, TENANT_B, () => svc.getById('inst-1'));
+    expect(read.discordBotToken).toBeNull();
+  });
+
+  test('update seals a rotated token and returns the new plaintext', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'i', channel: 'discord', discordBotToken: 'old-token', tenantId: TENANT_A } as never),
+    );
+    const updated = await inTenantScope(db, TENANT_A, () => svc.update('inst-1', { discordBotToken: 'new-token' }));
+
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(true);
+    expect(JSON.stringify(rows[0])).not.toContain('new-token');
+    expect(updated.discordBotToken).toBe('new-token');
+  });
+
+  test('a legacy plaintext row still reads through while sealing is on (transitional)', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    rows.push({ id: 'inst-1', channel: 'discord', tenantId: TENANT_A, discordBotToken: 'legacy-plain' });
+    const svc = new InstanceService(db, null);
+    const read = await inTenantScope(db, TENANT_A, () => svc.getById('inst-1'));
+    expect(read.discordBotToken).toBe('legacy-plain');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agent_providers.api_key + OpenClaw Ed25519 material in schema_config
+// ---------------------------------------------------------------------------
+
+function makeProvidersDb() {
+  const rows: Array<Record<string, unknown>> = [];
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    insert: () => ({
+      values: (v: Record<string, unknown>) => ({
+        returning: async () => {
+          const row = { id: 'prov-1', ...v };
+          rows.push(row);
+          return [row];
+        },
+      }),
+    }),
+    update: () => ({
+      set: (v: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            const row = rows[0];
+            if (!row) return [];
+            Object.assign(row, v);
+            return [row];
+          },
+        }),
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => (rows[0] ? [rows[0]] : []) }),
+        $dynamic: () => ({
+          where: () => ({ orderBy: async () => rows }),
+          orderBy: async () => rows,
+        }),
+      }),
+      $dynamic: () => ({
+        from: () => ({ orderBy: async () => rows }),
+      }),
+    }),
+  };
+  return { db: db as unknown as Database, rows };
+}
+
+describe('(g) agent_providers.api_key + OpenClaw device key', () => {
+  test('flag-off: api_key and device key stay plaintext', async () => {
+    const { db, rows } = makeProvidersDb();
+    const svc = new ProviderService(db);
+    await svc.create({
+      name: 'p',
+      baseUrl: 'ws://x',
+      apiKey: 'sk-provider',
+      schemaConfig: { devicePrivateKey: 'ed25519-priv', deviceToken: 'dev-tok', origin: 'https://x' },
+    } as never);
+    expect(rows[0]?.apiKey).toBe('sk-provider');
+    expect((rows[0]?.schemaConfig as Record<string, unknown>).devicePrivateKey).toBe('ed25519-priv');
+  });
+
+  test('KEY PRESENT but NO tenant scope: api_key and device key stay plaintext', async () => {
+    // Same reasoning as the instances case above: this is the combination that
+    // distinguishes `sealProviderSecrets`'s own `if (!tenantId) return data`
+    // guard from the codec's key check, and it is the one a "default tenant for
+    // legacy writes" regression would break.
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeProvidersDb();
+    const svc = new ProviderService(db);
+    const created = await svc.create({
+      name: 'p',
+      baseUrl: 'ws://x',
+      apiKey: 'sk-provider',
+      schemaConfig: { devicePrivateKey: 'ed25519-priv', deviceToken: 'dev-tok', origin: 'https://x' },
+    } as never);
+    expect(rows[0]?.apiKey).toBe('sk-provider');
+    expect((rows[0]?.schemaConfig as Record<string, unknown>).devicePrivateKey).toBe('ed25519-priv');
+    expect((rows[0]?.schemaConfig as Record<string, unknown>).deviceToken).toBe('dev-tok');
+    expect(created.apiKey).toBe('sk-provider');
+  });
+
+  test('tenant scope + key: api_key, devicePrivateKey and deviceToken are all sealed', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeProvidersDb();
+    const svc = new ProviderService(db);
+
+    const created = await inTenantScope(db, TENANT_A, () =>
+      svc.create({
+        name: 'p',
+        baseUrl: 'ws://x',
+        apiKey: 'sk-provider',
+        schemaConfig: {
+          devicePrivateKey: 'ed25519-priv',
+          deviceToken: 'dev-tok',
+          devicePublicKey: 'ed25519-pub',
+          origin: 'https://x',
+        },
+      } as never),
+    );
+
+    const at = JSON.stringify(rows[0]);
+    expect(at).not.toContain('sk-provider');
+    expect(at).not.toContain('ed25519-priv');
+    expect(at).not.toContain('dev-tok');
+    // The PUBLIC key and non-secret config are untouched — sealing is scoped to
+    // key material, not to the whole blob.
+    expect((rows[0]?.schemaConfig as Record<string, unknown>).devicePublicKey).toBe('ed25519-pub');
+    expect((rows[0]?.schemaConfig as Record<string, unknown>).origin).toBe('https://x');
+
+    expect(created.apiKey).toBe('sk-provider');
+    expect((created.schemaConfig as Record<string, unknown>).devicePrivateKey).toBe('ed25519-priv');
+  });
+
+  test('the owning tenant reads the provider secrets back; another tenant gets null', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db } = makeProvidersDb();
+    const svc = new ProviderService(db);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({
+        name: 'p',
+        baseUrl: 'ws://x',
+        apiKey: 'sk-provider',
+        schemaConfig: { devicePrivateKey: 'ed25519-priv' },
+      } as never),
+    );
+
+    const asA = await inTenantScope(db, TENANT_A, () => svc.getById('prov-1'));
+    expect(asA.apiKey).toBe('sk-provider');
+
+    const asB = await inTenantScope(db, TENANT_B, () => svc.getById('prov-1'));
+    expect(asB.apiKey).toBeNull();
+    expect((asB.schemaConfig as Record<string, unknown>).devicePrivateKey).toBeNull();
+  });
+
+  test('list() opens the secrets too — a read path missed here would fail closed silently', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db } = makeProvidersDb();
+    const svc = new ProviderService(db);
+    await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'p', baseUrl: 'ws://x', apiKey: 'sk-provider' } as never),
+    );
+    const listed = await inTenantScope(db, TENANT_A, () => svc.list());
+    expect(listed[0]?.apiKey).toBe('sk-provider');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// global_settings.value where is_secret
+// ---------------------------------------------------------------------------
+
+function makeSettingsDb() {
+  const rows: Array<Record<string, unknown>> = [];
+  const history: Array<Record<string, unknown>> = [];
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    insert: (table: unknown) => ({
+      values: (v: Record<string, unknown>) => {
+        const isHistory = table === settingChangeHistory;
+        const promise = (async () => {
+          if (isHistory) history.push(v);
+        })();
+        return Object.assign(promise, {
+          returning: async () => {
+            const row = { id: 'set-1', isSecret: true, ...v };
+            rows.push(row);
+            return [row];
+          },
+        });
+      },
+    }),
+    update: () => ({
+      set: (v: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            const row = rows[0];
+            if (!row) return [];
+            Object.assign(row, v);
+            return [row];
+          },
+        }),
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => (rows[0] ? [rows[0]] : []) }),
+        $dynamic: () => ({ where: () => ({ orderBy: async () => rows }), orderBy: async () => rows }),
+      }),
+      $dynamic: () => ({ from: () => ({ orderBy: async () => rows }) }),
+    }),
+  };
+  return { db: db as unknown as Database, rows, history };
+}
+
+describe('(g) global_settings secret values', () => {
+  test('flag-off: a secret setting is stored as plaintext, byte-identical', async () => {
+    const { db, rows } = makeSettingsDb();
+    const svc = new SettingsService(db);
+    await svc.setValue('elevenlabs.api_key', 'el-secret');
+    expect(rows[0]?.value).toBe('el-secret');
+  });
+
+  test('KEY PRESENT but NO tenant scope: a secret setting stays plaintext and reads back', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeSettingsDb();
+    const svc = new SettingsService(db);
+    await svc.setValue('elevenlabs.api_key', 'el-secret');
+    expect(isSealedCredentialField(rows[0]?.value)).toBe(false);
+    expect(rows[0]?.value).toBe('el-secret');
+    // And the scope-less reader still gets it — the surface is inert, not broken.
+    expect(await svc.getSecret('elevenlabs.api_key')).toBe('el-secret');
+  });
+
+  test('tenant scope + key: an is_secret value is sealed at rest and opens for its tenant', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeSettingsDb();
+    const svc = new SettingsService(db);
+
+    await inTenantScope(db, TENANT_A, () => svc.setValue('elevenlabs.api_key', 'el-secret'));
+    expect(isSealedCredentialField(rows[0]?.value)).toBe(true);
+    expect(String(rows[0]?.value)).not.toContain('el-secret');
+
+    const got = await inTenantScope(db, TENANT_A, () => svc.getSecret('elevenlabs.api_key'));
+    expect(got).toBe('el-secret');
+  });
+
+  test('the change-history receipt records the SEALED value, never the plaintext', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, history } = makeSettingsDb();
+    const svc = new SettingsService(db);
+    await inTenantScope(db, TENANT_A, () => svc.setValue('elevenlabs.api_key', 'first-secret'));
+    await inTenantScope(db, TENANT_A, () => svc.setValue('elevenlabs.api_key', 'second-secret'));
+
+    expect(history.length).toBe(1);
+    expect(JSON.stringify(history)).not.toContain('first-secret');
+    expect(JSON.stringify(history)).not.toContain('second-secret');
+  });
+
+  test('a NON-secret setting is never sealed', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeSettingsDb();
+    rows.push({ id: 'set-1', key: 'tts.provider', value: 'elevenlabs', valueType: 'string', isSecret: false });
+    const svc = new SettingsService(db);
+    await inTenantScope(db, TENANT_A, () => svc.setValue('tts.provider', 'openai'));
+    expect(rows[0]?.value).toBe('openai');
+  });
+
+  test('another tenant reading the sealed setting gets null, not the envelope', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db } = makeSettingsDb();
+    const svc = new SettingsService(db);
+    await inTenantScope(db, TENANT_A, () => svc.setValue('elevenlabs.api_key', 'el-secret'));
+    const got = await inTenantScope(db, TENANT_B, () => svc.getSecret('elevenlabs.api_key'));
+    expect(got).toBeUndefined();
+  });
+});

--- a/packages/api/src/services/__tests__/sealed-credential-tenant-symmetry.test.ts
+++ b/packages/api/src/services/__tests__/sealed-credential-tenant-symmetry.test.ts
@@ -1,0 +1,210 @@
+/**
+ * WRITE/READ TENANT SYMMETRY on the sealed `instances.*` surface
+ * (G5 deliverable (g); ADR-0008).
+ *
+ * `sealed-credential-surfaces.test.ts` proves the four surfaces seal and open.
+ * It cannot prove the property that actually decides whether a credential
+ * survives a round trip, because every one of its instance probes smuggles
+ * `tenantId: TENANT_A` into `create()` through an `as never` cast — a shape
+ * production cannot produce (`NewInstance` is `Omit<..., 'tenantId'>`, the v2
+ * route passes the validated body, and `instances` is the ownership ROOT so no
+ * derivation trigger and no column default stamps it either).
+ *
+ * The property is: THE TENANT A WRITE SEALS UNDER MUST BE THE TENANT THE
+ * PERSISTED ROW WILL PRESENT ON READ. `openInstanceCredentials` opens with
+ * `row.tenantId`; if a write sealed under the ACTIVE SCOPE while the row lands
+ * with `tenant_id` NULL, `openCredentialField(null, sealed)` fails closed to
+ * `null` and the credential is irrecoverable through every service read path —
+ * a silent, permanent loss on the very first rotation.
+ *
+ * Both halves are probed here:
+ *   1. the additive phase (row `tenant_id` NULL — every row production writes
+ *      today): the write must NOT seal, so create/rotate round-trip byte for
+ *      byte, exactly as they did pre-G5;
+ *   2. the owned phase (row carries its tenant): the write seals under THAT
+ *      tenant, and only that tenant opens it.
+ *
+ * Plus the read-side derivation itself, which no test in the leg pinned: every
+ * existing read probe runs with the active scope EQUAL to the row's owner, so
+ * `row.tenantId` and `currentTenantScope()` are indistinguishable there. The
+ * out-of-scope read below is the one shape that tells them apart.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { setTenantSecretMasterKey } from '@omni/core';
+import type { Database } from '@omni/db';
+import { isSealedCredentialField, sealCredentialField } from '../../tenancy/sealed-credentials';
+import { runInTenantScope } from '../../tenancy/tenant-scope';
+import { buildWorkerTenantContext } from '../../tenancy/worker-tenant-context';
+import { InstanceService } from '../instances';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const MASTER_KEY = Buffer.alloc(32, 5);
+
+afterEach(() => setTenantSecretMasterKey(null));
+
+/** One-row stand-in for `instances`; stores whatever the service writes. */
+function makeInstancesDb(seed?: Record<string, unknown>) {
+  const rows: Array<Record<string, unknown>> = seed ? [seed] : [];
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    insert: () => ({
+      values: (v: Record<string, unknown>) => ({
+        returning: async () => {
+          const row = { id: 'inst-1', channel: 'discord', ...v };
+          rows.push(row);
+          return [row];
+        },
+      }),
+    }),
+    update: () => ({
+      set: (v: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            const row = rows[0];
+            if (!row) return [];
+            Object.assign(row, v);
+            return [row];
+          },
+        }),
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        // `where(...)` is awaited directly by `listActive()` and `.limit()`-ed by
+        // the by-id reads, so it must be both a promise and a builder.
+        where: () =>
+          Object.assign(Promise.resolve([...rows]), {
+            limit: async () => (rows[0] ? [rows[0]] : []),
+          }),
+      }),
+    }),
+  };
+  return { db: db as unknown as Database, rows };
+}
+
+function inTenantScope<T>(db: Database, tenantId: string, fn: () => Promise<T>): Promise<T> {
+  return runInTenantScope(db, buildWorkerTenantContext(tenantId), fn);
+}
+
+describe('(g) instances.* — the write seals under the tenant the ROW will present', () => {
+  test('a production-shaped create (no tenantId) under a scope does NOT seal — it stays readable', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb();
+    const svc = new InstanceService(db, null);
+
+    // Exactly what `routes/v2/instances.ts` produces: the validated body. There
+    // is no `tenantId` here and there cannot be one — `NewInstance` omits it.
+    const created = await inTenantScope(db, TENANT_A, () =>
+      svc.create({ name: 'i', channel: 'discord', discordBotToken: 'MTIz.bot.token' } as never),
+    );
+
+    // The row lands with tenant_id NULL (no trigger, no default on the root),
+    // so a seal here would be unopenable by every later read.
+    expect(rows[0]?.tenantId ?? null).toBeNull();
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(false);
+    expect(rows[0]?.discordBotToken).toBe('MTIz.bot.token');
+    expect(created.discordBotToken).toBe('MTIz.bot.token');
+
+    const read = await inTenantScope(db, TENANT_A, () => svc.getById('inst-1'));
+    expect(read.discordBotToken).toBe('MTIz.bot.token');
+  });
+
+  test('rotating a token on an additive-phase row (tenant_id NULL) keeps the credential recoverable', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb({
+      id: 'inst-1',
+      channel: 'discord',
+      tenantId: null,
+      discordBotToken: 'MTIz.working.token',
+    });
+    const svc = new InstanceService(db, null);
+
+    const updated = await inTenantScope(db, TENANT_A, () =>
+      svc.update('inst-1', { discordBotToken: 'MTIz.rotated.token' }),
+    );
+
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(false);
+    expect(rows[0]?.discordBotToken).toBe('MTIz.rotated.token');
+    expect(updated.discordBotToken).toBe('MTIz.rotated.token');
+
+    const read = await inTenantScope(db, TENANT_A, () => svc.getById('inst-1'));
+    expect(read.discordBotToken).toBe('MTIz.rotated.token');
+  });
+
+  test('a rotation from a scope that does NOT own the row never seals under the writer', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb({
+      id: 'inst-1',
+      channel: 'discord',
+      tenantId: TENANT_A,
+      discordBotToken: 'MTIz.working.token',
+    });
+    const svc = new InstanceService(db, null);
+
+    // Under enforcement RLS refuses this write outright; the fake db has no RLS,
+    // which is precisely why the SERVICE must not seal under B either.
+    await inTenantScope(db, TENANT_B, () => svc.update('inst-1', { discordBotToken: 'MTIz.rotated.token' }));
+
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(false);
+    // The owner can still read it — nothing was sealed under a key it lacks.
+    const read = await inTenantScope(db, TENANT_A, () => svc.getById('inst-1'));
+    expect(read.discordBotToken).toBe('MTIz.rotated.token');
+  });
+
+  test('when the row DOES carry its tenant, the write seals under exactly that tenant', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db, rows } = makeInstancesDb({
+      id: 'inst-1',
+      channel: 'discord',
+      tenantId: TENANT_A,
+      discordBotToken: 'MTIz.working.token',
+    });
+    const svc = new InstanceService(db, null);
+
+    const updated = await inTenantScope(db, TENANT_A, () =>
+      svc.update('inst-1', { discordBotToken: 'MTIz.rotated.token' }),
+    );
+
+    expect(isSealedCredentialField(rows[0]?.discordBotToken)).toBe(true);
+    expect(JSON.stringify(rows[0])).not.toContain('MTIz.rotated.token');
+    expect(updated.discordBotToken).toBe('MTIz.rotated.token');
+
+    const asOwner = await inTenantScope(db, TENANT_A, () => svc.getById('inst-1'));
+    expect(asOwner.discordBotToken).toBe('MTIz.rotated.token');
+  });
+});
+
+describe('(g) instances.* — the READ tenant is the row, not the scope', () => {
+  test('a sealed row opens with NO active scope at all (the row carries the tenant)', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const { db } = makeInstancesDb({
+      id: 'inst-1',
+      channel: 'discord',
+      tenantId: TENANT_A,
+      // Sealed for A by construction — this probe is about the READ derivation,
+      // so it does not depend on any write path.
+      discordBotToken: sealCredentialField(TENANT_A, 'MTIz.bot.token'),
+    });
+    const svc = new InstanceService(db, null);
+
+    // No `runInTenantScope`: the legacy/worker/CLI read shape (media-processor's
+    // `runMediaDb(ctx, undefined, ...)`, session-cleaner, automation-actions).
+    // Deriving the tenant from `currentTenantScope()` here would yield null and
+    // fail closed on a row this caller is entitled to read.
+    const read = await svc.getById('inst-1');
+    expect(read.discordBotToken).toBe('MTIz.bot.token');
+
+    const listed = await svc.listActive();
+    expect(listed[0]?.discordBotToken).toBe('MTIz.bot.token');
+  });
+
+  // NOTE, deliberately NOT probed here: reading tenant A's row while scoped to
+  // tenant B. At the service level the row-derived tenant does open it, but
+  // asserting that would codify cross-tenant plaintext disclosure as a contract.
+  // What actually stops B is that RLS never hands B the row (proven against real
+  // PostgreSQL in `sealed-credentials-two-tenant-postgres.test.ts`), and the
+  // relabelled-row case is already pinned in `sealed-credential-surfaces.test.ts`.
+});

--- a/packages/api/src/services/__tests__/sealed-credentials-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/sealed-credentials-two-tenant-postgres.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Deliverable (g) over REAL PostgreSQL + RLS — the credential surfaces run14
+ * sealed (wish: omni-full-multitenancy, Group G5; ADR-0008;
+ * OWNERSHIP_MANIFEST `filesystem_session_state`).
+ *
+ * The unit probes prove the CODEC and the service wiring against fakes. This
+ * suite proves the thing a fake cannot: that the seal survives a round trip
+ * through actual columns, under actual row-level security, with two tenants
+ * whose rows sit in the same tables — and that the two protections are
+ * INDEPENDENT rather than one dressed up as two.
+ *
+ * That independence is the point worth testing. RLS alone would already hide
+ * tenant A's instance from tenant B, so a cross-tenant read failing proves
+ * nothing about the sealing. So the adversary here is stronger than RLS: the
+ * final block reads the ciphertext out with a SUPERUSER connection — the
+ * database-level bypass an RLS-only design has no answer for — and then tries to
+ * open it as the other tenant. It still fails, because the tenant is both the
+ * HKDF salt for the DEK and the AEAD associated data.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you (it auto-discovers `*-postgres.test.ts` suites, so this file
+ * needs no gate edit). No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTenantSecretMasterKey } from '@omni/core';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+} from '@omni/db';
+import { isSealedCredentialField, openCredentialField } from '../../tenancy/sealed-credentials';
+import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
+import { InstanceService } from '../instances';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111da';
+const TENANT_B = '22222222-2222-4222-8222-2222222222db';
+const INSTANCE_A = '55555555-5555-4555-8555-5555555555da';
+const INSTANCE_B = '55555555-5555-4555-8555-5555555555db';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+/**
+ * Repo-local, synthetic, per-run key material. Never read from an environment
+ * variable, a file, or a secret store — live KMS/Vault custody is the named G5
+ * deferral, and this file must not be the thing that quietly introduces it.
+ */
+const MASTER_KEY = Buffer.from(crypto.getRandomValues(new Uint8Array(32)));
+
+/** The plaintext bot tokens. If either appears in a column, the leg has failed. */
+const TOKEN_A = 'discord-bot-token-for-tenant-A';
+const TOKEN_B = 'discord-bot-token-for-tenant-B';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stdout: string; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-sealed-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+postgresDescribe('two-tenant sealed credentials at rest (real PostgreSQL)', () => {
+  const dbName = `omni_g5_seal_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let superDbUrl: string;
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'seal-tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'seal-tenant-b', 'Tenant B', 86400, 100, 100);
+
+      -- Both instances exist BEFORE any sealing, with NULL credential columns:
+      -- the service updates them under each tenant's scope below, which is the
+      -- real write path (routes/v2/instances.ts calls exactly this).
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'seal-inst-a', 'discord', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'seal-inst-b', 'discord', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // maxConnections=2, for the same reason as the sibling suites: an ambient
+    // (un-scoped) access takes the second connection, where `app.tenant_id` is
+    // unset and `omni_current_tenant_id()` RAISES — a loud failure, not a leak.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 2);
+  }, 180_000);
+
+  afterAll(async () => {
+    setTenantSecretMasterKey(null);
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  afterEach(() => setTenantSecretMasterKey(null));
+
+  /** Read a credential column with the SUPERUSER connection — bypassing RLS. */
+  function readColumnAsSuperuser(instanceId: string, column: string): string {
+    const result = runSqlOn(
+      superDbUrl,
+      `SELECT coalesce("${column}", '<null>') FROM instances WHERE id = '${instanceId}';`,
+    );
+    if (result.exitCode !== 0) throw new Error(`superuser read failed: ${result.stderr}`);
+    return result.stdout.trim();
+  }
+
+  test('flag-off (no master key): the column holds the plaintext token, byte-identical', async () => {
+    setTenantSecretMasterKey(null);
+    const svc = new InstanceService(runtimeDb, null);
+
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () =>
+      svc.update(INSTANCE_A, { discordBotToken: 'plaintext-legacy-token' }),
+    );
+
+    expect(readColumnAsSuperuser(INSTANCE_A, 'discord_bot_token')).toBe('plaintext-legacy-token');
+
+    const read = await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.getById(INSTANCE_A));
+    expect(read.discordBotToken).toBe('plaintext-legacy-token');
+  });
+
+  test('with a key: the column holds NO plaintext, and the owner still reads its token', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const svc = new InstanceService(runtimeDb, null);
+
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.update(INSTANCE_A, { discordBotToken: TOKEN_A }));
+    await runInWorkerTenantScope(runtimeDb, TENANT_B, () => svc.update(INSTANCE_B, { discordBotToken: TOKEN_B }));
+
+    const atRestA = readColumnAsSuperuser(INSTANCE_A, 'discord_bot_token');
+    expect(atRestA).not.toContain(TOKEN_A);
+    expect(isSealedCredentialField(atRestA)).toBe(true);
+
+    const aReadsA = await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.getById(INSTANCE_A));
+    expect(aReadsA.discordBotToken).toBe(TOKEN_A);
+
+    const bReadsB = await runInWorkerTenantScope(runtimeDb, TENANT_B, () => svc.getById(INSTANCE_B));
+    expect(bReadsB.discordBotToken).toBe(TOKEN_B);
+  });
+
+  test('RLS hides the row: tenant B’s scope cannot even load tenant A’s instance', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const svc = new InstanceService(runtimeDb, null);
+
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.update(INSTANCE_A, { discordBotToken: TOKEN_A }));
+
+    // `getById` throws NotFoundError rather than returning a foreign row — the
+    // first of the two independent layers.
+    await expect(runInWorkerTenantScope(runtimeDb, TENANT_B, () => svc.getById(INSTANCE_A))).rejects.toThrow();
+  });
+
+  test('SEALING SURVIVES AN RLS BYPASS: the ciphertext lifted by a superuser is still unopenable as tenant B', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const svc = new InstanceService(runtimeDb, null);
+
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.update(INSTANCE_A, { discordBotToken: TOKEN_A }));
+
+    // The adversary an RLS-only design cannot answer: a database-level read that
+    // ignores every policy. It gets the bytes — and the bytes are useless.
+    const stolen = readColumnAsSuperuser(INSTANCE_A, 'discord_bot_token');
+    expect(isSealedCredentialField(stolen)).toBe(true);
+
+    expect(openCredentialField(TENANT_B, stolen)).toBeNull();
+    // Rewriting the stored tenant label does not help either: the label is not
+    // what the key or the AAD is derived from.
+    const forged = JSON.stringify({ ...JSON.parse(stolen), t: TENANT_B });
+    expect(openCredentialField(TENANT_B, forged)).toBeNull();
+
+    // ...and the rightful owner opens it, so this is a binding, not a brick.
+    expect(openCredentialField(TENANT_A, stolen)).toBe(TOKEN_A);
+  });
+
+  test('the seal is re-derived per tenant: two tenants sealing the SAME secret produce different bytes', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const svc = new InstanceService(runtimeDb, null);
+    const sameSecret = 'identical-token-in-both-tenants';
+
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.update(INSTANCE_A, { discordBotToken: sameSecret }));
+    await runInWorkerTenantScope(runtimeDb, TENANT_B, () => svc.update(INSTANCE_B, { discordBotToken: sameSecret }));
+
+    const atRestA = readColumnAsSuperuser(INSTANCE_A, 'discord_bot_token');
+    const atRestB = readColumnAsSuperuser(INSTANCE_B, 'discord_bot_token');
+    expect(atRestA).not.toBe(atRestB);
+    expect(openCredentialField(TENANT_A, atRestB)).toBeNull();
+    expect(openCredentialField(TENANT_B, atRestA)).toBeNull();
+  });
+
+  test('a row sealed for A degrades to null — never the envelope — when the key is withdrawn', async () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const svc = new InstanceService(runtimeDb, null);
+    await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.update(INSTANCE_A, { discordBotToken: TOKEN_A }));
+
+    setTenantSecretMasterKey(null);
+    const read = await runInWorkerTenantScope(runtimeDb, TENANT_A, () => svc.getById(INSTANCE_A));
+    expect(read.discordBotToken).toBeNull();
+  });
+});

--- a/packages/api/src/services/__tests__/sync-jobs-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/sync-jobs-two-tenant-postgres.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Two-tenant SYNC-JOB containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * `sync_jobs` is one of the job tables ADR-0008 names explicitly ("Jobs, retries,
+ * dead letters, idempotency keys, consumer state, and callbacks preserve tenant
+ * context"). Its registry site was `pending-G5-conversion` for the dual-caller
+ * reason: `SyncJobService` already read through `scopedHandle`, but its WORKER
+ * callers — the daily contacts/groups crons and the `sync.started` /
+ * `instance.connected` consumers — established no scope, so every worker-created
+ * job reached the ambient pool.
+ *
+ * The service now takes a THREADED trusted tenant rather than being wrapped by
+ * its callers, because every mutating method writes the row AND publishes a
+ * `sync.*` event: a scope held across that publish would make the event a
+ * pre-commit side effect. This suite drives the service exactly as those callers
+ * now do and pins:
+ *
+ *   * a threaded tenant lands the row under that tenant and nowhere else;
+ *   * a job created for ANOTHER tenant's instance is refused by the WITH CHECK
+ *     (`sync_jobs` derives its tenant from the REQUIRED `instance_id` parent);
+ *   * every read path (`getById`, `getActiveForInstance`, `hasActiveJob`) and
+ *     every mutation (`start`, `complete`, `fail`, `updateProgress`) is confined
+ *     to the threaded tenant;
+ *   * the published envelope carries the tenant the ROW was stamped with, so the
+ *     downstream `sync.started` consumer derives from persisted ownership.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { EventBus } from '@omni/core';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+} from '@omni/db';
+import { SyncJobService } from '../sync-jobs';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-11111111aa1a';
+const TENANT_B = '22222222-2222-4222-8222-22222222bb2b';
+const INSTANCE_A = '55555555-5555-4555-8555-55555555aa1a';
+const INSTANCE_B = '55555555-5555-4555-8555-55555555bb2b';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-syncjobs-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+/** Records what a publish was told, so the envelope tenant can be asserted. */
+interface CapturedPublish {
+  type: string;
+  metadata: Record<string, unknown> | undefined;
+}
+
+postgresDescribe('two-tenant sync-job containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_syncjobs_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let service: SyncJobService;
+  const published: CapturedPublish[] = [];
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'job-tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'job-tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'job-inst-a', 'whatsapp-baileys', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'job-inst-b', 'whatsapp-baileys', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // maxConnections=2 — see the sibling suites: a worker transaction holds one,
+    // so an unscoped ambient read takes the other and fails LOUDLY under RLS
+    // rather than deadlocking.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 2);
+
+    const eventBus = {
+      publish: async (type: string, _payload: unknown, metadata?: Record<string, unknown>) => {
+        published.push({ type, metadata });
+        return { eventId: 'e', subject: 's' };
+      },
+    } as unknown as EventBus;
+    service = new SyncJobService(runtimeDb, eventBus);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('a threaded tenant lands the job under that tenant, and stamps the published envelope', async () => {
+    published.length = 0;
+    const job = await service.create({
+      instanceId: INSTANCE_A,
+      channelType: 'whatsapp-baileys',
+      type: 'contacts',
+      tenantId: TENANT_A,
+    });
+
+    expect(job.tenantId).toBe(TENANT_A);
+
+    // The `sync.started` publish carries the tenant the ROW was stamped with, so
+    // the consumer derives its worker scope from persisted ownership rather than
+    // from whatever scope happened to be active at publish time.
+    const started = published.find((p) => p.type === 'sync.started');
+    expect(started?.metadata?.tenantId).toBe(TENANT_A);
+
+    // Visible to A...
+    expect((await service.getById(job.id, TENANT_A)).id).toBe(job.id);
+    // ...and entirely invisible to B, which cannot even learn it exists.
+    await expect(service.getById(job.id, TENANT_B)).rejects.toThrow(/not found/i);
+  });
+
+  test('a job for ANOTHER tenant’s instance is refused by RLS, not silently mis-stamped', async () => {
+    await expect(
+      service.create({
+        instanceId: INSTANCE_A,
+        channelType: 'whatsapp-baileys',
+        type: 'groups',
+        tenantId: TENANT_B,
+      }),
+    ).rejects.toThrow(/row-level security/i);
+  });
+
+  test('the read paths a worker uses are confined to the threaded tenant', async () => {
+    const aJob = await service.create({
+      instanceId: INSTANCE_A,
+      channelType: 'whatsapp-baileys',
+      type: 'history-push',
+      tenantId: TENANT_A,
+    });
+    await service.start(aJob.id, TENANT_A);
+
+    // This is the exact pair the history-push tracker calls.
+    const aActive = await service.getActiveForInstance(INSTANCE_A, TENANT_A);
+    expect(aActive.map((j) => j.id)).toContain(aJob.id);
+    expect(await service.hasActiveJob(INSTANCE_A, 'history-push', TENANT_A)).toBe(true);
+
+    // B asking about A's instance sees no jobs and reports no active job — so a
+    // B-scoped tracker never creates a duplicate against A's work, and never
+    // learns A has any.
+    expect(await service.getActiveForInstance(INSTANCE_A, TENANT_B)).toEqual([]);
+    expect(await service.hasActiveJob(INSTANCE_A, 'history-push', TENANT_B)).toBe(false);
+
+    // And B's own instance is unaffected by A's job.
+    expect(await service.hasActiveJob(INSTANCE_B, 'history-push', TENANT_B)).toBe(false);
+  });
+
+  test('mutations cannot reach across tenants', async () => {
+    const aJob = await service.create({
+      instanceId: INSTANCE_A,
+      channelType: 'whatsapp-baileys',
+      type: 'messages',
+      tenantId: TENANT_A,
+    });
+
+    // B cannot advance, finish, or fail A's job: the row is not in its scope, so
+    // each lands as "not found" rather than as a cross-tenant write.
+    await expect(service.start(aJob.id, TENANT_B)).rejects.toThrow(/not found/i);
+    await expect(service.complete(aJob.id, TENANT_B)).rejects.toThrow(/not found/i);
+    await expect(service.fail(aJob.id, 'forged', TENANT_B)).rejects.toThrow(/not found/i);
+    await expect(service.updateProgress(aJob.id, { fetched: 99 }, TENANT_B)).rejects.toThrow(/not found/i);
+
+    // A's own job is untouched and still advances normally.
+    expect((await service.getById(aJob.id, TENANT_A)).status).toBe('pending');
+    await service.updateProgress(aJob.id, { fetched: 7 }, TENANT_A);
+    const done = await service.complete(aJob.id, TENANT_A);
+    expect(done.status).toBe('completed');
+    expect((done.progress as { fetched: number }).fetched).toBe(7);
+  });
+});

--- a/packages/api/src/services/__tests__/turn-monitor-worker-scope.test.ts
+++ b/packages/api/src/services/__tests__/turn-monitor-worker-scope.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Turn-monitor worker-context boundary (G5; ADR-0008).
+ *
+ * The monitor is a 10-second INTERVAL: no request, no credential, no envelope.
+ * Every tick it read whole-table (`turns.getStale`) and then, per stale turn,
+ * called `instanceService.getById` for the live stalled-timeout config plus
+ * `incrementNudge` / `close`. All of it on the ambient pool — which is why it
+ * was the worker caller keeping BOTH `services/instances.ts::instances` and
+ * `services/turns.ts::turns` in `pending-G5-conversion`.
+ *
+ * This file is the enforcement the static guard cannot provide (run12's
+ * FIX-FIRST lesson: the guard sees the SERVICE, never the CALL SITE). It probes
+ * every helper the tick reaches under a live tenant:
+ *
+ *   1. LEGACY WORLD IS BYTE-IDENTICAL — with no `db`/`authPlaneDb` wired, or
+ *      with the flag off, the tick is the pre-G5 one: one ambient `getStale`, no
+ *      enumeration, no scope, no extra query.
+ *   2. ENUMERATED, NOT SCANNED — flag-on, the stale read runs once per ACTIVE
+ *      tenant inside that tenant's worker scope. Under RLS enforcement the
+ *      global scan is not expressible, so a cron must discover whose work exists.
+ *   3. EVERY DB HELPER IS SCOPED — `getById`, `incrementNudge` and `close` each
+ *      observe the turn's own tenant scope, not merely the first one.
+ *   4. NO CROSS-TENANT BLEED — a turn owned by tenant B is never processed in
+ *      tenant A's pass.
+ *   5. THE SCOPE DOES NOT SPAN THE PUBLISH — `publishTurnNudge` and friends emit
+ *      events; a worker transaction held across a publish would make the event a
+ *      pre-commit side effect (a phantom on rollback).
+ */
+
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
+import { currentTenantScope } from '../../tenancy/tenant-scope';
+import * as turnEvents from '../turn-events';
+import { TurnMonitor } from '../turn-monitor';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+const FLAG_ON: NodeJS.ProcessEnv = { [MULTITENANCY_FLAG_ENV]: 'true' };
+const FLAG_OFF: NodeJS.ProcessEnv = {};
+
+const IDLE_15_MIN = () => new Date(Date.now() - 15 * 60_000);
+const IDLE_40_MIN = () => new Date(Date.now() - 40 * 60_000);
+
+interface StubTurn {
+  id: string;
+  instanceId: string;
+  chatId: string;
+  lastActivityAt: Date;
+  nudgeCount: number;
+  tenantId: string | null;
+  startedAt?: Date;
+  closedAt?: Date | null;
+  messagesSent?: number;
+}
+
+/** Auth-plane fake: returns the active tenants, counting its reads. */
+function fakeAuthPlaneDb(ids: string[], counter: { selects: number }): Database {
+  return {
+    select: () => {
+      counter.selects += 1;
+      return { from: () => ({ where: async () => ids.map((id) => ({ id })) }) };
+    },
+  } as unknown as Database;
+}
+
+/** Worker-scope fake: `transaction` runs the callback, counting openings. */
+function fakeScopeDb(counter: { transactions: number }): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      counter.transactions += 1;
+      return cb({ execute: async () => [] as unknown });
+    },
+  } as unknown as Database;
+}
+
+function makeMonitor(opts: {
+  turns: StubTurn[];
+  tenants?: string[];
+  env?: NodeJS.ProcessEnv;
+  wireDb?: boolean;
+}) {
+  const observed: Array<{ helper: string; turnId?: string; scope: string | null }> = [];
+  const counters = { selects: 0, transactions: 0 };
+  let staleReads = 0;
+
+  const db = fakeScopeDb(counters);
+  const monitor = new TurnMonitor({
+    turnService: {
+      getStale: async () => {
+        staleReads += 1;
+        observed.push({ helper: 'getStale', scope: currentTenantScope()?.tenantId ?? null });
+        return opts.turns;
+      },
+      incrementNudge: async (id: string) => {
+        observed.push({ helper: 'incrementNudge', turnId: id, scope: currentTenantScope()?.tenantId ?? null });
+      },
+      close: async (id: string) => {
+        observed.push({ helper: 'close', turnId: id, scope: currentTenantScope()?.tenantId ?? null });
+        return { id, startedAt: new Date(Date.now() - 60_000), closedAt: new Date(), messagesSent: 1 };
+      },
+    } as unknown as never,
+    instanceService: {
+      getById: async (id: string) => {
+        observed.push({ helper: 'getById', turnId: id, scope: currentTenantScope()?.tenantId ?? null });
+        return { id, agentStalledTimeoutMs: 600_000 };
+      },
+    } as unknown as never,
+    ...(opts.wireDb === false
+      ? {}
+      : { db, authPlaneDb: fakeAuthPlaneDb(opts.tenants ?? [], counters), env: opts.env ?? FLAG_OFF }),
+  });
+
+  const tick = () => (monitor as unknown as { tick: () => Promise<void> }).tick();
+  return { tick, observed, counters, staleReads: () => staleReads };
+}
+
+describe('turn-monitor — legacy world is byte-identical', () => {
+  test('no db wired: one ambient getStale, no enumeration, no scope', async () => {
+    const { tick, observed, counters, staleReads } = makeMonitor({
+      wireDb: false,
+      turns: [
+        { id: 't1', instanceId: 'i1', chatId: 'c1', lastActivityAt: IDLE_15_MIN(), nudgeCount: 0, tenantId: null },
+      ],
+    });
+    await tick();
+
+    expect(staleReads()).toBe(1);
+    expect(counters.selects).toBe(0);
+    expect(counters.transactions).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+    // The per-turn work still happened — this is a behaviour-preserving path.
+    expect(observed.map((o) => o.helper)).toContain('incrementNudge');
+  });
+
+  test('db wired but flag OFF: still one ambient pass and NO auth-plane query', async () => {
+    const { tick, observed, counters, staleReads } = makeMonitor({
+      env: FLAG_OFF,
+      tenants: [TENANT_A],
+      turns: [
+        { id: 't1', instanceId: 'i1', chatId: 'c1', lastActivityAt: IDLE_15_MIN(), nudgeCount: 0, tenantId: null },
+      ],
+    });
+    await tick();
+
+    expect(staleReads()).toBe(1);
+    expect(counters.selects).toBe(0);
+    expect(observed.every((o) => o.scope === null)).toBe(true);
+  });
+});
+
+describe('turn-monitor — tenant world', () => {
+  test('the stale read is enumerated per ACTIVE tenant and runs inside that tenant scope', async () => {
+    const { tick, observed, counters, staleReads } = makeMonitor({
+      env: FLAG_ON,
+      tenants: [TENANT_A, TENANT_B],
+      turns: [],
+    });
+    await tick();
+
+    expect(counters.selects).toBe(1);
+    // One scoped read per tenant, plus the transitional NULL-tenant pass that
+    // only exists outside enforcement.
+    expect(staleReads()).toBe(3);
+    const scopes = observed.filter((o) => o.helper === 'getStale').map((o) => o.scope);
+    expect(scopes).toEqual([TENANT_A, TENANT_B, null]);
+  });
+
+  test('EVERY per-turn DB helper observes the turn’s own tenant scope', async () => {
+    const { tick, observed } = makeMonitor({
+      env: FLAG_ON,
+      tenants: [TENANT_A],
+      turns: [
+        {
+          id: 't-nudge',
+          instanceId: 'i1',
+          chatId: 'c1',
+          lastActivityAt: IDLE_15_MIN(),
+          nudgeCount: 0,
+          tenantId: TENANT_A,
+        },
+        {
+          // The STALLED branch: `nudgeCount === 2` AND idle past the instance's
+          // stalled threshold (600s default; the stub instance keeps the
+          // default). It is a FOURTH scoped DB block — `handleStalled`'s own
+          // `incrementNudge` — that no other case in this file or in
+          // turn-monitor-fallback.test.ts reaches under a wired db, so without
+          // this stub deleting its `runTenantWorkDb` wrapper changes nothing
+          // any test can see.
+          id: 't-stalled',
+          instanceId: 'i3',
+          chatId: 'c3',
+          lastActivityAt: IDLE_15_MIN(),
+          nudgeCount: 2,
+          tenantId: TENANT_A,
+        },
+        {
+          id: 't-timeout',
+          instanceId: 'i2',
+          chatId: 'c2',
+          lastActivityAt: IDLE_40_MIN(),
+          nudgeCount: 1,
+          tenantId: TENANT_A,
+        },
+      ],
+    });
+    await tick();
+
+    const scopedHelpers = observed.filter((o) => o.helper !== 'getStale');
+    expect(scopedHelpers.length).toBeGreaterThan(0);
+    for (const entry of scopedHelpers) {
+      expect(entry.scope).toBe(TENANT_A);
+    }
+    // The stalled-timeout config read is the `instances` site this leg converts.
+    expect(scopedHelpers.some((o) => o.helper === 'getById')).toBe(true);
+    expect(scopedHelpers.some((o) => o.helper === 'close')).toBe(true);
+    // Both `incrementNudge` CALL SITES — the nudge branch and the stalled
+    // branch — each inside their own scope, named so a miss is legible.
+    expect(
+      scopedHelpers
+        .filter((o) => o.helper === 'incrementNudge')
+        .map((o) => o.turnId)
+        .sort(),
+    ).toEqual(['t-nudge', 't-stalled']);
+  });
+
+  test('a turn owned by tenant B is not processed in tenant A’s pass', async () => {
+    const { tick, observed } = makeMonitor({
+      env: FLAG_ON,
+      tenants: [TENANT_A],
+      turns: [
+        {
+          id: 't-b',
+          instanceId: 'i-b',
+          chatId: 'c-b',
+          lastActivityAt: IDLE_15_MIN(),
+          nudgeCount: 0,
+          tenantId: TENANT_B,
+        },
+      ],
+    });
+    await tick();
+
+    expect(observed.filter((o) => o.helper === 'incrementNudge')).toEqual([]);
+  });
+
+  test('the worker scope does NOT span the event publish', async () => {
+    // CAPTURE, then assert in the test body. An `expect` thrown INSIDE this mock
+    // would be swallowed on its way back: `periodic-tenant-work.ts`'s per-tenant
+    // catch logs `periodic tenant pass failed` and `turn-monitor.ts`'s tick catch
+    // logs `Turn monitor tick failed`, and Bun does not fail a test for a caught
+    // assertion — the probe for the spec's CRITICAL TRAP ("a worker transaction
+    // must never outlive its work item") would pass no matter what the code did.
+    // Same technique as agent-dispatcher-worker-scope.test.ts.
+    const scopesAtPublish: Array<string | null> = [];
+    const spy = spyOn(turnEvents, 'publishTurnNudge').mockImplementation(() => {
+      scopesAtPublish.push(currentTenantScope()?.tenantId ?? null);
+    });
+    try {
+      const { tick } = makeMonitor({
+        env: FLAG_ON,
+        tenants: [TENANT_A],
+        turns: [
+          {
+            id: 't1',
+            instanceId: 'i1',
+            chatId: 'c1',
+            lastActivityAt: IDLE_15_MIN(),
+            nudgeCount: 0,
+            tenantId: TENANT_A,
+          },
+        ],
+      });
+      await tick();
+      expect(spy).toHaveBeenCalledTimes(1);
+      // One publish, and the scope was already closed when it happened.
+      expect(scopesAtPublish).toEqual([null]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('one tenant’s failing pass does not starve the sibling', async () => {
+    const counters = { selects: 0, transactions: 0 };
+    const seen: string[] = [];
+    let first = true;
+    const monitor = new TurnMonitor({
+      turnService: {
+        getStale: async () => {
+          const tenantId = currentTenantScope()?.tenantId ?? null;
+          if (tenantId === TENANT_A && first) {
+            first = false;
+            throw new Error('tenant A read exploded');
+          }
+          if (tenantId) seen.push(tenantId);
+          return [];
+        },
+        incrementNudge: async () => {},
+        close: async () => null,
+      } as unknown as never,
+      instanceService: { getById: async () => ({}) } as unknown as never,
+      db: fakeScopeDb(counters),
+      authPlaneDb: fakeAuthPlaneDb([TENANT_A, TENANT_B], counters),
+      env: FLAG_ON,
+    });
+
+    await (monitor as unknown as { tick: () => Promise<void> }).tick();
+    expect(seen).toEqual([TENANT_B]);
+  });
+});
+
+afterEach(() => {
+  // Nothing global to reset — the monitor holds no module state — but keep the
+  // hook so a future addition has an obvious home.
+});

--- a/packages/api/src/services/access.ts
+++ b/packages/api/src/services/access.ts
@@ -20,6 +20,7 @@ import { type AccessMode, type AccessRule, type NewAccessRule, type RuleType, ac
 import { type SQL, and, count, desc, eq, gt, isNull, ne, or, sql } from 'drizzle-orm';
 import { CacheKeys, CacheTTL, authCacheTtlMs } from '../cache/cache-keys';
 import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 
 /** Default pairing request expiry: 1 hour */
 const DEFAULT_PAIRING_EXPIRY_MS = 60 * 60 * 1000;
@@ -186,6 +187,7 @@ export class AccessService {
     instance: { id: string; accessMode: AccessMode },
     platformUserId: string,
     _channel: string,
+    trustedTenantId?: string | null,
   ): Promise<CheckAccessResult> {
     const { id: instanceId, accessMode } = instance;
 
@@ -193,11 +195,21 @@ export class AccessService {
       return { allowed: true, reason: 'Access control disabled', mode: 'disabled' };
     }
 
+    // The cache key carries the instance UUID, which belongs to exactly one
+    // tenant, so a decision cached for tenant A is unreachable from tenant B
+    // without already knowing that tenant's instance id. No tenant segment is
+    // added: changing the key would change flag-off cache behaviour.
     const cacheKey = CacheKeys.accessCheck(instanceId, platformUserId);
     const cached = await this.cache?.get<CheckAccessResult>(cacheKey);
     if (cached) return cached;
 
-    const rules = await this.getApplicableRules(instanceId);
+    // Discrete DB block in the caller's world (G5, ADR-0008): a consumer threads
+    // its envelope-derived tenant, so the ALLOW/DENY decision is evaluated
+    // against rules read inside that tenant's transaction. The scope closes
+    // before the decision publish below. A request caller threads nothing and
+    // stays on the edge transaction; a legacy consumer runs ambient,
+    // byte-identically to pre-G5.
+    const rules = await runTenantWorkDb(this.pool, trustedTenantId, () => this.getApplicableRules(instanceId));
     const matchingRule = rules.find((rule) => this.ruleMatches(rule, platformUserId));
     const result = this.evaluateMode(accessMode, matchingRule);
 
@@ -245,105 +257,114 @@ export class AccessService {
     instanceId: string,
     platformUserId: string,
     options: { expiryMs?: number; channelType?: string } = {},
+    trustedTenantId?: string | null,
   ): Promise<PairingRequest | null> {
     const expiryMs = options.expiryMs ?? DEFAULT_PAIRING_EXPIRY_MS;
 
     // Run the check + insert atomically under a per-instance advisory lock.
     // pg_advisory_xact_lock serializes concurrent calls for the same instance
     // and is released automatically when the transaction ends.
-    const txResult = await this.db.transaction(async (tx) => {
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${instanceId}))`);
+    //
+    // G5 (ADR-0008): a consumer caller threads its envelope-derived tenant, so
+    // the whole locked block runs inside that tenant's worker transaction (the
+    // advisory lock and the pairing rows are then tenant-scoped together). The
+    // event publish below stays OUTSIDE it. A legacy caller threads nothing and
+    // the transaction opens on the ambient pool exactly as before.
+    const txResult = await runTenantWorkDb(this.pool, trustedTenantId, () =>
+      this.db.transaction(async (tx) => {
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${instanceId}))`);
 
-      // Clean expired requests
-      await tx
-        .delete(accessRules)
-        .where(
-          and(
-            eq(accessRules.instanceId, instanceId),
-            eq(accessRules.ruleType, 'pending_pairing'),
-            sql`${accessRules.expiresAt} <= now()`,
-          ),
-        );
+        // Clean expired requests
+        await tx
+          .delete(accessRules)
+          .where(
+            and(
+              eq(accessRules.instanceId, instanceId),
+              eq(accessRules.ruleType, 'pending_pairing'),
+              sql`${accessRules.expiresAt} <= now()`,
+            ),
+          );
 
-      // Reuse existing code if sender already has a pending request
-      const [existing] = await tx
-        .select()
-        .from(accessRules)
-        .where(
-          and(
-            eq(accessRules.instanceId, instanceId),
-            eq(accessRules.ruleType, 'pending_pairing'),
-            eq(accessRules.platformUserId, platformUserId),
-            gt(accessRules.expiresAt, new Date()),
-          ),
-        )
-        .limit(1);
+        // Reuse existing code if sender already has a pending request
+        const [existing] = await tx
+          .select()
+          .from(accessRules)
+          .where(
+            and(
+              eq(accessRules.instanceId, instanceId),
+              eq(accessRules.ruleType, 'pending_pairing'),
+              eq(accessRules.platformUserId, platformUserId),
+              gt(accessRules.expiresAt, new Date()),
+            ),
+          )
+          .limit(1);
 
-      if (existing) {
-        const metadata = existing.metadata as Record<string, unknown> | null;
+        if (existing) {
+          const metadata = existing.metadata as Record<string, unknown> | null;
+          return {
+            request: {
+              id: existing.id,
+              instanceId: existing.instanceId ?? instanceId,
+              platformUserId: existing.platformUserId ?? platformUserId,
+              pairingCode: (metadata?.pairingCode as string) ?? '',
+              expiresAt: existing.expiresAt ?? new Date(Date.now() + expiryMs),
+              createdAt: existing.createdAt,
+            } satisfies PairingRequest,
+            isNew: false,
+          };
+        }
+
+        // Rate limit: max pending per instance
+        const [countResult] = await tx
+          .select({ count: count() })
+          .from(accessRules)
+          .where(
+            and(
+              eq(accessRules.instanceId, instanceId),
+              eq(accessRules.ruleType, 'pending_pairing'),
+              gt(accessRules.expiresAt, new Date()),
+            ),
+          );
+
+        if ((countResult?.count ?? 0) >= MAX_PENDING_PER_INSTANCE) {
+          return null; // Rate-limited
+        }
+
+        // Generate code and insert new pairing request
+        const pairingCode = AccessService.generatePairingCode();
+        const expiresAt = new Date(Date.now() + expiryMs);
+
+        const [rule] = await tx
+          .insert(accessRules)
+          .values({
+            instanceId,
+            ruleType: 'pending_pairing',
+            platformUserId,
+            priority: 0,
+            enabled: true,
+            action: 'block',
+            expiresAt,
+            metadata: { pairingCode, requestedAt: Date.now() },
+          })
+          .returning();
+
+        if (!rule) {
+          throw new Error('Failed to create pairing request');
+        }
+
         return {
           request: {
-            id: existing.id,
-            instanceId: existing.instanceId ?? instanceId,
-            platformUserId: existing.platformUserId ?? platformUserId,
-            pairingCode: (metadata?.pairingCode as string) ?? '',
-            expiresAt: existing.expiresAt ?? new Date(Date.now() + expiryMs),
-            createdAt: existing.createdAt,
+            id: rule.id,
+            instanceId,
+            platformUserId,
+            pairingCode,
+            expiresAt,
+            createdAt: rule.createdAt,
           } satisfies PairingRequest,
-          isNew: false,
+          isNew: true,
         };
-      }
-
-      // Rate limit: max pending per instance
-      const [countResult] = await tx
-        .select({ count: count() })
-        .from(accessRules)
-        .where(
-          and(
-            eq(accessRules.instanceId, instanceId),
-            eq(accessRules.ruleType, 'pending_pairing'),
-            gt(accessRules.expiresAt, new Date()),
-          ),
-        );
-
-      if ((countResult?.count ?? 0) >= MAX_PENDING_PER_INSTANCE) {
-        return null; // Rate-limited
-      }
-
-      // Generate code and insert new pairing request
-      const pairingCode = AccessService.generatePairingCode();
-      const expiresAt = new Date(Date.now() + expiryMs);
-
-      const [rule] = await tx
-        .insert(accessRules)
-        .values({
-          instanceId,
-          ruleType: 'pending_pairing',
-          platformUserId,
-          priority: 0,
-          enabled: true,
-          action: 'block',
-          expiresAt,
-          metadata: { pairingCode, requestedAt: Date.now() },
-        })
-        .returning();
-
-      if (!rule) {
-        throw new Error('Failed to create pairing request');
-      }
-
-      return {
-        request: {
-          id: rule.id,
-          instanceId,
-          platformUserId,
-          pairingCode,
-          expiresAt,
-          createdAt: rule.createdAt,
-        } satisfies PairingRequest,
-        isNew: true,
-      };
-    });
+      }),
+    );
 
     if (!txResult) return null;
 

--- a/packages/api/src/services/access.ts
+++ b/packages/api/src/services/access.ts
@@ -18,7 +18,7 @@ import { NotFoundError } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type AccessMode, type AccessRule, type NewAccessRule, type RuleType, accessRules, instances } from '@omni/db';
 import { type SQL, and, count, desc, eq, gt, isNull, ne, or, sql } from 'drizzle-orm';
-import { CacheKeys } from '../cache/cache-keys';
+import { CacheKeys, CacheTTL, authCacheTtlMs } from '../cache/cache-keys';
 import { scopedHandle } from '../tenancy/tenant-scope';
 
 /** Default pairing request expiry: 1 hour */
@@ -201,7 +201,12 @@ export class AccessService {
     const matchingRule = rules.find((rule) => this.ruleMatches(rule, platformUserId));
     const result = this.evaluateMode(accessMode, matchingRule);
 
-    await this.cache?.set(cacheKey, result);
+    // G5 (RELEASE_SLOS auth_cache_invalidation_seconds_max): an allow/deny
+    // decision is cached authorization state — clamped to the revocation
+    // ceiling when multitenancy is enabled; the legacy 5-minute TTL flag-off
+    // (the explicit argument equals the cache's default, so flag-off behavior
+    // is unchanged).
+    await this.cache?.set(cacheKey, result, authCacheTtlMs(CacheTTL.ACCESS_CHECK));
     await this.publishResult(instanceId, platformUserId, result);
 
     return result;

--- a/packages/api/src/services/agent-heartbeat.ts
+++ b/packages/api/src/services/agent-heartbeat.ts
@@ -18,11 +18,39 @@
  * Backward compatibility: pre-publisher genie clients keep the current
  * behavior (they trip nudges); newer clients suppress their own false nudges.
  * No flag day.
+ *
+ * WORKER TENANT CONTEXT (wish: omni-full-multitenancy, G5; ADR-0008)
+ * ------------------------------------------------------------------
+ * This is a CONSUMER — a raw NATS subscription, not an eventBus one — and it
+ * used to call `recordActivity` straight onto the ambient pool without ever
+ * going through `classifyEnvelope`. It therefore had no world at all: no
+ * tenant, no legacy/quarantine distinction, and a write on whatever handle
+ * happened to be ambient. It is one of the two unscoped worker callers named in
+ * the `services/turns.ts::turns` registry justification.
+ *
+ * WHERE THE TENANT COMES FROM. A heartbeat is published by an EXTERNAL client
+ * as raw JSON, so nothing in the body may be believed — ADR-0008 requires the
+ * tenant to come from an authenticated context or a LOADED resource's persisted
+ * ownership. The message names an `instanceId`, and `instances` is the ownership
+ * ROOT, so the instance-owner registry (fed only by `instances` rows this
+ * process already read) is the trusted answer. `parseHeartbeat` returns ONLY its
+ * four validated fields, so a publisher cannot smuggle a `tenantId` or an
+ * `envelopeVersion` claim into the derivation. That tenant is then STAMPED onto
+ * an envelope and handed to `runConsumerInTenantContext`, which classifies it —
+ * so this consumer inherits exactly the same three worlds as every other one.
+ *
+ * DUAL WORLD: with no `db` wired (the shape every existing test constructs), or
+ * for an instance whose ownership this process never observed (every instance,
+ * flag-off), the call is the pre-G5 ambient one, byte for byte.
  */
 
-import { createLogger } from '@omni/core';
+import { createLogger, stampTenantEnvelope } from '@omni/core';
+import type { Database } from '@omni/db';
 import type { NatsConnection, Subscription } from 'nats';
 import { StringCodec } from 'nats';
+import { lookupInstanceOwner } from '../tenancy/instance-owner-registry';
+import { runDetachedFromTenantScope } from '../tenancy/tenant-scope';
+import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 import type { AgentHeartbeatEvent } from './turn-events';
 import type { TurnService } from './turns';
 
@@ -34,6 +62,14 @@ const HEARTBEAT_SUBJECT = 'omni.agent.heartbeat.>';
 export interface AgentHeartbeatStartOptions {
   natsConnection: NatsConnection;
   turnService: TurnService;
+  /**
+   * The runtime pool a per-message worker scope opens its transaction on.
+   *
+   * OPTIONAL, and its absence is the legacy world: without it the activity write
+   * is the pre-G5 ambient call. Wiring it (`index.ts`) is what opts this consumer
+   * into the tenant world.
+   */
+  db?: Database;
 }
 
 export class AgentHeartbeatConsumer {
@@ -43,7 +79,7 @@ export class AgentHeartbeatConsumer {
   start(options: AgentHeartbeatStartOptions): void {
     if (this.subscription) return;
 
-    const { natsConnection, turnService } = options;
+    const { natsConnection, turnService, db } = options;
 
     if (natsConnection.isClosed()) {
       log.warn('Cannot start agent-heartbeat: NATS connection is closed');
@@ -67,12 +103,17 @@ export class AgentHeartbeatConsumer {
             continue;
           }
 
-          turnService.recordActivity(parsed.turnId).catch((error) => {
-            log.warn('recordActivity failed for heartbeat (turn likely closed)', {
-              turnId: parsed.turnId,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
+          // The activity write, in the heartbeat's world. Detached because this
+          // is a fire-and-forget started from the subscription loop; scoped from
+          // the instance's PERSISTED ownership, never from the payload.
+          void runDetachedFromTenantScope(async () => recordHeartbeatActivity(turnService, db, parsed)).catch(
+            (error) => {
+              log.warn('recordActivity failed for heartbeat (turn likely closed)', {
+                turnId: parsed.turnId,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            },
+          );
 
           log.debug('Agent heartbeat applied', {
             turnId: parsed.turnId,
@@ -102,6 +143,31 @@ export class AgentHeartbeatConsumer {
       log.info('Agent heartbeat consumer stopped');
     }
   }
+}
+
+/**
+ * Apply one heartbeat's activity write in the right world.
+ *
+ * With no `db` wired this is the pre-G5 ambient call. With one, the instance's
+ * PERSISTED tenant is looked up, stamped onto an envelope, and classified by
+ * `runConsumerInTenantContext`: a known owner runs the write inside that
+ * tenant's worker transaction; an instance whose ownership this process never
+ * observed classifies `legacy` and runs ambient (which fails closed under
+ * enforcement — the correct posture, never someone else's tenant).
+ */
+async function recordHeartbeatActivity(
+  turnService: TurnService,
+  db: Database | undefined,
+  parsed: AgentHeartbeatEvent,
+): Promise<void> {
+  if (!db) {
+    await turnService.recordActivity(parsed.turnId);
+    return;
+  }
+  const trustedTenantId = lookupInstanceOwner(parsed.instanceId);
+  const base = { correlationId: `heartbeat-${parsed.turnId}`, instanceId: parsed.instanceId };
+  const metadata = trustedTenantId ? stampTenantEnvelope(base, trustedTenantId) : base;
+  await runConsumerInTenantContext(db, { metadata }, () => turnService.recordActivity(parsed.turnId));
 }
 
 function parseHeartbeat(raw: string): AgentHeartbeatEvent | null {

--- a/packages/api/src/services/agent-replay.ts
+++ b/packages/api/src/services/agent-replay.ts
@@ -5,6 +5,33 @@
  * On connect, checks if replay is enabled for the instance, queries messages
  * received after `lastSeenAt` (capped at 24h), and re-dispatches them through
  * the normal agent handler pipeline via the event bus.
+ *
+ * WORKER TENANT CONTEXT (wish: omni-full-multitenancy, G5; ADR-0008)
+ * ------------------------------------------------------------------
+ * Two callers reach this service and they live in different worlds:
+ *
+ *   * `routes/v2/instances.ts` — the manual replay endpoint, already inside the
+ *     edge tenant transaction (G4). It threads NOTHING, and every DB block
+ *     below therefore stays on the request's scope via `scopedHandle`.
+ *   * `plugins/event-listeners.ts` — the `instance.connected` /
+ *     `instance.disconnected` consumers, which call `onInstanceConnect` and
+ *     `updateLastSeenAt` FIRE-AND-FORGET. Those had no scope at all: the
+ *     instance read, the message pages and the `lastSeenAt` write hit the
+ *     ambient pool while the rest of the consumer ran tenant-scoped. They are
+ *     the unscoped worker callers that kept `agent-replay.ts::{instances,
+ *     messages}` in `pending-G5-conversion`.
+ *
+ * The conversion THREADS the envelope-derived tenant rather than wrapping the
+ * call, because `replayMissedMessages` PUBLISHES a `message.received` per
+ * replayed row and a worker transaction held across a publish would make the
+ * event a pre-commit side effect (a phantom on rollback). Each discrete DB
+ * block opens its OWN short worker scope through `runTenantWorkDb` — the same
+ * shape `turn-monitor.ts` uses — and the publishes happen between blocks.
+ *
+ * DUAL WORLD: `trustedTenantId` is `undefined`/`null` for every legacy caller,
+ * and `runTenantWorkDb` then runs the block exactly as the caller found it —
+ * inside a request scope it stays on that transaction, on a legacy worker path
+ * it hits the ambient pool byte-identically to pre-G5.
  */
 
 import type { EventBus } from '@omni/core';
@@ -13,6 +40,7 @@ import type { Database } from '@omni/db';
 import { chats, instances, messages } from '@omni/db';
 import { and, asc, eq, gt, lte, or, sql } from 'drizzle-orm';
 import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 
 const log = createLogger('agent-replay');
 
@@ -60,19 +88,29 @@ export class AgentReplayService {
    * Trigger replay for an instance on reconnect.
    * Checks if replay is enabled, then calls replayMissedMessages.
    * Updates `lastSeenAt` to now after replay completes.
+   *
+   * @param trustedTenantId - for the CONSUMER caller only
+   *   (`plugins/event-listeners.ts`), derived from the envelope via
+   *   `trustedEnvelopeTenant` — never from a payload claim. A request caller
+   *   omits it and keeps the edge transaction; a legacy envelope passes
+   *   `undefined` and every block below stays ambient.
    */
-  async onInstanceConnect(instanceId: string): Promise<void> {
-    const [instance] = await this.db
-      .select({
-        id: instances.id,
-        channel: instances.channel,
-        replayEnabled: instances.replayEnabled,
-        lastSeenAt: instances.lastSeenAt,
-        agentId: instances.agentId,
-      })
-      .from(instances)
-      .where(eq(instances.id, instanceId))
-      .limit(1);
+  async onInstanceConnect(instanceId: string, trustedTenantId?: string | null): Promise<void> {
+    // Discrete DB block: the instance read. Its own short worker scope, closed
+    // before anything else happens.
+    const [instance] = await runTenantWorkDb(this.pool, trustedTenantId, () =>
+      this.db
+        .select({
+          id: instances.id,
+          channel: instances.channel,
+          replayEnabled: instances.replayEnabled,
+          lastSeenAt: instances.lastSeenAt,
+          agentId: instances.agentId,
+        })
+        .from(instances)
+        .where(eq(instances.id, instanceId))
+        .limit(1),
+    );
 
     if (!instance) {
       log.warn('Instance not found for replay', { instanceId });
@@ -81,13 +119,13 @@ export class AgentReplayService {
 
     if (!instance.agentId) {
       log.debug('Instance has no agent, skipping replay', { instanceId });
-      await this.updateLastSeenAt(instanceId);
+      await this.updateLastSeenAt(instanceId, undefined, trustedTenantId);
       return;
     }
 
     if (!instance.replayEnabled) {
       log.debug('Replay disabled for instance', { instanceId });
-      await this.updateLastSeenAt(instanceId);
+      await this.updateLastSeenAt(instanceId, undefined, trustedTenantId);
       return;
     }
 
@@ -95,21 +133,21 @@ export class AgentReplayService {
 
     if (!since) {
       log.debug('No lastSeenAt recorded, skipping replay (first connect)', { instanceId });
-      await this.updateLastSeenAt(instanceId);
+      await this.updateLastSeenAt(instanceId, undefined, trustedTenantId);
       return;
     }
 
     log.info('Starting replay on reconnect', { instanceId, since: since.toISOString() });
 
     try {
-      const result = await this.replayMissedMessages({ instanceId, since });
+      const result = await this.replayMissedMessages({ instanceId, since }, trustedTenantId);
       log.info('Replay complete', {
         instanceId,
         replayed: result.replayed,
         skipped: result.skipped,
         since: result.since.toISOString(),
       });
-      await this.updateLastSeenAt(instanceId, result.until);
+      await this.updateLastSeenAt(instanceId, result.until, trustedTenantId);
     } catch (error) {
       log.error('Replay failed', { instanceId, error: String(error) });
     }
@@ -122,7 +160,7 @@ export class AgentReplayService {
    * (capped at 24h ago) and now, then re-publishes them as message.received
    * events on the event bus so the normal agent dispatcher handles them.
    */
-  async replayMissedMessages(options: ReplayOptions): Promise<ReplayResult> {
+  async replayMissedMessages(options: ReplayOptions, trustedTenantId?: string | null): Promise<ReplayResult> {
     const { instanceId } = options;
     const now = new Date();
     const cutoff = new Date(now.getTime() - MAX_REPLAY_WINDOW_MS);
@@ -139,58 +177,62 @@ export class AgentReplayService {
     const PAGE_SIZE = 1000;
 
     while (true) {
-      const rows = await this.db
-        .select({
-          id: messages.id,
-          chatId: messages.chatId,
-          externalId: messages.externalId,
-          messageType: messages.messageType,
-          textContent: messages.textContent,
-          mediaUrl: messages.mediaUrl,
-          mediaLocalPath: messages.mediaLocalPath,
-          mediaMimeType: messages.mediaMimeType,
-          senderPlatformUserId: messages.senderPlatformUserId,
-          replyToExternalId: messages.replyToExternalId,
-          rawPayload: messages.rawPayload,
-          platformTimestamp: messages.platformTimestamp,
-          isFromMe: messages.isFromMe,
-          senderAgentId: messages.senderAgentId,
-          // Join chat to get instanceId and externalId (the platform chat/JID)
-          chatExternalId: chats.externalId,
-          chatInstanceId: chats.instanceId,
-        })
-        .from(messages)
-        .innerJoin(chats, eq(messages.chatId, chats.id))
-        .where(
-          and(
-            eq(chats.instanceId, instanceId),
-            eq(messages.isFromMe, false),
-            // Only include non-agent-sent messages
-            sql`${messages.senderAgentId} IS NULL`,
-            // Only active messages
-            sql`${messages.deletedAt} IS NULL`,
-            // Skip messages that already have an agent reply after them in the same chat
-            // — means the agent already handled this message before the restart
-            sql`NOT EXISTS (
+      // Discrete DB block: ONE page. The scope closes before `redispatchRows`
+      // publishes, so no event is emitted from inside a worker transaction.
+      const rows = await runTenantWorkDb(this.pool, trustedTenantId, () =>
+        this.db
+          .select({
+            id: messages.id,
+            chatId: messages.chatId,
+            externalId: messages.externalId,
+            messageType: messages.messageType,
+            textContent: messages.textContent,
+            mediaUrl: messages.mediaUrl,
+            mediaLocalPath: messages.mediaLocalPath,
+            mediaMimeType: messages.mediaMimeType,
+            senderPlatformUserId: messages.senderPlatformUserId,
+            replyToExternalId: messages.replyToExternalId,
+            rawPayload: messages.rawPayload,
+            platformTimestamp: messages.platformTimestamp,
+            isFromMe: messages.isFromMe,
+            senderAgentId: messages.senderAgentId,
+            // Join chat to get instanceId and externalId (the platform chat/JID)
+            chatExternalId: chats.externalId,
+            chatInstanceId: chats.instanceId,
+          })
+          .from(messages)
+          .innerJoin(chats, eq(messages.chatId, chats.id))
+          .where(
+            and(
+              eq(chats.instanceId, instanceId),
+              eq(messages.isFromMe, false),
+              // Only include non-agent-sent messages
+              sql`${messages.senderAgentId} IS NULL`,
+              // Only active messages
+              sql`${messages.deletedAt} IS NULL`,
+              // Skip messages that already have an agent reply after them in the same chat
+              // — means the agent already handled this message before the restart
+              sql`NOT EXISTS (
               SELECT 1 FROM ${messages} AS reply
               WHERE reply.chat_id = ${messages.chatId}
                 AND reply.sender_agent_id IS NOT NULL
                 AND reply.platform_timestamp > ${messages.platformTimestamp}
                 AND reply.deleted_at IS NULL
             )`,
-            // Composite cursor: (timestamp > cursor) OR (timestamp = cursor AND id > cursorId)
-            // This avoids skipping messages with identical timestamps at page boundaries
-            cursorId
-              ? or(
-                  gt(messages.platformTimestamp, cursorTimestamp),
-                  and(eq(messages.platformTimestamp, cursorTimestamp), gt(messages.id, cursorId)),
-                )
-              : gt(messages.platformTimestamp, cursorTimestamp),
-            lte(messages.platformTimestamp, now),
-          ),
-        )
-        .orderBy(asc(messages.platformTimestamp), asc(messages.id))
-        .limit(PAGE_SIZE);
+              // Composite cursor: (timestamp > cursor) OR (timestamp = cursor AND id > cursorId)
+              // This avoids skipping messages with identical timestamps at page boundaries
+              cursorId
+                ? or(
+                    gt(messages.platformTimestamp, cursorTimestamp),
+                    and(eq(messages.platformTimestamp, cursorTimestamp), gt(messages.id, cursorId)),
+                  )
+                : gt(messages.platformTimestamp, cursorTimestamp),
+              lte(messages.platformTimestamp, now),
+            ),
+          )
+          .orderBy(asc(messages.platformTimestamp), asc(messages.id))
+          .limit(PAGE_SIZE),
+      );
 
       if (rows.length === 0) break;
 
@@ -222,11 +264,13 @@ export class AgentReplayService {
    * Update `lastSeenAt` for an instance to now.
    * Called on both clean connect and disconnect so the next replay window is accurate.
    */
-  async updateLastSeenAt(instanceId: string, timestamp?: Date): Promise<void> {
-    await this.db
-      .update(instances)
-      .set({ lastSeenAt: timestamp ?? new Date() })
-      .where(eq(instances.id, instanceId));
+  async updateLastSeenAt(instanceId: string, timestamp?: Date, trustedTenantId?: string | null): Promise<void> {
+    await runTenantWorkDb(this.pool, trustedTenantId, () =>
+      this.db
+        .update(instances)
+        .set({ lastSeenAt: timestamp ?? new Date() })
+        .where(eq(instances.id, instanceId)),
+    );
   }
 
   private async redispatchRows(

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -21,7 +21,7 @@ import type { AgentReplyFilter, AgentSessionStrategy, ChannelType, Instance } fr
 import type { Database } from '@omni/db';
 import { agentProviders, instances, persons } from '@omni/db';
 import { eq } from 'drizzle-orm';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 
 const log = createLogger('agent-runner');
 
@@ -315,16 +315,33 @@ async function* processStreamChunks(
 // ============================================================================
 
 export class AgentRunnerService {
+  /**
+   * Provider clients, keyed `providerId::tenant`.
+   *
+   * TENANT IN THE KEY (G5; ADR-0008). A cached `IAgentClient` holds the
+   * `apiKey` it was built with and sends it as the provider's bearer
+   * credential, so this map caches a CREDENTIAL. `agent_providers` has no
+   * `tenant_id` (G0-`split`), so one provider row is reachable from instances of
+   * different tenants; keyed by provider id alone the first caller's client —
+   * and its key — would be served to every later tenant. The scope-less legacy
+   * path keys on `-`, so it still shares exactly one client per provider.
+   */
   private clientCache: Map<string, IAgentClient> = new Map();
 
   constructor(private db: Database) {}
+
+  /** The cache key for `providerId` under the tenant scope active right now. */
+  private clientCacheKey(providerId: string): string {
+    return `${providerId}::${currentTenantScope()?.tenantId ?? '-'}`;
+  }
 
   /**
    * Get or create an Agno client for a provider
    */
   private async getClient(providerId: string): Promise<IAgentClient> {
     // Check cache
-    const cached = this.clientCache.get(providerId);
+    const cacheKey = this.clientCacheKey(providerId);
+    const cached = this.clientCache.get(cacheKey);
     if (cached) return cached;
 
     // Fetch provider config from DB
@@ -353,7 +370,7 @@ export class AgentRunnerService {
     });
 
     // Cache it
-    this.clientCache.set(providerId, client);
+    this.clientCache.set(cacheKey, client);
     return client;
   }
 
@@ -621,7 +638,11 @@ export class AgentRunnerService {
    */
   clearCache(providerId?: string): void {
     if (providerId) {
-      this.clientCache.delete(providerId);
+      // Every TENANT's client for this provider (the key is `providerId::tenant`).
+      const prefix = `${providerId}::`;
+      for (const key of this.clientCache.keys()) {
+        if (key.startsWith(prefix)) this.clientCache.delete(key);
+      }
     } else {
       this.clientCache.clear();
     }

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -21,6 +21,7 @@ import type { AgentReplyFilter, AgentSessionStrategy, ChannelType, Instance } fr
 import type { Database } from '@omni/db';
 import { agentProviders, instances, persons } from '@omni/db';
 import { eq } from 'drizzle-orm';
+import { scopedHandle } from '../tenancy/tenant-scope';
 
 const log = createLogger('agent-runner');
 
@@ -357,10 +358,29 @@ export class AgentRunnerService {
   }
 
   /**
-   * Get full instance config with provider details
+   * Get full instance config with provider details.
+   *
+   * TENANT BOUNDARY (G5, ADR-0008). This is the lookup EVERY dispatch path
+   * starts from and it has zero HTTP callers — every caller is a NATS consumer.
+   * The read now goes through `scopedHandle`, so:
+   *
+   *   * inside a worker tenant scope (the converted consumers, which open one
+   *     from their envelope-derived tenant) it runs on that tenant-stamped
+   *     transaction and RLS decides visibility — a forged/foreign instanceId
+   *     resolves to `null` and the dispatch simply has nothing to act on;
+   *   * with no scope active — a legacy envelope, or the deprecated
+   *     `agent-responder` path — `scopedHandle` returns the ambient pool and the
+   *     query issued is byte-for-byte the pre-G5 one.
+   *
+   * `null` therefore means "not visible to this tenant" as well as "absent", and
+   * every caller already treats `null` as "skip".
    */
   async getInstanceWithProvider(instanceId: string): Promise<Instance | null> {
-    const [instance] = await this.db.select().from(instances).where(eq(instances.id, instanceId)).limit(1);
+    const [instance] = await scopedHandle(this.db)
+      .select()
+      .from(instances)
+      .where(eq(instances.id, instanceId))
+      .limit(1);
 
     return instance ?? null;
   }

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -21,6 +21,7 @@ import type { AgentReplyFilter, AgentSessionStrategy, ChannelType, Instance } fr
 import type { Database } from '@omni/db';
 import { agentProviders, instances, persons } from '@omni/db';
 import { eq } from 'drizzle-orm';
+import { isSealedCredentialField, openCredentialField } from '../tenancy/sealed-credentials';
 import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 
 const log = createLogger('agent-runner');
@@ -357,15 +358,37 @@ export class AgentRunnerService {
       });
     }
 
-    if (!provider.apiKey) {
-      throw new ProviderError(`Provider ${providerId} has no API key configured`, 'AUTHENTICATION_FAILED', 401);
+    // G5 deliverable (g) (ADR-0008): `agent_providers.api_key` may hold a SEALED
+    // envelope. `ProviderService` is where that column is sealed, but this is a
+    // second reader — the legacy dispatch fallback and the `call_agent`
+    // automation action both land here — and what it produces goes on the wire
+    // as `Authorization: Bearer …`. Forwarding the envelope would leak
+    // ciphertext AND the tenant UUID into the provider's request logs and
+    // produce a 401 with no visible cause, which `tenancy/sealed-credentials.ts`
+    // names as the outcome that must never happen.
+    //
+    // DUAL WORLD, by construction: `openCredentialField` is the identity
+    // function for legacy plaintext and whenever no master key is configured, so
+    // a flag-off/key-absent deployment hands `createProviderClient` exactly the
+    // bytes it handed it before (g). Only a sealed value is decided here, and it
+    // fails CLOSED — a null never becomes a bearer token.
+    const apiKey = openCredentialField(currentTenantScope()?.tenantId ?? null, provider.apiKey);
+
+    if (!apiKey) {
+      throw new ProviderError(
+        isSealedCredentialField(provider.apiKey)
+          ? `Provider ${providerId} credential is not available in this tenant context`
+          : `Provider ${providerId} has no API key configured`,
+        'AUTHENTICATION_FAILED',
+        401,
+      );
     }
 
     // Create client
     const client = createProviderClient({
       schema: provider.schema,
       baseUrl: provider.baseUrl,
-      apiKey: provider.apiKey,
+      apiKey,
       defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
     });
 

--- a/packages/api/src/services/api-keys.ts
+++ b/packages/api/src/services/api-keys.ts
@@ -16,7 +16,7 @@ import { createLogger } from '@omni/core';
 import type { ApiKeyProfile, ApiKeyProfileOverrides, Database } from '@omni/db';
 import { type ApiKey, type NewApiKey, apiKeys } from '@omni/db';
 import { and, eq, gt, isNull, or, sql } from 'drizzle-orm';
-import { CacheKeys, CacheTTL, type CachedApiKey, apiKeyCache } from '../cache';
+import { CacheKeys, CacheTTL, type CachedApiKey, apiKeyCache, authCacheTtlMs } from '../cache';
 
 const log = createLogger('api-keys');
 
@@ -210,7 +210,9 @@ export class ApiKeyService {
       outboundRecipientAllowlist: apiKey.outboundRecipientAllowlist,
       profileOverrides: apiKey.profileOverrides ?? null,
     };
-    await apiKeyCache.set(cacheKey, cachedData, CacheTTL.API_KEY);
+    // G5 (RELEASE_SLOS auth_cache_invalidation_seconds_max): clamped to the
+    // revocation ceiling when multitenancy is enabled; legacy TTL flag-off.
+    await apiKeyCache.set(cacheKey, cachedData, authCacheTtlMs(CacheTTL.API_KEY));
 
     // Update usage asynchronously
     this.updateUsageAsync(apiKey.id, ip);

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -83,8 +83,18 @@ export class AutomationService {
       defaultConcurrency: 5,
     });
 
-    // Set up execution logger
-    this.engine.setLogger(async (log) => {
+    // Set up execution logger.
+    //
+    // The engine threads the executed envelope's trusted tenant as a second
+    // argument (G5, ADR-0008) — deliberately UNUSED here for now:
+    // `automation_logs` derives its tenant from the G2-`unowned` `automations`
+    // parent (tenancy-ownership.ts), so tenant_id stays NULL until the G6
+    // backfill decides ownership, and a worker-scoped insert would violate the
+    // strict RLS WITH CHECK and destroy the execution log. Scoping this write
+    // is G6-gated; when G6 lands, wrap the call in
+    // `runTenantWorkDb(this.pool, trustedTenantId, …)` — the threading is
+    // already in place.
+    this.engine.setLogger(async (log, _trustedTenantId) => {
       await this.logExecution(log);
     });
 

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -66,6 +66,9 @@ export class AutomationService {
       chatId: string,
       instanceId: string,
       eventSequenceIndex: number | null,
+      // Trusted tenant of the consumed envelope (G5, ADR-0008) — threaded by
+      // the engine from the producer-stamped metadata; null for legacy.
+      trustedTenantId?: string | null,
     ) => Promise<{ skip: boolean; reason?: string }>;
   }): Promise<void> {
     if (!this.eventBus) {

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -35,7 +35,7 @@ import {
   createMediaProcessingService,
 } from '@omni/media-processing';
 import { and, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
-import { isTenantWorkAdmissible } from '../tenancy/periodic-tenant-work';
+import { isTenantWorkAdmissible, runForEachActiveTenantRow } from '../tenancy/periodic-tenant-work';
 import { currentTenantScope, runDetachedFromTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import { BATCH_PRICING_VERSION, computeEstimatedCostCents } from './batch-pricing';
@@ -160,6 +160,13 @@ export class BatchJobService {
    */
   private authPlaneDb: Database | null = null;
 
+  /**
+   * Environment used for the flag/enforcement decisions of the RESUME fan-out.
+   * Tests override it; production leaves it undefined and the helper reads
+   * `process.env`.
+   */
+  private resumeEnv: NodeJS.ProcessEnv | undefined;
+
   constructor(
     private readonly pool: Database,
     private eventBus: EventBus | null,
@@ -175,6 +182,11 @@ export class BatchJobService {
    */
   setAuthPlane(authPlaneDb: Database): void {
     this.authPlaneDb = authPlaneDb;
+  }
+
+  /** Test seam for {@link resumeJobs}' flag/enforcement decisions. */
+  setResumeEnv(env: NodeJS.ProcessEnv | undefined): void {
+    this.resumeEnv = env;
   }
 
   /**
@@ -539,28 +551,60 @@ export class BatchJobService {
   }
 
   /**
-   * Resume jobs that were running when the API restarted
+   * Resume jobs that were running when the API restarted.
+   *
+   * G5 (ADR-0008/ADR-0003): this is restart recovery — no request, no
+   * credential, no envelope — and its read is a WHOLE-TABLE scan for
+   * `status = 'running'`. Under RLS enforcement that scan is not expressible at
+   * all, so recovery must ENUMERATE whose jobs exist (`runForEachActiveTenantRow`,
+   * the daily-sync / turn-monitor precedent) instead of scanning globally and
+   * sorting ownership out afterwards. Only the discrete READ is scoped; each
+   * job's executor is dispatched OUTSIDE it, because `executeJob` is a long
+   * fire-and-forget that opens its own short scope per DB block.
+   *
+   * Each job's trusted tenant is its OWN persisted `tenant_id` (G2, nullable) —
+   * never the enumerating pass's, never an ambient/inherited scope. The executor
+   * then revalidates that tenant is still admissible at this dequeue
+   * (RELEASE_SLOS `queued_retry_delayed_dlq_check`).
+   *
+   * LEGACY WORLD: with no auth plane wired, or with the flag off, this is the
+   * pre-G5 single ambient scan followed by the same dispatch loop — statement
+   * for statement.
    */
   async resumeJobs(): Promise<void> {
-    const runningJobs = await this.db.select().from(batchJobs).where(eq(batchJobs.status, 'running'));
-
-    if (runningJobs.length === 0) {
-      log.debug('No jobs to resume');
-      return;
-    }
-
-    log.info('Resuming batch jobs', { count: runningJobs.length });
-
-    for (const job of runningJobs) {
-      // No request scope exists at boot. Each job's trusted tenant is its OWN
-      // persisted `tenant_id` (G2, nullable) — not any ambient/inherited scope.
-      // A NULL-tenant row resumes ambient exactly as pre-G5 (legacy world); a
-      // tenant row resumes under its own worker scope, and the executor
-      // revalidates that tenant is still admissible at this dequeue.
+    const dispatch = (job: { id: string; tenantId: string | null }): void => {
       this.executeJob(job.id, job.tenantId ?? null).catch((error) => {
         log.error('Failed to resume job', { jobId: job.id, error: String(error) });
       });
+    };
+
+    if (!this.authPlaneDb) {
+      const runningJobs = await this.db.select().from(batchJobs).where(eq(batchJobs.status, 'running'));
+      if (runningJobs.length === 0) {
+        log.debug('No jobs to resume');
+        return;
+      }
+      log.info('Resuming batch jobs', { count: runningJobs.length });
+      for (const job of runningJobs) dispatch(job);
+      return;
     }
+
+    let resumed = 0;
+    await runForEachActiveTenantRow(
+      {
+        db: this.pool,
+        authPlaneDb: this.authPlaneDb,
+        jobName: 'batch-job-resume',
+        listActive: () => this.db.select().from(batchJobs).where(eq(batchJobs.status, 'running')),
+        env: this.resumeEnv,
+      },
+      async (job) => {
+        resumed += 1;
+        dispatch(job);
+      },
+    );
+    if (resumed === 0) log.debug('No jobs to resume');
+    else log.info('Resuming batch jobs', { count: resumed });
   }
 
   /**

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -35,7 +35,9 @@ import {
   createMediaProcessingService,
 } from '@omni/media-processing';
 import { and, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
-import { runDetachedFromTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { isTenantWorkAdmissible } from '../tenancy/periodic-tenant-work';
+import { currentTenantScope, runDetachedFromTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import { BATCH_PRICING_VERSION, computeEstimatedCostCents } from './batch-pricing';
 import { MediaStorageService } from './media-storage';
 
@@ -147,12 +149,52 @@ export class BatchJobService {
     return scopedHandle(this.pool);
   }
 
+  /**
+   * The auth-plane read connection, injected after construction by
+   * `services/index.ts` (mirrors `followUpSweeper.setAuthPlane`). It is the one
+   * runtime-process identity that may read `tenants` under enforcement, so it is
+   * where the background executor revalidates a job's tenant is still admissible
+   * at DEQUEUE time (see {@link isJobTenantAdmissible}). Legacy deployments and
+   * existing tests that never enable multitenancy can omit it — a NULL-tenant
+   * job is admissible without any read.
+   */
+  private authPlaneDb: Database | null = null;
+
   constructor(
     private readonly pool: Database,
     private eventBus: EventBus | null,
     private settings?: MediaSettingsReader,
   ) {
     this.mediaStorage = new MediaStorageService(this.pool);
+  }
+
+  /**
+   * Inject the auth-plane read connection (wired by `services/index.ts`). Used
+   * only for dequeue-time tenant revalidation of tenant-owned jobs; NULL-tenant
+   * (legacy) jobs never consult it.
+   */
+  setAuthPlane(authPlaneDb: Database): void {
+    this.authPlaneDb = authPlaneDb;
+  }
+
+  /**
+   * Dequeue-time tenant revalidation (RELEASE_SLOS
+   * "queued_retry_delayed_dlq_check"). A NULL-tenant (legacy) job is always
+   * admissible and never touches the auth plane. A tenant job is admissible only
+   * when its tenant is still `active` — a suspension/archival between job
+   * creation and this dequeue (or across a restart-resume) makes it inadmissible.
+   *
+   * Fails CLOSED for a tenant job when no auth-plane connection was injected:
+   * the multitenancy world always wires one (`services/index.ts`), so its
+   * absence under a tenant job is a misconfiguration we must not run through.
+   */
+  private async isJobTenantAdmissible(jobTenantId: string | null): Promise<boolean> {
+    if (!jobTenantId) return true;
+    if (!this.authPlaneDb) {
+      log.warn('Batch job has a tenant but no auth-plane connection is wired — refusing to run', { jobTenantId });
+      return false;
+    }
+    return isTenantWorkAdmissible(this.authPlaneDb, jobTenantId);
   }
 
   private getMediaService(): Promise<MediaProcessingService> {
@@ -203,9 +245,16 @@ export class BatchJobService {
   }
 
   /**
-   * Create and start a batch job
+   * Create and start a batch job.
+   *
+   * @param trustedTenantId - for NON-request callers only (e.g. the sync worker's
+   *   post-sync media backfill, which enqueues from OUTSIDE its per-item worker
+   *   scope). It threads the envelope-derived trusted tenant so the row is stamped
+   *   and the background executor revalidates the right tenant. A request caller
+   *   omits it: the tenant is captured from the active request scope, which is
+   *   edge-derived and trusted. Passing `null` explicitly forces a legacy job.
    */
-  async create(options: CreateBatchJobOptions): Promise<BatchJob> {
+  async create(options: CreateBatchJobOptions, trustedTenantId?: string | null): Promise<BatchJob> {
     const {
       jobType,
       instanceId,
@@ -258,11 +307,30 @@ export class BatchJobService {
       errors: [],
     };
 
-    const [created] = await this.db.insert(batchJobs).values(jobData).returning();
+    // Capture the TRUSTED tenant for this job BEFORE any detach. A request
+    // caller is inside its edge-opened tenant scope, so `currentTenantScope()`
+    // is the trusted, edge-derived tenant; a worker caller has no scope here and
+    // threads its envelope-derived tenant explicitly via `trustedTenantId`. This
+    // value travels into the detached executor as a PARAMETER — the executor
+    // never reads ALS (it runs detached, where ALS is empty anyway).
+    const activeScope = currentTenantScope();
+    const jobTenantId = trustedTenantId !== undefined ? trustedTenantId : (activeScope?.tenantId ?? null);
 
-    if (!created) {
-      throw new Error('Failed to create batch job');
-    }
+    // The INSERT stamps tenant ownership (`batch_jobs.tenant_id`) from the tenant
+    // transaction it runs in. A request caller is already inside that scope, so
+    // the insert joins the request transaction unchanged. A worker caller holds
+    // no scope but threaded a tenant, so it opens ONE short worker transaction
+    // here to stamp the row. A legacy caller (no tenant) inserts on the ambient
+    // pool, byte-identical to pre-G5.
+    const insertJob = async (): Promise<BatchJob> => {
+      const [row] = await this.db.insert(batchJobs).values(jobData).returning();
+      if (!row) {
+        throw new Error('Failed to create batch job');
+      }
+      return row;
+    };
+    const created =
+      activeScope || !jobTenantId ? await insertJob() : await runTenantWorkDb(this.pool, jobTenantId, insertJob);
 
     log.info('Batch job created', {
       jobId: created.id,
@@ -293,7 +361,7 @@ export class BatchJobService {
     // pooled connection has been released — issuing a query on it would be a
     // use-after-commit. Detaching pins the executor (and every query it makes
     // via `this.db`) to the ambient pool, the worker-context path G5 will own.
-    runDetachedFromTenantScope(() => this.executeJob(created.id)).catch((error) => {
+    runDetachedFromTenantScope(() => this.executeJob(created.id, jobTenantId)).catch((error) => {
       log.error('Job execution failed', { jobId: created.id, error: String(error) });
     });
 
@@ -484,17 +552,39 @@ export class BatchJobService {
     log.info('Resuming batch jobs', { count: runningJobs.length });
 
     for (const job of runningJobs) {
-      this.executeJob(job.id).catch((error) => {
+      // No request scope exists at boot. Each job's trusted tenant is its OWN
+      // persisted `tenant_id` (G2, nullable) — not any ambient/inherited scope.
+      // A NULL-tenant row resumes ambient exactly as pre-G5 (legacy world); a
+      // tenant row resumes under its own worker scope, and the executor
+      // revalidates that tenant is still admissible at this dequeue.
+      this.executeJob(job.id, job.tenantId ?? null).catch((error) => {
         log.error('Failed to resume job', { jobId: job.id, error: String(error) });
       });
     }
   }
 
   /**
-   * Execute a batch job (main processing loop)
+   * Execute a batch job (main processing loop).
+   *
+   * `jobTenantId` is the job's TRUSTED tenant, threaded as a value (never read
+   * from ALS): captured from the request scope at `create` time, threaded by a
+   * worker caller, or read from the persisted row at resume time. Every discrete
+   * DB block below runs in `runTenantWorkDb(this.pool, jobTenantId, ...)` — one
+   * short worker transaction per block, never one across the whole job — while
+   * downloads, AI calls, and event publishes stay OUTSIDE any scope. A NULL
+   * tenant runs every block on the ambient pool, byte-identical to pre-G5.
    */
-  private async executeJob(jobId: string): Promise<void> {
-    const job = await this.getById(jobId);
+  private async executeJob(jobId: string, jobTenantId: string | null): Promise<void> {
+    // DEQUEUE-TIME REVALIDATION #1 — before any work. A tenant suspended between
+    // create/resume and now (RELEASE_SLOS "queued_retry_delayed_dlq_check") must
+    // not have its queued job run. An inadmissible tenant STOPS the job with a
+    // clear error and performs NO side effects.
+    if (!(await this.isJobTenantAdmissible(jobTenantId))) {
+      await this.stopForInadmissibleTenant(jobId, jobTenantId);
+      return;
+    }
+
+    const job = await runTenantWorkDb(this.pool, jobTenantId, () => this.getById(jobId));
     const instanceId = this.requireInstanceId(job);
     const params = (job.requestParams ?? {}) as Partial<CreateBatchJobOptions>;
 
@@ -502,9 +592,25 @@ export class BatchJobService {
     this.activeJobs.set(jobId, { cancelled: false });
 
     try {
-      const { eligibleItems, totalItems, skippedItems } = await this.prepareJobExecution(job, instanceId, params);
+      const { eligibleItems, totalItems, skippedItems } = await this.prepareJobExecution(
+        job,
+        instanceId,
+        params,
+        jobTenantId,
+      );
 
-      await this.markJobRunning(jobId, instanceId, job.jobType as BatchJobType, totalItems);
+      // DEQUEUE-TIME REVALIDATION #2 — immediately before the durable side-effect
+      // batch (status→running, `batch-job.started` publish, and the whole
+      // processing loop of media writes + progress publishes). If the tenant was
+      // suspended during item preparation, stop here before the first durable
+      // effect.
+      if (!(await this.isJobTenantAdmissible(jobTenantId))) {
+        this.activeJobs.delete(jobId);
+        await this.stopForInadmissibleTenant(jobId, jobTenantId);
+        return;
+      }
+
+      await this.markJobRunning(jobId, instanceId, job.jobType as BatchJobType, totalItems, jobTenantId);
 
       const state = this.initializeJobState(job);
       const startTime = Date.now();
@@ -521,6 +627,7 @@ export class BatchJobService {
         state,
         delayMinMs,
         delayMaxMs,
+        jobTenantId,
       );
 
       await this.finalizeJob(
@@ -531,12 +638,31 @@ export class BatchJobService {
         skippedItems,
         state,
         startTime,
+        jobTenantId,
       );
     } catch (error) {
-      await this.handleJobError(jobId, instanceId, error);
+      await this.handleJobError(jobId, instanceId, error, jobTenantId);
     } finally {
       this.activeJobs.delete(jobId);
     }
+  }
+
+  /**
+   * Stop a job whose tenant is no longer admissible at dequeue. Marks it
+   * `failed` with a clear error and performs NO further side effects (no
+   * processing, no downloads, no event publishes). The status write itself runs
+   * in the job's tenant scope — a suspended tenant's row is still visible to its
+   * own worker transaction (RLS matches on `tenant_id`, not on status).
+   */
+  private async stopForInadmissibleTenant(jobId: string, jobTenantId: string | null): Promise<void> {
+    const message = `Tenant ${jobTenantId} is not admissible (suspended or archived); job stopped at dequeue`;
+    log.warn('Batch job stopped — tenant not admissible', { jobId, jobTenantId });
+    await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db
+        .update(batchJobs)
+        .set({ status: 'failed', completedAt: new Date(), errorMessage: message })
+        .where(eq(batchJobs.id, jobId)),
+    );
   }
 
   /**
@@ -546,15 +672,18 @@ export class BatchJobService {
     job: BatchJob,
     instanceId: string,
     params: Partial<CreateBatchJobOptions>,
+    jobTenantId: string | null,
   ): Promise<{ eligibleItems: Message[]; totalItems: number; skippedItems: number }> {
-    const items = await this.queryEligibleItems({
-      jobType: job.jobType as BatchJobType,
-      instanceId,
-      chatId: params.chatId,
-      daysBack: params.daysBack,
-      limit: params.limit,
-      contentTypes: params.contentTypes as ProcessableContentType[],
-    });
+    const items = await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.queryEligibleItems({
+        jobType: job.jobType as BatchJobType,
+        instanceId,
+        chatId: params.chatId,
+        daysBack: params.daysBack,
+        limit: params.limit,
+        contentTypes: params.contentTypes as ProcessableContentType[],
+      }),
+    );
 
     const eligibleItems = params.force === true ? items : items.filter((item) => !this.hasExistingContent(item));
     const totalItems = eligibleItems.length;
@@ -571,11 +700,15 @@ export class BatchJobService {
     instanceId: string,
     jobType: BatchJobType,
     totalItems: number,
+    jobTenantId: string | null,
   ): Promise<void> {
-    await this.db
-      .update(batchJobs)
-      .set({ status: 'running', startedAt: new Date(), totalItems })
-      .where(eq(batchJobs.id, jobId));
+    // DB block scoped to the job's tenant; the publish stays OUTSIDE the scope.
+    await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db
+        .update(batchJobs)
+        .set({ status: 'running', startedAt: new Date(), totalItems })
+        .where(eq(batchJobs.id, jobId)),
+    );
 
     log.info('Job started', { jobId, totalItems });
 
@@ -609,15 +742,19 @@ export class BatchJobService {
     state: JobProcessingState,
     delayMinMs: number,
     delayMaxMs: number,
+    jobTenantId: string | null,
   ): Promise<void> {
     for (let i = 0; i < eligibleItems.length; i++) {
-      if (await this.isJobCancelled(jobId)) break;
+      if (await this.isJobCancelled(jobId, jobTenantId)) break;
 
       const item = eligibleItems[i];
       if (!item) continue;
 
-      await this.db.update(batchJobs).set({ currentItem: item.id }).where(eq(batchJobs.id, jobId));
-      await this.processSingleItem(instanceId, item, jobId, state);
+      // DB block: mark the current item. External processing follows outside.
+      await runTenantWorkDb(this.pool, jobTenantId, () =>
+        this.db.update(batchJobs).set({ currentItem: item.id }).where(eq(batchJobs.id, jobId)),
+      );
+      await this.processSingleItem(instanceId, item, jobId, state, jobTenantId);
       await this.updateProgressIfNeeded(
         jobId,
         instanceId,
@@ -627,6 +764,7 @@ export class BatchJobService {
         skippedItems,
         item.id,
         state,
+        jobTenantId,
       );
       // Random delay between items to avoid API rate limits and behave humanly
       const delay = delayMinMs + Math.random() * (delayMaxMs - delayMinMs);
@@ -637,18 +775,16 @@ export class BatchJobService {
   /**
    * Check if job was cancelled (via memory flag or DB)
    */
-  private async isJobCancelled(jobId: string): Promise<boolean> {
+  private async isJobCancelled(jobId: string, jobTenantId: string | null): Promise<boolean> {
     const activeJob = this.activeJobs.get(jobId);
     if (activeJob?.cancelled) {
       log.info('Job cancelled by user', { jobId });
       return true;
     }
 
-    const [current] = await this.db
-      .select({ status: batchJobs.status })
-      .from(batchJobs)
-      .where(eq(batchJobs.id, jobId))
-      .limit(1);
+    const [current] = await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db.select({ status: batchJobs.status }).from(batchJobs).where(eq(batchJobs.id, jobId)).limit(1),
+    );
     if (current?.status === 'cancelled') {
       log.info('Job cancelled (DB check)', { jobId });
       return true;
@@ -665,9 +801,10 @@ export class BatchJobService {
     item: Message,
     jobId: string,
     state: JobProcessingState,
+    jobTenantId: string | null,
   ): Promise<void> {
     try {
-      const result = await this.processItem(instanceId, item, jobId);
+      const result = await this.processItem(instanceId, item, jobId, jobTenantId);
       if (result.success) {
         state.processedItems++;
         state.totalCostUsd += (result.costCents ?? 0) / 100;
@@ -695,6 +832,7 @@ export class BatchJobService {
     skippedItems: number,
     currentItemId: string,
     state: JobProcessingState,
+    jobTenantId: string | null,
   ): Promise<void> {
     const isProgressInterval = (index + 1) % BatchJobService.PROGRESS_UPDATE_INTERVAL === 0;
     const isLastItem = index === total - 1;
@@ -703,17 +841,20 @@ export class BatchJobService {
     const progressPercent =
       totalItems > 0 ? Math.round(((state.processedItems + state.failedItems) / totalItems) * 100) : 0;
 
-    await this.db
-      .update(batchJobs)
-      .set({
-        processedItems: state.processedItems,
-        failedItems: state.failedItems,
-        progressPercent,
-        totalCostUsd: String(state.totalCostUsd),
-        totalTokens: state.totalTokens,
-        errors: state.errors,
-      })
-      .where(eq(batchJobs.id, jobId));
+    // DB block scoped to the job's tenant; the progress publish stays outside.
+    await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db
+        .update(batchJobs)
+        .set({
+          processedItems: state.processedItems,
+          failedItems: state.failedItems,
+          progressPercent,
+          totalCostUsd: String(state.totalCostUsd),
+          totalTokens: state.totalTokens,
+          errors: state.errors,
+        })
+        .where(eq(batchJobs.id, jobId)),
+    );
 
     if (this.eventBus) {
       await this.eventBus.publish(
@@ -748,30 +889,32 @@ export class BatchJobService {
     skippedItems: number,
     state: JobProcessingState,
     startTime: number,
+    jobTenantId: string | null,
   ): Promise<void> {
-    const [finalStatus] = await this.db
-      .select({ status: batchJobs.status })
-      .from(batchJobs)
-      .where(eq(batchJobs.id, jobId))
-      .limit(1);
+    const [finalStatus] = await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db.select({ status: batchJobs.status }).from(batchJobs).where(eq(batchJobs.id, jobId)).limit(1),
+    );
     if (finalStatus?.status === 'cancelled') return;
 
     const durationMs = Date.now() - startTime;
 
-    await this.db
-      .update(batchJobs)
-      .set({
-        status: 'completed',
-        completedAt: new Date(),
-        processedItems: state.processedItems,
-        failedItems: state.failedItems,
-        progressPercent: 100,
-        totalCostUsd: String(state.totalCostUsd),
-        totalTokens: state.totalTokens,
-        errors: state.errors,
-        currentItem: null,
-      })
-      .where(eq(batchJobs.id, jobId));
+    // DB block scoped to the job's tenant; the completion publish stays outside.
+    await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db
+        .update(batchJobs)
+        .set({
+          status: 'completed',
+          completedAt: new Date(),
+          processedItems: state.processedItems,
+          failedItems: state.failedItems,
+          progressPercent: 100,
+          totalCostUsd: String(state.totalCostUsd),
+          totalTokens: state.totalTokens,
+          errors: state.errors,
+          currentItem: null,
+        })
+        .where(eq(batchJobs.id, jobId)),
+    );
 
     log.info('Job completed', {
       jobId,
@@ -806,13 +949,20 @@ export class BatchJobService {
   /**
    * Handle job execution error
    */
-  private async handleJobError(jobId: string, instanceId: string, error: unknown): Promise<void> {
+  private async handleJobError(
+    jobId: string,
+    instanceId: string,
+    error: unknown,
+    jobTenantId: string | null,
+  ): Promise<void> {
     log.error('Job execution failed', { jobId, error: String(error) });
 
-    await this.db
-      .update(batchJobs)
-      .set({ status: 'failed', completedAt: new Date(), errorMessage: String(error) })
-      .where(eq(batchJobs.id, jobId));
+    await runTenantWorkDb(this.pool, jobTenantId, () =>
+      this.db
+        .update(batchJobs)
+        .set({ status: 'failed', completedAt: new Date(), errorMessage: String(error) })
+        .where(eq(batchJobs.id, jobId)),
+    );
 
     if (this.eventBus) {
       await this.eventBus.publish('batch-job.failed', { jobId, instanceId, error: String(error) }, { instanceId });
@@ -822,14 +972,19 @@ export class BatchJobService {
   /**
    * Process a single media item
    */
-  private async processItem(instanceId: string, message: Message, batchJobId: string): Promise<ProcessingResult> {
+  private async processItem(
+    instanceId: string,
+    message: Message,
+    batchJobId: string,
+    jobTenantId: string | null,
+  ): Promise<ProcessingResult> {
     const mimeType = message.mediaMimeType;
     const mediaService = await this.getMediaService();
     if (!mimeType || !mediaService.canProcess(mimeType)) {
       return this.failedResult(`MIME type not processable: ${mimeType}`);
     }
 
-    const resolved = await this.resolveFilePath(instanceId, message, mimeType);
+    const resolved = await this.resolveFilePath(instanceId, message, mimeType, jobTenantId);
     if (!resolved.ok) {
       return this.failedResult(resolved.reason);
     }
@@ -849,7 +1004,7 @@ export class BatchJobService {
     }
 
     if (result.success && result.content) {
-      await this.persistProcessingResult(message.id, result, batchJobId);
+      await this.persistProcessingResult(message.id, result, batchJobId, jobTenantId);
     }
 
     return result;
@@ -883,6 +1038,7 @@ export class BatchJobService {
     instanceId: string,
     message: Message,
     mimeType: string,
+    jobTenantId: string | null,
   ): Promise<{ ok: true; path: string } | { ok: false; reason: string }> {
     if (message.mediaLocalPath) {
       return { ok: true, path: message.mediaLocalPath };
@@ -893,14 +1049,23 @@ export class BatchJobService {
     }
 
     try {
+      // Download + store is external work; the trusted tenant is threaded so the
+      // object lands under the tenant's storage prefix (media-storage `buildKey`).
       const result = await this.mediaStorage.storeFromUrl(
         instanceId,
         message.id,
         message.mediaUrl,
         mimeType,
         message.platformTimestamp ?? undefined,
+        undefined,
+        jobTenantId ?? undefined,
       );
-      await this.mediaStorage.updateMessageLocalPath(message.id, result.localPath);
+      // The message write is a discrete DB block — scoped to the job's tenant so
+      // it lands under the correct tenant transaction (RLS-policed under
+      // enforcement, ambient byte-identical for a legacy job).
+      await runTenantWorkDb(this.pool, jobTenantId, () =>
+        this.mediaStorage.updateMessageLocalPath(message.id, result.localPath),
+      );
       return { ok: true, path: result.localPath };
     } catch (error) {
       const reason = `storeFromUrl failed: ${error instanceof Error ? error.message : String(error)}`;
@@ -920,28 +1085,34 @@ export class BatchJobService {
     messageId: string,
     result: ProcessingResult,
     batchJobId: string,
+    jobTenantId: string | null,
   ): Promise<void> {
     // Content is guaranteed by caller check: `if (result.success && result.content)`
     const content = result.content ?? '';
 
-    await this.db.insert(mediaContent).values({
-      mediaId: messageId,
-      processingType: result.processingType,
-      content,
-      model: result.model,
-      provider: result.provider,
-      language: result.language,
-      duration: result.duration,
-      tokensUsed: result.inputTokens ? result.inputTokens + (result.outputTokens ?? 0) : undefined,
-      costUsd: result.costCents != null ? String(Math.round(result.costCents)) : null,
-      processingTimeMs: result.processingTimeMs,
-      batchJobId,
-    });
+    // One discrete DB block: the media_content insert plus the dependent message
+    // update, scoped to the job's tenant so both land in the same short worker
+    // transaction (legacy job → ambient, byte-identical).
+    await runTenantWorkDb(this.pool, jobTenantId, async () => {
+      await this.db.insert(mediaContent).values({
+        mediaId: messageId,
+        processingType: result.processingType,
+        content,
+        model: result.model,
+        provider: result.provider,
+        language: result.language,
+        duration: result.duration,
+        tokensUsed: result.inputTokens ? result.inputTokens + (result.outputTokens ?? 0) : undefined,
+        costUsd: result.costCents != null ? String(Math.round(result.costCents)) : null,
+        processingTimeMs: result.processingTimeMs,
+        batchJobId,
+      });
 
-    const updateData = this.getMessageUpdateForType(result.processingType, content);
-    if (updateData) {
-      await this.db.update(messages).set(updateData).where(eq(messages.id, messageId));
-    }
+      const updateData = this.getMessageUpdateForType(result.processingType, content);
+      if (updateData) {
+        await this.db.update(messages).set(updateData).where(eq(messages.id, messageId));
+      }
+    });
   }
 
   /**

--- a/packages/api/src/services/event-ops.ts
+++ b/packages/api/src/services/event-ops.ts
@@ -20,7 +20,9 @@ import {
 import type { Database, OmniEvent } from '@omni/db';
 import { omniEvents } from '@omni/db';
 import { and, asc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
-import { runDetachedFromTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { isTenantWorkAdmissible } from '../tenancy/periodic-tenant-work';
+import { currentTenantScope, runDetachedFromTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import type { DeadLetterService } from './dead-letters';
 import type { PayloadStoreService } from './payload-store';
 
@@ -82,12 +84,46 @@ export class EventOpsService {
     return scopedHandle(this.pool);
   }
 
+  /**
+   * The auth-plane read connection, injected after construction by
+   * `services/index.ts` (mirrors `followUpSweeper.setAuthPlane`). It is where the
+   * detached replay executor revalidates the replay's tenant is still admissible
+   * at dequeue (see {@link isReplayTenantAdmissible}). Legacy deployments omit it;
+   * a NULL-tenant replay is admissible without any read.
+   */
+  private authPlaneDb: Database | null = null;
+
   constructor(
     private readonly pool: Database,
     private eventBus: EventBus | null,
     private deadLetterService: DeadLetterService,
     private payloadStoreService: PayloadStoreService,
   ) {}
+
+  /**
+   * Inject the auth-plane read connection (wired by `services/index.ts`). Used
+   * only for dequeue-time tenant revalidation of the replay executor.
+   */
+  setAuthPlane(authPlaneDb: Database): void {
+    this.authPlaneDb = authPlaneDb;
+  }
+
+  /**
+   * Dequeue-time tenant revalidation for the background replay (RELEASE_SLOS
+   * "queued_retry_delayed_dlq_check"). A NULL-tenant (legacy) replay is always
+   * admissible and never touches the auth plane. A tenant replay is admissible
+   * only while its tenant is still `active`. Fails CLOSED for a tenant replay
+   * when no auth-plane connection was injected (the multitenancy world always
+   * wires one).
+   */
+  private async isReplayTenantAdmissible(replayTenantId: string | null): Promise<boolean> {
+    if (!replayTenantId) return true;
+    if (!this.authPlaneDb) {
+      log.warn('Replay has a tenant but no auth-plane connection is wired — refusing to run', { replayTenantId });
+      return false;
+    }
+    return isTenantWorkAdmissible(this.authPlaneDb, replayTenantId);
+  }
 
   // ===========================================================================
   // REPLAY OPERATIONS
@@ -96,7 +132,7 @@ export class EventOpsService {
   /**
    * Start a replay session
    */
-  async startReplay(options: ReplayOptions): Promise<ReplaySession> {
+  async startReplay(options: ReplayOptions, trustedTenantId?: string | null): Promise<ReplaySession> {
     // Validate options
     const validation = validateReplayOptions(options);
     if (!validation.valid) {
@@ -153,6 +189,12 @@ export class EventOpsService {
       }
     }
 
+    // Capture the TRUSTED replay tenant BEFORE detaching (G5, ADR-0008). A
+    // request path supplies it through the active scope; a non-request caller
+    // threads it explicitly. It travels into the executor as a VALUE — the
+    // executor must never read ALS (see the detach rationale below).
+    const replayTenantId = currentTenantScope()?.tenantId ?? trustedTenantId ?? null;
+
     // Start replay in background.
     //
     // `startReplay` may be running inside a tenant-scoped request transaction
@@ -160,9 +202,9 @@ export class EventOpsService {
     // scope: it outlives the request, and by the time its batch queries run the
     // request's transaction has committed and its pooled connection has been
     // released — issuing a query on it would be a use-after-commit. Detaching
-    // pins the executor (and every query it makes via `this.db`) to the ambient
-    // pool, the worker-context path G5 will own.
-    runDetachedFromTenantScope(() => this.executeReplay(sessionId, options)).catch((err) => {
+    // pins the executor to the ambient pool; each discrete DB block then opens
+    // its OWN short worker scope from the captured `replayTenantId`.
+    runDetachedFromTenantScope(() => this.executeReplay(sessionId, options, replayTenantId)).catch((err) => {
       log.error('Replay failed', { sessionId, error: String(err) });
     });
 
@@ -357,9 +399,23 @@ export class EventOpsService {
    * Execute replay in background
    */
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Replay execution is inherently complex
-  private async executeReplay(sessionId: string, options: ReplayOptions): Promise<void> {
+  private async executeReplay(sessionId: string, options: ReplayOptions, replayTenantId: string | null): Promise<void> {
     const session = this.replaySessions.get(sessionId);
     if (!session) return;
+
+    // Dequeue-time revalidation (RELEASE_SLOS "queued_retry_delayed_dlq_check"):
+    // between the request that started this replay and the moment the detached
+    // executor actually runs, the replay's tenant may have been suspended. A
+    // legacy (null-tenant) replay is always admissible. An inadmissible tenant
+    // stops the replay before ANY event is republished — no durable side effect.
+    if (!(await this.isReplayTenantAdmissible(replayTenantId))) {
+      session.status = 'failed';
+      session.error = 'replay tenant is no longer admissible (suspended/archived)';
+      session.completedAt = new Date();
+      this.activeReplayId = null;
+      log.warn('Replay refused at dequeue — tenant inadmissible', { sessionId, replayTenantId });
+      return;
+    }
 
     const errors: Array<{ eventId: string; error: string }> = [];
     const batchSize = 100;
@@ -367,14 +423,28 @@ export class EventOpsService {
 
     try {
       while (session.status === 'running') {
-        // Fetch batch of events
-        const events = await this.db
-          .select()
-          .from(omniEvents)
-          .where(this.buildReplayWhereClause(options))
-          .orderBy(asc(omniEvents.receivedAt))
-          .limit(batchSize)
-          .offset(offset);
+        // Re-revalidate before EACH batch of durable side effects (the batch
+        // below republishes events). A tenant suspended mid-replay stops at the
+        // next batch boundary. Legacy replays short-circuit to admissible.
+        if (!(await this.isReplayTenantAdmissible(replayTenantId))) {
+          session.status = 'failed';
+          session.error = 'replay tenant became inadmissible mid-replay (suspended/archived)';
+          log.warn('Replay halted mid-run — tenant inadmissible', { sessionId, replayTenantId });
+          break;
+        }
+
+        // Fetch batch of events — a discrete DB block scoped to the replay's
+        // tenant (G5): under enforcement only that tenant's `omni_events` are
+        // visible; a legacy replay reads ambient byte-identically.
+        const events = await runTenantWorkDb(this.pool, replayTenantId, () =>
+          this.db
+            .select()
+            .from(omniEvents)
+            .where(this.buildReplayWhereClause(options))
+            .orderBy(asc(omniEvents.receivedAt))
+            .limit(batchSize)
+            .offset(offset),
+        );
 
         if (events.length === 0) break;
 

--- a/packages/api/src/services/follow-up-lifecycle.ts
+++ b/packages/api/src/services/follow-up-lifecycle.ts
@@ -40,6 +40,8 @@ import {
 } from '@omni/db';
 import { and, eq, isNull, notInArray, or, sql } from 'drizzle-orm';
 import { isChatInActiveCloseState } from '../lib/close-contact-state';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 
 const log = createLogger('follow-up-lifecycle');
 
@@ -100,17 +102,48 @@ function readChatFollowUpConfig(row: Chat | null | undefined): FollowUpSequenceC
 }
 
 export class FollowUpLifecycleService {
-  private readonly repo: FollowUpLifecycleRepo;
-
   constructor(
-    private db: Database,
+    private pool: Database,
     private eventBus: EventBus | null,
     private logger: Logger = log,
-  ) {
-    this.repo = {
-      upsertArmed: async (input) => this.upsertArmed(input),
+  ) {}
+
+  /**
+   * The handle every query in this service must use (G4/G5 conversion). Inside
+   * a scope — a request transaction or a worker scope opened by
+   * {@link workDb} — this is that scope's tenant transaction; otherwise it is
+   * the ambient pool, byte-identical to the pre-conversion behavior.
+   */
+  private get db(): Database {
+    return scopedHandle(this.pool);
+  }
+
+  /**
+   * Run one discrete DB block in the right world (G5, ADR-0008). The lifecycle
+   * both writes the database AND publishes events, so its worker callers
+   * cannot wrap whole method calls in a scope — a worker transaction held
+   * across a publish would make the event a pre-commit side effect. Instead
+   * they THREAD the trusted tenant (from the consumed envelope or a loaded
+   * resource's persisted ownership, never a payload claim) via the optional
+   * `tenantId` on each input, and each DB block scopes itself; publishes stay
+   * between blocks and stamp the same tenant explicitly.
+   */
+  private workDb<T>(trustedTenantId: string | null | undefined, fn: () => Promise<T>): Promise<T> {
+    return runTenantWorkDb(this.pool, trustedTenantId, fn);
+  }
+
+  /**
+   * Repo bound to one work item's trusted tenant: each repo call is its own
+   * short scoped transaction; a legacy work item (no tenant) gets the exact
+   * pre-G5 ambient behavior.
+   */
+  private repoFor(trustedTenantId: string | null | undefined): FollowUpLifecycleRepo {
+    return {
+      upsertArmed: async (input) => this.workDb(trustedTenantId, () => this.upsertArmed(input)),
       disarmActive: async (input) =>
-        this.disarmActive(input.chatId, input.instanceId, input.reason, input.at, input.lastInboundCustomerMessageAt),
+        this.workDb(trustedTenantId, () =>
+          this.disarmActive(input.chatId, input.instanceId, input.reason, input.at, input.lastInboundCustomerMessageAt),
+        ),
     };
   }
 
@@ -123,16 +156,22 @@ export class FollowUpLifecycleService {
     chatId: string,
     instanceId: string,
     agentId: string | null,
+    trustedTenantId?: string | null,
   ): Promise<FollowUpSequenceConfig | null> {
-    const [chat] = await this.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
-    const [instance] = await this.db.select().from(instances).where(eq(instances.id, instanceId)).limit(1);
-    const agent = agentId ? (await this.db.select().from(agents).where(eq(agents.id, agentId)).limit(1))[0] : undefined;
-
-    const inputs: FollowUpConfigInputs = {
-      chat: readChatFollowUpConfig(chat),
-      instance: readInstanceFollowUpConfig(instance),
-      agent: readAgentFollowUpConfig(agent),
-    };
+    // One short scope for the three config reads — no publish happens between
+    // them, so a single transaction per resolution is the tight fit.
+    const inputs = await this.workDb(trustedTenantId, async (): Promise<FollowUpConfigInputs> => {
+      const [chat] = await this.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
+      const [instance] = await this.db.select().from(instances).where(eq(instances.id, instanceId)).limit(1);
+      const agent = agentId
+        ? (await this.db.select().from(agents).where(eq(agents.id, agentId)).limit(1))[0]
+        : undefined;
+      return {
+        chat: readChatFollowUpConfig(chat),
+        instance: readInstanceFollowUpConfig(instance),
+        agent: readAgentFollowUpConfig(agent),
+      };
+    });
 
     return resolveFollowUpConfig(inputs);
   }
@@ -142,11 +181,13 @@ export class FollowUpLifecycleService {
    */
   async armForOutbound(input: Omit<ArmSequenceInput, 'config'> & { config?: FollowUpSequenceConfig }): Promise<void> {
     if (!this.eventBus) return;
+    const tenantId = input.tenantId ?? null;
 
     // Close-contact guard — see `isInActiveCloseState` for the rationale.
-    if (await this.isInActiveCloseState(input.chatId, input.instanceId)) return;
+    if (await this.workDb(tenantId, () => this.isInActiveCloseState(input.chatId, input.instanceId))) return;
 
-    const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId ?? null));
+    const config =
+      input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId ?? null, tenantId));
     if (!config || config.enabled === false) return;
 
     // Refuse to arm when the triggering message is already older than the
@@ -170,17 +211,18 @@ export class FollowUpLifecycleService {
       }
     }
 
-    if (await this.shouldRefuseForTerminalDisarm(input)) return;
+    if (await this.workDb(tenantId, () => this.shouldRefuseForTerminalDisarm(input))) return;
 
     try {
       await armSequence(
-        { repo: this.repo, eventBus: this.eventBus, logger: this.logger },
+        { repo: this.repoFor(tenantId), eventBus: this.eventBus, logger: this.logger },
         {
           chatId: input.chatId,
           instanceId: input.instanceId,
           agentId: input.agentId ?? null,
           config,
           lastAgentMessageAt: input.lastAgentMessageAt,
+          tenantId,
         },
       );
     } catch (err) {
@@ -224,32 +266,38 @@ export class FollowUpLifecycleService {
     agentId: string | null;
     config?: FollowUpSequenceConfig;
     lastInboundCustomerMessageAt: Date;
+    /** Trusted tenant of the work item (G5) — see {@link workDb}. */
+    tenantId?: string | null;
   }): Promise<void> {
     if (!this.eventBus) return;
+    const tenantId = input.tenantId ?? null;
 
-    if (await this.isInActiveCloseState(input.chatId, input.instanceId)) return;
+    if (await this.workDb(tenantId, () => this.isInActiveCloseState(input.chatId, input.instanceId))) return;
 
-    const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId));
+    const config = input.config ?? (await this.resolveConfig(input.chatId, input.instanceId, input.agentId, tenantId));
     if (!config || config.enabled === false) return;
 
     if (
-      await this.shouldRefuseForTerminalDisarm({
-        chatId: input.chatId,
-        instanceId: input.instanceId,
-        lastAgentMessageAt: input.lastInboundCustomerMessageAt,
-      })
+      await this.workDb(tenantId, () =>
+        this.shouldRefuseForTerminalDisarm({
+          chatId: input.chatId,
+          instanceId: input.instanceId,
+          lastAgentMessageAt: input.lastInboundCustomerMessageAt,
+        }),
+      )
     ) {
       return;
     }
 
     try {
       await armSequence(
-        { repo: this.repo, eventBus: this.eventBus, logger: this.logger },
+        { repo: this.repoFor(tenantId), eventBus: this.eventBus, logger: this.logger },
         {
           chatId: input.chatId,
           instanceId: input.instanceId,
           agentId: input.agentId,
           config,
+          tenantId,
           // Anchor the schedule on the inbound timestamp. The persisted
           // `lastAgentMessageAt` will reflect this; that's intentional —
           // `nextFireAt = inbound + intervalsMinutes[0]` is what matters
@@ -280,12 +328,20 @@ export class FollowUpLifecycleService {
    * No-op when no row exists yet — the first outbound agent message will
    * create one.
    */
-  async touchInboundTimestamp(input: { chatId: string; instanceId: string; at: Date }): Promise<void> {
+  async touchInboundTimestamp(input: {
+    chatId: string;
+    instanceId: string;
+    at: Date;
+    /** Trusted tenant of the work item (G5) — see {@link workDb}. */
+    tenantId?: string | null;
+  }): Promise<void> {
     try {
-      await this.db
-        .update(chatFollowUpState)
-        .set({ lastInboundCustomerMessageAt: input.at, updatedAt: input.at })
-        .where(and(eq(chatFollowUpState.chatId, input.chatId), eq(chatFollowUpState.instanceId, input.instanceId)));
+      await this.workDb(input.tenantId, async () => {
+        await this.db
+          .update(chatFollowUpState)
+          .set({ lastInboundCustomerMessageAt: input.at, updatedAt: input.at })
+          .where(and(eq(chatFollowUpState.chatId, input.chatId), eq(chatFollowUpState.instanceId, input.instanceId)));
+      });
     } catch (err) {
       this.logger.warn('follow-up lifecycle: touchInboundTimestamp failed', {
         chatId: input.chatId,
@@ -303,7 +359,10 @@ export class FollowUpLifecycleService {
     if (!this.eventBus) return;
 
     try {
-      await disarmSequence({ repo: this.repo, eventBus: this.eventBus, logger: this.logger }, input);
+      // `input.tenantId` is the caller-threaded TRUSTED tenant (envelope or
+      // persisted ownership) — `repoFor` scopes the write, `disarmSequence`
+      // stamps the `follow_up.disarmed` envelope with the same value.
+      await disarmSequence({ repo: this.repoFor(input.tenantId), eventBus: this.eventBus, logger: this.logger }, input);
     } catch (err) {
       this.logger.error('follow-up lifecycle: disarm failed', {
         chatId: input.chatId,
@@ -485,11 +544,12 @@ export class FollowUpLifecycleService {
     chatId: string,
     instanceId: string,
     eventSequenceIndex: number | null,
+    trustedTenantId?: string | null,
   ): Promise<{ skip: boolean; reason?: string }> {
-    if (await this.isInActiveCloseState(chatId, instanceId)) {
+    if (await this.workDb(trustedTenantId, () => this.isInActiveCloseState(chatId, instanceId))) {
       return { skip: true, reason: 'chat_closed' };
     }
-    const row = await this.readExistingRow(chatId, instanceId);
+    const row = await this.workDb(trustedTenantId, () => this.readExistingRow(chatId, instanceId));
     if (row?.disarmReason) {
       return { skip: true, reason: `disarmed_${row.disarmReason}` };
     }

--- a/packages/api/src/services/follow-up-sweeper.ts
+++ b/packages/api/src/services/follow-up-sweeper.ts
@@ -17,6 +17,7 @@ import {
   type AdvanceInput,
   type ChannelType,
   type EventBus,
+  type FollowUpDisarmReason,
   type FollowUpSequenceConfig,
   type FollowUpStateRepo,
   type FollowUpStateRow,
@@ -27,9 +28,31 @@ import {
   sweepFollowUps,
 } from '@omni/core';
 import type { Database } from '@omni/db';
-import { chatFollowUpState, chats, instances } from '@omni/db';
-import { and, eq, gt, isNull, lt, lte, sql } from 'drizzle-orm';
+import { chatFollowUpState, chats, instances, resolveEnforcementMode } from '@omni/db';
+import { type SQL, and, eq, gt, isNull, lt, lte, sql } from 'drizzle-orm';
+import { isMultitenancyEnabled } from '../tenancy/feature-flag';
+import { enumerateActiveWorkTenants } from '../tenancy/periodic-tenant-work';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import type { FollowUpLifecycleService } from './follow-up-lifecycle';
+
+/**
+ * The world one sweep pass runs in (G5, ADR-0008).
+ *
+ *   * `all`         — flag-off: the single pre-G5 pass, byte-identical (no
+ *                     tenant column selected, no extra predicate, ambient pool).
+ *   * `tenant`      — one enumerated tenant: the claim carries an explicit
+ *                     `tenant_id = $tenant` predicate (defense in depth before
+ *                     enforcement installs RLS; redundant after) and every DB
+ *                     block runs in its own short worker tenant scope.
+ *   * `legacy-rows` — flag-on transitional: rows whose `tenant_id` is still
+ *                     NULL (pre-G6-backfill) sweep ambient exactly as before,
+ *                     so enabling the flag never silently abandons them. This
+ *                     pass is skipped under enforcement, where the mixed state
+ *                     cannot exist (enforcement requires zero unresolved
+ *                     ownership) and an ambient claim would fail closed.
+ */
+type SweepWorld = { kind: 'all' } | { kind: 'tenant'; tenantId: string } | { kind: 'legacy-rows' };
 
 const log = createLogger('follow-up-sweeper');
 
@@ -69,31 +92,81 @@ export interface SweepStats {
 }
 
 export class FollowUpSweeperService {
-  private readonly repo: FollowUpStateRepo;
   private readonly messagingWindowProbe: MessagingWindowProbe;
   private lifecycle: FollowUpLifecycleService | null = null;
+  private authPlaneDb: Database | null = null;
+  private warnedMissingAuthPlane = false;
 
   constructor(
-    private db: Database,
+    private pool: Database,
     private eventBus: EventBus | null,
     private logger: Logger = log,
   ) {
-    this.repo = {
-      findAndLockDue: async (now, limit) => this.findAndLockDue(now, limit),
-      recordFired: async (input) => this.recordFired(input),
-      recordDisarmed: async (id, reason, at) => {
-        await this.db
-          .update(chatFollowUpState)
-          .set({
-            disarmReason: reason,
-            disarmedAt: at,
-            nextFireAt: null,
-            updatedAt: at,
-          })
-          .where(eq(chatFollowUpState.id, id));
-      },
-    };
     this.messagingWindowProbe = createMessagingWindowProbe();
+  }
+
+  /**
+   * The handle every query in this service must use (G5 conversion). Inside a
+   * worker tenant scope opened by a `tenant`-world block this is that scope's
+   * transaction; otherwise it is the ambient pool, byte-identical to the
+   * pre-conversion behavior.
+   */
+  private get db(): Database {
+    return scopedHandle(this.pool);
+  }
+
+  /**
+   * Inject the auth-plane read connection after construction (mirrors
+   * `setLifecycle` — wired by `services/index.ts`). Required only for the
+   * multitenancy fan-out: it is the one runtime-process identity that may
+   * enumerate `tenants` under enforcement. Constructions that never enable the
+   * flag (legacy deployments, existing tests) can omit it.
+   */
+  setAuthPlane(authPlaneDb: Database): void {
+    this.authPlaneDb = authPlaneDb;
+  }
+
+  /**
+   * Repo bound to one sweep world. In a `tenant` world every repo call runs in
+   * its OWN short worker tenant scope — never one transaction across the whole
+   * pass, because `sweepFollowUps` publishes events between repo calls and a
+   * scope held across a publish would make the event a pre-commit side effect
+   * (and would hold the claim's row locks across the entire pass). The other
+   * worlds run ambient, exactly as the pre-G5 repo did.
+   */
+  private repoFor(world: SweepWorld): FollowUpStateRepo {
+    const tenantId = world.kind === 'tenant' ? world.tenantId : null;
+    return {
+      findAndLockDue: async (now, limit) =>
+        runTenantWorkDb(this.pool, tenantId, () => this.findAndLockDue(now, limit, world)),
+      recordFired: async (input) => runTenantWorkDb(this.pool, tenantId, () => this.recordFired(input)),
+      recordDisarmed: async (id, reason, at) =>
+        runTenantWorkDb(this.pool, tenantId, () => this.recordDisarmed(id, reason, at)),
+    };
+  }
+
+  /**
+   * Narrow a claim to one world's rows (G5): a `tenant` pass claims only that
+   * tenant's rows, the transitional `legacy-rows` pass only NULL-tenant rows,
+   * and the flag-off `all` pass adds nothing (byte-identical). Shared by both
+   * claim queries so the predicate logic lives in one place.
+   */
+  private worldRowPredicate(world: SweepWorld): SQL[] {
+    if (world.kind === 'tenant') return [eq(chatFollowUpState.tenantId, world.tenantId)];
+    if (world.kind === 'legacy-rows') return [isNull(chatFollowUpState.tenantId)];
+    return [];
+  }
+
+  private async recordDisarmed(id: string, reason: FollowUpDisarmReason, at: Date): Promise<void> {
+    await this.db
+      .update(chatFollowUpState)
+      .set({
+        disarmReason: reason,
+        disarmedAt: at,
+        nextFireAt: null,
+        updatedAt: at,
+      })
+      .where(eq(chatFollowUpState.id, id));
   }
 
   /**
@@ -120,14 +193,61 @@ export class FollowUpSweeperService {
     if (!this.eventBus) {
       return { scanned: 0, fired: 0, disarmed: 0, skipped: 0, rearmed: 0 };
     }
+
+    // Flag-off: the single pre-G5 pass, byte-identical — no enumeration, no
+    // tenant predicate, no new query of any kind.
+    if (!isMultitenancyEnabled()) {
+      return this.sweepWorld({ kind: 'all' });
+    }
+
+    // Flag-on: one pass per active tenant (each DB block in its own short
+    // worker scope; fired envelopes stamped with the row's tenant), then the
+    // transitional NULL-tenant pass outside enforcement. A suspended/archived
+    // tenant drops out of the enumeration, so its periodic work stops at the
+    // next tick — dequeue-time revalidation at cron cadence.
+    const totals: SweepStats = { scanned: 0, fired: 0, disarmed: 0, skipped: 0, rearmed: 0 };
+    if (this.authPlaneDb) {
+      const tenantIds = await enumerateActiveWorkTenants(this.authPlaneDb);
+      for (const tenantId of tenantIds) {
+        try {
+          this.accumulate(totals, await this.sweepWorld({ kind: 'tenant', tenantId }));
+        } catch (err) {
+          // One tenant's failure must not starve a sibling's sweep.
+          this.logger.warn('follow-up sweeper: tenant pass failed', {
+            tenantId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } else if (!this.warnedMissingAuthPlane) {
+      this.warnedMissingAuthPlane = true;
+      this.logger.warn(
+        'follow-up sweeper: multitenancy is enabled but no auth-plane connection was injected — tenant rows will not be swept',
+      );
+    }
+    if (resolveEnforcementMode(process.env) !== 'enforced') {
+      this.accumulate(totals, await this.sweepWorld({ kind: 'legacy-rows' }));
+    }
+    return totals;
+  }
+
+  private accumulate(totals: SweepStats, pass: SweepStats): void {
+    for (const key of ['scanned', 'fired', 'disarmed', 'skipped', 'rearmed'] as const) {
+      totals[key] = (totals[key] ?? 0) + (pass[key] ?? 0);
+    }
+  }
+
+  /** One sweep pass (re-arm + fire-due) in one world. */
+  private async sweepWorld(world: SweepWorld): Promise<SweepStats> {
     // Pass 1 — re-arm stale customer_replied pauses (#624).
     // Runs before the fire-due pass so any row that newly transitions back
     // to armed is eligible immediately on the next tick.
-    const rearmed = await this.sweepStaleCustomerReplied();
+    const rearmed = await this.sweepStaleCustomerReplied(world);
     // Pass 2 — original fire-due sweep.
     const fireStats = await sweepFollowUps({
-      repo: this.repo,
-      eventBus: this.eventBus,
+      repo: this.repoFor(world),
+      // biome-ignore lint/style/noNonNullAssertion: sweep() returns early when the bus is null
+      eventBus: this.eventBus!,
       logger: this.logger,
       messagingWindowProbe: this.messagingWindowProbe,
     });
@@ -153,9 +273,10 @@ export class FollowUpSweeperService {
    * `follow_up.armed`. Rows whose first interval is larger than the actual
    * inbound age are skipped (will be picked up next tick).
    */
-  private async sweepStaleCustomerReplied(): Promise<number> {
+  private async sweepStaleCustomerReplied(world: SweepWorld): Promise<number> {
     if (!this.lifecycle) return 0;
 
+    const trustedTenantId = world.kind === 'tenant' ? world.tenantId : null;
     const now = new Date();
     const minBoundary = new Date(now.getTime() - STALE_PAUSE_MAX_AGE_MS);
     const maxBoundary = new Date(now.getTime() - STALE_PAUSE_MIN_AGE_MS);
@@ -173,35 +294,44 @@ export class FollowUpSweeperService {
     //     work units from the same table; both should use the same
     //     concurrency primitive so a future maintainer doesn't have to
     //     reason about two different locking models.
-    const candidates = await this.db.transaction(async (tx) => {
-      return (
-        tx
-          .select({
-            chatId: chatFollowUpState.chatId,
-            instanceId: chatFollowUpState.instanceId,
-            agentId: chatFollowUpState.agentId,
-            sequenceConfig: chatFollowUpState.sequenceConfig,
-            lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
-          })
-          .from(chatFollowUpState)
-          .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
-          .where(
-            and(
-              eq(chatFollowUpState.disarmReason, 'customer_replied'),
-              gt(chatFollowUpState.lastInboundCustomerMessageAt, minBoundary),
-              lt(chatFollowUpState.lastInboundCustomerMessageAt, maxBoundary),
-              // Same null-safe agentPaused gate as `findAndLockDue` —
-              // preserves the #528 race fix for the re-arm path.
-              sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
-            ),
-          )
-          .orderBy(chatFollowUpState.lastInboundCustomerMessageAt)
-          .limit(STALE_PAUSE_MAX_PER_TICK)
-          // Lock only the state row, not the joined chat row — `FOR UPDATE`
-          // can't be applied to the nullable side of an outer join.
-          .for('update', { of: chatFollowUpState, skipLocked: true })
-      );
-    });
+    // The claim is one discrete DB block: in a tenant world it runs inside its
+    // own short worker scope (and carries the explicit tenant predicate); in
+    // the other worlds `runTenantWorkDb` is a pass-through and the transaction
+    // runs ambient exactly as before. `worldRowPredicate` narrows the claim to
+    // the world's rows — see {@link SweepWorld}.
+    const worldPredicate = this.worldRowPredicate(world);
+    const candidates = await runTenantWorkDb(this.pool, trustedTenantId, () =>
+      this.db.transaction(async (tx) => {
+        return (
+          tx
+            .select({
+              chatId: chatFollowUpState.chatId,
+              instanceId: chatFollowUpState.instanceId,
+              agentId: chatFollowUpState.agentId,
+              sequenceConfig: chatFollowUpState.sequenceConfig,
+              lastInboundCustomerMessageAt: chatFollowUpState.lastInboundCustomerMessageAt,
+            })
+            .from(chatFollowUpState)
+            .leftJoin(chats, eq(chatFollowUpState.chatId, chats.id))
+            .where(
+              and(
+                eq(chatFollowUpState.disarmReason, 'customer_replied'),
+                gt(chatFollowUpState.lastInboundCustomerMessageAt, minBoundary),
+                lt(chatFollowUpState.lastInboundCustomerMessageAt, maxBoundary),
+                // Same null-safe agentPaused gate as `findAndLockDue` —
+                // preserves the #528 race fix for the re-arm path.
+                sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
+                ...worldPredicate,
+              ),
+            )
+            .orderBy(chatFollowUpState.lastInboundCustomerMessageAt)
+            .limit(STALE_PAUSE_MAX_PER_TICK)
+            // Lock only the state row, not the joined chat row — `FOR UPDATE`
+            // can't be applied to the nullable side of an outer join.
+            .for('update', { of: chatFollowUpState, skipLocked: true })
+        );
+      }),
+    );
 
     let rearmed = 0;
     for (const row of candidates) {
@@ -228,6 +358,10 @@ export class FollowUpSweeperService {
           agentId: row.agentId,
           config,
           lastInboundCustomerMessageAt: row.lastInboundCustomerMessageAt,
+          // Thread the pass's trusted tenant (G5): the lifecycle scopes its
+          // own DB blocks from it and stamps the `follow_up.armed` envelope.
+          // Legacy worlds thread nothing and stay byte-identical.
+          tenantId: trustedTenantId,
         });
         rearmed += 1;
       } catch (err) {
@@ -258,7 +392,7 @@ export class FollowUpSweeperService {
    * the row either has a future `nextFireAt` (next sweep sees it then) or a
    * non-null `disarmReason` (next sweep skips it).
    */
-  private async findAndLockDue(now: Date, limit: number): Promise<FollowUpStateRow[]> {
+  private async findAndLockDue(now: Date, limit: number, world: SweepWorld): Promise<FollowUpStateRow[]> {
     // Select with FOR UPDATE SKIP LOCKED to claim rows atomically.
     // We immediately bump `updatedAt` inside the same transaction so that
     // any concurrent sweeper waiting on a row lock will observe the change
@@ -266,6 +400,13 @@ export class FollowUpSweeperService {
     //
     // The join on `instances` pulls the channel type into the row so the
     // 24h messaging-window probe can fire without a second query.
+    //
+    // World predicate (G5): a `tenant` pass claims only that tenant's rows and
+    // stamps them with its trusted tenant; the transitional `legacy-rows` pass
+    // claims only NULL-tenant rows; the flag-off `all` pass adds nothing and
+    // stays byte-identical. The caller (`repoFor`) supplies the worker scope
+    // for the `tenant` world — this method only shapes the query.
+    const worldPredicate = this.worldRowPredicate(world);
     const rows = await this.db.transaction(async (tx) => {
       const claimed = await tx
         .select({
@@ -298,6 +439,7 @@ export class FollowUpSweeperService {
             // and avoids a runtime cast error if a non-boolean value ever
             // lands in `settings.agentPaused`.
             sql`(${chats.settings}->>'agentPaused') IS DISTINCT FROM 'true'`,
+            ...worldPredicate,
           ),
         )
         .orderBy(chatFollowUpState.nextFireAt)
@@ -320,6 +462,11 @@ export class FollowUpSweeperService {
         lastAgentMessageAt: r.lastAgentMessageAt,
         lastInboundCustomerMessageAt: r.lastInboundCustomerMessageAt ?? null,
         channelType: (r.channelType ?? null) as ChannelType | null,
+        // A tenant pass stamps its rows with the pass tenant — the SAME value
+        // the claim's predicate matched, i.e. the row's persisted ownership —
+        // so every event this row fires carries a versioned tenant envelope.
+        // The `all` and `legacy-rows` worlds stamp nothing (legacy envelope).
+        ...(world.kind === 'tenant' ? { tenantId: world.tenantId } : {}),
       }),
     );
   }

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -22,6 +22,7 @@ import { OpenAiSttProvider } from '../providers/openai/stt';
 import { OpenAiTtsProvider } from '../providers/openai/tts';
 import { providerRegistry } from '../providers/registry';
 import { type AuthPlaneConnection, resolveAuthPlaneConnection } from '../tenancy/auth-plane-connection';
+import { isTenantWorkAdmissible } from '../tenancy/periodic-tenant-work';
 import { MembershipSelectionService, RequestAuthenticator } from '../tenancy/request-auth';
 import { AccessService } from './access';
 import { AgentRunnerService } from './agent-runner';
@@ -125,6 +126,16 @@ export interface Services {
    * payload is built from route-level state the service doesn't see.
    */
   eventBus: EventBus | null;
+  /**
+   * The runtime connection POOL these services were built on (G5, ADR-0008).
+   *
+   * Exposed for the periodic/cron surface: a cron has no request scope, so it
+   * must OPEN one per tenant (`tenancy/periodic-tenant-work.ts`), and opening a
+   * scope requires the same pool the services read through — `authPlane.db` is
+   * NOT interchangeable, since under enforcement it is a different role's pool.
+   * Request-path code must keep using the services, never this handle.
+   */
+  db: Database;
 }
 
 /**
@@ -188,6 +199,14 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
   const batchJobs = new BatchJobService(db, eventBus, settings);
   batchJobs.setAuthPlane(authPlane.db);
 
+  // G5 deliverable (c): a tenant-context presign is REFUSED once the tenant is
+  // revoked (RELEASE_SLOS `presigned_url_issue_or_refresh_after_revocation_max:
+  // 0`). The clamped TTL bounds one URL's life; this bounds how many a revoked
+  // tenant can mint, which is zero. Same auth-plane `tenants.status` read the
+  // dequeue gates use. Without this wiring a tenant presign fails closed.
+  const mediaStorage = new MediaStorageService(db);
+  mediaStorage.setTenantAdmissibilityCheck((tenantId) => isTenantWorkAdmissible(authPlane.db, tenantId));
+
   return {
     agents: new AgentService(db, eventBus),
     agentState: new AgentStateService(eventBus),
@@ -224,8 +243,9 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
     authPlane,
     tenantControlPlane: new TenantControlPlaneService(db),
     tenantKeys: new TenantKeyService(db),
-    mediaStorage: new MediaStorageService(db),
+    mediaStorage,
     eventBus,
+    db,
   };
 }
 

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -174,6 +174,19 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
   const followUpLifecycle = new FollowUpLifecycleService(db, eventBus);
   const followUpSweeper = new FollowUpSweeperService(db, eventBus);
   followUpSweeper.setLifecycle(followUpLifecycle);
+  // G5: the sweeper's multitenancy fan-out enumerates active tenants on the
+  // auth-plane read connection — the one runtime-process identity that may
+  // read `tenants` under enforcement (periodic-tenant-work.ts).
+  followUpSweeper.setAuthPlane(authPlane.db);
+
+  // G5: the detached executors (batch-job media retrofill, event replay)
+  // revalidate their work item's tenant at dequeue on the auth-plane read
+  // connection — the one runtime-process identity that may read `tenants` under
+  // enforcement (periodic-tenant-work.ts `isTenantWorkAdmissible`).
+  const eventOps = new EventOpsService(db, eventBus, deadLetters, payloadStore);
+  eventOps.setAuthPlane(authPlane.db);
+  const batchJobs = new BatchJobService(db, eventBus, settings);
+  batchJobs.setAuthPlane(authPlane.db);
 
   return {
     agents: new AgentService(db, eventBus),
@@ -192,13 +205,13 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
     routeResolver,
     deadLetters,
     payloadStore,
-    eventOps: new EventOpsService(db, eventBus, deadLetters, payloadStore),
+    eventOps,
     webhooks: new WebhookService(db, eventBus),
     automations: new AutomationService(db, eventBus),
     chats: new ChatService(db, eventBus),
     messages: new MessageService(db, eventBus),
     syncJobs: new SyncJobService(db, eventBus),
-    batchJobs: new BatchJobService(db, eventBus, settings),
+    batchJobs,
     agentRunner: new AgentRunnerService(db),
     tts,
     turns: new TurnService(db),

--- a/packages/api/src/services/instances.ts
+++ b/packages/api/src/services/instances.ts
@@ -1,5 +1,42 @@
 /**
  * Instance service - manages channel instance configurations
+ *
+ * TENANT-BOUND SEALING OF CHANNEL CREDENTIALS (G5 deliverable (g); ADR-0008)
+ * --------------------------------------------------------------------------
+ * An instance row carries the bot tokens and signing secrets for its channel —
+ * ADR-0008's "channel/provider/webhook credentials", which must be "encrypted
+ * with tenant-bound context" and whose "plaintext never appears in API
+ * responses, logs, caches, migration receipts, or object metadata".
+ * `SEALED_CREDENTIAL_COLUMNS` is that set, and every read/write path in this
+ * service passes through `openInstanceCredentials` / `sealInstanceCredentials`.
+ *
+ * The tenant binding needs no resolver seam here: `instances` IS the G2
+ * ownership root, so a row's own persisted `tenant_id` is the trusted answer —
+ * and it is the answer on BOTH sides. A write seals under the tenant the
+ * PERSISTED ROW will present back on read, never merely under the active scope.
+ *
+ * WHY THAT SYMMETRY IS THE WHOLE CONTRACT. Reads open with `row.tenant_id`; a
+ * write that sealed under the active scope while the row landed with
+ * `tenant_id` NULL would produce an envelope nothing can ever open —
+ * `openCredentialField(null, sealed)` fails closed to `null`, so a rotation
+ * would silently and permanently destroy a live bot token. Nothing stamps this
+ * root's `tenant_id` today (`NewInstance` omits it, the root has no derivation
+ * trigger and no column default, and the trusted ownership writer has no
+ * production caller), so every row production writes is still NULL-tenant and
+ * the sealing arm of (g) is INERT on this surface until root-ownership
+ * assignment lands. That is a ROLLOUT ORDERING CONSTRAINT, and it is enforced
+ * here rather than merely documented: master-key custody may precede ownership
+ * without any credential being lost, because a write only seals once the row
+ * actually carries the tenant it is sealed for. The active scope still bounds
+ * it — a write from a scope that does not own the row seals nothing.
+ *
+ * DUAL WORLD. Sealing engages only when BOTH a tenant is present AND a master
+ * key is configured (`setTenantSecretMasterKey`). Flag-off there is no tenant;
+ * with no key the codec is the identity function. In either case the column
+ * holds the same bytes it held before G5 and callers see the same plaintext —
+ * the deliverable is INERT until a deployment opts in. Reads are transitional:
+ * legacy plaintext rows and sealed rows coexist, each handled on its own shape,
+ * because G5 ships no credential backfill.
  */
 
 import type { EventBus } from '@omni/core';
@@ -8,13 +45,90 @@ import type { Database } from '@omni/db';
 import { type ChannelType, type Instance, type NewInstance, instances } from '@omni/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { forgetInstanceOwner, rememberInstanceOwners } from '../tenancy/instance-owner-registry';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import { credentialSealingEngages, openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
+import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 
 export interface ListInstancesOptions {
   channel?: ChannelType[];
   status?: ('active' | 'inactive')[];
   limit?: number;
   cursor?: string;
+}
+
+/**
+ * The `instances` columns that hold channel credential material.
+ *
+ * Deliberately an explicit allow-list rather than a heuristic on the column
+ * name: a heuristic that silently stopped matching (a renamed column, a new
+ * channel) would fail OPEN, writing a live bot token as plaintext with nothing
+ * to notice it. Adding a channel means adding its secret column here, and the
+ * per-column probe in `sealed-credential-surfaces.test.ts` asserts the whole
+ * list is honoured rather than only the first entry.
+ *
+ * `twilioAccountSid`, `twilioFrom`, the messaging-service SID and the callback
+ * URLs are identifiers, not secrets, and stay in the clear so operators can
+ * still read them out of the database.
+ */
+const SEALED_CREDENTIAL_COLUMNS = [
+  'discordBotToken',
+  'slackBotToken',
+  'slackAppToken',
+  'slackSigningSecret',
+  'telegramBotToken',
+  'gupshupAuthToken',
+  'webhookVerifyToken',
+  'twilioAuthToken',
+] as const satisfies readonly (keyof Instance)[];
+
+/**
+ * Seal the credential columns present in `data` for `tenantId`.
+ *
+ * Only keys the caller actually supplied are touched, so a partial update that
+ * does not mention a token cannot blank or re-seal it. Returns a NEW object;
+ * the caller's input is never mutated.
+ */
+function sealInstanceCredentials<T extends Record<string, unknown>>(tenantId: string | null, data: T): T {
+  const out: Record<string, unknown> = { ...data };
+  for (const column of SEALED_CREDENTIAL_COLUMNS) {
+    if (!(column in out)) continue;
+    const value = out[column];
+    if (typeof value !== 'string') continue;
+    out[column] = sealCredentialField(tenantId, value);
+  }
+  return out as T;
+}
+
+/** Does `data` actually carry a credential column a seal could reshape? */
+function hasSealableCredential(data: Record<string, unknown>): boolean {
+  return SEALED_CREDENTIAL_COLUMNS.some((column) => {
+    const value = data[column];
+    return typeof value === 'string' && value !== '';
+  });
+}
+
+/**
+ * Open the credential columns of a loaded row, using the row's OWN persisted
+ * tenant. A row that cannot be opened (sealed under a different tenant, or no
+ * key configured) yields `null` for that column — fail-closed, never the
+ * ciphertext envelope. See `sealed-credentials.ts` for why null and not a throw.
+ */
+function openInstanceCredentials<T extends { tenantId?: string | null }>(row: T): T {
+  const tenantId = row.tenantId ?? null;
+  let copy: Record<string, unknown> | null = null;
+  for (const column of SEALED_CREDENTIAL_COLUMNS) {
+    const stored = (row as Record<string, unknown>)[column];
+    if (typeof stored !== 'string') continue;
+    const opened = openCredentialField(tenantId, stored);
+    if (opened === stored) continue;
+    if (!copy) copy = { ...row };
+    copy[column] = opened;
+  }
+  return (copy ?? row) as T;
+}
+
+/** Open a batch of loaded rows. Identity when nothing in the batch is sealed. */
+function openInstanceCredentialsAll<T extends { tenantId?: string | null }>(rows: T[]): T[] {
+  return rows.map(openInstanceCredentials);
 }
 
 export class InstanceService {
@@ -90,7 +204,10 @@ export class InstanceService {
 
     const lastItem = items[items.length - 1];
     return {
-      items,
+      // Ownership is taught from the RAW rows above (the registry reads
+      // `tenant_id`, which sealing never touches); only what leaves this method
+      // is opened.
+      items: openInstanceCredentialsAll(items),
       hasMore,
       cursor: lastItem?.id,
     };
@@ -102,7 +219,7 @@ export class InstanceService {
   async listActive(): Promise<Instance[]> {
     const rows = await this.db.select().from(instances).where(eq(instances.isActive, true));
     rememberInstanceOwners(rows);
-    return rows;
+    return openInstanceCredentialsAll(rows);
   }
 
   /**
@@ -116,7 +233,7 @@ export class InstanceService {
     }
 
     rememberInstanceOwners([result]);
-    return result;
+    return openInstanceCredentials(result);
   }
 
   /**
@@ -129,14 +246,71 @@ export class InstanceService {
       throw new NotFoundError('Instance', name);
     }
 
-    return result;
+    return openInstanceCredentials(result);
+  }
+
+  /**
+   * The tenant a WRITE from this service seals under, given the tenant the
+   * PERSISTED ROW carries (or will carry).
+   *
+   * Two trusted facts must agree, and sealing happens only when they do:
+   *
+   *   * the ACTIVE tenant scope — what the G3/G4 boundary resolved from the
+   *     caller's credential. Null on every legacy/worker/CLI path;
+   *   * the ROW's own `tenant_id` — the ownership root's persisted answer, and
+   *     the only thing `openInstanceCredentials` will have on the read side.
+   *
+   * Disagreement (including the additive phase, where the row is NULL-tenant)
+   * returns null, which makes `sealCredentialField` the identity function: the
+   * column keeps the exact bytes it kept before G5. That is strictly safer than
+   * sealing — a value sealed under a tenant the row does not carry is
+   * unopenable FOREVER, while plaintext is exactly the pre-G5 posture. A caller
+   * still cannot choose the key: `NewInstance` omits `tenantId`, and a row
+   * tenant that does not equal the active scope seals nothing at all.
+   */
+  private sealTenantFor(rowTenantId: string | null | undefined): string | null {
+    const scope = currentTenantScope()?.tenantId ?? null;
+    if (!scope) return null;
+    return (rowTenantId ?? null) === scope ? scope : null;
+  }
+
+  /**
+   * The seal tenant for an UPDATE: the persisted row's own tenant, cross-checked
+   * against the active scope.
+   *
+   * The lookup is skipped whenever it could not change the outcome — no scope,
+   * no credential column in the patch, or no master key configured — so the
+   * legacy/inert world issues exactly the statements it issued before G5, not
+   * one more. It runs on `this.db`, i.e. inside the caller's tenant transaction
+   * when there is one.
+   */
+  private async updateSealTenant(id: string, data: Partial<NewInstance>): Promise<string | null> {
+    const scope = currentTenantScope()?.tenantId ?? null;
+    if (!credentialSealingEngages(scope)) return null;
+    if (!hasSealableCredential(data as Record<string, unknown>)) return null;
+
+    const [row] = await this.db
+      .select({ tenantId: instances.tenantId })
+      .from(instances)
+      .where(eq(instances.id, id))
+      .limit(1);
+
+    return this.sealTenantFor(row?.tenantId ?? null);
   }
 
   /**
    * Create a new instance
    */
   async create(data: NewInstance): Promise<Instance> {
-    const [created] = await this.db.insert(instances).values(data).returning();
+    // The row's tenant is whatever the insert persists. `NewInstance` omits
+    // `tenantId`, so in production that is NULL and nothing seals; the cast
+    // mirrors the ownership-carrying shape the G3 root writer produces.
+    const rowTenant = (data as { tenantId?: string | null }).tenantId ?? null;
+
+    const [created] = await this.db
+      .insert(instances)
+      .values(sealInstanceCredentials(this.sealTenantFor(rowTenant), data))
+      .returning();
 
     if (!created) {
       throw new Error('Failed to create instance');
@@ -158,16 +332,17 @@ export class InstanceService {
       });
     }
 
-    return created;
+    return openInstanceCredentials(created);
   }
 
   /**
    * Update an instance
    */
   async update(id: string, data: Partial<NewInstance>): Promise<Instance> {
+    const sealTenant = await this.updateSealTenant(id, data);
     const [updated] = await this.db
       .update(instances)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...sealInstanceCredentials(sealTenant, data), updatedAt: new Date() })
       .where(eq(instances.id, id))
       .returning();
 
@@ -176,7 +351,7 @@ export class InstanceService {
     }
 
     rememberInstanceOwners([updated]);
-    return updated;
+    return openInstanceCredentials(updated);
   }
 
   /**

--- a/packages/api/src/services/instances.ts
+++ b/packages/api/src/services/instances.ts
@@ -7,6 +7,7 @@ import { NotFoundError } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type ChannelType, type Instance, type NewInstance, instances } from '@omni/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
+import { forgetInstanceOwner, rememberInstanceOwners } from '../tenancy/instance-owner-registry';
 import { scopedHandle } from '../tenancy/tenant-scope';
 
 export interface ListInstancesOptions {
@@ -79,6 +80,14 @@ export class InstanceService {
       items.pop();
     }
 
+    // G5 (ADR-0008): every `instances` row this service loads teaches the
+    // ownership registry, so a channel plugin's later scope-less publish for
+    // that instance can stamp a TRUSTED tenant instead of falling back to a
+    // legacy envelope. The tenant comes from the persisted row, never a caller
+    // claim; a NULL tenant (flag-off) teaches nothing. See
+    // `tenancy/instance-owner-registry.ts`.
+    rememberInstanceOwners(items);
+
     const lastItem = items[items.length - 1];
     return {
       items,
@@ -91,7 +100,9 @@ export class InstanceService {
    * List all active instances
    */
   async listActive(): Promise<Instance[]> {
-    return this.db.select().from(instances).where(eq(instances.isActive, true));
+    const rows = await this.db.select().from(instances).where(eq(instances.isActive, true));
+    rememberInstanceOwners(rows);
+    return rows;
   }
 
   /**
@@ -104,6 +115,7 @@ export class InstanceService {
       throw new NotFoundError('Instance', id);
     }
 
+    rememberInstanceOwners([result]);
     return result;
   }
 
@@ -129,6 +141,12 @@ export class InstanceService {
     if (!created) {
       throw new Error('Failed to create instance');
     }
+
+    // Teach the ownership registry BEFORE the publish below: this is the first
+    // moment the instance exists, and the `instance.connected` consumers
+    // (history-push tracker, event-listeners) derive their worker tenant from
+    // the envelope this publish stamps.
+    rememberInstanceOwners([created]);
 
     if (this.eventBus) {
       await this.eventBus.publish('instance.connected', {
@@ -157,6 +175,7 @@ export class InstanceService {
       throw new NotFoundError('Instance', id);
     }
 
+    rememberInstanceOwners([updated]);
     return updated;
   }
 
@@ -201,6 +220,10 @@ export class InstanceService {
     if (!result.length) {
       throw new NotFoundError('Instance', id);
     }
+
+    // The instance is gone; drop its ownership entry so the registry stays
+    // bounded by what actually exists.
+    forgetInstanceOwner(id);
 
     if (this.eventBus) {
       await this.eventBus.publish('instance.disconnected', {

--- a/packages/api/src/services/media-storage.ts
+++ b/packages/api/src/services/media-storage.ts
@@ -174,6 +174,25 @@ export class MediaStorageService {
     return scopedHandle(this.pool);
   }
 
+  /**
+   * The revocation gate a tenant-context presign must pass (G5 deliverable (c);
+   * RELEASE_SLOS `presigned_url_issue_or_refresh_after_revocation_max: 0`).
+   *
+   * Wired by `services/index.ts` to `isTenantWorkAdmissible` on the auth-plane
+   * read connection — the same trusted, non-caller-controlled `tenants.status`
+   * read the batch-job and replay executors use for their dequeue gates. Null
+   * until wired, which is why a tenant-context presign fails CLOSED without it.
+   */
+  private tenantAdmissible: ((tenantId: string) => Promise<boolean>) | null = null;
+
+  /**
+   * Inject the revocation gate. Tests inject a synthetic epoch through this,
+   * which is what lets the ceiling be proven without a wall clock.
+   */
+  setTenantAdmissibilityCheck(check: (tenantId: string) => Promise<boolean>): void {
+    this.tenantAdmissible = check;
+  }
+
   constructor(
     private readonly pool: Database,
     basePath?: string,
@@ -314,7 +333,11 @@ export class MediaStorageService {
     // Fetch the media (fetchOptions allows callers to supply auth headers, e.g.
     // Slack bot token). The fetch is SSRF-guarded: private/metadata targets are
     // rejected before connecting, on the initial URL and on every redirect hop.
-    const response = await fetchMediaUrl(url, fetchOptions);
+    // In a tenant context the `OMNI_MEDIA_URL_GUARD=off` escape hatch is
+    // SUBSUMED (G5 deliverable (b), ADR-0009): the media URL comes from a
+    // tenant-controlled payload, so no per-deployment flag may open private
+    // ranges to it. Legacy callers pass no tenant and keep the hatch.
+    const response = await fetchMediaUrl(url, { ...fetchOptions, trustedTenantId });
     if (!response.ok) {
       throw new Error(`Failed to download media: ${response.status}`);
     }
@@ -481,12 +504,20 @@ export class MediaStorageService {
    *     (RELEASE_SLOS ≤ 60s), so a tenant-bound URL can never outlive the
    *     revocation-propagation window and no post-revocation refresh can extend it.
    *
-   * (The full synthetic-epoch revocation-ceiling proof — issue/refresh refused
-   * against a bumped epoch — is G5 deliverable (c); this method enforces the
-   * bound-lifetime half of that contract.)
+   *   * the authorization decision — the presign is REFUSED once the tenant is
+   *     revoked (suspended/archived), which is the other, independent half of
+   *     the RELEASE_SLOS pair: a clamped TTL bounds how long ONE url lives, but
+   *     `presigned_url_issue_or_refresh_after_revocation_max: 0` says a revoked
+   *     tenant issues NONE — without the gate it could mint a fresh 60-second
+   *     URL forever and every one would be "inside the ceiling".
+   *
+   * Proven against synthetic epochs in `presign-revocation-ceiling.test.ts`; no
+   * production timing is claimed anywhere in that contract.
    */
   async presignedUrl(reference: string, ttlSeconds?: number, trustedTenantId?: string): Promise<string> {
     if (trustedTenantId === undefined) {
+      // Legacy/flag-off: no tenant exists to revoke, so no gate and no clamp —
+      // byte-identical to pre-G5.
       return this.backend.presignedUrl(reference, ttlSeconds);
     }
 
@@ -495,6 +526,18 @@ export class MediaStorageService {
     if (!reference.startsWith(tenantPrefix)) {
       throw new Error('media-storage: refusing to presign an object outside the requesting tenant prefix');
     }
+
+    // Fail CLOSED when no gate is wired: the multitenancy world always wires one
+    // (`services/index.ts`), so its absence under a tenant-context presign is a
+    // misconfiguration we must not mint an unguarded URL through — the same
+    // stance `batch-jobs.ts` takes for a tenant job with no auth-plane handle.
+    if (!this.tenantAdmissible) {
+      throw new Error('media-storage: refusing to presign — no tenant revocation check is wired');
+    }
+    if (!(await this.tenantAdmissible(trustedTenantId))) {
+      throw new Error('media-storage: refusing to presign for a revoked tenant');
+    }
+
     const effectiveTtl = Math.min(ttlSeconds ?? PRESIGNED_URL_TTL_CEILING_SECONDS, PRESIGNED_URL_TTL_CEILING_SECONDS);
     return this.backend.presignedUrl(reference, effectiveTtl);
   }

--- a/packages/api/src/services/media-storage.ts
+++ b/packages/api/src/services/media-storage.ts
@@ -126,6 +126,38 @@ function getExtensionFromMime(mimeType: string): string {
   return mimeToExt[mimeType] ?? '.bin';
 }
 
+/**
+ * The presigned-URL lifetime ceiling for TENANT-CONTEXT URLs, sourced from
+ * `RELEASE_SLOS.yaml` `revocation.presigned_url_ttl_seconds_max`. A tenant-bound
+ * URL may never outlive this window, so a revoked tenant's already-minted URL
+ * self-expires inside the revocation-propagation ceiling and no post-revocation
+ * refresh can extend it. DUAL-WORLD: legacy/flag-off presigns carry no tenant to
+ * bind, so they are unaffected and keep the backend's own default TTL.
+ */
+export const PRESIGNED_URL_TTL_CEILING_SECONDS = 60;
+
+/** RFC-4122 shape — the only value admissible as a tenant-context key segment. */
+const KEY_SEGMENT_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Guard a path segment used to build a TENANT-CONTEXT object key or presign
+ * prefix. Every segment of a tenant-prefixed key must be a well-formed UUID,
+ * which serves two invariants at once:
+ *
+ *   * Trusted derivation — the tenant/instance/message come from the verified
+ *     worker scope/envelope (ADR-0008), never a request- or attacker-controllable
+ *     field, so a well-formed UUID is exactly the shape a trusted producer stamps.
+ *   * Traversal safety — a UUID contains no `/`, `\`, `.`, or `..`, so the
+ *     composed key can never escape its `tenants/<tenantId>/instances/<instanceId>/`
+ *     prefix (fail-closed: a non-UUID segment throws rather than write to an
+ *     unpredictable location).
+ */
+function assertTenantKeySegment(value: string, label: string): void {
+  if (typeof value !== 'string' || !KEY_SEGMENT_UUID.test(value)) {
+    throw new Error(`media-storage: refusing a non-UUID ${label} for a tenant-context object key`);
+  }
+}
+
 export class MediaStorageService {
   private basePath: string;
   private backend: MediaStorageBackend;
@@ -160,29 +192,64 @@ export class MediaStorageService {
 
   /**
    * Build the stable relative storage key for media.
-   * Format: {instanceId}/{YYYY-MM}/{messageId}.{ext}
+   *
+   * Legacy layout: `{instanceId}/{YYYY-MM}/{messageId}.{ext}`.
+   * Tenant-context layout (when `trustedTenantId` is supplied):
+   *   `tenants/{tenantId}/instances/{instanceId}/{YYYY-MM}/{messageId}.{ext}`.
    *
    * This key is both the local relative path and the S3 object key — it is what
    * gets recorded on the message row and never an expiring URL.
+   *
+   * `trustedTenantId` is derived by the CALLER from the verified worker
+   * scope/envelope (ADR-0008), never from a payload or request field. When
+   * present, the object is partitioned under a per-tenant prefix and every
+   * segment is UUID-validated, so the key is traversal-safe by construction.
+   * DUAL-WORLD: with no trusted tenant the key is byte-identical to pre-G5, and
+   * reads of already-stored legacy keys are unaffected — the stored reference is
+   * used verbatim, so migration of existing objects to the tenant prefix is a
+   * SEPARATE later backfill, not this path.
    */
-  buildKey(instanceId: string, messageId: string, mimeType?: string, timestamp?: Date): string {
+  buildKey(
+    instanceId: string,
+    messageId: string,
+    mimeType?: string,
+    timestamp?: Date,
+    trustedTenantId?: string,
+  ): string {
     const date = timestamp ?? new Date();
     const yearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
     const ext = mimeType ? getExtensionFromMime(mimeType) : '.bin';
+
+    if (trustedTenantId !== undefined) {
+      assertTenantKeySegment(trustedTenantId, 'tenantId');
+      assertTenantKeySegment(instanceId, 'instanceId');
+      assertTenantKeySegment(messageId, 'messageId');
+      return join('tenants', trustedTenantId, 'instances', instanceId, yearMonth, `${messageId}${ext}`);
+    }
 
     return join(instanceId, yearMonth, `${messageId}${ext}`);
   }
 
   /**
    * Build the absolute local storage path for media (local backend only).
-   * Format: {basePath}/{instanceId}/{YYYY-MM}/{messageId}.{ext}
+   * Mirrors {@link buildKey}: `{basePath}/{key}` for whichever layout applies.
    */
-  buildPath(instanceId: string, messageId: string, mimeType?: string, timestamp?: Date): string {
-    return join(this.basePath, this.buildKey(instanceId, messageId, mimeType, timestamp));
+  buildPath(
+    instanceId: string,
+    messageId: string,
+    mimeType?: string,
+    timestamp?: Date,
+    trustedTenantId?: string,
+  ): string {
+    return join(this.basePath, this.buildKey(instanceId, messageId, mimeType, timestamp, trustedTenantId));
   }
 
   /**
-   * Store media from base64 data
+   * Store media from base64 data.
+   *
+   * `trustedTenantId` (derived by the caller from the verified worker
+   * scope/envelope) tenant-prefixes the object key; omit it for legacy/flag-off
+   * writes, which stay byte-identical.
    */
   async storeFromBase64(
     instanceId: string,
@@ -190,9 +257,10 @@ export class MediaStorageService {
     base64Data: string,
     mimeType?: string,
     timestamp?: Date,
+    trustedTenantId?: string,
   ): Promise<StoredMediaResult> {
     const buffer = Buffer.from(base64Data, 'base64');
-    const key = this.buildKey(instanceId, messageId, mimeType, timestamp);
+    const key = this.buildKey(instanceId, messageId, mimeType, timestamp, trustedTenantId);
     const result = await this.backend.store({ key, buffer, mimeType });
 
     log.debug('Stored media from base64', { messageId, reference: result.reference, size: result.size });
@@ -205,7 +273,11 @@ export class MediaStorageService {
   }
 
   /**
-   * Store media from buffer
+   * Store media from buffer.
+   *
+   * `trustedTenantId` (derived by the caller from the verified worker
+   * scope/envelope) tenant-prefixes the object key; omit it for legacy/flag-off
+   * writes, which stay byte-identical.
    */
   async storeFromBuffer(
     instanceId: string,
@@ -213,8 +285,9 @@ export class MediaStorageService {
     buffer: Buffer,
     mimeType?: string,
     timestamp?: Date,
+    trustedTenantId?: string,
   ): Promise<StoredMediaResult> {
-    const key = this.buildKey(instanceId, messageId, mimeType, timestamp);
+    const key = this.buildKey(instanceId, messageId, mimeType, timestamp, trustedTenantId);
     const result = await this.backend.store({ key, buffer, mimeType });
 
     log.debug('Stored media from buffer', { messageId, reference: result.reference, size: result.size });
@@ -236,6 +309,7 @@ export class MediaStorageService {
     mimeType?: string,
     timestamp?: Date,
     fetchOptions?: MediaFetchOptions,
+    trustedTenantId?: string,
   ): Promise<StoredMediaResult> {
     // Fetch the media (fetchOptions allows callers to supply auth headers, e.g.
     // Slack bot token). The fetch is SSRF-guarded: private/metadata targets are
@@ -255,7 +329,7 @@ export class MediaStorageService {
 
     const contentType = mimeType ?? responseContentType;
 
-    return this.storeFromBuffer(instanceId, messageId, buffer, contentType, timestamp);
+    return this.storeFromBuffer(instanceId, messageId, buffer, contentType, timestamp, trustedTenantId);
   }
 
   /**
@@ -391,9 +465,38 @@ export class MediaStorageService {
   /**
    * Presign a time-limited GET URL for a stored reference (remote mode only).
    * Throws in local mode. Consumed by remote-mode URL emission (Group 2).
+   *
+   * DUAL-WORLD legacy path: a presign with NO trusted tenant is byte-identical to
+   * pre-G5 — the backend applies its own default TTL and there is no tenant
+   * binding (a flag-off deployment has no tenant to bind).
+   *
+   * Tenant-context path (`trustedTenantId` supplied, derived from the verified
+   * worker scope/envelope): the URL is bound to tenant + object + expiry per
+   * ADR-0008:
+   *   * tenant + object — a tenant may presign ONLY objects under its own
+   *     `tenants/<tenantId>/` prefix; a foreign- or legacy-keyed reference is
+   *     refused (the authorization decision, made against the trusted tenant, not
+   *     a caller claim);
+   *   * expiry — the lifetime is clamped to {@link PRESIGNED_URL_TTL_CEILING_SECONDS}
+   *     (RELEASE_SLOS ≤ 60s), so a tenant-bound URL can never outlive the
+   *     revocation-propagation window and no post-revocation refresh can extend it.
+   *
+   * (The full synthetic-epoch revocation-ceiling proof — issue/refresh refused
+   * against a bumped epoch — is G5 deliverable (c); this method enforces the
+   * bound-lifetime half of that contract.)
    */
-  async presignedUrl(reference: string, ttlSeconds?: number): Promise<string> {
-    return this.backend.presignedUrl(reference, ttlSeconds);
+  async presignedUrl(reference: string, ttlSeconds?: number, trustedTenantId?: string): Promise<string> {
+    if (trustedTenantId === undefined) {
+      return this.backend.presignedUrl(reference, ttlSeconds);
+    }
+
+    assertTenantKeySegment(trustedTenantId, 'tenantId');
+    const tenantPrefix = `${join('tenants', trustedTenantId)}/`;
+    if (!reference.startsWith(tenantPrefix)) {
+      throw new Error('media-storage: refusing to presign an object outside the requesting tenant prefix');
+    }
+    const effectiveTtl = Math.min(ttlSeconds ?? PRESIGNED_URL_TTL_CEILING_SECONDS, PRESIGNED_URL_TTL_CEILING_SECONDS);
+    return this.backend.presignedUrl(reference, effectiveTtl);
   }
 
   /**

--- a/packages/api/src/services/providers.ts
+++ b/packages/api/src/services/providers.ts
@@ -1,5 +1,34 @@
 /**
  * Provider service - manages agent providers
+ *
+ * TENANT-BOUND SEALING OF PROVIDER CREDENTIALS (G5 deliverable (g); ADR-0008)
+ * ---------------------------------------------------------------------------
+ * `agent_providers` holds two kinds of secret: the bearer `api_key` used against
+ * the provider's HTTP/WS endpoint, and — for the OpenClaw schema — the device
+ * identity in `schema_config`, whose `devicePrivateKey` is a raw Ed25519 private
+ * key and whose `deviceToken` is its bearer companion. ADR-0008 puts both in the
+ * "channel/provider/webhook credentials" class that must be encrypted with
+ * tenant-bound context.
+ *
+ * WHERE THE TENANT COMES FROM, AND WHY IT IS THE SCOPE
+ * ----------------------------------------------------
+ * Unlike `instances`, `agent_providers` is a G0-`split` table: it has no
+ * `tenant_id`, because the tenant-configured half (`tenant_provider_config`) and
+ * the immutable catalog half (`platform_provider_catalog`) have not been
+ * separated yet (G2 `SPLIT_DESTINATIONS`). So there is no per-row ownership to
+ * read, and the honest binding is the ACTIVE TENANT SCOPE: the tenant that
+ * configured the credential is the tenant that can use it, and every other
+ * context — including a worker that never established a scope — fails closed to
+ * a null secret rather than to someone else's key.
+ *
+ * The `devicePublicKey`, `deviceId`, `origin` and every other `schema_config`
+ * field stay in the clear: sealing is scoped to key material, so operators can
+ * still read and diff a provider's configuration.
+ *
+ * DUAL WORLD. With no scope (legacy/worker/CLI) or no master key the codec is
+ * the identity function and every column holds exactly the bytes it held before
+ * G5. Reads are transitional — legacy plaintext rows keep working while sealing
+ * is enabled, because G5 ships no credential backfill.
  */
 
 import { NotFoundError } from '@omni/core';
@@ -7,6 +36,8 @@ import type { Database } from '@omni/db';
 import { type AgentProvider, type NewAgentProvider, agentProviders } from '@omni/db';
 import { eq } from 'drizzle-orm';
 import { invalidateProviderCache } from '../plugins/agent-dispatcher';
+import { openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
+import { currentTenantScope } from '../tenancy/tenant-scope';
 
 export interface ProviderHealthResult {
   healthy: boolean;
@@ -14,8 +45,59 @@ export interface ProviderHealthResult {
   error?: string;
 }
 
+/**
+ * The `schema_config` keys that are key material. Explicit allow-list for the
+ * same reason as `instances`: a heuristic that stopped matching would fail OPEN.
+ */
+const SEALED_SCHEMA_CONFIG_KEYS = ['devicePrivateKey', 'deviceToken'] as const;
+
+/** Apply `codec` to `api_key` and the sealed `schema_config` keys of `row`. */
+function mapProviderSecrets<T extends Record<string, unknown>>(
+  row: T,
+  codec: (value: string) => string | null | undefined,
+): T {
+  const out: Record<string, unknown> = { ...row };
+
+  if (typeof out.apiKey === 'string') out.apiKey = codec(out.apiKey);
+
+  const schemaConfig = out.schemaConfig;
+  if (schemaConfig && typeof schemaConfig === 'object') {
+    const config = { ...(schemaConfig as Record<string, unknown>) };
+    let changed = false;
+    for (const key of SEALED_SCHEMA_CONFIG_KEYS) {
+      const value = config[key];
+      if (typeof value !== 'string') continue;
+      config[key] = codec(value);
+      changed = true;
+    }
+    if (changed) out.schemaConfig = config;
+  }
+
+  return out as T;
+}
+
+/** Seal the provider secrets present in `data` for `tenantId`. */
+function sealProviderSecrets<T extends Record<string, unknown>>(tenantId: string | null, data: T): T {
+  if (!tenantId) return data;
+  return mapProviderSecrets(data, (value) => sealCredentialField(tenantId, value));
+}
+
+/**
+ * Open a loaded provider row under `tenantId`. A secret sealed for another
+ * tenant (or unreadable because no key is configured) becomes `null` — never the
+ * envelope, which would otherwise be sent as an `Authorization: Bearer` value.
+ */
+function openProviderSecrets<T extends Record<string, unknown>>(tenantId: string | null, row: T): T {
+  return mapProviderSecrets(row, (value) => openCredentialField(tenantId, value) ?? null);
+}
+
 export class ProviderService {
   constructor(private db: Database) {}
+
+  /** The tenant this service seals under / opens with; null on legacy paths. */
+  private get tenantId(): string | null {
+    return currentTenantScope()?.tenantId ?? null;
+  }
 
   /**
    * List all providers
@@ -27,7 +109,9 @@ export class ProviderService {
       query = query.where(eq(agentProviders.isActive, options.active));
     }
 
-    return query.orderBy(agentProviders.name);
+    const rows = await query.orderBy(agentProviders.name);
+    const tenantId = this.tenantId;
+    return rows.map((row) => openProviderSecrets(tenantId, row));
   }
 
   /**
@@ -40,7 +124,7 @@ export class ProviderService {
       throw new NotFoundError('AgentProvider', id);
     }
 
-    return result;
+    return openProviderSecrets(this.tenantId, result);
   }
 
   /**
@@ -53,29 +137,31 @@ export class ProviderService {
       throw new NotFoundError('AgentProvider', name);
     }
 
-    return result;
+    return openProviderSecrets(this.tenantId, result);
   }
 
   /**
    * Create a new provider
    */
   async create(data: NewAgentProvider): Promise<AgentProvider> {
-    const [created] = await this.db.insert(agentProviders).values(data).returning();
+    const tenantId = this.tenantId;
+    const [created] = await this.db.insert(agentProviders).values(sealProviderSecrets(tenantId, data)).returning();
 
     if (!created) {
       throw new Error('Failed to create agent provider');
     }
 
-    return created;
+    return openProviderSecrets(tenantId, created);
   }
 
   /**
    * Update a provider
    */
   async update(id: string, data: Partial<NewAgentProvider>): Promise<AgentProvider> {
+    const tenantId = this.tenantId;
     const [updated] = await this.db
       .update(agentProviders)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...sealProviderSecrets(tenantId, data), updatedAt: new Date() })
       .where(eq(agentProviders.id, id))
       .returning();
 
@@ -85,7 +171,7 @@ export class ProviderService {
 
     invalidateProviderCache(id);
 
-    return updated;
+    return openProviderSecrets(tenantId, updated);
   }
 
   /**

--- a/packages/api/src/services/route-resolver.ts
+++ b/packages/api/src/services/route-resolver.ts
@@ -12,6 +12,8 @@ import type { Database } from '@omni/db';
 import { agentRoutes } from '@omni/db';
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { LRUCache } from 'lru-cache';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
 
 const log = createLogger('route-resolver');
 
@@ -98,8 +100,20 @@ export class RouteResolver {
   /**
    * Resolve the matching route for a given instance, chat, and person.
    * Returns null if no route matches (use instance default).
+   *
+   * `trustedTenantId` (G5, ADR-0008) is the envelope-derived tenant its
+   * consumer callers thread through `DispatchMetadata` — never a payload
+   * claim. When present, the DB read runs inside a short worker tenant scope
+   * AND the cache key includes the tenant, so one tenant's (positive or
+   * negative) entry can never answer another tenant's lookup. Undefined —
+   * the legacy world — keeps the pre-G5 key and ambient read byte-identically.
    */
-  async resolve(instanceId: string, chatId: string, personId?: string): Promise<ResolvedRoute | null> {
+  async resolve(
+    instanceId: string,
+    chatId: string,
+    personId?: string,
+    trustedTenantId?: string,
+  ): Promise<ResolvedRoute | null> {
     // Defense-in-depth: reject non-UUID chatIds before they reach SQL.
     // External IDs (e.g. WhatsApp LID JIDs like "12345:90@lid", phone JIDs like
     // "5511999@s.whatsapp.net") must NEVER be passed to UUID columns — PostgreSQL
@@ -113,7 +127,7 @@ export class RouteResolver {
       return null;
     }
 
-    const cacheKey = this.getCacheKey(instanceId, chatId, personId);
+    const cacheKey = this.getCacheKey(instanceId, chatId, personId, trustedTenantId);
     const cached = this.cache.get(cacheKey);
 
     // Check if we have a cached result (including negative cache via NO_ROUTE sentinel)
@@ -131,25 +145,32 @@ export class RouteResolver {
     // Note: personId ?? null handles SQL NULL semantics correctly - when personId is undefined,
     // the query becomes "personId = NULL" which is always false in SQL (use IS NULL instead).
     // This is intentional: undefined personId means "no user context", so user routes won't match.
-    const routes = await this.db
-      .select()
-      .from(agentRoutes)
-      .where(
-        and(
-          eq(agentRoutes.instanceId, instanceId),
-          eq(agentRoutes.isActive, true),
-          sql`(
+    // Tenant world: a short worker scope wraps exactly this read, so RLS
+    // confines it to the tenant's own routes; legacy world: the ambient read,
+    // byte-identical to pre-G5.
+    const queryRoutes = (handle: Database) =>
+      handle
+        .select()
+        .from(agentRoutes)
+        .where(
+          and(
+            eq(agentRoutes.instanceId, instanceId),
+            eq(agentRoutes.isActive, true),
+            sql`(
             (${agentRoutes.scope} = 'chat' AND ${agentRoutes.chatId} = ${chatId})
             OR (${agentRoutes.scope} = 'user' AND ${agentRoutes.personId} = ${personId ?? null})
           )`,
-        ),
-      )
-      .orderBy(
-        // Chat routes first, then user routes
-        sql`CASE ${agentRoutes.scope} WHEN 'chat' THEN 0 WHEN 'user' THEN 1 END`,
-        desc(agentRoutes.priority),
-      )
-      .limit(1);
+          ),
+        )
+        .orderBy(
+          // Chat routes first, then user routes
+          sql`CASE ${agentRoutes.scope} WHEN 'chat' THEN 0 WHEN 'user' THEN 1 END`,
+          desc(agentRoutes.priority),
+        )
+        .limit(1);
+    const routes = await (trustedTenantId === undefined
+      ? queryRoutes(this.db)
+      : runInWorkerTenantScope(this.db, trustedTenantId, () => queryRoutes(scopedHandle(this.db))));
 
     const dbRoute = routes[0];
     this.metrics.lastQueryMs = Date.now() - startMs;
@@ -227,7 +248,16 @@ export class RouteResolver {
   /**
    * Generate cache key from instance, chat, and person
    */
-  private getCacheKey(instanceId: string, chatId: string | null, personId: string | null | undefined): string {
-    return `${instanceId}:${chatId ?? 'null'}:${personId ?? 'null'}`;
+  private getCacheKey(
+    instanceId: string,
+    chatId: string | null,
+    personId: string | null | undefined,
+    trustedTenantId?: string,
+  ): string {
+    // Tenant-context lookups carry the tenant in the key (WISH: "cache keys
+    // include tenant identity") so a foreign scope's negative entry cannot
+    // shadow a tenant's real route. Legacy lookups keep the pre-G5 key.
+    const base = `${instanceId}:${chatId ?? 'null'}:${personId ?? 'null'}`;
+    return trustedTenantId === undefined ? base : `tenant:${trustedTenantId}:${base}`;
   }
 }

--- a/packages/api/src/services/settings.ts
+++ b/packages/api/src/services/settings.ts
@@ -1,11 +1,35 @@
 /**
  * Settings service - manages global settings
+ *
+ * TENANT-BOUND SEALING OF SECRET SETTINGS (G5 deliverable (g); ADR-0008)
+ * ----------------------------------------------------------------------
+ * A `global_settings` row flagged `is_secret` holds live credential material —
+ * `elevenlabs.api_key` and its siblings. ADR-0008 requires such values to be
+ * encrypted with tenant-bound context, and names one consequence explicitly:
+ * "plaintext never appears in ... migration receipts". `setting_change_history`
+ * IS that receipt, and it copies both the old and the new value on every change.
+ * Sealing before the write therefore protects the history rows for free — the
+ * receipt records ciphertext because there was never plaintext to record.
+ *
+ * `global_settings` is a G0-`split` table with no `tenant_id` yet (its
+ * destinations are `tenant_settings` / `platform_settings`), so — exactly as in
+ * `providers.ts` — the binding is the ACTIVE TENANT SCOPE rather than a per-row
+ * owner. Whether a row is secret is the row's own `is_secret` for an existing
+ * setting, and the seeded definition for a new one; a value whose secrecy cannot
+ * be established is left in the clear, so this can never seal an operational
+ * setting an operator needs to read.
+ *
+ * DUAL WORLD. No scope or no master key ⇒ the codec is the identity function and
+ * every value is stored and returned exactly as before G5. Reads are
+ * transitional: legacy plaintext and sealed values coexist.
  */
 
 import { NotFoundError, createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type GlobalSetting, type SettingValueType, globalSettings, settingChangeHistory } from '@omni/db';
 import { desc, eq } from 'drizzle-orm';
+import { openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
+import { currentTenantScope } from '../tenancy/tenant-scope';
 
 const log = createLogger('settings');
 
@@ -309,6 +333,39 @@ export interface SettingWithHistory extends GlobalSetting {
 export class SettingsService {
   constructor(private db: Database) {}
 
+  /** The tenant this service seals under / opens with; null on legacy paths. */
+  private get tenantId(): string | null {
+    return currentTenantScope()?.tenantId ?? null;
+  }
+
+  /**
+   * Whether the setting named `key` holds secret material.
+   *
+   * An existing row's own `is_secret` is authoritative. For a key being created
+   * for the first time, the seeded definition is consulted, so
+   * `setValue('elevenlabs.api_key', ...)` seals even before `seedDefaults` has
+   * run. Unknown keys are NOT secret — failing towards plaintext here is
+   * deliberate: sealing an operational setting nobody declared secret would hide
+   * it from operators with no way to tell why.
+   */
+  private isSecretSetting(key: string, existing?: GlobalSetting): boolean {
+    if (existing?.isSecret) return true;
+    // The seeded definition is the fallback in BOTH directions: for a key being
+    // created for the first time, and for a pre-existing row whose `is_secret`
+    // was never set (rows created by `setValue` before `seedDefaults` ran
+    // default the column to false). Without the second case a declared secret
+    // could be sealed on write and then not recognised on read.
+    return DEFAULT_SETTINGS.some((def) => def.key === key && def.isSecret);
+  }
+
+  /** Open a loaded row's value when it is a sealed secret; identity otherwise. */
+  private openSetting(row: GlobalSetting): GlobalSetting {
+    if (!this.isSecretSetting(row.key, row) || typeof row.value !== 'string') return row;
+    const opened = openCredentialField(this.tenantId, row.value);
+    if (opened === row.value) return row;
+    return { ...row, value: opened ?? null };
+  }
+
   /**
    * List all settings, optionally filtered by category
    */
@@ -319,7 +376,8 @@ export class SettingsService {
       query = query.where(eq(globalSettings.category, category));
     }
 
-    return query.orderBy(globalSettings.key);
+    const rows = await query.orderBy(globalSettings.key);
+    return rows.map((row) => this.openSetting(row));
   }
 
   /**
@@ -332,7 +390,7 @@ export class SettingsService {
       throw new NotFoundError('Setting', key);
     }
 
-    return result;
+    return this.openSetting(result);
   }
 
   /**
@@ -358,14 +416,22 @@ export class SettingsService {
     value: unknown,
     options?: { reason?: string; changedBy?: string },
   ): Promise<GlobalSetting> {
-    const stringValue = this.stringifyValue(value);
+    const plainValue = this.stringifyValue(value);
 
     // Get existing setting if it exists
     const existing = await this.db.select().from(globalSettings).where(eq(globalSettings.key, key)).limit(1);
 
     const existingSetting = existing[0];
+    // Seal BEFORE the write, so `stringValue` is what lands in the row AND in
+    // the history receipt below. A non-secret setting, a legacy path, or a
+    // deployment with no master key all leave this as the identity function.
+    const stringValue = this.isSecretSetting(key, existingSetting)
+      ? (sealCredentialField(this.tenantId, plainValue) ?? plainValue)
+      : plainValue;
+
     if (existingSetting) {
-      // Update existing
+      // Update existing. `oldValue` is the value AT REST — already sealed if the
+      // previous write sealed it — so the receipt never gains plaintext.
       const oldValue = existingSetting.value;
 
       const [updated] = await this.db
@@ -391,7 +457,7 @@ export class SettingsService {
         changeReason: options?.reason,
       });
 
-      return updated;
+      return this.openSetting(updated);
     }
 
     // Create new
@@ -410,7 +476,7 @@ export class SettingsService {
       throw new Error('Failed to create setting');
     }
 
-    return created;
+    return this.openSetting(created);
   }
 
   /**

--- a/packages/api/src/services/sync-jobs.ts
+++ b/packages/api/src/services/sync-jobs.ts
@@ -19,12 +19,21 @@ import {
 } from '@omni/db';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import { scopedHandle } from '../tenancy/tenant-scope';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 
 export interface CreateSyncJobOptions {
   instanceId: string;
   channelType: ChannelType;
   type: SyncJobType;
   config?: SyncJobConfig;
+  /**
+   * The work item's trusted tenant (G5, ADR-0008), threaded by a worker caller:
+   * the scheduler's per-tenant fan-out or the `sync.started` consumer's
+   * envelope. Derived from persisted ownership or producer-stamped metadata,
+   * NEVER from a payload claim. Omitted by route callers, which already run
+   * inside their own request scope, and by the flag-off world.
+   */
+  tenantId?: string | null;
 }
 
 export interface ListSyncJobsOptions {
@@ -52,6 +61,23 @@ export class SyncJobService {
     return scopedHandle(this.pool);
   }
 
+  /**
+   * Run one discrete DB block in the work item's world (G5, ADR-0008).
+   *
+   * Every mutating method here writes the database AND publishes a `sync.*`
+   * event, so a worker caller cannot wrap the whole call in a scope: a worker
+   * transaction held across a publish would make the event a pre-commit side
+   * effect — a phantom on rollback. Instead the caller THREADS its trusted
+   * tenant and each DB block scopes itself; the publish sits between blocks.
+   *
+   * With nothing threaded this passes straight through, so a route caller stays
+   * on its own request transaction and a legacy/flag-off worker keeps the exact
+   * pre-G5 ambient query.
+   */
+  private workDb<T>(trustedTenantId: string | null | undefined, fn: () => Promise<T>): Promise<T> {
+    return runTenantWorkDb(this.pool, trustedTenantId, fn);
+  }
+
   constructor(
     private readonly pool: Database,
     private eventBus: EventBus | null,
@@ -61,7 +87,7 @@ export class SyncJobService {
    * Create a new sync job
    */
   async create(options: CreateSyncJobOptions): Promise<SyncJob> {
-    const { instanceId, channelType, type, config = {} } = options;
+    const { instanceId, channelType, type, config = {}, tenantId } = options;
 
     const jobData: NewSyncJob = {
       instanceId,
@@ -72,13 +98,21 @@ export class SyncJobService {
       progress: { fetched: 0, stored: 0, duplicates: 0, mediaDownloaded: 0 },
     };
 
-    const [created] = await this.db.insert(syncJobs).values(jobData).returning();
+    // `sync_jobs` derives its tenant from the REQUIRED `instance_id` parent, so
+    // this insert is RLS-stamped under the threaded tenant and REFUSED outright
+    // if it names another tenant's instance.
+    const [created] = await this.workDb(tenantId, () => this.db.insert(syncJobs).values(jobData).returning());
 
     if (!created) {
       throw new Error('Failed to create sync job');
     }
 
-    // Emit sync.started event with proper metadata for hierarchical subjects
+    // Emit sync.started event with proper metadata for hierarchical subjects.
+    // The publish sits OUTSIDE the DB block above and carries the job's tenant
+    // EXPLICITLY (G5, ADR-0008): `created.tenantId` is what the row was actually
+    // stamped with by the derivation trigger, so the `sync.started` consumer
+    // derives its worker scope from persisted ownership rather than from
+    // whatever ambient scope happened to be active at publish time.
     if (this.eventBus) {
       await this.eventBus.publish(
         'sync.started',
@@ -88,7 +122,7 @@ export class SyncJobService {
           type,
           config,
         },
-        { instanceId, channelType },
+        { instanceId, channelType, tenantId: created.tenantId ?? undefined },
       );
     }
 
@@ -96,10 +130,17 @@ export class SyncJobService {
   }
 
   /**
-   * Get sync job by ID
+   * Get sync job by ID.
+   *
+   * `trustedTenantId` (G5, ADR-0008) is threaded by worker callers; a route
+   * caller omits it and stays on its own request scope. Under enforcement a job
+   * belonging to another tenant is invisible, so this raises `NotFoundError`
+   * rather than leaking its existence.
    */
-  async getById(id: string): Promise<SyncJob> {
-    const [result] = await this.db.select().from(syncJobs).where(eq(syncJobs.id, id)).limit(1);
+  async getById(id: string, trustedTenantId?: string | null): Promise<SyncJob> {
+    const [result] = await this.workDb(trustedTenantId, () =>
+      this.db.select().from(syncJobs).where(eq(syncJobs.id, id)).limit(1),
+    );
 
     if (!result) {
       throw new NotFoundError('SyncJob', id);
@@ -170,15 +211,17 @@ export class SyncJobService {
   /**
    * Start a sync job (set status to running)
    */
-  async start(id: string): Promise<SyncJob> {
-    const [updated] = await this.db
-      .update(syncJobs)
-      .set({
-        status: 'running',
-        startedAt: new Date(),
-      })
-      .where(eq(syncJobs.id, id))
-      .returning();
+  async start(id: string, trustedTenantId?: string | null): Promise<SyncJob> {
+    const [updated] = await this.workDb(trustedTenantId, () =>
+      this.db
+        .update(syncJobs)
+        .set({
+          status: 'running',
+          startedAt: new Date(),
+        })
+        .where(eq(syncJobs.id, id))
+        .returning(),
+    );
 
     if (!updated) {
       throw new NotFoundError('SyncJob', id);
@@ -190,8 +233,12 @@ export class SyncJobService {
   /**
    * Update job progress
    */
-  async updateProgress(id: string, progress: Partial<SyncJobProgress>): Promise<SyncJob> {
-    const job = await this.getById(id);
+  async updateProgress(
+    id: string,
+    progress: Partial<SyncJobProgress>,
+    trustedTenantId?: string | null,
+  ): Promise<SyncJob> {
+    const job = await this.getById(id, trustedTenantId);
     const currentProgress = (job.progress as SyncJobProgress) ?? {
       fetched: 0,
       stored: 0,
@@ -205,11 +252,9 @@ export class SyncJobService {
       lastProgressAt: new Date().toISOString(),
     };
 
-    const [updated] = await this.db
-      .update(syncJobs)
-      .set({ progress: updatedProgress })
-      .where(eq(syncJobs.id, id))
-      .returning();
+    const [updated] = await this.workDb(trustedTenantId, () =>
+      this.db.update(syncJobs).set({ progress: updatedProgress }).where(eq(syncJobs.id, id)).returning(),
+    );
 
     if (!updated) {
       throw new NotFoundError('SyncJob', id);
@@ -225,7 +270,7 @@ export class SyncJobService {
           type: job.type,
           progress: updatedProgress,
         },
-        { instanceId: job.instanceId, channelType: job.channel },
+        { instanceId: job.instanceId, channelType: job.channel, tenantId: updated.tenantId ?? undefined },
       );
     }
 
@@ -235,17 +280,19 @@ export class SyncJobService {
   /**
    * Complete a sync job successfully
    */
-  async complete(id: string): Promise<SyncJob> {
-    const job = await this.getById(id);
+  async complete(id: string, trustedTenantId?: string | null): Promise<SyncJob> {
+    const job = await this.getById(id, trustedTenantId);
 
-    const [updated] = await this.db
-      .update(syncJobs)
-      .set({
-        status: 'completed',
-        completedAt: new Date(),
-      })
-      .where(eq(syncJobs.id, id))
-      .returning();
+    const [updated] = await this.workDb(trustedTenantId, () =>
+      this.db
+        .update(syncJobs)
+        .set({
+          status: 'completed',
+          completedAt: new Date(),
+        })
+        .where(eq(syncJobs.id, id))
+        .returning(),
+    );
 
     if (!updated) {
       throw new NotFoundError('SyncJob', id);
@@ -261,7 +308,7 @@ export class SyncJobService {
           type: job.type,
           progress: job.progress,
         },
-        { instanceId: job.instanceId, channelType: job.channel },
+        { instanceId: job.instanceId, channelType: job.channel, tenantId: updated.tenantId ?? undefined },
       );
     }
 
@@ -271,18 +318,20 @@ export class SyncJobService {
   /**
    * Fail a sync job with error message
    */
-  async fail(id: string, errorMessage: string): Promise<SyncJob> {
-    const job = await this.getById(id);
+  async fail(id: string, errorMessage: string, trustedTenantId?: string | null): Promise<SyncJob> {
+    const job = await this.getById(id, trustedTenantId);
 
-    const [updated] = await this.db
-      .update(syncJobs)
-      .set({
-        status: 'failed',
-        errorMessage,
-        completedAt: new Date(),
-      })
-      .where(eq(syncJobs.id, id))
-      .returning();
+    const [updated] = await this.workDb(trustedTenantId, () =>
+      this.db
+        .update(syncJobs)
+        .set({
+          status: 'failed',
+          errorMessage,
+          completedAt: new Date(),
+        })
+        .where(eq(syncJobs.id, id))
+        .returning(),
+    );
 
     if (!updated) {
       throw new NotFoundError('SyncJob', id);
@@ -298,7 +347,7 @@ export class SyncJobService {
           type: job.type,
           error: errorMessage,
         },
-        { instanceId: job.instanceId, channelType: job.channel },
+        { instanceId: job.instanceId, channelType: job.channel, tenantId: updated.tenantId ?? undefined },
       );
     }
 
@@ -308,15 +357,17 @@ export class SyncJobService {
   /**
    * Cancel a sync job
    */
-  async cancel(id: string): Promise<SyncJob> {
-    const [updated] = await this.db
-      .update(syncJobs)
-      .set({
-        status: 'cancelled',
-        completedAt: new Date(),
-      })
-      .where(eq(syncJobs.id, id))
-      .returning();
+  async cancel(id: string, trustedTenantId?: string | null): Promise<SyncJob> {
+    const [updated] = await this.workDb(trustedTenantId, () =>
+      this.db
+        .update(syncJobs)
+        .set({
+          status: 'cancelled',
+          completedAt: new Date(),
+        })
+        .where(eq(syncJobs.id, id))
+        .returning(),
+    );
 
     if (!updated) {
       throw new NotFoundError('SyncJob', id);
@@ -328,28 +379,34 @@ export class SyncJobService {
   /**
    * Get active jobs for an instance
    */
-  async getActiveForInstance(instanceId: string): Promise<SyncJob[]> {
-    return this.db
-      .select()
-      .from(syncJobs)
-      .where(and(eq(syncJobs.instanceId, instanceId), inArray(syncJobs.status, ['pending', 'running'] as JobStatus[])));
+  async getActiveForInstance(instanceId: string, trustedTenantId?: string | null): Promise<SyncJob[]> {
+    return this.workDb(trustedTenantId, () =>
+      this.db
+        .select()
+        .from(syncJobs)
+        .where(
+          and(eq(syncJobs.instanceId, instanceId), inArray(syncJobs.status, ['pending', 'running'] as JobStatus[])),
+        ),
+    );
   }
 
   /**
    * Check if there's an active job of a specific type for an instance
    */
-  async hasActiveJob(instanceId: string, type: SyncJobType): Promise<boolean> {
-    const [job] = await this.db
-      .select()
-      .from(syncJobs)
-      .where(
-        and(
-          eq(syncJobs.instanceId, instanceId),
-          eq(syncJobs.type, type),
-          inArray(syncJobs.status, ['pending', 'running'] as JobStatus[]),
-        ),
-      )
-      .limit(1);
+  async hasActiveJob(instanceId: string, type: SyncJobType, trustedTenantId?: string | null): Promise<boolean> {
+    const [job] = await this.workDb(trustedTenantId, () =>
+      this.db
+        .select()
+        .from(syncJobs)
+        .where(
+          and(
+            eq(syncJobs.instanceId, instanceId),
+            eq(syncJobs.type, type),
+            inArray(syncJobs.status, ['pending', 'running'] as JobStatus[]),
+          ),
+        )
+        .limit(1),
+    );
 
     return !!job;
   }

--- a/packages/api/src/services/turn-monitor.ts
+++ b/packages/api/src/services/turn-monitor.ts
@@ -17,9 +17,41 @@
  *   Per-instance stalled-timeout config (`agentStalledTimeoutMs`) is re-read at
  *   the start of every tick via `instanceService.getById()` — it is NOT cached.
  *   A CLI change takes effect on the next tick without requiring a serve restart.
+ *
+ * WORKER TENANT CONTEXT (wish: omni-full-multitenancy, G5; ADR-0008)
+ * ------------------------------------------------------------------
+ * This monitor is an INTERVAL: it has no request, no credential and no envelope,
+ * so nothing hands it a tenant. Before this conversion every tick read the whole
+ * `turns` table and then called `instanceService.getById`, `incrementNudge` and
+ * `close` on the ambient pool — the unscoped worker caller that kept both
+ * `services/instances.ts::instances` and `services/turns.ts::turns` in
+ * `pending-G5-conversion`.
+ *
+ * It now adopts the same fan-out the daily sync crons use
+ * (`periodic-tenant-work.ts` `runForEachActiveTenantRow`), which is the shape
+ * for "list the active rows, then act on each" periodic work:
+ *
+ *   * the stale-turn READ runs once per ACTIVE tenant inside that tenant's
+ *     worker scope — under RLS enforcement a global scan is not expressible, so
+ *     a cron must ENUMERATE whose work exists rather than scan and sort out
+ *     ownership afterwards. A suspended tenant drops out of the enumeration, so
+ *     its turns stop being swept at the next tick (dequeue-time revalidation at
+ *     cron cadence);
+ *   * each per-turn action then opens its OWN short scope (`runTenantWorkDb`)
+ *     for its DB block, because the actions PUBLISH `turn.*` events and a worker
+ *     transaction held across a publish would make the event a pre-commit side
+ *     effect. The scope's lifetime is exactly one DB block, never the work item.
+ *
+ * THREE WORLDS, and the legacy one is byte-identical: with no `db`/`authPlaneDb`
+ * wired (the shape every existing test constructs), or with the flag off, the
+ * tick is EXACTLY the pre-G5 loop — one ambient `getStale`, no enumeration, not
+ * one additional query.
  */
 
 import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import { runForEachActiveTenantRow } from '../tenancy/periodic-tenant-work';
+import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
 import type { InstanceService } from './instances';
 import { publishTurnDone, publishTurnNudge, publishTurnStalled, publishTurnTimeout } from './turn-events';
 import type { TurnService } from './turns';
@@ -38,6 +70,21 @@ export interface TurnMonitorDeps {
   turnService: TurnService;
   /** Instance service for per-instance stalled-timeout config lookup (live, not cached). */
   instanceService: InstanceService;
+  /**
+   * The runtime pool the per-tenant worker scopes open transactions on.
+   *
+   * OPTIONAL, and its absence is the legacy world: with no `db` the tick runs
+   * the pre-G5 ambient pass unchanged. Wiring it (and `authPlaneDb`) is what
+   * opts this monitor into the tenant fan-out.
+   */
+  db?: Database;
+  /**
+   * The auth-plane read connection (`services.authPlane.db`) — per ADR-0003 the
+   * only runtime-process identity that may enumerate `tenants`.
+   */
+  authPlaneDb?: Database;
+  /** Environment used for the flag/enforcement decisions. Tests override it. */
+  env?: NodeJS.ProcessEnv;
 }
 
 export class TurnMonitor {
@@ -81,40 +128,81 @@ export class TurnMonitor {
     this.running = true;
 
     try {
-      // Get all turns idle for at least NUDGE_THRESHOLD_MS (the lowest threshold)
-      const staleTurns = await this.deps.turnService.getStale(NUDGE_THRESHOLD_MS);
+      const { db, authPlaneDb } = this.deps;
 
-      for (const turn of staleTurns) {
-        const idleMs = Date.now() - turn.lastActivityAt.getTime();
-        const idleSec = Math.round(idleMs / 1000);
-
-        // Force-close at TIMEOUT_THRESHOLD_MS
-        if (idleMs >= TIMEOUT_THRESHOLD_MS) {
-          await this.handleTimeout(turn.id, turn.instanceId, turn.chatId, idleSec, turn.nudgeCount);
-          continue;
+      // LEGACY WORLD (no pool wired): the pre-G5 pass, statement for statement.
+      if (!db || !authPlaneDb) {
+        const staleTurns = await this.deps.turnService.getStale(NUDGE_THRESHOLD_MS);
+        for (const turn of staleTurns) {
+          await this.processTurn(turn, null);
         }
-
-        // Per-instance stalled-timeout config (live — re-read every tick, no caching).
-        const instance = await this.deps.instanceService.getById(turn.instanceId).catch(() => null);
-        const stalledThresholdMs = instance?.agentStalledTimeoutMs ?? DEFAULT_STALLED_THRESHOLD_MS;
-
-        // Emit internal turn.stalled event once — when nudgeCount is exactly 2 and idle crosses the per-instance threshold
-        if (idleMs >= stalledThresholdMs && turn.nudgeCount === 2) {
-          await this.handleStalled(turn.id, turn.instanceId, turn.chatId, idleMs, stalledThresholdMs);
-          continue;
-        }
-
-        // Nudge at 120s intervals (nudgeCount 0 → nudge 1, nudgeCount 1 → nudge 2)
-        // Only nudge if idle exceeds the threshold for the *next* nudge
-        const expectedNudges = Math.floor(idleMs / NUDGE_THRESHOLD_MS);
-        if (turn.nudgeCount < expectedNudges && turn.nudgeCount < 2) {
-          await this.handleNudge(turn.id, turn.instanceId, turn.chatId, idleSec, turn.nudgeCount + 1);
-        }
+        return;
       }
+
+      // TENANT WORLD: enumerate, scope the read per tenant, act per row outside
+      // that read's scope. Flag-off this helper still runs exactly one ambient
+      // pass with `tenantId === null`, so the branch above and this one agree.
+      await runForEachActiveTenantRow(
+        {
+          db,
+          authPlaneDb,
+          jobName: 'turn-monitor',
+          listActive: () => this.deps.turnService.getStale(NUDGE_THRESHOLD_MS),
+          env: this.deps.env,
+        },
+        (turn, tenantId) => this.processTurn(turn, tenantId),
+      );
     } catch (error) {
       log.error('Turn monitor tick failed', { error: String(error) });
     } finally {
       this.running = false;
+    }
+  }
+
+  /**
+   * One stale turn's staleness decision and action.
+   *
+   * `tenantId` is the pass's TRUSTED tenant (from the enumeration, matched
+   * against the row's own persisted `tenant_id` by the fan-out helper) or null
+   * on the legacy path. Every DB block below threads it, so each opens its own
+   * short scope and closes before the event publish that follows it.
+   *
+   * A per-turn failure stays per-turn: one broken turn must not abort the rest
+   * of the tenant's sweep, which is also what the pre-G5 loop's outer catch did
+   * for the whole tick.
+   */
+  private async processTurn(
+    turn: { id: string; instanceId: string; chatId: string; lastActivityAt: Date; nudgeCount: number },
+    tenantId: string | null,
+  ): Promise<void> {
+    const idleMs = Date.now() - turn.lastActivityAt.getTime();
+    const idleSec = Math.round(idleMs / 1000);
+
+    // Force-close at TIMEOUT_THRESHOLD_MS
+    if (idleMs >= TIMEOUT_THRESHOLD_MS) {
+      await this.handleTimeout(turn.id, turn.instanceId, turn.chatId, idleSec, turn.nudgeCount, tenantId);
+      return;
+    }
+
+    // Per-instance stalled-timeout config (live — re-read every tick, no caching).
+    // This is the `instances` read the conversion exists for: its own short
+    // worker scope, closed before anything else happens.
+    const instance = await runTenantWorkDb(this.deps.db as never, tenantId, () =>
+      this.deps.instanceService.getById(turn.instanceId),
+    ).catch(() => null);
+    const stalledThresholdMs = instance?.agentStalledTimeoutMs ?? DEFAULT_STALLED_THRESHOLD_MS;
+
+    // Emit internal turn.stalled event once — when nudgeCount is exactly 2 and idle crosses the per-instance threshold
+    if (idleMs >= stalledThresholdMs && turn.nudgeCount === 2) {
+      await this.handleStalled(turn.id, turn.instanceId, turn.chatId, idleMs, stalledThresholdMs, tenantId);
+      return;
+    }
+
+    // Nudge at 120s intervals (nudgeCount 0 → nudge 1, nudgeCount 1 → nudge 2)
+    // Only nudge if idle exceeds the threshold for the *next* nudge
+    const expectedNudges = Math.floor(idleMs / NUDGE_THRESHOLD_MS);
+    if (turn.nudgeCount < expectedNudges && turn.nudgeCount < 2) {
+      await this.handleNudge(turn.id, turn.instanceId, turn.chatId, idleSec, turn.nudgeCount + 1, tenantId);
     }
   }
 
@@ -124,8 +212,9 @@ export class TurnMonitor {
     chatId: string,
     idleSec: number,
     nudgeCount: number,
+    tenantId: string | null,
   ): Promise<void> {
-    await this.deps.turnService.incrementNudge(turnId);
+    await runTenantWorkDb(this.deps.db as never, tenantId, () => this.deps.turnService.incrementNudge(turnId));
 
     publishTurnNudge(instanceId, chatId, {
       turnId,
@@ -143,9 +232,10 @@ export class TurnMonitor {
     chatId: string,
     stalledAtMs: number,
     threshold: number,
+    tenantId: string | null,
   ): Promise<void> {
     // Increment nudge count to 3 to mark stalled as emitted so we never retry.
-    await this.deps.turnService.incrementNudge(turnId);
+    await runTenantWorkDb(this.deps.db as never, tenantId, () => this.deps.turnService.incrementNudge(turnId));
 
     const payload = { turnId, instanceId, chatId, stalledAtMs, threshold };
 
@@ -159,11 +249,14 @@ export class TurnMonitor {
     chatId: string,
     idleSec: number,
     nudgeCount: number,
+    tenantId: string | null,
   ): Promise<void> {
-    const closed = await this.deps.turnService.close(turnId, {
-      action: 'timeout',
-      reason: `Idle for ${idleSec}s`,
-    });
+    const closed = await runTenantWorkDb(this.deps.db as never, tenantId, () =>
+      this.deps.turnService.close(turnId, {
+        action: 'timeout',
+        reason: `Idle for ${idleSec}s`,
+      }),
+    );
 
     if (!closed) return;
 

--- a/packages/api/src/tenancy/__tests__/inflight-revocation.test.ts
+++ b/packages/api/src/tenancy/__tests__/inflight-revocation.test.ts
@@ -1,0 +1,193 @@
+/**
+ * In-flight privileged-work revocation monitor, proven with a SYNTHETIC clock
+ * (wish: omni-full-multitenancy, Group G5, deliverable (c); ADR-0006;
+ * RELEASE_SLOS `revocation.inflight_privileged_work_revocation_seconds_max: 30`).
+ *
+ * A long-running work item (a multi-thousand-message sync, a slow batch loop)
+ * can outlive its dequeue-time admissibility check by minutes. The monitor
+ * gives such loops a bounded observation window: `assertAdmissible()` is
+ * called once per item, consults the injected clock, and re-checks the
+ * tenant's admissibility whenever the recheck interval has elapsed — so a
+ * revocation that lands mid-flight is OBSERVED within the interval, and the
+ * interval is half the ceiling (the same cadence-vs-ceiling rationale as the
+ * stream-termination sweep: a flip landing right after one check is still
+ * caught by the next one, inside the ceiling).
+ *
+ * Every number here is driven from the injected `now` — no wall-clock waits,
+ * no production timing claims. Legacy work (null tenant) never checks and
+ * never gains a query: the dual world, byte-identical.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  INFLIGHT_REVOCATION_CEILING_SECONDS,
+  InflightRevocationError,
+  createInflightRevocationMonitor,
+} from '../inflight-revocation';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+
+describe('the ceiling constant (RELEASE_SLOS inflight_privileged_work_revocation_seconds_max)', () => {
+  test('is 30 seconds, and the default recheck cadence is half of it', () => {
+    expect(INFLIGHT_REVOCATION_CEILING_SECONDS).toBe(30);
+  });
+});
+
+describe('inflight revocation monitor (synthetic clock)', () => {
+  test('checks at the first gate, then re-checks only when the interval elapses', async () => {
+    let now = 0;
+    const checks: number[] = [];
+    const monitor = createInflightRevocationMonitor({
+      tenantId: TENANT_A,
+      check: async () => {
+        checks.push(now);
+        return true;
+      },
+      now: () => now,
+    });
+
+    await monitor.assertAdmissible(); // first gate always checks
+    expect(checks).toEqual([0]);
+
+    now = 14_999; // inside the cadence — no new query
+    await monitor.assertAdmissible();
+    expect(checks).toEqual([0]);
+
+    now = 15_000; // cadence reached — re-check
+    await monitor.assertAdmissible();
+    expect(checks).toEqual([0, 15_000]);
+
+    now = 29_999;
+    await monitor.assertAdmissible();
+    expect(checks).toEqual([0, 15_000]);
+
+    now = 30_000;
+    await monitor.assertAdmissible();
+    expect(checks).toEqual([0, 15_000, 30_000]);
+  });
+
+  test('a mid-flight revocation is observed within the 30s ceiling', async () => {
+    let now = 0;
+    let revoked = false;
+    let observedAt: number | null = null;
+    const monitor = createInflightRevocationMonitor({
+      tenantId: TENANT_A,
+      check: async () => {
+        if (revoked) observedAt = now;
+        return !revoked;
+      },
+      now: () => now,
+    });
+
+    await monitor.assertAdmissible();
+
+    // The revocation lands immediately after the first check — the worst case.
+    now = 1;
+    revoked = true;
+
+    // The loop keeps calling the gate as it processes items; the flip must be
+    // observed at the next cadence tick, which is within the ceiling.
+    let refused = false;
+    for (const t of [5_000, 10_000, 14_999, 15_000, 20_000]) {
+      now = t;
+      try {
+        await monitor.assertAdmissible();
+      } catch (error) {
+        expect(error).toBeInstanceOf(InflightRevocationError);
+        refused = true;
+        break;
+      }
+    }
+
+    expect(refused).toBe(true);
+    expect(observedAt).not.toBeNull();
+    // Observed 15s after the flip landed — inside the 30s ceiling.
+    expect((observedAt ?? Number.POSITIVE_INFINITY) - 1).toBeLessThanOrEqual(
+      INFLIGHT_REVOCATION_CEILING_SECONDS * 1000,
+    );
+  });
+
+  test('once refused, the monitor stays refused — no side effect after the flip is observable', async () => {
+    let now = 0;
+    let admissible = true;
+    const monitor = createInflightRevocationMonitor({
+      tenantId: TENANT_A,
+      check: async () => admissible,
+      now: () => now,
+    });
+
+    await monitor.assertAdmissible();
+    admissible = false;
+    now = 15_000;
+    await expect(monitor.assertAdmissible()).rejects.toThrow(InflightRevocationError);
+
+    // Even if the tenant were somehow admissible again, this work item is dead.
+    admissible = true;
+    now = 30_000;
+    await expect(monitor.assertAdmissible()).rejects.toThrow(InflightRevocationError);
+  });
+
+  test('a first-gate refusal stops the work item before ANY side effect (dequeue-time shape)', async () => {
+    const monitor = createInflightRevocationMonitor({
+      tenantId: TENANT_A,
+      check: async () => false,
+      now: () => 0,
+    });
+    await expect(monitor.assertAdmissible()).rejects.toThrow(/no longer admissible/);
+  });
+
+  test('a check that THROWS refuses fail-closed — auth-plane silence is not admissibility', async () => {
+    let calls = 0;
+    const monitor = createInflightRevocationMonitor({
+      tenantId: TENANT_A,
+      check: async () => {
+        calls++;
+        throw new Error('auth plane unreachable');
+      },
+      now: () => 0,
+    });
+
+    // The module doc pins this: privileged work that cannot verify its tenant
+    // stops. The check's error must not surface as-is (callers key on the
+    // typed refusal) and must not be swallowed into admissibility.
+    await expect(monitor.assertAdmissible()).rejects.toThrow(InflightRevocationError);
+    expect(calls).toBe(1);
+  });
+
+  test('a check-error refusal is sticky — the dead work item never re-queries, even past the cadence', async () => {
+    let now = 0;
+    let calls = 0;
+    const monitor = createInflightRevocationMonitor({
+      tenantId: TENANT_A,
+      check: async () => {
+        calls++;
+        throw new Error('auth plane unreachable');
+      },
+      now: () => now,
+    });
+
+    await expect(monitor.assertAdmissible()).rejects.toThrow(InflightRevocationError);
+
+    // Even a full ceiling later — when the auth plane may be healthy again —
+    // this work item stays refused and consults nothing.
+    now = INFLIGHT_REVOCATION_CEILING_SECONDS * 1000;
+    await expect(monitor.assertAdmissible()).rejects.toThrow(InflightRevocationError);
+    expect(calls).toBe(1);
+  });
+
+  test('legacy work (null tenant) never checks and never refuses — byte-identical', async () => {
+    let checked = 0;
+    const monitor = createInflightRevocationMonitor({
+      tenantId: null,
+      check: async () => {
+        checked++;
+        return false; // would refuse if ever consulted
+      },
+      now: () => 0,
+    });
+
+    await monitor.assertAdmissible();
+    await monitor.assertAdmissible();
+    expect(checked).toBe(0);
+  });
+});

--- a/packages/api/src/tenancy/__tests__/instance-owner-registry.test.ts
+++ b/packages/api/src/tenancy/__tests__/instance-owner-registry.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The instance→tenant ownership registry that lets a channel plugin's publish
+ * stamp a trusted tenant (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { resolveInstanceOwnerTenantId, setEnvelopeInstanceTenantResolver } from '@omni/core';
+import {
+  INSTANCE_OWNER_REGISTRY_MAX_ENTRIES,
+  __resetInstanceOwnerRegistry,
+  forgetInstanceOwner,
+  installInstanceOwnerResolver,
+  instanceOwnerRegistrySize,
+  lookupInstanceOwner,
+  rememberInstanceOwner,
+  rememberInstanceOwners,
+} from '../instance-owner-registry';
+
+const TENANT_A = '11111111-1111-4111-8111-111111111fa1';
+const TENANT_B = '22222222-2222-4222-8222-222222222fb2';
+const INSTANCE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaafa1';
+const INSTANCE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbfb2';
+
+afterEach(() => {
+  __resetInstanceOwnerRegistry();
+  setEnvelopeInstanceTenantResolver(null);
+});
+
+describe('instance owner registry', () => {
+  test('remembers a loaded instance row’s persisted tenant and hands it back', () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    expect(lookupInstanceOwner(INSTANCE_A)).toBe(TENANT_A);
+    expect(lookupInstanceOwner(INSTANCE_B)).toBeNull();
+  });
+
+  test('a NULL-tenant row (flag-off / pre-backfill) is remembered as ABSENT, never as a tenant', () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: null });
+    expect(lookupInstanceOwner(INSTANCE_A)).toBeNull();
+    expect(instanceOwnerRegistrySize()).toBe(0);
+  });
+
+  test('a malformed tenant is refused — the registry cannot be poisoned into stamping one', () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: 'not-a-uuid' });
+    rememberInstanceOwner({ id: INSTANCE_B, tenantId: '' });
+    expect(lookupInstanceOwner(INSTANCE_A)).toBeNull();
+    expect(lookupInstanceOwner(INSTANCE_B)).toBeNull();
+    expect(instanceOwnerRegistrySize()).toBe(0);
+  });
+
+  test('re-remembering the same instance under a DIFFERENT tenant is refused', () => {
+    // An instance's tenant is its ownership ROOT and does not change. A second,
+    // conflicting derivation means something upstream is wrong; silently taking
+    // the newer value would let one bad read redirect a live instance's whole
+    // event stream into another tenant.
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_B });
+    expect(lookupInstanceOwner(INSTANCE_A)).toBe(TENANT_A);
+  });
+
+  test('forget removes an entry (instance deleted)', () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    forgetInstanceOwner(INSTANCE_A);
+    expect(lookupInstanceOwner(INSTANCE_A)).toBeNull();
+  });
+
+  test('bulk remember skips the rows it cannot use and keeps the rest', () => {
+    rememberInstanceOwners([
+      { id: INSTANCE_A, tenantId: TENANT_A },
+      { id: INSTANCE_B, tenantId: null },
+    ]);
+    expect(lookupInstanceOwner(INSTANCE_A)).toBe(TENANT_A);
+    expect(lookupInstanceOwner(INSTANCE_B)).toBeNull();
+  });
+
+  test('the registry is BOUNDED — it cannot grow without limit', () => {
+    for (let i = 0; i < INSTANCE_OWNER_REGISTRY_MAX_ENTRIES + 50; i++) {
+      rememberInstanceOwner({ id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(i).padStart(12, '0')}`, tenantId: TENANT_A });
+    }
+    expect(instanceOwnerRegistrySize()).toBeLessThanOrEqual(INSTANCE_OWNER_REGISTRY_MAX_ENTRIES);
+  });
+
+  test('installing the resolver makes @omni/core’s publish path see the ownership', () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    installInstanceOwnerResolver();
+    expect(resolveInstanceOwnerTenantId(INSTANCE_A)).toBe(TENANT_A);
+    expect(resolveInstanceOwnerTenantId(INSTANCE_B)).toBeNull();
+  });
+
+  test('without installing, @omni/core stamps nothing (dual world)', () => {
+    rememberInstanceOwner({ id: INSTANCE_A, tenantId: TENANT_A });
+    expect(resolveInstanceOwnerTenantId(INSTANCE_A)).toBeNull();
+  });
+});

--- a/packages/api/src/tenancy/__tests__/periodic-tenant-work.test.ts
+++ b/packages/api/src/tenancy/__tests__/periodic-tenant-work.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Periodic-work tenant fan-out — enumeration gating, per-tenant scope, failure
+ * isolation (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0003).
+ *
+ * The DB is faked (a select chain returning canned tenant rows; a transaction
+ * that runs its callback) so these assert the FAN-OUT semantics with no
+ * PostgreSQL:
+ *
+ *   1. flag-off runs NO query and enumerates nothing — the legacy cron path
+ *      must not gain a single statement;
+ *   2. flag-on enumerates exactly the ACTIVE tenants from the auth-plane read;
+ *   3. every per-tenant pass runs inside ITS OWN worker tenant scope;
+ *   4. one tenant's failure never aborts a sibling's pass.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { MULTITENANCY_FLAG_ENV } from '../feature-flag';
+import { enumerateActiveWorkTenants, runForEachActiveWorkTenant } from '../periodic-tenant-work';
+import { requireTenantScope } from '../tenant-scope';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+const FLAG_ON: NodeJS.ProcessEnv = { [MULTITENANCY_FLAG_ENV]: 'true' };
+const FLAG_OFF: NodeJS.ProcessEnv = {};
+
+/** Auth-plane Database fake: records whether a select ran, returns `rows`. */
+function fakeAuthPlaneDb(rows: Array<{ id: string }>, counter: { selects: number }): Database {
+  return {
+    select: () => {
+      counter.selects += 1;
+      return { from: () => ({ where: async () => rows }) };
+    },
+  } as unknown as Database;
+}
+
+/** Worker-scope Database fake: `transaction` runs the callback with a no-op tx. */
+function fakeScopeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({ execute: async () => [] as unknown }),
+  } as unknown as Database;
+}
+
+describe('enumerateActiveWorkTenants', () => {
+  test('flag-off enumerates nothing and issues NO query', async () => {
+    const counter = { selects: 0 };
+    const authPlane = fakeAuthPlaneDb([{ id: TENANT_A }], counter);
+    expect(await enumerateActiveWorkTenants(authPlane, FLAG_OFF)).toEqual([]);
+    expect(counter.selects).toBe(0);
+  });
+
+  test('flag-on returns the active tenants from the auth-plane read', async () => {
+    const counter = { selects: 0 };
+    const authPlane = fakeAuthPlaneDb([{ id: TENANT_A }, { id: TENANT_B }], counter);
+    expect(await enumerateActiveWorkTenants(authPlane, FLAG_ON)).toEqual([TENANT_A, TENANT_B]);
+    expect(counter.selects).toBe(1);
+  });
+});
+
+describe('runForEachActiveWorkTenant', () => {
+  test('flag-off runs no pass at all', async () => {
+    const counter = { selects: 0 };
+    const seen: string[] = [];
+    const stats = await runForEachActiveWorkTenant(
+      fakeScopeDb(),
+      fakeAuthPlaneDb([{ id: TENANT_A }], counter),
+      'test-job',
+      async (tenantId) => {
+        seen.push(tenantId);
+      },
+      FLAG_OFF,
+    );
+    expect(seen).toEqual([]);
+    expect(counter.selects).toBe(0);
+    expect(stats).toEqual({ tenants: 0, succeeded: 0, failed: 0 });
+  });
+
+  test('each pass runs inside its own worker scope stamped with THAT tenant', async () => {
+    const counter = { selects: 0 };
+    const scoped: Array<{ arg: string; scope: string }> = [];
+    const stats = await runForEachActiveWorkTenant(
+      fakeScopeDb(),
+      fakeAuthPlaneDb([{ id: TENANT_A }, { id: TENANT_B }], counter),
+      'test-job',
+      async (tenantId) => {
+        scoped.push({ arg: tenantId, scope: requireTenantScope().tenantId });
+      },
+      FLAG_ON,
+    );
+    expect(scoped).toEqual([
+      { arg: TENANT_A, scope: TENANT_A },
+      { arg: TENANT_B, scope: TENANT_B },
+    ]);
+    expect(stats).toEqual({ tenants: 2, succeeded: 2, failed: 0 });
+  });
+
+  test("one tenant's failure is isolated — the sibling pass still runs", async () => {
+    const counter = { selects: 0 };
+    const seen: string[] = [];
+    const stats = await runForEachActiveWorkTenant(
+      fakeScopeDb(),
+      fakeAuthPlaneDb([{ id: TENANT_A }, { id: TENANT_B }], counter),
+      'test-job',
+      async (tenantId) => {
+        if (tenantId === TENANT_A) throw new Error('tenant A pass exploded');
+        seen.push(tenantId);
+      },
+      FLAG_ON,
+    );
+    expect(seen).toEqual([TENANT_B]);
+    expect(stats).toEqual({ tenants: 2, succeeded: 1, failed: 1 });
+  });
+});

--- a/packages/api/src/tenancy/__tests__/sealed-credentials.test.ts
+++ b/packages/api/src/tenancy/__tests__/sealed-credentials.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The tenant-bound credential-FIELD codec (G5 deliverable (g); ADR-0008).
+ *
+ * `tenant-secret-box` seals a secret into a structured envelope. Most of the
+ * remaining credential surfaces store their secret in a `text` COLUMN
+ * (`instances.discord_bot_token`, `agent_providers.api_key`,
+ * `plugin_storage.value`, `global_settings.value`), so they need the envelope
+ * flattened into a string and, critically, a TRANSITIONAL read that still
+ * accepts the legacy plaintext already sitting in those columns.
+ *
+ * What these tests pin:
+ *   * DUAL WORLD — no tenant, or no master key, means the value passes through
+ *     UNCHANGED in both directions. That is the byte-identical legacy contract;
+ *     the codec must not even reshape the string.
+ *   * SEALED — with tenant + key the stored string contains no plaintext and the
+ *     owning tenant reads it back exactly.
+ *   * CROSS-TENANT REFUSAL — tenant B opening tenant A's sealed field fails
+ *     CLOSED to null, never to the ciphertext and never to a throw.
+ *   * TRANSITIONAL READ — a legacy plaintext column value survives a read even
+ *     while sealing is enabled (that is what makes the rollout incremental).
+ *   * NO PLAINTEXT DOWNGRADE ON A BLIND READ — a sealed field read with no
+ *     tenant available yields null, not the envelope string. A caller must never
+ *     be handed a blob it would then send to a channel as a bot token.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { setTenantSecretMasterKey } from '@omni/core';
+import { isSealedCredentialField, openCredentialField, sealCredentialField } from '../sealed-credentials';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const MASTER_KEY = Buffer.alloc(32, 7);
+
+afterEach(() => setTenantSecretMasterKey(null));
+
+describe('sealed-credentials — dual world (inert without a key)', () => {
+  test('no master key: seal is the identity function even with a tenant', () => {
+    setTenantSecretMasterKey(null);
+    expect(sealCredentialField(TENANT_A, 'xoxb-super-secret')).toBe('xoxb-super-secret');
+  });
+
+  test('no tenant: seal is the identity function even with a key', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    expect(sealCredentialField(null, 'xoxb-super-secret')).toBe('xoxb-super-secret');
+    expect(sealCredentialField(undefined, 'xoxb-super-secret')).toBe('xoxb-super-secret');
+  });
+
+  test('null/undefined plaintext passes through unchanged in every world', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    expect(sealCredentialField(TENANT_A, null)).toBeNull();
+    expect(sealCredentialField(TENANT_A, undefined)).toBeUndefined();
+    expect(openCredentialField(TENANT_A, null)).toBeNull();
+    expect(openCredentialField(TENANT_A, undefined)).toBeUndefined();
+  });
+
+  test('empty string is not sealed (nothing to protect, and callers treat it as absent)', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    expect(sealCredentialField(TENANT_A, '')).toBe('');
+  });
+});
+
+describe('sealed-credentials — sealed at rest', () => {
+  test('tenant + key: the stored string carries no plaintext and the owner round-trips it', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const stored = sealCredentialField(TENANT_A, 'xoxb-super-secret');
+    if (typeof stored !== 'string') throw new Error('expected a sealed string');
+
+    expect(stored).not.toContain('xoxb-super-secret');
+    expect(isSealedCredentialField(stored)).toBe(true);
+    expect(openCredentialField(TENANT_A, stored)).toBe('xoxb-super-secret');
+  });
+
+  test('two seals of the same secret differ (fresh nonce), and both open', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const a = sealCredentialField(TENANT_A, 'same-token');
+    const b = sealCredentialField(TENANT_A, 'same-token');
+    expect(a).not.toBe(b);
+    expect(openCredentialField(TENANT_A, a as string)).toBe('same-token');
+    expect(openCredentialField(TENANT_A, b as string)).toBe('same-token');
+  });
+});
+
+describe('sealed-credentials — cross-tenant refusal', () => {
+  test('tenant B cannot open a field sealed for tenant A (null, not a throw, not the blob)', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const stored = sealCredentialField(TENANT_A, 'tenant-a-bot-token') as string;
+    expect(openCredentialField(TENANT_B, stored)).toBeNull();
+  });
+
+  test('rewriting the stored tenant label does not make it openable by the forger', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const stored = sealCredentialField(TENANT_A, 'tenant-a-bot-token') as string;
+    const forged = JSON.stringify({ ...JSON.parse(stored), t: TENANT_B });
+    expect(openCredentialField(TENANT_B, forged)).toBeNull();
+  });
+
+  test('a sealed field read with NO tenant yields null — never the envelope string', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const stored = sealCredentialField(TENANT_A, 'tenant-a-bot-token') as string;
+    expect(openCredentialField(null, stored)).toBeNull();
+  });
+
+  test('a sealed field read after the key is withdrawn yields null, not the blob', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const stored = sealCredentialField(TENANT_A, 'tenant-a-bot-token') as string;
+    setTenantSecretMasterKey(null);
+    expect(openCredentialField(TENANT_A, stored)).toBeNull();
+  });
+});
+
+describe('sealed-credentials — transitional reads', () => {
+  test('legacy plaintext still reads through while sealing is enabled', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    expect(openCredentialField(TENANT_A, 'legacy-plaintext-token')).toBe('legacy-plaintext-token');
+  });
+
+  test('a JSON value that is not a sealed envelope is left alone', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const notSealed = '{"v":1,"hello":"world"}';
+    expect(isSealedCredentialField(notSealed)).toBe(false);
+    expect(openCredentialField(TENANT_A, notSealed)).toBe(notSealed);
+  });
+
+  test('a value that merely looks like the sealed prefix but is malformed JSON is left alone', () => {
+    setTenantSecretMasterKey(MASTER_KEY);
+    const junk = '{"v":not-json';
+    expect(isSealedCredentialField(junk)).toBe(false);
+    expect(openCredentialField(TENANT_A, junk)).toBe(junk);
+  });
+});

--- a/packages/api/src/tenancy/__tests__/tenant-stream-subscriptions.test.ts
+++ b/packages/api/src/tenancy/__tests__/tenant-stream-subscriptions.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Streaming / long-lived-state tenant keying — G5 deliverable (e)
+ * (wish: omni-full-multitenancy; ADR-0008, ADR-0006; RELEASE_SLOS
+ * `revocation.websocket_sse_channel_provider_session_termination_seconds_max`).
+ *
+ * WHAT THESE PROBES FIX
+ * ---------------------
+ *   1. a long-lived subscription is keyed AND authorized by tenant, not only by
+ *      resource UUID — knowing a session/chat id is not authority to receive it;
+ *   2. fan-out to a resource never crosses a tenant boundary, even when two
+ *      tenants' subscriptions name the SAME resource id;
+ *   3. subscriptions terminate on revocation (suspension OR a bumped revocation
+ *      epoch) inside the RELEASE_SLOS ceiling, proven with SYNTHETIC epochs and
+ *      a synthetic clock — never a production timing claim;
+ *   4. DUAL WORLD: flag-off/legacy subscriptions carry no tenant, fan out by
+ *      resource exactly as pre-G5, and the sweeper issues NO query at all.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import {
+  STREAM_TERMINATION_CEILING_SECONDS,
+  TenantStreamRegistry,
+  authorizeStreamSubscription,
+  resolveStreamSweepIntervalMs,
+  streamSubscriptionKey,
+  sweepRevokedStreamSubscriptions,
+} from '../tenant-stream-subscriptions';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const SESSION = 'voice-session-shared';
+
+const FLAG_ON = { OMNI_MULTITENANCY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv;
+const FLAG_OFF = {} as unknown as NodeJS.ProcessEnv;
+
+/** A recording sink standing in for a live socket. */
+function socket() {
+  const sent: string[] = [];
+  const closed: string[] = [];
+  return {
+    sent,
+    closed,
+    send: (data: string) => sent.push(data),
+    close: (reason: string) => closed.push(reason),
+  };
+}
+
+/**
+ * A synthetic `tenants` control-plane table, injected through the same reader
+ * seam production uses. Epochs here are SYNTHETIC — nothing about these numbers
+ * claims a production propagation time.
+ */
+function fakeStateReader(rows: Record<string, { status: string; revocationEpoch: number }>) {
+  const reads: string[] = [];
+  const read = async (_db: Database, tenantId: string) => {
+    reads.push(tenantId);
+    return rows[tenantId] ?? null;
+  };
+  return { read, reads };
+}
+
+/** An auth-plane handle that fails the test if it is ever queried. */
+function forbiddenAuthPlane(): Database {
+  return {
+    select: () => {
+      throw new Error('flag-off sweep must not touch the database');
+    },
+  } as unknown as Database;
+}
+
+describe('authorizeStreamSubscription — authority, not resource knowledge', () => {
+  test('legacy world: no tenant context and no owned resource is admitted unchanged', () => {
+    expect(authorizeStreamSubscription({ authenticatedTenantId: null, resourceTenantId: null })).toEqual({ ok: true });
+  });
+
+  test('a tenant may subscribe to its OWN resource', () => {
+    expect(authorizeStreamSubscription({ authenticatedTenantId: TENANT_A, resourceTenantId: TENANT_A })).toEqual({
+      ok: true,
+    });
+  });
+
+  test('knowing tenant B resource id is NOT authority — cross-tenant subscribe refused', () => {
+    expect(authorizeStreamSubscription({ authenticatedTenantId: TENANT_A, resourceTenantId: TENANT_B })).toEqual({
+      ok: false,
+      reason: 'cross_tenant_resource',
+    });
+  });
+
+  test('fail-closed: a tenant-context subscriber may not bind an unowned resource', () => {
+    expect(authorizeStreamSubscription({ authenticatedTenantId: TENANT_A, resourceTenantId: null })).toEqual({
+      ok: false,
+      reason: 'unowned_resource',
+    });
+  });
+
+  test('fail-closed: an owned resource may not be bound without a tenant context', () => {
+    expect(authorizeStreamSubscription({ authenticatedTenantId: null, resourceTenantId: TENANT_A })).toEqual({
+      ok: false,
+      reason: 'tenant_context_required',
+    });
+  });
+
+  test('a malformed tenant is refused before it can key anything', () => {
+    expect(
+      authorizeStreamSubscription({ authenticatedTenantId: 'not-a-uuid', resourceTenantId: 'not-a-uuid' }),
+    ).toEqual({ ok: false, reason: 'malformed_tenant' });
+  });
+});
+
+describe('streamSubscriptionKey — a resource UUID alone cannot address a stream', () => {
+  test('the same resource under two tenants yields two distinct keys', () => {
+    expect(streamSubscriptionKey(TENANT_A, SESSION)).not.toBe(streamSubscriptionKey(TENANT_B, SESSION));
+  });
+
+  test('the legacy key is stable and distinct from every tenant key', () => {
+    const legacy = streamSubscriptionKey(null, SESSION);
+    expect(legacy).not.toBe(streamSubscriptionKey(TENANT_A, SESSION));
+    expect(legacy).toBe(streamSubscriptionKey(null, SESSION));
+  });
+});
+
+describe('TenantStreamRegistry — fan-out never crosses a tenant', () => {
+  test('two tenants subscribed to the SAME resource id receive only their own payloads', () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const a = socket();
+    const b = socket();
+    registry.add(a, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 1, close: a.close });
+    registry.add(b, { tenantId: TENANT_B, resourceId: SESSION, revocationEpoch: 1, close: b.close });
+
+    for (const [conn] of registry.matching(SESSION, TENANT_A)) conn.send('for-A');
+
+    expect(a.sent).toEqual(['for-A']);
+    expect(b.sent).toEqual([]);
+  });
+
+  test('DUAL WORLD: legacy subscriptions fan out by resource alone, as pre-G5', () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const one = socket();
+    const two = socket();
+    registry.add(one, { tenantId: null, resourceId: SESSION, revocationEpoch: 0, close: one.close });
+    registry.add(two, { tenantId: null, resourceId: SESSION, revocationEpoch: 0, close: two.close });
+
+    for (const [conn] of registry.matching(SESSION, null)) conn.send('legacy');
+
+    expect(one.sent).toEqual(['legacy']);
+    expect(two.sent).toEqual(['legacy']);
+  });
+
+  test('a legacy fan-out does not reach a tenant-bound subscriber, and vice versa', () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const legacy = socket();
+    const bound = socket();
+    registry.add(legacy, { tenantId: null, resourceId: SESSION, revocationEpoch: 0, close: legacy.close });
+    registry.add(bound, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 1, close: bound.close });
+
+    for (const [conn] of registry.matching(SESSION, null)) conn.send('legacy');
+    for (const [conn] of registry.matching(SESSION, TENANT_A)) conn.send('tenant');
+
+    expect(legacy.sent).toEqual(['legacy']);
+    expect(bound.sent).toEqual(['tenant']);
+  });
+
+  test('terminateTenant closes only the named tenant, leaving siblings connected', () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const a = socket();
+    const b = socket();
+    registry.add(a, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 1, close: a.close });
+    registry.add(b, { tenantId: TENANT_B, resourceId: SESSION, revocationEpoch: 1, close: b.close });
+
+    const closed = registry.terminateTenant(TENANT_A, 'tenant_suspended');
+
+    expect(closed).toBe(1);
+    expect(a.closed).toEqual(['tenant_suspended']);
+    expect(b.closed).toEqual([]);
+    expect(registry.size).toBe(1);
+  });
+});
+
+describe('revocation sweep — synthetic epochs, RELEASE_SLOS ceiling', () => {
+  test('the sweep cadence is at or under the RELEASE_SLOS termination ceiling', () => {
+    expect(STREAM_TERMINATION_CEILING_SECONDS).toBe(30);
+    expect(resolveStreamSweepIntervalMs()).toBeLessThanOrEqual(STREAM_TERMINATION_CEILING_SECONDS * 1000);
+  });
+
+  test('a SUSPENDED tenant loses its subscriptions; the active sibling keeps its own', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const a = socket();
+    const b = socket();
+    registry.add(a, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 1, close: a.close });
+    registry.add(b, { tenantId: TENANT_B, resourceId: SESSION, revocationEpoch: 1, close: b.close });
+
+    const plane = fakeStateReader({
+      [TENANT_A]: { status: 'suspended', revocationEpoch: 2 },
+      [TENANT_B]: { status: 'active', revocationEpoch: 1 },
+    });
+
+    const stats = await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_ON, plane.read);
+
+    expect(stats.terminated).toBe(1);
+    expect(a.closed).toEqual(['tenant_revoked']);
+    expect(b.closed).toEqual([]);
+  });
+
+  test('a BUMPED revocation epoch terminates a still-active tenant subscription', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const stale = socket();
+    registry.add(stale, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 7, close: stale.close });
+
+    const plane = fakeStateReader({ [TENANT_A]: { status: 'active', revocationEpoch: 8 } });
+    const stats = await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_ON, plane.read);
+
+    expect(stats.terminated).toBe(1);
+    expect(stale.closed).toEqual(['tenant_revoked']);
+    expect(registry.size).toBe(0);
+  });
+
+  test('an unchanged epoch on an active tenant terminates nothing', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const live = socket();
+    registry.add(live, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 7, close: live.close });
+
+    const plane = fakeStateReader({ [TENANT_A]: { status: 'active', revocationEpoch: 7 } });
+    const stats = await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_ON, plane.read);
+
+    expect(stats.terminated).toBe(0);
+    expect(live.closed).toEqual([]);
+    expect(registry.size).toBe(1);
+  });
+
+  test('fail-closed: a tenant that no longer resolves at all is terminated', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const orphan = socket();
+    registry.add(orphan, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 1, close: orphan.close });
+
+    const stats = await sweepRevokedStreamSubscriptions(
+      forbiddenAuthPlane(),
+      registry,
+      FLAG_ON,
+      fakeStateReader({}).read,
+    );
+
+    expect(stats.terminated).toBe(1);
+    expect(orphan.closed).toEqual(['tenant_revoked']);
+  });
+
+  test('one auth-plane read per DISTINCT tenant, not per connection', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    for (let i = 0; i < 5; i += 1) {
+      const s = socket();
+      registry.add(s, { tenantId: TENANT_A, resourceId: `res-${i}`, revocationEpoch: 1, close: s.close });
+    }
+    const plane = fakeStateReader({ [TENANT_A]: { status: 'active', revocationEpoch: 1 } });
+    await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_ON, plane.read);
+    expect(plane.reads).toEqual([TENANT_A]);
+  });
+
+  test('DUAL WORLD: flag-off sweeps nothing and issues no query', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const legacy = socket();
+    registry.add(legacy, { tenantId: null, resourceId: SESSION, revocationEpoch: 0, close: legacy.close });
+
+    const stats = await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_OFF);
+
+    expect(stats.terminated).toBe(0);
+    expect(legacy.closed).toEqual([]);
+    expect(registry.size).toBe(1);
+  });
+
+  test('flag-on: legacy (tenantless) subscriptions are never swept or queried', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const legacy = socket();
+    registry.add(legacy, { tenantId: null, resourceId: SESSION, revocationEpoch: 0, close: legacy.close });
+
+    const plane = fakeStateReader({});
+    const stats = await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_ON, plane.read);
+
+    expect(stats.terminated).toBe(0);
+    expect(plane.reads).toEqual([]);
+    expect(legacy.closed).toEqual([]);
+  });
+
+  test('SYNTHETIC CLOCK: a revocation at t=0 is terminated within the ceiling', async () => {
+    const registry = new TenantStreamRegistry<ReturnType<typeof socket>>();
+    const s = socket();
+    registry.add(s, { tenantId: TENANT_A, resourceId: SESSION, revocationEpoch: 1, close: s.close });
+
+    // Synthetic timeline: the tenant is suspended at t=0; the sweeper's next tick
+    // lands at `resolveStreamSweepIntervalMs()`. No wall clock is consulted.
+    const revokedAtMs = 0;
+    const sweptAtMs = revokedAtMs + resolveStreamSweepIntervalMs();
+
+    const plane = fakeStateReader({ [TENANT_A]: { status: 'suspended', revocationEpoch: 2 } });
+    const stats = await sweepRevokedStreamSubscriptions(forbiddenAuthPlane(), registry, FLAG_ON, plane.read);
+
+    expect(stats.terminated).toBe(1);
+    expect((sweptAtMs - revokedAtMs) / 1000).toBeLessThanOrEqual(STREAM_TERMINATION_CEILING_SECONDS);
+  });
+});

--- a/packages/api/src/tenancy/__tests__/worker-context-two-tenant-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/worker-context-two-tenant-postgres.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Two-tenant WORKER-context containment over real PostgreSQL + RLS
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * `two-tenant-adversarial-postgres.test.ts` proves a REQUEST scope contains. This
+ * asks the async question G5 owns: when a consumer establishes its tenant from a
+ * versioned envelope via `runInWorkerTenantScope` — no request, no credential —
+ * does its DB work stay inside that tenant, and does a producer LYING about the
+ * tenant get rejected by the server-side ownership derivation rather than
+ * trusted?
+ *
+ * It exercises the real converted consumer (`setupEventPersistence`) end to end:
+ * the same handler the NATS subscription calls, driven with tenant-A and
+ * tenant-B envelopes against the runtime role under FORCE RLS.
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { EventBus, OmniEvent } from '@omni/core';
+import {
+  DEFAULT_ROLE_NAMES,
+  type Database,
+  applyTenancyRoles,
+  applyTenantRlsEnforcement,
+  createDbHandle,
+  omniEvents,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { setupEventPersistence } from '../../plugins/event-persistence';
+import { InstanceService } from '../../services/instances';
+import { scopedHandle } from '../tenant-scope';
+import { runInWorkerTenantScope } from '../worker-tenant-context';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+const INSTANCE_A = '55555555-5555-4555-8555-55555555555a';
+const INSTANCE_B = '55555555-5555-4555-8555-55555555555b';
+const CHAT_A = '66666666-6666-4666-8666-66666666666a';
+const CHAT_B = '66666666-6666-4666-8666-66666666666b';
+
+const SHARED_JID = '5511999990000@s.whatsapp.net';
+const SHARED_TIMESTAMP = '2026-01-01 00:00:00+00';
+
+function password(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-g5-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string, user?: { name: string; password: string }): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  if (user) {
+    url.username = user.name;
+    url.password = user.password;
+  }
+  return url.toString();
+}
+
+/** A message.received envelope for `instanceId`, optionally stamped for a tenant. */
+function receivedEvent(
+  instanceId: string,
+  externalId: string,
+  tenant: { envelopeVersion: number; tenantId: string } | null,
+): OmniEvent {
+  return {
+    id: crypto.randomUUID(),
+    type: 'message.received',
+    timestamp: Date.now(),
+    payload: {
+      externalId,
+      chatId: SHARED_JID,
+      from: 'someone',
+      content: { type: 'text', text: 'hello' },
+    },
+    metadata: {
+      correlationId: crypto.randomUUID(),
+      instanceId,
+      channelType: 'whatsapp-baileys',
+      ...(tenant ?? {}),
+    },
+  } as OmniEvent;
+}
+
+postgresDescribe('two-tenant worker-context containment (real PostgreSQL)', () => {
+  const dbName = `omni_g5_${crypto.randomUUID().replaceAll('-', '')}`;
+  const passwords = { ddl: password(), runtime: password(), authPlane: password() };
+  const closers: (() => Promise<void>)[] = [];
+  let runtimeDb: Database;
+  let instances: InstanceService;
+
+  /** The captured NATS handlers, keyed by event type. */
+  const handlers = new Map<string, (event: unknown) => Promise<void>>();
+
+  function openDb(url: string, maxConnections: number): Database {
+    const handle = createDbHandle({ url, maxConnections });
+    closers.push(() => handle.close().catch(() => undefined));
+    return handle.db;
+  }
+
+  /** Read this tenant's omni_events rows for an externalId, as a worker would. */
+  const eventsForTenant = (tenantId: string, externalId: string): Promise<{ id: string }[]> =>
+    runInWorkerTenantScope(runtimeDb, tenantId, async () =>
+      scopedHandle(runtimeDb)
+        .select({ id: omniEvents.id })
+        .from(omniEvents)
+        .where(eq(omniEvents.externalId, externalId)),
+    );
+
+  beforeAll(async () => {
+    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+
+    const migrations = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+      .join('\n');
+    const superDbUrl = urlFor(superUrl, dbName);
+    const migrated = runSqlOn(superDbUrl, migrations);
+    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+
+    const seeded = runSqlOn(
+      superDbUrl,
+      `
+      INSERT INTO tenants (id, slug, display_name, max_key_ttl_seconds, max_key_rate_limit, max_key_budget) VALUES
+        ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 100, 100),
+        ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 100, 100);
+
+      INSERT INTO instances (id, name, channel, tenant_id, created_at) VALUES
+        ('${INSTANCE_A}', 'inst-a', 'whatsapp-baileys', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${INSTANCE_B}', 'inst-b', 'whatsapp-baileys', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+
+      -- Same external JID on both sides: only tenant_id distinguishes them.
+      INSERT INTO chats (id, instance_id, external_id, canonical_id, chat_type, channel, name, tenant_id, created_at)
+      VALUES
+        ('${CHAT_A}', '${INSTANCE_A}', '${SHARED_JID}', '${SHARED_JID}', 'direct', 'whatsapp-baileys',
+         'Chat', '${TENANT_A}', '${SHARED_TIMESTAMP}'),
+        ('${CHAT_B}', '${INSTANCE_B}', '${SHARED_JID}', '${SHARED_JID}', 'direct', 'whatsapp-baileys',
+         'Chat', '${TENANT_B}', '${SHARED_TIMESTAMP}');
+      `,
+    );
+    if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
+
+    const provisioner = openDb(superDbUrl, 3);
+    await applyTenantRlsEnforcement(provisioner);
+    await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
+
+    // ONE physical connection shared by both tenants' workers: any bleed shows
+    // here rather than being hidden by pool luck.
+    runtimeDb = openDb(urlFor(superUrl, dbName, { name: DEFAULT_ROLE_NAMES.runtime, password: passwords.runtime }), 1);
+    instances = new InstanceService(runtimeDb, null);
+
+    // Capture the real consumer handlers exactly as the NATS bus would.
+    const captureBus = {
+      subscribe: async (type: string, handler: (event: unknown) => Promise<void>) => {
+        handlers.set(type, handler);
+      },
+    } as unknown as EventBus;
+    await setupEventPersistence(captureBus, runtimeDb);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  describe('a worker scope contains a real service to one tenant', () => {
+    test('a worker for A lists only A instances; a worker for B only B', async () => {
+      const a = await runInWorkerTenantScope(runtimeDb, TENANT_A, () => instances.list());
+      const b = await runInWorkerTenantScope(runtimeDb, TENANT_B, () => instances.list());
+      expect(a.items.map((i) => i.id)).toEqual([INSTANCE_A]);
+      expect(b.items.map((i) => i.id)).toEqual([INSTANCE_B]);
+    });
+
+    test('a worker for A cannot fetch B’s instance by its real id (not-found, as if it never existed)', async () => {
+      // `getById` throws NotFoundError for a foreign id exactly as for a
+      // nonexistent one — the row is invisible under A's scope, so there is no
+      // oracle distinguishing "belongs to B" from "does not exist".
+      await expect(runInWorkerTenantScope(runtimeDb, TENANT_A, () => instances.getById(INSTANCE_B))).rejects.toThrow();
+      await expect(
+        runInWorkerTenantScope(runtimeDb, TENANT_A, () => instances.getById('00000000-0000-4000-8000-000000000000')),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('event-persistence consumer isolates by envelope tenant', () => {
+    test('an A-stamped event lands only under tenant A; a B-stamped event only under B', async () => {
+      const received = handlers.get('message.received');
+      if (!received) throw new Error('message.received handler not captured');
+
+      const extA = `ext-a-${crypto.randomUUID()}`;
+      const extB = `ext-b-${crypto.randomUUID()}`;
+      await received(receivedEvent(INSTANCE_A, extA, { envelopeVersion: 1, tenantId: TENANT_A }));
+      await received(receivedEvent(INSTANCE_B, extB, { envelopeVersion: 1, tenantId: TENANT_B }));
+
+      // A sees its own event and NOT B's; B sees its own and NOT A's.
+      expect((await eventsForTenant(TENANT_A, extA)).length).toBe(1);
+      expect((await eventsForTenant(TENANT_B, extA)).length).toBe(0);
+      expect((await eventsForTenant(TENANT_B, extB)).length).toBe(1);
+      expect((await eventsForTenant(TENANT_A, extB)).length).toBe(0);
+    });
+
+    test('a producer LYING about tenant is rejected by server-side ownership, not trusted', async () => {
+      const received = handlers.get('message.received');
+      if (!received) throw new Error('message.received handler not captured');
+
+      // Envelope claims tenant B, but the instance it names is owned by A. The
+      // BEFORE INSERT derivation trigger stamps tenant_id from the instance (A);
+      // under the worker's B scope the RLS WITH CHECK (A = B) rejects it. The
+      // handler swallows the error (best-effort persistence) — the point is that
+      // NO row lands under EITHER tenant, so the lie buys nothing.
+      const extLie = `ext-lie-${crypto.randomUUID()}`;
+      await received(receivedEvent(INSTANCE_A, extLie, { envelopeVersion: 1, tenantId: TENANT_B }));
+
+      expect((await eventsForTenant(TENANT_A, extLie)).length).toBe(0);
+      expect((await eventsForTenant(TENANT_B, extLie)).length).toBe(0);
+    });
+  });
+});

--- a/packages/api/src/tenancy/__tests__/worker-tenant-context.test.ts
+++ b/packages/api/src/tenancy/__tests__/worker-tenant-context.test.ts
@@ -19,7 +19,12 @@ import { classifyEnvelope } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type TenantAuthContext, freezeContext } from '../auth-context';
 import { currentTenantScope, requireTenantScope, runInTenantScope } from '../tenant-scope';
-import { buildWorkerTenantContext, runInWorkerTenantScope } from '../worker-tenant-context';
+import {
+  WorkerTenantContextError,
+  buildWorkerTenantContext,
+  runInWorkerTenantScope,
+  trustedEnvelopeTenant,
+} from '../worker-tenant-context';
 
 const TENANT_A = '11111111-1111-4111-8111-11111111111a';
 const TENANT_B = '22222222-2222-4222-8222-22222222222b';
@@ -115,5 +120,50 @@ describe('the trusted tenant comes from the envelope, not the payload', () => {
       async () => requireTenantScope().tenantId,
     );
     expect(seen).toBe(TENANT_A);
+  });
+});
+
+/**
+ * `trustedEnvelopeTenant` — the VALUE form of the consumer bridge.
+ *
+ * Three call sites thread it (`plugins/event-listeners.ts` twice,
+ * `plugins/agent-responder.ts`) and none of them can pin its contract: each
+ * wraps the call in fire-and-forget work whose rejection is swallowed by a
+ * `.catch(log)`, so a quarantined envelope that returned `undefined` instead of
+ * throwing would simply run the replay/response GLOBALLY on the ambient pool —
+ * the "global processing fallback" ADR-0008 forbids — with every gate green.
+ *
+ * The subscription layer already TERMs quarantined envelopes, so this branch is
+ * defence in depth; that is a reason to pin it, not a reason to leave it
+ * unexecuted.
+ */
+describe('trustedEnvelopeTenant — the threaded value, in all three worlds', () => {
+  test('tenant envelope → the envelope’s trusted tenant', () => {
+    expect(trustedEnvelopeTenant({ metadata: { correlationId: 'c', envelopeVersion: 1, tenantId: TENANT_A } })).toBe(
+      TENANT_A,
+    );
+  });
+
+  test('legacy envelope → undefined, so every threaded block stays ambient', () => {
+    expect(trustedEnvelopeTenant({ metadata: { correlationId: 'c' } })).toBeUndefined();
+  });
+
+  test('quarantined envelope → THROWS; it never degrades to undefined', () => {
+    // A tenant claim with no envelope version is the `malformed_envelope`
+    // quarantine: something asserted a tenant without the producer stamp that
+    // makes it trustworthy. Returning `undefined` here would process it globally.
+    const quarantined = { metadata: { correlationId: 'c', tenantId: TENANT_A } };
+    expect(classifyEnvelope(quarantined.metadata).world).toBe('quarantine');
+    expect(() => trustedEnvelopeTenant(quarantined)).toThrow(WorkerTenantContextError);
+    expect(() => trustedEnvelopeTenant(quarantined)).toThrow(/quarantined envelope/);
+  });
+
+  test('a malformed tenant claim is quarantined, not silently downgraded to legacy', () => {
+    // The other quarantine shape: a stamped envelope whose tenant is not a
+    // well-formed id. `undefined` would be indistinguishable from a legacy
+    // envelope, which is precisely the confusion the throw prevents.
+    const malformed = { metadata: { correlationId: 'c', envelopeVersion: 1, tenantId: 'not-a-uuid' } };
+    expect(classifyEnvelope(malformed.metadata).world).toBe('quarantine');
+    expect(() => trustedEnvelopeTenant(malformed)).toThrow(WorkerTenantContextError);
   });
 });

--- a/packages/api/src/tenancy/__tests__/worker-tenant-context.test.ts
+++ b/packages/api/src/tenancy/__tests__/worker-tenant-context.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Worker-context tenant boundary — ALS detachment, per-item scope, fail-closed
+ * derivation (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * These probes fix the two invariants the G4 leg-2 review made non-negotiable:
+ *
+ *   1. a background/worker path must NEVER inherit a request's ALS tenant scope
+ *      — it establishes its own from the trusted envelope tenant;
+ *   2. a worker derivation refuses a caller-claimed tenant — only a well-formed,
+ *      producer-derived tenant is admitted.
+ *
+ * The DB is faked here (a transaction that runs its callback against a no-op
+ * handle) so these can assert the SCOPE semantics with no PostgreSQL. The real
+ * two-tenant isolation is proven separately under the pg-gate.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { classifyEnvelope } from '@omni/core';
+import type { Database } from '@omni/db';
+import { type TenantAuthContext, freezeContext } from '../auth-context';
+import { currentTenantScope, requireTenantScope, runInTenantScope } from '../tenant-scope';
+import { buildWorkerTenantContext, runInWorkerTenantScope } from '../worker-tenant-context';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+/** A Database whose `transaction` just runs the callback with a no-op tx. */
+function fakeDb(): Database {
+  return {
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({ execute: async () => [] as unknown }),
+  } as unknown as Database;
+}
+
+function requestContext(tenantId: string): TenantAuthContext {
+  return freezeContext({
+    credentialClass: 'tenant',
+    requestId: `req-${tenantId}`,
+    principalId: '33333333-3333-4333-8333-333333333331',
+    credentialId: '99999999-9999-4999-8999-999999999992',
+    tenantId,
+    actorRole: 'tenant-admin',
+    scopes: [],
+    membershipId: '44444444-4444-4444-8444-444444444441',
+    resourceConstraints: {},
+    expiresAt: null,
+    rateLimit: null,
+    budget: null,
+    delegationDepth: 0,
+    rootKeyId: 'root-1',
+    policyVersion: 1,
+    revocationEpoch: 0,
+    tenantKeyLineageId: 'lin-1',
+  }) as TenantAuthContext;
+}
+
+describe('runInWorkerTenantScope establishes a per-item tenant scope', () => {
+  test('the work item runs inside a scope stamped with the trusted tenant', async () => {
+    const seen = await runInWorkerTenantScope(fakeDb(), TENANT_A, async () => requireTenantScope().tenantId);
+    expect(seen).toBe(TENANT_A);
+  });
+
+  test('the scope is torn down when the work item completes (does not outlive it)', async () => {
+    await runInWorkerTenantScope(fakeDb(), TENANT_A, async () => undefined);
+    expect(currentTenantScope()).toBeNull();
+  });
+});
+
+describe('a worker NEVER inherits a request scope (G4 leg-2 trap)', () => {
+  test('called from inside tenant A request scope, a worker for B sees B — not A', async () => {
+    const observed = await runInTenantScope(fakeDb(), requestContext(TENANT_A), async () => {
+      // We are now inside tenant A's request scope.
+      expect(requireTenantScope().tenantId).toBe(TENANT_A);
+      // A worker spawned here must detach and establish B, never inherit A.
+      return runInWorkerTenantScope(fakeDb(), TENANT_B, async () => requireTenantScope().tenantId);
+    });
+    expect(observed).toBe(TENANT_B);
+  });
+
+  test('after the worker returns, the outer request scope is intact', async () => {
+    const outerAfter = await runInTenantScope(fakeDb(), requestContext(TENANT_A), async () => {
+      await runInWorkerTenantScope(fakeDb(), TENANT_B, async () => undefined);
+      return requireTenantScope().tenantId;
+    });
+    expect(outerAfter).toBe(TENANT_A);
+  });
+});
+
+describe('worker derivation is fail-closed — a caller-claimed tenant is refused', () => {
+  test('a non-UUID tenant is rejected before any transaction opens', async () => {
+    await expect(runInWorkerTenantScope(fakeDb(), 'tenant-a', async () => 1)).rejects.toThrow();
+  });
+
+  test('an empty tenant is rejected', async () => {
+    await expect(runInWorkerTenantScope(fakeDb(), '', async () => 1)).rejects.toThrow();
+  });
+
+  test('buildWorkerTenantContext mints a fresh internal requestId, not a caller value', () => {
+    const a = buildWorkerTenantContext(TENANT_A);
+    const b = buildWorkerTenantContext(TENANT_A);
+    expect(a.credentialClass).toBe('tenant');
+    expect(a.tenantId).toBe(TENANT_A);
+    // Internally minted and unique per work item — never a caller-supplied id.
+    expect(a.requestId).not.toBe(b.requestId);
+  });
+});
+
+describe('the trusted tenant comes from the envelope, not the payload', () => {
+  test('a validated tenant envelope drives the worker scope', async () => {
+    const classification = classifyEnvelope({ correlationId: 'c', envelopeVersion: 1, tenantId: TENANT_A });
+    expect(classification.world).toBe('tenant');
+    if (classification.world !== 'tenant') throw new Error('unreachable');
+    const seen = await runInWorkerTenantScope(
+      fakeDb(),
+      classification.tenantId,
+      async () => requireTenantScope().tenantId,
+    );
+    expect(seen).toBe(TENANT_A);
+  });
+});

--- a/packages/api/src/tenancy/inflight-revocation.ts
+++ b/packages/api/src/tenancy/inflight-revocation.ts
@@ -50,7 +50,7 @@ const log = createLogger('inflight-revocation');
 export const INFLIGHT_REVOCATION_CEILING_SECONDS = 30;
 
 /** Half the ceiling — see the cadence rationale in the module doc. */
-export function resolveInflightRecheckIntervalMs(): number {
+function resolveInflightRecheckIntervalMs(): number {
   return Math.floor((INFLIGHT_REVOCATION_CEILING_SECONDS * 1000) / 2);
 }
 

--- a/packages/api/src/tenancy/inflight-revocation.ts
+++ b/packages/api/src/tenancy/inflight-revocation.ts
@@ -1,0 +1,118 @@
+/**
+ * In-flight privileged-work revocation monitor (wish: omni-full-multitenancy,
+ * Group G5, deliverable (c); ADR-0006; RELEASE_SLOS
+ * `revocation.inflight_privileged_work_revocation_seconds_max: 30`).
+ *
+ * WHAT PROBLEM THIS SOLVES
+ * ------------------------
+ * Dequeue-time revalidation (`isTenantWorkAdmissible` at the top of a handler)
+ * bounds the gap between REVOCATION and the START of work. It does not bound
+ * the gap between revocation and the END of work: a multi-thousand-message
+ * sync or a slow batch loop can run for minutes after its single up-front
+ * check. The release ceiling says in-flight privileged work must OBSERVE a
+ * revocation within 30 seconds — so a long loop needs a re-check cadence, not
+ * a one-shot gate.
+ *
+ * THE CADENCE
+ * -----------
+ * `assertAdmissible()` is called once per work sub-item (per synced message,
+ * per batch row). It is CHEAP by design: it consults the injected clock and
+ * only re-queries the auth plane when the recheck interval has elapsed. The
+ * interval is HALF the ceiling — the same rationale as the stream-termination
+ * sweep cadence: a revocation landing immediately after one check is still
+ * caught by the next one, within the ceiling. The first call always checks,
+ * which doubles as the dequeue-time revalidation for callers that start their
+ * loop with it.
+ *
+ * FAIL-CLOSED, STICKY
+ * -------------------
+ * An inadmissible answer throws {@link InflightRevocationError} and the
+ * monitor STAYS refused: one work item never resumes after observing its
+ * tenant's revocation, even if the tenant is later reinstated — the
+ * reinstated tenant's next work item gets a fresh monitor. A check that
+ * THROWS (auth plane unreachable) also refuses: silence is not admissibility
+ * for privileged work that has already proven it can outlive its gate.
+ *
+ * DUAL WORLD
+ * ----------
+ * A null/undefined tenant (legacy/flag-off work) never checks, never queries,
+ * never refuses — byte-identical to the pre-G5 loop.
+ */
+
+import { createLogger } from '@omni/core';
+
+const log = createLogger('inflight-revocation');
+
+/**
+ * Sourced from `RELEASE_SLOS.yaml`
+ * `revocation.inflight_privileged_work_revocation_seconds_max`.
+ */
+export const INFLIGHT_REVOCATION_CEILING_SECONDS = 30;
+
+/** Half the ceiling — see the cadence rationale in the module doc. */
+export function resolveInflightRecheckIntervalMs(): number {
+  return Math.floor((INFLIGHT_REVOCATION_CEILING_SECONDS * 1000) / 2);
+}
+
+export class InflightRevocationError extends Error {
+  readonly code = 'inflight_tenant_revoked';
+  constructor(tenantId: string) {
+    super(`inflight-revocation: tenant ${tenantId} is no longer admissible (suspended/archived/revoked)`);
+    this.name = 'InflightRevocationError';
+  }
+}
+
+export interface InflightRevocationMonitor {
+  /**
+   * The per-item gate. Cheap between cadence ticks; re-checks admissibility
+   * when the interval has elapsed; throws {@link InflightRevocationError}
+   * once the tenant is observed inadmissible (and on every call after).
+   */
+  assertAdmissible(): Promise<void>;
+}
+
+export function createInflightRevocationMonitor(options: {
+  /** Trusted tenant of the work item; null/undefined = legacy, never checked. */
+  tenantId: string | null | undefined;
+  /** The admissibility read (`isTenantWorkAdmissible` over the auth plane). */
+  check: (tenantId: string) => Promise<boolean>;
+  /** Injectable clock for synthetic-time tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Override cadence (tests only). Defaults to half the ceiling. */
+  recheckIntervalMs?: number;
+}): InflightRevocationMonitor {
+  const { tenantId, check } = options;
+  const now = options.now ?? Date.now;
+  const intervalMs = options.recheckIntervalMs ?? resolveInflightRecheckIntervalMs();
+
+  let lastCheckedAt: number | null = null;
+  let refused = false;
+
+  return {
+    async assertAdmissible(): Promise<void> {
+      if (!tenantId) return; // legacy work — byte-identical, zero queries
+      if (refused) throw new InflightRevocationError(tenantId);
+
+      const at = now();
+      if (lastCheckedAt !== null && at - lastCheckedAt < intervalMs) return;
+
+      let admissible = false;
+      try {
+        admissible = await check(tenantId);
+      } catch (error) {
+        // Fail closed: privileged work that cannot verify its tenant stops.
+        log.warn('Admissibility check failed — refusing in-flight work', {
+          tenantId,
+          error: String(error),
+        });
+        admissible = false;
+      }
+      lastCheckedAt = at;
+
+      if (!admissible) {
+        refused = true;
+        throw new InflightRevocationError(tenantId);
+      }
+    },
+  };
+}

--- a/packages/api/src/tenancy/instance-owner-registry.ts
+++ b/packages/api/src/tenancy/instance-owner-registry.ts
@@ -1,0 +1,166 @@
+/**
+ * The instance→tenant ownership registry — producer-side tenant derivation for
+ * channel-plugin publishes (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * WHAT PROBLEM THIS SOLVES
+ * ------------------------
+ * G5 leg A gave every NATS envelope a version + trusted tenant and wired
+ * `setEnvelopeTenantResolver` to the per-request tenant scope. That covers
+ * publishes made INSIDE a request. It does not cover the path that carries
+ * almost all of the platform's events: `BaseChannelPlugin.publishEventInternal`
+ * emits `message.received`, `instance.connected`, `reaction.*`, `sync.*` from a
+ * socket callback with no request and no scope. Those publishes stamped nothing,
+ * so every real channel event classified `legacy` — and the consumers legs A–E
+ * converted (`event-persistence`, `media-processor`, `sync-worker`,
+ * `event-listeners`, `agent-dispatcher`, the follow-up cluster) never entered
+ * the tenant world for live traffic. The conversions were correct and unreachable.
+ *
+ * THE DERIVATION, AND WHY IT IS TRUSTED
+ * -------------------------------------
+ * ADR-0008: "Publishers derive tenant from authenticated/LOADED RESOURCES, never
+ * caller claims." A plugin publish always names the `instanceId` it is emitting
+ * for, and `instances` is THE ownership root (G0/G2 `tenancy-ownership.ts`) — the
+ * instance row's `tenant_id` IS the answer, and it is persisted server-side
+ * state, not anything a payload can assert. `envelope.ts`'s own subject
+ * rationale already relies on this: "Instances carry their tenant ... so the
+ * tenant is derivable at PUBLISH time from the loaded instance."
+ *
+ * This registry is the carrier for that derivation. Every entry is written from
+ * an `instances` ROW the API layer has already loaded — startup reconnect, the
+ * monitor's fetches, `InstanceService` reads/writes — never from an event
+ * payload, a header, or a caller-supplied hint. There is no path that inserts a
+ * tenant this process did not read out of the database.
+ *
+ * WHY A REGISTRY AND NOT A QUERY
+ * ------------------------------
+ * A publish must not grow a database round trip, and under RLS enforcement a
+ * scope-less `instances` read is not even expressible — the runtime role's
+ * ambient reads fail closed (`omni_current_tenant_id()` RAISES). A read-through
+ * cache would therefore have nowhere to read from. The map is instead populated
+ * by the reads that legitimately happen anyway.
+ *
+ * IMMUTABILITY, AND WHAT THAT BUYS
+ * --------------------------------
+ * An instance's tenant is its ownership root: it is assigned once and does not
+ * move. So a conflicting second derivation is a BUG somewhere upstream, not an
+ * update — and `rememberInstanceOwner` refuses it (first write wins) rather than
+ * letting one bad read redirect a live instance's entire event stream into
+ * another tenant. Because the mapping never legitimately changes, staleness is
+ * not a failure mode here.
+ *
+ * Tenant SUSPENSION/REVOCATION is deliberately NOT this seam's concern. Stamping
+ * the correct tenant on an event is orthogonal to whether that tenant may still
+ * have work done for it; the latter is enforced at dequeue and before every
+ * durable side effect (`periodic-tenant-work.ts` `isTenantWorkAdmissible`).
+ * Refusing to stamp a suspended tenant would produce an UNTENANTED envelope,
+ * which consumers process on the legacy path — the exact global-processing
+ * fallback ADR-0008 forbids.
+ *
+ * THE DUAL WORLD
+ * --------------
+ * Flag-off, every `instances.tenant_id` is NULL, so every `rememberInstanceOwner`
+ * stores nothing, the resolver returns null, and publishes stay legacy —
+ * byte-identical to pre-G5, with no flag check anywhere in this module. The
+ * dual-world behavior falls out of the data rather than out of a branch.
+ */
+
+import { createLogger, setEnvelopeInstanceTenantResolver } from '@omni/core';
+
+const log = createLogger('instance-owner-registry');
+
+/** Mirrors the shape `tenant-transaction.ts` enforces at the DB boundary. */
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Hard ceiling on entries.
+ *
+ * One entry per instance is small and inherently bounded by the deployment, but
+ * an in-memory map on the publish path must not be able to grow without limit on
+ * any input, so the bound is explicit rather than assumed. Reaching it means the
+ * deployment has more instances than this ceiling anticipates: further entries
+ * are dropped and the publish for those instances stays legacy — a degradation,
+ * loudly logged, never a wrong tenant.
+ */
+export const INSTANCE_OWNER_REGISTRY_MAX_ENTRIES = 10_000;
+
+const owners = new Map<string, string>();
+let capacityWarned = false;
+
+/** The minimum shape of a loaded `instances` row this registry accepts. */
+export interface InstanceOwnerRow {
+  readonly id: string;
+  readonly tenantId?: string | null;
+}
+
+/**
+ * Record one loaded instance row's persisted ownership.
+ *
+ * A NULL/absent/malformed tenant is recorded as ABSENT — never as a tenant, and
+ * never as a placeholder that could later be mistaken for one.
+ */
+export function rememberInstanceOwner(row: InstanceOwnerRow): void {
+  const { id, tenantId } = row;
+  if (typeof id !== 'string' || id.length === 0) return;
+  if (typeof tenantId !== 'string' || !UUID.test(tenantId)) return;
+
+  const existing = owners.get(id);
+  if (existing !== undefined) {
+    if (existing !== tenantId) {
+      // First write wins. See the module header: this is a bug signal, not an
+      // update, and taking the newer value would move a live instance's whole
+      // event stream to another tenant.
+      log.error('refusing a conflicting instance ownership derivation', { instanceId: id });
+    }
+    return;
+  }
+
+  if (owners.size >= INSTANCE_OWNER_REGISTRY_MAX_ENTRIES) {
+    if (!capacityWarned) {
+      capacityWarned = true;
+      log.error('instance ownership registry is full; further instances publish legacy envelopes', {
+        max: INSTANCE_OWNER_REGISTRY_MAX_ENTRIES,
+      });
+    }
+    return;
+  }
+
+  owners.set(id, tenantId);
+}
+
+/** Record a batch of loaded rows; each is validated on its own. */
+export function rememberInstanceOwners(rows: readonly InstanceOwnerRow[]): void {
+  for (const row of rows) rememberInstanceOwner(row);
+}
+
+/** Drop an instance's entry — it was deleted. */
+export function forgetInstanceOwner(instanceId: string): void {
+  owners.delete(instanceId);
+}
+
+/** The persisted tenant of `instanceId`, or null when unknown. */
+export function lookupInstanceOwner(instanceId: string): string | null {
+  return owners.get(instanceId) ?? null;
+}
+
+/** Entry count. Exposed for the bound probe and for operational logging. */
+export function instanceOwnerRegistrySize(): number {
+  return owners.size;
+}
+
+/**
+ * Hand this registry to `@omni/core`'s publish path.
+ *
+ * Called once at startup, next to `setEnvelopeTenantResolver`. Until it is
+ * called, `@omni/core` stamps nothing from ownership — which is what keeps every
+ * unit test and every embedded/library use of the event bus on the legacy path
+ * unless it opts in.
+ */
+export function installInstanceOwnerResolver(): void {
+  setEnvelopeInstanceTenantResolver((instanceId) => lookupInstanceOwner(instanceId));
+}
+
+/** Test-only: drop all state, including the capacity warning latch. */
+export function __resetInstanceOwnerRegistry(): void {
+  owners.clear();
+  capacityWarned = false;
+}

--- a/packages/api/src/tenancy/periodic-tenant-work.ts
+++ b/packages/api/src/tenancy/periodic-tenant-work.ts
@@ -1,0 +1,260 @@
+/**
+ * Periodic-work tenant fan-out (wish: omni-full-multitenancy, Group G5;
+ * ADR-0008, ADR-0003).
+ *
+ * WHAT PROBLEM THIS SOLVES
+ * ------------------------
+ * A consumer derives its tenant from the versioned envelope; a cron/interval
+ * loop has NO envelope and no credential — it wakes on a timer and must
+ * DISCOVER whose work exists. Under RLS enforcement the runtime role cannot
+ * run that discovery ambient: every tenant-scoped query outside a tenant
+ * transaction RAISES (`omni_current_tenant_id()` is fail-closed), so "scan the
+ * whole table, then sort out ownership" stops being expressible. Periodic work
+ * therefore needs a tenant ENUMERATION step, then a per-tenant scope for each
+ * pass — the same shape `runConsumerInTenantContext` gives a consumer, driven
+ * from a list instead of an envelope.
+ *
+ * WHERE THE TENANT LIST COMES FROM
+ * --------------------------------
+ * The one pre-context read surface ADR-0003 gives the runtime process is the
+ * auth plane: its role is granted SELECT on the credential index — including
+ * `tenants` (`AUTH_PLANE_TABLES`, tenancy-roles.ts), which `auth-bootstrap.ts`
+ * already reads on this same connection for the freshness check. Enumerating
+ * `status = 'active'` tenants there is a trusted, non-caller-controlled
+ * derivation: the list is persisted control-plane state, not anything a
+ * payload could assert. Suspended/archived tenants are excluded, so a
+ * suspension stops that tenant's periodic work at the NEXT tick — dequeue-time
+ * revalidation for cron work, bounded by the cron cadence.
+ *
+ * Under enforcement WITHOUT a dedicated `OMNI_DB_AUTH_PLANE_URL`, the shared
+ * runtime handle cannot read `tenants` and the enumeration FAILS CLOSED (the
+ * caller's tick errors; nothing runs unscoped) — the same documented posture
+ * as the confirming-hint path in `auth-plane-connection.ts`.
+ *
+ * THE DUAL WORLD
+ * --------------
+ * Flag-off, this module runs NO query and enumerates nothing: callers keep
+ * their pre-G5 single ambient pass byte-identically. The fan-out binds only to
+ * the multitenancy world, where the enumerated tenants exist at all.
+ */
+
+import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import { resolveEnforcementMode, tenants } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { isMultitenancyEnabled } from './feature-flag';
+import { runInWorkerTenantScope } from './worker-tenant-context';
+
+const log = createLogger('periodic-tenant-work');
+
+/**
+ * Enumerate the tenants whose periodic work should run this tick.
+ *
+ * Returns `[]` without touching the database when multitenancy is off — the
+ * flag-off world has no tenants and its crons must not gain a query.
+ *
+ * @param authPlaneDb - the auth-plane read connection
+ *   (`services.authPlane.db`); the only runtime-process identity that may read
+ *   `tenants` under enforcement.
+ */
+export async function enumerateActiveWorkTenants(
+  authPlaneDb: Database,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string[]> {
+  if (!isMultitenancyEnabled(env)) return [];
+  const rows = await authPlaneDb.select({ id: tenants.id }).from(tenants).where(eq(tenants.status, 'active'));
+  return rows.map((row) => row.id);
+}
+
+/**
+ * Dequeue-time tenant admissibility for QUEUED work (RELEASE_SLOS
+ * "queued_retry_delayed_dlq_check"; ADR-0008, ADR-0003).
+ *
+ * A consumer/executor derives its tenant at PRODUCE time (envelope stamp) or
+ * CREATE time (request scope), then the work item sits in a queue or a
+ * fire-and-forget background loop that may outlive the moment of derivation by
+ * seconds, minutes, or a full process restart. Between derivation and dequeue
+ * the tenant may have been suspended or archived. This is the gate that stops a
+ * suspended tenant's still-queued work from running: the executor calls it
+ * BEFORE it begins a tenant job AND again immediately before each durable
+ * side-effect batch, and refuses to proceed when it returns false.
+ *
+ * WHY A `tenants.status` READ IS THE RIGHT GATE HERE
+ * --------------------------------------------------
+ * Suspension/archival of a tenant bumps that tenant's revocation epoch (the
+ * control-plane invariant every credential-issuing path honours). A full
+ * per-credential epoch-snapshot comparison — "was this exact credential's epoch
+ * superseded" — belongs to callback-token/credential work, where a token
+ * carries the epoch it was minted under. A fire-and-forget executor holds no
+ * such token: it acts on the tenant's OWN persisted resources under a synthetic
+ * worker context. For it, the admissibility question collapses to "is the tenant
+ * itself still active", and the `tenants.status` read on the auth plane is the
+ * epoch-propagation gate for that question — the same trusted, non-caller
+ * controlled read `enumerateActiveWorkTenants` uses, narrowed to one tenant.
+ *
+ * A NULL/absent tenant is admissible by definition: a legacy (flag-off / pre-G2)
+ * job has no tenant to revalidate and runs on the ambient pool byte-identically,
+ * so this returns true WITHOUT touching the database. Flag-off callers therefore
+ * never gain a query.
+ *
+ * @param authPlaneDb - the auth-plane read connection (`services.authPlane.db`);
+ *   the only runtime-process identity that may read `tenants` under enforcement.
+ * @param tenantId - the trusted tenant of the work item, or null/undefined for a
+ *   legacy job.
+ */
+export async function isTenantWorkAdmissible(
+  authPlaneDb: Database,
+  tenantId: string | null | undefined,
+): Promise<boolean> {
+  if (!tenantId) return true;
+  const [row] = await authPlaneDb
+    .select({ status: tenants.status })
+    .from(tenants)
+    .where(eq(tenants.id, tenantId))
+    .limit(1);
+  return row?.status === 'active';
+}
+
+export interface TenantFanOutStats {
+  /** Tenants enumerated for this tick. */
+  tenants: number;
+  /** Tenant passes that completed. */
+  succeeded: number;
+  /** Tenant passes that threw (logged, never propagated to siblings). */
+  failed: number;
+}
+
+/**
+ * Run one periodic pass per active tenant, each inside its own worker tenant
+ * scope (`runInWorkerTenantScope` — detached from any inherited request scope,
+ * one tenant-stamped transaction per pass).
+ *
+ * One tenant's failure is logged and counted, never propagated: tenant A's
+ * broken state must not starve tenant B's sweep — the same isolation rule the
+ * converted batch consumers apply per item.
+ *
+ * Flag-off this enumerates nothing and runs nothing; the caller is expected to
+ * keep its legacy single-pass path unchanged.
+ */
+export async function runForEachActiveWorkTenant(
+  db: Database,
+  authPlaneDb: Database,
+  jobName: string,
+  fn: (tenantId: string) => Promise<void>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<TenantFanOutStats> {
+  const tenantIds = await enumerateActiveWorkTenants(authPlaneDb, env);
+  const stats: TenantFanOutStats = { tenants: tenantIds.length, succeeded: 0, failed: 0 };
+  for (const tenantId of tenantIds) {
+    try {
+      await runInWorkerTenantScope(db, tenantId, async () => fn(tenantId));
+      stats.succeeded += 1;
+    } catch (err) {
+      stats.failed += 1;
+      log.warn('periodic tenant pass failed', {
+        job: jobName,
+        tenantId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return stats;
+}
+
+/** A row a periodic "list-then-act" job fans out over; carries its ownership. */
+export interface TenantOwnedRow {
+  tenantId: string | null;
+}
+
+export interface RowFanOutStats extends TenantFanOutStats {
+  /** Rows `perRow` was invoked for, summed across every pass this tick. */
+  rows: number;
+}
+
+/**
+ * Fan out a periodic "list the active rows, then act on each" job across
+ * tenants (G5, ADR-0008) — the shape for a cron/interval whose read is a
+ * whole-table scan (`listActive`) followed by a per-row side effect that
+ * PUBLISHES an event or performs a NETWORK call (create-sync-job, plugin
+ * health-probe, reconnect).
+ *
+ * Unlike {@link runForEachActiveWorkTenant}, which wraps a tenant's WHOLE pass
+ * in one worker transaction, this scopes ONLY the discrete `listActive` READ per
+ * tenant and runs `perRow` OUTSIDE that scope — because holding a worker
+ * transaction across a publish would make the event a pre-commit side effect,
+ * and holding one across a network wait would pin a connection for the round
+ * trip. `perRow` receives the pass's trusted tenant so a converted downstream
+ * (`syncJobs.create({ ..., tenantId })`, `runTenantWorkDb`) can scope its OWN
+ * short DB block and stamp its OWN envelope.
+ *
+ * The three worlds mirror the follow-up sweeper:
+ *   * flag-off      — one ambient `listActive`, `perRow(row, null)` for each; no
+ *                     enumeration, no predicate, byte-identical to pre-G5.
+ *   * `tenant`      — per active tenant: the read runs in a worker scope (so it
+ *                     succeeds under RLS enforcement) and is narrowed to the
+ *                     tenant's own rows by an explicit `row.tenantId === tenantId`
+ *                     filter (defense in depth before enforcement installs RLS;
+ *                     redundant after). `perRow(row, tenantId)` runs detached.
+ *   * `legacy-rows` — flag-on transitional: NULL-tenant rows act ambient exactly
+ *                     as before. Skipped under enforcement, where the mixed state
+ *                     cannot exist and an ambient read would fail closed.
+ *
+ * One tenant's failure is logged and isolated; siblings still run. `perRow` owns
+ * its OWN per-item error handling (the pre-G5 loops already caught per row).
+ */
+export async function runForEachActiveTenantRow<Row extends TenantOwnedRow>(
+  deps: {
+    db: Database;
+    authPlaneDb: Database;
+    jobName: string;
+    listActive: () => Promise<Row[]>;
+    env?: NodeJS.ProcessEnv;
+  },
+  perRow: (row: Row, tenantId: string | null) => Promise<void>,
+): Promise<RowFanOutStats> {
+  const env = deps.env ?? process.env;
+  const stats: RowFanOutStats = { tenants: 0, succeeded: 0, failed: 0, rows: 0 };
+
+  // Flag-off: the single pre-G5 ambient pass, byte-identical — no enumeration,
+  // no tenant predicate, no new query of any kind.
+  if (!isMultitenancyEnabled(env)) {
+    const rows = await deps.listActive();
+    for (const row of rows) {
+      await perRow(row, null);
+      stats.rows += 1;
+    }
+    return stats;
+  }
+
+  // Flag-on: one pass per active tenant, then the transitional NULL-tenant pass
+  // outside enforcement.
+  const tenantIds = await enumerateActiveWorkTenants(deps.authPlaneDb, env);
+  stats.tenants = tenantIds.length;
+  for (const tenantId of tenantIds) {
+    try {
+      // Discrete DB READ block only — scope closes before `perRow` runs.
+      const rows = await runInWorkerTenantScope(deps.db, tenantId, () => deps.listActive());
+      for (const row of rows.filter((r) => r.tenantId === tenantId)) {
+        await perRow(row, tenantId);
+        stats.rows += 1;
+      }
+      stats.succeeded += 1;
+    } catch (err) {
+      stats.failed += 1;
+      log.warn('periodic tenant pass failed', {
+        job: deps.jobName,
+        tenantId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (resolveEnforcementMode(env) !== 'enforced') {
+    const rows = (await deps.listActive()).filter((r) => r.tenantId == null);
+    for (const row of rows) {
+      await perRow(row, null);
+      stats.rows += 1;
+    }
+  }
+  return stats;
+}

--- a/packages/api/src/tenancy/sealed-credentials.ts
+++ b/packages/api/src/tenancy/sealed-credentials.ts
@@ -1,0 +1,141 @@
+/**
+ * Tenant-bound sealing for credential COLUMNS (wish: omni-full-multitenancy,
+ * Group G5, deliverable (g); ADR-0008; WISH "Async and storage enforcement").
+ *
+ * WHY THIS EXISTS ALONGSIDE `tenant-secret-box`
+ * ---------------------------------------------
+ * `@omni/core`'s `tenant-secret-box` is the primitive: AES-256-GCM under a
+ * per-tenant HKDF DEK with the tenant id as AEAD associated data, so a secret
+ * sealed for tenant A cannot be opened under tenant B even by someone who
+ * rewrites the stored tenant label. `session-storage.ts` uses it directly
+ * because `agent_sessions.provider_session_data` is a JSONB column that can hold
+ * the envelope OBJECT.
+ *
+ * The remaining credential surfaces cannot: they store their secret in a `text`
+ * column — `instances.discord_bot_token` and its seven siblings,
+ * `agent_providers.api_key`, `plugin_storage.value`, `global_settings.value`.
+ * They need the envelope flattened to a string, and they need a read that still
+ * accepts the LEGACY PLAINTEXT already sitting in those columns, because there
+ * is no backfill in G5 (object/credential migration is a named separate pass).
+ * This module is that codec, and it is the only place the two shapes meet.
+ *
+ * THE DUAL-WORLD CONTRACT, BY CONSTRUCTION
+ * ----------------------------------------
+ * `sealCredentialField` is the IDENTITY function whenever there is no tenant or
+ * no master key. Not "a plaintext branch that happens to match" — the same
+ * string object flows through, so a flag-off deployment writes the exact bytes
+ * it wrote before G5 and no caller can observe that this module was consulted.
+ * Sealing therefore binds to exactly one situation: a tenant-context write in a
+ * deployment that has explicitly configured a master key
+ * (`setTenantSecretMasterKey`, wired only from repo-local/synthetic material —
+ * live KMS/Vault custody is a named G5 deferral). With no key configured the
+ * whole deliverable is INERT.
+ *
+ * FAIL-CLOSED, AND WHY IT IS NULL RATHER THAN A THROW
+ * ---------------------------------------------------
+ * Opening a sealed field under the wrong tenant, with no tenant, or with the key
+ * withdrawn returns `null` — the same posture `session-storage.ts` takes. The
+ * alternative that must NEVER happen is returning the envelope string itself: a
+ * caller would hand that to Discord/Slack/Twilio as a bot token, leaking
+ * ciphertext into third-party logs and producing an authentication failure whose
+ * cause is invisible. `null` means "this credential is not available to you",
+ * which every one of these call sites already models (the columns are nullable).
+ * A throw was rejected because these reads sit on hot paths (`getById` on every
+ * message) where one unopenable row must not take down an unrelated request.
+ *
+ * NOTE ON THE DETECTION PREFIX
+ * ----------------------------
+ * `JSON.stringify` of a `SealedSecret` always begins `{"v":` because the
+ * literal's key order is fixed in `tenant-secret-box.ts`. The prefix check is a
+ * cheap pre-filter so a hot read path does not JSON-parse every plaintext token;
+ * the authority is still `isSealedSecret`, and a plaintext value that happens to
+ * start with the prefix but is not a sealed envelope is passed through
+ * unchanged.
+ */
+
+import {
+  type SealedSecret,
+  isSealedSecret,
+  isTenantSecretSealingEnabled,
+  openTenantSecret,
+  sealTenantSecret,
+} from '@omni/core';
+
+/** Cheap pre-filter — see the module header. */
+const SEALED_PREFIX = '{"v":';
+
+/**
+ * Is `value` a sealed credential-field string (as opposed to legacy plaintext)?
+ *
+ * Never throws: malformed JSON that merely starts with the prefix is "not
+ * sealed", which routes it to the transitional plaintext path.
+ */
+export function isSealedCredentialField(value: unknown): value is string {
+  if (typeof value !== 'string' || !value.startsWith(SEALED_PREFIX)) return false;
+  try {
+    return isSealedSecret(JSON.parse(value));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Seal `plaintext` for `tenantId`, or return it UNCHANGED.
+ *
+ * Unchanged when: no tenant (legacy/worker/control-plane write), no master key
+ * (the deliverable is inert), or the value is null/undefined/empty (nothing to
+ * protect, and every caller treats empty as absent).
+ *
+ * Overloads keep the caller's nullability: a service spreading a partial update
+ * must be able to write `{ ...data, discordBotToken: sealCredentialField(t,
+ * data.discordBotToken) }` without widening the column's type.
+ */
+export function sealCredentialField(tenantId: string | null | undefined, plaintext: string): string;
+export function sealCredentialField(
+  tenantId: string | null | undefined,
+  plaintext: string | null | undefined,
+): string | null | undefined;
+export function sealCredentialField(
+  tenantId: string | null | undefined,
+  plaintext: string | null | undefined,
+): string | null | undefined {
+  if (plaintext == null || plaintext === '') return plaintext;
+  if (!tenantId || !isTenantSecretSealingEnabled()) return plaintext;
+  return JSON.stringify(sealTenantSecret(tenantId, plaintext));
+}
+
+/**
+ * Would `sealCredentialField` actually reshape a value for `tenantId`?
+ *
+ * The codec is deliberately branch-free at its call sites, so a caller normally
+ * never needs this. The exception is a caller that must SPEND SOMETHING (an
+ * extra query) to learn the tenant a write may seal under: asking first keeps
+ * the inert world byte-identical down to the statements issued, instead of
+ * paying for a lookup whose answer the identity function would discard.
+ */
+export function credentialSealingEngages(tenantId: string | null | undefined): boolean {
+  return !!tenantId && isTenantSecretSealingEnabled();
+}
+
+/**
+ * Open a stored credential field under `tenantId`.
+ *
+ *   * legacy plaintext (including null/undefined/empty) → returned UNCHANGED,
+ *     which is what makes the rollout incremental: sealed and unsealed rows
+ *     coexist and each is handled on its own shape;
+ *   * sealed + right tenant + key → the plaintext secret;
+ *   * sealed + wrong/absent tenant, no key, or tampering → `null`, fail-closed.
+ */
+export function openCredentialField(
+  tenantId: string | null | undefined,
+  stored: string | null | undefined,
+): string | null | undefined {
+  if (stored == null || stored === '') return stored;
+  if (!isSealedCredentialField(stored)) return stored;
+  if (!tenantId || !isTenantSecretSealingEnabled()) return null;
+  try {
+    return openTenantSecret(tenantId, JSON.parse(stored) as SealedSecret);
+  } catch {
+    return null;
+  }
+}

--- a/packages/api/src/tenancy/tenant-stream-subscriptions.ts
+++ b/packages/api/src/tenancy/tenant-stream-subscriptions.ts
@@ -267,7 +267,7 @@ export type TenantRevocationStateReader = (
  * handle the read FAILS CLOSED (it raises), and the sweep treats that as
  * "unknown" — which terminates, never grants.
  */
-export const readTenantRevocationState: TenantRevocationStateReader = async (authPlaneDb, tenantId) => {
+const readTenantRevocationState: TenantRevocationStateReader = async (authPlaneDb, tenantId) => {
   const [row] = await authPlaneDb
     .select({ status: tenants.status, revocationEpoch: tenants.revocationEpoch })
     .from(tenants)

--- a/packages/api/src/tenancy/tenant-stream-subscriptions.ts
+++ b/packages/api/src/tenancy/tenant-stream-subscriptions.ts
@@ -1,0 +1,399 @@
+/**
+ * Streaming and long-lived-state tenant keying — G5 deliverable (e)
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0006; RELEASE_SLOS
+ * `revocation.websocket_sse_channel_provider_session_termination_seconds_max`).
+ *
+ * WHAT PROBLEM THIS SOLVES
+ * ------------------------
+ * A request lives for milliseconds and re-derives its authority on every hop.
+ * A WebSocket/SSE subscription, an in-memory channel/plugin registry entry, or a
+ * provider session lives for HOURS on authority derived exactly once, at connect
+ * time — and the pre-G5 registries key those long-lived entries by RESOURCE UUID
+ * alone (`client.params.sessionId !== sessionId` in `ws/voice.ts`,
+ * `sub.chatId !== update.chatId` in `ws/chats.ts`). Two failure modes follow:
+ *
+ *   1. **Knowledge is treated as authority.** Any authenticated connection that
+ *      can name a session/chat id joins its fan-out. Under multitenancy that id
+ *      may belong to another tenant, so a resource-only match IS the cross-tenant
+ *      read. WISH ("Streaming and long-lived state") states the rule directly:
+ *      subscriptions are keyed AND authorized by tenant, not only by resource
+ *      UUID.
+ *   2. **Authority goes stale and nothing notices.** A tenant suspended (or a
+ *      revocation epoch bumped) at 12:00 keeps streaming into a socket opened at
+ *      09:00, because nothing re-checks. RELEASE_SLOS caps that window at
+ *      {@link STREAM_TERMINATION_CEILING_SECONDS}.
+ *
+ * This module supplies the two devices those surfaces lack: a composite
+ * (tenant, resource) key with an explicit authorization decision at subscribe
+ * time, and a periodic revocation sweep that terminates a tenant's live
+ * subscriptions inside the ceiling.
+ *
+ * WHY A SWEEP RATHER THAN AN EVENT
+ * --------------------------------
+ * Suspension/archival happens in `tenant-control-plane.ts`, possibly in another
+ * process from the one holding the socket. An in-process event would only reach
+ * connections owned by the process that performed the suspension — every other
+ * node would keep streaming. A poll of the SAME trusted control-plane state
+ * `periodic-tenant-work.ts` reads is process-independent, and its cadence is what
+ * the ceiling actually bounds. The cadence is therefore derived FROM the ceiling
+ * ({@link resolveStreamSweepIntervalMs}) rather than chosen independently.
+ *
+ * FAIL-CLOSED
+ * -----------
+ * Every ambiguous state terminates or refuses: a tenant-context subscriber may
+ * not bind a resource of unknown ownership, an owned resource may not be bound
+ * without a tenant context, and a tenant that no longer resolves in the control
+ * plane loses its subscriptions. Silence is never read as permission.
+ *
+ * DUAL WORLD
+ * ----------
+ * Flag-off, no connection carries a tenant: {@link TenantStreamRegistry.matching}
+ * degenerates to the pre-G5 resource-only match, {@link authorizeStreamSubscription}
+ * admits every legacy pairing, and the sweep returns without a single query.
+ * Flag-on, a tenantless (legacy/transitional) subscription is likewise never
+ * swept — it has no tenant whose revocation could apply. The tenant-keyed
+ * behaviour binds ONLY to subscriptions that carry a trusted tenant.
+ */
+
+import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import { tenants } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { isMultitenancyEnabled } from './feature-flag';
+
+const log = createLogger('tenant-stream-subscriptions');
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * The termination ceiling for long-lived subscriptions, sourced from
+ * `RELEASE_SLOS.yaml`
+ * `revocation.websocket_sse_channel_provider_session_termination_seconds_max`.
+ * A revoked tenant's WebSocket/SSE/provider session must be closed within this
+ * window.
+ */
+export const STREAM_TERMINATION_CEILING_SECONDS = 30;
+
+/**
+ * The sweep cadence. Half the ceiling, so a revocation landing immediately
+ * after one tick is still caught by the next one WITHIN the ceiling — a cadence
+ * equal to the ceiling would leave a worst case of exactly one full ceiling plus
+ * the sweep's own duration.
+ */
+export function resolveStreamSweepIntervalMs(): number {
+  return Math.floor((STREAM_TERMINATION_CEILING_SECONDS * 1000) / 2);
+}
+
+export type StreamAuthorizationRefusal =
+  /** the subscriber's tenant is not the resource's persisted owner */
+  | 'cross_tenant_resource'
+  /** a tenant-context subscriber named a resource with no known owner */
+  | 'unowned_resource'
+  /** an owned resource was named by a connection carrying no tenant */
+  | 'tenant_context_required'
+  /** a supplied tenant is not a well-formed UUID */
+  | 'malformed_tenant';
+
+export type StreamAuthorization = { ok: true } | { ok: false; reason: StreamAuthorizationRefusal };
+
+/**
+ * The subscribe-time authorization decision (WISH "Streaming and long-lived
+ * state").
+ *
+ * Both inputs must be TRUSTED derivations: `authenticatedTenantId` from the
+ * connection's authenticated credential (never a query parameter or a socket
+ * message), and `resourceTenantId` from the resource row's PERSISTED ownership
+ * (the same derivation G2 defined) — never from the client's claim about what it
+ * is subscribing to.
+ *
+ * The four states are decided explicitly rather than by a truthiness chain, so
+ * no combination falls through to "allow":
+ *
+ *   | tenant ctx | resource owner | decision                       |
+ *   |------------|----------------|--------------------------------|
+ *   | absent     | absent         | allow  (legacy/flag-off world) |
+ *   | present    | equal          | allow                          |
+ *   | present    | different      | refuse cross_tenant_resource   |
+ *   | present    | absent         | refuse unowned_resource        |
+ *   | absent     | present        | refuse tenant_context_required |
+ */
+export function authorizeStreamSubscription(input: {
+  authenticatedTenantId: string | null;
+  resourceTenantId: string | null;
+}): StreamAuthorization {
+  const { authenticatedTenantId, resourceTenantId } = input;
+
+  for (const value of [authenticatedTenantId, resourceTenantId]) {
+    if (value !== null && !UUID.test(value)) return { ok: false, reason: 'malformed_tenant' };
+  }
+
+  if (authenticatedTenantId === null) {
+    return resourceTenantId === null ? { ok: true } : { ok: false, reason: 'tenant_context_required' };
+  }
+  if (resourceTenantId === null) return { ok: false, reason: 'unowned_resource' };
+  return authenticatedTenantId === resourceTenantId ? { ok: true } : { ok: false, reason: 'cross_tenant_resource' };
+}
+
+/**
+ * The composite address of a subscription. A resource UUID alone is NOT a key:
+ * the same session/chat id under two tenants yields two distinct keys, so a
+ * fan-out computed from a resource id can never reach the other tenant even if
+ * the ids collide.
+ *
+ * `null` produces the reserved legacy key, distinct from every tenant key, so a
+ * legacy fan-out and a tenant fan-out never intersect either.
+ */
+export function streamSubscriptionKey(tenantId: string | null, resourceId: string): string {
+  return `${tenantId ?? 'legacy'}::${resourceId}`;
+}
+
+/** One live long-lived subscription's tenancy state. */
+export interface StreamSubscriptionBinding {
+  /** The trusted tenant this connection was authorized for; null = legacy. */
+  readonly tenantId: string | null;
+  /** The resource (voice session, chat, instance, agent) the stream is bound to. */
+  readonly resourceId: string;
+  /**
+   * The tenant revocation epoch observed when the connection was authorized. A
+   * later epoch in the control plane means the authority this connection was
+   * opened under has been superseded, and the connection must close even if the
+   * tenant is still `active` (ADR-0006).
+   */
+  readonly revocationEpoch: number;
+  /** Terminate the transport. Must be idempotent-safe from the sweeper's view. */
+  close(reason: string): void;
+}
+
+/**
+ * A registry of long-lived connections keyed by (tenant, resource).
+ *
+ * `C` is the transport handle (a `ws`, an SSE stream, a provider session); this
+ * class owns only the tenancy bookkeeping, never the transport semantics — the
+ * concrete registries (`VoiceStreamRegistry`, the chat WS handler) keep their own
+ * per-connection payload state and consult this for WHO may receive WHAT.
+ */
+export class TenantStreamRegistry<C> {
+  private readonly bindings = new Map<C, StreamSubscriptionBinding>();
+
+  add(connection: C, binding: StreamSubscriptionBinding): void {
+    this.bindings.set(connection, binding);
+  }
+
+  remove(connection: C): void {
+    this.bindings.delete(connection);
+  }
+
+  get(connection: C): StreamSubscriptionBinding | undefined {
+    return this.bindings.get(connection);
+  }
+
+  get size(): number {
+    return this.bindings.size;
+  }
+
+  /**
+   * The tenant-narrowed fan-out set for one resource.
+   *
+   * A caller broadcasting tenant A's update passes A's trusted tenant and
+   * reaches ONLY A's subscribers of that resource. A legacy caller passes `null`
+   * and reaches only the legacy subscribers — the pre-G5 resource-only match,
+   * byte-identical, because flag-off every binding is tenantless.
+   */
+  *matching(resourceId: string, tenantId: string | null): Generator<[C, StreamSubscriptionBinding]> {
+    const wanted = streamSubscriptionKey(tenantId, resourceId);
+    for (const [connection, binding] of this.bindings) {
+      if (streamSubscriptionKey(binding.tenantId, binding.resourceId) === wanted) {
+        yield [connection, binding];
+      }
+    }
+  }
+
+  /** Every binding, for sweeps and diagnostics. */
+  entries(): IterableIterator<[C, StreamSubscriptionBinding]> {
+    return this.bindings.entries();
+  }
+
+  /** The distinct tenants holding at least one live subscription (legacy excluded). */
+  activeTenantIds(): string[] {
+    const seen = new Set<string>();
+    for (const [, binding] of this.bindings) {
+      if (binding.tenantId !== null) seen.add(binding.tenantId);
+    }
+    return [...seen];
+  }
+
+  /**
+   * Close and drop every subscription belonging to one tenant. Returns the count
+   * closed. A `close` that throws is logged and does not stop the sweep — a
+   * wedged socket must not keep a sibling's revocation from landing.
+   */
+  terminateTenant(tenantId: string, reason: string): number {
+    let closed = 0;
+    for (const [connection, binding] of [...this.bindings]) {
+      if (binding.tenantId !== tenantId) continue;
+      try {
+        binding.close(reason);
+      } catch (err) {
+        log.warn('stream termination failed', {
+          tenantId,
+          reason,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      this.bindings.delete(connection);
+      closed += 1;
+    }
+    return closed;
+  }
+}
+
+/** The control-plane freshness state a live subscription is revalidated against. */
+export interface TenantRevocationState {
+  status: string;
+  revocationEpoch: number;
+}
+
+export type TenantRevocationStateReader = (
+  authPlaneDb: Database,
+  tenantId: string,
+) => Promise<TenantRevocationState | null>;
+
+/**
+ * Read one tenant's live status + revocation epoch from the auth plane.
+ *
+ * Same trusted, non-caller-controlled source and same connection posture as
+ * `periodic-tenant-work.ts`: `tenants` is an AUTH-PLANE table, so this must run
+ * on `services.authPlane.db`. Under enforcement without a dedicated auth-plane
+ * handle the read FAILS CLOSED (it raises), and the sweep treats that as
+ * "unknown" — which terminates, never grants.
+ */
+export const readTenantRevocationState: TenantRevocationStateReader = async (authPlaneDb, tenantId) => {
+  const [row] = await authPlaneDb
+    .select({ status: tenants.status, revocationEpoch: tenants.revocationEpoch })
+    .from(tenants)
+    .where(eq(tenants.id, tenantId))
+    .limit(1);
+  return row ?? null;
+};
+
+export interface StreamSweepStats {
+  /** Distinct tenants revalidated this tick. */
+  tenantsChecked: number;
+  /** Subscriptions closed this tick. */
+  terminated: number;
+}
+
+/**
+ * One revocation pass over every live tenant-bound subscription (RELEASE_SLOS
+ * `websocket_sse_channel_provider_session_termination_seconds_max`).
+ *
+ * For each DISTINCT tenant holding a subscription — one control-plane read per
+ * tenant, not per connection — the pass terminates when the tenant is not
+ * `active` (suspended/archived), when the tenant's current revocation epoch is
+ * AHEAD of the epoch the connection was authorized under, or when the tenant no
+ * longer resolves at all. A read that throws also terminates: an auth plane we
+ * cannot consult is not evidence of continued authority.
+ *
+ * Flag-off, and for tenantless legacy subscriptions flag-on, this does nothing
+ * and issues no query.
+ *
+ * @param readState - seam for the control-plane read; production callers use the
+ *   default. Tests inject synthetic epochs through it, which is why the ceiling
+ *   proofs need no wall clock.
+ */
+export async function sweepRevokedStreamSubscriptions(
+  authPlaneDb: Database,
+  registry: TenantStreamRegistry<unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+  readState: TenantRevocationStateReader = readTenantRevocationState,
+): Promise<StreamSweepStats> {
+  const stats: StreamSweepStats = { tenantsChecked: 0, terminated: 0 };
+  if (!isMultitenancyEnabled(env)) return stats;
+
+  for (const tenantId of registry.activeTenantIds()) {
+    stats.tenantsChecked += 1;
+
+    let state: TenantRevocationState | null;
+    try {
+      state = await readState(authPlaneDb, tenantId);
+    } catch (err) {
+      log.warn('stream revocation read failed; terminating fail-closed', {
+        tenantId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      stats.terminated += registry.terminateTenant(tenantId, 'tenant_revoked');
+      continue;
+    }
+
+    if (state === null || state.status !== 'active') {
+      stats.terminated += registry.terminateTenant(tenantId, 'tenant_revoked');
+      continue;
+    }
+
+    stats.terminated += terminateSupersededEpochs(registry, tenantId, state.revocationEpoch);
+  }
+
+  return stats;
+}
+
+/**
+ * Close a tenant's connections whose authorized epoch has been SUPERSEDED, while
+ * the tenant itself is still active (ADR-0006).
+ *
+ * Per connection rather than per tenant, so a socket that reauthorized at the
+ * current epoch survives the same tick that closes its stale siblings.
+ */
+function terminateSupersededEpochs(
+  registry: TenantStreamRegistry<unknown>,
+  tenantId: string,
+  currentEpoch: number,
+): number {
+  let terminated = 0;
+  for (const [connection, binding] of [...registry.entries()]) {
+    if (binding.tenantId !== tenantId) continue;
+    if (binding.revocationEpoch >= currentEpoch) continue;
+    try {
+      binding.close('tenant_revoked');
+    } catch (err) {
+      log.warn('stream termination failed', {
+        tenantId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    registry.remove(connection);
+    terminated += 1;
+  }
+  return terminated;
+}
+
+/**
+ * Start the periodic revocation sweep, returning a stop handle.
+ *
+ * Flag-off this starts NO timer at all — the pre-G5 process gains no background
+ * work. The interval is `unref`'d where the runtime supports it so a sweeping
+ * process can still exit.
+ */
+export function startStreamRevocationSweeper(
+  authPlaneDb: Database,
+  registry: TenantStreamRegistry<unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): { stop: () => void } {
+  if (!isMultitenancyEnabled(env)) return { stop: () => {} };
+
+  const timer = setInterval(() => {
+    void sweepRevokedStreamSubscriptions(authPlaneDb, registry, env).then(
+      (stats) => {
+        if (stats.terminated > 0) {
+          log.info('terminated revoked stream subscriptions', {
+            terminated: stats.terminated,
+            tenantsChecked: stats.tenantsChecked,
+          });
+        }
+      },
+      (err) => log.warn('stream revocation sweep failed', { error: err instanceof Error ? err.message : String(err) }),
+    );
+  }, resolveStreamSweepIntervalMs());
+
+  (timer as unknown as { unref?: () => void }).unref?.();
+  return { stop: () => clearInterval(timer) };
+}

--- a/packages/api/src/tenancy/worker-tenant-context.ts
+++ b/packages/api/src/tenancy/worker-tenant-context.ts
@@ -165,6 +165,39 @@ export async function runTenantWorkDb<T>(
 }
 
 /**
+ * Derive a consumer's TRUSTED tenant from its envelope, as a VALUE.
+ *
+ * {@link runConsumerInTenantContext} is the right tool when the handler's whole
+ * DB block fits in one scope. It is the WRONG tool when the work interleaves DB
+ * blocks with publishes or network calls — a worker transaction held across a
+ * publish makes the event a pre-commit side effect. Those handlers need the
+ * tenant as a value they can THREAD into a service that scopes each block
+ * itself (`runTenantWorkDb`), which is what this returns.
+ *
+ * Same three worlds, same fail-closed posture as the wrapper:
+ *   * `tenant`     → the envelope's trusted tenant;
+ *   * `legacy`     → `undefined`, so every threaded block stays ambient and
+ *                    byte-identical to pre-G5;
+ *   * `quarantine` → THROWS. Returning `undefined` here would process the
+ *                    message globally, which is exactly the fallback ADR-0008
+ *                    forbids. The subscription layer already rejects
+ *                    quarantined envelopes, so this is defence in depth and the
+ *                    caller's catch logs and drops it.
+ *
+ * The provenance guarantee is the same one `classifyEnvelope` gives: the value
+ * comes from producer-stamped METADATA, never from the event payload.
+ */
+export function trustedEnvelopeTenant(event: Pick<OmniEvent, 'metadata'>): string | undefined {
+  const classification = classifyEnvelope(event.metadata);
+  if (classification.world === 'quarantine') {
+    throw new WorkerTenantContextError(
+      `refusing to derive a tenant from a quarantined envelope (${classification.reason})`,
+    );
+  }
+  return classification.world === 'tenant' ? classification.tenantId : undefined;
+}
+
+/**
  * The consumer bridge: run an event handler's DB work in the right world.
  *
  * Classifies the inbound envelope and:

--- a/packages/api/src/tenancy/worker-tenant-context.ts
+++ b/packages/api/src/tenancy/worker-tenant-context.ts
@@ -1,0 +1,168 @@
+/**
+ * The worker/consumer tenant boundary — G5's conversion device for async work
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0004).
+ *
+ * WHAT PROBLEM THIS SOLVES
+ * ------------------------
+ * G4 established the per-request tenant scope (`tenant-scope.ts`): the edge opens
+ * `withTenantTransaction`, and every converted service reads `scopedHandle(db)`
+ * from an `AsyncLocalStorage`. That works because a request carries a credential
+ * from which a tenant is derived. A NATS consumer, a cron/interval, or a
+ * fire-and-forget executor has NO request and NO credential — so it has no scope,
+ * and `scopedHandle` hands it the ambient pool. That is the unscoped worker
+ * access the db-access guard books as `pending-G5-conversion`.
+ *
+ * This module is the worker counterpart of `runInTenantScope`. It takes a
+ * TRUSTED tenant — derived by the producer and carried in the versioned envelope
+ * (`@omni/core` `classifyEnvelope`), or read from a loaded resource's persisted
+ * ownership — and runs one work item inside its own tenant-stamped transaction.
+ * Once inside, a converted consumer's `scopedHandle(db)` returns that
+ * transaction exactly as it does for a request, so the SAME service code is
+ * scoped whether its caller is a route or a worker.
+ *
+ * TWO TRAPS THIS MODULE EXISTS TO AVOID (G4 leg-2 review)
+ * ------------------------------------------------------
+ *   1. **A worker must never inherit a request's ALS scope.** A worker spawned
+ *      from inside a request (a fire-and-forget executor) would otherwise see the
+ *      request's committed-and-released transaction through the ambient store —
+ *      a use-after-commit, AND a cross-context tenant leak if the work item
+ *      belongs to a different tenant than the request. So the FIRST thing this
+ *      does is `runDetachedFromTenantScope`, suspending any inherited scope
+ *      before establishing its own.
+ *   2. **A worker transaction must never outlive its work item.** The scope is
+ *      opened by `runInTenantScope` → `withTenantTransaction`, which commits when
+ *      `fn` resolves. The transaction's lifetime is exactly `fn`'s. Background
+ *      work `fn` itself spawns must open its OWN worker scope — this module does
+ *      not lend its transaction across the fire-and-forget boundary.
+ *
+ * FAIL-CLOSED DERIVATION
+ * ----------------------
+ * The tenant is validated as a UUID before a transaction opens; a missing,
+ * empty, or malformed value is refused. The provenance guarantee — that the
+ * tenant was derived by a trusted producer and not asserted by a caller/payload
+ * — is upheld by the CALL SITE: a consumer obtains this value from
+ * `classifyEnvelope(...).tenantId` (which reads producer-stamped metadata, never
+ * payload) or from a control-plane resource read, never from the event body.
+ *
+ * DUAL WORLD
+ * ----------
+ * Like `tenant-scope.ts`, this establishes a scope UNCONDITIONALLY (a worker
+ * with a trusted tenant is always scoped); only the DB/RLS layer is
+ * enforcement-gated. A flag-off deployment never reaches here with a tenant,
+ * because nothing stamps one — legacy envelopes classify as `legacy` and the
+ * consumer processes them on the ambient pool exactly as before.
+ */
+
+import { type OmniEvent, classifyEnvelope } from '@omni/core';
+import type { Database } from '@omni/db';
+import { type TenantAuthContext, freezeContext } from './auth-context';
+import { runDetachedFromTenantScope, runInTenantScope } from './tenant-scope';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export class WorkerTenantContextError extends Error {
+  readonly code = 'worker_tenant_context_denied';
+  constructor(reason: string) {
+    super(`worker-tenant-context: ${reason}`);
+    this.name = 'WorkerTenantContextError';
+  }
+}
+
+/**
+ * Build the synthetic authenticated context a worker runs under.
+ *
+ * It is a `tenant`-class context carrying only what the tenant transaction
+ * needs: the trusted tenant id. Everything else is a worker-appropriate,
+ * NON-caller-controlled placeholder:
+ *
+ *   * `requestId` is freshly minted per work item (`crypto.randomUUID`), never
+ *     an inbound/caller value — the same discipline the edge adopted after the
+ *     leg-2 cross-tenant-DoS fix, so a worker's audit/trace id cannot be forged
+ *     or collided by a caller.
+ *   * `actorRole`/`scopes`/ceilings are the empty/most-restrictive shape: a
+ *     worker acts on the tenant's own persisted resources, not on a delegated
+ *     human's authority, so it carries no scopes to widen.
+ *
+ * @throws WorkerTenantContextError when `tenantId` is not a well-formed UUID.
+ */
+export function buildWorkerTenantContext(tenantId: string): TenantAuthContext {
+  if (typeof tenantId !== 'string' || !UUID.test(tenantId)) {
+    throw new WorkerTenantContextError(`refusing a non-UUID tenant (${String(tenantId)})`);
+  }
+  return freezeContext({
+    credentialClass: 'tenant',
+    requestId: `worker-${crypto.randomUUID()}`,
+    principalId: `worker-${tenantId}`,
+    credentialId: `worker-${tenantId}`,
+    tenantId,
+    tenantSlug: null,
+    actorRole: 'tenant-admin',
+    scopes: [],
+    membershipId: `worker-${tenantId}`,
+    resourceConstraints: {},
+    expiresAt: null,
+    rateLimit: null,
+    budget: null,
+    delegationDepth: 0,
+    rootKeyId: `worker-${tenantId}`,
+    policyVersion: 0,
+    revocationEpoch: 0,
+    tenantKeyLineageId: `worker-${tenantId}`,
+  }) as TenantAuthContext;
+}
+
+/**
+ * Run one work item under a fresh worker tenant scope.
+ *
+ * Detaches any inherited request scope, opens a tenant-stamped transaction for
+ * `trustedTenantId`, and runs `fn` inside it. Converted consumer/worker code
+ * reads `scopedHandle(db)` inside `fn` and gets that transaction.
+ *
+ * @throws WorkerTenantContextError - before any transaction opens - when
+ *   `trustedTenantId` is missing/empty/malformed.
+ */
+export async function runInWorkerTenantScope<T>(
+  db: Database,
+  trustedTenantId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  // Validate BEFORE detaching/opening anything, so a bad tenant cannot even
+  // start a transaction. `async` turns this fail-closed throw into a rejection,
+  // so every failure mode reaches the caller through the same promise.
+  const context = buildWorkerTenantContext(trustedTenantId);
+  // Trap #1: suspend any inherited request scope, THEN establish our own. The
+  // whole `runInTenantScope` chain runs detached from the outer scope.
+  return runDetachedFromTenantScope(() => runInTenantScope(db, context, fn));
+}
+
+/**
+ * The consumer bridge: run an event handler's DB work in the right world.
+ *
+ * Classifies the inbound envelope and:
+ *   * `tenant`     → runs `fn` inside a fresh worker tenant scope for the
+ *                    envelope's trusted tenant (converted, scoped, RLS-policed);
+ *   * `legacy`     → runs `fn` directly on the ambient pool — byte-identical to
+ *                    pre-G5, the dual-world contract;
+ *   * `quarantine` → refuses. The subscription layer rejects quarantined
+ *                    envelopes before any handler runs, so this is defence in
+ *                    depth: if one reaches here, it is a bug, and processing it
+ *                    globally is exactly the fallback ADR-0008 forbids.
+ *
+ * A converted consumer wraps its DB work in this and reads `scopedHandle(db)`
+ * inside `fn`; the same handler body is then correct in both worlds.
+ */
+export async function runConsumerInTenantContext<T>(
+  db: Database,
+  event: Pick<OmniEvent, 'metadata'>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const classification = classifyEnvelope(event.metadata);
+  if (classification.world === 'quarantine') {
+    throw new WorkerTenantContextError(`refusing to process a quarantined envelope (${classification.reason})`);
+  }
+  if (classification.world === 'tenant') {
+    return runInWorkerTenantScope(db, classification.tenantId, fn);
+  }
+  // legacy — no tenant context exists to establish; run as today.
+  return fn();
+}

--- a/packages/api/src/tenancy/worker-tenant-context.ts
+++ b/packages/api/src/tenancy/worker-tenant-context.ts
@@ -136,6 +136,35 @@ export async function runInWorkerTenantScope<T>(
 }
 
 /**
+ * The threaded-tenant bridge: run one DISCRETE DB block of a work item in the
+ * right world from an explicitly threaded trusted tenant.
+ *
+ * This is the generalization of the dispatcher's `runDispatchDb` for services
+ * whose worker callers thread a tenant instead of wrapping the whole call —
+ * required wherever a method both writes the database AND publishes events,
+ * because holding a worker transaction across a publish would make the event a
+ * pre-commit side effect (a phantom on rollback). The caller derives
+ * `trustedTenantId` from its envelope (`classifyEnvelope`) or the loaded
+ * resource's persisted ownership, NEVER from a payload claim, and the method
+ * wraps each DB block individually, publishing between blocks.
+ *
+ *   * tenant threaded → the block runs in its own worker tenant scope
+ *     (detached, tenant-stamped, exactly one transaction for the block);
+ *   * nothing threaded → the block runs as the caller found it: inside an
+ *     active request scope it stays on that scope's transaction via
+ *     `scopedHandle`, and on a legacy worker path it hits the ambient pool
+ *     byte-identically.
+ */
+export async function runTenantWorkDb<T>(
+  db: Database,
+  trustedTenantId: string | null | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!trustedTenantId) return fn();
+  return runInWorkerTenantScope(db, trustedTenantId, fn);
+}
+
+/**
  * The consumer bridge: run an event handler's DB work in the right world.
  *
  * Classifies the inbound envelope and:

--- a/packages/api/src/utils/__tests__/media-guard-tenant-subsumption.test.ts
+++ b/packages/api/src/utils/__tests__/media-guard-tenant-subsumption.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The `OMNI_MEDIA_URL_GUARD=off` escape hatch is subsumed for TENANT contexts
+ * (wish: omni-full-multitenancy, Group G5, deliverable (b); ADR-0009).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `safe-media-fetch.ts` predates multitenancy. It ships a documented escape
+ * hatch — `OMNI_MEDIA_URL_GUARD=off` disables the private-range checks — for
+ * single-tenant deployments that intentionally fetch media from an RFC1918 host
+ * (a lab MinIO, say). In a single-tenant world that is an operator's own
+ * decision about their own network, and G5 must not change it.
+ *
+ * In a MULTI-tenant world the same switch is a cross-tenant SSRF hole: the URL
+ * being fetched came from a tenant-controlled message payload, and one operator
+ * flag would let any tenant's payload reach loopback, RFC1918, and the cloud
+ * metadata endpoint on the shared host. ADR-0009 is default-deny for
+ * tenant-controlled egress, and the G5 brief is explicit — "The
+ * `OMNI_MEDIA_URL_GUARD=off` escape hatch is removed/subsumed for tenant
+ * contexts".
+ *
+ * SUBSUMED, NOT REMOVED, and the distinction is the dual-world contract:
+ *   * no tenant context (flag-off, legacy) → the hatch works exactly as before,
+ *     byte-identical;
+ *   * a tenant context → the hatch is IGNORED. Private ranges are denied no
+ *     matter what the environment says, because no per-deployment flag may
+ *     lower one tenant's isolation from another.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { type AddressLookup, UnsafeMediaUrlError, assertSafeMediaUrl } from '../safe-media-fetch';
+
+const TENANT = '11111111-1111-4111-8111-1111111111ed';
+
+const GUARD_OFF = { OMNI_MEDIA_URL_GUARD: 'off' } as NodeJS.ProcessEnv;
+const GUARD_DEFAULT = {} as NodeJS.ProcessEnv;
+
+const publicLookup: AddressLookup = async () => [{ address: '93.184.216.34' }];
+const privateLookup: AddressLookup = async () => [{ address: '10.1.2.3' }];
+const metadataLookup: AddressLookup = async () => [{ address: '169.254.169.254' }];
+
+describe('no tenant context — the escape hatch is untouched (dual world)', () => {
+  test('guard off allows a literal private address, exactly as before G5', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('http://10.0.0.5/media.jpg'), publicLookup, GUARD_OFF),
+    ).resolves.toBeUndefined();
+  });
+
+  test('guard off allows a host that RESOLVES private, exactly as before G5', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('http://lab.internal/media.jpg'), privateLookup, GUARD_OFF),
+    ).resolves.toBeUndefined();
+  });
+
+  test('guard off still refuses a non-http scheme — the hatch never covered that', async () => {
+    await expect(assertSafeMediaUrl(new URL('file:///etc/passwd'), publicLookup, GUARD_OFF)).rejects.toThrow(
+      UnsafeMediaUrlError,
+    );
+  });
+});
+
+describe('tenant context — the escape hatch is subsumed', () => {
+  test('a literal private address is refused even with the guard switched off', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('http://10.0.0.5/media.jpg'), publicLookup, GUARD_OFF, TENANT),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+  });
+
+  test('loopback is refused even with the guard switched off', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('http://127.0.0.1:9000/media.jpg'), publicLookup, GUARD_OFF, TENANT),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+  });
+
+  test('cloud metadata is refused even with the guard switched off', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('http://metadata.example/x'), metadataLookup, GUARD_OFF, TENANT),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+  });
+
+  test('a host that RESOLVES private is refused even with the guard switched off (DNS rebinding)', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('http://looks-public.example/media.jpg'), privateLookup, GUARD_OFF, TENANT),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+  });
+
+  test('a genuinely public target still passes — subsumption denies private, not everything', async () => {
+    await expect(
+      assertSafeMediaUrl(new URL('https://cdn.example/media.jpg'), publicLookup, GUARD_OFF, TENANT),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertSafeMediaUrl(new URL('https://cdn.example/media.jpg'), publicLookup, GUARD_DEFAULT, TENANT),
+    ).resolves.toBeUndefined();
+  });
+
+  test('with the guard at its DEFAULT, tenant and non-tenant behave identically', async () => {
+    // The subsumption only ever removes the hatch; it never adds a rule the
+    // enforced default did not already have.
+    await expect(assertSafeMediaUrl(new URL('http://10.0.0.5/m.jpg'), publicLookup, GUARD_DEFAULT)).rejects.toThrow(
+      UnsafeMediaUrlError,
+    );
+    await expect(
+      assertSafeMediaUrl(new URL('http://10.0.0.5/m.jpg'), publicLookup, GUARD_DEFAULT, TENANT),
+    ).rejects.toThrow(UnsafeMediaUrlError);
+  });
+});

--- a/packages/api/src/utils/safe-media-fetch.ts
+++ b/packages/api/src/utils/safe-media-fetch.ts
@@ -29,6 +29,16 @@
  * (NOT the scheme check) for deployments that intentionally fetch media from
  * private hosts (e.g. a lab MinIO serving media URLs on RFC1918). Default is
  * enforced.
+ *
+ * THE ESCAPE HATCH IS SUBSUMED IN A TENANT CONTEXT (G5 deliverable (b);
+ * ADR-0009). In a single-tenant deployment the hatch is an operator's decision
+ * about their own network, and G5 does not touch it. In a multi-tenant one the
+ * URL being fetched came from a TENANT-CONTROLLED payload, so the same switch
+ * would let any tenant reach loopback, RFC1918, and the cloud metadata endpoint
+ * on the shared host — a per-deployment flag must never be able to lower one
+ * tenant's isolation from another. When a `trustedTenantId` is supplied the
+ * hatch is therefore IGNORED and private ranges are denied regardless of the
+ * environment. Passing no tenant keeps the pre-G5 behavior byte-identical.
  */
 
 import { lookup } from 'node:dns/promises';
@@ -46,8 +56,15 @@ export type AddressLookup = (hostname: string) => Promise<Array<{ address: strin
 
 const defaultLookup: AddressLookup = async (hostname) => lookup(hostname, { all: true });
 
-/** Private-range checks are on unless explicitly switched off. */
-export function isMediaUrlGuardEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+/**
+ * Private-range checks are on unless explicitly switched off — EXCEPT in a
+ * tenant context, where the switch does not apply at all (see the module
+ * header). `trustedTenantId` must come from a verified worker scope/envelope,
+ * never a caller claim; its mere PRESENCE is what removes the hatch, so a
+ * forged value could only ever make the policy stricter.
+ */
+export function isMediaUrlGuardEnabled(env: NodeJS.ProcessEnv = process.env, trustedTenantId?: string): boolean {
+  if (trustedTenantId !== undefined) return true;
   return env.OMNI_MEDIA_URL_GUARD?.trim().toLowerCase() !== 'off';
 }
 
@@ -92,12 +109,13 @@ export async function assertSafeMediaUrl(
   url: URL,
   resolveAddresses: AddressLookup = defaultLookup,
   env: NodeJS.ProcessEnv = process.env,
+  trustedTenantId?: string,
 ): Promise<void> {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new UnsafeMediaUrlError(url.toString(), `scheme ${url.protocol} is not allowed`);
   }
 
-  if (!isMediaUrlGuardEnabled(env)) return;
+  if (!isMediaUrlGuardEnabled(env, trustedTenantId)) return;
 
   // URL keeps IPv6 literals bracketed ([::1]) — strip for the family check.
   const hostname = url.hostname.replace(/^\[|\]$/g, '');
@@ -125,6 +143,14 @@ export async function assertSafeMediaUrl(
 }
 
 export interface MediaFetchOptions extends RequestInit {
+  /**
+   * The verified tenant this fetch is performed for (G5, ADR-0009). Supplying it
+   * SUBSUMES the `OMNI_MEDIA_URL_GUARD=off` escape hatch for this call and every
+   * redirect hop it follows. Derived from a worker scope/envelope, never a
+   * payload claim. Omitted on the legacy/flag-off path, which stays
+   * byte-identical.
+   */
+  trustedTenantId?: string;
   /**
    * Host suffixes where Authorization should be preserved across manual
    * redirects. Fetch strips Authorization on cross-origin redirects; some
@@ -165,10 +191,10 @@ function headersWithOptionalAuthorization(
  * files.slack.com → files-pri.slack.com).
  */
 export async function fetchMediaUrl(url: string, fetchOptions?: MediaFetchOptions): Promise<Response> {
-  const { preserveAuthRedirectHostSuffixes, ...init } = fetchOptions ?? {};
+  const { preserveAuthRedirectHostSuffixes, trustedTenantId, ...init } = fetchOptions ?? {};
 
   let currentUrl = new URL(url);
-  await assertSafeMediaUrl(currentUrl);
+  await assertSafeMediaUrl(currentUrl, defaultLookup, process.env, trustedTenantId);
   let currentHeaders = new Headers(init.headers);
 
   for (let redirects = 0; redirects <= MAX_MEDIA_REDIRECTS; redirects++) {
@@ -184,7 +210,9 @@ export async function fetchMediaUrl(url: string, fetchOptions?: MediaFetchOption
     if (!location) return response;
 
     const nextUrl: URL = new URL(location, currentUrl);
-    await assertSafeMediaUrl(nextUrl);
+    // Every hop is revalidated under the SAME tenant context, so a redirect
+    // cannot be used to re-acquire the escape hatch mid-chain.
+    await assertSafeMediaUrl(nextUrl, defaultLookup, process.env, trustedTenantId);
 
     const preserveAuthorization =
       nextUrl.origin === currentUrl.origin ||

--- a/packages/api/src/ws/chats.ts
+++ b/packages/api/src/ws/chats.ts
@@ -6,6 +6,7 @@
 
 import { type EventBus, createLogger } from '@omni/core';
 import type { Database } from '@omni/db';
+import { TenantStreamRegistry } from '../tenancy/tenant-stream-subscriptions';
 
 /**
  * Subscribe to chat updates
@@ -53,6 +54,20 @@ interface ChatUpdateMessage {
 }
 
 /**
+ * The tenancy of one connection, established at `open()` from the authenticated
+ * upgrade — NEVER from a socket message (G5 deliverable (e); WISH "Streaming and
+ * long-lived state"). A connection with no binding is a legacy/flag-off one.
+ */
+export interface ChatConnectionBinding {
+  /** Trusted tenant of the connection. */
+  tenantId: string;
+  /** Tenant revocation epoch observed when the connection was authorized. */
+  revocationEpoch: number;
+  /** Terminate the transport — used by the revocation sweep. */
+  close?: (reason: string) => void;
+}
+
+/**
  * Subscription options
  */
 interface SubscriptionOptions {
@@ -60,12 +75,33 @@ interface SubscriptionOptions {
   includeTyping: boolean;
   includePresence: boolean;
   includeReadReceipts: boolean;
+  /**
+   * The connection's trusted tenant, copied from its `open()` binding on every
+   * (re)subscribe. It is deliberately NOT read from the client message: a
+   * `subscribe` payload carrying a `tenantId` is ignored, so a caller cannot
+   * widen what it receives.
+   */
+  tenantId: string | null;
 }
 
 /**
  * Check if a subscriber should receive an update based on their filter settings
+ *
+ * `updateTenantId` is the TRUSTED tenant of the update (null for a legacy/
+ * flag-off update). It must equal the subscriber's own trusted tenant: a
+ * tenant-bound update never reaches a legacy subscriber and vice versa, so the
+ * two worlds cannot mix even while both exist.
  */
-function shouldReceiveUpdate(sub: SubscriptionOptions, update: ChatUpdateMessage): boolean {
+function shouldReceiveUpdate(
+  sub: SubscriptionOptions,
+  update: ChatUpdateMessage,
+  updateTenantId: string | null,
+): boolean {
+  // Tenant gate first — a chat id is not authority to receive a chat.
+  if (sub.tenantId !== updateTenantId) {
+    return false;
+  }
+
   // Check chat filter
   if (sub.chatId && sub.chatId !== update.chatId) {
     return false;
@@ -109,19 +145,63 @@ function sendToSocket(ws: unknown, data: string, instanceId: string): void {
  */
 export function createChatWebSocketHandler(_db: Database, _eventBus: EventBus | null, instanceId: string) {
   const subscriptions = new Map<unknown, SubscriptionOptions>();
+  const bindings = new Map<unknown, ChatConnectionBinding>();
+  /** Tenancy bookkeeping for the revocation sweep (RELEASE_SLOS ≤ 30s). */
+  const streamRegistry = new TenantStreamRegistry<unknown>();
   const log = createLogger('ws:chats');
 
+  function forget(ws: unknown): void {
+    subscriptions.delete(ws);
+    bindings.delete(ws);
+    streamRegistry.remove(ws);
+  }
+
   return {
+    /** The live tenancy view, for the revocation sweep. */
+    streamRegistry,
+
     /**
      * Handle WebSocket open
+     *
+     * `binding` carries the connection's TRUSTED tenant, derived by the upgrade
+     * handler from the authenticated credential. Omitted ⇒ a legacy/flag-off
+     * connection, byte-identical to pre-G5.
      */
-    open(ws: unknown): void {
+    open(ws: unknown, binding?: ChatConnectionBinding): void {
       log.debug('Client connected', { instanceId });
+      if (binding) bindings.set(ws, binding);
       subscriptions.set(ws, {
         includeTyping: true,
         includePresence: true,
         includeReadReceipts: true,
+        tenantId: binding?.tenantId ?? null,
       });
+      streamRegistry.add(ws, {
+        tenantId: binding?.tenantId ?? null,
+        resourceId: instanceId,
+        revocationEpoch: binding?.revocationEpoch ?? 0,
+        close: (reason) => binding?.close?.(reason),
+      });
+    },
+
+    /**
+     * Close and drop every subscription of a revoked tenant (RELEASE_SLOS
+     * `websocket_sse_channel_provider_session_termination_seconds_max`).
+     * Legacy/tenantless connections are untouched.
+     */
+    terminateTenant(tenantId: string, reason: string): number {
+      let closed = 0;
+      for (const [ws, sub] of [...subscriptions]) {
+        if (sub.tenantId !== tenantId) continue;
+        try {
+          bindings.get(ws)?.close?.(reason);
+        } catch {
+          // Socket already gone — the drop below is what matters.
+        }
+        forget(ws);
+        closed += 1;
+      }
+      return closed;
     },
 
     /**
@@ -139,6 +219,9 @@ export function createChatWebSocketHandler(_db: Database, _eventBus: EventBus | 
               includeTyping: data.includeTyping ?? true,
               includePresence: data.includePresence ?? true,
               includeReadReceipts: data.includeReadReceipts ?? true,
+              // From the CONNECTION's binding, never from `data` — a tenant in
+              // the payload is ignored.
+              tenantId: bindings.get(ws)?.tenantId ?? null,
             });
             break;
 
@@ -160,17 +243,21 @@ export function createChatWebSocketHandler(_db: Database, _eventBus: EventBus | 
      */
     close(ws: unknown): void {
       log.debug('Client disconnected', { instanceId });
-      subscriptions.delete(ws);
+      forget(ws);
     },
 
     /**
      * Broadcast a chat update to relevant subscribers
+     *
+     * @param updateTenantId - the TRUSTED tenant that owns this update, derived
+     *   by the producer from the chat's persisted ownership. Omitted ⇒ a
+     *   legacy/flag-off update, delivered only to legacy subscribers.
      */
-    broadcast(update: ChatUpdateMessage): void {
+    broadcast(update: ChatUpdateMessage, updateTenantId: string | null = null): void {
       const payload = JSON.stringify(update);
 
       for (const [ws, sub] of subscriptions) {
-        if (shouldReceiveUpdate(sub, update)) {
+        if (shouldReceiveUpdate(sub, update, updateTenantId)) {
           sendToSocket(ws, payload, instanceId);
         }
       }

--- a/packages/api/src/ws/voice-instance-ownership.ts
+++ b/packages/api/src/ws/voice-instance-ownership.ts
@@ -1,0 +1,53 @@
+/**
+ * The voice upgrade's ownership read — G5 deliverable (e)
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0003).
+ *
+ * WHY THIS IS ITS OWN MODULE
+ * --------------------------
+ * The db-access guard keys sites by (file, table), and `packages/api/src/index.ts`
+ * is already registered `control-plane` for `instances` — the process-startup
+ * read. Putting this query there would have let a TENANT-BOUNDARY read inherit a
+ * control-plane exemption it does not deserve, and the guard would never have
+ * booked it. Splitting it out gives the read its own honest `tenant-boundary`
+ * registration.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Resolves an instance's PERSISTED owner — `instances` is THE ownership root
+ * (G0/G2 `tenancy-ownership.ts`) — for the voice WebSocket upgrade, which runs
+ * in `Bun.serve`'s raw `fetch` before Hono and therefore has no request scope of
+ * its own.
+ *
+ * The read runs inside `runInWorkerTenantScope` for the CREDENTIAL's tenant, so:
+ *
+ *   * it is detached from any inherited ALS scope (the G4 leg-2 trap) and its
+ *     transaction closes before the socket is registered — it never outlives the
+ *     work item;
+ *   * under enforcement, RLS itself decides visibility. An instance belonging to
+ *     another tenant simply does not resolve, so the caller's comparison is
+ *     defence in depth rather than the only barrier.
+ *
+ * Returning `null` means "not owned by this tenant, or not visible" — never
+ * "owned"; the caller (`authorizeVoiceUpgrade`) treats it as a refusal.
+ */
+
+import type { Database } from '@omni/db';
+import { instances } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import { runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
+
+export async function resolveInstanceTenantId(
+  db: Database,
+  instanceId: string,
+  trustedTenantId: string,
+): Promise<string | null> {
+  return runInWorkerTenantScope(db, trustedTenantId, async () => {
+    const [row] = await scopedHandle(db)
+      .select({ tenantId: instances.tenantId })
+      .from(instances)
+      .where(eq(instances.id, instanceId))
+      .limit(1);
+    return row?.tenantId ?? null;
+  });
+}

--- a/packages/api/src/ws/voice-upgrade-authorization.ts
+++ b/packages/api/src/ws/voice-upgrade-authorization.ts
@@ -1,0 +1,134 @@
+/**
+ * Voice WebSocket upgrade authorization — G5 deliverable (e)
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008, ADR-0003;
+ * WISH "Streaming and long-lived state").
+ *
+ * WHAT PROBLEM THIS SOLVES
+ * ------------------------
+ * The voice stream upgrade lives in `Bun.serve`'s raw `fetch`, BEFORE Hono — so
+ * it never passes through the tenancy middleware G1–G4 installed on the HTTP
+ * edge. Its pre-G5 authorization was, in full:
+ *
+ *     globalChannelRegistry.getAll().find(p => isVoiceCapable(p) && p.voiceSession(id))
+ *
+ * "does ANY loaded plugin, for ANY tenant's instance, hold a session with this
+ * id?" That is a resource-UUID-only check: naming a session IS permission to
+ * join its audio. This module replaces it with a tenant-authorized decision.
+ *
+ * THE DERIVATION CHAIN (all trusted, none caller-supplied)
+ * -------------------------------------------------------
+ *   credential  → tenant       — from the authenticated `api_key` via the auth
+ *                                plane, the same index the HTTP edge uses. The
+ *                                URL has no tenant parameter, and
+ *                                `parseVoiceStreamParams` cannot produce one.
+ *   sessionId   → instanceId   — from the plugin's live `VoiceSession`, which
+ *                                carries the instance it was opened for.
+ *   instanceId  → tenantId     — from `instances`, THE ownership root (G0/G2),
+ *                                read INSIDE the credential tenant's scope so
+ *                                RLS itself decides visibility. A foreign
+ *                                instance simply does not resolve.
+ *
+ * The two tenants are then compared by {@link authorizeStreamSubscription}, the
+ * same decision table every other long-lived surface uses.
+ *
+ * FAIL-CLOSED
+ * -----------
+ * Every unresolvable step refuses. A credential lookup or ownership read that
+ * THROWS also refuses: an auth plane or a database we cannot consult is not
+ * evidence of permission. This is the opposite of the pre-G5 handler, which
+ * swallowed a lookup failure and continued.
+ *
+ * DUAL WORLD
+ * ----------
+ * Flag-off, this performs the pre-G5 decision EXACTLY — session exists or not —
+ * with no credential-tenant resolution, no ownership read, and no tenant on the
+ * resulting connection. The new lookups bind only to the multitenancy world.
+ *
+ * KNOWN LEGACY-WORLD GAP (not changed here, reported in the G5 handoff): the
+ * pre-G5 handler calls `ApiKeyService.validate` and inspects only THROWN errors,
+ * while an invalid key resolves to `null` — so flag-off, an unrecognised key is
+ * admitted. Fixing that alters default legacy runtime behaviour, which G5 is not
+ * authorized to do; flag-on, `resolveCredentialTenant` returning null refuses,
+ * so the multitenancy world is closed.
+ */
+
+import { isMultitenancyEnabled } from '../tenancy/feature-flag';
+import { authorizeStreamSubscription } from '../tenancy/tenant-stream-subscriptions';
+
+/** The trusted tenancy of an authenticated voice credential. */
+export interface VoiceCredentialTenant {
+  tenantId: string;
+  /** The tenant revocation epoch the credential was validated against. */
+  revocationEpoch: number;
+}
+
+export interface VoiceUpgradeDeps {
+  /**
+   * Resolve the api key to its tenant via the auth plane. Returns null when the
+   * key is unknown, revoked, expired, or platform-class (a platform credential
+   * has no tenant of its own to bind a stream to).
+   */
+  resolveCredentialTenant: (apiKey: string) => Promise<VoiceCredentialTenant | null>;
+  /** The instance a live voice session was opened for, or null if unknown. */
+  resolveSessionInstanceId: (sessionId: string) => string | null;
+  /**
+   * The instance's PERSISTED owner, read inside `tenantId`'s scope so RLS
+   * decides visibility. Returns null when the instance is not visible/owned.
+   */
+  resolveInstanceTenantId: (instanceId: string, tenantId: string) => Promise<string | null>;
+}
+
+export type VoiceUpgradeRefusal =
+  | 'unauthenticated'
+  | 'session_not_found'
+  | 'cross_tenant_resource'
+  | 'unowned_resource'
+  | 'tenant_context_required'
+  | 'malformed_tenant';
+
+export type VoiceUpgradeDecision =
+  | { ok: true; tenantId: string | null; revocationEpoch: number }
+  | { ok: false; reason: VoiceUpgradeRefusal };
+
+export async function authorizeVoiceUpgrade(
+  request: { apiKey: string; sessionId: string },
+  deps: VoiceUpgradeDeps,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<VoiceUpgradeDecision> {
+  // Flag-off: the pre-G5 decision, unchanged — the session must exist, and the
+  // connection carries no tenant. No tenancy lookup is performed at all.
+  if (!isMultitenancyEnabled(env)) {
+    return deps.resolveSessionInstanceId(request.sessionId) === null
+      ? { ok: false, reason: 'session_not_found' }
+      : { ok: true, tenantId: null, revocationEpoch: 0 };
+  }
+
+  let credential: VoiceCredentialTenant | null;
+  try {
+    credential = await deps.resolveCredentialTenant(request.apiKey);
+  } catch {
+    // An auth plane we cannot consult is not evidence of authority.
+    return { ok: false, reason: 'unauthenticated' };
+  }
+  if (!credential) return { ok: false, reason: 'unauthenticated' };
+
+  const instanceId = deps.resolveSessionInstanceId(request.sessionId);
+  if (instanceId === null) return { ok: false, reason: 'session_not_found' };
+
+  let resourceTenantId: string | null;
+  try {
+    resourceTenantId = await deps.resolveInstanceTenantId(instanceId, credential.tenantId);
+  } catch {
+    // An ownership read that failed (RLS denial included) resolves to "not
+    // owned", never to "owned".
+    resourceTenantId = null;
+  }
+
+  const decision = authorizeStreamSubscription({
+    authenticatedTenantId: credential.tenantId,
+    resourceTenantId,
+  });
+  if (!decision.ok) return { ok: false, reason: decision.reason };
+
+  return { ok: true, tenantId: credential.tenantId, revocationEpoch: credential.revocationEpoch };
+}

--- a/packages/api/src/ws/voice.ts
+++ b/packages/api/src/ws/voice.ts
@@ -66,6 +66,7 @@
 
 import { createLogger } from '@omni/core';
 import { OpusCodec } from '@omni/voice-client';
+import { TenantStreamRegistry } from '../tenancy/tenant-stream-subscriptions';
 
 const log = createLogger('ws:voice');
 
@@ -125,22 +126,101 @@ export interface VoiceStreamParams {
   filterUserId?: string;
 }
 
-/** A connected WS client subscription. */
+/**
+ * A connected WS client subscription.
+ *
+ * `tenantId` is deliberately NOT part of {@link VoiceStreamParams}: params are
+ * parsed from the caller's URL, and a tenant must never come from a caller. It
+ * is set by the upgrade handler from the connection's authenticated credential
+ * after {@link authorizeStreamSubscription} confirmed the session's persisted
+ * owner matches (G5 deliverable (e); WISH "Streaming and long-lived state").
+ */
 export interface VoiceStreamClient {
   params: VoiceStreamParams;
+  /** Trusted tenant of this connection; absent on a legacy/flag-off connection. */
+  tenantId?: string | null;
+  /** Tenant revocation epoch observed when the connection was authorized. */
+  revocationEpoch?: number;
   send: (data: string | ArrayBuffer | Uint8Array) => void;
+  /** Terminate the transport — used by the revocation sweep. */
+  close?: (reason: string) => void;
 }
 
 /**
  * Registry of active voice stream WS clients.
  * The voice session pushes audio here; the WS handler pushes client audio to the session.
+ *
+ * TENANT KEYING (G5 deliverable (e))
+ * ----------------------------------
+ * Pre-G5 every fan-out matched on `params.sessionId` alone, so naming a session
+ * WAS the authorization to receive it. Two tenants can hold sessions with the
+ * same plugin-generated id, so a resource-only match is a cross-tenant read.
+ *
+ * The narrowing device is a session→tenant BINDING, registered by the API side
+ * when a session's persisted ownership is resolved. Producers keep the pre-G5
+ * `AudioStreamSink` signature (`pushAudio(sessionId, userId, data, format)`) —
+ * the discord `VoiceManager` never learns about tenants. When a session is
+ * bound, its fan-out reaches only clients carrying that tenant; when it is NOT
+ * bound (flag-off, legacy), the match is the pre-G5 session-only one,
+ * byte-identical.
  */
 export class VoiceStreamRegistry {
   private clients = new Map<unknown, VoiceStreamClient>();
+  /** Trusted owner per voice session; absent = legacy/flag-off session. */
+  private sessionTenants = new Map<string, string>();
+  /** Tenancy bookkeeping for the revocation sweep (RELEASE_SLOS ≤ 30s). */
+  readonly streamRegistry = new TenantStreamRegistry<unknown>();
+
+  /**
+   * Record a voice session's TRUSTED owner, derived from the session's persisted
+   * resource ownership — never from a socket message or query parameter.
+   */
+  bindSession(sessionId: string, trustedTenantId: string): void {
+    this.sessionTenants.set(sessionId, trustedTenantId);
+  }
+
+  /** Drop a session's tenant binding when the session ends. */
+  unbindSession(sessionId: string): void {
+    this.sessionTenants.delete(sessionId);
+  }
+
+  /** The trusted owner of a session, or null when the session is unbound. */
+  sessionTenant(sessionId: string): string | null {
+    return this.sessionTenants.get(sessionId) ?? null;
+  }
+
+  /**
+   * Whether a client may receive a session's traffic.
+   *
+   * Unbound session → the pre-G5 session-id match. Bound session → the client's
+   * trusted tenant must equal the session's owner; a tenantless client on a
+   * bound session is refused (fail-closed).
+   */
+  private deliverableTo(client: VoiceStreamClient, sessionId: string): boolean {
+    if (client.params.sessionId !== sessionId) return false;
+    const owner = this.sessionTenants.get(sessionId);
+    if (owner === undefined) return true;
+    return client.tenantId === owner;
+  }
 
   /** Register a new WS client. */
   add(ws: unknown, client: VoiceStreamClient): void {
     this.clients.set(ws, client);
+    this.streamRegistry.add(ws, {
+      tenantId: client.tenantId ?? null,
+      resourceId: client.params.sessionId,
+      revocationEpoch: client.revocationEpoch ?? 0,
+      // The sweep terminates through this binding, so it must drop the client
+      // from the AUDIO map too — a socket the sweep closed must stop being a
+      // `pushAudio` target, not merely disappear from the tenancy view.
+      close: (reason) => {
+        try {
+          client.close?.(reason);
+        } finally {
+          this.clients.delete(ws);
+        }
+      },
+    });
     log.info('Voice WS client connected', {
       sessionId: client.params.sessionId,
       format: client.params.format,
@@ -151,6 +231,28 @@ export class VoiceStreamRegistry {
   /** Remove a WS client. */
   remove(ws: unknown): void {
     this.clients.delete(ws);
+    this.streamRegistry.remove(ws);
+  }
+
+  /**
+   * Close and drop every socket belonging to a revoked tenant
+   * (RELEASE_SLOS `websocket_sse_channel_provider_session_termination_seconds_max`).
+   * Legacy/tenantless sockets are untouched.
+   */
+  terminateTenant(tenantId: string, reason: string): number {
+    let closed = 0;
+    for (const [ws, client] of [...this.clients]) {
+      if (client.tenantId !== tenantId) continue;
+      try {
+        client.close?.(reason);
+      } catch {
+        // Socket already gone — the drop below is what matters.
+      }
+      this.clients.delete(ws);
+      this.streamRegistry.remove(ws);
+      closed += 1;
+    }
+    return closed;
   }
 
   /** Get client info for a WS. */
@@ -161,7 +263,7 @@ export class VoiceStreamRegistry {
   /** Push a tagged audio frame to all matching clients for a session. */
   pushAudio(sessionId: string, userId: string, audioData: Uint8Array, format: AudioFormat): void {
     for (const [, client] of this.clients) {
-      if (client.params.sessionId !== sessionId) continue;
+      if (!this.deliverableTo(client, sessionId)) continue;
       if (client.params.filterUserId && client.params.filterUserId !== userId) continue;
 
       try {
@@ -183,7 +285,7 @@ export class VoiceStreamRegistry {
   broadcast(sessionId: string, message: Record<string, unknown>): void {
     const json = JSON.stringify(message);
     for (const [, client] of this.clients) {
-      if (client.params.sessionId !== sessionId) continue;
+      if (!this.deliverableTo(client, sessionId)) continue;
       try {
         client.send(json);
       } catch {
@@ -201,7 +303,7 @@ export class VoiceStreamRegistry {
   getClientsForSession(sessionId: string): VoiceStreamClient[] {
     const result: VoiceStreamClient[] = [];
     for (const [, client] of this.clients) {
-      if (client.params.sessionId === sessionId) result.push(client);
+      if (this.deliverableTo(client, sessionId)) result.push(client);
     }
     return result;
   }

--- a/packages/core/src/automations/__tests__/debounce.test.ts
+++ b/packages/core/src/automations/__tests__/debounce.test.ts
@@ -44,7 +44,9 @@ describe('DebounceManager', () => {
       manager.addMessage('key', message, { id: '123' }, 'wa-001');
 
       expect(callback).toHaveBeenCalledTimes(1);
-      expect(callback).toHaveBeenCalledWith('key', [message], { id: '123' }, 'wa-001');
+      // Trailing `null` = the window's envelope stamp (G5): mode-none fires
+      // straight through with the message's own (legacy) world.
+      expect(callback).toHaveBeenCalledWith('key', [message], { id: '123' }, 'wa-001', null);
     });
   });
 

--- a/packages/core/src/automations/__tests__/engine-integration.test.ts
+++ b/packages/core/src/automations/__tests__/engine-integration.test.ts
@@ -94,10 +94,13 @@ describe('Full automation flow with real WhatsApp payloads', () => {
       expect(results).toHaveLength(1);
       expect(getFixture(results, 0).status).toBe('success');
       expect(mockSendMessage).toHaveBeenCalledTimes(1);
+      // Trailing `undefined` = trustedTenantId (G5): a direct `executeActions`
+      // call with nothing threaded stays in the legacy world.
       expect(mockSendMessage).toHaveBeenCalledWith(
         instanceId,
         '5511999990001@s.whatsapp.net',
         'Thanks for your message: "Buenas como q tão as coisas aí"',
+        undefined,
       );
     });
 
@@ -263,7 +266,12 @@ describe('Full automation flow with real WhatsApp payloads', () => {
         expect(getFixture(results, 1).status).toBe('success');
 
         // Verify the agent response was passed to send_message
-        expect(mockSendMessage).toHaveBeenCalledWith(instanceId, '5511999990001@s.whatsapp.net', 'Hello from agent!');
+        expect(mockSendMessage).toHaveBeenCalledWith(
+          instanceId,
+          '5511999990001@s.whatsapp.net',
+          'Hello from agent!',
+          undefined,
+        );
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/packages/core/src/automations/__tests__/engine-tenant-threading.test.ts
+++ b/packages/core/src/automations/__tests__/engine-tenant-threading.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Automation-engine tenant threading (wish: omni-full-multitenancy, Group G5;
+ * ADR-0008).
+ *
+ * The engine consumes NATS events and executes tenant-controlled actions
+ * (send_message, call_agent, webhook, emit_event). Until this leg the trusted
+ * tenant the producer stamped on the envelope stopped at the stale-idle gate —
+ * the ACTION callbacks and the execution logger never saw it, so every DB read
+ * and egress decision they made ran tenantless even for a tenant-world event.
+ *
+ * Contract probed here:
+ *   1. a tenant-classified envelope threads its trusted tenant into
+ *      `sendMessage` / `callAgent` / the execution logger — derived from the
+ *      producer-stamped METADATA via `classifyEnvelope`, never from payload;
+ *   2. a legacy envelope threads exactly `null` and behaves as before;
+ *   3. a quarantine-class envelope (defence in depth — the subscription layer
+ *      already refuses them) executes NO actions and logs a refusal, never a
+ *      global-processing fallback;
+ *   4. the debounce path CARRIES the stamp: the synthetic flush event is
+ *      re-stamped from the window, so a debounced tenant automation does not
+ *      silently degrade to the legacy world;
+ *   5. a stamp CHANGE inside a debounce window flushes the old window first —
+ *      one flush never mixes two worlds;
+ *   6. the webhook action binds the trusted tenant into the egress broker's
+ *      context (ADR-0009), so a bound tenant policy enforces default-deny while
+ *      the legacy world stays `(unbound)` passthrough;
+ *   7. the emit_event action threads the trusted tenant into the re-publish
+ *      metadata, so the NEXT hop's envelope is stamped by the publisher seam
+ *      (`resolvePublishTenantId` explicit-tenant precedence).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { setEgressPolicyResolver } from '../../egress';
+import type { EventBus, Subscription } from '../../events/bus';
+import type { EventType, OmniEvent } from '../../events/types';
+import { AutomationEngine } from '../engine';
+import type { Automation } from '../types';
+
+const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
+const TENANT_B = '22222222-2222-4222-8222-2222222222bb';
+
+interface CapturedPublish {
+  type: string;
+  payload: Record<string, unknown>;
+  metadata: Record<string, unknown> | undefined;
+}
+
+function captureBus(): {
+  bus: EventBus;
+  handlers: Map<string, (event: OmniEvent) => Promise<void>>;
+  published: CapturedPublish[];
+} {
+  const handlers = new Map<string, (event: OmniEvent) => Promise<void>>();
+  const published: CapturedPublish[] = [];
+  const bus = {
+    publish: async () => ({ id: 'pub', timestamp: Date.now() }),
+    publishGeneric: async (type: string, payload: Record<string, unknown>, metadata?: Record<string, unknown>) => {
+      published.push({ type, payload, metadata });
+      return { id: 'pub-generic', timestamp: Date.now() };
+    },
+    subscribe: async () => ({ unsubscribe: async () => {} }) as Subscription,
+    subscribePattern: async (pattern: string, handler: (event: OmniEvent) => Promise<void>) => {
+      handlers.set(pattern, handler);
+      return { unsubscribe: async () => {} } as Subscription;
+    },
+    flush: async () => {},
+    close: async () => {},
+  } as unknown as EventBus;
+  return { bus, handlers, published };
+}
+
+function automation(overrides: Partial<Automation> & { actions: Automation['actions'] }): Automation {
+  return {
+    id: 'auto-1',
+    name: 'threading probe',
+    enabled: true,
+    priority: 0,
+    triggerEventType: 'custom.tenant-probe',
+    triggerConditions: [],
+    conditionLogic: 'and',
+    debounce: null,
+    ...overrides,
+  } as Automation;
+}
+
+function event(metadata: Record<string, unknown>, payload: Record<string, unknown> = {}): OmniEvent {
+  return {
+    id: `evt-${crypto.randomUUID()}`,
+    type: 'custom.tenant-probe' as EventType,
+    payload: {
+      instanceId: 'inst-1',
+      chatId: 'chat-ext-1',
+      from: { id: 'person-1', name: 'P' },
+      content: { type: 'text', text: 'hello' },
+      ...payload,
+    },
+    metadata: { correlationId: 'corr-1', instanceId: 'inst-1', ...metadata },
+    timestamp: Date.now(),
+  } as OmniEvent;
+}
+
+interface Harness {
+  engine: AutomationEngine;
+  handlers: Map<string, (event: OmniEvent) => Promise<void>>;
+  published: CapturedPublish[];
+  sendCalls: Array<{ instanceId: string; to: string; content: string; trustedTenantId: string | null | undefined }>;
+  agentCalls: Array<{ instanceId: string; trustedTenantId: string | null | undefined }>;
+  logged: Array<{ status: string; error?: string | null; trustedTenantId: string | null | undefined }>;
+  fire: (e: OmniEvent) => Promise<void>;
+}
+
+async function startEngine(automations: Automation[]): Promise<Harness> {
+  const { bus, handlers, published } = captureBus();
+  const sendCalls: Harness['sendCalls'] = [];
+  const agentCalls: Harness['agentCalls'] = [];
+  const logged: Harness['logged'] = [];
+
+  const engine = new AutomationEngine({ defaultConcurrency: 2, reconcileIntervalMs: 0 });
+  engine.setLogger(async (log, trustedTenantId) => {
+    logged.push({ status: log.status as string, error: log.error ?? null, trustedTenantId });
+  });
+  await engine.start(bus, automations, {
+    sendMessage: async (instanceId, to, content, trustedTenantId) => {
+      sendCalls.push({ instanceId, to, content, trustedTenantId });
+    },
+    callAgent: async (ctx, _cfg, trustedTenantId) => {
+      agentCalls.push({ instanceId: ctx.instanceId, trustedTenantId });
+      return {
+        parts: ['ok'],
+        fullResponse: 'ok',
+        metadata: { runId: 'r', sessionId: 's', status: 'completed' as const },
+      };
+    },
+  });
+
+  const fire = async (e: OmniEvent) => {
+    const handler = handlers.get('custom.tenant-probe.>');
+    if (!handler) throw new Error('engine did not subscribe to the trigger');
+    await handler(e);
+  };
+
+  return { engine, handlers, published, sendCalls, agentCalls, logged, fire };
+}
+
+const SEND_ACTION = {
+  type: 'send_message' as const,
+  config: { instanceId: '{{payload.instanceId}}', to: '{{payload.chatId}}', contentTemplate: 'reply' },
+};
+const AGENT_ACTION = {
+  type: 'call_agent' as const,
+  config: { agentId: '' },
+};
+
+afterEach(async () => {
+  setEgressPolicyResolver(null);
+});
+
+describe('automation engine threads the envelope tenant (G5, ADR-0008)', () => {
+  test('tenant envelope: sendMessage, callAgent and the logger receive the trusted tenant', async () => {
+    const h = await startEngine([automation({ actions: [SEND_ACTION, AGENT_ACTION] })]);
+    try {
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }));
+
+      expect(h.sendCalls).toEqual([
+        { instanceId: 'inst-1', to: 'chat-ext-1', content: 'reply', trustedTenantId: TENANT_A },
+      ]);
+      expect(h.agentCalls).toEqual([{ instanceId: 'inst-1', trustedTenantId: TENANT_A }]);
+      expect(h.logged).toEqual([{ status: 'success', error: null, trustedTenantId: TENANT_A }]);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('the tenant comes from METADATA, never from a payload claim', async () => {
+    const h = await startEngine([automation({ actions: [SEND_ACTION] })]);
+    try {
+      // Legacy metadata + a forged payload tenant: the payload claim must not
+      // reach the callbacks.
+      await h.fire(event({}, { tenantId: TENANT_B }));
+      expect(h.sendCalls).toEqual([
+        { instanceId: 'inst-1', to: 'chat-ext-1', content: 'reply', trustedTenantId: null },
+      ]);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('legacy envelope: callbacks and logger receive exactly null', async () => {
+    const h = await startEngine([automation({ actions: [SEND_ACTION] })]);
+    try {
+      await h.fire(event({}));
+      expect(h.sendCalls).toEqual([
+        { instanceId: 'inst-1', to: 'chat-ext-1', content: 'reply', trustedTenantId: null },
+      ]);
+      expect(h.logged).toEqual([{ status: 'success', error: null, trustedTenantId: null }]);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('quarantine envelope: NO action executes; the refusal is logged, never processed globally', async () => {
+    const h = await startEngine([automation({ actions: [SEND_ACTION, AGENT_ACTION] })]);
+    try {
+      // A tenant claim with no version contract — `malformed_envelope`.
+      await h.fire(event({ tenantId: TENANT_A }));
+
+      expect(h.sendCalls).toEqual([]);
+      expect(h.agentCalls).toEqual([]);
+      expect(h.logged.length).toBe(1);
+      expect(h.logged[0]?.status).toBe('failed');
+      expect(h.logged[0]?.error ?? '').toContain('quarantine');
+      expect(h.logged[0]?.trustedTenantId).toBe(null);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('debounce: the synthetic flush event carries the window stamp into the callbacks', async () => {
+    const h = await startEngine([
+      automation({ actions: [SEND_ACTION], debounce: { mode: 'fixed', delayMs: 5 } as Automation['debounce'] }),
+    ]);
+    try {
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }, { content: { type: 'text', text: 'm1' } }));
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }, { content: { type: 'text', text: 'm2' } }));
+      await new Promise((r) => setTimeout(r, 40));
+
+      expect(h.sendCalls.length).toBe(1); // debounced into one flush
+      expect(h.sendCalls[0]?.trustedTenantId).toBe(TENANT_A);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('debounce: a legacy window flushes with null — no stamp is invented', async () => {
+    const h = await startEngine([
+      automation({ actions: [SEND_ACTION], debounce: { mode: 'fixed', delayMs: 5 } as Automation['debounce'] }),
+    ]);
+    try {
+      await h.fire(event({}));
+      await new Promise((r) => setTimeout(r, 40));
+      expect(h.sendCalls.length).toBe(1);
+      expect(h.sendCalls[0]?.trustedTenantId).toBe(null);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('debounce: a stamp change flushes the old window first — one flush never mixes worlds', async () => {
+    const h = await startEngine([
+      automation({ actions: [SEND_ACTION], debounce: { mode: 'fixed', delayMs: 25 } as Automation['debounce'] }),
+    ]);
+    try {
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }, { content: { type: 'text', text: 'a1' } }));
+      // Same conversation key, different trusted tenant (cannot happen while an
+      // instance's tenant is immutable — defence in depth against a producer bug).
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_B }, { content: { type: 'text', text: 'b1' } }));
+      await new Promise((r) => setTimeout(r, 80));
+
+      expect(h.sendCalls.length).toBe(2);
+      expect(h.sendCalls[0]?.trustedTenantId).toBe(TENANT_A);
+      expect(h.sendCalls[1]?.trustedTenantId).toBe(TENANT_B);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('webhook action: the egress broker context binds the trusted tenant (legacy stays unbound)', async () => {
+    const seenTenants: string[] = [];
+    setEgressPolicyResolver((context) => {
+      seenTenants.push(context.tenantId);
+      return null; // observe-only: no policy bound, passthrough behavior
+    });
+    const WEBHOOK_ACTION = {
+      type: 'webhook' as const,
+      // Port 9 (discard) — connection refused locally; the action catches and
+      // records a failure. No external network is touched.
+      config: { url: 'http://127.0.0.1:9/hook', method: 'POST' as const, timeoutMs: 1000 },
+    };
+    const h = await startEngine([automation({ actions: [WEBHOOK_ACTION] })]);
+    try {
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }));
+      await h.fire(event({}));
+      expect(seenTenants).toEqual([TENANT_A, '(unbound)']);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('emit_event action: the re-publish metadata carries the trusted tenant for the next hop', async () => {
+    const EMIT_ACTION = {
+      type: 'emit_event' as const,
+      config: { eventType: 'custom.downstream' },
+    };
+    const h = await startEngine([automation({ actions: [EMIT_ACTION] })]);
+    try {
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }));
+      await h.fire(event({}));
+
+      expect(h.published.length).toBe(2);
+      expect(h.published[0]?.metadata?.tenantId).toBe(TENANT_A);
+      // Legacy re-publish threads NO tenant — the publisher seam decides, and
+      // with nothing registered the envelope stays legacy/byte-identical.
+      expect(h.published[1]?.metadata?.tenantId ?? undefined).toBeUndefined();
+    } finally {
+      await h.engine.stop();
+    }
+  });
+});

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -98,6 +98,12 @@ export interface ActionDependencies {
     chatId: string,
     instanceId: string,
     eventSequenceIndex: number | null,
+    /**
+     * Trusted tenant of the consumed envelope (G5, ADR-0008) — the engine
+     * classifies the event's producer-stamped metadata and threads the result;
+     * `null` for a legacy envelope. The gate scopes its DB reads from it.
+     */
+    trustedTenantId?: string | null,
   ) => Promise<{ skip: boolean; reason?: string }>;
 }
 

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -60,15 +60,28 @@ export interface AgentCallContext {
 
 /**
  * Dependencies needed by action executors
+ *
+ * TENANT THREADING (G5, ADR-0008): the engine classifies each consumed
+ * envelope (`classifyEnvelope`) and threads the producer-stamped trusted
+ * tenant into `sendMessage` / `callAgent` as the trailing `trustedTenantId`
+ * argument — `null` for a legacy envelope. The value is derived from envelope
+ * METADATA, never from the event payload, and the callback implementations
+ * (packages/api `automation-actions.ts`) scope their DB blocks with it. A
+ * caller that threads nothing (the route-side manual `execute`, existing
+ * tests) leaves it `undefined` and the callbacks behave exactly as before.
  */
 export interface ActionDependencies {
   eventBus: EventBus | null;
-  sendMessage?: (instanceId: string, to: string, content: string) => Promise<void>;
+  sendMessage?: (instanceId: string, to: string, content: string, trustedTenantId?: string | null) => Promise<void>;
   /**
    * Call an AI agent and return the response.
    * The response is stored in variables for use in subsequent actions.
    */
-  callAgent?: (context: AgentCallContext, config: CallAgentActionConfig) => Promise<AgentRunResult>;
+  callAgent?: (
+    context: AgentCallContext,
+    config: CallAgentActionConfig,
+    trustedTenantId?: string | null,
+  ) => Promise<AgentRunResult>;
   /**
    * Optional consumer-side stale-event gate. Invoked by the engine for
    * `chat.idle_timeout` events before matching automations execute.
@@ -135,6 +148,7 @@ async function executeWebhookAction(
   config: WebhookActionConfig,
   context: TemplateContext,
   _deps: ActionDependencies,
+  trustedTenantId?: string | null,
 ): Promise<{ success: boolean; result?: unknown; error?: string }> {
   try {
     const url = substituteTemplate(config.url, context);
@@ -151,13 +165,19 @@ async function executeWebhookAction(
     // byte-identical passthrough to the previous raw `fetch`; with a bound policy
     // it enforces the default-deny SSRF broker. The `egress` marker carries the
     // audit context; the request init is otherwise unchanged.
+    //
+    // G5 tenant threading: a consumer-side execution binds the CONSUMED
+    // envelope's trusted tenant (threaded by the engine), so the broker can
+    // resolve that tenant's policy; the request-side ambient resolver only
+    // applies when no envelope tenant exists. A legacy envelope threads null
+    // and the marker stays `(unbound)` — passthrough, byte-identical.
     const response = await brokeredFetch(url, {
       method,
       headers,
       body: method !== 'GET' ? body : undefined,
       signal: AbortSignal.timeout(config.timeoutMs ?? 30000),
       egress: {
-        tenantId: resolveAmbientTenantId() ?? '(unbound)',
+        tenantId: trustedTenantId ?? resolveAmbientTenantId() ?? '(unbound)',
         actorCredentialId: null,
         integration: 'automations.webhook',
       },
@@ -190,6 +210,7 @@ async function executeSendMessageAction(
   config: SendMessageActionConfig,
   context: TemplateContext,
   deps: ActionDependencies,
+  trustedTenantId?: string | null,
 ): Promise<{ success: boolean; result?: unknown; error?: string }> {
   try {
     if (!deps.sendMessage) {
@@ -216,7 +237,7 @@ async function executeSendMessageAction(
 
     logger.debug('Sending message', { instanceId, to, contentLength: content.length });
 
-    await deps.sendMessage(instanceId, to, content);
+    await deps.sendMessage(instanceId, to, content, trustedTenantId);
 
     return {
       success: true,
@@ -239,6 +260,7 @@ async function executeEmitEventAction(
   config: EmitEventActionConfig,
   context: TemplateContext,
   deps: ActionDependencies,
+  trustedTenantId?: string | null,
 ): Promise<{ success: boolean; result?: unknown; error?: string }> {
   try {
     if (!deps.eventBus) {
@@ -260,9 +282,16 @@ async function executeEmitEventAction(
 
     logger.debug('Emitting event', { eventType });
 
+    // G5 (ADR-0008): a tenant-world execution threads its trusted tenant into
+    // the re-publish metadata, so the publisher seam
+    // (`resolvePublishTenantId`, explicit-tenant precedence) stamps the NEXT
+    // hop's envelope — a consumer chain never silently drops back to the
+    // legacy world. With nothing threaded the metadata is unchanged and the
+    // publish stays byte-identical.
     const result = await deps.eventBus.publishGeneric(eventType, payload, {
       correlationId: (context.payload.correlationId as string) ?? undefined,
       source: 'automation',
+      ...(trustedTenantId ? { tenantId: trustedTenantId } : {}),
     });
 
     return {
@@ -403,6 +432,7 @@ async function executeCallAgentAction(
   config: CallAgentActionConfig,
   context: TemplateContext,
   deps: ActionDependencies,
+  trustedTenantId?: string | null,
 ): Promise<{ success: boolean; result?: unknown; error?: string }> {
   if (!deps.callAgent) {
     return { success: false, error: 'callAgent dependency not provided' };
@@ -424,7 +454,9 @@ async function executeCallAgentAction(
   });
 
   try {
-    const result = await deps.callAgent(agentContext, config);
+    // `agentContext` is payload-derived; the trusted tenant travels as its own
+    // argument so the trust boundary stays visible at the callback signature.
+    const result = await deps.callAgent(agentContext, config, trustedTenantId);
 
     logger.info('Agent call completed', {
       runId: result.metadata.runId,
@@ -455,6 +487,7 @@ export async function executeAction(
   action: AutomationAction,
   context: TemplateContext,
   deps: ActionDependencies,
+  trustedTenantId?: string | null,
 ): Promise<ActionExecutionResult> {
   const start = Date.now();
 
@@ -462,19 +495,19 @@ export async function executeAction(
 
   switch (action.type) {
     case 'webhook':
-      result = await executeWebhookAction(action.config, context, deps);
+      result = await executeWebhookAction(action.config, context, deps, trustedTenantId);
       break;
     case 'send_message':
-      result = await executeSendMessageAction(action.config, context, deps);
+      result = await executeSendMessageAction(action.config, context, deps, trustedTenantId);
       break;
     case 'emit_event':
-      result = await executeEmitEventAction(action.config, context, deps);
+      result = await executeEmitEventAction(action.config, context, deps, trustedTenantId);
       break;
     case 'log':
       result = await executeLogAction(action.config, context, deps);
       break;
     case 'call_agent':
-      result = await executeCallAgentAction(action.config, context, deps);
+      result = await executeCallAgentAction(action.config, context, deps, trustedTenantId);
       break;
     default:
       // TypeScript should catch this, but just in case
@@ -502,6 +535,7 @@ export async function executeActions(
   actions: AutomationAction[],
   context: TemplateContext,
   deps: ActionDependencies,
+  trustedTenantId?: string | null,
 ): Promise<ActionExecutionResult[]> {
   const results: ActionExecutionResult[] = [];
   const variables = { ...context.variables };
@@ -513,7 +547,7 @@ export async function executeActions(
       variables,
     };
 
-    const result = await executeAction(action, actionContext, deps);
+    const result = await executeAction(action, actionContext, deps, trustedTenantId);
     results.push(result);
 
     // Store response as variable if configured (for webhook and call_agent)

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -4,7 +4,9 @@
  * Actions are the "do Y" part of "when X happens, do Y".
  */
 
+import { brokeredFetch } from '../egress';
 import type { EventBus } from '../events/bus';
+import { resolveAmbientTenantId } from '../events/envelope';
 import type { CustomEventType, GenericEventPayload } from '../events/types';
 import { createLogger } from '../logger';
 import { type TemplateContext, substituteTemplate, substituteTemplateObject } from './templates';
@@ -138,11 +140,21 @@ async function executeWebhookAction(
 
     logger.debug(`Webhook ${method} ${url}`, { method, url, waitForResponse: config.waitForResponse });
 
-    const response = await fetch(url, {
+    // ADR-0009: tenant-controlled egress goes through the audited egress broker.
+    // With no tenant policy bound (flag-off / no tenant scope) this is a
+    // byte-identical passthrough to the previous raw `fetch`; with a bound policy
+    // it enforces the default-deny SSRF broker. The `egress` marker carries the
+    // audit context; the request init is otherwise unchanged.
+    const response = await brokeredFetch(url, {
       method,
       headers,
       body: method !== 'GET' ? body : undefined,
       signal: AbortSignal.timeout(config.timeoutMs ?? 30000),
+      egress: {
+        tenantId: resolveAmbientTenantId() ?? '(unbound)',
+        actorCredentialId: null,
+        integration: 'automations.webhook',
+      },
     });
 
     if (!config.waitForResponse) {

--- a/packages/core/src/automations/debounce.ts
+++ b/packages/core/src/automations/debounce.ts
@@ -25,6 +25,28 @@ export interface DebouncedMessage {
 }
 
 /**
+ * The tenant-envelope stamp a debounce window carries (wish:
+ * omni-full-multitenancy, G5; ADR-0008).
+ *
+ * The flush callback builds a SYNTHETIC event, so without carrying the
+ * producer-stamped envelope fields through the window, a debounced
+ * tenant-world automation would silently degrade to the legacy world at
+ * flush time. The stamp is taken from the CLASSIFIED envelope metadata of the
+ * events that entered the window (`classifyEnvelope` — trusted, never a
+ * payload claim); `null` means every event in the window was legacy.
+ */
+export interface DebounceEnvelopeStamp {
+  envelopeVersion: number;
+  tenantId: string;
+}
+
+/** Whether two window stamps describe the same world. */
+export function stampsEqual(a: DebounceEnvelopeStamp | null, b: DebounceEnvelopeStamp | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.tenantId === b.tenantId && a.envelopeVersion === b.envelopeVersion;
+}
+
+/**
  * Key for grouping messages: instanceId + personId
  */
 export type ConversationKey = string;
@@ -57,6 +79,8 @@ interface DebounceWindow {
     name?: string;
   };
   instanceId: string;
+  /** Envelope world of every message in this window — see DebounceEnvelopeStamp. */
+  stamp: DebounceEnvelopeStamp | null;
 }
 
 /**
@@ -67,6 +91,8 @@ export type DebounceCallback = (
   messages: DebouncedMessage[],
   from: { id: string; name?: string },
   instanceId: string,
+  /** The window's envelope stamp; `null` when the window is legacy. */
+  stamp: DebounceEnvelopeStamp | null,
 ) => void;
 
 /**
@@ -82,20 +108,38 @@ export class DebounceManager {
 
   /**
    * Add a message to the debounce queue
+   *
+   * `stamp` is the message's classified envelope world (G5). A window only
+   * ever holds ONE world: when a message arrives with a different stamp than
+   * the open window (which cannot happen while an instance's tenant is
+   * immutable — this is defence in depth against a producer bug), the open
+   * window is flushed FIRST and a fresh window starts with the new stamp, so
+   * no flush ever mixes two worlds and no message is dropped.
    */
   addMessage(
     key: ConversationKey,
     message: DebouncedMessage,
     from: { id: string; name?: string },
     instanceId: string,
+    stamp: DebounceEnvelopeStamp | null = null,
   ): void {
     // If mode is none, fire immediately
     if (this.config.mode === 'none') {
-      this.callback(key, [message], from, instanceId);
+      this.callback(key, [message], from, instanceId, stamp);
       return;
     }
 
     let window = this.windows.get(key);
+
+    if (window && !stampsEqual(window.stamp, stamp)) {
+      logger.warn('Debounce window stamp changed — flushing old window before starting a new one', {
+        key,
+        oldTenant: window.stamp?.tenantId ?? null,
+        newTenant: stamp?.tenantId ?? null,
+      });
+      this.fireWindow(key);
+      window = undefined;
+    }
 
     if (!window) {
       window = {
@@ -105,6 +149,7 @@ export class DebounceManager {
         timer: null,
         from,
         instanceId,
+        stamp,
       };
       this.windows.set(key, window);
     }
@@ -213,9 +258,9 @@ export class DebounceManager {
     this.windows.delete(key);
 
     // Callback with all messages
-    const { messages, from, instanceId } = window;
+    const { messages, from, instanceId, stamp } = window;
     logger.debug('Debounce window fired', { key, messageCount: messages.length });
-    this.callback(key, messages, from, instanceId);
+    this.callback(key, messages, from, instanceId, stamp);
   }
 
   /**

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -15,7 +15,13 @@ import { generateId } from '../ids';
 import { createLogger } from '../logger';
 import { type ActionDependencies, executeActions } from './actions';
 import { evaluateConditionsWithDetails } from './conditions';
-import { type ConversationKey, DebounceManager, type DebouncedMessage, buildConversationKey } from './debounce';
+import {
+  type ConversationKey,
+  type DebounceEnvelopeStamp,
+  DebounceManager,
+  type DebouncedMessage,
+  buildConversationKey,
+} from './debounce';
 import { type TemplateContext, createTemplateContext } from './templates';
 import type { ActionExecutionResult, Automation, AutomationLogStatus, DebounceConfig, NewAutomationLog } from './types';
 
@@ -52,8 +58,15 @@ export interface ExecutionResult {
 
 /**
  * Callback for logging execution results
+ *
+ * `trustedTenantId` is the executed event's classified envelope tenant (G5,
+ * ADR-0008) — `null` for a legacy envelope or a refused quarantine. The
+ * API-side logger currently CANNOT scope its `automation_logs` write with it:
+ * that table derives its tenant from the G2-`unowned` `automations` parent,
+ * so scoping is G6-gated — but the value is threaded now so the G6 unblock is
+ * a service-side change only.
  */
-export type ExecutionLogger = (log: NewAutomationLog) => Promise<void>;
+export type ExecutionLogger = (log: NewAutomationLog, trustedTenantId?: string | null) => Promise<void>;
 
 /**
  * Configuration for the automation engine
@@ -463,6 +476,22 @@ export class AutomationEngine {
       return;
     }
 
+    // Classify the envelope BEFORE the event enters a window (G5, ADR-0008):
+    // the flush callback builds a SYNTHETIC event, so the window must carry the
+    // producer-stamped world or a debounced tenant automation would silently
+    // degrade to legacy at flush. A quarantine-class envelope never enters a
+    // window — it goes through the immediate path, whose central refusal in
+    // `executeAutomation` logs it without running any action.
+    const classification = classifyEnvelope(event.metadata);
+    if (classification.world === 'quarantine') {
+      await this.handleImmediate(automation, event);
+      return;
+    }
+    const stamp: DebounceEnvelopeStamp | null =
+      classification.world === 'tenant'
+        ? { envelopeVersion: classification.envelopeVersion, tenantId: classification.tenantId }
+        : null;
+
     // Build debounced message
     const content = payload.content as { type: string; text?: string } | undefined;
     const message: DebouncedMessage = {
@@ -472,7 +501,7 @@ export class AutomationEngine {
       payload,
     };
 
-    manager.addMessage(key, message, from, instanceId);
+    manager.addMessage(key, message, from, instanceId, stamp);
   }
 
   /**
@@ -494,6 +523,7 @@ export class AutomationEngine {
       messages: DebouncedMessage[],
       from: { id: string; name?: string },
       instanceId: string,
+      stamp: DebounceEnvelopeStamp | null,
     ) => {
       // Get the last message (should always exist since callback only fires with messages)
       const lastMessage = messages[messages.length - 1];
@@ -515,7 +545,10 @@ export class AutomationEngine {
         },
       });
 
-      // Create a synthetic event
+      // Create a synthetic event. The window's envelope stamp (G5) is carried
+      // onto the synthetic metadata — same fields, same version the producer
+      // stamped — so `executeAutomation`'s classification sees exactly the
+      // world the original events belonged to. A legacy window stamps nothing.
       const syntheticEvent: OmniEvent = {
         id: generateId(),
         type: automation.triggerEventType as EventType,
@@ -523,6 +556,7 @@ export class AutomationEngine {
         metadata: {
           correlationId: generateId(),
           instanceId,
+          ...(stamp ? { envelopeVersion: stamp.envelopeVersion, tenantId: stamp.tenantId } : {}),
         },
         timestamp: Date.now(),
       };
@@ -602,7 +636,37 @@ export class AutomationEngine {
     const start = Date.now();
     queue.activeCount++;
 
+    // Classify the envelope ONCE for the whole execution (G5, ADR-0008). The
+    // trusted tenant is read from producer-stamped METADATA — the payload can
+    // carry any claim it likes and it never reaches this decision.
+    const classification = classifyEnvelope(event.metadata);
+    const trustedTenantId = classification.world === 'tenant' ? classification.tenantId : null;
+
     try {
+      if (classification.world === 'quarantine') {
+        // Defence in depth: the subscription layer already refuses quarantined
+        // envelopes before any handler runs. If one reaches here anyway,
+        // executing its actions "globally" is exactly the fallback ADR-0008
+        // forbids — refuse, log, alert.
+        logger.error('Refusing to execute automation for a quarantine-class envelope', {
+          automationId: automation.id,
+          eventId: event.id,
+          reason: classification.reason,
+        });
+        const result: ExecutionResult = {
+          automationId: automation.id,
+          automationName: automation.name,
+          eventId: event.id,
+          status: 'failed',
+          conditionsMatched: false,
+          actionsExecuted: [],
+          error: `refused quarantine-class envelope (${classification.reason})`,
+          executionTimeMs: Date.now() - start,
+        };
+        await this.logExecution(result, null);
+        return result;
+      }
+
       // Evaluate conditions — merge metadata so conditions can reference
       // fields like instanceId, channelType, correlationId etc.
       const conditionPayload = {
@@ -626,15 +690,16 @@ export class AutomationEngine {
           executionTimeMs: Date.now() - start,
         };
 
-        await this.logExecution(result);
+        await this.logExecution(result, trustedTenantId);
         return result;
       }
 
-      // Execute actions
+      // Execute actions, threading the envelope's trusted tenant (null = legacy).
       const actionsExecuted = await executeActions(
         automation.actions as Parameters<typeof executeActions>[0],
         context,
         this.deps,
+        trustedTenantId,
       );
 
       // Determine overall status
@@ -651,7 +716,7 @@ export class AutomationEngine {
         executionTimeMs: Date.now() - start,
       };
 
-      await this.logExecution(result);
+      await this.logExecution(result, trustedTenantId);
       return result;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -667,7 +732,7 @@ export class AutomationEngine {
         executionTimeMs: Date.now() - start,
       };
 
-      await this.logExecution(result);
+      await this.logExecution(result, trustedTenantId);
       return result;
     } finally {
       queue.activeCount--;
@@ -686,17 +751,20 @@ export class AutomationEngine {
   /**
    * Log execution result
    */
-  private async logExecution(result: ExecutionResult): Promise<void> {
+  private async logExecution(result: ExecutionResult, trustedTenantId: string | null = null): Promise<void> {
     if (this.logger) {
-      await this.logger({
-        automationId: result.automationId,
-        eventId: result.eventId,
-        status: result.status,
-        conditionsMatched: result.conditionsMatched,
-        actionsExecuted: result.actionsExecuted,
-        error: result.error,
-        executionTimeMs: result.executionTimeMs,
-      });
+      await this.logger(
+        {
+          automationId: result.automationId,
+          eventId: result.eventId,
+          status: result.status,
+          conditionsMatched: result.conditionsMatched,
+          actionsExecuted: result.actionsExecuted,
+          error: result.error,
+          executionTimeMs: result.executionTimeMs,
+        },
+        trustedTenantId,
+      );
     }
 
     logger.info('Automation executed', {

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -9,6 +9,7 @@
  */
 
 import type { EventBus, Subscription } from '../events/bus';
+import { classifyEnvelope } from '../events/envelope';
 import type { EventType, GenericEventPayload, OmniEvent } from '../events/types';
 import { generateId } from '../ids';
 import { createLogger } from '../logger';
@@ -360,7 +361,20 @@ export class AutomationEngine {
     const eventSequenceIndex = typeof payload?.sequenceIndex === 'number' ? payload.sequenceIndex : null;
 
     try {
-      const verdict = await this.deps.staleIdleTimeoutGate(chatId, payloadInstanceId, eventSequenceIndex);
+      // Thread the envelope's trusted tenant (G5): the gate's DB reads scope
+      // themselves from it. A legacy envelope threads null and the gate reads
+      // ambient exactly as before. A quarantine-class envelope never reaches
+      // here (the subscription layer terms it before any handler runs); if one
+      // does, classify refuses a tenant and the gate stays unscoped rather
+      // than trusting a malformed claim.
+      const classification = classifyEnvelope(event.metadata);
+      const trustedTenantId = classification.world === 'tenant' ? classification.tenantId : null;
+      const verdict = await this.deps.staleIdleTimeoutGate(
+        chatId,
+        payloadInstanceId,
+        eventSequenceIndex,
+        trustedTenantId,
+      );
       if (verdict.skip) {
         logger.info('Skipping stale chat.idle_timeout event', {
           eventId: event.id,

--- a/packages/core/src/automations/follow-up/lifecycle.ts
+++ b/packages/core/src/automations/follow-up/lifecycle.ts
@@ -99,6 +99,13 @@ export interface ArmSequenceInput {
   config: FollowUpSequenceConfig;
   /** Wall-clock timestamp of the outbound agent message. */
   lastAgentMessageAt: Date;
+  /**
+   * Trusted tenant of the chat's instance (G5, ADR-0008) — derived by the
+   * caller from the consumed envelope or the loaded resource's persisted
+   * ownership, never from a payload claim. When set, the `follow_up.armed`
+   * publish stamps a versioned tenant envelope; unset keeps it legacy.
+   */
+  tenantId?: string | null;
 }
 
 export interface ArmResult {
@@ -142,6 +149,7 @@ export async function armSequence(deps: LifecycleDeps, input: ArmSequenceInput):
     await deps.eventBus.publish('follow_up.armed', payload, {
       instanceId: input.instanceId,
       ...(input.agentId ? { agentId: input.agentId } : {}),
+      ...(input.tenantId ? { tenantId: input.tenantId } : {}),
     });
   } catch (err) {
     deps.logger.warn('follow-up lifecycle: failed to emit follow_up.armed', {
@@ -161,6 +169,12 @@ export interface DisarmSequenceInput {
   reason: FollowUpDisarmReason;
   /** Only meaningful for `reason === 'customer_replied'`. */
   lastInboundCustomerMessageAt?: Date;
+  /**
+   * Trusted tenant (G5, ADR-0008) — same contract as
+   * {@link ArmSequenceInput.tenantId}: producer-derived, stamps the
+   * `follow_up.disarmed` envelope when set, legacy when unset.
+   */
+  tenantId?: string | null;
 }
 
 export interface DisarmResult {
@@ -201,6 +215,7 @@ export async function disarmSequence(deps: LifecycleDeps, input: DisarmSequenceI
     await deps.eventBus.publish('follow_up.disarmed', payload, {
       instanceId: input.instanceId,
       ...(input.agentId ? { agentId: input.agentId } : {}),
+      ...(input.tenantId ? { tenantId: input.tenantId } : {}),
     });
   } catch (err) {
     deps.logger.warn('follow-up lifecycle: failed to emit follow_up.disarmed', {

--- a/packages/core/src/automations/follow-up/sweeper.ts
+++ b/packages/core/src/automations/follow-up/sweeper.ts
@@ -50,6 +50,14 @@ export interface FollowUpStateRow {
   channelType?: ChannelType | null;
   /** Timestamp of the most recent inbound customer message — consumed by the 24h BSP window guard. */
   lastInboundCustomerMessageAt?: Date | null;
+  /**
+   * Trusted tenant of the row (G5, ADR-0008) — the row's PERSISTED ownership,
+   * read by the repo's claim query, never a caller/payload assertion. When set,
+   * every event this row fires carries it as explicit envelope metadata so
+   * downstream consumers classify `tenant` and establish the worker context.
+   * Legacy rows leave it unset and their envelopes stay byte-identical.
+   */
+  tenantId?: string | null;
 }
 
 /**
@@ -156,6 +164,20 @@ export function renderSyntheticPrompt(
 }
 
 /**
+ * Envelope metadata for a row's fired events. Spreads the row's trusted tenant
+ * (persisted ownership, claimed by the repo — G5, ADR-0008) when present so the
+ * publish stamps a versioned tenant envelope; a legacy row spreads nothing and
+ * its envelope is byte-identical to pre-G5.
+ */
+function rowEventMetadata(row: FollowUpStateRow): Record<string, string> {
+  return {
+    instanceId: row.instanceId,
+    ...(row.agentId ? { agentId: row.agentId } : {}),
+    ...(row.tenantId ? { tenantId: row.tenantId } : {}),
+  };
+}
+
+/**
  * Run one sweep tick. Safe to call concurrently thanks to the repo's locking
  * contract (see `findAndLockDue`).
  */
@@ -233,10 +255,7 @@ async function processRow(row: FollowUpStateRow, now: Date, deps: SweeperDeps, s
     ...(row.chatName ? { chatName: row.chatName } : {}),
   };
 
-  await deps.eventBus.publish('chat.idle_timeout', idlePayload, {
-    instanceId: row.instanceId,
-    ...(row.agentId ? { agentId: row.agentId } : {}),
-  });
+  await deps.eventBus.publish('chat.idle_timeout', idlePayload, rowEventMetadata(row));
 
   const firedPayload: FollowUpFiredPayload = {
     chatId: row.chatId,
@@ -246,10 +265,7 @@ async function processRow(row: FollowUpStateRow, now: Date, deps: SweeperDeps, s
     firedAt: now.getTime(),
     syntheticPrompt,
   };
-  await deps.eventBus.publish('follow_up.fired', firedPayload, {
-    instanceId: row.instanceId,
-    ...(row.agentId ? { agentId: row.agentId } : {}),
-  });
+  await deps.eventBus.publish('follow_up.fired', firedPayload, rowEventMetadata(row));
 
   // Advance the sequence — compute next fire or complete.
   const nextFireAtMs = computeNextFireAt(row.sequenceConfig, row.sequenceIndex, now.getTime());
@@ -288,10 +304,7 @@ async function processRow(row: FollowUpStateRow, now: Date, deps: SweeperDeps, s
     sequenceIndex: nextIndex,
     nextFireAt: nextFireAtMs,
   };
-  await deps.eventBus.publish('follow_up.armed', armedPayload, {
-    instanceId: row.instanceId,
-    ...(row.agentId ? { agentId: row.agentId } : {}),
-  });
+  await deps.eventBus.publish('follow_up.armed', armedPayload, rowEventMetadata(row));
 
   stats.fired += 1;
 }
@@ -319,10 +332,7 @@ async function emitDisarmed(
     sequenceIndex,
     reason,
   };
-  await deps.eventBus.publish('follow_up.disarmed', payload, {
-    instanceId: row.instanceId,
-    ...(row.agentId ? { agentId: row.agentId } : {}),
-  });
+  await deps.eventBus.publish('follow_up.disarmed', payload, rowEventMetadata(row));
 }
 
 async function emitSkipped(deps: SweeperDeps, row: FollowUpStateRow, reason: string): Promise<void> {
@@ -334,10 +344,7 @@ async function emitSkipped(deps: SweeperDeps, row: FollowUpStateRow, reason: str
     reason,
   };
   try {
-    await deps.eventBus.publish('follow_up.skipped', payload, {
-      instanceId: row.instanceId,
-      ...(row.agentId ? { agentId: row.agentId } : {}),
-    });
+    await deps.eventBus.publish('follow_up.skipped', payload, rowEventMetadata(row));
   } catch (err) {
     deps.logger.error('follow-up sweeper: failed to emit follow_up.skipped', {
       id: row.id,

--- a/packages/core/src/egress/__tests__/broker.test.ts
+++ b/packages/core/src/egress/__tests__/broker.test.ts
@@ -1,0 +1,323 @@
+/**
+ * TenantEgressBroker behaviour (wish: omni-full-multitenancy, Group G5;
+ * ADR-0009).
+ *
+ * The policy suite proves the DECISION for every rejection class; this suite
+ * proves the broker never even CONNECTS to a rejected destination (against a
+ * real loopback listener that counts connections), and that the fetch mechanics
+ * — per-redirect revalidation, DNS-rebinding denial, credential stripping,
+ * bounded redirects/body, audited decisions without secrets, and the dual-world
+ * passthrough — behave as specified. Reject tests use real local listeners;
+ * accept/mechanics tests inject the transport so no approved public host is
+ * needed (an approved host can never be loopback — that is the point).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createServer } from 'node:net';
+import {
+  type AddressLookup,
+  type EgressAuditRecord,
+  EgressBlockedError,
+  type EgressContext,
+  EgressLimitError,
+  type EgressTransport,
+  TenantEgressBroker,
+  brokeredFetch,
+  setEgressPolicyResolver,
+} from '../broker';
+import type { EgressPolicy } from '../policy';
+
+const CONTEXT: EgressContext = { tenantId: 't-1', actorCredentialId: 'cred-9', integration: 'test.integration' };
+
+/** A resolver that maps every host to `address` — the rebinding test lever. */
+function resolverTo(address: string): AddressLookup {
+  return async () => [{ address }];
+}
+
+/** A transport that records calls and returns a caller-supplied Response. */
+function stubTransport(handler: (url: string, init: RequestInit) => Response): {
+  transport: EgressTransport;
+  calls: Array<{ url: string; init: RequestInit }>;
+} {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const transport: EgressTransport = async (url, init) => {
+    calls.push({ url, init });
+    return handler(url, init);
+  };
+  return { transport, calls };
+}
+
+afterEach(() => setEgressPolicyResolver(null));
+
+describe('broker — never connects to a rejected destination (real listener)', () => {
+  test('a loopback destination is blocked and the listener receives ZERO connections', async () => {
+    let connections = 0;
+    const server = createServer((socket) => {
+      connections += 1;
+      socket.destroy();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    // Approve the literal host so ONLY the reserved-range denial can refuse it.
+    const policy: EgressPolicy = { policyVersion: 1, approvedHostSuffixes: ['127.0.0.1'], approvedPorts: [port] };
+    const records: EgressAuditRecord[] = [];
+    const broker = new TenantEgressBroker({ audit: (r) => records.push(r) });
+
+    await expect(broker.send({ url: `https://127.0.0.1:${port}/` }, policy, CONTEXT)).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+
+    // Give any (erroneous) connection a tick to land, then assert none did.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(connections).toBe(0);
+    expect(records.at(-1)?.destinationClass).toBe('loopback');
+    expect(records.at(-1)?.outcome).toBe('blocked');
+    server.close();
+  });
+});
+
+describe('broker — DNS rebinding and per-hop revalidation', () => {
+  const policy: EgressPolicy = { policyVersion: 5, approvedHostSuffixes: ['approved.example'] };
+
+  test('an approved host that RESOLVES to a private address is blocked before connect', async () => {
+    const { transport, calls } = stubTransport(() => new Response('should not happen'));
+    const broker = new TenantEgressBroker({ resolveAddresses: resolverTo('10.0.0.5'), transport });
+    await expect(broker.send({ url: 'https://approved.example/' }, policy, CONTEXT)).rejects.toMatchObject({
+      destinationClass: 'private-rfc1918',
+    });
+    expect(calls.length).toBe(0); // never reached the transport
+  });
+
+  test('a numeric-leading HOSTNAME (not an IP literal) is still DNS-revalidated', async () => {
+    // `123.example.com` starts with digits but is a name; it must be resolved
+    // and its addresses classified, so a rebind to a private address is caught.
+    const numericPolicy: EgressPolicy = { policyVersion: 1, approvedHostSuffixes: ['example.com'] };
+    const { transport, calls } = stubTransport(() => new Response('should not happen'));
+    const broker = new TenantEgressBroker({ resolveAddresses: resolverTo('10.9.8.7'), transport });
+    await expect(broker.send({ url: 'https://123.example.com/' }, numericPolicy, CONTEXT)).rejects.toMatchObject({
+      destinationClass: 'private-rfc1918',
+    });
+    expect(calls.length).toBe(0);
+  });
+
+  test('a redirect to a loopback host is revalidated and blocked mid-chain', async () => {
+    const { transport, calls } = stubTransport((url) => {
+      if (url.startsWith('https://approved.example')) {
+        return new Response(null, { status: 302, headers: { location: 'https://127.0.0.1/' } });
+      }
+      return new Response('reached internal');
+    });
+    const broker = new TenantEgressBroker({ resolveAddresses: resolverTo('93.184.216.34'), transport });
+    await expect(broker.send({ url: 'https://approved.example/' }, policy, CONTEXT)).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+    // The first hop was sent; the redirect target was refused before a second.
+    expect(calls.map((c) => c.url)).toEqual(['https://approved.example/']);
+  });
+
+  test('a public resolution is allowed and reaches the transport once', async () => {
+    const { transport, calls } = stubTransport(() => new Response('ok', { status: 200 }));
+    const records: EgressAuditRecord[] = [];
+    const broker = new TenantEgressBroker({
+      resolveAddresses: resolverTo('93.184.216.34'),
+      transport,
+      audit: (r) => records.push(r),
+    });
+    const res = await broker.send({ url: 'https://approved.example/hook' }, policy, CONTEXT);
+    expect(res.status).toBe(200);
+    expect(calls.length).toBe(1);
+    expect(records.at(-1)).toMatchObject({ outcome: 'allowed', destinationClass: 'approved-public', policyVersion: 5 });
+  });
+});
+
+describe('broker — credential handling and bounds', () => {
+  const policy: EgressPolicy = { policyVersion: 1, approvedHostSuffixes: ['approved.example', 'other.example'] };
+
+  test('authorization is dropped on a cross-origin redirect', async () => {
+    const seen: Array<string | null> = [];
+    const { transport } = stubTransport((url, init) => {
+      seen.push(new Headers(init.headers).get('authorization'));
+      if (url.startsWith('https://approved.example')) {
+        return new Response(null, { status: 302, headers: { location: 'https://other.example/' } });
+      }
+      return new Response('ok');
+    });
+    const broker = new TenantEgressBroker({ resolveAddresses: resolverTo('93.184.216.34'), transport });
+    await broker.send(
+      { url: 'https://approved.example/', headers: { authorization: 'Bearer secret-token' } },
+      policy,
+      CONTEXT,
+    );
+    expect(seen[0]).toBe('Bearer secret-token'); // sent to the original host
+    expect(seen[1]).toBeNull(); // stripped for the cross-origin hop
+  });
+
+  test('all credential headers are dropped on a cross-origin redirect but kept same-origin', async () => {
+    const seen: Array<{ authorization: string | null; cookie: string | null; proxyAuth: string | null }> = [];
+    const { transport } = stubTransport((url, init) => {
+      const h = new Headers(init.headers);
+      seen.push({
+        authorization: h.get('authorization'),
+        cookie: h.get('cookie'),
+        proxyAuth: h.get('proxy-authorization'),
+      });
+      // First a same-origin hop (path change), then a cross-origin hop.
+      if (url === 'https://approved.example/') {
+        return new Response(null, { status: 302, headers: { location: 'https://approved.example/step2' } });
+      }
+      if (url === 'https://approved.example/step2') {
+        return new Response(null, { status: 302, headers: { location: 'https://other.example/' } });
+      }
+      return new Response('ok');
+    });
+    const broker = new TenantEgressBroker({ resolveAddresses: resolverTo('93.184.216.34'), transport });
+    await broker.send(
+      {
+        url: 'https://approved.example/',
+        headers: {
+          authorization: 'Bearer secret-token',
+          cookie: 'session=abc',
+          'proxy-authorization': 'Basic proxy-secret',
+        },
+      },
+      policy,
+      CONTEXT,
+    );
+    // Hop 0 (original) and hop 1 (same-origin) keep every credential header.
+    expect(seen[0]).toEqual({
+      authorization: 'Bearer secret-token',
+      cookie: 'session=abc',
+      proxyAuth: 'Basic proxy-secret',
+    });
+    expect(seen[1]).toEqual({
+      authorization: 'Bearer secret-token',
+      cookie: 'session=abc',
+      proxyAuth: 'Basic proxy-secret',
+    });
+    // Hop 2 is cross-origin: authorization, cookie, and proxy-authorization all dropped.
+    expect(seen[2]).toEqual({ authorization: null, cookie: null, proxyAuth: null });
+  });
+
+  test('too many redirects raises a limit error', async () => {
+    const { transport } = stubTransport(
+      (_url) => new Response(null, { status: 302, headers: { location: 'https://approved.example/next' } }),
+    );
+    const broker = new TenantEgressBroker({
+      resolveAddresses: resolverTo('93.184.216.34'),
+      transport,
+      limits: { maxRedirects: 2 },
+    });
+    await expect(broker.send({ url: 'https://approved.example/' }, policy, CONTEXT)).rejects.toBeInstanceOf(
+      EgressLimitError,
+    );
+  });
+
+  test('a response whose declared length exceeds the cap is refused', async () => {
+    const { transport } = stubTransport(
+      () => new Response('x', { status: 200, headers: { 'content-length': String(50 * 1024 * 1024) } }),
+    );
+    const broker = new TenantEgressBroker({ resolveAddresses: resolverTo('93.184.216.34'), transport });
+    await expect(broker.send({ url: 'https://approved.example/' }, policy, CONTEXT)).rejects.toBeInstanceOf(
+      EgressLimitError,
+    );
+  });
+
+  test('readBounded refuses a stream that exceeds the cap', async () => {
+    const big = new Uint8Array(1024);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 100; i++) controller.enqueue(big);
+        controller.close();
+      },
+    });
+    const broker = new TenantEgressBroker({ limits: { maxResponseBytes: 4096 } });
+    await expect(broker.readBounded(new Response(body))).rejects.toBeInstanceOf(EgressLimitError);
+  });
+});
+
+describe('broker — audit record carries no secrets', () => {
+  test('the record has the tenant/actor/integration/class/outcome and only a bare host', async () => {
+    const { transport } = stubTransport(() => new Response('ok', { status: 200 }));
+    const records: EgressAuditRecord[] = [];
+    const broker = new TenantEgressBroker({
+      resolveAddresses: resolverTo('93.184.216.34'),
+      transport,
+      audit: (r) => records.push(r),
+    });
+    const policy: EgressPolicy = { policyVersion: 3, approvedHostSuffixes: ['approved.example'] };
+    await broker.send(
+      { url: 'https://approved.example/path/to/hook?token=SUPER_SECRET', headers: { authorization: 'Bearer SECRET' } },
+      policy,
+      CONTEXT,
+    );
+    const rec = records.at(-1) as EgressAuditRecord;
+    expect(rec.tenantId).toBe('t-1');
+    expect(rec.actorCredentialId).toBe('cred-9');
+    expect(rec.integration).toBe('test.integration');
+    expect(rec.host).toBe('approved.example');
+    // No field of the record carries the query token, path, or the auth header.
+    const serialized = JSON.stringify(rec);
+    expect(serialized).not.toContain('SUPER_SECRET');
+    expect(serialized).not.toContain('SECRET');
+    expect(serialized).not.toContain('/path/to/hook');
+  });
+});
+
+describe('brokeredFetch — dual world', () => {
+  test('with no policy resolver registered it is a byte-identical passthrough', async () => {
+    // No resolver → passthrough → uses the global fetch verbatim. Mock global
+    // fetch to observe the exact forwarded init and prove no broker mangling.
+    const originalFetch = globalThis.fetch;
+    const seen: Array<{ input: unknown; init: RequestInit | undefined }> = [];
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      seen.push({ input, init });
+      return new Response('legacy', { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await brokeredFetch('https://anything.internal/x', {
+        method: 'POST',
+        headers: { authorization: 'Bearer legacy' },
+        egress: CONTEXT,
+      });
+      expect(await res.text()).toBe('legacy');
+      expect(seen.length).toBe(1);
+      expect(seen[0]?.input).toBe('https://anything.internal/x');
+      // The `egress` marker is stripped; everything else is forwarded verbatim.
+      expect(seen[0]?.init?.method).toBe('POST');
+      expect(new Headers(seen[0]?.init?.headers).get('authorization')).toBe('Bearer legacy');
+      expect('egress' in (seen[0]?.init ?? {})).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('with a resolver binding a default-deny policy, a disallowed host is blocked', async () => {
+    setEgressPolicyResolver(() => ({ policyVersion: 2, approvedHostSuffixes: ['only-this.example'] }));
+    const originalFetch = globalThis.fetch;
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('should not happen');
+    }) as unknown as typeof fetch;
+    try {
+      await expect(brokeredFetch('https://evil.example/', { egress: CONTEXT })).rejects.toBeInstanceOf(
+        EgressBlockedError,
+      );
+      // Default-deny miss is decided before any transport call.
+      expect(called).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('a resolver that throws fails CLOSED (denies), never passes through', async () => {
+    setEgressPolicyResolver(() => {
+      throw new Error('policy store unavailable');
+    });
+    await expect(brokeredFetch('https://anything.example/', { egress: CONTEXT })).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+  });
+});

--- a/packages/core/src/egress/__tests__/egress-access-guard.test.ts
+++ b/packages/core/src/egress/__tests__/egress-access-guard.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Egress architecture guard test (wish: omni-full-multitenancy, Group G5;
+ * ADR-0009).
+ *
+ * The sibling of the db-access guard test. Fails closed: a global `fetch`/socket
+ * call site in a scanned root that the registry does not list is a test failure.
+ * The seeded-site tests at the bottom are the ones that matter most — they prove
+ * the guard actually catches a NEW raw tenant `fetch` (and a new socket) rather
+ * than merely agreeing with a registry generated from the same scan.
+ */
+
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  PENDING_EGRESS_CEILING,
+  REGISTERED_EGRESS,
+  evaluateEgressGuard,
+  scanEgressSites,
+} from '../egress-access-guard';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..', '..', '..', '..', '..');
+
+const found = scanEgressSites(repoRoot);
+const report = evaluateEgressGuard(found);
+
+// Seed rogue files under a real scanned root so the scanner actually walks them.
+const scratchDir = join(repoRoot, 'packages', 'core', 'src', '__g5_egress_scratch__');
+afterAll(() => rmSync(scratchDir, { recursive: true, force: true }));
+
+describe('egress-access guard', () => {
+  test('the scan finds egress sites at all (guards against a broken scanner)', () => {
+    expect(found.length).toBeGreaterThan(15);
+    expect(REGISTERED_EGRESS.length).toBe(found.length);
+  });
+
+  test('every discovered egress site is registered', () => {
+    expect(report.unregistered).toEqual([]);
+  });
+
+  test('no registry entry is stale', () => {
+    expect(report.stale).toEqual([]);
+  });
+
+  test('no registered file has a drifted site count (a new fetch in a known file fails)', () => {
+    expect(report.countDrift).toEqual([]);
+  });
+
+  test('every registered egress site carries a justification', () => {
+    expect(report.unjustified).toEqual([]);
+    for (const entry of REGISTERED_EGRESS) expect((entry.justification ?? '').length).toBeGreaterThan(40);
+  });
+
+  test('every entry falls into an authorised class', () => {
+    const allowed = new Set(['platform-vendor', 'media-guard', 'infra', 'pending-egress-broker']);
+    for (const entry of REGISTERED_EGRESS) expect(allowed.has(entry.class)).toBe(true);
+  });
+
+  test('every pending-egress-broker entry names ADR-0009 and the tenant-controlled source', () => {
+    const pending = REGISTERED_EGRESS.filter((e) => e.class === 'pending-egress-broker');
+    expect(pending.length).toBeGreaterThan(0);
+    for (const entry of pending) {
+      expect(entry.justification).toContain('ADR-0009');
+      expect(entry.justification).toMatch(
+        /tenant-controlled|tenant-configured|per-instance|baseUrl|config\.|callback/i,
+      );
+    }
+  });
+
+  test('the pending-egress-broker class is at or below its ceiling — it may shrink, never grow', () => {
+    expect(report.counts['pending-egress-broker']).toBeLessThanOrEqual(PENDING_EGRESS_CEILING);
+  });
+
+  test('the converted reference site (automations/actions.ts) is absent from the scan', () => {
+    // A brokered file has no raw `fetch` — conversion is proven by absence.
+    expect(found.some((s) => s.file.endsWith('automations/actions.ts'))).toBe(false);
+    expect(REGISTERED_EGRESS.some((e) => e.file.endsWith('automations/actions.ts'))).toBe(false);
+  });
+
+  test('a new unregistered raw tenant fetch fails the guard', () => {
+    mkdirSync(scratchDir, { recursive: true });
+    const seeded = join(scratchDir, 'rogue-egress.ts');
+    writeFileSync(
+      seeded,
+      [
+        'export async function leak(tenantUrl: string) {',
+        '  return fetch(tenantUrl, { method: "POST" });',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const files = evaluateEgressGuard(scanEgressSites(repoRoot)).unregistered.map((s) => s.file);
+    expect(files).toContain('packages/core/src/__g5_egress_scratch__/rogue-egress.ts');
+
+    rmSync(scratchDir, { recursive: true, force: true });
+    // And the guard goes quiet again once the site is gone.
+    expect(evaluateEgressGuard(scanEgressSites(repoRoot)).unregistered).toEqual([]);
+  });
+
+  test('a new raw socket/WebSocket site is also caught, not just fetch', () => {
+    mkdirSync(scratchDir, { recursive: true });
+    writeFileSync(
+      join(scratchDir, 'rogue-socket.ts'),
+      ['export function open(url: string) {', '  return new WebSocket(url);', '}', ''].join('\n'),
+    );
+    const files = evaluateEgressGuard(scanEgressSites(repoRoot)).unregistered.map((s) => s.file);
+    expect(files).toContain('packages/core/src/__g5_egress_scratch__/rogue-socket.ts');
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  test('the scanner reads code not prose, and ignores method .fetch() calls', () => {
+    mkdirSync(scratchDir, { recursive: true });
+    writeFileSync(
+      join(scratchDir, 'not-egress.ts'),
+      [
+        '// This comment says fetch( the user from the cache.',
+        '/* another fetch( in a block comment */',
+        'export async function ok(client: any, app: any, id: string, req: Request) {',
+        '  await client.channels.fetch(id);', // method call — not global egress
+        '  await client.messages.fetch(id);', // method call — not global egress
+        '  return app.fetch(req);', // method call — not global egress
+        '}',
+        '',
+      ].join('\n'),
+    );
+    const sites = scanEgressSites(repoRoot).filter((s) => s.file.endsWith('not-egress.ts'));
+    rmSync(scratchDir, { recursive: true, force: true });
+    // Neither the comments nor the `.fetch(` method calls are egress sites.
+    expect(sites).toEqual([]);
+  });
+
+  test('the broker source itself is skipped (it is the definition, not a site)', () => {
+    expect(found.some((s) => s.file === 'packages/core/src/egress/broker.ts')).toBe(false);
+    expect(REGISTERED_EGRESS.some((e) => e.file === 'packages/core/src/egress/broker.ts')).toBe(false);
+  });
+});

--- a/packages/core/src/egress/__tests__/policy.test.ts
+++ b/packages/core/src/egress/__tests__/policy.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The egress destination-policy rejection matrix (wish: omni-full-multitenancy,
+ * Group G5; ADR-0009).
+ *
+ * One assertion per rejection CLASS the ADR names, plus the accept case. These
+ * are pure and need no network — they prove the decision, not the connection.
+ * The broker suite proves the connection is never even attempted for a rejected
+ * class (against real local listeners).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { type EgressPolicy, canonicalizeIpv4, classifyResolvedAddress, classifyUrl, isAllowedClass } from '../policy';
+
+/** A policy that approves `example.com` over https:443 — the happy destination. */
+const policy: EgressPolicy = {
+  policyVersion: 7,
+  approvedHostSuffixes: ['example.com', '93.184.216.34'],
+};
+
+function classify(url: string, p: EgressPolicy = policy) {
+  return classifyUrl(new URL(url), p);
+}
+
+describe('egress policy — accepts exactly the approved public destination', () => {
+  test('an approved https host on the default port is allowed (pending DNS)', () => {
+    const d = classify('https://api.example.com/webhook');
+    expect(d.allowed).toBe(true);
+    expect(d.destinationClass).toBe('approved-public');
+    expect(isAllowedClass(d.destinationClass)).toBe(true);
+    expect(d.policyVersion).toBe(7);
+  });
+
+  test('the decision carries the policy version for audit correlation', () => {
+    expect(classify('https://example.com').policyVersion).toBe(7);
+  });
+});
+
+describe('egress policy — default-deny', () => {
+  test('a public host NOT on the allowlist is refused', () => {
+    const d = classify('https://not-approved.org/');
+    expect(d.allowed).toBe(false);
+    expect(d.destinationClass).toBe('not-approved');
+  });
+
+  test('a lookalike suffix does not match on a non-label boundary', () => {
+    // evil-example.com must NOT match the suffix example.com.
+    expect(classify('https://evilexample.com/').allowed).toBe(false);
+    expect(classify('https://notexample.com/').destinationClass).toBe('not-approved');
+  });
+
+  test('an empty allowlist approves nothing', () => {
+    const empty: EgressPolicy = { policyVersion: 1, approvedHostSuffixes: [] };
+    expect(classify('https://example.com/', empty).allowed).toBe(false);
+  });
+});
+
+describe('egress policy — scheme, port, and userinfo', () => {
+  test('a non-http(s) scheme is refused even for an approved host', () => {
+    expect(classify('file:///etc/passwd').destinationClass).toBe('unapproved-scheme');
+    expect(classify('gopher://example.com/').destinationClass).toBe('unapproved-scheme');
+    expect(classify('unix:/var/run/docker.sock').destinationClass).toBe('unapproved-scheme');
+  });
+
+  test('http is refused when only https is approved (default)', () => {
+    expect(classify('http://example.com/').destinationClass).toBe('unapproved-scheme');
+  });
+
+  test('a non-approved port is refused', () => {
+    expect(classify('https://example.com:8443/').destinationClass).toBe('unapproved-port');
+  });
+
+  test('a credential-bearing URL (userinfo confusion) is refused', () => {
+    expect(classify('https://user:pass@example.com/').destinationClass).toBe('credentialed-url');
+    expect(classify('https://attacker@example.com/').destinationClass).toBe('credentialed-url');
+  });
+});
+
+describe('egress policy — literal reserved ranges (each class)', () => {
+  const approveAny: EgressPolicy = {
+    policyVersion: 1,
+    // Approve everything by suffix so the ONLY thing that can refuse is the
+    // absolute reserved-range denial — proving the denial is not overridable.
+    approvedHostSuffixes: [
+      '.',
+      'com',
+      'org',
+      'net',
+      'internal',
+      'local',
+      '0',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+    ],
+    approvedPorts: [80, 443],
+    approvedSchemes: ['http:', 'https:'],
+  };
+  const c = (url: string) => classify(url, approveAny).destinationClass;
+
+  test('loopback IPv4 and IPv6', () => {
+    expect(c('https://127.0.0.1/')).toBe('loopback');
+    expect(c('https://[::1]/')).toBe('loopback');
+  });
+  test('unspecified', () => {
+    expect(c('https://0.0.0.0/')).toBe('unspecified');
+    expect(c('https://[::]/')).toBe('unspecified');
+  });
+  test('RFC1918 private', () => {
+    expect(c('https://10.0.0.5/')).toBe('private-rfc1918');
+    expect(c('https://172.16.4.4/')).toBe('private-rfc1918');
+    expect(c('https://192.168.1.1/')).toBe('private-rfc1918');
+  });
+  test('CGNAT (RFC 6598)', () => {
+    expect(c('https://100.64.0.1/')).toBe('cgnat');
+  });
+  test('link-local and cloud metadata', () => {
+    expect(c('https://169.254.0.1/')).toBe('link-local');
+    expect(c('https://169.254.169.254/')).toBe('link-local'); // AWS/GCP metadata
+    expect(c('https://[fe80::1]/')).toBe('link-local');
+  });
+  test('IPv6 ULA', () => {
+    expect(c('https://[fc00::1]/')).toBe('ipv6-ula');
+    expect(c('https://[fd12:3456::1]/')).toBe('ipv6-ula');
+  });
+  test('multicast', () => {
+    expect(c('https://224.0.0.1/')).toBe('multicast');
+    expect(c('https://[ff02::1]/')).toBe('multicast');
+  });
+  test('IPv4-mapped IPv6 re-projects onto the IPv4 policy', () => {
+    expect(c('https://[::ffff:127.0.0.1]/')).toBe('loopback');
+    expect(c('https://[::ffff:10.0.0.1]/')).toBe('private-rfc1918');
+    expect(c('https://[::ffff:169.254.169.254]/')).toBe('link-local');
+  });
+  test('6to4 (2002::/16) literal embedding an internal IPv4 is rejected', () => {
+    expect(c('https://[2002:7f00:1::]/')).toBe('loopback'); // 127.0.0.1
+    expect(c('https://[2002:a9fe:a9fe::]/')).toBe('link-local'); // 169.254.169.254 metadata
+  });
+  test('6to4 relay anycast 192.88.99.0/24 is reserved', () => {
+    expect(c('https://192.88.99.1/')).toBe('reserved');
+  });
+});
+
+describe('egress policy — IPv6 transition encodings cannot smuggle an internal IPv4', () => {
+  test('6to4 (2002::/16) re-projects the embedded IPv4', () => {
+    expect(classifyResolvedAddress('2002:7f00:1::')).toBe('loopback'); // 127.0.0.1
+    expect(classifyResolvedAddress('2002:a00:1::')).toBe('private-rfc1918'); // 10.0.0.1
+    expect(classifyResolvedAddress('2002:a9fe:a9fe::')).toBe('link-local'); // 169.254.169.254 metadata
+    expect(classifyResolvedAddress('2002:808:808::')).toBeNull(); // 8.8.8.8 stays public
+  });
+  test('NAT64 (64:ff9b::/96) re-projects the embedded IPv4', () => {
+    expect(classifyResolvedAddress('64:ff9b::7f00:1')).toBe('loopback'); // 127.0.0.1
+    expect(classifyResolvedAddress('64:ff9b::a9fe:a9fe')).toBe('link-local'); // 169.254.169.254 metadata
+    expect(classifyResolvedAddress('64:ff9b::a00:1')).toBe('private-rfc1918'); // 10.0.0.1
+  });
+  test('Teredo (2001:0::/32) re-projects the server and obfuscated client IPv4', () => {
+    // Internal IPv4 in the plain server field (hextets 2-3).
+    expect(classifyResolvedAddress('2001:0:7f00:1::')).toBe('loopback'); // server 127.0.0.1
+    // Internal IPv4 in the obfuscated client field (last two hextets, XOR 0xffff),
+    // with a realistic public server field (65.54.227.120 = 4136:e378).
+    expect(classifyResolvedAddress('2001:0:4136:e378::80ff:fffe')).toBe('loopback'); // client 127.0.0.1
+    expect(classifyResolvedAddress('2001:0:4136:e378::5601:5601')).toBe('link-local'); // client 169.254.169.254
+  });
+});
+
+describe('egress policy — alternate IPv4 encodings cannot smuggle a reserved address', () => {
+  const approveAny: EgressPolicy = {
+    policyVersion: 1,
+    approvedHostSuffixes: Array.from({ length: 10 }, (_, i) => String(i)),
+    approvedPorts: [443],
+  };
+  const c = (url: string) => classify(url, approveAny).destinationClass;
+
+  test('decimal integer form of 127.0.0.1', () => {
+    expect(canonicalizeIpv4('2130706433')).toEqual({ ipv4: '127.0.0.1' });
+    expect(c('https://2130706433/')).toBe('loopback');
+  });
+  test('hex form of 127.0.0.1', () => {
+    expect(c('https://0x7f000001/')).toBe('loopback');
+  });
+  test('octal dotted form of 127.0.0.1', () => {
+    expect(c('https://0177.0.0.1/')).toBe('loopback');
+  });
+  test('short form 127.1 expands to 127.0.0.1', () => {
+    expect(canonicalizeIpv4('127.1')).toEqual({ ipv4: '127.0.0.1' });
+    expect(c('https://127.1/')).toBe('loopback');
+  });
+  test('decimal form of metadata 169.254.169.254', () => {
+    expect(c('https://2852039166/')).toBe('link-local');
+  });
+  test('canonicalizeIpv4 fails a malformed numeric address closed (defence in depth)', () => {
+    // The WHATWG URL parser already rejects `https://999.1.1.1/` at construction,
+    // so classifyUrl rarely sees these; canonicalizeIpv4 is the belt to that
+    // suspenders for any numeric host that reaches it un-canonicalised.
+    expect(canonicalizeIpv4('999.1.1.1')).toEqual({ invalid: true });
+    expect(canonicalizeIpv4('0x1.0x2.0x3.0x4.0x5')).toEqual({ invalid: true });
+    expect(canonicalizeIpv4('256')).toEqual({ ipv4: '0.0.1.0' });
+    expect(canonicalizeIpv4('4294967296')).toEqual({ invalid: true }); // > 32 bits
+  });
+  test('a real hostname with a numeric label is still a hostname (falls to DNS)', () => {
+    // Not all-numeric parts → not an IPv4 literal → default-deny miss, not an
+    // encoding error (the broker would resolve it).
+    expect(canonicalizeIpv4('123.example.com')).toBeNull();
+    expect(classify('https://123.example.com/').allowed).toBe(true); // on allowlist
+  });
+});
+
+describe('egress policy — resolved-address classification (the DNS-hop check)', () => {
+  test('public addresses pass', () => {
+    expect(classifyResolvedAddress('93.184.216.34')).toBeNull();
+    expect(classifyResolvedAddress('2606:2800:220:1:248:1893:25c8:1946')).toBeNull();
+  });
+  test('reserved addresses are caught', () => {
+    expect(classifyResolvedAddress('127.0.0.1')).toBe('loopback');
+    expect(classifyResolvedAddress('10.1.2.3')).toBe('private-rfc1918');
+    expect(classifyResolvedAddress('169.254.169.254')).toBe('link-local');
+    expect(classifyResolvedAddress('::1')).toBe('loopback');
+  });
+  test('a non-IP string is refused, never treated as public', () => {
+    expect(classifyResolvedAddress('not-an-ip')).toBe('invalid-ip-encoding');
+  });
+});

--- a/packages/core/src/egress/broker.ts
+++ b/packages/core/src/egress/broker.ts
@@ -1,0 +1,493 @@
+/**
+ * The tenant-egress broker — the single audited chokepoint for tenant-controlled
+ * outbound HTTP (wish: omni-full-multitenancy, Group G5; ADR-0009, WISH
+ * "Tenant-controlled outbound egress").
+ *
+ * WHAT IT GUARANTEES
+ * ------------------
+ * Every request it sends has, in order:
+ *   1. passed {@link classifyUrl} against the tenant's default-deny policy
+ *      (scheme, userinfo, port, allowlist, literal-IP reserved ranges);
+ *   2. had its hostname resolved immediately before connect, with EVERY resolved
+ *      address checked by {@link classifyResolvedAddress} — the DNS-rebinding
+ *      defence, re-run on every redirect hop;
+ *   3. been sent with bounded connect/read timeout, a bounded redirect count, and
+ *      a bounded response-body size, under a per-broker concurrency cap;
+ *   4. carried NO ambient credentials the broker added — it forwards only the
+ *      caller's explicit headers, strips `authorization` across cross-origin
+ *      redirects, and never attaches cookies, proxy credentials, or cloud
+ *      identity headers.
+ * and has recorded an audit decision carrying the tenant, actor, integration,
+ * normalized destination class, policy version, and outcome — never a secret,
+ * URL path, query, header, or body.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO
+ * --------------------------------
+ * This is the application-layer control. ADR-0009's SECOND layer — a runtime
+ * network policy that blocks egress at the sandbox/pod boundary — is NOT
+ * repo-local and is a named deferral (deployment / G8A staging scope). The
+ * residual TOCTOU between "resolve+validate" and the transport's own resolution
+ * is what that layer closes; here the window is minimised by validating
+ * immediately before each connect and revalidating every hop.
+ *
+ * G7 owns the full adversarial SSRF/rebinding matrix; G5 ships this broker with
+ * foundational accept/reject coverage for every rejection class.
+ *
+ * DUAL WORLD
+ * ----------
+ * The broker is reached only from a tenant-controlled egress path that has been
+ * explicitly converted to call it. A flag-off deployment binds no policies and
+ * routes nothing here, so its legacy egress is byte-identical until converted.
+ */
+
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import {
+  type EgressDecision,
+  type EgressDestinationClass,
+  type EgressPolicy,
+  canonicalizeIpv4,
+  classifyResolvedAddress,
+  classifyUrl,
+} from './policy';
+
+/** Injectable DNS resolver so tests drive rebinding without a network. */
+export type AddressLookup = (hostname: string) => Promise<Array<{ address: string }>>;
+
+/** Injectable transport so tests exercise redirect/limit logic without a network. */
+export type EgressTransport = (url: string, init: RequestInit) => Promise<Response>;
+
+const defaultLookup: AddressLookup = async (hostname) => lookup(hostname, { all: true });
+const defaultTransport: EgressTransport = (url, init) => fetch(url, init);
+
+/** A non-secret audit record for one egress decision. Safe to log/emit. */
+export interface EgressAuditRecord {
+  readonly tenantId: string;
+  readonly actorCredentialId: string | null;
+  /** The integration class making the call, e.g. `automations.webhook`. */
+  readonly integration: string;
+  readonly destinationClass: EgressDestinationClass;
+  readonly policyVersion: number;
+  readonly outcome: 'allowed' | 'blocked' | 'error';
+  /** Normalized host only — never a path, query, header, or body. */
+  readonly host: string;
+  readonly redirectHops: number;
+  readonly reason: string;
+}
+
+export type EgressAuditSink = (record: EgressAuditRecord) => void;
+
+/** Bounds applied to every brokered request. All have safe, tight defaults. */
+export interface EgressLimits {
+  /** Per-attempt connect+read timeout (ms). */
+  readonly timeoutMs: number;
+  /** Maximum redirect hops followed (each revalidated). */
+  readonly maxRedirects: number;
+  /** Maximum response body size accepted (bytes). */
+  readonly maxResponseBytes: number;
+  /** Maximum concurrent in-flight brokered requests. */
+  readonly maxConcurrency: number;
+}
+
+export const DEFAULT_EGRESS_LIMITS: EgressLimits = {
+  timeoutMs: 10_000,
+  maxRedirects: 3,
+  maxResponseBytes: 8 * 1024 * 1024,
+  maxConcurrency: 16,
+};
+
+/** The tenant/actor/integration a brokered call is made on behalf of. */
+export interface EgressContext {
+  readonly tenantId: string;
+  readonly actorCredentialId: string | null;
+  readonly integration: string;
+}
+
+export class EgressBlockedError extends Error {
+  readonly code = 'egress_blocked';
+  readonly destinationClass: EgressDestinationClass;
+  constructor(destinationClass: EgressDestinationClass, reason: string) {
+    // The message names the CLASS and reason, never the full URL/secret.
+    super(`egress blocked (${destinationClass}): ${reason}`);
+    this.name = 'EgressBlockedError';
+    this.destinationClass = destinationClass;
+  }
+}
+
+export class EgressLimitError extends Error {
+  readonly code = 'egress_limit';
+  constructor(reason: string) {
+    super(`egress limit exceeded: ${reason}`);
+    this.name = 'EgressLimitError';
+  }
+}
+
+export interface TenantEgressBrokerOptions {
+  readonly resolveAddresses?: AddressLookup;
+  readonly transport?: EgressTransport;
+  readonly audit?: EgressAuditSink;
+  readonly limits?: Partial<EgressLimits>;
+}
+
+export interface BrokeredRequest {
+  readonly url: string;
+  readonly method?: string;
+  /** Only these headers are forwarded. The broker adds none of its own. */
+  readonly headers?: RequestInit['headers'];
+  readonly body?: RequestInit['body'];
+  /**
+   * Host suffixes across which `authorization` may survive a cross-origin
+   * redirect (e.g. a platform-owned CDN split). Empty by default — auth is
+   * dropped on any cross-origin hop.
+   */
+  readonly preserveAuthRedirectHostSuffixes?: readonly string[];
+}
+
+function hostMatchesSuffix(hostname: string, suffix: string): boolean {
+  const h = hostname.toLowerCase();
+  const s = suffix.toLowerCase().replace(/^\.+/, '');
+  return h === s || h.endsWith(`.${s}`);
+}
+
+/**
+ * Credential-bearing headers dropped on ANY non-same-origin redirect hop. A
+ * cross-origin 302 to an attacker-influenced (but allowlisted) host must not
+ * carry the caller's ambient credentials onward: `authorization`, session
+ * `cookie`s, or upstream `proxy-authorization` are all a webhook-credential leak.
+ */
+const CROSS_ORIGIN_CREDENTIAL_HEADERS: readonly string[] = ['authorization', 'cookie', 'proxy-authorization'];
+
+/**
+ * Build the header set for the next redirect hop from ONLY the caller's original
+ * headers (never accumulating ambient state), dropping every credential-bearing
+ * header (see {@link CROSS_ORIGIN_CREDENTIAL_HEADERS}) unless the hop is
+ * same-origin or both hosts are on an explicitly preserved suffix.
+ */
+function nextHopHeaders(request: BrokeredRequest, currentUrl: URL, nextUrl: URL): Headers {
+  const headers = new Headers(request.headers ?? {});
+  const sameOrigin = nextUrl.origin === currentUrl.origin;
+  const preserved = Boolean(
+    request.preserveAuthRedirectHostSuffixes?.some(
+      (suffix) => hostMatchesSuffix(currentUrl.hostname, suffix) && hostMatchesSuffix(nextUrl.hostname, suffix),
+    ),
+  );
+  if (!sameOrigin && !preserved) {
+    for (const header of CROSS_ORIGIN_CREDENTIAL_HEADERS) headers.delete(header);
+  }
+  return headers;
+}
+
+/**
+ * A minimal FIFO semaphore. Bounds concurrent in-flight brokered requests so a
+ * tenant cannot exhaust sockets/file descriptors through the broker.
+ */
+class Semaphore {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+  constructor(private readonly max: number) {}
+  async acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active += 1;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+    this.active += 1;
+  }
+  release(): void {
+    this.active -= 1;
+    const next = this.waiters.shift();
+    if (next) next();
+  }
+}
+
+export class TenantEgressBroker {
+  private readonly resolveAddresses: AddressLookup;
+  private readonly transport: EgressTransport;
+  private readonly audit: EgressAuditSink;
+  private readonly limits: EgressLimits;
+  private readonly semaphore: Semaphore;
+
+  constructor(options: TenantEgressBrokerOptions = {}) {
+    this.resolveAddresses = options.resolveAddresses ?? defaultLookup;
+    this.transport = options.transport ?? defaultTransport;
+    this.audit = options.audit ?? (() => {});
+    this.limits = { ...DEFAULT_EGRESS_LIMITS, ...options.limits };
+    this.semaphore = new Semaphore(this.limits.maxConcurrency);
+  }
+
+  private record(
+    context: EgressContext,
+    decision: EgressDecision,
+    outcome: EgressAuditRecord['outcome'],
+    hops: number,
+  ): void {
+    this.audit({
+      tenantId: context.tenantId,
+      actorCredentialId: context.actorCredentialId,
+      integration: context.integration,
+      destinationClass: decision.destinationClass,
+      policyVersion: decision.policyVersion,
+      outcome,
+      host: decision.host,
+      redirectHops: hops,
+      reason: decision.reason,
+    });
+  }
+
+  /**
+   * Validate one URL fully: URL-shape/allowlist via {@link classifyUrl}, then —
+   * for a DNS hostname — resolve and classify EVERY address. Throws
+   * {@link EgressBlockedError} on any denial. Returns the decision on success.
+   */
+  private async validateDestination(
+    url: URL,
+    policy: EgressPolicy,
+    context: EgressContext,
+    hops: number,
+  ): Promise<EgressDecision> {
+    const decision = classifyUrl(url, policy);
+    if (!decision.allowed) {
+      this.record(context, decision, 'blocked', hops);
+      throw new EgressBlockedError(decision.destinationClass, decision.reason);
+    }
+
+    // A literal-IP host (any family/encoding) was already classified fully by
+    // classifyUrl. Only a real hostname still needs DNS resolution + per-address
+    // classification. `canonicalizeIpv4` is the SAME test classifyUrl used, so a
+    // hostname that merely starts with digits (`123.example.com`) is correctly
+    // treated as a name and resolved — not mistaken for a numeric literal.
+    const host = decision.host;
+    const canon = canonicalizeIpv4(host);
+    const isLiteralIp = isIP(host) !== 0 || (canon !== null && 'ipv4' in canon);
+    if (!isLiteralIp) {
+      let addresses: Array<{ address: string }>;
+      try {
+        addresses = await this.resolveAddresses(host);
+      } catch (error) {
+        // Resolution failure: nothing private became reachable. Surface as a
+        // limit-class error so the caller can distinguish it from a policy block.
+        throw new EgressLimitError(
+          `DNS resolution failed for host: ${error instanceof Error ? error.message : 'unknown'}`,
+        );
+      }
+      if (addresses.length === 0) {
+        throw new EgressLimitError('DNS resolution returned no addresses');
+      }
+      for (const { address } of addresses) {
+        const addrClass = classifyResolvedAddress(address);
+        if (addrClass !== null) {
+          const blocked: EgressDecision = {
+            allowed: false,
+            destinationClass: addrClass,
+            reason: `host ${host} resolves to a ${addrClass} address`,
+            policyVersion: policy.policyVersion,
+            host,
+          };
+          this.record(context, blocked, 'blocked', hops);
+          throw new EgressBlockedError(addrClass, blocked.reason);
+        }
+      }
+    }
+    return decision;
+  }
+
+  /**
+   * Send a tenant-controlled request through the broker. Resolves to the final
+   * {@link Response} (body bounded to `maxResponseBytes`). Throws
+   * {@link EgressBlockedError} on a policy denial and {@link EgressLimitError} on
+   * a timeout / redirect / body-size / resolution failure.
+   */
+  async send(request: BrokeredRequest, policy: EgressPolicy, context: EgressContext): Promise<Response> {
+    await this.semaphore.acquire();
+    try {
+      let currentUrl = new URL(request.url);
+      let lastDecision = await this.validateDestination(currentUrl, policy, context, 0);
+      // Fresh Headers from ONLY the caller's explicit headers — the broker adds
+      // nothing ambient (no cookies, proxy creds, or cloud-identity headers).
+      let headers = new Headers(request.headers ?? {});
+
+      for (let hop = 0; hop <= this.limits.maxRedirects; hop++) {
+        const response = await this.transport(currentUrl.toString(), {
+          method: request.method ?? 'GET',
+          headers,
+          body: request.body ?? undefined,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(this.limits.timeoutMs),
+        });
+
+        if (response.status < 300 || response.status >= 400) {
+          this.enforceBodyLimit(response);
+          this.record(context, lastDecision, 'allowed', hop);
+          return response;
+        }
+
+        const location = response.headers.get('location');
+        if (!location) {
+          this.enforceBodyLimit(response);
+          this.record(context, lastDecision, 'allowed', hop);
+          return response;
+        }
+
+        const nextUrl = new URL(location, currentUrl);
+        lastDecision = await this.validateDestination(nextUrl, policy, context, hop + 1);
+        headers = nextHopHeaders(request, currentUrl, nextUrl);
+        currentUrl = nextUrl;
+      }
+
+      const exhausted: EgressDecision = {
+        allowed: false,
+        destinationClass: lastDecision.destinationClass,
+        reason: 'too many redirects',
+        policyVersion: policy.policyVersion,
+        host: lastDecision.host,
+      };
+      this.record(context, exhausted, 'error', this.limits.maxRedirects);
+      throw new EgressLimitError('too many redirects');
+    } catch (error) {
+      if (!(error instanceof EgressBlockedError) && !(error instanceof EgressLimitError)) {
+        // Transport/timeout error: audit it as an error outcome with no host leak.
+        this.audit({
+          tenantId: context.tenantId,
+          actorCredentialId: context.actorCredentialId,
+          integration: context.integration,
+          destinationClass: 'approved-public',
+          policyVersion: policy.policyVersion,
+          outcome: 'error',
+          host: safeHost(request.url),
+          redirectHops: 0,
+          reason: error instanceof Error ? error.name : 'transport error',
+        });
+      }
+      throw error;
+    } finally {
+      this.semaphore.release();
+    }
+  }
+
+  /**
+   * Reject a response whose declared length exceeds the cap. A body with no
+   * Content-Length is left to the caller to read; callers that stream should use
+   * {@link readBounded}.
+   */
+  private enforceBodyLimit(response: Response): void {
+    const declared = response.headers.get('content-length');
+    if (declared) {
+      const length = Number.parseInt(declared, 10);
+      if (!Number.isNaN(length) && length > this.limits.maxResponseBytes) {
+        throw new EgressLimitError(`response body ${length} exceeds ${this.limits.maxResponseBytes} bytes`);
+      }
+    }
+  }
+
+  /**
+   * Read a response body with a hard byte cap, for callers that consume the
+   * stream. Throws {@link EgressLimitError} if the stream exceeds the cap.
+   */
+  async readBounded(response: Response): Promise<Uint8Array> {
+    const cap = this.limits.maxResponseBytes;
+    const reader = response.body?.getReader();
+    if (!reader) return new Uint8Array(0);
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > cap) {
+          await reader.cancel();
+          throw new EgressLimitError(`response body exceeds ${cap} bytes`);
+        }
+        chunks.push(value);
+      }
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return out;
+  }
+}
+
+/** Extract a bare host for audit without throwing on a malformed URL. */
+function safeHost(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return '(unparseable)';
+  }
+}
+
+// --- the dual-world gateway -------------------------------------------------
+
+/**
+ * Injectable seam that maps an egress call's context to the tenant's bound
+ * policy, WITHOUT `@omni/core` depending on the API layer where a policy store /
+ * tenant scope lives. The API registers a resolver; a flag-off deployment
+ * registers none.
+ *
+ * When the resolver yields `null` — every flag-off deployment, and every call
+ * with no tenant policy in scope — {@link brokeredFetch} is a byte-identical
+ * passthrough to the global `fetch`, which is the dual-world contract: no tenants
+ * exist to bind a default-deny policy to, so legacy egress is unchanged. When it
+ * yields a policy, the call is fully brokered.
+ */
+let egressPolicyResolver: ((context: EgressContext) => EgressPolicy | null) | null = null;
+
+export function setEgressPolicyResolver(resolver: ((context: EgressContext) => EgressPolicy | null) | null): void {
+  egressPolicyResolver = resolver;
+}
+
+export function resolveEgressPolicy(context: EgressContext): EgressPolicy | null {
+  if (!egressPolicyResolver) return null;
+  try {
+    return egressPolicyResolver(context) ?? null;
+  } catch {
+    // A resolver that throws must fail CLOSED for a real tenant context, but a
+    // flag-off deployment has no resolver at all and never reaches here. We
+    // cannot know the tenant's intent from a thrown resolver, so we deny by
+    // returning a policy that approves nothing.
+    return { policyVersion: -1, approvedHostSuffixes: [] };
+  }
+}
+
+const sharedBroker = new TenantEgressBroker();
+
+/**
+ * The drop-in replacement for a raw `fetch` on a tenant-controlled egress path.
+ *
+ * A converted call site changes `fetch(url, init)` into
+ * `brokeredFetch(url, { ...init, egress })`. Behaviour:
+ *   * no bound policy (flag-off / no tenant scope) → byte-identical passthrough;
+ *   * a bound policy → the full {@link TenantEgressBroker} enforcement path.
+ *
+ * The passthrough uses the same global `fetch` and the caller's own `init`
+ * verbatim (minus the `egress` marker), so a flag-off deployment observes no
+ * change — the same redirect-follow, the same caller timeout, the same headers.
+ */
+export async function brokeredFetch(
+  input: string,
+  init: RequestInit & { egress: EgressContext },
+  broker: TenantEgressBroker = sharedBroker,
+): Promise<Response> {
+  const { egress, ...rest } = init;
+  const policy = resolveEgressPolicy(egress);
+  if (!policy) {
+    // Legacy / flag-off: byte-identical passthrough. No policy is bound, so the
+    // broker's enforcement (default-deny, manual redirects, bounded limits) does
+    // not apply — exactly as before conversion.
+    return fetch(input, rest);
+  }
+  return broker.send(
+    {
+      url: input,
+      method: typeof rest.method === 'string' ? rest.method : undefined,
+      headers: rest.headers,
+      body: rest.body ?? null,
+    },
+    policy,
+    egress,
+  );
+}

--- a/packages/core/src/egress/egress-access-guard.ts
+++ b/packages/core/src/egress/egress-access-guard.ts
@@ -294,7 +294,13 @@ export const REGISTERED_EGRESS: readonly RegisteredEgress[] = [
     sites: 1,
     justification:
       'The existing SSRF-guarded media fetch primitive: deny-lists private/reserved ranges and revalidates every ' +
-      'redirect hop. Transitional; the broker generalises it. Its escape hatch is named in the G5 handoff.',
+      'redirect hop. Transitional; the broker generalises it. ITS ESCAPE HATCH IS NOW SUBSUMED FOR TENANT ' +
+      'CONTEXTS (G5 deliverable (b)): `OMNI_MEDIA_URL_GUARD=off` is ignored when a `trustedTenantId` is supplied, ' +
+      'on the initial URL and on every redirect hop, so no per-deployment flag can open private ranges to a ' +
+      'tenant-controlled media URL. All three production callers thread that tenant from persisted ownership or ' +
+      'the request scope (media-storage `storeFromUrl`, the dispatcher history-media chain, routes/v2/messages). ' +
+      'A caller passing NO tenant keeps the pre-G5 hatch, which is the single-tenant deployment the hatch was ' +
+      'written for. Proven in media-guard-tenant-subsumption.test.ts.',
   },
 
   // --- platform-vendor: compile-time-fixed vendor/first-party hosts --------

--- a/packages/core/src/egress/egress-access-guard.ts
+++ b/packages/core/src/egress/egress-access-guard.ts
@@ -73,7 +73,7 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.turbo', '__tests__
 const SKIP_FILES = new Set(['packages/core/src/egress/broker.ts', 'packages/core/src/egress/egress-access-guard.ts']);
 
 /** The package roots that contain tenant-reachable egress. */
-export const EGRESS_SCAN_ROOTS = [
+const EGRESS_SCAN_ROOTS = [
   'packages/core/src',
   'packages/api/src',
   'packages/channel-discord/src',

--- a/packages/core/src/egress/egress-access-guard.ts
+++ b/packages/core/src/egress/egress-access-guard.ts
@@ -1,0 +1,395 @@
+/**
+ * Egress architecture guard (wish: omni-full-multitenancy, Group G5; ADR-0009,
+ * WISH "Tenant-controlled outbound egress").
+ *
+ * The machine-checkable half of ADR-0009's first enforcement layer: it fails the
+ * build when a direct `fetch`/socket call site appears in a tenant-controlled
+ * path outside the {@link TenantEgressBroker}. It is the exact sibling of the
+ * database-access guard (`@omni/db` `tenancy-db-access-guard.ts`): a scanner, a
+ * hand-classified registry, and a ratchet ceiling that may shrink but never grow.
+ *
+ * WHY A REGISTRY RATHER THAN A BAN
+ * --------------------------------
+ * The repository has raw `fetch` in three honestly-different situations:
+ *   * TENANT-CONTROLLED egress (an automation's `config.url`, a provider
+ *     `baseUrl`, a per-instance callback) — the SSRF surface. These must move
+ *     behind the broker. Until they do they are `pending-egress-broker` DEBT,
+ *     capped by {@link PENDING_EGRESS_CEILING}.
+ *   * PLATFORM-VENDOR egress to a compile-time-fixed first-party/vendor host
+ *     (Discord/Slack/Telegram/Twilio APIs, OpenAI/Groq/Gemini vendors, AWS STS).
+ *     The tenant cannot influence the destination, so it is not the broker's
+ *     concern — but it is named, not waved through.
+ *   * The MEDIA guard (`safe-media-fetch.ts`), a transitional SSRF guard for
+ *     channel-payload media URLs, and platform INFRA (the inbound Bun server
+ *     handler, which is not egress at all).
+ *
+ * A site the scanner finds that the registry does not list fails the build. That
+ * is the whole point: a new raw `fetch` in a tenant path cannot land silently.
+ *
+ * SCANNING PRECISION
+ * ------------------
+ * Only the GLOBAL `fetch(` counts — a method call like `client.channels.fetch()`
+ * (discord.js) or `app.fetch(req)` (Hono) is a library call to a fixed API, not
+ * outbound egress this guard governs, so the match requires no `.`/word char
+ * before `fetch`. Comments are blanked first (English prose says "fetch the
+ * user"), mirroring the db-guard's `stripComments`.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+export type EgressClass =
+  /** Compile-time-fixed first-party/vendor host; tenant cannot influence it. */
+  | 'platform-vendor'
+  /** The transitional SSRF-guarded media fetch (`safe-media-fetch.ts`). */
+  | 'media-guard'
+  /** Not egress: the inbound server request handler. */
+  | 'infra'
+  /** Tenant-controlled egress not yet behind the broker — capped debt. */
+  | 'pending-egress-broker';
+
+export interface EgressSite {
+  /** Repo-relative path. */
+  readonly file: string;
+  /** Number of global egress call sites found in the file. */
+  readonly sites: number;
+}
+
+export interface RegisteredEgress {
+  readonly file: string;
+  readonly class: EgressClass;
+  /** Expected number of global egress call sites — a new one bumps this. */
+  readonly sites: number;
+  readonly justification?: string;
+}
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.turbo', '__tests__', 'coverage']);
+
+/**
+ * Files that DEFINE the egress primitives being measured, not call sites subject
+ * to the policy. `broker.ts` is the one place the global `fetch` legitimately
+ * lives — it is the broker. This guard's own source mentions `fetch(` in strings.
+ */
+const SKIP_FILES = new Set(['packages/core/src/egress/broker.ts', 'packages/core/src/egress/egress-access-guard.ts']);
+
+/** The package roots that contain tenant-reachable egress. */
+export const EGRESS_SCAN_ROOTS = [
+  'packages/core/src',
+  'packages/api/src',
+  'packages/channel-discord/src',
+  'packages/channel-slack/src',
+  'packages/channel-telegram/src',
+  'packages/channel-gupshup/src',
+  'packages/channel-twilio-whatsapp/src',
+  'packages/channel-whatsapp/src',
+  'packages/channel-sdk/src',
+] as const;
+
+function isTestFile(path: string): boolean {
+  return path.includes('/__tests__/') || /\.(test|spec)\.ts$/.test(path);
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return; // a root that does not exist in this checkout is simply skipped
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (full.endsWith('.ts') && !isTestFile(full)) out.push(full);
+  }
+}
+
+/** Blank `//` and block comments, preserving offsets/newlines (see db-guard). */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (comment) => comment.replace(/[^\n]/g, ' '));
+}
+
+/**
+ * Global outbound-egress call sites:
+ *   * `fetch(` NOT preceded by `.` or a word char (excludes `.fetch(` methods);
+ *   * `new WebSocket(`;
+ *   * `net.connect` / `net.createConnection` / `tls.connect`;
+ *   * `http.request` / `https.request`.
+ */
+const EGRESS_CALL =
+  /(?<![.\w])fetch\s*\(|new\s+WebSocket\s*\(|(?<![.\w])(?:net|tls)\.(?:connect|createConnection)\s*\(|(?<![.\w])https?\.request\s*\(/g;
+
+/** Scan the egress roots; returns one {@link EgressSite} per file with ≥1 site. */
+export function scanEgressSites(repoRoot: string, roots: readonly string[] = EGRESS_SCAN_ROOTS): EgressSite[] {
+  const files: string[] = [];
+  for (const root of roots) walk(join(repoRoot, root), files);
+
+  const out: EgressSite[] = [];
+  for (const file of files) {
+    const rel = relative(repoRoot, file).split('\\').join('/');
+    if (SKIP_FILES.has(rel)) continue;
+    const source = stripComments(readFileSync(file, 'utf-8'));
+    const matches = source.match(EGRESS_CALL);
+    EGRESS_CALL.lastIndex = 0;
+    if (matches && matches.length > 0) out.push({ file: rel, sites: matches.length });
+  }
+  return out.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+export interface EgressGuardReport {
+  /** Files the scan found that the registry does not list. Any entry fails. */
+  readonly unregistered: EgressSite[];
+  /** Registry entries whose file no longer has an egress site. Any entry fails. */
+  readonly stale: RegisteredEgress[];
+  /** Registered files whose scanned site count differs from the recorded one. */
+  readonly countDrift: Array<{ file: string; registered: number; scanned: number }>;
+  /** Non-broker entries missing a justification. */
+  readonly unjustified: RegisteredEgress[];
+  readonly counts: Record<EgressClass, number>;
+}
+
+export function evaluateEgressGuard(
+  scanned: readonly EgressSite[],
+  registry: readonly RegisteredEgress[] = REGISTERED_EGRESS,
+): EgressGuardReport {
+  const registered = new Map(registry.map((e) => [e.file, e]));
+  const found = new Map(scanned.map((s) => [s.file, s]));
+
+  const unregistered = scanned.filter((s) => !registered.has(s.file));
+  const stale = registry.filter((e) => !found.has(e.file));
+  const countDrift: EgressGuardReport['countDrift'] = [];
+  for (const entry of registry) {
+    const site = found.get(entry.file);
+    if (site && site.sites !== entry.sites) {
+      countDrift.push({ file: entry.file, registered: entry.sites, scanned: site.sites });
+    }
+  }
+  const unjustified = registry.filter((e) => (e.justification ?? '').trim().length === 0);
+
+  const counts: Record<EgressClass, number> = {
+    'platform-vendor': 0,
+    'media-guard': 0,
+    infra: 0,
+    'pending-egress-broker': 0,
+  };
+  for (const entry of registry) counts[entry.class] += 1;
+
+  return { unregistered, stale, countDrift, unjustified, counts };
+}
+
+/**
+ * Ceiling on the `pending-egress-broker` class — the number of FILES still doing
+ * tenant-controlled egress with a raw `fetch`/socket rather than through the
+ * broker.
+ *
+ * Opened by G5 at 10. The classifier found 11 tenant-controlled egress files;
+ * `automations/actions.ts` — ADR-0009's canonical example — was converted to the
+ * broker (`brokeredFetch`) in the same change. A brokered file has NO raw
+ * `fetch`/socket, so it is ABSENT from the scan entirely — conversion is proven
+ * by this ceiling falling and by the file dropping out of the inventory, not by a
+ * registry class. The class therefore opens at the remaining 10. Like the
+ * db-access ceiling this is a ratchet: it may fall as files move behind the
+ * broker, never rise. The ten are named individually below with the
+ * tenant-configured field that supplies each destination.
+ */
+export const PENDING_EGRESS_CEILING = 10;
+
+/**
+ * Committed inventory of every global outbound-egress call site in the scanned
+ * roots. Hand-classified. A site the scanner finds that is absent here fails the
+ * guard test — the mechanism that stops a new raw tenant `fetch` from landing
+ * silently.
+ */
+export const REGISTERED_EGRESS: readonly RegisteredEgress[] = [
+  // NOTE: `packages/core/src/automations/actions.ts` — ADR-0009's canonical
+  // tenant webhook action — was converted to `brokeredFetch` in this change and
+  // therefore has NO raw egress site; it is intentionally ABSENT here.
+
+  // --- pending-egress-broker: tenant-controlled debt (capped) --------------
+  {
+    file: 'packages/core/src/providers/webhook-provider.ts',
+    class: 'pending-egress-broker',
+    sites: 2,
+    justification:
+      'ADR-0009 tenant-controlled egress: destination is the tenant-configured provider `config.webhookUrl`. Not ' +
+      'yet routed through the TenantEgressBroker — pending-egress-broker debt, capped by the ratchet.',
+  },
+  {
+    file: 'packages/core/src/providers/a2a-client.ts',
+    class: 'pending-egress-broker',
+    sites: 3,
+    justification:
+      'ADR-0009 tenant-controlled egress: destination is the tenant-configured agent provider `config.baseUrl`. ' +
+      'Pending broker routing.',
+  },
+  {
+    file: 'packages/core/src/providers/ag-ui-client.ts',
+    class: 'pending-egress-broker',
+    sites: 2,
+    justification:
+      'ADR-0009 tenant-controlled egress: destination is the tenant-configured agent provider `config.baseUrl`. ' +
+      'Pending broker routing.',
+  },
+  {
+    file: 'packages/core/src/providers/agno-client.ts',
+    class: 'pending-egress-broker',
+    sites: 2,
+    justification:
+      'ADR-0009 tenant-controlled egress: the fetch primitive behind every Agno REST call builds its URL from the ' +
+      'tenant-configured `config.baseUrl`, and one path fetches a request-supplied `file.url`. Pending broker routing.',
+  },
+  {
+    file: 'packages/core/src/providers/openclaw/client.ts',
+    class: 'pending-egress-broker',
+    sites: 1,
+    justification:
+      'ADR-0009 tenant-controlled egress: a `new WebSocket(config.url)` to the tenant-configured Openclaw endpoint. ' +
+      'A long-lived socket rather than a fetch; broker WebSocket support is pending.',
+  },
+  {
+    file: 'packages/api/src/services/providers.ts',
+    class: 'pending-egress-broker',
+    sites: 1,
+    justification:
+      'ADR-0009 tenant-controlled egress: a health probe to `new URL("/health", provider.baseUrl)`, where baseUrl is ' +
+      'the tenant-configured agentProviders row. Pending broker routing.',
+  },
+  {
+    file: 'packages/channel-gupshup/src/client.ts',
+    class: 'pending-egress-broker',
+    sites: 2,
+    justification:
+      'ADR-0009 tenant-controlled egress: despite the vendor name the destination is the per-instance tenant ' +
+      'credential `gupshupCallbackUrl`, not a fixed Gupshup host. Pending broker routing.',
+  },
+  {
+    file: 'packages/channel-discord/src/senders/media.ts',
+    class: 'pending-egress-broker',
+    sites: 2,
+    justification:
+      'ADR-0009 tenant-controlled egress: a raw download of an agent/tenant-chosen outbound `mediaUrl`. Pending ' +
+      'routing through the broker or safe-media-fetch (media-download-shaped).',
+  },
+  {
+    file: 'packages/channel-slack/src/senders/media.ts',
+    class: 'pending-egress-broker',
+    sites: 1,
+    justification:
+      'ADR-0009 tenant-controlled egress: a raw download of an agent/tenant-chosen outbound media `options.url`. ' +
+      'Pending routing through the broker or safe-media-fetch.',
+  },
+  {
+    file: 'packages/channel-whatsapp/src/utils/audio-converter.ts',
+    class: 'pending-egress-broker',
+    sites: 1,
+    justification:
+      'ADR-0009 tenant-controlled egress: a raw download of an agent/tenant-chosen audio `url` for conversion. ' +
+      'Pending routing through the broker or safe-media-fetch.',
+  },
+
+  // --- media-guard: the transitional SSRF-guarded media fetch --------------
+  {
+    file: 'packages/api/src/utils/safe-media-fetch.ts',
+    class: 'media-guard',
+    sites: 1,
+    justification:
+      'The existing SSRF-guarded media fetch primitive: deny-lists private/reserved ranges and revalidates every ' +
+      'redirect hop. Transitional; the broker generalises it. Its escape hatch is named in the G5 handoff.',
+  },
+
+  // --- platform-vendor: compile-time-fixed vendor/first-party hosts --------
+  {
+    file: 'packages/api/src/providers/openai/imagegen.ts',
+    class: 'platform-vendor',
+    sites: 2,
+    justification:
+      'Fixed OpenAI image API constant, plus a download of OpenAI’s own returned image URL. Not tenant-influenceable.',
+  },
+  {
+    file: 'packages/api/src/providers/openai/tts.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification: 'Compile-time OpenAI speech endpoint constant. Not tenant-influenceable.',
+  },
+  {
+    file: 'packages/api/src/providers/openai/stt.ts',
+    class: 'platform-vendor',
+    sites: 2,
+    justification: 'Compile-time OpenAI chat/transcription endpoint constants. Not tenant-influenceable.',
+  },
+  {
+    file: 'packages/api/src/providers/groq/stt.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification: 'Compile-time Groq transcription endpoint constant. Not tenant-influenceable.',
+  },
+  {
+    file: 'packages/api/src/providers/deepseek/vision.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification:
+      'Vendor base URL from the platform-admin `deepseek.anthropic_url` setting/env, not a per-tenant value; a ' +
+      'tenant cannot influence the destination.',
+  },
+  {
+    file: 'packages/api/src/providers/gemini/videogen.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification: 'Downloads a URI returned by Gemini’s own Veo API. Destination fixed by the vendor, not the tenant.',
+  },
+  {
+    file: 'packages/api/src/services/tts.ts',
+    class: 'platform-vendor',
+    sites: 2,
+    justification: 'Hard-coded ElevenLabs API base constants. Not tenant-influenceable.',
+  },
+  {
+    file: 'packages/api/src/plugins/agent-dispatcher.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification: 'Hard-coded Google generativelanguage endpoint for a Gemini gate check. Not tenant-influenceable.',
+  },
+  {
+    file: 'packages/channel-twilio-whatsapp/src/client.ts',
+    class: 'platform-vendor',
+    sites: 3,
+    justification: 'Hard-coded api.twilio.com / messaging.twilio.com hosts; only path segments are interpolated.',
+  },
+  {
+    file: 'packages/channel-telegram/src/utils/media-download.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification:
+      'Fixed api.telegram.org file host; additionally passes the channel-sdk downloadGuard response check.',
+  },
+  {
+    file: 'packages/channel-slack/src/handlers/files.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification:
+      'Slack private-file download with its own manual-redirect and slack.com host guard. Source URL from Slack’s API.',
+  },
+  {
+    file: 'packages/channel-discord/src/handlers/forwarded-attachments.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification:
+      'Discord CDN attachment URL taken from an inbound Discord message object. Destination is the Discord CDN.',
+  },
+  {
+    file: 'packages/channel-sdk/src/media-backends/web-identity.ts',
+    class: 'platform-vendor',
+    sites: 1,
+    justification:
+      'AWS STS AssumeRoleWithWebIdentity token exchange to the fixed STS endpoint. Platform infra credential exchange.',
+  },
+
+  // --- infra: not egress ----------------------------------------------------
+  {
+    file: 'packages/api/src/index.ts',
+    class: 'infra',
+    sites: 1,
+    justification:
+      'The Bun server INBOUND request handler (`fetch(req, server)`), not an outbound call. No tenant-influenced destination.',
+  },
+];

--- a/packages/core/src/egress/index.ts
+++ b/packages/core/src/egress/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Tenant-egress broker module (wish: omni-full-multitenancy, Group G5; ADR-0009).
+ *
+ * The single audited chokepoint for tenant-controlled outbound HTTP, plus the
+ * default-deny SSRF policy engine it enforces. The architecture guard that fails
+ * the build on direct `fetch`/socket use from a tenant-controlled path outside
+ * this broker lives beside it in `egress-access-guard.ts` (not re-exported from
+ * the package root — it is a dev/test tool, like the db-access guard).
+ */
+
+export * from './policy';
+export * from './broker';

--- a/packages/core/src/egress/policy.ts
+++ b/packages/core/src/egress/policy.ts
@@ -1,0 +1,489 @@
+/**
+ * Tenant-egress destination policy — the SSRF decision engine (wish:
+ * omni-full-multitenancy, Group G5; ADR-0009, WISH "Tenant-controlled outbound
+ * egress").
+ *
+ * WHAT THIS IS
+ * -----------
+ * A pure, synchronous classifier for a single candidate destination. Given a
+ * parsed URL and a tenant-bound {@link EgressPolicy}, it answers one question:
+ * may this destination be connected to? It is DEFAULT-DENY — a destination is
+ * refused unless the tenant's policy explicitly approves its host AND the
+ * destination survives an absolute reserved-range denial that no allowlist can
+ * override.
+ *
+ * The two layers, in order:
+ *   1. **Absolute denial** (never overridable): non-approved scheme, a
+ *      credential-bearing/userinfo URL, a non-approved port, and — for a literal
+ *      IP host or a resolved address — any reserved range (loopback, RFC1918,
+ *      CGNAT, link-local, cloud metadata, multicast, unspecified, IPv6 ULA,
+ *      IPv4-mapped IPv6). Alternate IPv4 encodings (decimal/octal/hex) are
+ *      canonicalised before classification so `0x7f000001` cannot smuggle
+ *      loopback past a dotted-quad check.
+ *   2. **Default-deny allowlist**: the host must match the tenant policy's
+ *      approved host set. No match → refused, even for a public address.
+ *
+ * DNS lives in the broker, not here: {@link classifyUrl} decides everything that
+ * is knowable from the URL text (and classifies a literal-IP host completely),
+ * and {@link classifyResolvedAddress} is applied by the broker to every address
+ * a hostname resolves to, immediately before connect and again on every redirect
+ * hop. That split is what lets the broker defend against DNS rebinding while
+ * keeping this module pure and unit-testable without a network.
+ *
+ * DUAL WORLD
+ * ----------
+ * This module has no notion of the flag. It is invoked only by the broker, and
+ * the broker is invoked only on tenant-controlled egress once a caller routes
+ * through it. A flag-off deployment has no tenants and binds no policies; its
+ * legacy egress paths are byte-identical until a path is explicitly converted to
+ * call the broker.
+ */
+
+import { isIP } from 'node:net';
+
+/**
+ * The normalized destination class recorded on every egress decision. It never
+ * carries the raw host or any secret — it is the *category* of the outcome, safe
+ * to log and to use as a bounded metric label.
+ */
+export type EgressDestinationClass =
+  | 'approved-public' // allowed: a public address on the tenant allowlist
+  | 'not-approved' // default-deny miss: public but not on the allowlist
+  | 'loopback' // 127.0.0.0/8, ::1
+  | 'unspecified' // 0.0.0.0/8, ::
+  | 'private-rfc1918' // 10/8, 172.16/12, 192.168/16
+  | 'cgnat' // 100.64.0.0/10 (RFC 6598)
+  | 'link-local' // 169.254.0.0/16, fe80::/10 — includes cloud metadata
+  | 'ipv6-ula' // fc00::/7
+  | 'multicast' // 224.0.0.0/4, ff00::/8
+  | 'reserved' // other reserved/unroutable IPv4 blocks
+  | 'ipv4-mapped-ipv6' // ::ffff:a.b.c.d re-projected onto the IPv4 policy
+  | 'invalid-ip-encoding' // an all-numeric host that is not a valid IP
+  | 'unapproved-scheme' // not http(s) / not an approved scheme
+  | 'unapproved-port' // a port outside the approved set
+  | 'credentialed-url' // userinfo present (user:pass@host)
+  | 'malformed-url'; // host missing/empty, or unparseable
+
+/** Whether a class is a permit. Exactly one class permits. */
+export function isAllowedClass(destinationClass: EgressDestinationClass): boolean {
+  return destinationClass === 'approved-public';
+}
+
+/**
+ * A tenant-bound egress policy. Default-deny: an empty `approvedHostSuffixes`
+ * approves nothing. A host is approved when it equals, or is a subdomain of, one
+ * of the suffixes (case-insensitive). Suffix matching is on label boundaries —
+ * `evil-example.com` does NOT match the suffix `example.com`.
+ */
+export interface EgressPolicy {
+  /** Opaque version stamped onto every decision for audit/rollback correlation. */
+  readonly policyVersion: number;
+  /** Host suffixes the tenant is permitted to reach (label-boundary match). */
+  readonly approvedHostSuffixes: readonly string[];
+  /** Approved URL schemes. Defaults to `['https:']` when omitted/empty. */
+  readonly approvedSchemes?: readonly string[];
+  /** Approved ports. Defaults to `[443]` when omitted/empty. */
+  readonly approvedPorts?: readonly number[];
+}
+
+export interface EgressDecision {
+  readonly allowed: boolean;
+  readonly destinationClass: EgressDestinationClass;
+  /** Non-secret human reason. Never contains credentials or payloads. */
+  readonly reason: string;
+  /** The policy version this decision was taken under. */
+  readonly policyVersion: number;
+  /** Lower-cased hostname (or canonical IP) the decision was about. */
+  readonly host: string;
+}
+
+const DEFAULT_SCHEMES: readonly string[] = ['https:'];
+const DEFAULT_PORTS: readonly number[] = [443];
+
+function schemesFor(policy: EgressPolicy): readonly string[] {
+  return policy.approvedSchemes && policy.approvedSchemes.length > 0 ? policy.approvedSchemes : DEFAULT_SCHEMES;
+}
+
+function portFor(url: URL): number | null {
+  if (url.port) {
+    const parsed = Number.parseInt(url.port, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  // No explicit port — the scheme default.
+  if (url.protocol === 'https:') return 443;
+  if (url.protocol === 'http:') return 80;
+  return null;
+}
+
+function portsFor(policy: EgressPolicy): readonly number[] {
+  return policy.approvedPorts && policy.approvedPorts.length > 0 ? policy.approvedPorts : DEFAULT_PORTS;
+}
+
+/**
+ * Label-boundary suffix match. `host` matches `suffix` when it equals it or ends
+ * with `.suffix`. Both are lower-cased by the caller.
+ */
+function hostMatchesSuffix(host: string, suffix: string): boolean {
+  const s = suffix.toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '');
+  if (s.length === 0) return false;
+  return host === s || host.endsWith(`.${s}`);
+}
+
+function isApprovedHost(host: string, policy: EgressPolicy): boolean {
+  return policy.approvedHostSuffixes.some((suffix) => hostMatchesSuffix(host, suffix));
+}
+
+// --- IPv4 encoding canonicalisation ----------------------------------------
+
+/**
+ * Parse a single IPv4 part in any of the encodings a permissive resolver would
+ * accept: decimal (`10`), hex (`0x0a`), or octal (`012`). Returns `null` for
+ * anything that is not a valid numeric part, which the caller treats as "this is
+ * not an IPv4 literal after all".
+ */
+function parseIpv4Part(part: string): number | null {
+  if (part.length === 0) return null;
+  let value: number;
+  if (/^0x[0-9a-f]+$/i.test(part)) value = Number.parseInt(part.slice(2), 16);
+  else if (/^0[0-7]+$/.test(part)) value = Number.parseInt(part, 8);
+  else if (/^[0-9]+$/.test(part)) value = Number.parseInt(part, 10);
+  else return null;
+  return Number.isNaN(value) ? null : value;
+}
+
+/**
+ * Canonicalise an all-numeric / dotted host to a dotted-quad IPv4 string, or
+ * return a marker telling the caller whether the host even looks like an IPv4
+ * literal.
+ *
+ *   * `{ ipv4: 'a.b.c.d' }`     — a valid IPv4 in some encoding.
+ *   * `{ invalid: true }`       — looks like an IPv4 literal (all parts numeric,
+ *                                 or a bare integer) but is out of range /
+ *                                 malformed. FAIL CLOSED: this must be refused,
+ *                                 not treated as a DNS name.
+ *   * `null`                    — not an IPv4 literal at all; treat as a hostname.
+ *
+ * Handles the classic SSRF encodings: `2130706433` (a bare 32-bit integer),
+ * `0x7f.0.0.1`, `0177.0.0.1`, `0x7f000001`.
+ */
+export function canonicalizeIpv4(host: string): { ipv4: string } | { invalid: true } | null {
+  const parts = host.split('.');
+  // A host is "numeric-shaped" only if EVERY dot-part is a numeric token. A real
+  // hostname like `api.example.com` has non-numeric parts and falls through to
+  // DNS. `1e2` is not matched by any numeric form below, so it stays a hostname.
+  const looksNumeric = parts.every((p) => /^(0x[0-9a-f]+|[0-9]+)$/i.test(p));
+  if (!looksNumeric) return null;
+  if (parts.length > 4) return { invalid: true };
+
+  const values = parts.map(parseIpv4Part);
+  if (values.some((v) => v === null)) return { invalid: true };
+  const nums = values as number[];
+
+  // Compress the trailing part per inet_aton: with fewer than 4 parts the last
+  // part spans the remaining low-order bytes (e.g. `127.1` => 127.0.0.1).
+  let ip32: number;
+  if (nums.length === 1) {
+    ip32 = nums[0] as number;
+    if (ip32 > 0xffffffff) return { invalid: true };
+  } else {
+    const leading = nums.slice(0, -1);
+    const last = nums[nums.length - 1] as number;
+    if (leading.some((n) => n > 0xff)) return { invalid: true };
+    const maxLast = 2 ** (8 * (4 - leading.length));
+    if (last >= maxLast) return { invalid: true };
+    ip32 = last;
+    for (let i = 0; i < leading.length; i++) {
+      ip32 += (leading[i] as number) * 2 ** (8 * (3 - i));
+    }
+  }
+  if (ip32 < 0 || ip32 > 0xffffffff) return { invalid: true };
+  const a = (ip32 >>> 24) & 0xff;
+  const b = (ip32 >>> 16) & 0xff;
+  const c = (ip32 >>> 8) & 0xff;
+  const d = ip32 & 0xff;
+  return { ipv4: `${a}.${b}.${c}.${d}` };
+}
+
+// --- reserved-range classification -----------------------------------------
+
+/** Parse a dotted-quad to its 32-bit integer, or null when malformed. */
+function ipv4ToInt(address: string): number | null {
+  const octets = address.split('.');
+  if (octets.length !== 4) return null;
+  let value = 0;
+  for (const octet of octets) {
+    if (!/^[0-9]{1,3}$/.test(octet)) return null;
+    const n = Number.parseInt(octet, 10);
+    if (n > 255) return null;
+    value = value * 256 + n;
+  }
+  return value >>> 0;
+}
+
+/** `base/prefixBits` → inclusive `[lo, hi]` of the block, as 32-bit ints. */
+function cidr(base: string, bits: number): [number, number] {
+  const lo = ipv4ToInt(base) as number;
+  const size = 2 ** (32 - bits);
+  return [lo, lo + size - 1];
+}
+
+/**
+ * Reserved IPv4 blocks, in longest-prefix-irrelevant order (they are disjoint).
+ * First containing block wins; a `null` result means public/routable.
+ */
+const RESERVED_IPV4: ReadonlyArray<readonly [number, number, EgressDestinationClass]> = [
+  [...cidr('0.0.0.0', 8), 'unspecified'],
+  [...cidr('10.0.0.0', 8), 'private-rfc1918'],
+  [...cidr('127.0.0.0', 8), 'loopback'],
+  [...cidr('100.64.0.0', 10), 'cgnat'],
+  [...cidr('169.254.0.0', 16), 'link-local'], // includes cloud metadata 169.254.169.254
+  [...cidr('172.16.0.0', 12), 'private-rfc1918'],
+  [...cidr('192.168.0.0', 16), 'private-rfc1918'],
+  [...cidr('192.88.99.0', 24), 'reserved'], // 6to4 relay anycast (RFC 7526)
+  [...cidr('192.0.0.0', 24), 'reserved'],
+  [...cidr('192.0.2.0', 24), 'reserved'], // TEST-NET-1
+  [...cidr('198.18.0.0', 15), 'reserved'], // benchmarking
+  [...cidr('198.51.100.0', 24), 'reserved'], // TEST-NET-2
+  [...cidr('203.0.113.0', 24), 'reserved'], // TEST-NET-3
+  [...cidr('224.0.0.0', 4), 'multicast'],
+  [...cidr('240.0.0.0', 4), 'reserved'], // includes 255.255.255.255
+] as const;
+
+function classifyIpv4(address: string): EgressDestinationClass | null {
+  const value = ipv4ToInt(address);
+  if (value === null) return 'invalid-ip-encoding';
+  for (const [lo, hi, cls] of RESERVED_IPV4) {
+    if (value >= lo && value <= hi) return cls;
+  }
+  return null; // public
+}
+
+/**
+ * Convert the suffix of an IPv4-mapped/compatible IPv6 address to dotted IPv4.
+ * Handles both serializations the WHATWG URL parser may emit: dotted
+ * (`::ffff:127.0.0.1`) and two hex hextets (`::ffff:7f00:1`).
+ */
+function mappedSuffixToIpv4(suffix: string): string | null {
+  if (suffix.includes('.')) return isIP(suffix) === 4 ? suffix : null;
+  const hextets = suffix.split(':');
+  if (hextets.length !== 2) return null;
+  const hi = Number.parseInt(hextets[0] as string, 16);
+  const lo = Number.parseInt(hextets[1] as string, 16);
+  if (Number.isNaN(hi) || Number.isNaN(lo) || hi > 0xffff || lo > 0xffff) return null;
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+/** Two 16-bit hextets → dotted-quad IPv4 (high hextet is the top two octets). */
+function hextetsToIpv4(hi: number, lo: number): string {
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+/**
+ * Expand a valid IPv6 literal (as accepted by `isIP`) to its eight 16-bit
+ * hextets, resolving `::` compression and any trailing embedded dotted IPv4.
+ * Returns `null` for anything that does not expand to exactly eight hextets.
+ */
+function ipv6ToHextets(normalized: string): number[] | null {
+  const parseGroups = (groups: string[]): number[] | null => {
+    const out: number[] = [];
+    for (let i = 0; i < groups.length; i++) {
+      const g = groups[i] as string;
+      if (g.includes('.')) {
+        if (i !== groups.length - 1) return null; // dotted IPv4 only as the last group
+        const octets = g.split('.').map((o) => Number.parseInt(o, 10));
+        if (octets.length !== 4 || octets.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return null;
+        out.push(((octets[0] as number) << 8) | (octets[1] as number));
+        out.push(((octets[2] as number) << 8) | (octets[3] as number));
+      } else {
+        const n = Number.parseInt(g, 16);
+        if (Number.isNaN(n) || n < 0 || n > 0xffff) return null;
+        out.push(n);
+      }
+    }
+    return out;
+  };
+
+  const dc = normalized.indexOf('::');
+  if (dc >= 0) {
+    const before = normalized.slice(0, dc);
+    const after = normalized.slice(dc + 2);
+    const head = before === '' ? [] : before.split(':');
+    const tail = after === '' ? [] : after.split(':');
+    const h = parseGroups(head);
+    const t = parseGroups(tail);
+    if (h === null || t === null) return null;
+    const fill = 8 - h.length - t.length;
+    if (fill < 0) return null;
+    return [...h, ...new Array<number>(fill).fill(0), ...t];
+  }
+  const g = parseGroups(normalized.split(':'));
+  if (g === null || g.length !== 8) return null;
+  return g;
+}
+
+/**
+ * Re-project an IPv6 transition-encoding (6to4, Teredo, NAT64) onto the IPv4
+ * classifier so an internal IPv4 embedded in one of them cannot slip through as
+ * "public IPv6". Returns the reserved class when an embedded IPv4 is reserved,
+ * `null` when every embedded IPv4 is public, or `undefined` when `normalized` is
+ * not one of these transition encodings (caller continues its own checks).
+ */
+function classifyIpv6Transition(normalized: string): EgressDestinationClass | null | undefined {
+  const hextets = ipv6ToHextets(normalized);
+  if (hextets === null) return undefined;
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets as [number, number, number, number, number, number, number, number];
+
+  // 6to4 — 2002::/16: the embedded IPv4 is hextets 1-2 (2002:AABB:CCDD::/48).
+  if (h0 === 0x2002) {
+    return classifyIpv4(hextetsToIpv4(h1, h2));
+  }
+
+  // NAT64 well-known prefix — 64:ff9b::/96: embedded IPv4 is the last two hextets.
+  if (h0 === 0x0064 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return classifyIpv4(hextetsToIpv4(h6, h7));
+  }
+
+  // Teredo — 2001:0000::/32: the server IPv4 is hextets 2-3 (plain) and the
+  // client IPv4 is the last two hextets obfuscated by XOR 0xffff. Reject if
+  // EITHER embedded IPv4 is reserved; fail closed.
+  if (h0 === 0x2001 && h1 === 0x0000) {
+    const server = classifyIpv4(hextetsToIpv4(h2, h3));
+    if (server !== null) return server;
+    const client = classifyIpv4(hextetsToIpv4(h6 ^ 0xffff, h7 ^ 0xffff));
+    if (client !== null) return client;
+    return null;
+  }
+
+  return undefined;
+}
+
+function classifyIpv6(address: string): EgressDestinationClass | null {
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, '');
+  if (normalized === '::' || normalized === '::0' || normalized === '0:0:0:0:0:0:0:0') return 'unspecified';
+  if (normalized === '::1') return 'loopback';
+  // IPv4-mapped (::ffff:*) and the deprecated IPv4-compatible (::*) forms:
+  // re-project onto the IPv4 policy so a mapped private/loopback/metadata
+  // address cannot slip through as "public IPv6".
+  const mappedFfff = /^::ffff:([0-9a-f:.]+)$/.exec(normalized);
+  const compat = /^::([0-9a-f]{1,4}:[0-9a-f]{1,4}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(normalized);
+  const suffix = mappedFfff?.[1] ?? compat?.[1];
+  if (suffix) {
+    const v4 = mappedSuffixToIpv4(suffix);
+    if (v4) {
+      const inner = classifyIpv4(v4);
+      return inner ?? 'ipv4-mapped-ipv6';
+    }
+  }
+  // 6to4 / Teredo / NAT64 transition encodings: re-project any embedded IPv4.
+  const transition = classifyIpv6Transition(normalized);
+  if (transition !== undefined) return transition;
+  const firstHextet = normalized.split(':', 1)[0] ?? '';
+  if (firstHextet.startsWith('fc') || firstHextet.startsWith('fd')) return 'ipv6-ula'; // fc00::/7
+  if (/^fe[89ab]/.test(firstHextet)) return 'link-local'; // fe80::/10
+  if (firstHextet.startsWith('ff')) return 'multicast'; // ff00::/8
+  return null; // public
+}
+
+/**
+ * Classify a canonical IP literal (v4 or v6). `null` means public/routable.
+ * Applied by the broker to every resolved address, and by {@link classifyUrl} to
+ * a literal-IP host.
+ */
+export function classifyResolvedAddress(address: string): EgressDestinationClass | null {
+  const family = isIP(address);
+  if (family === 4) return classifyIpv4(address);
+  if (family === 6) return classifyIpv6(address);
+  return 'invalid-ip-encoding';
+}
+
+function decide(
+  allowed: boolean,
+  destinationClass: EgressDestinationClass,
+  reason: string,
+  policy: EgressPolicy,
+  host: string,
+): EgressDecision {
+  return { allowed, destinationClass, reason, policyVersion: policy.policyVersion, host };
+}
+
+/**
+ * Decide everything knowable from the URL text.
+ *
+ *   * Rejects non-approved schemes, credential-bearing URLs, non-approved ports.
+ *   * For a literal-IP host (in any encoding), classifies the address fully — an
+ *     allowed literal IP still has to be a public address AND on the allowlist.
+ *   * For a hostname, applies the default-deny allowlist. The broker then
+ *     resolves it and applies {@link classifyResolvedAddress} to every address
+ *     before connecting.
+ *
+ * A permit here for a hostname means "the URL shape and allowlist are fine";
+ * it is NOT a permit to connect until DNS is checked. The broker enforces that.
+ */
+export function classifyUrl(url: URL, policy: EgressPolicy): EgressDecision {
+  // Scheme first: a `file:`/`unix:`/`gopher:` scheme is refused before anything
+  // else, and this is the one check with no allowlist escape.
+  if (!schemesFor(policy).includes(url.protocol)) {
+    return decide(false, 'unapproved-scheme', `scheme ${url.protocol} is not approved`, policy, url.hostname);
+  }
+
+  // Credentials in the URL (user:pass@ / user@) are refused outright: they are a
+  // userinfo-confusion vector and must never be forwarded.
+  if (url.username !== '' || url.password !== '') {
+    return decide(false, 'credentialed-url', 'URL carries userinfo credentials', policy, url.hostname);
+  }
+
+  const port = portFor(url);
+  if (port === null || !portsFor(policy).includes(port)) {
+    return decide(false, 'unapproved-port', `port ${url.port || '(default)'} is not approved`, policy, url.hostname);
+  }
+
+  // Strip IPv6 brackets for classification; keep a lower-cased host for matching.
+  const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (host.length === 0) {
+    return decide(false, 'malformed-url', 'URL has no host', policy, host);
+  }
+  return classifyHost(host, policy);
+}
+
+/**
+ * Classify a URL's host after the URL-shape checks have passed: a literal IP (any
+ * family/encoding) is classified fully; a hostname is subjected to the
+ * default-deny allowlist and left for the broker to resolve.
+ */
+function classifyHost(host: string, policy: EgressPolicy): EgressDecision {
+  if (isIP(host) !== 0) {
+    const literalClass = classifyResolvedAddress(host);
+    if (literalClass !== null) {
+      return decide(false, literalClass, `literal IP ${host} is in a ${literalClass} range`, policy, host);
+    }
+    // Public literal IP: still default-deny — approved only if the tenant listed
+    // that exact address.
+    return approvedOrDenied(isApprovedHost(host, policy), 'literal IP', host, policy);
+  }
+
+  // Not an IP by `isIP`, but it may be an alternate IPv4 encoding a resolver would
+  // accept (decimal/octal/hex). Canonicalise and re-check; a numeric-shaped host
+  // that is not a valid IP fails closed.
+  const canon = canonicalizeIpv4(host);
+  if (canon !== null) {
+    if ('invalid' in canon) {
+      return decide(false, 'invalid-ip-encoding', `host ${host} is a malformed numeric address`, policy, host);
+    }
+    const literalClass = classifyResolvedAddress(canon.ipv4);
+    if (literalClass !== null) {
+      return decide(false, literalClass, `host ${host} canonicalises to ${canon.ipv4} (${literalClass})`, policy, host);
+    }
+    const approved = isApprovedHost(canon.ipv4, policy) || isApprovedHost(host, policy);
+    return approvedOrDenied(approved, 'numeric IP', host, policy);
+  }
+
+  // A real hostname. Default-deny by allowlist; DNS classification is the broker's
+  // job before connect.
+  return approvedOrDenied(isApprovedHost(host, policy), 'host', host, policy);
+}
+
+function approvedOrDenied(approved: boolean, kind: string, host: string, policy: EgressPolicy): EgressDecision {
+  return approved
+    ? decide(true, 'approved-public', `approved ${kind} (allowlist match; DNS pending for names)`, policy, host)
+    : decide(false, 'not-approved', `${kind} ${host} is not on the tenant allowlist`, policy, host);
+}

--- a/packages/core/src/events/__tests__/envelope.test.ts
+++ b/packages/core/src/events/__tests__/envelope.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Versioned tenant-aware envelope — classification and stamping
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * These are the RED-before-implement probes for the consumer-validation contract
+ * ADR-0008 assigns to G5:
+ *
+ *   * every tenant-context publish carries a versioned envelope with a trusted
+ *     `tenantId`;
+ *   * consumers validate version + tenant BEFORE processing; an unknown version
+ *     or a missing/ambiguous tenant is quarantined, never processed globally;
+ *   * a truly legacy envelope (no version marker, no tenant) is processed exactly
+ *     as today — the dual-world contract — and is NOT quarantined.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { CURRENT_ENVELOPE_VERSION, KNOWN_ENVELOPE_VERSIONS, classifyEnvelope, stampTenantEnvelope } from '../envelope';
+import type { EventMetadata } from '../types';
+
+const TENANT = '11111111-1111-4111-8111-11111111111a';
+
+function meta(overrides: Partial<EventMetadata> = {}): EventMetadata {
+  return { correlationId: 'corr-1', ...overrides };
+}
+
+describe('envelope classification (consumer validation)', () => {
+  test('a legacy envelope — no version, no tenant — is processed, not quarantined (dual world)', () => {
+    expect(classifyEnvelope(meta())).toEqual({ world: 'legacy' });
+  });
+
+  test('a current-version envelope with a valid tenant is a tenant-context message', () => {
+    const result = classifyEnvelope(meta({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: TENANT }));
+    expect(result).toEqual({ world: 'tenant', tenantId: TENANT, envelopeVersion: CURRENT_ENVELOPE_VERSION });
+  });
+
+  test('an UNKNOWN envelope version is quarantined — no global processing fallback', () => {
+    const future = Math.max(...KNOWN_ENVELOPE_VERSIONS) + 99;
+    const result = classifyEnvelope(meta({ envelopeVersion: future, tenantId: TENANT }));
+    expect(result).toEqual({ world: 'quarantine', reason: 'unknown_version' });
+  });
+
+  test('a versioned envelope with NO tenant is quarantined (missing/ambiguous tenant)', () => {
+    const result = classifyEnvelope(meta({ envelopeVersion: CURRENT_ENVELOPE_VERSION }));
+    expect(result).toEqual({ world: 'quarantine', reason: 'missing_tenant' });
+  });
+
+  test('a versioned envelope with a non-UUID tenant is quarantined', () => {
+    const result = classifyEnvelope(meta({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: 'not-a-uuid' }));
+    expect(result).toEqual({ world: 'quarantine', reason: 'invalid_tenant' });
+  });
+
+  test('a tenant claim WITHOUT the version marker is malformed and quarantined', () => {
+    // An envelope asserting a tenant but omitting the version contract is not a
+    // legacy envelope (those carry no tenant) — it is a forged/corrupt one.
+    const result = classifyEnvelope(meta({ tenantId: TENANT }));
+    expect(result).toEqual({ world: 'quarantine', reason: 'malformed_envelope' });
+  });
+
+  test('an empty-string tenant on a versioned envelope is missing, not invalid', () => {
+    const result = classifyEnvelope(meta({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: '' }));
+    expect(result).toEqual({ world: 'quarantine', reason: 'missing_tenant' });
+  });
+});
+
+describe('envelope stamping (trusted producer)', () => {
+  test('stamping sets both the version and the trusted tenant, preserving other metadata', () => {
+    const stamped = stampTenantEnvelope(meta({ instanceId: 'inst-1', source: 'omni-api' }), TENANT);
+    expect(stamped.envelopeVersion).toBe(CURRENT_ENVELOPE_VERSION);
+    expect(stamped.tenantId).toBe(TENANT);
+    expect(stamped.instanceId).toBe('inst-1');
+    expect(stamped.source).toBe('omni-api');
+  });
+
+  test('a stamped envelope classifies as a tenant-context message — the round trip', () => {
+    const stamped = stampTenantEnvelope(meta(), TENANT);
+    expect(classifyEnvelope(stamped)).toEqual({
+      world: 'tenant',
+      tenantId: TENANT,
+      envelopeVersion: CURRENT_ENVELOPE_VERSION,
+    });
+  });
+
+  test('stamping refuses a non-UUID tenant — a producer cannot stamp a claim it did not derive', () => {
+    expect(() => stampTenantEnvelope(meta(), 'tenant-a')).toThrow();
+  });
+
+  test('stamping does NOT mutate the input metadata', () => {
+    const input = meta({ instanceId: 'inst-1' });
+    stampTenantEnvelope(input, TENANT);
+    expect(input.tenantId).toBeUndefined();
+    expect(input.envelopeVersion).toBeUndefined();
+  });
+});

--- a/packages/core/src/events/__tests__/instance-owner-stamping.test.ts
+++ b/packages/core/src/events/__tests__/instance-owner-stamping.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Producer-side tenant derivation for PLUGIN-ORIGINATED publishes
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * Leg A gave every publish a versioned envelope and wired
+ * `setEnvelopeTenantResolver` to the per-request tenant scope. That covers
+ * request-originated publishes. It does NOT cover the dominant traffic path:
+ * `BaseChannelPlugin.publishEventInternal` emits `message.received`,
+ * `instance.connected`, `reaction.received` and friends from a socket callback
+ * with no request and no scope, so `resolveAmbientTenantId()` returned null and
+ * every such envelope classified `legacy`. The consumers legs A–E converted
+ * therefore never entered the tenant world for real channel traffic.
+ *
+ * ADR-0008 names the derivation: "Publishers derive tenant from authenticated/
+ * loaded resources, never caller claims", and `envelope.ts`'s own subject
+ * rationale already says it — "Instances carry their tenant (G2,
+ * `instances.tenant_id`), so the tenant is derivable at PUBLISH time from the
+ * loaded instance". This seam is that derivation: a resolver the API layer
+ * registers, mapping an instanceId to the tenant its PERSISTED `instances` row
+ * carries. It is not a caller claim and not an ambient inheritance.
+ *
+ * PRECEDENCE, and why it is in this order:
+ *   1. an EXPLICIT `metadata.tenantId` — a worker/consumer republish that
+ *      already derived the tenant from its own loaded resource;
+ *   2. the REQUEST scope — the authenticated caller's tenant, which the edge
+ *      already validated;
+ *   3. the INSTANCE OWNER registry — the plugin/worker case, where neither of
+ *      the above exists.
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+import {
+  CURRENT_ENVELOPE_VERSION,
+  classifyEnvelope,
+  resolveInstanceOwnerTenantId,
+  resolvePublishTenantId,
+  setEnvelopeInstanceTenantResolver,
+  setEnvelopeTenantResolver,
+} from '../envelope';
+
+const TENANT_OWNER = '11111111-1111-4111-8111-111111111ee1';
+const TENANT_REQUEST = '22222222-2222-4222-8222-222222222ee2';
+const TENANT_EXPLICIT = '33333333-3333-4333-8333-333333333ee3';
+const INSTANCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaee1';
+
+describe('producer-side instance-owner tenant derivation', () => {
+  beforeEach(() => {
+    setEnvelopeTenantResolver(null);
+    setEnvelopeInstanceTenantResolver(null);
+  });
+
+  test('with nothing registered, a plugin publish stamps nothing (flag-off is byte-identical)', () => {
+    expect(resolveInstanceOwnerTenantId(INSTANCE)).toBeNull();
+    expect(resolvePublishTenantId(undefined, INSTANCE)).toBeNull();
+  });
+
+  test('a registered owner resolver supplies the tenant for a scope-less plugin publish', () => {
+    setEnvelopeInstanceTenantResolver((instanceId) => (instanceId === INSTANCE ? TENANT_OWNER : null));
+
+    expect(resolveInstanceOwnerTenantId(INSTANCE)).toBe(TENANT_OWNER);
+    expect(resolvePublishTenantId(undefined, INSTANCE)).toBe(TENANT_OWNER);
+
+    // An instance the registry does not know stays legacy rather than borrowing
+    // some other instance's tenant.
+    expect(resolvePublishTenantId(undefined, 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbee9')).toBeNull();
+    // And a publish with no instance at all has nothing to derive from.
+    expect(resolvePublishTenantId(undefined, undefined)).toBeNull();
+  });
+
+  test('an explicit metadata tenant wins over both resolvers', () => {
+    setEnvelopeTenantResolver(() => TENANT_REQUEST);
+    setEnvelopeInstanceTenantResolver(() => TENANT_OWNER);
+
+    expect(resolvePublishTenantId(TENANT_EXPLICIT, INSTANCE)).toBe(TENANT_EXPLICIT);
+  });
+
+  test('the request scope wins over the owner registry', () => {
+    setEnvelopeTenantResolver(() => TENANT_REQUEST);
+    setEnvelopeInstanceTenantResolver(() => TENANT_OWNER);
+
+    expect(resolvePublishTenantId(undefined, INSTANCE)).toBe(TENANT_REQUEST);
+  });
+
+  test('a malformed owner tenant is refused, not stamped', () => {
+    setEnvelopeInstanceTenantResolver(() => 'not-a-uuid');
+    expect(resolveInstanceOwnerTenantId(INSTANCE)).toBeNull();
+    expect(resolvePublishTenantId(undefined, INSTANCE)).toBeNull();
+
+    // An explicit non-UUID claim is likewise refused and falls through — a
+    // producer must never be able to stamp a value a consumer would then trust.
+    setEnvelopeInstanceTenantResolver(() => TENANT_OWNER);
+    expect(resolvePublishTenantId('../../etc/passwd', INSTANCE)).toBe(TENANT_OWNER);
+  });
+
+  test('a throwing resolver degrades to legacy rather than failing the publish', () => {
+    setEnvelopeInstanceTenantResolver(() => {
+      throw new Error('registry exploded');
+    });
+    expect(resolveInstanceOwnerTenantId(INSTANCE)).toBeNull();
+  });
+
+  test('a stamped plugin envelope classifies as `tenant` end-to-end', () => {
+    setEnvelopeInstanceTenantResolver(() => TENANT_OWNER);
+    const tenantId = resolvePublishTenantId(undefined, INSTANCE);
+    expect(tenantId).not.toBeNull();
+
+    const classification = classifyEnvelope({
+      correlationId: 'c',
+      traceId: 't',
+      instanceId: INSTANCE,
+      ...(tenantId ? { envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId } : {}),
+    });
+    expect(classification).toEqual({
+      world: 'tenant',
+      tenantId: TENANT_OWNER,
+      envelopeVersion: CURRENT_ENVELOPE_VERSION,
+    });
+  });
+});

--- a/packages/core/src/events/envelope.ts
+++ b/packages/core/src/events/envelope.ts
@@ -92,7 +92,16 @@ export type EnvelopeClassification =
  * the payload — the trust boundary is that a tenant is derived by the producer,
  * not asserted by whatever data the event carries.
  */
-export function classifyEnvelope(metadata: EventMetadata): EnvelopeClassification {
+export function classifyEnvelope(metadata: EventMetadata | null | undefined): EnvelopeClassification {
+  // An envelope with NO metadata object at all carries no version and no tenant
+  // — which is precisely the definition of `legacy`, not of a corruption. It is
+  // deliberately not quarantined: quarantine is for a versioned envelope whose
+  // tenant is missing/ambiguous, or a tenant claim with no version contract, and
+  // this is neither. Throwing here would let one shapeless message kill a
+  // consumer outright, which is a strictly worse failure than processing it on
+  // the same legacy path it took before G5.
+  if (metadata === null || metadata === undefined) return { world: 'legacy' };
+
   const { envelopeVersion, tenantId } = metadata;
 
   if (envelopeVersion === undefined || envelopeVersion === null) {
@@ -166,4 +175,75 @@ export function resolveAmbientTenantId(): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * The PLUGIN-PRODUCER seam (G5, ADR-0008).
+ *
+ * The resolver above carries a REQUEST-originated tenant. The dominant traffic
+ * path has no request: `BaseChannelPlugin.publishEventInternal` emits
+ * `message.received`, `instance.connected`, `reaction.*` and friends from a
+ * socket callback, so without this seam every real channel event stamps nothing
+ * and classifies `legacy` — and the consumers G5 converted never enter the
+ * tenant world at all.
+ *
+ * ADR-0008 names the derivation for exactly this case: "Publishers derive tenant
+ * from authenticated/LOADED RESOURCES, never caller claims", and this module's
+ * subject rationale above already relies on it — instances carry their tenant
+ * (G2, `instances.tenant_id`), so a publish that names an instance can derive
+ * that instance's PERSISTED owner.
+ *
+ * The API layer registers a resolver backed by an ownership registry populated
+ * from `instances` rows it has already loaded (startup reconnect, instance
+ * create/update, the monitor's per-instance fetch). It is deliberately
+ * SYNCHRONOUS: a publish must not grow a database round trip, and the mapping is
+ * immutable in practice — an instance's tenant is its ownership ROOT and does
+ * not change. Tenant SUSPENSION is not this seam's job; it is enforced at
+ * dequeue and before side effects (`isTenantWorkAdmissible`).
+ *
+ * Flag-off nothing registers, so this returns null and every envelope stays
+ * legacy/byte-identical — the same dual-world shape as the ambient resolver.
+ */
+let instanceOwnerTenantResolver: ((instanceId: string) => string | null | undefined) | null = null;
+
+export function setEnvelopeInstanceTenantResolver(
+  resolver: ((instanceId: string) => string | null | undefined) | null,
+): void {
+  instanceOwnerTenantResolver = resolver;
+}
+
+export function resolveInstanceOwnerTenantId(instanceId: string | undefined | null): string | null {
+  if (!instanceOwnerTenantResolver || !instanceId) return null;
+  try {
+    const tenantId = instanceOwnerTenantResolver(instanceId);
+    return isStampableTenantId(tenantId) ? tenantId : null;
+  } catch {
+    // A broken registry must degrade to `legacy` — never fail the publish, and
+    // never fall through to something less trustworthy.
+    return null;
+  }
+}
+
+/**
+ * The single decision every publisher makes about which tenant to stamp.
+ *
+ * Precedence, most-trusted first:
+ *   1. `explicitTenantId` — a worker/consumer republish that already derived the
+ *      tenant from ITS OWN loaded resource or consumed envelope. A non-UUID
+ *      value is not a claim this function honours; it falls through rather than
+ *      poisoning the envelope.
+ *   2. the REQUEST scope — the authenticated caller's tenant, which the edge
+ *      validated before the handler ran.
+ *   3. the INSTANCE OWNER registry — the plugin/worker case, derived from the
+ *      instance's persisted ownership.
+ *
+ * Returns null when none applies: the envelope then carries neither field and is
+ * `legacy`, exactly as before G5.
+ */
+export function resolvePublishTenantId(
+  explicitTenantId: unknown,
+  instanceId: string | undefined | null,
+): string | null {
+  if (isStampableTenantId(explicitTenantId)) return explicitTenantId;
+  return resolveAmbientTenantId() ?? resolveInstanceOwnerTenantId(instanceId);
 }

--- a/packages/core/src/events/envelope.ts
+++ b/packages/core/src/events/envelope.ts
@@ -1,0 +1,169 @@
+/**
+ * Versioned tenant-aware event envelope (wish: omni-full-multitenancy, Group G5;
+ * ADR-0008, WISH "Async and storage enforcement").
+ *
+ * THE SUBJECT DECISION
+ * --------------------
+ * ADR-0008 permits either a tenant-aware subject strategy OR consumer-validated
+ * envelopes. The live subject layout is `{eventType}.{channelType}.{instanceId}`
+ * (`nats/subjects.ts`), and every subscribe pattern in the system depends on
+ * that three-token hierarchy (`{type}.>`), so folding a tenant token into the
+ * subject would rewrite every producer AND every consumer and break the
+ * instance-keyed routing the platform already relies on. Instances carry their
+ * tenant (G2, `instances.tenant_id`), so the tenant is derivable at PUBLISH time
+ * from the loaded instance and travels in the envelope. G5 therefore takes the
+ * consumer-validated path: the subject is unchanged, and the trusted `tenantId`
+ * rides inside the envelope where a consumer validates it before processing.
+ *
+ * THE DUAL WORLD
+ * --------------
+ * Both new fields are OPTIONAL and additive. A publisher stamps them ONLY when a
+ * tenant context is present (`stampTenantEnvelope`), which only happens once
+ * multitenancy is enabled and a scope/loaded resource supplies the tenant. A
+ * flag-off deployment stamps nothing, so every envelope it produces is
+ * `legacy` and every envelope it consumes classifies as `legacy` and is
+ * processed byte-for-byte as it was before G5. The classification below is the
+ * single place the two worlds diverge, and it diverges only for envelopes that
+ * actually declare a version.
+ *
+ * THE TRUST BOUNDARY
+ * ------------------
+ * `tenantId` is read from the envelope METADATA the producer stamped, never from
+ * the caller-facing payload. A producer stamps it from an authenticated context
+ * or a loaded resource's persisted ownership; a consumer trusts that stamp and
+ * refuses to fall back to any payload-carried tenant claim. `classifyEnvelope`
+ * takes `EventMetadata`, not payload, precisely so a payload field named
+ * `tenantId` can never reach this decision.
+ */
+
+import type { EventMetadata } from './types';
+
+/**
+ * The envelope version this build produces and understands.
+ *
+ * Bump — and add the old value to {@link KNOWN_ENVELOPE_VERSIONS} only if this
+ * build can still process it — when the envelope's tenant-relevant shape
+ * changes. A consumer that meets a version it does not know quarantines rather
+ * than guesses, which is the whole point of carrying the number.
+ */
+export const CURRENT_ENVELOPE_VERSION = 1;
+
+/** Every envelope version THIS build is able to process. */
+export const KNOWN_ENVELOPE_VERSIONS: ReadonlySet<number> = new Set([CURRENT_ENVELOPE_VERSION]);
+
+/**
+ * RFC 4122 shape. A fail-closed guard, not an injection guard: a producer must
+ * not be able to stamp — and a consumer must not accept — a `tenantId` that is
+ * not a well-formed tenant identifier. Mirrors the shape `tenant-transaction.ts`
+ * enforces at the DB boundary, kept local so `@omni/core` does not depend on
+ * `@omni/api`.
+ */
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type EnvelopeQuarantineReason =
+  /** A version marker this build does not recognise. */
+  | 'unknown_version'
+  /** A versioned envelope carrying no tenant at all. */
+  | 'missing_tenant'
+  /** A versioned envelope whose tenant is not a well-formed UUID. */
+  | 'invalid_tenant'
+  /** A tenant claim with no version marker — not legacy (legacy carries none). */
+  | 'malformed_envelope';
+
+/**
+ * The three worlds a consumer must tell apart before it touches an event.
+ *
+ *   * `legacy`     — no version, no tenant: pre-G5 / flag-off. Process as today.
+ *   * `tenant`     — a known version with a valid trusted tenant: establish the
+ *                    worker tenant context from `tenantId` and process.
+ *   * `quarantine` — a version this build cannot honour, or a tenant that is
+ *                    missing/ambiguous/forged: route to quarantine/DLQ + alert,
+ *                    never process. There is NO global-processing fallback.
+ */
+export type EnvelopeClassification =
+  | { readonly world: 'legacy' }
+  | { readonly world: 'tenant'; readonly tenantId: string; readonly envelopeVersion: number }
+  | { readonly world: 'quarantine'; readonly reason: EnvelopeQuarantineReason };
+
+/**
+ * Classify an inbound envelope from its stamped metadata.
+ *
+ * Reads ONLY the producer-stamped `envelopeVersion`/`tenantId`. Never consults
+ * the payload — the trust boundary is that a tenant is derived by the producer,
+ * not asserted by whatever data the event carries.
+ */
+export function classifyEnvelope(metadata: EventMetadata): EnvelopeClassification {
+  const { envelopeVersion, tenantId } = metadata;
+
+  if (envelopeVersion === undefined || envelopeVersion === null) {
+    // A legacy envelope carries NEITHER field. A tenant claim without the
+    // version contract is a corruption/forgery, not a legacy message, so it is
+    // refused rather than processed as-today.
+    if (tenantId !== undefined && tenantId !== null) {
+      return { world: 'quarantine', reason: 'malformed_envelope' };
+    }
+    return { world: 'legacy' };
+  }
+
+  if (typeof envelopeVersion !== 'number' || !KNOWN_ENVELOPE_VERSIONS.has(envelopeVersion)) {
+    return { world: 'quarantine', reason: 'unknown_version' };
+  }
+
+  if (tenantId === undefined || tenantId === null || tenantId === '') {
+    return { world: 'quarantine', reason: 'missing_tenant' };
+  }
+  if (typeof tenantId !== 'string' || !UUID.test(tenantId)) {
+    return { world: 'quarantine', reason: 'invalid_tenant' };
+  }
+
+  return { world: 'tenant', tenantId, envelopeVersion };
+}
+
+/**
+ * Stamp a trusted tenant onto an envelope's metadata (returns a new object;
+ * never mutates the input).
+ *
+ * @throws when `tenantId` is not a well-formed UUID — a producer cannot stamp a
+ *   tenant it could not have derived from a real resource, which is what keeps a
+ *   bogus claim from ever entering the wire.
+ */
+export function stampTenantEnvelope(metadata: EventMetadata, tenantId: string): EventMetadata {
+  if (typeof tenantId !== 'string' || !UUID.test(tenantId)) {
+    throw new Error(`stampTenantEnvelope: refusing to stamp a non-UUID tenant (${String(tenantId)})`);
+  }
+  return { ...metadata, envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId };
+}
+
+/** Whether `tenantId` is a value a producer may stamp / a consumer may trust. */
+export function isStampableTenantId(tenantId: unknown): tenantId is string {
+  return typeof tenantId === 'string' && UUID.test(tenantId);
+}
+
+/**
+ * Injectable seam so `@omni/core`'s publisher can stamp the request's tenant
+ * WITHOUT depending on `@omni/api`, where the per-request tenant scope
+ * (`AsyncLocalStorage`) actually lives. The API layer registers a resolver that
+ * returns `currentTenantScope()?.tenantId`; a flag-off deployment registers
+ * nothing, so publishes stamp nothing and stay legacy/byte-identical.
+ *
+ * This carries a REQUEST-originated tenant to the envelope. It is deliberately
+ * NOT a fallback for worker/consumer publishes — those must pass an explicit
+ * `metadata.tenantId` derived from the loaded resource, never inherit an ambient
+ * one, which is the G4 leg-2 cross-context trap the worker-context module
+ * guards against.
+ */
+let ambientTenantResolver: (() => string | null | undefined) | null = null;
+
+export function setEnvelopeTenantResolver(resolver: (() => string | null | undefined) | null): void {
+  ambientTenantResolver = resolver;
+}
+
+export function resolveAmbientTenantId(): string | null {
+  if (!ambientTenantResolver) return null;
+  try {
+    const tenantId = ambientTenantResolver();
+    return isStampableTenantId(tenantId) ? tenantId : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -4,6 +4,7 @@
 
 export * from './types';
 export * from './bus';
+export * from './envelope';
 export * from './nats';
 export * from './dead-letter';
 export * from './payload-store';

--- a/packages/core/src/events/nats/__tests__/subscription-quarantine.test.ts
+++ b/packages/core/src/events/nats/__tests__/subscription-quarantine.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Consumer envelope validation at the subscription boundary
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * `envelope.test.ts` proves the classification in isolation. This proves the
+ * consume loop ACTS on it: a quarantined envelope is termed and routed to the
+ * quarantine hook WITHOUT ever reaching the handler, while a legacy or
+ * tenant-context envelope reaches the handler exactly as before (the dual-world
+ * byte-identical contract for the legacy case).
+ *
+ * No broker: a fake `JsMsg`/consumer drives one message through, matching the
+ * repo's mock-the-`nats`-client test convention.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ConsumerMessages } from 'nats';
+import { CURRENT_ENVELOPE_VERSION } from '../../envelope';
+import type { OmniEvent } from '../../types';
+import { createSubscription } from '../subscription';
+
+const TENANT = '11111111-1111-4111-8111-11111111111a';
+
+interface Recorded {
+  acked: boolean;
+  termed: boolean;
+  nakDelay: number | null;
+}
+
+function fakeMsg(event: OmniEvent, rec: Recorded, redeliveryCount = 0) {
+  return {
+    data: new TextEncoder().encode(JSON.stringify(event)),
+    headers: undefined,
+    info: { streamSequence: 1, redeliveryCount },
+    ack: () => {
+      rec.acked = true;
+    },
+    term: () => {
+      rec.termed = true;
+    },
+    nak: (delay: number) => {
+      rec.nakDelay = delay;
+    },
+  };
+}
+
+/** A consumer that yields exactly one message then completes. */
+function oneShotConsumer(msg: unknown): AsyncIterable<unknown> & { close: () => Promise<void> } {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield msg;
+    },
+    close: async () => undefined,
+  };
+}
+
+function eventWith(metadata: Partial<OmniEvent['metadata']>): OmniEvent {
+  return {
+    id: crypto.randomUUID(),
+    type: 'message.received',
+    payload: { instanceId: 'inst-1', chatId: 'chat-1' },
+    timestamp: Date.now(),
+    metadata: { correlationId: 'corr-1', ...metadata },
+  } as OmniEvent;
+}
+
+/** Drive one message through a real subscription and collect the outcome. */
+async function drive(
+  event: OmniEvent,
+  redeliveryCount = 0,
+): Promise<{
+  rec: Recorded;
+  handlerCalls: number;
+  quarantined: { reason: string; tenantId: string | undefined } | null;
+}> {
+  const rec: Recorded = { acked: false, termed: false, nakDelay: null };
+  let handlerCalls = 0;
+  let quarantined: { reason: string; tenantId: string | undefined } | null = null;
+
+  createSubscription({
+    pattern: 'message.received.>',
+    consumer: oneShotConsumer(fakeMsg(event, rec, redeliveryCount)) as unknown as ConsumerMessages,
+    handler: async () => {
+      handlerCalls++;
+    },
+    onQuarantine: async (evt, classification) => {
+      quarantined = { reason: classification.reason, tenantId: evt.metadata.tenantId };
+    },
+  });
+
+  // Let the fire-and-forget processing loop settle.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  return { rec, handlerCalls, quarantined };
+}
+
+describe('subscription quarantines bad envelopes before the handler', () => {
+  test('legacy envelope reaches the handler and is acked (byte-identical dual world)', async () => {
+    const { rec, handlerCalls, quarantined } = await drive(eventWith({}));
+    expect(handlerCalls).toBe(1);
+    expect(rec.acked).toBe(true);
+    expect(rec.termed).toBe(false);
+    expect(quarantined).toBeNull();
+  });
+
+  test('tenant-context envelope reaches the handler and is acked', async () => {
+    const { rec, handlerCalls, quarantined } = await drive(
+      eventWith({ envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId: TENANT }),
+    );
+    expect(handlerCalls).toBe(1);
+    expect(rec.acked).toBe(true);
+    expect(quarantined).toBeNull();
+  });
+
+  test('unknown-version envelope is quarantined and termed, never handled', async () => {
+    const { rec, handlerCalls, quarantined } = await drive(eventWith({ envelopeVersion: 999, tenantId: TENANT }));
+    expect(handlerCalls).toBe(0);
+    expect(rec.acked).toBe(false);
+    expect(rec.termed).toBe(true);
+    expect(rec.nakDelay).toBeNull(); // no poison-loop retry
+    expect(quarantined?.reason).toBe('unknown_version');
+  });
+
+  test('versioned envelope with no tenant is quarantined, never handled', async () => {
+    const { rec, handlerCalls, quarantined } = await drive(eventWith({ envelopeVersion: CURRENT_ENVELOPE_VERSION }));
+    expect(handlerCalls).toBe(0);
+    expect(rec.termed).toBe(true);
+    expect(quarantined?.reason).toBe('missing_tenant');
+  });
+});

--- a/packages/core/src/events/nats/client.ts
+++ b/packages/core/src/events/nats/client.ts
@@ -23,6 +23,7 @@ import {
   headers as natsHeaders,
 } from 'nats';
 import { createLogger } from '../../logger';
+import { CURRENT_ENVELOPE_VERSION, isStampableTenantId, resolveAmbientTenantId } from '../envelope';
 
 const log = createLogger('nats');
 
@@ -239,6 +240,14 @@ export class NatsEventBus implements EventBus {
     const eventId = crypto.randomUUID();
     const timestamp = Date.now();
 
+    // Versioned tenant-aware envelope (G5, ADR-0008). An explicit
+    // `metadata.tenantId` (a worker/consumer republish, derived from the loaded
+    // resource) wins; otherwise the request-scope resolver supplies it. When
+    // NEITHER yields a tenant — every flag-off publish, and every publish with
+    // no active tenant context — both fields stay undefined and the envelope is
+    // `legacy`, i.e. byte-identical to pre-G5.
+    const tenantId = isStampableTenantId(metadata?.tenantId) ? metadata.tenantId : resolveAmbientTenantId();
+
     const event: OmniEvent = {
       id: eventId,
       type,
@@ -254,6 +263,7 @@ export class NatsEventBus implements EventBus {
         source: metadata?.source ?? this.config.serviceName,
         ingestMode: metadata?.ingestMode,
         timings: metadata?.timings,
+        ...(tenantId ? { envelopeVersion: CURRENT_ENVELOPE_VERSION, tenantId } : {}),
       },
     };
 
@@ -501,6 +511,25 @@ export class NatsEventBus implements EventBus {
             error: error.message,
             retryCount,
             timestamp: Date.now(),
+          },
+          { source: this.config.serviceName },
+        );
+      },
+      onQuarantine: async (event, classification) => {
+        // Route a quarantined envelope (G5, ADR-0008) to the dead-letter stream
+        // with an explicit quarantine marker + the classification reason. The
+        // trusted tenant (when present) travels in the DLQ payload so a redrive
+        // tool can re-derive context; no payload/secret is copied.
+        await this.publishGeneric(
+          'system.dead_letter',
+          {
+            originalEventId: event.id,
+            originalEventType: event.type,
+            error: `envelope_quarantined:${classification.reason}`,
+            retryCount: 0,
+            timestamp: Date.now(),
+            quarantineReason: classification.reason,
+            tenantId: event.metadata.tenantId,
           },
           { source: this.config.serviceName },
         );

--- a/packages/core/src/events/nats/client.ts
+++ b/packages/core/src/events/nats/client.ts
@@ -23,7 +23,7 @@ import {
   headers as natsHeaders,
 } from 'nats';
 import { createLogger } from '../../logger';
-import { CURRENT_ENVELOPE_VERSION, isStampableTenantId, resolveAmbientTenantId } from '../envelope';
+import { CURRENT_ENVELOPE_VERSION, resolvePublishTenantId } from '../envelope';
 
 const log = createLogger('nats');
 
@@ -240,13 +240,14 @@ export class NatsEventBus implements EventBus {
     const eventId = crypto.randomUUID();
     const timestamp = Date.now();
 
-    // Versioned tenant-aware envelope (G5, ADR-0008). An explicit
-    // `metadata.tenantId` (a worker/consumer republish, derived from the loaded
-    // resource) wins; otherwise the request-scope resolver supplies it. When
-    // NEITHER yields a tenant — every flag-off publish, and every publish with
-    // no active tenant context — both fields stay undefined and the envelope is
-    // `legacy`, i.e. byte-identical to pre-G5.
-    const tenantId = isStampableTenantId(metadata?.tenantId) ? metadata.tenantId : resolveAmbientTenantId();
+    // Versioned tenant-aware envelope (G5, ADR-0008). One decision, three
+    // sources in trust order — explicit republish tenant, then the request
+    // scope, then the named instance's PERSISTED owner (the channel-plugin
+    // producer path, which has neither of the first two). When none yields a
+    // tenant — every flag-off publish, and every publish naming no known
+    // instance — both fields stay undefined and the envelope is `legacy`, i.e.
+    // byte-identical to pre-G5.
+    const tenantId = resolvePublishTenantId(metadata?.tenantId, metadata?.instanceId);
 
     const event: OmniEvent = {
       id: eventId,

--- a/packages/core/src/events/nats/subscription.ts
+++ b/packages/core/src/events/nats/subscription.ts
@@ -12,6 +12,7 @@ import type { ConsumerMessages, JsMsg } from 'nats';
 import type { ZodSchema, z } from 'zod';
 import { createLogger } from '../../logger';
 import type { GenericEventHandler, SubscribeOptions, Subscription } from '../bus';
+import { type EnvelopeClassification, classifyEnvelope } from '../envelope';
 import type { EventType, GenericEventPayload, OmniEvent } from '../types';
 import { DEFAULT_CONSUMER_CONFIG, calculateBackoffDelay } from './consumer';
 import { eventRegistry } from './registry';
@@ -75,6 +76,19 @@ export interface SubscriptionWrapperOptions extends SubscribeOptions {
   handler: GenericEventHandler;
   /** Optional callback when event processing fails permanently */
   onDeadLetter?: (event: OmniEvent, error: Error, retryCount: number) => Promise<void>;
+  /**
+   * Optional callback when an envelope is QUARANTINED by consumer validation
+   * (G5, ADR-0008) — an unknown envelope version or a missing/ambiguous/forged
+   * tenant. Distinct from `onDeadLetter`: a quarantine is a rejection BEFORE
+   * processing (the handler never ran and never will for this envelope), so it
+   * is termed immediately with no retry and no poison-loop. The classification's
+   * `reason` and the envelope's trusted `tenantId` (when present) travel to this
+   * hook so the alert can name both without logging payload secrets.
+   */
+  onQuarantine?: (
+    event: OmniEvent,
+    classification: Extract<EnvelopeClassification, { world: 'quarantine' }>,
+  ) => Promise<void>;
 }
 
 /**
@@ -89,6 +103,7 @@ export function createSubscription(options: SubscriptionWrapperOptions): Subscri
     retryDelayMs = DEFAULT_CONSUMER_CONFIG.retryDelayMs,
     concurrency = 1,
     onDeadLetter,
+    onQuarantine,
   } = options;
 
   const subscriptionId = crypto.randomUUID();
@@ -158,6 +173,36 @@ export function createSubscription(options: SubscriptionWrapperOptions): Subscri
     } catch (parseError) {
       // Can't parse message, terminate it (don't retry)
       log.error('Failed to parse message', { subscriptionId, error: String(parseError) });
+      msg.term();
+      return;
+    }
+
+    // Consumer envelope validation (G5, ADR-0008) — BEFORE any handler runs.
+    //
+    // A quarantined envelope (unknown version, or a missing/ambiguous/forged
+    // tenant) is rejected here: termed with no retry, routed to the quarantine
+    // hook, never handled. There is no global-processing fallback. A `legacy`
+    // envelope (no version marker, no tenant) or a `tenant` envelope proceeds
+    // exactly as before — so a flag-off deployment, which stamps nothing, sees
+    // byte-identical behaviour.
+    const classification = classifyEnvelope(event.metadata);
+    if (classification.world === 'quarantine') {
+      log.error('Envelope quarantined by consumer validation', {
+        subscriptionId,
+        eventType: event.type,
+        eventId: event.id,
+        reason: classification.reason,
+        // Trusted tenant only — never the payload.
+        tenantId: event.metadata.tenantId ?? null,
+      });
+      if (onQuarantine) {
+        try {
+          await onQuarantine(event, classification);
+        } catch (qError) {
+          log.error('Quarantine handler failed', { subscriptionId, error: String(qError) });
+        }
+      }
+      // A bad envelope will not become good on redelivery — term, do not nak.
       msg.term();
       return;
     }

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -181,6 +181,18 @@ export interface EventMetadata {
   timings?: Record<string, number>;
   /** agents.id UUID — set when an agent processes/sends this event */
   agentId?: string;
+  /**
+   * Versioned tenant-aware envelope (G5, ADR-0008). Both fields are stamped
+   * together by `stampTenantEnvelope` ONLY when a tenant context is present;
+   * a flag-off/legacy publish leaves both undefined and behaves byte-for-byte
+   * as before. Consumers classify on these via `classifyEnvelope` — see
+   * `events/envelope.ts`. `tenantId` is a trusted value derived by the producer
+   * from an authenticated context or a loaded resource's persisted ownership,
+   * never a caller/payload claim.
+   */
+  envelopeVersion?: number;
+  /** Trusted tenant this event belongs to; see `envelopeVersion`. */
+  tenantId?: string;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,11 @@ export * from './metrics';
 // ADR-0008). The bounded/redacted metric-label counterpart travels with ./metrics.
 export * from './observability';
 
+// Tenant-bound secret sealing — credential/session-secret encryption with a
+// per-tenant key + tenant-as-AAD binding (G5; ADR-0008;
+// OWNERSHIP_MANIFEST `filesystem_session_state`).
+export * from './secrets';
+
 // Automations
 export * from './automations';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,3 +72,7 @@ export * from './tracing';
 
 // Hooks
 export * from './hooks';
+
+// Tenant-egress broker (ADR-0009). The architecture guard beside it is a
+// dev/test tool and is intentionally NOT re-exported from the package root.
+export * from './egress';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,10 @@ export {
 // Metrics
 export * from './metrics';
 
+// Observability sink — redacted tenant fields for audit logs and traces (G5;
+// ADR-0008). The bounded/redacted metric-label counterpart travels with ./metrics.
+export * from './observability';
+
 // Automations
 export * from './automations';
 

--- a/packages/core/src/metrics/__tests__/tenant-labels.test.ts
+++ b/packages/core/src/metrics/__tests__/tenant-labels.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Bounded/redacted tenant metric label tests
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * The load-bearing probe is the cardinality one: it feeds far more distinct
+ * tenants than the bucket ceiling and proves the number of distinct label
+ * values never exceeds it. That is the "metrics avoid unbounded tenant labels"
+ * guarantee the WISH requires, checked mechanically rather than asserted.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_TENANT_LABEL_BUCKETS,
+  TENANTLESS_LABEL,
+  boundedTenantLabel,
+  configureTenantLabelBuckets,
+  resetTenantLabelConfig,
+  tenantLabelBucketCount,
+} from '../tenant-labels';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function uuidFrom(n: number): string {
+  // Deterministic synthetic UUIDs — no Math.random / Date needed, and the test
+  // stays reproducible run to run.
+  const hex = n.toString(16).padStart(32, '0');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+describe('boundedTenantLabel', () => {
+  afterEach(() => resetTenantLabelConfig());
+
+  test('no tenant context maps to the tenantless label (legacy/flag-off is undistinguished)', () => {
+    expect(boundedTenantLabel(undefined)).toBe(TENANTLESS_LABEL);
+    expect(boundedTenantLabel(null)).toBe(TENANTLESS_LABEL);
+    expect(boundedTenantLabel('')).toBe(TENANTLESS_LABEL);
+  });
+
+  test('the label is never the raw tenant id (no tenant-inventory leak)', () => {
+    const tenantId = uuidFrom(1);
+    const label = boundedTenantLabel(tenantId);
+    expect(label).not.toBe(tenantId);
+    expect(label).not.toContain(tenantId);
+    // Redacted form is a short opaque bucket token, not a UUID.
+    expect(UUID.test(label)).toBe(false);
+    expect(label).toMatch(/^t\d+$/);
+  });
+
+  test('the same tenant is stable; the label survives repeated calls', () => {
+    const tenantId = uuidFrom(42);
+    expect(boundedTenantLabel(tenantId)).toBe(boundedTenantLabel(tenantId));
+  });
+
+  test('CARDINALITY IS BOUNDED: 20k distinct tenants collapse to at most bucketCount labels', () => {
+    const labels = new Set<string>();
+    for (let i = 1; i <= 20_000; i++) labels.add(boundedTenantLabel(uuidFrom(i)));
+    expect(labels.size).toBeLessThanOrEqual(tenantLabelBucketCount());
+    expect(tenantLabelBucketCount()).toBe(DEFAULT_TENANT_LABEL_BUCKETS);
+    // Sanity: with 20k tenants across 128 buckets, essentially every bucket is
+    // used, so the ceiling is a real ceiling and not accidentally slack.
+    expect(labels.size).toBeGreaterThan(DEFAULT_TENANT_LABEL_BUCKETS / 2);
+  });
+
+  test('the ceiling is explicitly controllable and enforced after reconfiguration', () => {
+    configureTenantLabelBuckets(4);
+    expect(tenantLabelBucketCount()).toBe(4);
+    const labels = new Set<string>();
+    for (let i = 1; i <= 5_000; i++) labels.add(boundedTenantLabel(uuidFrom(i)));
+    expect(labels.size).toBeLessThanOrEqual(4);
+  });
+
+  test('a non-positive or non-integer bucket ceiling is rejected', () => {
+    expect(() => configureTenantLabelBuckets(0)).toThrow();
+    expect(() => configureTenantLabelBuckets(-1)).toThrow();
+    expect(() => configureTenantLabelBuckets(2.5)).toThrow();
+  });
+});

--- a/packages/core/src/metrics/__tests__/tenant-metrics-surface.test.ts
+++ b/packages/core/src/metrics/__tests__/tenant-metrics-surface.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tenant metric surface probe
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008; Success Criterion 11).
+ *
+ * Proves the wired tenant-scoped counter is safe on the operator `/metrics`
+ * surface: recording events for thousands of tenants produces a bounded number
+ * of series and leaks no raw tenant identifier into the exposition text.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { getMetricsText, recordTenantEventProcessed, resetMetrics } from '../index';
+import { resetTenantLabelConfig, tenantLabelBucketCount } from '../tenant-labels';
+
+const UUID_IN_TEXT = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
+function uuidFrom(n: number): string {
+  const hex = n.toString(16).padStart(32, '0');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+describe('tenant metric surface', () => {
+  afterEach(async () => {
+    await resetMetrics();
+    resetTenantLabelConfig();
+  });
+
+  test('recording 5k tenants yields bounded series and no raw tenant id in /metrics text', async () => {
+    for (let i = 1; i <= 5_000; i++) {
+      recordTenantEventProcessed(uuidFrom(i), 'message.received', 'success');
+    }
+    const text = await getMetricsText();
+
+    // No raw tenant UUID appears anywhere in the exposition text.
+    expect(UUID_IN_TEXT.test(text)).toBe(false);
+
+    // Distinct tenant_bucket label values are bounded by the configured ceiling.
+    const buckets = new Set<string>();
+    for (const line of text.split('\n')) {
+      const m = line.match(/tenant_bucket="([^"]+)"/);
+      if (m) buckets.add(m[1] as string);
+    }
+    expect(buckets.size).toBeGreaterThan(0);
+    expect(buckets.size).toBeLessThanOrEqual(tenantLabelBucketCount());
+  });
+
+  test('a tenantless recording uses the tenantless bucket, byte-identical to unlabelled legacy work', async () => {
+    recordTenantEventProcessed(undefined, 'message.received', 'success');
+    const text = await getMetricsText();
+    expect(text).toContain('tenant_bucket="none"');
+  });
+});

--- a/packages/core/src/metrics/index.ts
+++ b/packages/core/src/metrics/index.ts
@@ -8,6 +8,11 @@
  */
 
 import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import { boundedTenantLabel } from './tenant-labels';
+
+// Bounded/redacted tenant labels (wish G5; ADR-0008). Re-exported here so the
+// metric label helper travels with the metrics it labels.
+export * from './tenant-labels';
 
 /**
  * Singleton registry for all metrics
@@ -53,6 +58,20 @@ export const eventsProcessed = new Counter({
   name: 'omni_events_processed_total',
   help: 'Total number of events processed',
   labelNames: ['event_type', 'status'] as const,
+  registers: [registry],
+});
+
+/**
+ * Counter for events processed, labelled by a BOUNDED, REDACTED tenant bucket
+ * (wish G5; ADR-0008). The `tenant_bucket` label is never a raw tenant id and
+ * its cardinality is capped by construction — see ./tenant-labels. This is the
+ * tenant-aware sibling of {@link eventsProcessed}; the unlabelled counter is
+ * left untouched so legacy dashboards are byte-identical.
+ */
+export const tenantEventsProcessed = new Counter({
+  name: 'omni_tenant_events_processed_total',
+  help: 'Events processed, labelled by bounded/redacted tenant bucket (never a raw tenant id)',
+  labelNames: ['tenant_bucket', 'event_type', 'status'] as const,
   registers: [registry],
 });
 
@@ -355,11 +374,36 @@ export const openclawCircuitBreakerState = new Gauge({
 // ============================================================================
 
 /**
- * Record event processing
+ * Record event processing.
+ *
+ * When a trusted `tenantId` is supplied (a converted worker/consumer that has
+ * established a tenant context), a bounded/redacted tenant-labelled sample is
+ * ALSO recorded via {@link recordTenantEventProcessed}. Omitting it — every
+ * legacy/flag-off caller — records exactly what it always did, so the unlabelled
+ * series is byte-identical.
  */
-export function recordEventProcessed(eventType: string, status: 'success' | 'failure', durationSeconds: number): void {
+export function recordEventProcessed(
+  eventType: string,
+  status: 'success' | 'failure',
+  durationSeconds: number,
+  tenantId?: string | null,
+): void {
   eventsProcessed.inc({ event_type: eventType, status });
   eventProcessingDuration.observe({ event_type: eventType }, durationSeconds);
+  if (tenantId) recordTenantEventProcessed(tenantId, eventType, status);
+}
+
+/**
+ * Record a tenant-scoped event sample under a bounded, redacted tenant bucket.
+ * `tenantId` may be null/undefined for tenantless work, which lands in the
+ * shared tenantless bucket (see {@link boundedTenantLabel}).
+ */
+export function recordTenantEventProcessed(
+  tenantId: string | null | undefined,
+  eventType: string,
+  status: 'success' | 'failure',
+): void {
+  tenantEventsProcessed.inc({ tenant_bucket: boundedTenantLabel(tenantId), event_type: eventType, status });
 }
 
 /**

--- a/packages/core/src/metrics/tenant-labels.ts
+++ b/packages/core/src/metrics/tenant-labels.ts
@@ -1,0 +1,89 @@
+/**
+ * Bounded, redacted tenant labels for metrics
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008; WISH "Async and storage
+ * enforcement": "metrics avoid unbounded tenant labels unless explicitly
+ * controlled").
+ *
+ * A raw tenant UUID is the wrong value for a Prometheus label, for two
+ * independent reasons:
+ *
+ *   1. Unbounded cardinality. One time series per tenant, retained forever, is
+ *      a metrics-backend DoS as tenants accrue — the exact "unbounded tenant
+ *      labels" the WISH forbids.
+ *   2. Tenant-inventory disclosure. `/metrics` is an operator surface; a raw
+ *      tenant id there enumerates every tenant that has ever been active.
+ *
+ * `boundedTenantLabel` fixes both by construction. It maps a tenant id to one
+ * of a FIXED number of opaque buckets via a non-reversible hash, so:
+ *   - the number of distinct label values can never exceed the bucket count —
+ *     cardinality is bounded regardless of how many tenants exist or the order
+ *     they arrive — and
+ *   - the label is a short hash-derived token, never the tenant id itself, so
+ *     `/metrics` carries no tenant identifier.
+ *
+ * Metrics deliberately do NOT identify individual tenants; that is the job of
+ * audit logs and traces (see ../observability), which carry the full tenant id
+ * and actor credential id under access control. Metrics get bounded, redacted
+ * buckets only.
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * Default number of tenant label buckets. This is the ceiling on distinct
+ * tenant-label cardinality per metric.
+ */
+export const DEFAULT_TENANT_LABEL_BUCKETS = 128;
+
+/**
+ * The label used when no tenant context is present (legacy / flag-off work).
+ * Such work was never labelled per tenant before G5 and still is not — this is
+ * one shared bucket, so behaviour is byte-identical to the unlabelled past.
+ */
+export const TENANTLESS_LABEL = 'none';
+
+let bucketCount = DEFAULT_TENANT_LABEL_BUCKETS;
+
+/**
+ * Configure the number of tenant label buckets — the "explicitly controlled"
+ * knob the WISH allows. An operator picks the cardinality ceiling up front; it
+ * can never be exceeded at runtime. Must be a positive integer.
+ */
+export function configureTenantLabelBuckets(count: number): void {
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`tenant-labels: bucket count must be a positive integer, got ${count}`);
+  }
+  bucketCount = count;
+}
+
+/**
+ * The active bucket ceiling — the maximum distinct *tenant* label cardinality.
+ * Note: the true label cardinality ceiling is `bucketCount + 1` whenever
+ * tenantless `'none'` work is also present, since `TENANTLESS_LABEL` is a
+ * separate value outside the `t<bucket>` space.
+ */
+export function tenantLabelBucketCount(): number {
+  return bucketCount;
+}
+
+/**
+ * Map a tenant id to a bounded, redacted metric label.
+ *
+ * - No tenant → {@link TENANTLESS_LABEL} (legacy/flag-off work is undistinguished).
+ * - A tenant id → `t<bucket>` where `bucket = sha256(tenantId) mod bucketCount`.
+ *   The output alphabet is `t` + digits; there are at most `bucketCount`
+ *   distinct values; the tenant id is not recoverable from it.
+ */
+export function boundedTenantLabel(tenantId: string | null | undefined): string {
+  if (!tenantId) return TENANTLESS_LABEL;
+  const digest = createHash('sha256').update(tenantId).digest();
+  // Read 4 bytes as an unsigned int, mod the bucket ceiling. 4 bytes gives ample
+  // headroom over any sane bucket count and keeps the distribution uniform.
+  const bucket = digest.readUInt32BE(0) % bucketCount;
+  return `t${bucket}`;
+}
+
+/** Reset the bucket configuration to the default. For tests only. */
+export function resetTenantLabelConfig(): void {
+  bucketCount = DEFAULT_TENANT_LABEL_BUCKETS;
+}

--- a/packages/core/src/observability/__tests__/tenant-observability.test.ts
+++ b/packages/core/src/observability/__tests__/tenant-observability.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Redacted tenant audit/trace field tests
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * The load-bearing probe is the redaction one: given an operation whose
+ * surrounding metadata carries secrets, the emitted audit/trace record must
+ * carry the tenant id and the actor credential id and NO secret. That is the
+ * WISH's "audit logs/traces include tenant ID and actor credential ID" plus
+ * "plaintext never appears in ... logs".
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  buildTenantAuditFields,
+  buildTenantAuditRecord,
+  redactSecrets,
+  tenantTraceAttributes,
+} from '../tenant-observability';
+
+const TENANT = '11111111-1111-4111-8111-111111111111';
+const ACTOR = 'cred_01HZY8ABCDEF';
+const REQUEST = 'req_abc123';
+
+describe('buildTenantAuditFields', () => {
+  test('carries the full tenant id and actor credential id (audit surfaces are access-controlled)', () => {
+    const fields = buildTenantAuditFields({ tenantId: TENANT, actorCredentialId: ACTOR, requestId: REQUEST });
+    expect(fields.tenantId).toBe(TENANT);
+    expect(fields.actorCredentialId).toBe(ACTOR);
+    expect(fields.requestId).toBe(REQUEST);
+  });
+
+  test('requestId is optional (not every audit point has an edge request id)', () => {
+    const fields = buildTenantAuditFields({ tenantId: TENANT, actorCredentialId: ACTOR });
+    expect(fields.requestId).toBeUndefined();
+  });
+
+  test('rejects a malformed tenant id — a bad tenant must not reach an audit sink silently', () => {
+    expect(() => buildTenantAuditFields({ tenantId: 'not-a-uuid', actorCredentialId: ACTOR })).toThrow();
+    expect(() => buildTenantAuditFields({ tenantId: '', actorCredentialId: ACTOR })).toThrow();
+  });
+
+  test('rejects an empty actor credential id', () => {
+    expect(() => buildTenantAuditFields({ tenantId: TENANT, actorCredentialId: '' })).toThrow();
+  });
+
+  test('copies only the named identifier fields, so a secret alongside them cannot ride through', () => {
+    const fields = buildTenantAuditFields({
+      tenantId: TENANT,
+      actorCredentialId: ACTOR,
+      // deliberately over-supplied to prove a secret sibling does not pass through
+      apiSecret: 'omni_sk_shouldnotsurvive',
+    } as unknown as Parameters<typeof buildTenantAuditFields>[0]);
+    expect(Object.keys(fields).sort()).toEqual(['actorCredentialId', 'tenantId']);
+    expect(JSON.stringify(fields)).not.toContain('omni_sk_');
+  });
+});
+
+describe('redactSecrets', () => {
+  test('scrubs secret-shaped keys but keeps tenant id, actor credential id, and request id', () => {
+    const scrubbed = redactSecrets({
+      tenantId: TENANT,
+      actorCredentialId: ACTOR,
+      requestId: REQUEST,
+      apiSecret: 'omni_sk_live_deadbeef',
+      authorization: 'Bearer abc.def.ghi',
+      webhookSecret: 's3cr3t',
+      keyHash: 'abcd1234',
+      password: 'hunter2',
+      instanceId: 'inst-9',
+    });
+    // Identifiers survive.
+    expect(scrubbed.tenantId).toBe(TENANT);
+    expect(scrubbed.actorCredentialId).toBe(ACTOR);
+    expect(scrubbed.requestId).toBe(REQUEST);
+    expect(scrubbed.instanceId).toBe('inst-9');
+    // Secrets are gone entirely (not masked-in-place with the value still readable).
+    const serialized = JSON.stringify(scrubbed);
+    expect(serialized).not.toContain('omni_sk_');
+    expect(serialized).not.toContain('Bearer');
+    expect(serialized).not.toContain('s3cr3t');
+    expect(serialized).not.toContain('hunter2');
+    expect(serialized).not.toContain('abcd1234');
+    expect('apiSecret' in scrubbed).toBe(false);
+    expect('password' in scrubbed).toBe(false);
+  });
+
+  test('scrubs a secret-shaped value even under a non-obvious key (omni_sk_ prefix)', () => {
+    const scrubbed = redactSecrets({ note: 'omni_sk_live_leaked', ok: 'plain' });
+    expect(JSON.stringify(scrubbed)).not.toContain('omni_sk_');
+    expect(scrubbed.ok).toBe('plain');
+  });
+
+  test('does not scrub the actor credential id despite the word "credential"', () => {
+    const scrubbed = redactSecrets({ actorCredentialId: ACTOR });
+    expect(scrubbed.actorCredentialId).toBe(ACTOR);
+  });
+
+  test('scrubs the broadened secret-shaped keys (bare token/key, session_key, credentials, jwt, refresh_token)', () => {
+    const scrubbed = redactSecrets({
+      token: 'abc.def.ghi',
+      key: 'some-opaque-key-material',
+      session_key: 'sess-value',
+      credentials: 'user:pass',
+      jwt: 'header.payload.signature',
+      refresh_token: 'rt-value',
+      ok: 'plain',
+    });
+    expect('token' in scrubbed).toBe(false);
+    expect('key' in scrubbed).toBe(false);
+    expect('session_key' in scrubbed).toBe(false);
+    expect('credentials' in scrubbed).toBe(false);
+    expect('jwt' in scrubbed).toBe(false);
+    expect('refresh_token' in scrubbed).toBe(false);
+    expect(scrubbed.ok).toBe('plain');
+  });
+
+  test('scrubs a raw JWT value under an innocuous key (three base64url segments)', () => {
+    const rawJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const scrubbed = redactSecrets({ note: rawJwt, ok: 'plain' });
+    expect('note' in scrubbed).toBe(false);
+    expect(JSON.stringify(scrubbed)).not.toContain('eyJ');
+    expect(scrubbed.ok).toBe('plain');
+  });
+
+  test('scrubs a raw third-party sk- token value under an innocuous key', () => {
+    const scrubbed = redactSecrets({ note: 'sk-proj-9f8e7d6c5b4a3210deadbeef01', ok: 'plain' });
+    expect('note' in scrubbed).toBe(false);
+    expect(JSON.stringify(scrubbed)).not.toContain('sk-proj-');
+    expect(scrubbed.ok).toBe('plain');
+  });
+
+  test('identity fields ALWAYS survive — including UUID-valued ids — despite the broadened denylist', () => {
+    const tenantUuid = '22222222-2222-4222-8222-222222222222';
+    const actorUuid = '33333333-3333-4333-8333-333333333333';
+    const scrubbed = redactSecrets({
+      tenantId: tenantUuid,
+      actorCredentialId: actorUuid,
+      requestId: REQUEST,
+      instanceId: 'inst-9',
+    });
+    expect(scrubbed.tenantId).toBe(tenantUuid);
+    expect(scrubbed.actorCredentialId).toBe(actorUuid);
+    expect(scrubbed.requestId).toBe(REQUEST);
+    expect(scrubbed.instanceId).toBe('inst-9');
+  });
+
+  test('a bare UUID value under a non-identity key is NOT redacted (structured, not secret material)', () => {
+    const scrubbed = redactSecrets({ correlationRef: TENANT });
+    expect(scrubbed.correlationRef).toBe(TENANT);
+  });
+
+  test('still catches omni_sk_ and PEM private-key values under innocuous keys', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n-----END RSA PRIVATE KEY-----';
+    const scrubbed = redactSecrets({ a: 'omni_sk_live_x', b: pem, ok: 'plain' });
+    expect('a' in scrubbed).toBe(false);
+    expect('b' in scrubbed).toBe(false);
+    expect(scrubbed.ok).toBe('plain');
+  });
+});
+
+describe('buildTenantAuditRecord', () => {
+  test('REDACTION PROBE: tenant id + actor credential id present, secrets absent', () => {
+    const record = buildTenantAuditRecord(
+      { tenantId: TENANT, actorCredentialId: ACTOR, requestId: REQUEST },
+      { apiSecret: 'omni_sk_live_x', authorization: 'Bearer y', action: 'agent.dispatch' },
+    );
+    expect(record.tenantId).toBe(TENANT);
+    expect(record.actorCredentialId).toBe(ACTOR);
+    expect(record.requestId).toBe(REQUEST);
+    expect(record.action).toBe('agent.dispatch');
+    const serialized = JSON.stringify(record);
+    expect(serialized).not.toContain('omni_sk_');
+    expect(serialized).not.toContain('Bearer');
+  });
+
+  test('the identity fields win over any same-named key in the extra metadata bag', () => {
+    const record = buildTenantAuditRecord(
+      { tenantId: TENANT, actorCredentialId: ACTOR },
+      // hostile bag trying to spoof the tenant id through the extra-metadata channel
+      { tenantId: '99999999-9999-4999-8999-999999999999' },
+    );
+    expect(record.tenantId).toBe(TENANT);
+  });
+
+  test('a dotted-key identity spoof cannot coexist with the validated identity', () => {
+    const record = buildTenantAuditRecord(
+      { tenantId: TENANT, actorCredentialId: ACTOR, requestId: REQUEST },
+      // hostile bag using OTEL-style dotted identity keys to smuggle a fake tenant
+      {
+        'tenant.id': '99999999-9999-4999-8999-999999999999',
+        'actor.credential_id': 'cred_FAKE',
+        'request.id': 'req_FAKE',
+      },
+    );
+    // The dotted spoof keys are stripped; only the validated camelCase identity remains.
+    expect(record['tenant.id']).toBeUndefined();
+    expect(record['actor.credential_id']).toBeUndefined();
+    expect(record['request.id']).toBeUndefined();
+    expect(record.tenantId).toBe(TENANT);
+    expect(JSON.stringify(record)).not.toContain('99999999-9999-4999-8999-999999999999');
+    expect(JSON.stringify(record)).not.toContain('cred_FAKE');
+  });
+});
+
+describe('tenantTraceAttributes', () => {
+  test('produces OTEL-style attribute keys carrying tenant + actor + request id', () => {
+    const attrs = tenantTraceAttributes(
+      buildTenantAuditFields({ tenantId: TENANT, actorCredentialId: ACTOR, requestId: REQUEST }),
+    );
+    expect(attrs['tenant.id']).toBe(TENANT);
+    expect(attrs['actor.credential_id']).toBe(ACTOR);
+    expect(attrs['request.id']).toBe(REQUEST);
+  });
+
+  test('omits request.id when there is no edge request id', () => {
+    const attrs = tenantTraceAttributes(buildTenantAuditFields({ tenantId: TENANT, actorCredentialId: ACTOR }));
+    expect('request.id' in attrs).toBe(false);
+  });
+});

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Observability sink (wish: omni-full-multitenancy, Group G5; ADR-0008).
+ *
+ * Redacted tenant fields for audit logs and traces. The metric-label counterpart
+ * (bounded/redacted tenant buckets) lives in ../metrics/tenant-labels.
+ */
+
+export * from './tenant-observability';

--- a/packages/core/src/observability/tenant-observability.ts
+++ b/packages/core/src/observability/tenant-observability.ts
@@ -1,0 +1,218 @@
+/**
+ * Redacted tenant fields for audit logs and traces
+ * (wish: omni-full-multitenancy, Group G5; ADR-0008; WISH "Async and storage
+ * enforcement": "Audit logs/traces include tenant ID and actor credential ID"
+ * and "plaintext never appears in ... logs").
+ *
+ * Two guarantees:
+ *
+ *   1. Audit logs and traces DO carry the full tenant id and the actor's
+ *      credential id — unlike metrics (see ../metrics/tenant-labels), which get
+ *      bounded/redacted buckets. Audit surfaces are access-controlled, so the
+ *      real identifiers belong there.
+ *   2. No secret ever rides along. {@link buildTenantAuditFields} copies ONLY
+ *      the three named identifier fields, so a secret sitting in the surrounding
+ *      context cannot leak through it; {@link redactSecrets} is the
+ *      defence-in-depth scrubber for the broader metadata bags that logging
+ *      sometimes attaches.
+ *
+ * External request-id correlation uses the edge `requestId` (Hono
+ * `c.get('requestId')`), never the auth-plane `context.requestId` (the G4 leg-2
+ * cross-tenant-DoS fix): that internal id is per-auth-construction and must not
+ * become an external correlation handle. The edge id is treated strictly as an
+ * opaque correlation label here — it is never used to select a tenant or make
+ * an authorization decision.
+ */
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Identity field names that must ALWAYS survive redaction, checked BEFORE the
+ * secret-key denylist below. The denylist is deliberately broad (it now catches
+ * bare `key`, `token`, `credentials`, …), which would otherwise clip these
+ * required identity fields — notably `actorCredentialId` (contains `credential`)
+ * and any future `key`/`token`-ish identity name. This preserve-list makes
+ * identity win by construction: no matter how the denylist grows, these exact
+ * keys pass through untouched. Matched exactly (case-sensitive canonical names).
+ */
+const PRESERVE_KEYS: ReadonlySet<string> = new Set(['tenantId', 'actorCredentialId', 'requestId', 'instanceId']);
+
+/**
+ * Substrings whose presence in a metadata KEY marks the value a secret. Curated
+ * to fail closed (over-scrubbing a metadata field is safe; under-scrubbing a
+ * secret is not). It is intentionally broad — including bare `key`, `token`,
+ * `credentials`, `jwt` — because a secret can hide under a terse key. The
+ * required identity fields are NOT protected by careful substring exclusion here
+ * (that is brittle as the list grows); they are protected by {@link PRESERVE_KEYS}
+ * which is consulted first. Matched case-insensitively.
+ */
+const SECRET_KEY_SUBSTRINGS: readonly string[] = [
+  'secret',
+  'password',
+  'passwd',
+  'apikey',
+  'api_key',
+  'api-key',
+  'privatekey',
+  'private_key',
+  'private-key',
+  'plaintext',
+  'plain_text',
+  'plain-text',
+  'bearer',
+  'authorization',
+  'auth_token',
+  'authtoken',
+  'access_key',
+  'accesskey',
+  'signing_key',
+  'session_secret',
+  'session_key',
+  'webhook_secret',
+  'keyhash',
+  'key_hash',
+  'cookie',
+  'signature',
+  'token',
+  'refresh_token',
+  'key',
+  'credentials',
+  'jwt',
+];
+
+/**
+ * Value-shaped secret markers. Even under an innocuous key, a value that looks
+ * like a minted platform secret is scrubbed. Kept intentionally narrow so it
+ * only fires on unambiguous secret material.
+ */
+const SECRET_VALUE_PATTERNS: readonly RegExp[] = [/omni_sk_/i, /-----BEGIN [A-Z ]*PRIVATE KEY-----/];
+
+/** JWT shape: three non-empty base64url segments joined by dots (`header.payload.signature`). */
+const JWT_VALUE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+/** The placeholder a scrubbed field is replaced with is: nothing — the key is dropped. */
+function keyIsSecret(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SECRET_KEY_SUBSTRINGS.some((needle) => lower.includes(needle));
+}
+
+/**
+ * High-entropy token heuristic: a long, dense string drawn from a token alphabet
+ * that mixes letters and digits (e.g. a third-party `sk-…`, an opaque bearer or
+ * session token). Deliberately fail-closed. Short, human-readable, or structured
+ * values (UUIDs, dotted actions, URLs with `:`/spaces) do not match.
+ */
+function looksLikeHighEntropyToken(value: string): boolean {
+  if (value.length < 24) return false;
+  // Token alphabet only — reject spaces, ':' (URLs), and other prose punctuation.
+  if (!/^[A-Za-z0-9._~+/=-]+$/.test(value)) return false;
+  return /[A-Za-z]/.test(value) && /[0-9]/.test(value);
+}
+
+function valueLooksSecret(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  // Identity ids are UUIDs (tenantId, actorCredentialId): short and structured —
+  // never secret material. Exempt them so the entropy heuristic cannot clip them.
+  if (UUID.test(value)) return false;
+  if (SECRET_VALUE_PATTERNS.some((re) => re.test(value))) return true;
+  if (JWT_VALUE.test(value)) return true;
+  return looksLikeHighEntropyToken(value);
+}
+
+/**
+ * Return a shallow copy of `metadata` with every secret-shaped entry removed
+ * (dropped, not masked-in-place — a masked value is still a value that a later
+ * formatter can mishandle). An entry is dropped when its key names a secret or
+ * its value looks like minted secret material. {@link PRESERVE_KEYS} identity
+ * fields are always kept, checked before the denylist so identity always wins.
+ */
+export function redactSecrets(metadata: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (PRESERVE_KEYS.has(key)) {
+      out[key] = value;
+      continue;
+    }
+    if (keyIsSecret(key)) continue;
+    if (valueLooksSecret(value)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/** The identity fields every tenant-context audit log / trace carries. */
+export interface TenantAuditFields {
+  /** Full tenant UUID. Audit/trace surfaces are access-controlled, so this is the real id, not a bucket. */
+  readonly tenantId: string;
+  /** The acting credential's id (never its secret/hash). */
+  readonly actorCredentialId: string;
+  /** Edge correlation id (Hono `c.get('requestId')`); optional. */
+  readonly requestId?: string;
+}
+
+export interface TenantAuditFieldsInput {
+  readonly tenantId: string;
+  readonly actorCredentialId: string;
+  readonly requestId?: string;
+}
+
+/**
+ * Assemble the identity fields for a tenant-context audit log or trace.
+ *
+ * Copies ONLY `tenantId`, `actorCredentialId`, and (when present) `requestId`,
+ * so any secret in the caller's surrounding context cannot pass through. Throws
+ * when the tenant id is not a well-formed UUID or the actor credential id is
+ * empty — a malformed identity must never reach an audit sink silently.
+ */
+export function buildTenantAuditFields(input: TenantAuditFieldsInput): TenantAuditFields {
+  if (typeof input.tenantId !== 'string' || !UUID.test(input.tenantId)) {
+    throw new Error('tenant-observability: tenantId must be a well-formed UUID');
+  }
+  if (typeof input.actorCredentialId !== 'string' || input.actorCredentialId.length === 0) {
+    throw new Error('tenant-observability: actorCredentialId must be a non-empty string');
+  }
+  const fields: TenantAuditFields = {
+    tenantId: input.tenantId,
+    actorCredentialId: input.actorCredentialId,
+    ...(input.requestId ? { requestId: input.requestId } : {}),
+  };
+  return fields;
+}
+
+/**
+ * OTEL-style dotted identity keys. A hostile bag can smuggle these past the
+ * camelCase identity merge (they are not secrets and not same-named), leaving a
+ * spoofed `tenant.id` sitting beside the validated `tenantId`. They are stripped
+ * so only the validated identity is ever present in the record.
+ */
+const DOTTED_IDENTITY_KEYS: readonly string[] = ['tenant.id', 'actor.credential_id', 'request.id'];
+
+/**
+ * Build a complete audit/trace record: the validated identity fields merged
+ * over a redacted copy of an optional extra metadata bag. The identity fields
+ * are applied LAST, so a hostile bag cannot spoof `tenantId` (or any identity
+ * field) and no secret in the bag survives the {@link redactSecrets} pass. Any
+ * OTEL-style dotted identity key ({@link DOTTED_IDENTITY_KEYS}) in the bag is
+ * dropped so it cannot coexist with — and be mistaken for — the validated id.
+ */
+export function buildTenantAuditRecord(
+  input: TenantAuditFieldsInput,
+  extraMetadata: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const identity = buildTenantAuditFields(input);
+  const scrubbed = redactSecrets(extraMetadata);
+  for (const dotted of DOTTED_IDENTITY_KEYS) delete scrubbed[dotted];
+  return { ...scrubbed, ...identity };
+}
+
+/**
+ * Render the identity fields as OpenTelemetry-style span attributes. Keys use
+ * the OTEL dotted convention (`tenant.id`, `actor.credential_id`, `request.id`).
+ */
+export function tenantTraceAttributes(fields: TenantAuditFields): Record<string, string> {
+  return {
+    'tenant.id': fields.tenantId,
+    'actor.credential_id': fields.actorCredentialId,
+    ...(fields.requestId ? { 'request.id': fields.requestId } : {}),
+  };
+}

--- a/packages/core/src/secrets/__tests__/tenant-secret-box.test.ts
+++ b/packages/core/src/secrets/__tests__/tenant-secret-box.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tenant-bound secret sealing — the credential/session-secret encryption
+ * contract (wish: omni-full-multitenancy, Group G5; ADR-0008;
+ * OWNERSHIP_MANIFEST `filesystem_session_state`).
+ *
+ * These are the RED-before-implement probes for deliverable (g):
+ *
+ *   * channel/provider/webhook credentials and session secrets are encrypted
+ *     with a TENANT-BOUND context — the tenant id is both the per-tenant key
+ *     salt and the AEAD associated data, so a secret sealed for tenant A CANNOT
+ *     be decrypted under tenant B's context (the manifest's verification target,
+ *     "session state cannot be decrypted/exported under another tenant");
+ *   * plaintext never appears in the serialized sealed form (never in logs,
+ *     caches, migration receipts, or object metadata);
+ *   * DUAL WORLD: with no master key configured (flag-off/legacy) sealing is
+ *     disabled and the wiring layer stores plaintext byte-identically — this
+ *     module simply refuses to seal, it does not silently no-op into plaintext.
+ *
+ * Key material here is a synthetic, repo-local 32-byte constant. Live KMS/Vault
+ * key custody is a NAMED DEFERRAL (see the module header).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  SECRET_BOX_VERSION,
+  TenantSecretError,
+  TenantSecretUnconfiguredError,
+  isSealedSecret,
+  isTenantSecretSealingEnabled,
+  openTenantSecret,
+  openTenantSecretJson,
+  sealTenantSecret,
+  sealTenantSecretJson,
+  setTenantSecretMasterKey,
+} from '../tenant-secret-box';
+
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+// Synthetic, repo-local master key — never a real/production secret.
+const MASTER_KEY = Buffer.alloc(32, 7);
+
+function withKey(): void {
+  setTenantSecretMasterKey(MASTER_KEY);
+}
+
+afterEach(() => {
+  // Reset the module seam so one test's key cannot leak into another.
+  setTenantSecretMasterKey(null);
+});
+
+describe('tenant-secret-box — sealing enablement (dual world)', () => {
+  test('with no master key, sealing is disabled and seal refuses (not a silent plaintext no-op)', () => {
+    setTenantSecretMasterKey(null);
+    expect(isTenantSecretSealingEnabled()).toBe(false);
+    expect(() => sealTenantSecret(TENANT_A, 'the-secret')).toThrow(TenantSecretUnconfiguredError);
+  });
+
+  test('with a master key configured, sealing is enabled', () => {
+    withKey();
+    expect(isTenantSecretSealingEnabled()).toBe(true);
+  });
+});
+
+describe('tenant-secret-box — round trip within a tenant', () => {
+  test('seal then open under the SAME tenant recovers the plaintext', () => {
+    withKey();
+    const sealed = sealTenantSecret(TENANT_A, 'baileys-session-creds');
+    expect(isSealedSecret(sealed)).toBe(true);
+    expect(sealed.v).toBe(SECRET_BOX_VERSION);
+    expect(openTenantSecret(TENANT_A, sealed)).toBe('baileys-session-creds');
+  });
+
+  test('JSON helper round-trips an object credential blob', () => {
+    withKey();
+    const creds = { apiKey: 'sk-live-xyz', refreshToken: 'rt-abc', nested: { n: 1 } };
+    const sealed = sealTenantSecretJson(TENANT_A, creds);
+    expect(openTenantSecretJson(TENANT_A, sealed)).toEqual(creds);
+  });
+
+  test('two seals of the same plaintext differ (fresh nonce — no deterministic leak)', () => {
+    withKey();
+    const a = sealTenantSecret(TENANT_A, 'same');
+    const b = sealTenantSecret(TENANT_A, 'same');
+    expect(a.ct).not.toBe(b.ct);
+    expect(a.iv).not.toBe(b.iv);
+  });
+});
+
+describe('tenant-secret-box — cross-tenant refusal (the manifest verification target)', () => {
+  test('a secret sealed for tenant A cannot be opened under tenant B', () => {
+    withKey();
+    const sealed = sealTenantSecret(TENANT_A, 'tenant-a-only');
+    expect(() => openTenantSecret(TENANT_B, sealed)).toThrow(TenantSecretError);
+  });
+
+  test('rewriting the tenant tag to the attacker tenant still fails (crypto binds, not just the label)', () => {
+    withKey();
+    const sealed = sealTenantSecret(TENANT_A, 'tenant-a-only');
+    // Forge the stored tenant label to tenant B and try to open as B: the
+    // per-tenant DEK and AAD are both derived from B, so decryption fails.
+    const forged = { ...sealed, t: TENANT_B };
+    expect(() => openTenantSecret(TENANT_B, forged)).toThrow(TenantSecretError);
+  });
+
+  test('a tampered ciphertext is rejected (AEAD integrity)', () => {
+    withKey();
+    const sealed = sealTenantSecret(TENANT_A, 'tenant-a-only');
+    const tampered = { ...sealed, ct: Buffer.from('deadbeef', 'utf8').toString('base64') };
+    expect(() => openTenantSecret(TENANT_A, tampered)).toThrow(TenantSecretError);
+  });
+});
+
+describe('tenant-secret-box — non-exportable / no plaintext leak', () => {
+  test('the serialized sealed form contains no plaintext substring', () => {
+    withKey();
+    const secret = 'super-secret-refresh-token';
+    const sealed = sealTenantSecret(TENANT_A, secret);
+    expect(JSON.stringify(sealed)).not.toContain(secret);
+  });
+
+  test('isSealedSecret discriminates a sealed envelope from a legacy plaintext object', () => {
+    withKey();
+    const sealed = sealTenantSecret(TENANT_A, 's');
+    expect(isSealedSecret(sealed)).toBe(true);
+    expect(isSealedSecret({ sessionId: 'legacy-plaintext' })).toBe(false);
+    expect(isSealedSecret(null)).toBe(false);
+    expect(isSealedSecret('a-string')).toBe(false);
+  });
+});
+
+describe('tenant-secret-box — fail-closed input validation', () => {
+  test('seal refuses a non-UUID tenant', () => {
+    withKey();
+    expect(() => sealTenantSecret('not-a-uuid', 's')).toThrow(TenantSecretError);
+  });
+
+  test('open refuses a non-sealed value', () => {
+    withKey();
+    expect(() => openTenantSecret(TENANT_A, { sessionId: 'legacy' } as any)).toThrow(TenantSecretError);
+  });
+
+  test('open without a configured key throws Unconfigured', () => {
+    withKey();
+    const sealed = sealTenantSecret(TENANT_A, 's');
+    setTenantSecretMasterKey(null);
+    expect(() => openTenantSecret(TENANT_A, sealed)).toThrow(TenantSecretUnconfiguredError);
+  });
+});

--- a/packages/core/src/secrets/index.ts
+++ b/packages/core/src/secrets/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Tenant-bound secret sealing (G5; ADR-0008). Credential/session-secret
+ * encryption with a per-tenant key + tenant-as-AAD binding.
+ */
+
+export * from './tenant-secret-box';

--- a/packages/core/src/secrets/tenant-secret-box.ts
+++ b/packages/core/src/secrets/tenant-secret-box.ts
@@ -1,0 +1,241 @@
+/**
+ * Tenant-bound secret sealing (wish: omni-full-multitenancy, Group G5;
+ * ADR-0008; WISH "Async and storage enforcement";
+ * OWNERSHIP_MANIFEST `filesystem_session_state`).
+ *
+ * WHAT THIS IS
+ * ------------
+ * Channel/provider/webhook credentials and session secrets are "tenant-owned
+ * secret material" (OWNERSHIP_MANIFEST line 427). ADR-0008 and the WISH require
+ * them to be "non-exportable by default and encrypted with tenant-bound context
+ * (for example per-tenant DEKs or tenant ID as authenticated encryption
+ * context); plaintext never appears in API responses, logs, caches, migration
+ * receipts, or object metadata." This module is that primitive: it seals a
+ * secret so it can ONLY be opened again inside the SAME tenant's context.
+ *
+ * HOW THE TENANT BINDING WORKS (two independent layers)
+ * -----------------------------------------------------
+ *   1. **Per-tenant DEK.** The data-encryption key is `HKDF-SHA256(masterKey,
+ *      salt = tenantId, info = DEK_INFO)`. A different tenant derives a
+ *      different key, so it cannot even produce the right keystream.
+ *   2. **Tenant as AEAD associated data.** The tenant id is also the AES-256-GCM
+ *      associated data. Even if two tenants somehow shared a key, GCM
+ *      authentication fails when the AAD (tenant) does not match what was sealed.
+ *
+ * Opening ALWAYS derives the key and AAD from the CALLER-SUPPLIED tenant, never
+ * from the label stored in the envelope — so an attacker who rewrites the stored
+ * `t` label still cannot open a foreign secret (proved in the test). This is the
+ * manifest's verification target: "session state cannot be decrypted/exported
+ * under another tenant context."
+ *
+ * DUAL WORLD
+ * ----------
+ * Sealing is active ONLY when a master key is configured (`setTenantSecretMaster
+ * Key`). A flag-off / legacy deployment configures no key, so
+ * `isTenantSecretSealingEnabled()` is false and callers store plaintext exactly
+ * as before — byte-identical. This module never silently degrades to plaintext:
+ * `sealTenantSecret` THROWS when unconfigured, so a caller must make the
+ * dual-world choice explicitly (check `isTenantSecretSealingEnabled()` first).
+ *
+ * KEY CUSTODY — NAMED DEFERRAL
+ * ----------------------------
+ * The master key is injected through a module seam (mirroring
+ * `setEnvelopeTenantResolver`). Repo-local/synthetic key material only. Live
+ * KMS/Vault grant custody, rotation, and per-tenant DEK escrow are OUT OF SCOPE
+ * for G5 (deployment/G8A + G9 credential-custody scope) and are recorded as an
+ * explicit deferral in the G5 handoff — never implemented against a live secret
+ * store here.
+ */
+
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from 'node:crypto';
+
+/** The sealed-envelope format version. Bump when the sealed shape changes. */
+export const SECRET_BOX_VERSION = 1;
+
+/** Node cipher id for AES-256-GCM. */
+const CIPHER = 'aes-256-gcm';
+/** GCM standard nonce length. */
+const IV_BYTES = 12;
+/** Derived data-encryption-key length (AES-256). */
+const DEK_BYTES = 32;
+/** HKDF context string — domain-separates this DEK from any other use of the key. */
+const DEK_INFO = 'omni-tenant-secret-box:v1:dek';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * A sealed secret. Every field is ciphertext or public metadata — there is no
+ * plaintext here, so it is safe to persist in a JSON column, log, or receipt.
+ *
+ *   * `t`   — the tenant this was sealed for. A convenience label and an early
+ *             fail-closed check; NOT the source of truth for decryption (the
+ *             caller-supplied tenant is).
+ *   * `iv`  — base64 GCM nonce.
+ *   * `ct`  — base64 ciphertext.
+ *   * `tag` — base64 GCM authentication tag.
+ */
+export interface SealedSecret {
+  readonly v: number;
+  readonly alg: 'A256GCM';
+  readonly kdf: 'HKDF-SHA256';
+  readonly t: string;
+  readonly iv: string;
+  readonly ct: string;
+  readonly tag: string;
+}
+
+/** A tenant-binding / integrity / validation failure. Fail-closed by default. */
+export class TenantSecretError extends Error {
+  readonly code = 'tenant_secret_denied';
+  constructor(reason: string) {
+    super(`tenant-secret-box: ${reason}`);
+    this.name = 'TenantSecretError';
+  }
+}
+
+/** Raised when sealing/opening is attempted with no master key configured. */
+export class TenantSecretUnconfiguredError extends Error {
+  readonly code = 'tenant_secret_unconfigured';
+  constructor() {
+    super('tenant-secret-box: no master key configured (sealing disabled)');
+    this.name = 'TenantSecretUnconfiguredError';
+  }
+}
+
+/**
+ * The injected master key. `null` means sealing is disabled (dual-world
+ * flag-off). Mirrors `setEnvelopeTenantResolver`: the API layer wires a
+ * repo-local/synthetic key when multitenancy secret-sealing is enabled; a
+ * flag-off deployment wires nothing.
+ */
+let masterKey: Buffer | null = null;
+
+/**
+ * Configure (or clear) the master key. Pass a >= 32-byte key. Passing `null`
+ * disables sealing (flag-off / test teardown).
+ *
+ * @throws TenantSecretError if the key is shorter than 32 bytes — a short key
+ *   would silently weaken every derived DEK.
+ */
+export function setTenantSecretMasterKey(key: Buffer | Uint8Array | null): void {
+  if (key === null) {
+    masterKey = null;
+    return;
+  }
+  if (key.length < DEK_BYTES) {
+    throw new TenantSecretError(`master key must be at least ${DEK_BYTES} bytes`);
+  }
+  masterKey = Buffer.from(key);
+}
+
+/** Whether a master key is configured (i.e. sealing is active). */
+export function isTenantSecretSealingEnabled(): boolean {
+  return masterKey !== null;
+}
+
+function requireKey(): Buffer {
+  if (masterKey === null) throw new TenantSecretUnconfiguredError();
+  return masterKey;
+}
+
+function requireTenant(tenantId: string): void {
+  if (typeof tenantId !== 'string' || !UUID.test(tenantId)) {
+    throw new TenantSecretError(`refusing a non-UUID tenant (${String(tenantId)})`);
+  }
+}
+
+/** Per-tenant DEK: HKDF-SHA256(masterKey, salt = tenantId, info = DEK_INFO). */
+function deriveDek(key: Buffer, tenantId: string): Buffer {
+  const derived = hkdfSync('sha256', key, Buffer.from(tenantId, 'utf8'), Buffer.from(DEK_INFO, 'utf8'), DEK_BYTES);
+  return Buffer.from(derived);
+}
+
+/**
+ * Seal a plaintext secret for exactly one tenant.
+ *
+ * @throws TenantSecretUnconfiguredError when no master key is configured — the
+ *   caller must decide the dual-world path (check `isTenantSecretSealingEnabled`).
+ * @throws TenantSecretError when `tenantId` is not a well-formed UUID.
+ */
+export function sealTenantSecret(tenantId: string, plaintext: string): SealedSecret {
+  const key = requireKey();
+  requireTenant(tenantId);
+  const dek = deriveDek(key, tenantId);
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(CIPHER, dek, iv);
+  cipher.setAAD(Buffer.from(tenantId, 'utf8'));
+  const ct = Buffer.concat([cipher.update(Buffer.from(plaintext, 'utf8')), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    v: SECRET_BOX_VERSION,
+    alg: 'A256GCM',
+    kdf: 'HKDF-SHA256',
+    t: tenantId,
+    iv: iv.toString('base64'),
+    ct: ct.toString('base64'),
+    tag: tag.toString('base64'),
+  };
+}
+
+/**
+ * Open a sealed secret under a tenant context. The key AND the AAD are derived
+ * from the CALLER-supplied `tenantId`, so a foreign tenant cannot open it.
+ *
+ * @throws TenantSecretUnconfiguredError when no master key is configured.
+ * @throws TenantSecretError when the value is not a sealed envelope, the stored
+ *   tenant label mismatches, or AEAD authentication fails (wrong tenant,
+ *   tampering, or an unknown format version).
+ */
+export function openTenantSecret(tenantId: string, sealed: SealedSecret): string {
+  const key = requireKey();
+  requireTenant(tenantId);
+  if (!isSealedSecret(sealed)) {
+    throw new TenantSecretError('value is not a sealed secret');
+  }
+  if (sealed.v !== SECRET_BOX_VERSION) {
+    throw new TenantSecretError(`unknown sealed-secret version (${String(sealed.v)})`);
+  }
+  // Cheap early fail-closed layer: the stored label must match the opening
+  // tenant. The crypto below is the real guarantee, but this gives a clear error
+  // and refuses even before touching the key.
+  if (sealed.t !== tenantId) {
+    throw new TenantSecretError('tenant mismatch');
+  }
+  const dek = deriveDek(key, tenantId);
+  try {
+    const decipher = createDecipheriv(CIPHER, dek, Buffer.from(sealed.iv, 'base64'));
+    decipher.setAAD(Buffer.from(tenantId, 'utf8'));
+    decipher.setAuthTag(Buffer.from(sealed.tag, 'base64'));
+    const pt = Buffer.concat([decipher.update(Buffer.from(sealed.ct, 'base64')), decipher.final()]);
+    return pt.toString('utf8');
+  } catch {
+    // GCM authentication failure — wrong tenant, tampered ciphertext/tag, or a
+    // corrupt envelope. Never surface the underlying crypto error verbatim.
+    throw new TenantSecretError('authentication failed (wrong tenant or tampered secret)');
+  }
+}
+
+/** Seal a JSON-serializable credential blob (e.g. a session/creds object). */
+export function sealTenantSecretJson(tenantId: string, value: unknown): SealedSecret {
+  return sealTenantSecret(tenantId, JSON.stringify(value));
+}
+
+/** Open a sealed JSON credential blob back to its value. */
+export function openTenantSecretJson(tenantId: string, sealed: SealedSecret): unknown {
+  return JSON.parse(openTenantSecret(tenantId, sealed));
+}
+
+/** Structural guard: is `value` a sealed envelope (vs a legacy plaintext blob)? */
+export function isSealedSecret(value: unknown): value is SealedSecret {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  return (
+    typeof s.v === 'number' &&
+    s.alg === 'A256GCM' &&
+    s.kdf === 'HKDF-SHA256' &&
+    typeof s.t === 'string' &&
+    typeof s.iv === 'string' &&
+    typeof s.ct === 'string' &&
+    typeof s.tag === 'string'
+  );
+}

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -218,9 +218,12 @@ describe('db-access guard', () => {
       // (`inSyncWorkerScope`) were brought inside a scope too. Paths that POLL
       // for another consumer's commit scope each ATTEMPT separately — a single
       // spanning transaction could never see the row it waits for.
-      // `chats.ts::chats`, `instances.ts::instances` and
-      // `persons.ts::platform_identities` keep their own pending entries; the
-      // other sites in these three files are converted.
+      // `instances.ts::instances` and `persons.ts::platform_identities` keep
+      // their own pending entries; the other sites in these three files are
+      // converted. `chats.ts::chats` joined the converted set in leg I (run13)
+      // when the automation-engine callbacks — its last unscoped caller —
+      // moved to `plugins/automation-actions.ts` and began scoping their
+      // resolution reads from the engine-threaded envelope tenant.
       'packages/api/src/services/chats.ts',
       'packages/api/src/services/messages.ts',
       'packages/api/src/services/persons.ts',

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -140,6 +140,10 @@ describe('db-access guard', () => {
       // any DB work. Its only callers are those consumers, so every caller is
       // now scoped.
       'packages/api/src/plugins/event-persistence.ts',
+      // G5 leg B: the media-processor consumer threads its versioned envelope
+      // into `processMessageMedia`, whose DB blocks run through
+      // `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers.
+      'packages/api/src/plugins/media-processor.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -149,6 +149,22 @@ describe('db-access guard', () => {
       // `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers, and
       // both tables derive tenant from the `instances` root.
       'packages/api/src/plugins/sync-worker.ts',
+      // G5 leg B pt3: the connection/LID/contact-names/unread listeners scope
+      // each discrete (per-item, for the batch loops) DB block through
+      // `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers;
+      // the one cross-tenant access (the connection gauge) was split into
+      // `connection-gauge.ts`, which stays pending under its own entry.
+      'packages/api/src/plugins/event-listeners.ts',
+      // G5 leg C2: the dispatcher's per-thread markers, handoff audit insert,
+      // and self-send enumeration (tenant-keyed cache) run through
+      // `runDispatchDb` → worker scope + `scopedHandle`, keyed by the
+      // envelope-derived DispatchMetadata tenant. Its `agents` site alone
+      // stays pending (G6 persons backfill + session-cleaner caller).
+      'packages/api/src/plugins/agent-dispatcher.ts',
+      // G5 leg C2: `resolve()` scopes its `agent_routes` read from the
+      // threaded envelope tenant and tenant-keys its LRU cache. Its only
+      // callers are the dispatcher consumer paths above.
+      'packages/api/src/services/route-resolver.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -207,6 +207,23 @@ describe('db-access guard', () => {
       // fan-out, the `sync.started` consumer, the history-push tracker, and the
       // post-reconnect backfill.
       'packages/api/src/services/sync-jobs.ts',
+      // G5 leg H (the read-path leg): the `chats`/`messages`/`persons` services
+      // were already scope-aware (the `private get db()` -> `scopedHandle`
+      // getter, G4); what changed is that their LAST unscoped callers were
+      // converted. `message-persistence.ts` — the dominant inbound consumer —
+      // now wraps its five handlers in `runConsumerInTenantContext` and gives
+      // every fire-and-forget write it spawns its own `runTenantWorkDb` scope;
+      // the READ helpers of `agent-dispatcher.ts` (`runDispatchDb`),
+      // `media-processor.ts` (`runMediaDb`) and `sync-worker.ts`
+      // (`inSyncWorkerScope`) were brought inside a scope too. Paths that POLL
+      // for another consumer's commit scope each ATTEMPT separately — a single
+      // spanning transaction could never see the row it waits for.
+      // `chats.ts::chats`, `instances.ts::instances` and
+      // `persons.ts::platform_identities` keep their own pending entries; the
+      // other sites in these three files are converted.
+      'packages/api/src/services/chats.ts',
+      'packages/api/src/services/messages.ts',
+      'packages/api/src/services/persons.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -186,6 +186,27 @@ describe('db-access guard', () => {
       // the URL. Split out of `index.ts` precisely so it could NOT inherit that
       // file's `control-plane` startup exemption.
       'packages/api/src/ws/voice-instance-ownership.ts',
+      // G5 leg G: `getInstanceWithProvider` — the lookup every dispatch path
+      // starts from, with zero HTTP callers — reads through `scopedHandle`, and
+      // its consumer callers (session-cleaner's `runTenantWorkDb`, the four
+      // agent-dispatcher `runDispatchDb` sites) each open a short worker scope
+      // from the envelope's trusted tenant.
+      'packages/api/src/services/agent-runner.ts',
+      // G5 leg G: the cleanup path's participant read runs through
+      // `scopedHandle` inside the world its callers already threaded.
+      // `chat_participants` roots at `instances` via its REQUIRED `chat_id`, so
+      // it does not wait on the G6 `persons` backfill.
+      'packages/api/src/plugins/session-cleaner.ts',
+      // G5 leg G (deliverable (g)): every discrete `agent_sessions` block runs
+      // in a worker scope for the tenant the store's resolver returns, which the
+      // dispatcher supplies from the LOADED instance's persisted `tenantId`.
+      'packages/api/src/plugins/session-storage.ts',
+      // G5 leg G: `SyncJobService` takes a THREADED trusted tenant per discrete
+      // DB block (threaded, not caller-wrapped, because every mutation also
+      // publishes). All four worker callers thread it: the per-tenant cron
+      // fan-out, the `sync.started` consumer, the history-push tracker, and the
+      // post-reconnect backfill.
+      'packages/api/src/services/sync-jobs.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -144,6 +144,11 @@ describe('db-access guard', () => {
       // into `processMessageMedia`, whose DB blocks run through
       // `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers.
       'packages/api/src/plugins/media-processor.ts',
+      // G5 leg B pt2: the sync-worker `sync.started` consumer scopes each discrete
+      // per-item DB block (anchor read, group/guild upsert) through
+      // `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers, and
+      // both tables derive tenant from the `instances` root.
+      'packages/api/src/plugins/sync-worker.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -178,6 +178,14 @@ describe('db-access guard', () => {
       // detaching and scopes each `omni_events` batch read, revalidating tenant
       // admissibility at dequeue and before each durable side-effect batch.
       'packages/api/src/services/event-ops.ts',
+      // G5 leg F (deliverable (e)): the voice WebSocket upgrade's ownership
+      // read. It runs in `Bun.serve`'s raw `fetch`, before Hono, so it has no
+      // request scope; it opens its OWN worker scope for the CREDENTIAL's tenant
+      // and reads `instances` through `scopedHandle`. Its only caller is that
+      // upgrade path, which derives the tenant from the auth plane — never from
+      // the URL. Split out of `index.ts` precisely so it could NOT inherit that
+      // file's `control-plane` startup exemption.
+      'packages/api/src/ws/voice-instance-ownership.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -113,12 +113,13 @@ describe('db-access guard', () => {
     }
   });
 
-  test('tenant-boundary is the G3 boundary modules plus the services G4 fully converted', () => {
+  test('tenant-boundary is the G3 boundary modules plus the services G4/G5 fully converted', () => {
     // G3 could only claim this class for `tenancy/` itself. G4 converts service
     // files, so the assertion widens — but only to services whose EVERY caller
     // carries a request context. A service with a consumer or cron caller stays
     // in a pending class, which is what keeps this from becoming "anything that
-    // has been edited".
+    // has been edited". G5 widens it once more, to CONSUMER files whose worker
+    // callers now establish a tenant scope from the versioned envelope.
     const boundary = REGISTERED_DB_ACCESS.filter((e) => e.class === 'tenant-boundary');
     expect(boundary.length).toBeGreaterThan(0);
     const converted = new Set([
@@ -134,6 +135,11 @@ describe('db-access guard', () => {
       // `c.get('db')` to the request transaction.
       'packages/api/src/routes/v2/handoffs.ts',
       'packages/api/src/routes/v2/messages.ts',
+      // G5 leg A: consumer-only plugin whose NATS handlers now open a worker
+      // tenant scope from the envelope (tenancy/worker-tenant-context.ts) before
+      // any DB work. Its only callers are those consumers, so every caller is
+      // now scoped.
+      'packages/api/src/plugins/event-persistence.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -269,6 +269,33 @@ describe('db-access guard', () => {
       'packages/api/src/services/chats.ts',
       'packages/api/src/services/messages.ts',
       'packages/api/src/services/persons.ts',
+      // G5 run15: the periodic instance sweeps. The 30s health check and the
+      // once-per-boot `reconnectWithPool` fan out with `runForEachActiveTenantRow`
+      // (only the `listActive` READ is scoped; every plugin `getStatus`/`connect`
+      // runs outside it), and the single-row `fetchInstanceById` /
+      // `markInstanceInactive` paths derive their tenant from the instance-owner
+      // registry. Its only callers are its own timers and `index.ts`.
+      'packages/api/src/plugins/instance-monitor.ts',
+      // G5 run15: the batch executor was already fully scoped from the job's
+      // captured trusted tenant; `resumeJobs` — the restart-recovery whole-table
+      // scan, and the file's LAST unscoped caller — now fans out per active
+      // tenant and dispatches each job under its OWN persisted `tenant_id`.
+      'packages/api/src/services/batch-jobs.ts',
+      // G5 run15: both fire-and-forget `event-listeners` callers
+      // (`onInstanceConnect`, `updateLastSeenAt`) run detached and thread
+      // `trustedEnvelopeTenant(event)`; each DB block (instance read, message
+      // PAGE, `lastSeenAt` write) opens its own short scope so no worker
+      // transaction spans a `message.received` republish.
+      'packages/api/src/services/agent-replay.ts',
+      // G5 run15: `updateMessageLocalPath` is this file's only `messages` access
+      // and its last unscoped caller (`media-processor.downloadMediaFromUrl`) now
+      // wraps it in `runMediaDb`, keeping the network download outside the scope.
+      'packages/api/src/services/media-storage.ts',
+      // G5 run15: `access.ts` appears here for its `instances` access ONLY — the
+      // `approvePairingRequest` channel lookup, whose single caller is
+      // `routes/v2/instances.ts` inside the request transaction. Its sibling
+      // `access_rules` site keeps its own pending entry (held by `trpc/router.ts`).
+      'packages/api/src/services/access.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -165,6 +165,19 @@ describe('db-access guard', () => {
       // threaded envelope tenant and tenant-keys its LRU cache. Its only
       // callers are the dispatcher consumer paths above.
       'packages/api/src/services/route-resolver.ts',
+      // G5 leg E: the follow-up lifecycle scopes every discrete DB block from a
+      // caller-threaded trusted tenant (hooks/sweeper/dispatcher/session-cleaner/
+      // automation-gate/routes all establish it), publishing between blocks. Its
+      // `agents` site alone stays pending (G6 persons backfill).
+      'packages/api/src/services/follow-up-lifecycle.ts',
+      // G5 leg E: the sweeper cron enumerates active tenants on the auth-plane
+      // connection and runs per-tenant scoped passes (plus a transitional
+      // NULL-tenant pass skipped under enforcement).
+      'packages/api/src/services/follow-up-sweeper.ts',
+      // G5 leg E: the event-replay executor captures its trusted tenant before
+      // detaching and scopes each `omni_events` batch read, revalidating tenant
+      // admissibility at dequeue and before each durable side-effect batch.
+      'packages/api/src/services/event-ops.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -21,6 +21,7 @@ import {
   evaluateDbAccessGuard,
   scanDbAccessSites,
 } from './tenancy-db-access-guard';
+import { TENANT_OWNERSHIP_SPECS } from './tenancy-ownership';
 import { RLS_EXCLUSIONS, RLS_TENANT_TABLES } from './tenancy-rls';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -111,6 +112,47 @@ describe('db-access guard', () => {
       );
       expect(entry.justification).toContain('ADR-0008');
     }
+  });
+
+  test('a pending site whose table cannot carry a tenant before G6 says so', () => {
+    // WHY THIS EXISTS. "Convertible" and "gated" are different kinds of pending,
+    // and only the registry text distinguishes them. A site on a table whose
+    // derivation chain bottoms out in a G2-`unowned` root is stamped NULL by its
+    // trigger, so a scoped read finds NOTHING and a scoped insert fails the
+    // RLS `WITH CHECK` — converting it would ratchet the ceiling down on a
+    // conversion that cannot exist until the G6 backfill. The four `agents`
+    // sites are held on exactly that reasoning; this test is what keeps the
+    // reasoning from being applied unevenly (`turns` derives from `agent_id`,
+    // NOT NULL, so it inherits the same gate).
+    //
+    // The walk mirrors the trigger, not the spec's `required` flag: a derived
+    // table is gated when it has no resolvable parent at all, when EVERY parent
+    // is gated, or when any REQUIRED parent is gated (the trigger nulls the row
+    // as soon as one non-null parent has a null tenant).
+    const specs = new Map(TENANT_OWNERSHIP_SPECS.map((spec) => [spec.table, spec]));
+    const gated = (table: string, seen: Set<string> = new Set()): boolean => {
+      const spec = specs.get(table);
+      if (!spec || seen.has(table)) return false;
+      seen.add(table);
+      if (spec.derivation === 'unowned') return true;
+      if (spec.derivation === 'root') return false;
+      if (spec.parents.length === 0) return true;
+      if (spec.parents.every((parent) => gated(parent.parentTable, new Set(seen)))) return true;
+      return spec.parents.some((parent) => parent.required && gated(parent.parentTable, new Set(seen)));
+    };
+
+    // The chain the finding proved: turns -> agent_id (NOT NULL) -> agents ->
+    // owner_id -> persons (`unowned`).
+    expect(gated('turns')).toBe(true);
+    expect(gated('agents')).toBe(true);
+    // …and the ownership ROOT is of course not gated, so this is not vacuous.
+    expect(gated('instances')).toBe(false);
+
+    const turns = REGISTERED_DB_ACCESS.find(
+      (entry) => entry.file === 'packages/api/src/services/turns.ts' && entry.table === 'turns',
+    );
+    expect(turns?.class).toBe('pending-G5-conversion');
+    expect(turns?.justification ?? '').toMatch(/G6/);
   });
 
   test('tenant-boundary is the G3 boundary modules plus the services G4/G5 fully converted', () => {

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -488,8 +488,43 @@ export const PENDING_G4_CEILING = 6;
  * derivation (the publish's `instanceId` -> the instance row's persisted
  * `tenant_id`), so those envelopes now carry a trusted tenant and the converted
  * consumers actually enter the tenant world.
+ *
+ * LOWERED TO 20 BY G5 LEG H — the READ-PATH leg. Six sites CONVERTED across the
+ * `chats`/`messages`/`persons` services. The blocker they shared was not the
+ * services (scope-aware since G4, via the `private get db()` -> `scopedHandle`
+ * getter) but their callers, and specifically the LAST big unconverted consumer
+ * plus the read halves of three already-converted ones:
+ *
+ *   * `message-persistence.ts` — the dominant inbound consumer (every message on
+ *     every channel) was wholly unconverted. Its five handlers now wrap their
+ *     awaited work in `runConsumerInTenantContext`, and each fire-and-forget
+ *     write it spawns (the LID upserts, the chat/instance recency bumps, the
+ *     new-identity profile fetch) gets its OWN `runTenantWorkDb` scope rather
+ *     than inheriting a transaction that is about to commit — the G4 leg-2
+ *     use-after-commit trap, which this handler was the largest instance of.
+ *   * `agent-dispatcher.ts` — its WRITE blocks were converted in legs A/C2, but
+ *     eight READ helpers still called the services bare. Each now runs through
+ *     `runDispatchDb`.
+ *   * `media-processor.ts` — same shape; the new local `runMediaDb` wraps its
+ *     instance/chat/message reads.
+ *   * `sync-worker.ts` — the anchor discovery, DM-rename and contact-identity
+ *     reads were outside `inSyncWorkerScope`; they are inside it now.
+ *
+ * A NOTE ON POLLING, because it is the one place this leg could have been got
+ * badly wrong. Four of these paths poll for ANOTHER consumer's commit
+ * (`resolvePersonId`, `awaitMediaProcessing`, the media chat/message waits).
+ * Wrapping such a poll in ONE transaction would be worse than leaving it
+ * unscoped: the snapshot can never contain the row being waited for, so the loop
+ * would spin to its deadline every time, and the transaction would outlive its
+ * work item. Each poll ATTEMPT therefore opens and closes its own short scope.
+ *
+ * `persons.ts::platform_identities` did NOT convert, and its entry now says why
+ * precisely: every async caller is scoped, and the only thing still holding it
+ * is `trpc/router.ts` — a second synchronous edge with no tenant boundary at
+ * all. That is G4-surface debt wearing a G5 label; the entry carries it as an
+ * open question rather than silently reclassifying it.
  */
-export const PENDING_G5_CEILING = 26;
+export const PENDING_G5_CEILING = 20;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -529,8 +564,12 @@ export const PENDING_G5_CEILING = 26;
  * 32 after G5 leg G (6 + 26): the four dispatch/session/job sites were
  * CONVERTED, not relabelled. No site moved between the two pending classes this
  * leg, and no new pending site was opened.
+ *
+ * 26 after G5 leg H (6 + 20): the six `chats`/`messages`/`persons` service sites
+ * were CONVERTED by scoping their callers, not relabelled. No site moved between
+ * the two pending classes this leg, and no new pending site was opened.
  */
-export const TOTAL_PENDING_CEILING = 32;
+export const TOTAL_PENDING_CEILING = 26;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -1048,20 +1087,30 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/chats.ts',
     table: 'chat_id_mappings',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED. Every method that touches `chat_id_mappings` (`create`, `findByExternalIdSmart`, ' +
+      '`findLidMapping`, `findOrCreate`, `getAllExternalIds`, `upsertLidMapping`) now reaches this file only from ' +
+      'a scoped caller: the routes through the request tenant transaction, and the async side through ' +
+      '`message-persistence` (converted this leg — its five consumers wrap their awaited work in ' +
+      '`runConsumerInTenantContext` and hand each fire-and-forget LID upsert its own `runTenantWorkDb` scope), ' +
+      '`agent-dispatcher` (`runDispatchDb` per discrete read block, including the media/identity polls), ' +
+      '`media-processor` (`runMediaDb`), `sync-worker` (`inSyncWorkerScope`), `session-cleaner` and ' +
+      '`follow-up-hooks` (`runTenantWorkDb`). The one remaining unscoped caller of this FILE — the automation ' +
+      'engine callbacks in `index.ts` — calls only `chats.getById`, which touches `chats` and nothing else; that ' +
+      'keeps the `chats` site pending, not this one.',
   },
   {
     file: 'packages/api/src/services/chats.ts',
     table: 'chat_participants',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED. The participant methods (`findOrCreateParticipant`, `recordParticipantActivity`, ' +
+      '`addParticipant`, `getParticipants`, `removeParticipant`, `updateParticipantRole`, ' +
+      '`linkParticipantToPerson`, and `list` via `enrichDmNames`) are reached from exactly two places: the ' +
+      'routes, inside the request tenant transaction, and `message-persistence`, converted this leg. No other ' +
+      'worker calls a participant method — verified caller-by-caller across every plugin, the scheduler and ' +
+      '`index.ts`.',
   },
   {
     file: 'packages/api/src/services/chats.ts',
@@ -1075,11 +1124,11 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/chats.ts',
     table: 'omni_groups',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED. `omni_groups` is touched only by the private `enrichGroupNames`, reached only from ' +
+      '`ChatService.list`, whose sole caller is `routes/v2/chats.ts` — inside the request tenant transaction. No ' +
+      'consumer, cron or fire-and-forget path calls `list`.',
   },
   {
     file: 'packages/api/src/services/conversations.ts',
@@ -1204,20 +1253,24 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/messages.ts',
     table: 'chats',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED. Every caller of this file is now scoped: the routes through the request tenant transaction, and ' +
+      'the four async callers through their own worker scopes — `message-persistence` ' +
+      '(`runConsumerInTenantContext`, converted this leg), `agent-dispatcher` (`runDispatchDb`, its read helpers ' +
+      'converted this leg), `media-processor` (`runMediaDb`, converted this leg) and `sync-worker` ' +
+      "(`inSyncWorkerScope`). The dispatcher and media-processor POLL for message-persistence's commit, so each " +
+      'poll ATTEMPT opens and closes its own short scope — one transaction spanning the poll could never observe ' +
+      'the row it waits for, and would outlive its work item.',
   },
   {
     file: 'packages/api/src/services/messages.ts',
     table: 'messages',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED. Same caller set and same per-attempt scoping as the `chats` site in this file: routes inside the ' +
+      'request tenant transaction; `message-persistence`, `agent-dispatcher`, `media-processor` and `sync-worker` ' +
+      'each inside their own worker tenant scope, one per discrete DB block.',
   },
   {
     file: 'packages/api/src/services/payload-store.ts',
@@ -1233,11 +1286,14 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/persons.ts',
     table: 'chat_id_mappings',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED. `chat_id_mappings` is reached in this file from `findOrCreateIdentity` (via the private ' +
+      '`resolvePhoneFromLid`) and from `update`. `update` is called only by `routes/v2/persons.ts`, inside the ' +
+      'request tenant transaction; `findOrCreateIdentity` is called only by `message-persistence` (converted this ' +
+      "leg) and `sync-worker`'s contact sync (wrapped in `inSyncWorkerScope` this leg). The tRPC router, which is " +
+      'the last unscoped caller of this FILE, calls none of them — it reaches `platform_identities` only, which ' +
+      'is why that sibling site stays pending and this one does not.',
   },
   {
     file: 'packages/api/src/services/persons.ts',
@@ -1255,9 +1311,19 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'platform_identities',
     class: 'pending-G5-conversion',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'ASYNC SIDE CONVERTED; held pending by a SYNCHRONOUS caller, so the class is now an honest overstatement of ' +
+      'G5 debt rather than a G5 gap. Every worker caller is scoped: `message-persistence` ' +
+      '(`runConsumerInTenantContext`), `agent-dispatcher` (`runDispatchDb` around `resolvePersonId`, ' +
+      "`fetchSenderMetadata` and `resolveCustomerContext` — `resolvePersonId` POLLS for message-persistence's " +
+      'commit, so each ATTEMPT gets its own short scope), and `sync-worker` (`inSyncWorkerScope` around the ' +
+      'contact-sync identity write). What remains is `trpc/router.ts` — `getPresence`, `linkIdentities`, ' +
+      '`unlinkIdentity` — which has NO tenant boundary of any kind: it is a second synchronous edge alongside the ' +
+      'Hono routes, and giving it one is G4-surface work, not the async-context work ADR-0008 assigns to G5 (that ' +
+      'half is done). The router is exported as ' +
+      '`@omni/api/trpc` but no handler in this repository mounts it, so it is not currently a live path. OPEN ' +
+      'QUESTION for the orchestrator: either give the tRPC edge the same `withTenantTransaction` boundary the ' +
+      'Hono edge got in G4, or retire the unmounted surface. Not reclassified unilaterally — an unmounted export ' +
+      'is still callable by an out-of-repo consumer, and "nothing mounts it today" is not a boundary.',
   },
   {
     // G5-CONVERTED (leg C2). `resolve()` takes the envelope-derived

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -457,8 +457,19 @@ export const PENDING_G4_CEILING = 6;
  * LOWERED TO 35, same leg: the `route-resolver.ts` `agent_routes` site
  * converted — `resolve()` scopes its read from the threaded envelope tenant
  * and tenant-keys its LRU cache. Consumer-only (dispatcher) callers.
+ *
+ * LOWERED TO 30 BY G5 LEG E. Five sites CONVERTED (not relabelled): the
+ * follow-up cluster — `follow-up-lifecycle.ts` (`chat_follow_up_state`, `chats`,
+ * `instances`) and `follow-up-sweeper.ts` (`chat_follow_up_state`) — plus
+ * `event-ops.ts` (`omni_events`). The lifecycle now scopes every discrete DB
+ * block from a caller-threaded trusted tenant (hooks/sweeper/dispatcher/
+ * session-cleaner/automation-gate/routes all establish it); the sweeper cron
+ * enumerates active tenants on the auth-plane connection and runs per-tenant
+ * scoped passes; the event replay executor captures its tenant before detaching
+ * and scopes each batch read with dequeue-time revalidation.
+ * (`follow-up-lifecycle.ts::agents` stays pending on the G6 persons backfill.)
  */
-export const PENDING_G5_CEILING = 35;
+export const PENDING_G5_CEILING = 30;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -491,8 +502,11 @@ export const PENDING_G5_CEILING = 35;
  * backfill).
  *
  * 41 after the same leg's `route-resolver.ts` conversion (6 + 35).
+ *
+ * 36 after G5 leg E (6 + 30): the follow-up cluster's four sites and
+ * `event-ops.ts`'s `omni_events` were CONVERTED, not relabelled.
  */
-export const TOTAL_PENDING_CEILING = 41;
+export const TOTAL_PENDING_CEILING = 36;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -1041,16 +1055,18 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'two-tenant-adversarial-postgres.test.ts.',
   },
   {
+    // G5-CONVERTED. Both paths now reach a tenant transaction. The route-facing
+    // `getMetrics`/`startReplay` count run inside the request scope. The
+    // background replay executor is STILL request-detached (it outlives the
+    // request), but `startReplay` now captures the trusted tenant BEFORE
+    // detaching and threads it as a VALUE into `executeReplay`, whose every
+    // `omni_events` batch read runs in its OWN short worker scope
+    // (`runTenantWorkDb`). It revalidates the tenant is still admissible at
+    // dequeue and before each durable side-effect batch. A legacy replay
+    // (null tenant) reads ambient byte-identically.
     file: 'packages/api/src/services/event-ops.ts',
     table: 'omni_events',
-    class: 'pending-G5-conversion',
-    justification:
-      'Two paths reach this service. The route-facing startReplay count/metrics paths run inside the request tenant ' +
-      'transaction and are scoped. The background replay executor is a worker-context path: it is spawned ' +
-      'fire-and-forget and DELIBERATELY request-detached from the request scope (tenant-scope.ts ' +
-      'runDetachedFromTenantScope), because it outlives the request transaction and must run on the ambient pool to ' +
-      'avoid a use-after-commit. Converting that worker path to its own tenant scope needs the G5 async context ' +
-      '(ADR-0008).',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/services/events.ts',
@@ -1062,48 +1078,56 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'agents',
     class: 'pending-G5-conversion',
     justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+      'CONVERTED IN CODE but honestly still pending, blocked on G6. The `agents` read in `resolveConfig` now runs ' +
+      'inside the same `workDb(trustedTenantId, …)` block as its sibling `chats`/`instances` sites (which flipped ' +
+      'to tenant-boundary this leg): the ADR-0008 async mechanism — the follow-up eventBus consumer hooks and the ' +
+      'follow-up-sweeper cron — threads a trusted tenant into every caller. What keeps the class: `agents` derives ' +
+      'its tenant via owner_id -> persons, and `persons` is G2-`unowned`, so the fail-closed derivation trigger ' +
+      'leaves every `agents` row NULL-tenant until the G6 persons backfill — a scoped read finds no config row yet. ' +
+      'Flips to tenant-boundary when G6 lands.',
   },
   {
+    // G5-CONVERTED. Every entry into `FollowUpLifecycleService` now establishes
+    // tenant context: `armForOutbound`/`armForInbound`/`disarm`/
+    // `touchInboundTimestamp`/`resolveConfig`/`evaluateIdleTimeoutFreshness`
+    // each run their discrete DB blocks through `workDb(trustedTenantId, …)` /
+    // `repoFor(trustedTenantId)`. The callers thread that trusted tenant: the
+    // follow-up hooks (`trustedTenantOf(event)`), the sweeper (per-tenant world),
+    // the agent-dispatcher (`runDispatchDb` envelope tenant), the session-cleaner
+    // (envelope tenant), the automation-engine idle-timeout gate (envelope
+    // tenant), and real routes (their request scope, via `workDb`'s passthrough).
+    // Publishes sit BETWEEN scoped blocks, never inside one. Legacy work threads
+    // null → ambient byte-identical.
     file: 'packages/api/src/services/follow-up-lifecycle.ts',
     table: 'chat_follow_up_state',
-    class: 'pending-G5-conversion',
-    justification:
-      'The lifecycle writes (follow-up-lifecycle.ts:286, :428, :525, :585) are reached from the follow-up NATS ' +
-      'hooks (`setupFollowUpHooks` subscriptions, follow-up-hooks.ts:54/:86/:128/:149/:169), from the ' +
-      '`follow-up-sweeper` cron running every 15 seconds (scheduler.ts:221), and from the session-cleaner and ' +
-      'agent-dispatcher consumers — alongside real routes. The timer and consumer callers have no request context, ' +
-      'which is the ADR-0008 async problem G5 owns. `follow-up-sweeper.ts` writing this same table was already ' +
-      'deferred for the identical reason.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (see the chat_follow_up_state entry above). The `chats` reads
+    // in `resolveConfig`/`isInActiveCloseState` run through the same
+    // `workDb(trustedTenantId, …)` blocks; all entry points scope.
     file: 'packages/api/src/services/follow-up-lifecycle.ts',
     table: 'chats',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (see the chat_follow_up_state entry above). The `instances`
+    // read in `resolveConfig` runs through the same scoped block.
     file: 'packages/api/src/services/follow-up-lifecycle.ts',
     table: 'instances',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED. The sweeper is a cron: flag-off it runs one ambient pass
+    // byte-identical; flag-on it enumerates active tenants on the auth-plane
+    // connection (periodic-tenant-work.ts) and runs one pass per tenant, each
+    // claim/fire/disarm DB block in its own short worker scope with an explicit
+    // `tenant_id = $tenant` predicate, plus a transitional NULL-tenant pass that
+    // is SKIPPED under enforcement (where the mixed state cannot exist). A
+    // suspended tenant drops out of the enumeration at the next tick.
     file: 'packages/api/src/services/follow-up-sweeper.ts',
     table: 'chat_follow_up_state',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from a scheduled/interval loop (scheduler cron or setInterval), which runs on a timer with no ' +
-      'request and no credential. Tenant context for periodic work requires the G5 worker-context semantics ' +
-      '(ADR-0008).',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/services/instances.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -434,8 +434,31 @@ export const PENDING_G4_CEILING = 6;
  * -> `persons`, and `persons` is G2-`unowned`, so the fail-closed derivation trigger
  * leaves their `tenant_id` NULL until the G6 `persons` backfill — they stay pending,
  * blocked on G6, see the handoff.)
+ *
+ * LOWERED TO 39 BY G5 LEG B pt3. The three `event-listeners.ts` sites
+ * (`instances` connect/disconnect state, `chat_id_mappings` LID batch, `chats`
+ * contact-names/unread) converted: each handler runs its DISCRETE DB block
+ * through `runConsumerInTenantContext` + `scopedHandle` (per-item scopes for
+ * the batch loops, mirroring their previous per-statement transactions). The
+ * one access that could not convert — the CROSS-tenant connection gauge —
+ * moved to `connection-gauge.ts` and re-registered pending (+1), so the net is
+ * 41 - 3 + 1 = 39 with the un-convertible read still visible as debt.
+ *
+ * LOWERED TO 36 BY G5 LEG C2. Three of the four `agent-dispatcher.ts` sites
+ * (`agent_sessions` per-thread markers, `handoff_logs` audit insert,
+ * `instances` self-send enumeration + tenant-keyed cache) converted: each
+ * discrete DB block runs through `runDispatchDb` → `runInWorkerTenantScope` +
+ * `scopedHandle`, keyed by the envelope-derived `DispatchMetadata.
+ * trustedTenantId` stamped at the subscription boundary — never a payload
+ * claim. The fourth (`agents`) is converted IN CODE but stays pending: its
+ * rows are NULL-tenant until the G6 `persons` backfill and session-cleaner
+ * still calls it tenant-less (see its entry).
+ *
+ * LOWERED TO 35, same leg: the `route-resolver.ts` `agent_routes` site
+ * converted — `resolve()` scopes its read from the threaded envelope tenant
+ * and tenant-keys its LRU cache. Consumer-only (dispatcher) callers.
  */
-export const PENDING_G5_CEILING = 41;
+export const PENDING_G5_CEILING = 35;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -457,8 +480,19 @@ export const PENDING_G5_CEILING = 41;
  *
  * 47 after G5 leg B pt2 (6 + 41): the two `sync-worker.ts` consumer sites were
  * CONVERTED, not relabelled.
+ *
+ * 45 after G5 leg B pt3 (6 + 39): the three `event-listeners.ts` consumer sites
+ * were CONVERTED; the cross-tenant connection gauge those handlers also called
+ * was split into `connection-gauge.ts` and re-registered pending (+1), so the
+ * net -2 is real conversion, not relabelling.
+ *
+ * 42 after G5 leg C2 (6 + 36): three `agent-dispatcher.ts` consumer sites were
+ * CONVERTED, not relabelled (`agents` stays pending on the G6 persons
+ * backfill).
+ *
+ * 41 after the same leg's `route-resolver.ts` conversion (6 + 35).
  */
-export const TOTAL_PENDING_CEILING = 47;
+export const TOTAL_PENDING_CEILING = 41;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -590,70 +624,91 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'propagation ADR-0008 assigns to G5.',
   },
   {
+    // G5-CONVERTED (leg C2). The per-thread init marker (check/mark pair) runs
+    // through `scopedHandle` inside a short worker scope keyed by the
+    // envelope-derived `DispatchMetadata.trustedTenantId` (`runDispatchDb`).
+    // Consumer-only callers; a legacy envelope runs on the ambient pool
+    // byte-identically.
     file: 'packages/api/src/plugins/agent-dispatcher.ts',
     table: 'agent_sessions',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/plugins/agent-dispatcher.ts',
     table: 'agents',
     class: 'pending-G5-conversion',
     justification:
-      'No HTTP caller exists. Both accesses — `dispatchViaTurnBasedProvider` (agent-dispatcher.ts:2453) and ' +
-      '`applyAgentFkOverrides` (:4190) — are reached only through the eventBus/NATS consumer registered by ' +
-      '`setupAgentDispatcher` (:5253), and `applyAgentFkOverrides` additionally from the `session-cleaner` durable ' +
-      'consumer (session-cleaner.ts:135). A consumer callback carries no credential to derive a tenant from, so ' +
-      'this needs the async message-context propagation ADR-0008 assigns to G5. Its sibling site in this same file ' +
-      '(`agent_sessions`) was already classified this way for the same callers.',
+      'CONVERTED IN CODE but honestly still pending, twice over. Both accesses — the turn-based agent lookup and ' +
+      '`applyAgentFkOverrides` — now run through `scopedHandle` inside a short worker scope from the envelope-derived ' +
+      'tenant (`runDispatchDb`), and its NATS-consumer callers all thread that tenant. What keeps the class: (a) the ' +
+      '`session-cleaner` durable consumer (session-cleaner.ts:135) still calls `applyAgentFkOverrides` with no ' +
+      'tenant — its conversion is blocked on the G6 `persons` backfill; and (b) `agents` itself derives its tenant ' +
+      'via owner_id -> persons (G2-unowned), so the derivation trigger leaves every row NULL-tenant until that same ' +
+      'backfill — a scoped read finds nothing yet. Flips to tenant-boundary when G6 lands and session-cleaner ' +
+      'converts; the async mechanism is the ADR-0008 consumer context above.',
   },
   {
+    // G5-CONVERTED (leg C2). The error-handoff audit insert
+    // (`persistErrorHandoffSideEffects`) runs through `scopedHandle` inside a
+    // short worker scope keyed by the envelope-derived tenant; the derivation
+    // trigger stamps the tenant from the instance, so a scope aimed at a
+    // foreign chat is refused by the WITH CHECK. Consumer-only callers.
     file: 'packages/api/src/plugins/agent-dispatcher.ts',
     table: 'handoff_logs',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg C2). The self-send-guard enumeration
+    // (`listActiveOwnerIdentifiers`) runs scoped under the envelope tenant with
+    // a TENANT-KEYED cache (a global cache would serve one tenant's owner
+    // identifiers to another inside the TTL); the legacy path keeps the global
+    // cache and ambient read byte-identically. Consumer-only caller
+    // (`shouldProcessMessage` in the message.received consumer).
     file: 'packages/api/src/plugins/agent-dispatcher.ts',
     table: 'instances',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg B pt3). The `custom.lid-mapping.batch` consumer runs
+    // each mapping insert through `scopedHandle` inside its own per-item
+    // worker scope (`runConsumerInTenantContext`), mirroring the per-statement
+    // implicit transactions the loop had before. Consumer-only site, so every
+    // caller now reaches a tenant transaction; legacy envelopes run on the
+    // ambient pool byte-identically.
     file: 'packages/api/src/plugins/event-listeners.ts',
     table: 'chat_id_mappings',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg B pt3) — see the sibling `chat_id_mappings` entry.
+    // The contact-names rename (`updateChatName`) and the unread-count sync
+    // both run through `scopedHandle` inside the envelope's worker scope.
     file: 'packages/api/src/plugins/event-listeners.ts',
     table: 'chats',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg B pt3) — see the sibling `chat_id_mappings` entry.
+    // The connect/disconnect state updates run through `scopedHandle` inside
+    // the envelope's worker scope. The one access that could NOT convert — the
+    // cross-tenant connection gauge — moved to `connection-gauge.ts` with its
+    // own pending registration below, so it cannot hide behind this site.
     file: 'packages/api/src/plugins/event-listeners.ts',
+    table: 'instances',
+    class: 'tenant-boundary',
+  },
+  {
+    file: 'packages/api/src/plugins/connection-gauge.ts',
     table: 'instances',
     class: 'pending-G5-conversion',
     justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+      'Called fire-and-forget from the connect/disconnect eventBus consumer handlers in event-listeners.ts, from ' +
+      'which it was extracted during the ADR-0008 G5 conversion of that file. It is a platform-wide observability ' +
+      'aggregate (active instances per channel, NO tenant labels), so the worker tenant scope those consumers now ' +
+      'establish can by definition not compute it, and under RLS enforcement the ambient runtime-role read returns ' +
+      'nothing — the gauge needs an observability-plane read credential or a per-tenant emission design. OPEN ' +
+      'QUESTION for the orchestrator: control-plane reclassification vs. G8A deployment-scope credential; until ' +
+      'decided this stays pending rather than silently reclassified.',
   },
   {
     // G5-CONVERTED. Both handlers now wrap their DB work in
@@ -1127,13 +1182,15 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
   },
   {
+    // G5-CONVERTED (leg C2). `resolve()` takes the envelope-derived
+    // `trustedTenantId` its dispatcher-consumer callers thread through
+    // `DispatchMetadata`; the read runs through `scopedHandle` inside a short
+    // worker scope AND the LRU cache key includes the tenant, so a foreign
+    // scope's negative entry cannot shadow a tenant's real route. Consumer-only
+    // callers; legacy lookups keep the pre-G5 key and ambient read.
     file: 'packages/api/src/services/route-resolver.ts',
     table: 'agent_routes',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/services/routes.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -422,8 +422,20 @@ export const PENDING_G4_CEILING = 6;
  * `runConsumerInTenantContext` + `scopedHandle` while the media download/AI work
  * stays outside the transaction. All three were consumer-only sites, so every
  * caller now reaches a tenant transaction; they became `tenant-boundary`.
+ *
+ * LOWERED TO 41 BY G5 LEG B pt2. The two `sync-worker.ts` sites (`messages` via
+ * `buildWhatsAppAnchors`, `omni_groups` via `upsertSyncedGroup`/`onGuild`)
+ * converted: the `sync.started` consumer threads its envelope into each processor,
+ * which scopes each DISCRETE per-item DB block through `runConsumerInTenantContext`
+ * + `scopedHandle` (never the long `fetchHistory`/`fetchGroups` job). Both tables
+ * derive their tenant from the `instances` root, so RLS scopes them; consumer-only
+ * callers → `tenant-boundary`. (`session-cleaner.ts`'s `agents`/`chat_participants`
+ * were NOT converted this leg: both derive their tenant from `owner_id`/`person_id`
+ * -> `persons`, and `persons` is G2-`unowned`, so the fail-closed derivation trigger
+ * leaves their `tenant_id` NULL until the G6 `persons` backfill — they stay pending,
+ * blocked on G6, see the handoff.)
  */
-export const PENDING_G5_CEILING = 43;
+export const PENDING_G5_CEILING = 41;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -442,8 +454,11 @@ export const PENDING_G5_CEILING = 43;
  *
  * 49 after G5 leg B (6 + 43): the three `media-processor.ts` consumer sites were
  * CONVERTED, not relabelled.
+ *
+ * 47 after G5 leg B pt2 (6 + 41): the two `sync-worker.ts` consumer sites were
+ * CONVERTED, not relabelled.
  */
-export const TOTAL_PENDING_CEILING = 49;
+export const TOTAL_PENDING_CEILING = 47;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -725,22 +740,29 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'absence of request context. Converting it requires the async storage context of ADR-0008 (G5).',
   },
   {
+    // G5-CONVERTED (leg B pt2). The `sync.started` consumer threads its versioned
+    // envelope into `processMessageSync`, which scopes the anchor read
+    // `buildWhatsAppAnchors` (this `messages` site) through
+    // `runConsumerInTenantContext` + `scopedHandle` as a discrete per-item DB
+    // block — NOT the long `fetchHistory` job it precedes. Its only callers are
+    // that consumer, so every caller now reaches a tenant transaction. `messages`
+    // derives its tenant from the `instances` root, so RLS scopes it (proven in
+    // sync-worker-two-tenant-postgres.test.ts). Legacy envelope → ambient pool,
+    // byte-identical.
     file: 'packages/api/src/plugins/sync-worker.ts',
     table: 'messages',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg B pt2). The per-group/per-guild upsert (`upsertSyncedGroup`
+    // and the inline Discord `onGuild` block) now runs inside
+    // `runConsumerInTenantContext` + `scopedHandle` — one worker tenant scope per
+    // work item, never across the `fetchGroups`/`fetchGuilds` job. `omni_groups`
+    // derives its tenant from the required `instances` root, so the insert is
+    // RLS-stamped/checked (proven in sync-worker-two-tenant-postgres.test.ts).
     file: 'packages/api/src/plugins/sync-worker.ts',
     table: 'omni_groups',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/routes/v2/handoffs.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -568,6 +568,16 @@ export const PENDING_G5_CEILING = 20;
  * 26 after G5 leg H (6 + 20): the six `chats`/`messages`/`persons` service sites
  * were CONVERTED by scoping their callers, not relabelled. No site moved between
  * the two pending classes this leg, and no new pending site was opened.
+ *
+ * STILL 26 after G5 leg I (6 + 20), and the flat number deserves scepticism, so
+ * here is its anatomy: `chats.ts::chats` was CONVERTED (-1) by scoping its last
+ * unscoped caller (the automation-engine callbacks, plus the sync-worker and
+ * session-cleaner instance reads along the way), and the callbacks' direct
+ * `agents` read — which had been hiding under `index.ts`'s control-plane
+ * STARTUP entry since G4 — was extracted to `automation-actions.ts` and
+ * honestly registered pending (+1) on the same G6 `agents` gate as the
+ * dispatcher and session-cleaner sites. Net zero by count; strictly better by
+ * honesty: a consumer read no longer wears a bootstrap exemption.
  */
 export const TOTAL_PENDING_CEILING = 26;
 
@@ -679,13 +689,6 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   },
   {
     file: 'packages/api/src/index.ts',
-    table: 'agents',
-    class: 'control-plane',
-    justification:
-      'Process startup: migrate-on-boot, schema-drift verification, and the boot banner. WISH "Public and bootstrap surfaces" classifies startup as a control-plane operation with an explicit credential class.',
-  },
-  {
-    file: 'packages/api/src/index.ts',
     table: 'instances',
     class: 'control-plane',
     justification:
@@ -715,14 +718,14 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'agents',
     class: 'pending-G5-conversion',
     justification:
-      'CONVERTED IN CODE but honestly still pending, twice over. Both accesses — the turn-based agent lookup and ' +
+      'CONVERTED IN CODE but honestly still pending. Both accesses — the turn-based agent lookup and ' +
       '`applyAgentFkOverrides` — now run through `scopedHandle` inside a short worker scope from the envelope-derived ' +
-      'tenant (`runDispatchDb`), and its NATS-consumer callers all thread that tenant. What keeps the class: (a) the ' +
-      '`session-cleaner` durable consumer (session-cleaner.ts:135) still calls `applyAgentFkOverrides` with no ' +
-      'tenant — its conversion is blocked on the G6 `persons` backfill; and (b) `agents` itself derives its tenant ' +
-      'via owner_id -> persons (G2-unowned), so the derivation trigger leaves every row NULL-tenant until that same ' +
-      'backfill — a scoped read finds nothing yet. Flips to tenant-boundary when G6 lands and session-cleaner ' +
-      'converts; the async mechanism is the ADR-0008 consumer context above.',
+      'tenant (`runDispatchDb`), and its NATS-consumer callers all thread that tenant (the `session-cleaner` caller ' +
+      'threads it too since its own conversion — the earlier session-cleaner.ts:135 no-tenant clause is closed, ' +
+      'run13 accuracy fix). What keeps the class: `agents` itself derives its tenant via owner_id -> persons ' +
+      '(G2-unowned), so the derivation trigger leaves every row NULL-tenant until the G6 backfill — a scoped read ' +
+      'finds nothing yet. Flips to tenant-boundary when G6 lands; the async mechanism is the ADR-0008 consumer ' +
+      'context above.',
   },
   {
     // G5-CONVERTED (leg C2). The error-handoff audit insert
@@ -744,6 +747,30 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     file: 'packages/api/src/plugins/agent-dispatcher.ts',
     table: 'instances',
     class: 'tenant-boundary',
+  },
+  {
+    // G5 leg I (run13). The automation engine's `call_agent` callback resolves
+    // the agent row directly; it lived inline in `index.ts`, where the scanner
+    // filed it under that file's `control-plane` STARTUP entry — a consumer
+    // read hiding under a bootstrap exemption. Extracted here, it now runs
+    // through `scopedHandle` inside a short worker scope for the tenant the
+    // engine threads from the consumed envelope (legacy envelopes read the
+    // ambient pool byte-identically), and the engine is its only caller.
+    // CONVERTED IN CODE but honestly still pending: `agents` derives its
+    // tenant via owner_id -> persons (G2-unowned), so the derivation trigger
+    // leaves every row NULL-tenant until the G6 backfill — under enforcement a
+    // scoped read finds nothing and `call_agent` fails closed ("Agent not
+    // found", proven in automation-actions-two-tenant-postgres.test.ts).
+    // Flips to tenant-boundary when G6 lands, same gate as the
+    // agent-dispatcher and session-cleaner `agents` sites.
+    file: 'packages/api/src/plugins/automation-actions.ts',
+    table: 'agents',
+    class: 'pending-G5-conversion',
+    justification:
+      'Converted in code (engine-threaded envelope tenant, scopedHandle worker scope, caller-complete) but the ' +
+      '`agents` table derives tenant via owner_id -> persons (G2-unowned): rows stay NULL-tenant until the G6 ' +
+      'persons backfill, so a scoped read finds nothing under enforcement. Same G6 gate as the dispatcher and ' +
+      'session-cleaner `agents` sites; the async mechanism is the ADR-0008 consumer context.',
   },
   {
     // G5-NEW (leg E, deliverable (e)). The voice WebSocket upgrade runs in
@@ -1036,9 +1063,13 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'automation_logs',
     class: 'pending-G5-conversion',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      "Written by the automation engine's execution logger from its NATS consumer callback (and by the route-side " +
+      'manual execute). The engine now THREADS the consumed envelope tenant to the logger (run13), but the service ' +
+      'deliberately does not scope the write yet: `automation_logs` derives its tenant from the REQUIRED ' +
+      '`automation_id` parent and `automations` is G2-unowned (tenant_id NULL until the G6 backfill), so a ' +
+      'worker-scoped insert would fail the strict RLS WITH CHECK and destroy the execution log. G6-gated; when ' +
+      'the backfill lands, wrap the logger callback in runTenantWorkDb (the ADR-0008 consumer context) — the ' +
+      'threading is already in place.',
   },
   {
     file: 'packages/api/src/services/automations.ts',
@@ -1115,11 +1146,16 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/chats.ts',
     table: 'chats',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED (leg I, run13). The service was scope-aware since G4 (`scopedHandle` getter); what remained was ' +
+      'its last unscoped caller — the automation-engine action callbacks, extracted to ' +
+      'plugins/automation-actions.ts, which now wrap their `chats.getById` resolution in `runTenantWorkDb` with ' +
+      'the tenant the engine threads from the consumed envelope (including debounce-window carry). Verified ' +
+      'caller-by-caller: routes (request transaction), message-persistence/agent-dispatcher/media-processor/' +
+      'sync-worker/session-cleaner/follow-up-hooks (worker scopes, legs G-H), and the callbacks (leg I). ' +
+      'trpc/router.ts calls NO chats method. Cross-tenant refusal proven on real RLS in ' +
+      'automation-actions-two-tenant-postgres.test.ts.',
   },
   {
     file: 'packages/api/src/services/chats.ts',
@@ -1237,9 +1273,15 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'instances',
     class: 'pending-G5-conversion',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'Route paths run inside the request transaction, and leg I (run13) scoped the biggest worker callers: the ' +
+      'automation-engine callbacks (automation-actions.ts, engine-threaded envelope tenant), the sync-worker ' +
+      'channel-type lookup (inSyncWorkerScope), and the session-cleaner confirmation send (runTenantWorkDb). ' +
+      'What still reaches this site unscoped in the tenant world: (a) turn-monitor.ts per-tick `getById` — its ' +
+      'conversion belongs to the turns surface (turns.ts::turns, same leg); (b) the scheduler unread-count-refresh ' +
+      'cron `listActive` — a per-instance cron that should adopt the runForEachActiveTenantRow fan-out; (c) ' +
+      'trpc/router.ts, the exported-but-unmounted synchronous edge with no tenant boundary, held for the same ' +
+      'open decision as persons.ts::platform_identities. A site is only as scoped as its least-scoped caller; ' +
+      'the remaining conversions are the ADR-0008 async-context work above.',
   },
   {
     file: 'packages/api/src/services/media-storage.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -704,9 +704,14 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     class: 'tenant-boundary',
   },
   {
-    // G5-CONVERTED (leg B) — the `media_content` FK existence check
-    // (`resolveSafeMediaContentEventId`) now reads `omni_events` through
-    // `scopedHandle(ctx.db)` within the same worker scope as the insert it feeds.
+    // G5-CONVERTED (leg B; refined run6/carry-forward #2). The `media_content` FK
+    // existence check (`resolveSafeMediaContentEventId`) reads `omni_events`
+    // through `scopedHandle(ctx.db)` inside a worker tenant scope
+    // (`runConsumerInTenantContext`), so this stays a tenant-boundary. Run6 moved
+    // that read into its OWN short worker scope(s) resolved BEFORE the persist
+    // scope, so the <=250ms poll no longer holds the persist transaction open
+    // across its sleeps — the read remains scoped (a plain ambient read would
+    // regress this to pending AND, under RLS, resolve nothing).
     file: 'packages/api/src/plugins/media-processor.ts',
     table: 'omni_events',
     class: 'tenant-boundary',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -468,8 +468,28 @@ export const PENDING_G4_CEILING = 6;
  * scoped passes; the event replay executor captures its tenant before detaching
  * and scopes each batch read with dequeue-time revalidation.
  * (`follow-up-lifecycle.ts::agents` stays pending on the G6 persons backfill.)
+ *
+ * LOWERED TO 26 BY G5 LEG G. Four sites CONVERTED, all in one caller graph — the
+ * dispatch/session consumers and the job table they drive:
+ * `agent-runner.ts::instances` (the lookup every dispatch path starts from),
+ * `session-cleaner.ts::chat_participants`, `session-storage.ts::agent_sessions`
+ * (deliverable (g)'s store, now scoped from the loaded instance's persisted
+ * ownership), and `sync-jobs.ts::sync_jobs` (every worker caller threads:
+ * per-tenant cron fan-out, the `sync.started` consumer, the history-push
+ * tracker, the post-reconnect backfill).
+ *
+ * This leg also closed the PRODUCER gap those conversions depended on, which the
+ * registry cannot see and which is worth reading here because it changes what
+ * every earlier leg's number MEANS. Channel plugins publish from a socket
+ * callback with no request scope, so `BaseChannelPlugin.publishEventInternal`
+ * stamped no tenant and every real channel event classified `legacy` — the
+ * consumers legs A–E converted were correct and UNREACHABLE for live traffic.
+ * `tenancy/instance-owner-registry.ts` supplies the ADR-0008 "loaded resource"
+ * derivation (the publish's `instanceId` -> the instance row's persisted
+ * `tenant_id`), so those envelopes now carry a trusted tenant and the converted
+ * consumers actually enter the tenant world.
  */
-export const PENDING_G5_CEILING = 30;
+export const PENDING_G5_CEILING = 26;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -505,8 +525,12 @@ export const PENDING_G5_CEILING = 30;
  *
  * 36 after G5 leg E (6 + 30): the follow-up cluster's four sites and
  * `event-ops.ts`'s `omni_events` were CONVERTED, not relabelled.
+ *
+ * 32 after G5 leg G (6 + 26): the four dispatch/session/job sites were
+ * CONVERTED, not relabelled. No site moved between the two pending classes this
+ * leg, and no new pending site was opened.
  */
-export const TOTAL_PENDING_CEILING = 36;
+export const TOTAL_PENDING_CEILING = 32;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -809,22 +833,34 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'query on the ambient pool, which is the async message-context problem ADR-0008 assigns to G5.',
   },
   {
+    // G5-CONVERTED (leg G). `resolveCleanupPersonId`'s participant read runs
+    // through `scopedHandle` (extracted as `readChatParticipant`) inside the
+    // `runTenantWorkDb` block its callers already threaded — the durable
+    // `session-cleaner` consumer threads the envelope tenant, the
+    // `routes/v2/chats.ts` caller threads nothing and stays on its own request
+    // scope. `chat_participants` derives its tenant from the REQUIRED `chat_id`
+    // parent, so it is rooted at `instances` and RLS scopes it; it does NOT wait
+    // on the G6 `persons` backfill, even though `person_id` is the column read —
+    // the column's VALUE is opaque here, only the ROW's visibility matters.
     file: 'packages/api/src/plugins/session-cleaner.ts',
     table: 'chat_participants',
-    class: 'pending-G5-conversion',
-    justification:
-      '`resolveCleanupPersonId` (session-cleaner.ts:72) is called only from `clearAgentSession` (:107) and so ' +
-      'inherits its callers exactly: the durable `session-cleaner` NATS consumer (:305) plus ' +
-      '`routes/v2/chats.ts:1043`. Deferred with its parent for the one reason — the consumer callback has no ' +
-      'request context — that ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg G). Every discrete DB block (`getSession`'s lookup plus
+    // its staleness deletes, `upsertSession`, `deleteSession`) runs through
+    // `runTenantWorkDb` + `scopedHandle` under the tenant the store's
+    // `resolveTenantId` returns. The agent-dispatcher — its only production
+    // caller — now supplies that resolver from the LOADED instance's persisted
+    // `tenantId` (the G2 ownership root), never a payload claim, so the store is
+    // scoped for the same instance it is already storing sessions for.
+    // `agent_sessions` derives its tenant from the REQUIRED `instances` parent,
+    // so a write aimed at another tenant's instance is refused by the WITH CHECK
+    // (proven in session-cluster-two-tenant-postgres.test.ts). With no resolver
+    // — the legacy shape — no scope opens and the query is byte-identical.
     file: 'packages/api/src/plugins/session-storage.ts',
     table: 'agent_sessions',
-    class: 'pending-G5-conversion',
-    justification:
-      'A storage path constructed and invoked only from within the agent-dispatch consumer, and so inherits that ' +
-      'absence of request context. Converting it requires the async storage context of ADR-0008 (G5).',
+    class: 'tenant-boundary',
   },
   {
     // G5-CONVERTED (leg B pt2). The `sync.started` consumer threads its versioned
@@ -903,15 +939,20 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
   },
   {
+    // G5-CONVERTED (leg G). `getInstanceWithProvider` — the lookup EVERY dispatch
+    // path starts from — now reads through `scopedHandle`, and each of its
+    // consumer callers wraps it in a short worker scope from the envelope's
+    // trusted tenant: `session-cleaner` via `runTenantWorkDb`, and the four
+    // `agent-dispatcher` sites (`shouldProcessMessage`, `shouldProcessReaction`,
+    // the debouncer fallback, the `presence.typing` handler) via `runDispatchDb`.
+    // Under RLS a forged/foreign instanceId resolves to `null`, which every
+    // caller already treats as "skip". The deprecated `agent-responder.ts` copy
+    // is dead code (`plugins/index.ts` re-exports `setupAgentResponder` from
+    // agent-dispatcher, so this module's version is never wired); with no scope
+    // active `scopedHandle` returns the ambient pool, so it stays byte-identical.
     file: 'packages/api/src/services/agent-runner.ts',
     table: 'instances',
-    class: 'pending-G5-conversion',
-    justification:
-      '`getInstanceWithProvider` (agent-runner.ts:363) has ZERO HTTP callers. Every caller is an eventBus/NATS ' +
-      'consumer: session-cleaner.ts:89, agent-dispatcher.ts:4793/:4996/:5218/:5480, and agent-responder.ts:547/' +
-      ':626/:692. With no request anywhere in its call graph there was never a tenant for G4 to derive; it needs ' +
-      'the consumer message-context ADR-0008 assigns to G5. The sibling `persons` site in this same file was ' +
-      'already classified this way.',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/services/agent-runner.ts',
@@ -1235,13 +1276,24 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg G). `SyncJobService` already read through `scopedHandle`;
+    // what was missing was a WORLD for its worker callers. Each method now takes
+    // a THREADED trusted tenant and wraps its own discrete DB block in
+    // `workDb` — threaded rather than caller-wrapped because every mutation also
+    // PUBLISHES a `sync.*` event, and a worker transaction held across that
+    // publish would make the event a pre-commit side effect. All four worker
+    // callers now thread: the daily contacts/groups crons via
+    // `runForEachActiveTenantRow` (per-active-tenant scoped `listActive`, so a
+    // suspended tenant drops out at the next tick), the `sync.started` consumer
+    // and the three history-push tracker subscribers via `trustedSyncTenant`,
+    // and `message-persistence`'s post-reconnect backfill via the
+    // `instance.connected` envelope. Route callers thread nothing and stay on
+    // their request scope. The published envelope carries `created.tenantId` —
+    // what the row was actually stamped with — so the downstream consumer
+    // derives from persisted ownership.
     file: 'packages/api/src/services/sync-jobs.ts',
     table: 'sync_jobs',
-    class: 'pending-G5-conversion',
-    justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/services/tenant-control-plane.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -1274,15 +1274,17 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'instances',
     class: 'pending-G5-conversion',
     justification:
-      'Route paths run inside the request transaction, and leg I (run13) scoped the biggest worker callers: the ' +
-      'automation-engine callbacks (automation-actions.ts, engine-threaded envelope tenant), the sync-worker ' +
-      'channel-type lookup (inSyncWorkerScope), and the session-cleaner confirmation send (runTenantWorkDb). ' +
-      'What still reaches this site unscoped in the tenant world: (a) turn-monitor.ts per-tick `getById` — its ' +
-      'conversion belongs to the turns surface (turns.ts::turns, same leg); (b) the scheduler unread-count-refresh ' +
-      'cron `listActive` — a per-instance cron that should adopt the runForEachActiveTenantRow fan-out; (c) ' +
-      'trpc/router.ts, the exported-but-unmounted synchronous edge with no tenant boundary, held for the same ' +
-      'open decision as persons.ts::platform_identities. A site is only as scoped as its least-scoped caller; ' +
-      'the remaining conversions are the ADR-0008 async-context work above.',
+      'ASYNC SIDE COMPLETE (run14); held pending by ONE synchronous caller. Every route path runs inside the ' +
+      'request transaction; the async callers were closed across run13 and run14 — the automation-engine ' +
+      'callbacks (automation-actions.ts, engine-threaded envelope tenant), the sync-worker channel-type lookup ' +
+      '(inSyncWorkerScope), the session-cleaner confirmation send (runTenantWorkDb), the scheduler ' +
+      'unread-count-refresh cron (runForEachActiveTenantRow, the daily-sync precedent) and turn-monitor.ts ' +
+      '(runForEachActiveTenantRow over getStale, each per-turn `getById` in its own runTenantWorkDb scope). What ' +
+      'remains is trpc/router.ts alone: a second synchronous edge with NO tenant boundary of any kind, which ' +
+      'reaches list/getById/getByName/create/update/delete here. Giving it one is G4-surface work, not the ' +
+      'ADR-0008 async-context work assigned to G5. Held for the SAME open decision as ' +
+      'persons.ts::platform_identities — add the withTenantTransaction edge, or retire the unmounted export. ' +
+      'Not reclassified unilaterally: an unmounted export is still callable by an out-of-repo consumer.',
   },
   {
     file: 'packages/api/src/services/media-storage.ts',
@@ -1437,9 +1439,24 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'turns',
     class: 'pending-G5-conversion',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'Route paths run inside the request transaction, and two of the four worker callers are now scoped: ' +
+      'agent-dispatcher.ts `turns.open` (runDispatchDb, envelope-derived tenant) and turn-monitor.ts — whose ' +
+      'whole tick run14 converted to the runForEachActiveTenantRow fan-out with each getStale/incrementNudge/' +
+      'close in its own short worker scope. TWO unscoped callers remain, both fire-and-forget and neither in ' +
+      "run14's scope: (a) middleware/auth.ts, which starts `getOpenByApiKey().then(recordActivity)` from a " +
+      'REQUEST and detaches nothing — its continuations can outlive the request transaction (the G4 leg-2 ' +
+      'use-after-commit trap) and it needs runDetachedFromTenantScope plus a worker scope derived from the ' +
+      "validated key's tenant; (b) services/agent-heartbeat.ts, a NATS consumer whose heartbeat carries an " +
+      'instanceId but is not yet classified through classifyEnvelope. A site is only as scoped as its ' +
+      'least-scoped caller, so those two are the ADR-0008 async-context work that remains. BUT CONVERTING ' +
+      'THEM DOES NOT FLIP THIS ENTRY: `turns` is ALSO G6-GATED, on exactly the chain that holds the four ' +
+      '`agents` sites. It derives from BOTH instance_id and agent_id (tenancy-ownership.ts, required), ' +
+      'turns.agent_id is NOT NULL, and `agents` derives via owner_id -> persons (G2-`unowned`), so ' +
+      'omni_tenant_ownership_agents leaves every agents row NULL-tenant and omni_tenant_ownership_turns ' +
+      'therefore stamps turns.tenant_id NULL for every row. Under enforcement a scoped read returns nothing ' +
+      'and turns.open fails the INSERT WITH CHECK (the composite FK (tenant_id, agent_id) -> agents cannot ' +
+      'be satisfied either). So this flips to tenant-boundary only once BOTH the async callers are converted ' +
+      'AND the G6 persons backfill lands — it is a G6-gated site, not still-convertible G5 work.',
   },
   {
     file: 'packages/api/src/services/webhooks.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -683,6 +683,19 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     class: 'tenant-boundary',
   },
   {
+    // G5-NEW (leg E, deliverable (e)). The voice WebSocket upgrade runs in
+    // `Bun.serve`'s raw `fetch`, BEFORE Hono, so it has no request scope; it
+    // resolves the session's instance owner itself inside
+    // `runInWorkerTenantScope` for the CREDENTIAL's tenant, reading through
+    // `scopedHandle`. Under enforcement RLS decides visibility, so a foreign
+    // instance never resolves. Deliberately NOT folded into `index.ts`, whose
+    // `instances` site is registered `control-plane` for process startup — a
+    // tenant-boundary read must not inherit that exemption.
+    file: 'packages/api/src/ws/voice-instance-ownership.ts',
+    table: 'instances',
+    class: 'tenant-boundary',
+  },
+  {
     // G5-CONVERTED (leg B pt3). The `custom.lid-mapping.batch` consumer runs
     // each mapping insert through `scopedHandle` inside its own per-item
     // worker scope (`runConsumerInTenantContext`), mirroring the per-statement

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -524,8 +524,34 @@ export const PENDING_G4_CEILING = 6;
  * is `trpc/router.ts` — a second synchronous edge with no tenant boundary at
  * all. That is G4-surface debt wearing a G5 label; the entry carries it as an
  * open question rather than silently reclassifying it.
+ *
+ * 12 after run15 (was 20). EIGHT sites were CONVERTED by scoping their callers,
+ * not relabelled: `instance-monitor.ts::instances` (health sweep + boot
+ * reconnect fanned out, single-row paths registry-derived),
+ * `batch-jobs.ts::{batch_jobs,media_content,messages}` (the last unscoped
+ * caller, `resumeJobs`, fanned out), `agent-replay.ts::{instances,messages}`
+ * (the two fire-and-forget event-listener callers detached and threaded),
+ * `access.ts::instances` (traced to a single request-only caller) and
+ * `media-storage.ts::messages` (the media-processor download's message write).
+ * No site moved between the two pending classes and no new pending site was
+ * opened.
+ *
+ * The REMAINING 12 are the honest floor, and none of them is unconverted G5
+ * async work:
+ *   * 8 G6-GATED — the table's tenant derives through a G2-`unowned` root, so a
+ *     scoped read finds nothing until the G6 backfill:
+ *     `idempotency.ts::processed_events`, `agent-runner.ts::persons`,
+ *     `automations.ts::automation_logs`, the four `agents` sites
+ *     (`agent-dispatcher`, `automation-actions`, `session-cleaner`,
+ *     `follow-up-lifecycle`) and `turns.ts::turns`. All are converted IN CODE.
+ *   * 4 DECISION-HELD — `connection-gauge.ts::instances` (control-plane
+ *     reclassification vs a G8A deployment credential), and
+ *     `instances.ts::instances`, `persons.ts::platform_identities` and
+ *     `access.ts::access_rules`, each held by `trpc/router.ts` alone.
+ *     `access.ts::access_rules` joined this group in run15: its two consumer
+ *     callers were converted, and the caller trace then found the tRPC edge.
  */
-export const PENDING_G5_CEILING = 20;
+export const PENDING_G5_CEILING = 12;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -579,8 +605,17 @@ export const PENDING_G5_CEILING = 20;
  * honestly registered pending (+1) on the same G6 `agents` gate as the
  * dispatcher and session-cleaner sites. Net zero by count; strictly better by
  * honesty: a consumer read no longer wears a bootstrap exemption.
+ *
+ * STILL 26 after G5 run14 (6 + 20): that leg shipped deliverable (g) and closed
+ * the async side of `instances.ts::instances`, but the site is held by
+ * `trpc/router.ts` alone, so nothing could be ratcheted honestly.
+ *
+ * 18 after G5 run15 (6 + 12): eight sites were CONVERTED by scoping their
+ * callers — see PENDING_G5_CEILING for the itemisation and for why the
+ * remaining 12 are a floor rather than a backlog. No site moved between the two
+ * pending classes this run, and no new pending site was opened.
  */
-export const TOTAL_PENDING_CEILING = 26;
+export const TOTAL_PENDING_CEILING = 18;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -849,11 +884,24 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/plugins/instance-monitor.ts',
     table: 'instances',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Reached only from a scheduled/interval loop (scheduler cron or setInterval), which runs on a timer with no ' +
-      'request and no credential. Tenant context for periodic work requires the G5 worker-context semantics ' +
-      '(ADR-0008).',
+      'CONVERTED (run15). Every path in this file is periodic work with no request, credential or envelope, and each ' +
+      'now derives its tenant without one. The two WHOLE-TABLE sweeps — the 30s health check and the once-per-boot ' +
+      'reconnectWithPool — adopt runForEachActiveTenantRow (the daily-sync/turn-monitor precedent): the discrete ' +
+      "listActive READ runs in each ACTIVE tenant's worker scope, while every plugin getStatus/connect (network work) " +
+      'runs outside it. The SINGLE-ROW paths (fetchInstanceById, and the markInstanceInactive DEACTIVATION) derive ' +
+      'their tenant from the instance-owner registry — persisted instances.tenant_id this process already loaded, ' +
+      "never a caller value — through runTenantWorkDb. Callers: the monitor's own timers plus index.ts, which wires " +
+      'services.authPlane.db via setAuthPlane and resolves a short-lived auth-plane handle for the boot reconnect ' +
+      '(services do not exist yet at that point). No tRPC caller. All four query sites issue on scopedHandle (the ' +
+      'class getter over the injected pool, and scopedHandle(db) in reconnectWithPool) — the run16 fix: opening a ' +
+      'worker scope is only half the conversion, because set_config(app.tenant_id) is TRANSACTION-local and a query ' +
+      'left on the injected pool takes a different connection that never saw the stamp. Flag-off/no-auth-plane is ' +
+      'the pre-G5 single ambient scan. Pinned by plugins/__tests__/instance-monitor-worker-scope.test.ts, whose ' +
+      'fake transaction yields a DISTINCT handle so a scope-opened/pool-queried site is visible, and which now also ' +
+      'drives reconnectWithPool directly (it previously had no executable coverage anywhere); real-RLS evidence for ' +
+      'both sweeps is plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts.',
   },
   {
     // G5-CONVERTED (leg B). The `message.received` consumer now passes its
@@ -974,36 +1022,73 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     table: 'access_rules',
     class: 'pending-G5-conversion',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'ASYNC SIDE COMPLETE (run15); held pending by a SYNCHRONOUS caller. Both consumer callers are now scoped: ' +
+      'agent-dispatcher.ts checkAccessWithFallback (all three checkAccess attempts — primary id, Baileys ' +
+      'participantAlt, LID->phone resolvedSenderPhone — plus the fire-and-forget requestPairing) and ' +
+      'agent-responder.ts processIncomingMessage, each threading its envelope-derived tenant so the ALLOW/DENY read ' +
+      "and the pairing transaction run in the message's world and the access.* publishes stay outside the scope. " +
+      'Every Hono route path runs inside the request transaction. What remains is trpc/router.ts — list, getById, ' +
+      'create and checkAccess — a second synchronous edge with NO tenant boundary of any kind; giving it one is ' +
+      'G4-surface work, not the ADR-0008 async-context work assigned to G5. Held for the SAME open decision as ' +
+      'services/instances.ts::instances and services/persons.ts::platform_identities: add the withTenantTransaction ' +
+      'edge, or retire the unmounted export. Not reclassified unilaterally — an unmounted export is still callable ' +
+      "by an out-of-repo consumer. NOTE: run15's prompt listed this site as still-convertible; the caller trace " +
+      'found the tRPC edge and it is reported as a decision-held site rather than ratcheted to fit. Async side ' +
+      'pinned by services/__tests__/access-worker-scope.test.ts for the SERVICE contract and by ' +
+      'plugins/__tests__/agent-dispatcher-access-callsite-scope.test.ts for the CALL SITES — the second was added ' +
+      'in run16 because the first, which invokes checkAccess/requestPairing with a literal tenant, stayed green ' +
+      'when the threaded argument was deleted from both dispatcher guards (the parameter is optional, so tsc and ' +
+      'biome stayed clean too). A caller-threading claim needs a caller-driven probe.',
   },
   {
     file: 'packages/api/src/services/access.ts',
     table: 'instances',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      "CONVERTED (run15). `instances` is read in this file from exactly ONE place: approvePairingRequest's " +
+      'channel-type lookup, used to route the access.pairing_approved subject. Its only caller is ' +
+      'routes/v2/instances.ts, mounted on protectedApp behind tenancyMiddleware, so the read runs inside the request ' +
+      'tenant transaction. No consumer, no cron and no tRPC procedure reaches it — the sibling access_rules site ' +
+      'stays pending precisely because the tRPC router reaches THAT table and not this one (the same per-table ' +
+      'distinction that split persons.ts::chat_id_mappings from persons.ts::platform_identities). The generic ' +
+      '"called from BOTH a route and a non-request caller" text this entry carried was G3-era boilerplate, not a ' +
+      'traced caller. Pinned by services/__tests__/access-worker-scope.test.ts.',
   },
   {
     file: 'packages/api/src/services/agent-replay.ts',
     table: 'instances',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED (run15). Two callers. routes/v2/instances.ts drives replayMissedMessages inside the request tenant ' +
+      'transaction and threads nothing, so every block stays on that transaction. plugins/event-listeners.ts calls ' +
+      'onInstanceConnect / updateLastSeenAt FIRE-AND-FORGET from the instance.connected/disconnected consumers; both ' +
+      'now run through runDetachedFromTenantScope (the G4 leg-2 rule) and thread trustedEnvelopeTenant(event) — the ' +
+      'producer-stamped envelope tenant, quarantine-refusing, never a payload claim. The tenant is THREADED rather ' +
+      'than wrapped because replay publishes one message.received per replayed row and a worker transaction held ' +
+      'across a publish would make the event a pre-commit side effect; each DB block (the instance read, each ' +
+      'message PAGE, the lastSeenAt write) opens its own short runTenantWorkDb scope. Legacy envelopes thread ' +
+      'undefined and every block stays ambient. Pinned by services/__tests__/agent-replay-worker-scope.test.ts for ' +
+      'the SERVICE contract and by plugins/__tests__/event-listeners-replay-callsite-scope.test.ts for the CALL ' +
+      'SITES (run16: the fire-and-forget is swallowed by a .catch(log), so dropping the threaded tenant left every ' +
+      'gate green — the caller-driven probe is what makes this justification checkable).',
   },
   {
     file: 'packages/api/src/services/agent-replay.ts',
     table: 'messages',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      'CONVERTED (run15). Two callers. routes/v2/instances.ts drives replayMissedMessages inside the request tenant ' +
+      'transaction and threads nothing, so every block stays on that transaction. plugins/event-listeners.ts calls ' +
+      'onInstanceConnect / updateLastSeenAt FIRE-AND-FORGET from the instance.connected/disconnected consumers; both ' +
+      'now run through runDetachedFromTenantScope (the G4 leg-2 rule) and thread trustedEnvelopeTenant(event) — the ' +
+      'producer-stamped envelope tenant, quarantine-refusing, never a payload claim. The tenant is THREADED rather ' +
+      'than wrapped because replay publishes one message.received per replayed row and a worker transaction held ' +
+      'across a publish would make the event a pre-commit side effect; each DB block (the instance read, each ' +
+      'message PAGE, the lastSeenAt write) opens its own short runTenantWorkDb scope. Legacy envelopes thread ' +
+      'undefined and every block stays ambient. Pinned by services/__tests__/agent-replay-worker-scope.test.ts for ' +
+      'the SERVICE contract and by plugins/__tests__/event-listeners-replay-callsite-scope.test.ts for the CALL ' +
+      'SITES (run16: the fire-and-forget is swallowed by a .catch(log), so dropping the threaded tenant left every ' +
+      'gate green — the caller-driven probe is what makes this justification checkable).',
   },
   {
     // G5-CONVERTED (leg G). `getInstanceWithProvider` — the lookup EVERY dispatch
@@ -1086,35 +1171,68 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/batch-jobs.ts',
     table: 'batch_jobs',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Two paths reach this service. The route-facing create/list/get paths run inside the request tenant ' +
-      'transaction and are scoped. The background job executor is a worker-context path: it is spawned ' +
-      'fire-and-forget and DELIBERATELY detached from the request scope (tenant-scope.ts runDetachedFromTenantScope), ' +
-      'because it outlives the request transaction and must run on the ambient pool to avoid a use-after-commit. ' +
-      'Converting that worker path to its own tenant scope needs the G5 async context (ADR-0008).',
+      'CONVERTED (run15). The route-facing create/list/get/cancel/estimate paths run inside the request tenant ' +
+      'transaction. The fire-and-forget executor stays DETACHED (it outlives the request — the use-after-commit ' +
+      "rule) but is no longer unscoped: create captures the job's TRUSTED tenant as a VALUE before detaching " +
+      "(currentTenantScope for a request caller, threaded trustedTenantId for the sync-worker's post-sync " +
+      'backfill), stamps it on the row, and every discrete DB block inside executeJob runs in its own short ' +
+      'runTenantWorkDb scope with downloads, AI calls and publishes outside — plus dequeue-time and ' +
+      'pre-side-effect tenant revalidation (RELEASE_SLOS queued_retry_delayed_dlq_check). run15 closed the LAST ' +
+      'unscoped caller: resumeJobs, the restart-recovery whole-table scan for status=running, now fans out with ' +
+      'runForEachActiveTenantRow and dispatches each job under its OWN persisted tenant_id outside the read scope. ' +
+      'No tRPC caller. Flag-off/no-auth-plane is the pre-G5 single ambient scan, pinned by ' +
+      'services/__tests__/batch-jobs-resume-worker-scope.test.ts (plus batch-jobs-tenant-scope and ' +
+      'batch-jobs-dequeue-revalidation for the executor). The sync-worker threading named above is pinned by ' +
+      'plugins/__tests__/sync-worker-media-backfill-scope.test.ts, which drives the real sync.started handler: ' +
+      'run16 found that call site passing no tenant at all, so an enqueue from OUTSIDE every per-item scope would ' +
+      'have stamped a NULL-tenant row whose detached executor ran the whole media backfill unscoped and skipped ' +
+      'the dequeue-time revocation gate (a null tenant is admissible by definition).',
   },
   {
     file: 'packages/api/src/services/batch-jobs.ts',
     table: 'media_content',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Two paths reach this service. The route-facing create/list/get paths run inside the request tenant ' +
-      'transaction and are scoped. The background job executor is a worker-context path: it is spawned ' +
-      'fire-and-forget and DELIBERATELY detached from the request scope (tenant-scope.ts runDetachedFromTenantScope), ' +
-      'because it outlives the request transaction and must run on the ambient pool to avoid a use-after-commit. ' +
-      'Converting that worker path to its own tenant scope needs the G5 async context (ADR-0008).',
+      'CONVERTED (run15). The route-facing create/list/get/cancel/estimate paths run inside the request tenant ' +
+      'transaction. The fire-and-forget executor stays DETACHED (it outlives the request — the use-after-commit ' +
+      "rule) but is no longer unscoped: create captures the job's TRUSTED tenant as a VALUE before detaching " +
+      "(currentTenantScope for a request caller, threaded trustedTenantId for the sync-worker's post-sync " +
+      'backfill), stamps it on the row, and every discrete DB block inside executeJob runs in its own short ' +
+      'runTenantWorkDb scope with downloads, AI calls and publishes outside — plus dequeue-time and ' +
+      'pre-side-effect tenant revalidation (RELEASE_SLOS queued_retry_delayed_dlq_check). run15 closed the LAST ' +
+      'unscoped caller: resumeJobs, the restart-recovery whole-table scan for status=running, now fans out with ' +
+      'runForEachActiveTenantRow and dispatches each job under its OWN persisted tenant_id outside the read scope. ' +
+      'No tRPC caller. Flag-off/no-auth-plane is the pre-G5 single ambient scan, pinned by ' +
+      'services/__tests__/batch-jobs-resume-worker-scope.test.ts (plus batch-jobs-tenant-scope and ' +
+      'batch-jobs-dequeue-revalidation for the executor). The sync-worker threading named above is pinned by ' +
+      'plugins/__tests__/sync-worker-media-backfill-scope.test.ts, which drives the real sync.started handler: ' +
+      'run16 found that call site passing no tenant at all, so an enqueue from OUTSIDE every per-item scope would ' +
+      'have stamped a NULL-tenant row whose detached executor ran the whole media backfill unscoped and skipped ' +
+      'the dequeue-time revocation gate (a null tenant is admissible by definition).',
   },
   {
     file: 'packages/api/src/services/batch-jobs.ts',
     table: 'messages',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Two paths reach this service. The route-facing create/list/get paths run inside the request tenant ' +
-      'transaction and are scoped. The background job executor is a worker-context path: it is spawned ' +
-      'fire-and-forget and DELIBERATELY detached from the request scope (tenant-scope.ts runDetachedFromTenantScope), ' +
-      'because it outlives the request transaction and must run on the ambient pool to avoid a use-after-commit. ' +
-      'Converting that worker path to its own tenant scope needs the G5 async context (ADR-0008).',
+      'CONVERTED (run15). The route-facing create/list/get/cancel/estimate paths run inside the request tenant ' +
+      'transaction. The fire-and-forget executor stays DETACHED (it outlives the request — the use-after-commit ' +
+      "rule) but is no longer unscoped: create captures the job's TRUSTED tenant as a VALUE before detaching " +
+      "(currentTenantScope for a request caller, threaded trustedTenantId for the sync-worker's post-sync " +
+      'backfill), stamps it on the row, and every discrete DB block inside executeJob runs in its own short ' +
+      'runTenantWorkDb scope with downloads, AI calls and publishes outside — plus dequeue-time and ' +
+      'pre-side-effect tenant revalidation (RELEASE_SLOS queued_retry_delayed_dlq_check). run15 closed the LAST ' +
+      'unscoped caller: resumeJobs, the restart-recovery whole-table scan for status=running, now fans out with ' +
+      'runForEachActiveTenantRow and dispatches each job under its OWN persisted tenant_id outside the read scope. ' +
+      'No tRPC caller. Flag-off/no-auth-plane is the pre-G5 single ambient scan, pinned by ' +
+      'services/__tests__/batch-jobs-resume-worker-scope.test.ts (plus batch-jobs-tenant-scope and ' +
+      'batch-jobs-dequeue-revalidation for the executor). The sync-worker threading named above is pinned by ' +
+      'plugins/__tests__/sync-worker-media-backfill-scope.test.ts, which drives the real sync.started handler: ' +
+      'run16 found that call site passing no tenant at all, so an enqueue from OUTSIDE every per-item scope would ' +
+      'have stamped a NULL-tenant row whose detached executor ran the whole media backfill unscoped and skipped ' +
+      'the dequeue-time revocation gate (a null tenant is admissible by definition).',
   },
   {
     file: 'packages/api/src/services/chats.ts',
@@ -1289,11 +1407,16 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   {
     file: 'packages/api/src/services/media-storage.ts',
     table: 'messages',
-    class: 'pending-G5-conversion',
+    class: 'tenant-boundary',
     justification:
-      'Called from BOTH a route and a non-request caller (eventBus consumer and/or scheduler cron). The route path ' +
-      'now runs inside the tenant transaction, but the site cannot be called converted while its worker caller ' +
-      'still reaches the ambient pool — closing that caller needs the G5 async context (ADR-0008).',
+      "CONVERTED (run15). This site is ONE query — updateMessageLocalPath's update(messages) — and all three of its " +
+      'callers are scoped. routes/v2/messages.ts runs inside the request tenant transaction; services/batch-jobs.ts ' +
+      "resolveFilePath already wrapped it in runTenantWorkDb with the job's tenant; and run15 closed the last one, " +
+      'plugins/media-processor.ts downloadMediaFromUrl, which threaded its envelope tenant into storeFromUrl (for the ' +
+      'tenant-prefixed object key and the egress policy) but left the message write on the ambient handle. It now ' +
+      'runs through runMediaDb, so the NETWORK download stays outside any scope and the write lands in the same ' +
+      'tenant transaction as the rest of the item. Legacy envelopes write ambient, byte-identically. Pinned by ' +
+      'plugins/__tests__/media-storage-worker-scope.test.ts.',
   },
   {
     file: 'packages/api/src/services/messages.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -415,8 +415,15 @@ export const PENDING_G4_CEILING = 6;
  * (tenancy/worker-tenant-context.ts) and run their DB work through
  * `scopedHandle`, so every caller — the only callers are those NATS consumers —
  * now reaches a tenant transaction. They became `tenant-boundary`.
+ *
+ * LOWERED TO 43 BY G5 LEG B. The three `media-processor.ts` sites (`media_content`,
+ * `messages`, `omni_events`) converted: the `message.received` consumer threads
+ * its versioned envelope into `processMessageMedia`, whose DB blocks run inside
+ * `runConsumerInTenantContext` + `scopedHandle` while the media download/AI work
+ * stays outside the transaction. All three were consumer-only sites, so every
+ * caller now reaches a tenant transaction; they became `tenant-boundary`.
  */
-export const PENDING_G5_CEILING = 46;
+export const PENDING_G5_CEILING = 43;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -432,8 +439,11 @@ export const PENDING_G5_CEILING = 46;
  *
  * 52 after G5 leg A (6 + 46): the two `event-persistence.ts` consumer sites were
  * CONVERTED, not relabelled — the only move that lowers this number.
+ *
+ * 49 after G5 leg B (6 + 43): the three `media-processor.ts` consumer sites were
+ * CONVERTED, not relabelled.
  */
-export const TOTAL_PENDING_CEILING = 52;
+export const TOTAL_PENDING_CEILING = 49;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -658,31 +668,33 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       '(ADR-0008).',
   },
   {
+    // G5-CONVERTED (leg B). The `message.received` consumer now passes its
+    // versioned envelope into `processMessageMedia`, whose two DB blocks —
+    // `persistProcessingResult` (this `media_content` insert + the `messages`
+    // content write) and the error-marker `messages` update — run inside
+    // `runConsumerInTenantContext`, so `scopedHandle(ctx.db)` returns the worker
+    // transaction and this insert is RLS-scoped. The media download + AI work
+    // stay OUTSIDE the transaction (no tx across network I/O). A legacy envelope
+    // runs on the ambient pool byte-identically; a quarantined one is refused.
     file: 'packages/api/src/plugins/media-processor.ts',
     table: 'media_content',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg B) — see the sibling `media_content` entry above. Both
+    // the success content write and the failure marker go through
+    // `scopedHandle(ctx.db)` inside the worker tenant scope.
     file: 'packages/api/src/plugins/media-processor.ts',
     table: 'messages',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED (leg B) — the `media_content` FK existence check
+    // (`resolveSafeMediaContentEventId`) now reads `omni_events` through
+    // `scopedHandle(ctx.db)` within the same worker scope as the insert it feeds.
     file: 'packages/api/src/plugins/media-processor.ts',
     table: 'omni_events',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/plugins/session-cleaner.ts',

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -408,8 +408,15 @@ export const PENDING_G4_CEILING = 6;
  * The honest check on a raised cap is not the cap itself but the TOTAL, since
  * relabelling moves a site between the two pending classes without changing it.
  * `TOTAL_PENDING_CEILING` below is that check, and it went DOWN.
+ *
+ * LOWERED TO 46 BY G5 LEG A. The two `event-persistence.ts` sites (`chats`,
+ * `omni_events`) converted: their consumer handlers now establish a worker
+ * tenant scope from the versioned envelope's trusted tenant
+ * (tenancy/worker-tenant-context.ts) and run their DB work through
+ * `scopedHandle`, so every caller — the only callers are those NATS consumers —
+ * now reaches a tenant transaction. They became `tenant-boundary`.
  */
-export const PENDING_G5_CEILING = 48;
+export const PENDING_G5_CEILING = 46;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -422,8 +429,11 @@ export const PENDING_G5_CEILING = 48;
  * retired by the scanner-precision fix and 1 real site closed as the auth-plane
  * bootstrap. The 5 G4→G5 moves changed it by exactly zero, which is the
  * property that makes them checkable rather than merely argued.
+ *
+ * 52 after G5 leg A (6 + 46): the two `event-persistence.ts` consumer sites were
+ * CONVERTED, not relabelled — the only move that lowers this number.
  */
-export const TOTAL_PENDING_CEILING = 54;
+export const TOTAL_PENDING_CEILING = 52;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -621,22 +631,22 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
       'propagation ADR-0008 assigns to G5.',
   },
   {
+    // G5-CONVERTED. Both handlers now wrap their DB work in
+    // `runConsumerInTenantContext` (tenancy/worker-tenant-context.ts): a
+    // versioned envelope's trusted tenant opens a fresh worker tenant scope, and
+    // `scopedHandle(db)` returns that transaction, so this `chats` lookup is
+    // RLS-scoped exactly as a converted route service. A legacy envelope runs on
+    // the ambient pool byte-identically; a quarantined one never reaches the
+    // handler (subscription.ts rejects it first).
     file: 'packages/api/src/plugins/event-persistence.ts',
     table: 'chats',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
+    // G5-CONVERTED — see the sibling `chats` entry above.
     file: 'packages/api/src/plugins/event-persistence.ts',
     table: 'omni_events',
-    class: 'pending-G5-conversion',
-    justification:
-      'Reached only from an eventBus/NATS consumer callback, which has no HTTP request and therefore no credential ' +
-      'to derive a tenant from. Establishing tenant context for a consumer requires the async message-context ' +
-      'propagation ADR-0008 assigns to G5.',
+    class: 'tenant-boundary',
   },
   {
     file: 'packages/api/src/plugins/instance-monitor.ts',

--- a/scripts/disposable-pg-cluster.ts
+++ b/scripts/disposable-pg-cluster.ts
@@ -164,11 +164,20 @@ export async function createDisposableCluster(bins: PgBinaries = resolvePgBinari
   const pgData = join(dataDir, 'data');
   // Loopback only. An `initdb` default already omits listen_addresses, but
   // being explicit means a stray postgresql.conf template cannot widen it.
+  // The socket lives in the data dir: distribution builds (Debian/Ubuntu
+  // pgdg) default unix_socket_directories to /var/run/postgresql, which an
+  // unprivileged CI runner cannot write — the postmaster then dies on its
+  // lock file before ever listening.
   writeFileSync(
     join(pgData, 'postgresql.auto.conf'),
-    ["listen_addresses = '127.0.0.1'", 'fsync = off', 'synchronous_commit = off', 'full_page_writes = off', ''].join(
-      '\n',
-    ),
+    [
+      "listen_addresses = '127.0.0.1'",
+      `unix_socket_directories = '${pgData}'`,
+      'fsync = off',
+      'synchronous_commit = off',
+      'full_page_writes = off',
+      '',
+    ].join('\n'),
   );
 
   let started: { port: number } | null = null;
@@ -188,8 +197,16 @@ export async function createDisposableCluster(bins: PgBinaries = resolvePgBinari
     }
   }
   if (started === null) {
+    // pg_ctl's stderr only says "could not start server" — the reason lives
+    // in server.log, so capture it before the data dir is destroyed.
+    let serverLog = '';
+    try {
+      serverLog = readFileSync(join(dataDir, 'server.log'), 'utf-8');
+    } catch {
+      serverLog = '(no server.log was written)';
+    }
     rmSync(dataDir, { recursive: true, force: true });
-    throw new Error(`disposable-pg: postmaster would not start after 8 attempts\n${lastError}`);
+    throw new Error(`disposable-pg: postmaster would not start after 8 attempts\n${lastError}\n${serverLog}`);
   }
 
   const url = `postgres://${superuser}:${encodeURIComponent(password)}@127.0.0.1:${started.port}/postgres`;


### PR DESCRIPTION
# omni full multitenancy — G5 (asynchronous surface conversion)

Continues #866 (G0–G4). Converts the **asynchronous/worker plane** to tenant-scoped execution: NATS consumers, schedulers, automation engine, streaming, storage, and credential surfaces. Enforcement remains **test-activated only** — flag-off behavior is byte-identical everywhere; merging this PR changes nothing at runtime for existing deployments.

## Deliverables (all complete)

- **(a) Versioned event envelope** with validation + quarantine; producer-side tenant stamping; engine-level quarantine refusal.
- **(b) Tenant-egress broker** with SSRF guard; `OMNI_MEDIA_URL_GUARD=off` subsumed for tenant contexts. (10 raw-fetch files remain an accepted floor, carried to G7 — Felipe ruling 07-23.)
- **(c) Revocation propagation ceilings** proven with synthetic epochs: presign-after-revoke=0, WS/SSE termination ≤30s, auth-cache ≤15s, inflight privileged work ≤30s (numbers from RELEASE_SLOS.yaml).
- **(d) Storage prefixing + presign TTL≤60s** with revocation gate.
- **(e) Streaming/long-lived-state tenant keying**; revocation-terminated sessions.
- **(f) Observability sink** — bounded labels + redacted audit.
- **(g) Credential/session-secret AEAD sealing** (AES-256-GCM, HKDF per-tenant DEK, tenantId as AAD, fail-closed; opt-in — no master key in tracked code, no credential backfill in this PR).

## Ratchet

49 pending sites at G5 start → **12 at close** (honest floor: 8 G6-gated on `persons.tenant_id` backfill + 4 held by open decisions on `trpc/router.ts` and `connection-gauge`). PENDING_G4 floor of 6 untouched. Ceilings only go down; the db-access guard enforces them in CI.

## Review trail

15 execution legs (run1–run15), each through a 5-lens review (invariant / security / ratchet / tests / process) with adversarial verification of findings and RED→GREEN fixer probes; all legs closed SHIP. Notable catches fixed in-branch: a sealed-envelope-as-bearer-token credential leak in `AgentRunnerService.getClient`, and a probe-pattern blind spot that had let `instance-monitor.ts` ratchet without `scopedHandle`.

## Merge with dev

`origin/dev` (post-#866/#868/#869) merged in at `7e261e3e`: the idle-timeout gate keeps both G5's `trustedTenantId` threading and #869's `claimToken`/`releaseIdleTimeoutClaim` semantics; the voice-WS null-refusal fix (#868) and mixed-tenancy boot warning carry through unchanged.

## Gates at HEAD

- pg-gate: **PASSED — 247 assertions / 20 suites / 0 skipped** (two-tenant Postgres, FORCE RLS)
- db-access guard: OK — 6 pending-G4 / 12 pending-G5 / 18 total, all at ceiling
- turbo typecheck (api, core, db): 9/9 · biome: clean

## Out of scope

G6 (persons backfill — follows this PR), G7 adversarial qualification, G8A staging/canary. Production enablement is gated behind G7/G8A per WISH; `production_authorized=false` stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
