### PR TITLE
fix(api): mount /handoffs above the root /:id catch-all (GET /api/v2/handoffs 500s)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/v2-mount-order.test.ts
+++ b/packages/api/src/routes/v2/__tests__/v2-mount-order.test.ts
@@ -1,0 +1,127 @@
+/**
+ * v2 mount-order invariant (issue #496, regressed for /handoffs).
+ *
+ * `automationsRoutes` is mounted TWICE in routes/v2/index.ts: at `/automations`
+ * and at the v2 root (so `/automation-logs` and `/automation-metrics` resolve).
+ * It defines `get('/:id')`, so the root mount registers `GET /api/v2/:id` — a
+ * single-segment catch-all over the entire v2 surface. Hono resolves
+ * same-path handlers in REGISTRATION ORDER, so any prefix router mounted below
+ * the root mounts loses its bare collection path to that catch-all.
+ *
+ * In production this made `GET /api/v2/handoffs` reach the automations `/:id`
+ * handler, which passed the literal string "handoffs" into
+ * `where(eq(automations.id, id))` with no uuid guard:
+ *
+ *   HTTP 500 {"error":{"code":"INTERNAL_ERROR",
+ *             "message":"invalid input syntax for type uuid: \"handoffs\""}}
+ *
+ * INVARIANT: every router with a bare collection route (`get('/')`) must be
+ * mounted ABOVE the first root mount that installs a single-segment `/:id`
+ * catch-all. In practice: above the root-mount block at the end of index.ts.
+ *
+ * The check is driven from the source of index.ts rather than from a live
+ * Hono instance so it needs no database, and so it names the offending line
+ * when it fails.
+ */
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const V2_DIR = join(import.meta.dir, '..');
+const INDEX_SRC = readFileSync(join(V2_DIR, 'index.ts'), 'utf8');
+
+interface Mount {
+  path: string;
+  ident: string;
+  line: number;
+}
+
+/** `import { fooRoutes } from './foo';` -> fooRoutes => ./foo */
+function importedModules(src: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const re = /import\s*\{\s*([A-Za-z0-9_,\s]+?)\s*\}\s*from\s*'(\.\/[^']+)'/g;
+  for (const m of src.matchAll(re)) {
+    const [, names, modulePath] = m;
+    if (!names || !modulePath) continue;
+    for (const raw of names.split(',')) {
+      const ident = raw.trim();
+      if (ident) map.set(ident, modulePath);
+    }
+  }
+  return map;
+}
+
+/** `v2Routes.route('/x', xRoutes);` in registration order. */
+function mounts(src: string): Mount[] {
+  const out: Mount[] = [];
+  src.split('\n').forEach((text, i) => {
+    const m = text.match(/^\s*v2Routes\.route\(\s*'([^']*)'\s*,\s*([A-Za-z0-9_]+)\s*\)/);
+    const [, path, ident] = m ?? [];
+    if (path !== undefined && ident) out.push({ path, ident, line: i + 1 });
+  });
+  return out;
+}
+
+function moduleSource(modulePath: string): string {
+  return readFileSync(join(V2_DIR, `${modulePath.replace(/^\.\//, '')}.ts`), 'utf8');
+}
+
+/** Does the router module register a bare collection GET (`get('/')`)? */
+function hasBareCollectionGet(ident: string, modulePath: string): boolean {
+  return new RegExp(`\\b${ident}\\.get\\(\\s*'/'`).test(moduleSource(modulePath));
+}
+
+/**
+ * Does the module register a single-segment param GET (`get('/:id')`)? Mounted
+ * at the root, that is the `GET /api/v2/:id` catch-all. Multi-segment routes
+ * (`/events/:id/payloads`) never match a one-segment request and are harmless.
+ */
+function hasSingleSegmentParamGet(ident: string, modulePath: string): boolean {
+  return new RegExp(`\\b${ident}\\.get\\(\\s*'/:[^'/]+'`).test(moduleSource(modulePath));
+}
+
+describe('v2 route mount order', () => {
+  const all = mounts(INDEX_SRC);
+  const modules = importedModules(INDEX_SRC);
+
+  /** First root mount that installs a `GET /api/v2/:id` catch-all. */
+  const catchAll = all.findIndex((m) => {
+    if (m.path !== '/') return false;
+    const mod = modules.get(m.ident);
+    return mod ? hasSingleSegmentParamGet(m.ident, mod) : false;
+  });
+
+  it('parses the mount table and finds the root catch-all', () => {
+    expect(all.length).toBeGreaterThan(20);
+    expect(catchAll).toBeGreaterThan(-1);
+    expect(all[catchAll]?.ident).toBe('automationsRoutes');
+  });
+
+  it('mounts every router with a bare collection GET above the root /:id catch-all', () => {
+    const shadowed = all
+      .slice(catchAll + 1)
+      .filter((m) => m.path !== '/')
+      .filter((m) => {
+        const mod = modules.get(m.ident);
+        return mod ? hasBareCollectionGet(m.ident, mod) : false;
+      })
+      .map((m) => `index.ts:${m.line} ${m.ident} at '${m.path}'`);
+
+    // Any name here is shadowed by GET /api/v2/:id from the root automations
+    // mount and will 500 on its collection path. Move it above the root mounts.
+    expect(shadowed).toEqual([]);
+  });
+
+  it('mounts /handoffs before the root catch-all (the #496 regression)', () => {
+    const handoffs = all.findIndex((m) => m.path === '/handoffs');
+    expect(handoffs).toBeGreaterThan(-1);
+    expect(handoffs).toBeLessThan(catchAll);
+  });
+
+  it('still exposes the root automations mount that made the catch-all necessary', () => {
+    // Guards the fix from being "solved" by deleting the root mount, which
+    // would break /automation-logs and /automation-metrics.
+    expect(all.some((m) => m.path === '/' && m.ident === 'automationsRoutes')).toBe(true);
+    expect(all.some((m) => m.path === '/automations' && m.ident === 'automationsRoutes')).toBe(true);
+  });
+});

