### PR TITLE
Promote dev to main: plugin revamp planning + Hermes profile

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "author": {
         "name": "Automagik"
       },

--- a/.genie/INDEX.md
+++ b/.genie/INDEX.md
@@ -6,6 +6,6 @@
 
 ## Ready
 
-- [omni-plugin-revamp](brainstorms/omni-plugin-revamp/DESIGN.md) — simplify plugins/omni to genie-plugin conventions; kill stale v4 surface (design review pending)
-
 ## Poured
+
+- [omni-plugin-revamp](wishes/omni-plugin-revamp/WISH.md) — simplify plugins/omni to genie-plugin conventions; kill stale v4 surface. Design SHIP, plan SHIP, status APPROVED; 4 groups on the board.

--- a/.genie/INDEX.md
+++ b/.genie/INDEX.md
@@ -1,0 +1,11 @@
+# Plans Index
+
+## Raw
+
+## Simmering
+
+## Ready
+
+- [omni-plugin-revamp](brainstorms/omni-plugin-revamp/DESIGN.md) — simplify plugins/omni to genie-plugin conventions; kill stale v4 surface (design review pending)
+
+## Poured

--- a/.genie/brainstorms/omni-plugin-revamp/DESIGN.md
+++ b/.genie/brainstorms/omni-plugin-revamp/DESIGN.md
@@ -19,6 +19,10 @@ change silently invalidates hardcoded command lists.
 ## Scope
 
 ### IN
+
+Primary surface is `plugins/omni/**`; the last two bullets also touch repo-root
+`.claude/` and two doc files, because the same rot lives there.
+
 - `plugins/omni/**`: skills, commands, agents, hooks, `plugin.json`
 - Restructure to the genie plugin shape: one router skill (`omni`) + flat peer
   skills, each ≤ 100 lines (hard CI budget; aim lower), long material moved to
@@ -48,12 +52,19 @@ change silently invalidates hardcoded command lists.
 - Repo-root `.claude/skills/*.md` flat files that never load: convert the ones
   worth keeping to `<name>/SKILL.md` dirs, delete the rest; wire or delete the
   orphaned `hooks/wish-validator.md`
+- Delete the doc sections that describe an MCP server omni does not have:
+  `docs/architecture/overview.md` "MCP Integration" (nine tools, HTTP/stdio,
+  port 8882) and the `packages/mcp/` row in `.claude/CLAUDE.md`'s structure
+  table — same doc-rot class as the genie-v4 commands this wish removes
 
 ### OUT
-- MCP server exposure in `plugin.json` — `packages/mcp` does not exist (the
-  project-structure table in `.claude/CLAUDE.md` is aspirational); authoring an
-  MCP server is its own wish. The user's genie-parity intent is recorded there,
-  not here.
+- MCP entirely — the plugin drives omni through the CLI and nothing else. No
+  `packages/mcp` exists anywhere on `dev` (verified: `git ls-tree -r origin/dev`
+  matches zero `mcp` paths), and the user's decision is CLI-only, so no MCP
+  server is written, exposed, or planned. Instead this wish deletes the two
+  places that document a server as if it ships: the MCP section of
+  `docs/architecture/overview.md` and the `packages/mcp/` row in
+  `.claude/CLAUDE.md`'s structure table.
 - `packages/cli/src/commands/connect.ts` genie-v4 contract bug — product code,
   ships as its own `fix(cli)` commit/PR independent of this wish
 - Any behavior change to the omni product API or CLI
@@ -88,7 +99,7 @@ independently.
 |---|----------|-----------|
 | 1 | Delete all 11 slash commands | User decision. Genie ships zero; skills are the only surface; removes ~280 lines duplicating references 1:1. |
 | 2 | Simplify SessionStart hook: probe only, no auto-install | User decision. Keeps fresh-session signal; removes a 430-line shim silently installing software. |
-| 3 | MCP exposure deferred to its own wish | The user chose "add it" on the (wrong) premise that `packages/mcp` exists; it does not, and authoring a server breaks single-wish scope. Deferred with intent preserved. |
+| 3 | CLI-only: no MCP, now or planned | The user first chose "add it" on my wrong premise that `packages/mcp` exists; once corrected they chose CLI-only. One surface (the CLI) is the simpler contract, and the stale docs claiming an MCP server get deleted here. |
 | 4 | Single skill location + CI gates, no mirror sync | Omni skills have exactly one consumer (the plugin); sync machinery is YAGNI. |
 | 5 | Fold bot-framework and automation-builder agents; keep feature-implementor | The first two are prose pointers into omni-ops; the third targets repo-internal dev work no skill covers. |
 | 6 | `connect.ts` v4-contract bug ships separately | Product code bug with its own test surface; keeping the wish plugin-only keeps it reviewable. |
@@ -113,10 +124,12 @@ src/term-commands/omni.ts).
 ## Success Criteria
 
 - [ ] `plugins/omni/commands/` no longer exists; plugin loads cleanly without it
-- [ ] Every `SKILL.md` under `plugins/omni/skills/` is ≤ 100 lines, carries only
-      `name`, `description`, and (where it shells out) `allowed-tools`
-      frontmatter, and uses the operational section grammar
-      (`When to Use → Flow → Rules`)
+- [ ] Every `SKILL.md` under `plugins/omni/skills/` is ≤ 100 lines and carries
+      only `name`, `description`, and (where it shells out) `allowed-tools`
+      frontmatter. Peer skills use the operational grammar
+      (`When to Use → Flow → Rules`); the router is exempt from the grammar
+      check and uses a routing shape (intent table → rules), as genie's router
+      does
 - [ ] No skill or reference names a `genie` v4 command (`genie serve`,
       `genie dir`) — grep returns zero hits
 - [ ] No skill hardcodes an `omni` subcommand list; each instructs discovering
