### PR TITLE
fix(cli): move @omni/channel-hermes to devDependencies (unbreak main image build)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "omni",
       "description": "Full Omni platform control — multichannel messaging, automations, events, batch ops via the omni CLI",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "author": {
         "name": "Automagik"
       },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/ui",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/ui": {
       "name": "@omni/ui",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -51,7 +51,7 @@
     },
     "packages/api": {
       "name": "@omni/api",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@google/genai": "^1.0.0",
         "@hono/swagger-ui": "^0.4.1",
@@ -92,7 +92,7 @@
     },
     "packages/channel-a2a": {
       "name": "@omni/channel-a2a",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -108,7 +108,7 @@
     },
     "packages/channel-discord": {
       "name": "@omni/channel-discord",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -125,7 +125,7 @@
     },
     "packages/channel-gupshup": {
       "name": "@omni/channel-gupshup",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -141,7 +141,7 @@
     },
     "packages/channel-hermes": {
       "name": "@omni/channel-hermes",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -156,7 +156,7 @@
     },
     "packages/channel-internal": {
       "name": "@omni/channel-internal",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -171,7 +171,7 @@
     },
     "packages/channel-sdk": {
       "name": "@omni/channel-sdk",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "zod": "^3.24.1",
@@ -183,7 +183,7 @@
     },
     "packages/channel-slack": {
       "name": "@omni/channel-slack",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/channel-telegram": {
       "name": "@omni/channel-telegram",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -217,7 +217,7 @@
     },
     "packages/channel-twilio-whatsapp": {
       "name": "@omni/channel-twilio-whatsapp",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/channel-whatsapp": {
       "name": "@omni/channel-whatsapp",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@omni/channel-sdk": "workspace:*",
@@ -253,7 +253,7 @@
     },
     "packages/channel-whatsapp-cloud": {
       "name": "@omni/channel-whatsapp-cloud",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/channel-sdk": "workspace:*",
         "@omni/core": "workspace:*",
@@ -269,7 +269,7 @@
     },
     "packages/cli": {
       "name": "@automagik/omni",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "bin": {
         "omni": "./bin/omni",
       },
@@ -309,7 +309,7 @@
     },
     "packages/core": {
       "name": "@omni/core",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
         "@opentelemetry/api": "^1.9.1",
@@ -325,7 +325,7 @@
     },
     "packages/db": {
       "name": "@omni/db",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@omni/core": "workspace:*",
         "drizzle-orm": "^0.38.4",
@@ -339,7 +339,7 @@
     },
     "packages/media-processing": {
       "name": "@omni/media-processing",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@omni/core": "workspace:*",
@@ -358,7 +358,7 @@
     },
     "packages/plugin-openclaw": {
       "name": "@omni/plugin-openclaw",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.3",
@@ -366,7 +366,7 @@
     },
     "packages/sdk": {
       "name": "@omni/sdk",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "openapi-fetch": "^0.13.6",
       },