--- a/packages/api/src/routes/v2/index.ts
+++ b/packages/api/src/routes/v2/index.ts
@@ -69,11 +69,26 @@ v2Routes.route('/keys', keysRoutes); // API key management
 v2Routes.route('/context', contextRoutes); // Conversation context for turn-based agents
 v2Routes.route('/turns', turnsRoutes); // Turn lifecycle for turn-based agents
 v2Routes.route('/trust', trustRoutes); // Genie host fingerprint trust (omni-host-fingerprint-trust wish)
+v2Routes.route('/voice', voiceRoutes); // Voice session management - must be before root /:id catch-all (issue #496)
+v2Routes.route('/follow-up', followUpRoutes); // Idle-chat follow-up config at /api/v2/follow-up/{agents|instances|chats}/:id (issue #404) - must be before root /:id catch-all (issue #496)
+v2Routes.route('/handoffs', handoffsRoutes); // Handoff audit log at /api/v2/handoffs - must be before root /:id catch-all (issue #496)
+
+// ---------------------------------------------------------------------------
+// ROOT MOUNTS — this block installs the '/' mounts and MUST stay last.
+//
+// INVARIANT: every router with a bare collection route (`get('/')`, and by
+// extension any single-segment path) must be mounted ABOVE this line.
+//
+// `automationsRoutes` is mounted at the root so `/api/v2/automation-logs` and
+// `/api/v2/automation-metrics` resolve, but it also defines `get('/:id')`,
+// which at the root becomes `GET /api/v2/:id` — a single-segment catch-all over
+// the whole v2 surface. Hono resolves same-path handlers in REGISTRATION ORDER,
+// so any prefix router registered below it loses its bare collection path to
+// the catch-all (issue #496; regressed for /handoffs, see this file's test in
+// __tests__/v2-mount-order.test.ts).
+// ---------------------------------------------------------------------------
 v2Routes.route('/', payloadsRoutes); // Payloads routes at /api/v2/events/:id/payloads and /api/v2/payload-config
 v2Routes.route('/', webhooksRoutes); // Webhook routes at /api/v2/webhooks/:source, /api/v2/webhook-sources, /api/v2/events/trigger
 v2Routes.route('/automations', automationsRoutes); // Automation routes at /api/v2/automations
 v2Routes.route('/', automationsRoutes); // Also mount at root for /api/v2/automation-logs, /api/v2/automation-metrics
 v2Routes.route('/', routesRoutes); // Agent routing routes at /api/v2/instances/:instanceId/routes and /api/v2/routes/metrics
-v2Routes.route('/voice', voiceRoutes); // Voice session management
-v2Routes.route('/follow-up', followUpRoutes); // Idle-chat follow-up config at /api/v2/follow-up/{agents|instances|chats}/:id (issue #404)
-v2Routes.route('/handoffs', handoffsRoutes); // Handoff audit log at /api/v2/handoffs


### PR DESCRIPTION
## Summary