@@ -124,8 +137,9 @@ src/term-commands/omni.ts).
 - [ ] Agents directory contains exactly `omni-feature-implementor`;
       `rules/omni-agent.md` is gone, its content folded into the omni-agent skill
 - [ ] SessionStart hook performs no installation; probe script ≤ 80 lines
-- [ ] `plugin.json` declares repository, license, keywords (no MCP entry —
-      deferred wish)
+- [ ] `plugin.json` declares repository, license, keywords, and no `mcpServers`
+      key; `rg -i mcp` over `plugins/omni/`, `docs/architecture/overview.md`,
+      and `.claude/CLAUDE.md` returns zero hits claiming a shipped MCP server
 - [ ] CI gate builds the CLI from `packages/cli` and fails on: over-budget
       skill, malformed frontmatter, a named CLI subcommand absent from
       `omni --help`, fresh-install smoke failure
@@ -141,7 +155,7 @@ After an independent design review returns SHIP, persist the evidence below and 
 ## Design Review Evidence
 
 - **Verdict:** SHIP
-- **Reviewed content SHA-256:** `e628e5280d3fcd4134c45ff1fef2a874c76ea2e6b95610d400d0fabf2f0bd4e4`
-- **Reviewer:** design-reviewer-a783b2fe
-- **Reviewed at:** 2026-07-28T22:08:19.000Z
+- **Reviewed content SHA-256:** `c81dc644dbb5d7d530d8b766578ba0ae0a34f6196afa3b7c49ce7a0d92c658b6`
+- **Reviewer:** design-reviewer-ae3b4037
+- **Reviewed at:** 2026-07-29T00:17:22.000Z
 <!-- genie-design-review:end -->