@@ -380,7 +380,7 @@
     },
     "packages/voice-client": {
       "name": "@omni/voice-client",
-      "version": "2.260730.2",
+      "version": "2.260730.3",
       "dependencies": {
         "@snazzah/davey": "^0.1.11",
         "libsodium-wrappers": "^0.7.15",

--- a/bun.lock
+++ b/bun.lock
@@ -275,7 +275,6 @@
       },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-        "@omni/channel-hermes": "workspace:*",
         "@sentry/bun": "^10.43.0",
         "@snazzah/davey": "^0.1.11",
         "chalk": "^5.4.0",
@@ -295,6 +294,7 @@
         "@omni/channel-a2a": "workspace:*",
         "@omni/channel-discord": "workspace:*",
         "@omni/channel-gupshup": "workspace:*",
+        "@omni/channel-hermes": "workspace:*",
         "@omni/channel-sdk": "workspace:*",
         "@omni/channel-slack": "workspace:*",
         "@omni/channel-telegram": "workspace:*",

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # homolog. The chart's default image tag is v<appVersion>, so a promoted tree
 # always references exactly the image its own promotion publishes. Do not edit
 # by hand — scripts/verify-versions.ts fails CI on drift.
-appVersion: "2.260730.2"
+appVersion: "2.260730.3"
 keywords:
   - omni
   - messaging

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omni-v2",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "private": true,
   "type": "module",
   "workspaces": ["packages/*", "apps/ui"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/api",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-a2a/package.json
+++ b/packages/channel-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-a2a",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "A2A protocol server channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-discord",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Discord channel plugin for Omni using discord.js",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-gupshup/package.json
+++ b/packages/channel-gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-gupshup",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Gupshup WhatsApp BSP channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-hermes/package.json
+++ b/packages/channel-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-hermes",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Hermes API (Mutant) WhatsApp gateway channel plugin for Omni — per-instance webhook + REST outbound with JWT auth",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-internal/package.json
+++ b/packages/channel-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-internal",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Internal agent-to-agent routing channel for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-sdk/package.json
+++ b/packages/channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-sdk",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/channel-slack/package.json
+++ b/packages/channel-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-slack",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Slack channel plugin for Omni using Bolt.js with Socket Mode",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-telegram",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Telegram channel plugin for Omni using grammy",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-twilio-whatsapp/package.json
+++ b/packages/channel-twilio-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-twilio-whatsapp",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Twilio WhatsApp channel plugin for Omni",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp-cloud/package.json
+++ b/packages/channel-whatsapp-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp-cloud",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "WhatsApp Cloud API (Meta) channel plugin for Omni — webhook + REST outbound, Embedded Signup OAuth, templates HSM",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/channel-whatsapp/package.json
+++ b/packages/channel-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/channel-whatsapp",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "WhatsApp channel plugin for Omni using Baileys",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-    "@omni/channel-hermes": "workspace:*",
     "@sentry/bun": "^10.43.0",
     "@snazzah/davey": "^0.1.11",
     "chalk": "^5.4.0",
@@ -58,6 +57,7 @@
     "@omni/channel-a2a": "workspace:*",
     "@omni/channel-discord": "workspace:*",
     "@omni/channel-gupshup": "workspace:*",
+    "@omni/channel-hermes": "workspace:*",
     "@omni/channel-sdk": "workspace:*",
     "@omni/channel-slack": "workspace:*",
     "@omni/channel-telegram": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/omni",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "LLM-optimized CLI for Omni",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/core",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/db",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/media-processing/package.json
+++ b/packages/media-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/media-processing",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/plugin-openclaw",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Expose Omni as a native messaging channel in OpenClaw",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/sdk",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice-client/package.json
+++ b/packages/voice-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni/voice-client",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "type": "module",
   "exports": {
     ".": {

--- a/plugins/omni/.claude-plugin/plugin.json
+++ b/plugins/omni/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omni",
-  "version": "2.260730.2",
+  "version": "2.260730.3",
   "description": "Full Omni platform control — three-tier skill system for agents (omni-agent), first-time setup (omni-setup), and platform ops (omni-ops)",
   "author": {
     "name": "Automagik"


### PR DESCRIPTION
## Hotfix: main Publish Image build is red

[Run 30589096808](https://github.com/automagik-dev/omni/actions/runs/30589096808) failed in the `build-push` job:

```
error: Workspace dependency "@omni/channel-hermes" not found
error: @omni/channel-hermes@workspace:* failed to resolve
```

### Cause
PR #878 added `@omni/channel-hermes` to `packages/cli` **`dependencies`** instead of `devDependencies`. The Dockerfile's `prod-deps` stage strips devDependencies and runs a standalone `bun install --production` outside the monorepo, where `workspace:*` cannot resolve. Every other `@omni/*` channel lives in devDependencies because they are inlined into the server bundle by `build:server`.

### Fix
Move `@omni/channel-hermes` to `devDependencies` (it's pure TS, no native deps, imported by `bundled-server-entry.ts` and inlined like the rest). Lockfile refreshed.

### Verification
- Simulated the exact `prod-deps` stage locally (strip devDeps → `bun install --production --ignore-scripts`): **passes**, no workspace errors
- `bun run build:server`: bundles 3800 modules, hermes resolves inlined
- Full pre-push gate (typecheck + `bun test packages apps/ui`): green

Carry-exact promotion, version 2.260730.3 (bumped on dev).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Omni platform and its components to version **2.260730.3**.
  * Updated the CLI packaging configuration to ensure the Hermes channel is handled during development and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->