`GET /api/v2/handoffs` returns **500** on `dev` (and on the released `v2.260728.2`). The handoffs router is never reached — the request is swallowed by a `GET /api/v2/:id` catch-all created by the root mount of `automationsRoutes`, and the literal string `"handoffs"` is handed to Postgres as a uuid.

This moves the three mounts that were appended *below* the root-mount block back above it, matching the convention already present in the file, and adds a regression test that pins the invariant.

Root-caused against a live production deployment (omni-api `v2.260728.2`) where the admin UI's Handoffs page crashed. The BFF and the reverse proxy were ruled out with evidence before the code was touched.

## Repro

```sh
curl -s -H "x-api-key: $OMNI_API_KEY" \
  'http://127.0.0.1:8882/api/v2/handoffs?limit=100'
```

```
HTTP 500
{"error":{"code":"INTERNAL_ERROR","message":"invalid input syntax for type uuid: \"handoffs\""}}
```

The query string is irrelevant — bare `/api/v2/handoffs` fails identically.

Server log:

```json
{"level":"error","time":1785299529857,"module":"api:error","msg":"Server error",
 "requestId":"req_ms5l8tiu_dmcg70k",
 "error":"invalid input syntax for type uuid: \"handoffs\"",
 "stack":"PostgresError: invalid input syntax for type uuid: \"handoffs\"\n
    at ErrorResponse (dist/server/index.js:340736:38)\n
    at handle (dist/server/index.js:340524:703)\n
    at data (dist/server/index.js:340415:15)"}
{"level":"info","module":"http","msg":"→ GET /api/v2/handoffs","status":500,"ms":50}
```

All three hops return byte-identical responses, so the proxy chain is faithful and the defect is in `packages/api`:

```
omni-api direct     127.0.0.1:8882/api/v2/handoffs?limit=100        -> 500
BFF loopback        127.0.0.1:8883/omni/api/v2/handoffs?limit=100   -> 500
Caddy + basic_auth  Host: admin.…  /omni/api/v2/handoffs?limit=100  -> 500
```

## Root cause

`packages/api/src/routes/v2/index.ts` mounts the automations router **twice** — once at `/automations`, and once at the v2 root so `/automation-logs` and `/automation-metrics` resolve:

```ts
line 72:  v2Routes.route('/', payloadsRoutes);
line 73:  v2Routes.route('/', webhooksRoutes);
line 74:  v2Routes.route('/automations', automationsRoutes);
line 75:  v2Routes.route('/', automationsRoutes);   // <-- root mount
line 76:  v2Routes.route('/', routesRoutes);
line 77:  v2Routes.route('/voice', voiceRoutes);
line 78:  v2Routes.route('/follow-up', followUpRoutes);
line 79:  v2Routes.route('/handoffs', handoffsRoutes);   // <-- registered too late
```

`automationsRoutes` defines `automationsRoutes.get('/:id', …)` (`routes/v2/automations.ts:210`). Mounted at the root, that becomes **`GET /api/v2/:id`** — a single-segment catch-all over the whole v2 surface. Hono resolves same-path handlers in **registration order**, so any router mounted *after* line 75 loses its bare collection path to it.

`handoffsRoutes` does define the list handler (`routes/v2/handoffs.ts:29`, `handoffsRoutes.get('/', …)`), but it is registered at line 79 — four lines too late. `GET /api/v2/handoffs` therefore lands in the automations `/:id` handler, which passes the literal string `"handoffs"` into `where(eq(automations.id, id))` with no uuid validation, and Postgres rejects the cast.

**The codebase already knows about this hazard** — line 62 carries `// … must be before root /:id catch-all (issue #496)`, and lines 65–67 repeat it. This is the same class of regression: three mounts were appended below the root mounts instead of above them.

## Blast radius

Ten single-segment collections currently fall into the catch-all and return 500:

```
a2a  agent-state  auth  follow-up  handoffs  journeys  logs  media  trust  voice
```

Of these, **`handoffs` is the only genuine loss of function** — it is the only one whose router actually defines a `GET /` list handler. The other **nine have no bare collection route by design**, so the catch-all is merely converting what should be a `404 NOT_FOUND` into a misleading `500 INTERNAL_ERROR`. Worth fixing for correctness, but no other endpoint stopped working.

Nested paths are unaffected (two or more segments never match `/:id`), which is why the rest of the admin UI is healthy:

```
/api/v2/trust/hosts        -> 200
/api/v2/voice/sessions     -> 200   {"items":[]}
/api/v2/follow-up/chats/…  -> 200
/api/v2/automations        -> 200   (mounted at line 74, before the root mount)
```