--- a/.genie/brainstorms/omni-plugin-revamp/DESIGN.md
+++ b/.genie/brainstorms/omni-plugin-revamp/DESIGN.md
@@ -1,0 +1,147 @@
+# Design: Omni Plugin Revamp — genie-shape simplification
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `omni-plugin-revamp` |
+| **Date** | 2026-07-28 |
+| **WRS** | 100/100 |
+
+## Problem
+
+The omni Claude Code plugin (`plugins/omni/**`) has rotted since its single bulk
+commit on 2026-07-04: its setup skill teaches genie v4 commands that no longer
+exist, 11 slash commands (~280 lines) duplicate the omni-ops references 1:1,
+two routing layers stack on each other, two of three agents are prose pointers,
+and nothing mechanically prevents further drift. Plugin users get wrong
+instructions today (`genie serve start` fails on genie v5), and every omni CLI
+change silently invalidates hardcoded command lists.
+
+## Scope
+
+### IN
+- `plugins/omni/**`: skills, commands, agents, hooks, `plugin.json`
+- Restructure to the genie plugin shape: one router skill (`omni`) + flat peer
+  skills, each ≤ 100 lines (hard CI budget; aim lower), long material moved to
+  `references/`. Section grammar per skill class, matching genie's actual
+  practice: operational skills (omni-agent, omni-setup, ops peers) use
+  `When to Use → Flow → Rules`; only audit-class skills (none planned today)
+  use the Lens → Mandate → … audit grammar
+- Delete all 11 slash commands (`commands/` directory removed)
+- Rewrite `omni-setup` against the real genie v5 surface
+  (`genie omni serve|status|inbox|handshake`), in discover-ground-truth style
+  (read `omni --help` / `genie omni --help` at use time; never hardcode
+  subcommand lists); verify the NATS topic table against the v5 bridge or drop it
+- Fold `omni-bot-framework` and `omni-automation-builder` agents into the
+  skills they point at; keep `omni-feature-implementor` (genuinely distinct:
+  repo-internal platform development)
+- Collapse the two routing layers: the `omni` router dispatches directly to
+  peer skills; `omni-ops` becomes references consumed by those skills, not a
+  second router
+- Simplify the SessionStart hook: keep the health probe, remove auto-install
+  (detect + one-line install hint); shrink `omni-runner.js` accordingly
+- Fold `rules/omni-agent.md` (12 lines duplicating the omni-agent skill) into
+  the omni-agent skill; delete the rules file
+- Enrich `plugin.json` metadata: repository, license, keywords (genie parity)
+- CI anti-rot gates: skills lint (size budget, frontmatter shape, section
+  grammar) + fresh-install smoke (plugin loads, router resolves, every CLI
+  subcommand a skill names exists in `omni --help` output)
+- Repo-root `.claude/skills/*.md` flat files that never load: convert the ones
+  worth keeping to `<name>/SKILL.md` dirs, delete the rest; wire or delete the
+  orphaned `hooks/wish-validator.md`
+
+### OUT
+- MCP server exposure in `plugin.json` — `packages/mcp` does not exist (the
+  project-structure table in `.claude/CLAUDE.md` is aspirational); authoring an
+  MCP server is its own wish. The user's genie-parity intent is recorded there,
+  not here.
+- `packages/cli/src/commands/connect.ts` genie-v4 contract bug — product code,
+  ships as its own `fix(cli)` commit/PR independent of this wish
+- Any behavior change to the omni product API or CLI
+- A canonical-dir + mirror sync layer (genie needs it because its skills ship
+  to multiple tiers; omni's skills live only in the plugin — single location
+  plus CI gates is simpler and sufficient)
+- khal-ui, docs site, marketplace mechanics
+
+## Approach
+
+**Chosen: subtractive restructure to the genie shape, gated by CI.** Delete the
+command layer, flatten routing to one router + peers, fold pointer-agents,
+rewrite the one stale skill against v5, and encode the new shape in lint +
+smoke gates so it cannot silently rot again.
+
+Alternatives considered:
+- *Incremental dedupe (keep commands, strip to pointers):* preserves `/send`
+  muscle memory but keeps three surfaces (commands, router, references) that
+  drift independently — rejected by the "delete all" decision.
+- *Full genie clone incl. canonical/mirror sync:* the sync machinery earns its
+  keep only when skills ship to multiple consumers; omni has one. Rejected as
+  YAGNI.
+
+Isolation: each peer skill has a single purpose describable in one sentence;
+skills depend on the CLI contract (discovered at use time), never on each
+other's internals; the smoke gate tests each skill's named surface
+independently.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Delete all 11 slash commands | User decision. Genie ships zero; skills are the only surface; removes ~280 lines duplicating references 1:1. |
+| 2 | Simplify SessionStart hook: probe only, no auto-install | User decision. Keeps fresh-session signal; removes a 430-line shim silently installing software. |
+| 3 | MCP exposure deferred to its own wish | The user chose "add it" on the (wrong) premise that `packages/mcp` exists; it does not, and authoring a server breaks single-wish scope. Deferred with intent preserved. |
+| 4 | Single skill location + CI gates, no mirror sync | Omni skills have exactly one consumer (the plugin); sync machinery is YAGNI. |
+| 5 | Fold bot-framework and automation-builder agents; keep feature-implementor | The first two are prose pointers into omni-ops; the third targets repo-internal dev work no skill covers. |
+| 6 | `connect.ts` v4-contract bug ships separately | Product code bug with its own test surface; keeping the wish plugin-only keeps it reviewable. |
+| 7 | Discover-ground-truth style everywhere | Hardcoded command lists are the rot vector that broke omni-setup; genie's `--help`-at-use-time pattern prevents recurrence. |
+| 8 | Keep `allowed-tools` frontmatter | It is functional (permission-prompt UX), not metadata bloat; "minimal frontmatter" means `name`, `description`, and `allowed-tools` where the skill shells out — nothing else. |
+| 9 | CI runs `omni --help` from source | The gate builds the CLI from `packages/cli` in-repo (`make cli-build` / `bun run`) instead of depending on a globally installed `omni`; no auto-installer needed in CI. |
+
+## Risks & Assumptions
+
+| # | Risk | Severity | Mitigation |
+|---|------|----------|------------|
+| 1 | Users with `/send` etc. muscle memory lose commands | Medium | Router skill answers the same intents; CHANGELOG + README migration note mapping each removed command to its phrase. |
+| 2 | genie v5 surface drifts again (lives in another repo) | Medium | Discover-ground-truth style + smoke gate shells `genie omni --help` when genie is present; skill states the contract version it was written against. |
+| 3 | Dropping auto-install changes fresh-install UX | Low | Probe prints the exact install command; README quickstart covers it. |
+| 4 | NATS topic table in omni-setup may be wrong for v5 bridge | Low | Verify against the v5 bridge during rewrite; drop the table if unverifiable (discover at runtime instead). |
+| 5 | Removing `allowed-tools` would regress permission UX | Low | Decision 8: keep it. |
+
+Assumptions: genie v5's `genie omni serve|status|inbox|handshake` is the stable
+integration surface (confirmed in ../genie README and
+src/term-commands/omni.ts).
+
+## Success Criteria
+
+- [ ] `plugins/omni/commands/` no longer exists; plugin loads cleanly without it
+- [ ] Every `SKILL.md` under `plugins/omni/skills/` is ≤ 100 lines, carries only
+      `name`, `description`, and (where it shells out) `allowed-tools`
+      frontmatter, and uses the operational section grammar
+      (`When to Use → Flow → Rules`)
+- [ ] No skill or reference names a `genie` v4 command (`genie serve`,
+      `genie dir`) — grep returns zero hits
+- [ ] No skill hardcodes an `omni` subcommand list; each instructs discovering
+      via `--help`
+- [ ] Agents directory contains exactly `omni-feature-implementor`;
+      `rules/omni-agent.md` is gone, its content folded into the omni-agent skill
+- [ ] SessionStart hook performs no installation; probe script ≤ 80 lines
+- [ ] `plugin.json` declares repository, license, keywords (no MCP entry —
+      deferred wish)
+- [ ] CI gate builds the CLI from `packages/cli` and fails on: over-budget
+      skill, malformed frontmatter, a named CLI subcommand absent from
+      `omni --help`, fresh-install smoke failure
+- [ ] Repo-root `.claude/skills/` contains only loadable `<name>/SKILL.md` dirs
+      (or is empty); no orphaned hook docs
+- [ ] Migration note maps each of the 11 removed commands to its router phrase
+
+## Next Step
+
+After an independent design review returns SHIP, persist the evidence below and verify its content digest before running `wish`.
+
+<!-- genie-design-review:start -->
+## Design Review Evidence
+
+- **Verdict:** SHIP
+- **Reviewed content SHA-256:** `e628e5280d3fcd4134c45ff1fef2a874c76ea2e6b95610d400d0fabf2f0bd4e4`
+- **Reviewer:** design-reviewer-a783b2fe
+- **Reviewed at:** 2026-07-28T22:08:19.000Z
+<!-- genie-design-review:end -->

--- a/.genie/brainstorms/omni-plugin-revamp/DRAFT.md
+++ b/.genie/brainstorms/omni-plugin-revamp/DRAFT.md
@@ -1,0 +1,71 @@
+# omni-plugin-revamp — DRAFT
+
+WRS: ██████████ 100/100
+ Problem ✅ | Scope ✅ | Decisions ✅ | Risks ✅ | Criteria ✅
+
+Decisions resolved 2026-07-28 (user): delete all 11 commands; simplify hook
+(probe only, no auto-install); add MCP server to plugin.json. Crystallized to
+DESIGN.md.
+
+## Problem
+
+The omni Claude Code plugin (`plugins/omni/**`) has drifted since its one bulk
+commit on 2026-07-04: its setup skill and the `omni connect` CLI command
+hardcode genie v4 commands that no longer exist (`genie serve start`,
+`genie dir add/ls`; the real v5 surface is `genie omni serve|status|inbox|handshake`),
+its 11 slash commands (~280 lines) 1:1 duplicate the omni-ops references, it
+carries two stacked routing layers and two agents that are prose pointers, and
+nothing mechanically prevents further rot. The genie plugin (recently reviewed)
+demonstrates the target shape.
+
+## Scope
+
+IN:
+- `plugins/omni/**` — skills, commands, agents, hooks, plugin.json
+- Adopting genie conventions: single router + flat peer skills (~50-line budget,
+  uniform section grammar), long material in `references/`, anti-staleness by
+  discovering ground truth (`omni --help`) instead of hardcoded command lists,
+  minimal frontmatter
+- Canonical-source + synced-mirror + CI gate (sync --check, skills lint,
+  fresh-install smoke) if adopted
+- Fixing or explicitly deprecating stale genie-v4 content in omni-setup
+- Repo-root `.claude/skills/*.md` flat files that never load (fix or delete)
+
+OUT (separate work):
+- `packages/cli/src/commands/connect.ts` genie-v4 contract bug — product code,
+  ships as its own fix(cli) (plugin wish depends on knowing the v5 surface but
+  does not implement the CLI fix)
+- Any change to the omni product API/CLI behavior itself
+- khal-ui, docs site
+
+## Decisions (open)
+
+1. Slash commands: delete all (genie has zero) vs keep a minimal high-frequency
+   set (send, trace/monitor?) — USER
+2. SessionStart hook `omni-runner.js` (430-line node shim, auto-installs CLI):
+   keep as-is / simplify / drop — USER
+3. MCP server exposure in plugin.json (genie has it, omni doesn't) — USER
+4. Canonical skills location: keep authoring under `plugins/omni/skills/`
+   directly vs adopt genie's canonical-dir + mirror sync — lean: adopt only if
+   omni skills are also consumed outside the plugin; otherwise single location
+   + lint/smoke gates is simpler
+5. Agents: fold omni-bot-framework + omni-automation-builder into skills;
+   keep omni-feature-implementor (genuinely distinct, repo-internal dev) — lean yes
+
+## Risks
+
+- Users may have muscle memory / automation on the 11 slash commands — removal
+  is a breaking UX change for plugin users
+- omni-setup rewrite must match the real genie v5 handshake, which lives in a
+  different repo and can drift again — mitigation: discover-ground-truth style
+  plus a smoke test that shells `genie omni --help`
+- The SessionStart hook auto-installs the CLI; dropping it changes fresh-install
+  UX
+- NATS topic table in omni-setup unverified against genie v5 bridge
+
+## Criteria (to fill)
+
+- (draft) fresh-install smoke: plugin loads, router skill resolves, no skill
+  references a CLI subcommand that `omni --help`/`genie omni --help` does not list
+- (draft) size budget: every SKILL.md under N lines, no commands/ file
+  duplicating a reference

--- a/.genie/wishes/omni-plugin-revamp/WISH.md
+++ b/.genie/wishes/omni-plugin-revamp/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | APPROVED |
 | **Slug** | `omni-plugin-revamp` |
 | **Date** | 2026-07-29 |
 | **Author** | Felipe Rosa |
@@ -316,6 +316,34 @@ _What must be verified on dev after merge. The QA agent tests each criterion._
 ## Review Results
 
 _The read-only reviewer returns evidence; the invoking orchestrator appends a timestamped block here after plan, execution, and PR reviews._
+
+### Plan review — 2026-07-29 — SHIP
+
+Reviewer: plan-reviewer-ac0c4527 (loop 2, independent of the author).
+
+Loop 1 returned FIX-FIRST on three gaps, all resolved and re-verified:
+
+1. **[HIGH] groups 1 and 2 were not disjoint** — both write the same four
+   `SKILL.md` files while the wish claimed they ran in parallel. Resolved by
+   serializing: Wave 1 is groups 1 and 3, Wave 2 is group 2 (`depends-on: 1`),
+   Wave 3 is group 4. Group 3 confirmed genuinely disjoint.
+2. **[HIGH] group 3 carried an always-pass validation** — `rg -q "packages/mcp"`
+   never matched, since the real row is `└── mcp/` at `.claude/CLAUDE.md:195`,
+   so deliverable 4 could be skipped with the gate still green. Now
+   `! rg -qi "mcp"`, proven to fail today.
+3. **[MEDIUM] group 4 invoked script aliases nothing created** — `skills:lint`
+   and `plugin:smoke` are now a declared deliverable with `package.json` in
+   Files to Create/Modify.
+
+All four group validations were executed by the reviewer and exit 1 today for
+the correct reason. Design fidelity holds against all 11 DESIGN.md criteria; no
+placeholders; ordering sound.
+
+Two LOW notes carried into execution (non-blocking): group 3 deliverable 2
+(`plugin.json` metadata) has no mechanical check in its own validation block —
+success criterion only; and group 3's acceptance text still says "zero hits
+claiming a shipped MCP server" while its validation is the stricter flat grep.
+The validation governs, so there is no escape hatch.
 
 ---
 

--- a/.genie/wishes/omni-plugin-revamp/WISH.md
+++ b/.genie/wishes/omni-plugin-revamp/WISH.md
@@ -1,0 +1,345 @@
+# Wish: Omni Plugin Revamp — genie-shape simplification
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `omni-plugin-revamp` |
+| **Date** | 2026-07-29 |
+| **Author** | Felipe Rosa |
+| **Appetite** | medium |
+| **Branch** | `wish/omni-plugin-revamp` |
+| **Repos touched** | omni |
+| **Design** | [DESIGN.md](../../brainstorms/omni-plugin-revamp/DESIGN.md) |
+
+## Summary
+
+The omni Claude Code plugin has rotted since its single bulk commit on
+2026-07-04: it teaches genie v4 commands that no longer exist, ships 11 slash
+commands that duplicate the omni-ops references 1:1, stacks two routing layers,
+and carries two agents that are only prose pointers. This wish restructures it
+to the genie plugin shape — one router plus flat peer skills, CLI-only — and
+encodes that shape in CI gates so it cannot silently rot again.
+
+## Scope
+
+### IN
+
+- Delete `plugins/omni/commands/` (all 11 command files)
+- Collapse routing: the `omni` router dispatches directly to peer skills;
+  `omni-ops` becomes references, not a second router
+- Rewrite `omni-setup` against the real genie v5 surface
+  (`genie omni serve|status|inbox|handshake`) in discover-ground-truth style
+- Fold `omni-bot-framework` and `omni-automation-builder` into skills; keep
+  `omni-feature-implementor`
+- Fold `plugins/omni/rules/omni-agent.md` into the omni-agent skill; delete it
+- Simplify the SessionStart hook to a probe (no auto-install); shrink
+  `omni-runner.js` to ≤ 80 lines
+- Enrich `plugin.json`: repository, license, keywords; no `mcpServers` key
+- CI anti-rot gates: skills lint (size, frontmatter, grammar) + fresh-install
+  smoke that builds the CLI from source and checks every named subcommand
+  against `omni --help`
+- Repo-root `.claude/skills/*.md` flat files → loadable `<name>/SKILL.md` dirs
+  or deleted; wire or delete orphaned `.claude/hooks/wish-validator.md`
+- Delete the three stale MCP claims: the `## MCP Integration` section and the
+  `MCP Tools` diagram box in `docs/architecture/overview.md`, and the
+  `packages/mcp/` row in `.claude/CLAUDE.md`
+- Migration note mapping each removed command to its router phrase
+
+### OUT
+
+- MCP entirely — no server written, exposed, or planned (CLI-only decision;
+  zero `mcp` paths exist on `origin/dev`)
+- `packages/cli/src/commands/connect.ts` genie-v4 contract bug — product code,
+  ships as its own `fix(cli)`
+- Any behavior change to the omni product API or CLI
+- Canonical-dir + mirror sync layer (genie needs it; omni has one consumer)
+- khal-ui, docs site, marketplace mechanics
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Delete all 11 slash commands | User decision. Genie ships zero; removes ~280 lines duplicating references 1:1. |
+| 2 | SessionStart hook: probe only, no auto-install | User decision. Keeps the signal, drops a 430-line shim that installs software silently. |
+| 3 | CLI-only: no MCP, now or planned | User decision after learning `packages/mcp` does not exist. One surface is the simpler contract. |
+| 4 | Single skill location + CI gates, no mirror sync | Omni skills have exactly one consumer. |
+| 5 | Fold the two pointer-agents; keep `omni-feature-implementor` | The first two point into omni-ops; the third covers repo-internal dev no skill does. |
+| 6 | Discover ground truth via `--help` at use time | Hardcoded command lists are the rot vector that broke omni-setup. |
+| 7 | Keep `allowed-tools` frontmatter | Functional permission-prompt UX, not metadata bloat. |
+| 8 | CI builds the CLI from `packages/cli` | The gate cannot depend on the auto-installer this wish deletes. |
+| 9 | Router skill exempt from the operational grammar check | Genie's own router uses a routing shape; the gate must not fight it. |
+
+## Simplicity Case
+
+- **Simplest complete design:** delete the duplicated surfaces, rewrite the one
+  stale skill, and add a lint plus a smoke test. Everything else is subtraction.
+- **Added machinery:** two CI gates. Justified by present evidence — the plugin
+  rotted undetected for ~3 weeks, and the survey found wrong instructions
+  shipping to users today. Nothing else is added.
+- **Deferred until measured:** canonical-dir/mirror sync (trigger: a second
+  consumer of omni skills appears); an MCP server (trigger: an explicit user
+  need — currently CLI-only by decision).
+- **Complexity removed:** 11 command files, one routing layer, two agents, one
+  rules file, ~350 lines of the hook shim, three false MCP doc claims.
+
+## Dependencies
+
+**depends-on:** none
+**blocks:** none
+
+## Success Criteria
+
+- [ ] `plugins/omni/commands/` does not exist; plugin loads without it
+- [ ] Every peer `SKILL.md` is ≤ 100 lines, carries only `name`, `description`,
+      and (where it shells out) `allowed-tools`, and uses
+      `When to Use → Flow → Rules`; the router is exempt from the grammar check
+- [ ] `rg -n "genie serve|genie dir|genie ls --source"` over `plugins/omni/`
+      returns zero hits
+- [ ] No skill hardcodes an `omni` subcommand list; each discovers via `--help`
+- [ ] `plugins/omni/agents/` contains exactly `omni-feature-implementor`;
+      `plugins/omni/rules/` is gone
+- [ ] `omni-runner.js` performs no installation and is ≤ 80 lines
+- [ ] `plugin.json` has repository, license, keywords, and no `mcpServers` key
+- [ ] `rg -i mcp docs/architecture/overview.md .claude/CLAUDE.md plugins/omni/`
+      returns zero hits
+- [ ] `.claude/skills/` contains only loadable `<name>/SKILL.md` dirs (or is
+      empty); no orphaned hook docs
+- [ ] The new CI job fails on: over-budget skill, malformed frontmatter, a named
+      subcommand absent from `omni --help`, or smoke failure
+- [ ] A migration note maps each of the 11 removed commands to its router phrase
+
+## Execution Strategy
+
+Groups 1 and 2 both write the same four `SKILL.md` files — group 1 moves
+structure and folds content in, group 2 then rewrites that content against
+ground truth — so they are serialized, not parallel. Group 3 touches
+`scripts/`, `.claude-plugin/`, `docs/`, and root `.claude/` only, so it runs
+alongside them. Group 4 must observe the final tree and runs last.
+
+### Wave 1 (parallel)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| 1 | engineer | 2 (+1 prompt-skill change, +1 no deterministic test) | `engineer-standard` / medium | Delete commands, collapse routing, fold agents and rules |
+| 3 | engineer | 1 (+1 no deterministic test) | `engineer-trivial` / low | Hook simplification, plugin.json metadata, stale MCP doc deletion, root `.claude/` cleanup |
+
+### Wave 2 (after group 1)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| 2 | engineer | 3 (+1 prompt-skill change, +1 no deterministic test, +1 cross-repo contract) | `engineer-standard` / high | Rewrite omni-setup against genie v5; discover-ground-truth pass over the collapsed skill tree |
+
+### Wave 3 (after groups 1, 2, 3)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| 4 | engineer | 3 (+1 CI work, +1 multi-package, +1 prompt-skill change) | `engineer-standard` / high | Skills lint + fresh-install smoke CI job, migration note |
+
+Complexity scoring rubric: score each group independently and record the total plus a short rationale in **Complexity**. Add:
+
+- **+2** each for orchestration / agent-lifecycle / routing; cost / model / escalation; stateful work; subjective acceptance.
+- **+1** each for multi-package work; OTel-label dependency; no deterministic test; prior rework; prompt-skill change; CI / release work.
+
+Route the total in **Model** by portable role and reasoning effort: **0–1** →
+`engineer-trivial` / low; **2–3** → `engineer-standard` / medium or high;
+**4–6** → `engineer-complex` / high; **7+** → `engineer-complex` plus an
+independent `final-gate` at the highest justified effort. Codex maps these to
+the `genie_*` profiles; other runtimes use their matching native roles. Keep
+model and effort in runtime session/agent configuration, never skill frontmatter.
+
+## Execution Groups
+
+### Group 1: Delete duplicated surfaces
+
+**Goal:** Remove the command layer, the second routing layer, and the two
+pointer-agents so skills are the only surface.
+
+**Deliverables:**
+1. `plugins/omni/commands/` deleted (all 11 files)
+2. `plugins/omni/skills/omni/SKILL.md` router dispatches directly to peer
+   skills; `omni-ops/SKILL.md` demoted to references consumed by peers
+3. `omni-bot-framework` and `omni-automation-builder` folded into the skills
+   they pointed at; both agent files deleted
+4. `plugins/omni/rules/omni-agent.md` folded into the omni-agent skill; the
+   `rules/` directory deleted
+
+**Acceptance Criteria:**
+- [ ] `plugins/omni/commands/` and `plugins/omni/rules/` do not exist
+- [ ] `plugins/omni/agents/` contains exactly `omni-feature-implementor.md`
+- [ ] No skill routes to another router — the `omni` router names peer skills
+- [ ] No content lost: the intent each deleted command served is answerable from
+      a peer skill — enumerated in the group 4 migration note, which must list
+      all 11 with a non-empty replacement phrase
+
+**Validation:**
+```bash
+test ! -d plugins/omni/commands && test ! -d plugins/omni/rules &&
+  test "$(ls plugins/omni/agents | wc -l)" -eq 1
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Rewrite against real ground truth
+
+**Goal:** Make every skill's factual claims true today and self-correcting
+tomorrow. Runs after group 1 so it rewrites the collapsed tree, not a moving one.
+
+**Deliverables:**
+1. `omni-setup` rewritten against `genie omni serve|status|inbox|handshake`,
+   with the genie contract version it was written against stated inline
+2. Every skill converted to discover-ground-truth style — read `omni --help` /
+   `genie omni --help` at use time instead of hardcoding subcommand lists
+3. NATS topic table verified against the genie v5 bridge, or dropped
+4. All peer skills conform to `When to Use → Flow → Rules` and the ≤ 100-line
+   budget; long material moved to `references/`
+
+**Acceptance Criteria:**
+- [ ] `rg -n "genie serve|genie dir|genie ls --source" plugins/omni/` → zero hits
+- [ ] Every `genie`/`omni` subcommand named in a skill exists in the
+      corresponding `--help` output
+- [ ] Every peer `SKILL.md` ≤ 100 lines with the operational grammar
+- [ ] Frontmatter is `name` + `description` (+ `allowed-tools` where it shells out)
+
+**Validation:**
+```bash
+bash -c '! rg -q "genie serve|genie dir|genie ls --source" plugins/omni/ || exit 1
+for f in plugins/omni/skills/*/SKILL.md; do
+  [ "$(wc -l < "$f")" -le 100 ] || { echo "over budget: $f"; exit 1; }
+done'
+```
+
+Note: the budget loop passes today (skills are 38–98 lines) — the grep is the
+load-bearing half here. Frontmatter shape and the subcommand-exists-in-`--help`
+criterion are mechanically enforced by group 4's lint, which is why group 4
+carries this group's remaining acceptance evidence.
+
+**depends-on:** 1
+
+---
+
+### Group 3: Hook, manifest, and stale-doc cleanup
+
+**Goal:** Strip the auto-installer, complete the manifest metadata, and delete
+every doc claim about software omni does not ship.
+
+**Deliverables:**
+1. `omni-runner.js` reduced to a health probe that prints the install command;
+   no installation performed; ≤ 80 lines
+2. `plugin.json` gains repository, license, keywords; no `mcpServers` key
+3. `docs/architecture/overview.md`: `## MCP Integration` section and the
+   `MCP Tools` box in the architecture diagram (line ~46) deleted
+4. `.claude/CLAUDE.md`: `packages/mcp/` row removed from the structure table
+5. Repo-root `.claude/skills/*.md` converted to `<name>/SKILL.md` dirs or
+   deleted; `.claude/hooks/wish-validator.md` wired or deleted
+
+**Acceptance Criteria:**
+- [ ] `omni-runner.js` ≤ 80 lines and contains no install/exec of a package manager
+- [ ] `rg -i mcp docs/architecture/overview.md .claude/CLAUDE.md` → zero hits
+      claiming a shipped omni MCP server
+- [ ] No flat `.md` files directly under `.claude/skills/`
+- [ ] SessionStart still reports CLI presence/absence on a fresh session
+
+**Validation:**
+```bash
+[ "$(wc -l < plugins/omni/scripts/omni-runner.js)" -le 80 ] &&
+  ! rg -qi "mcp" docs/architecture/overview.md &&
+  ! rg -qi "mcp" .claude/CLAUDE.md &&
+  ! ls .claude/skills/*.md 2>/dev/null | grep -q .
+```
+
+**depends-on:** none
+
+---
+
+### Group 4: Anti-rot CI gates and migration note
+
+**Goal:** Make the new shape mechanically enforced so the next drift fails CI
+instead of reaching users.
+
+**Deliverables:**
+1. Skills lint script: size budget, frontmatter shape, operational grammar for
+   peers (router exempt), no hardcoded subcommand lists
+2. Fresh-install smoke: builds the CLI from `packages/cli`, loads the plugin,
+   resolves the router, and asserts every subcommand named in a skill appears
+   in `omni --help`
+3. `package.json` declares `skills:lint` and `plugin:smoke` script aliases for
+   the two scripts above
+4. Both wired into a CI job on PRs touching `plugins/omni/**`
+5. Migration note (CHANGELOG + plugin README) mapping each of the 11 removed
+   commands to its router phrase, all 11 with a non-empty replacement
+
+**Acceptance Criteria:**
+- [ ] The lint fails on a deliberately over-budget skill (proven by a temporary
+      edit, reverted)
+- [ ] The smoke fails on a deliberately invented subcommand (proven, reverted)
+- [ ] The job runs on PRs touching `plugins/omni/**` and passes on the final tree
+- [ ] The migration note lists all 11 removed commands with replacements
+
+**Validation:**
+```bash
+bun scripts/skills-lint.ts && bun scripts/plugin-smoke.ts &&
+  bun run skills:lint && bun run plugin:smoke
+```
+
+**depends-on:** 1, 2, 3
+
+---
+
+## QA Criteria
+
+_What must be verified on dev after merge. The QA agent tests each criterion._
+
+- [ ] Functional: in a fresh Claude Code session with the plugin enabled, asking
+      to send a message and to list instances both resolve through the router
+      without any slash command
+- [ ] Integration: `omni-setup`'s documented flow completes against a real genie
+      v5 install (`genie omni handshake` path works as written)
+- [ ] Regression: SessionStart still reports CLI status; no session errors from
+      the removed auto-install path
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Users with `/send` muscle memory lose commands | Medium | Router answers the same intents; migration note maps every removed command to its phrase |
+| genie v5 surface drifts again (other repo) | Medium | Discover-ground-truth style; smoke shells `genie omni --help` when genie is present; skill states the contract version |
+| Dropping auto-install changes fresh-install UX | Low | Probe prints the exact install command; README quickstart covers it |
+| NATS topic table may be wrong for the v5 bridge | Low | Verify during rewrite; drop the table if unverifiable |
+| Group 4's smoke needs a built CLI in CI | Low | Decision 8: build from `packages/cli` (`make cli-build`) |
+
+---
+
+## Review Results
+
+_The read-only reviewer returns evidence; the invoking orchestrator appends a timestamped block here after plan, execution, and PR reviews._
+
+---
+
+## Files to Create/Modify
+
+```
+plugins/omni/commands/                      DELETE (11 files)
+plugins/omni/rules/omni-agent.md            DELETE
+plugins/omni/agents/omni-bot-framework.md   DELETE
+plugins/omni/agents/omni-automation-builder.md DELETE
+plugins/omni/agents/omni-feature-implementor.md KEEP
+plugins/omni/skills/omni/SKILL.md           REWRITE (router → peers)
+plugins/omni/skills/omni-agent/SKILL.md     REWRITE (+ folded rules)
+plugins/omni/skills/omni-setup/SKILL.md     REWRITE (genie v5)
+plugins/omni/skills/omni-ops/               DEMOTE to references
+plugins/omni/scripts/omni-runner.js         SHRINK (probe only, ≤80 lines)
+plugins/omni/.claude-plugin/plugin.json     MODIFY (metadata, no mcpServers)
+docs/architecture/overview.md               MODIFY (delete MCP section + diagram box)
+.claude/CLAUDE.md                           MODIFY (drop packages/mcp row)
+.claude/skills/*.md                         CONVERT or DELETE
+.claude/hooks/wish-validator.md             WIRE or DELETE
+scripts/skills-lint.ts                      CREATE
+scripts/plugin-smoke.ts                     CREATE
+package.json                                MODIFY (skills:lint, plugin:smoke)
+.github/workflows/ci.yml                    MODIFY (plugin gate job)
+CHANGELOG.md / plugins/omni/README.md       MODIFY (migration note)
+```

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ coverage/
 .worktrees/
 .claude/worktrees/
 
+# Repository-local coding environment
+.dev/
+
 # Misc
 *.bak
 *.tmp
@@ -61,6 +64,35 @@ memory/
 .genie/
 docs/reports/
 docs/reports/tmp/
+
+# Repository-local Hermes profile: keep portable profile files tracked while
+# excluding credentials, conversations, logs, caches, and mutable runtime state.
+.hermes/.env
+.hermes/.hermes_history
+.hermes/.update_check
+.hermes/auth.json
+.hermes/auth.lock
+.hermes/state.db*
+.hermes/projects.db*
+.hermes/sessions/
+.hermes/logs/
+.hermes/cache/
+.hermes/home/
+.hermes/bin/
+.hermes/shared/
+.hermes/skills/
+.hermes/plugins/
+.hermes/plans/
+.hermes/audio_cache/
+.hermes/cron/
+.hermes/memories/
+.hermes/__pycache__/
+.hermes/.codex_gpt55_autoraise_notice
+.hermes/.skills_prompt_snapshot.json
+.hermes/context_length_cache.yaml
+.hermes/models_dev_cache.json
+.hermes/ollama_cloud_models_cache.json
+.hermes/provider_models_cache.json
 
 # Claude Code local settings
 .claude/settings.local.json

--- a/.hermes/SOUL.md
+++ b/.hermes/SOUL.md
@@ -1,0 +1,7 @@
+# Omni Hermes
+
+You are Omni's repository-local engineering specialist, not a live turn bot.
+
+Work across Omni's REST APIs, CLI, SDKs, channels, migrations, and events. Ground conclusions in repository evidence, inspect existing patterns before changing them, and validate work with the safest relevant static gates.
+
+Use `say` or `done` only while handling a real `OMNI_INSTANCE` turn. Never create a handshake, register routes, contact external systems, start daemons, access databases, or touch production without explicit approval.

--- a/.hermes/config.yaml
+++ b/.hermes/config.yaml
@@ -1,0 +1,11 @@
+model:
+  default: gpt-5.6-sol
+  provider: openai-codex
+  base_url: https://chatgpt.com/backend-api/codex
+
+terminal:
+  backend: local
+  timeout: 300
+
+security:
+  redact_secrets: true

--- a/.hermes/profile.yaml
+++ b/.hermes/profile.yaml
@@ -1,0 +1,2 @@
+description: Repository-local Hermes coding profile for Omni. Coding work is the default; live Omni wiring is a separate, explicitly approved mode.
+description_auto: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,12 @@
-@../../AGENTS.md
+# Omni repository contract
+
+Omni is a Bun and TypeScript monorepo built around Hono, tRPC, Drizzle, and NATS.
+
+- Validate every external boundary with Zod.
+- Represent state changes with events.
+- Never edit a deployed migration or use `drizzle push` against shared or production databases.
+- Change the schema and its generated SQL migration together.
+- Inspect nearby code and established repository patterns before implementing.
+- Do not start services, access databases or production systems, or send external messages without explicit approval.
+- Prefer safe static gates for routine validation.
+- Use a disposable database for database-backed or full integration tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@../../AGENTS.md
+@AGENTS.md

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/biome.json
+++ b/biome.json
@@ -59,6 +59,8 @@
       "omni-*",
       ".worktrees",
       ".genie",
+      ".dev",
+      ".hermes",
       "repos",
       "apps/khal-ui/scripts/openapi.snapshot.json",
       "apps/khal-ui/package/src/capabilities/capabilities.json",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -91,7 +91,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -124,7 +124,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -140,7 +140,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -167,7 +167,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -291,7 +291,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -305,7 +305,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -324,7 +324,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -332,7 +332,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -346,7 +346,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260728.1",
+      "version": "2.260728.2",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260728.1"
+appVersion: "2.260728.2"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260728.1",
+  "version": "2.260728.2",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Summary

Carry-exact promotion of `dev` → `main`. Six commits, no product-code changes beyond the version bump.

- `chore(version)`: bump to 2.260728.2
- `chore`: repository-local Hermes profile (`.hermes/`, gitignore, AGENTS.md)
- `docs(brainstorm)` ×2: omni plugin revamp design — design review SHIP, digest-bound evidence verified
- `docs(wish)` ×2: omni plugin revamp execution plan — plan review SHIP after one fix loop, status APPROVED

## Risk

Low. The four docs commits touch only `.genie/` planning artifacts. The Hermes commit is config plus an AGENTS.md note. No runtime, schema, or API change.

## Validation

Predecessor PR #870 merged green, including the newly wired PostgreSQL Isolation Gate (tenancy/RLS suites, previously skipping in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Omni platform, packages, UI, deployment chart, and plugin to version **2.260728.2**.
  * This release keeps all package metadata aligned for consistent installation and deployment.

* **Documentation**
  * Added planning and design documentation for a future Omni plugin simplification and modernization.

* **Maintenance**
  * Improved repository configuration for local development environments and profile-related generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->