## UI consequence

`HandoffsPage.tsx` calls `ext.handoffs.list({ limit: 100 })`. The 500 leaves the query result undefined and the page then reads `.length` off it, producing `Cannot read properties of undefined (reading 'length')` and `Route render error`. Only the Handoffs route is affected; the rest of the SPA renders.

The client/server contract itself is correct — `ext.ts:962` expects `{ data?: HandoffRecord[], meta?… }` and the route returns exactly that — so **no client change is needed** once the mount order is fixed.

## Ruled out with evidence

- **Not a missing table/migration.** `handoff_logs` exists with the expected columns; the route's `handoffLogs` maps to it.
- **Not an empty-table edge case.** `select count(*) from handoff_logs` → `0`, but the failure happens before any handoffs query runs — the request never reaches `handoffsRoutes`.
- **Not a multitenancy/legacy-mode gap.** No tenancy branch is involved; the request is misrouted at the HTTP layer.
- **Not the BFF, not the proxy.** Identical 500 on the direct `:8882` call with neither in path.

## The change

- Move `/voice`, `/follow-up` and `/handoffs` above the root-mount block, each carrying the existing `must be before root /:id catch-all (issue #496)` comment.
- Add a block comment at the root mounts stating the invariant explicitly: **every router with a bare collection GET must be mounted before the root `/:id` catch-all**, and why the root automations mount exists at all.
- **No route is added or removed.** Both automations mounts are kept, so `/api/v2/automations`, `/api/v2/automation-logs` and `/api/v2/automation-metrics` are unaffected.

## Test

New `packages/api/src/routes/v2/__tests__/v2-mount-order.test.ts` derives the mount table and the catch-all boundary from the source of `index.ts`, so it needs no database and names the offending line when it breaks:

- every router with a bare `get('/')` is mounted above the first root mount that installs a single-segment `/:id` catch-all;
- `/handoffs` specifically precedes it (the #496 regression);
- both automations mounts still exist — so the invariant cannot be "satisfied" by deleting the root mount and breaking `/automation-logs`.

Verified non-vacuous: against the pre-fix ordering it fails with exactly

```
+ [
+   "index.ts:79 handoffsRoutes at '/handoffs'",
+ ]
(fail) v2 route mount order > mounts every router with a bare collection GET above the root /:id catch-all
(fail) v2 route mount order > mounts /handoffs before the root catch-all (the #496 regression)
```

Gates run (targeted, not the full suite):

```
bun test v2-mount-order + voice-routes + follow-up-routes + agent-routes
         + console-profile-scope-coverage    ->  31 pass, 17 skip, 0 fail
packages/api: tsc --noEmit                   ->  clean
biome check . (pre-commit)                   ->  1560 files, no fixes applied
```

## Suggested follow-up (not in this PR)

Add a uuid guard to the root-mounted automations `/:id` handler, so an unmatched single-segment collection name **404s instead of reaching the database**. That converts the remaining nine misleading 500s into correct 404s and makes any future mount-order slip a clean not-found rather than a Postgres error.

## Related findings, not fixed here

Two adjacent issues surfaced during the same investigation. Both are separate from the routing bug and are reported here only so they are not lost:

1. **`GET /api/v2/messages/tts/voices` returns `400 VALIDATION` when the optional provider is simply not configured.**

   ```
   HTTP 400
   {"error":{"code":"VALIDATION","message":"ElevenLabs API key not configured.
    Set it in Settings > TTS or via ELEVENLABS_API_KEY env var."}}
   ```

   A missing *optional* provider credential is a configuration state, not a client validation error. Returning `400 VALIDATION` makes the SPA surface it as a red console error on a page whose correct rendering is the empty state "TTS not configured". Either a `200` with an empty `voices` array plus a `configured: false` flag, or a `501`/`503` with a distinguishable code, would let the UI render an informative empty state instead of an error.

2. **khal-ui ships no favicon.** `apps/khal-ui/dev/` has no `public/` directory, and the built `index.html` declares no `<link rel="icon">`, so browsers fall back to `/favicon.ico` and get a 404 on every load. The durable fix is upstream: add `apps/khal-ui/dev/public/favicon.ico` and the corresponding `<link rel="icon">` in `dev/index.html`. (The only icon in the repo is `apps/ui/public/favicon.svg`, the old dashboard's purple mark, which clashes with khal-ui's monochrome palette.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
