### PR TITLE
fix(debouncer): re-arm the window for mid-flight arrivals

### DIFF
--- a/packages/api/src/plugins/__tests__/message-debouncer.test.ts
+++ b/packages/api/src/plugins/__tests__/message-debouncer.test.ts
@@ -88,8 +88,8 @@ describe('MessageDebouncer', () => {
 
       // Release the first flush
       resolveFirstFlush!();
-      // Allow the re-flush setTimeout(0) to fire
-      await wait(50);
+      // Late arrivals now wait out a fresh debounce window before firing.
+      await wait(200);
 
       // Second flush should have picked up the late arrivals
       expect(flushCalls.length).toBe(2);
@@ -245,7 +245,8 @@ describe('MessageDebouncer', () => {
 
       // Release first flush
       resolveFirstFlush!();
-      await wait(50);
+      // Late arrivals now wait out a fresh debounce window before firing.
+      await wait(200);
 
       // Should have exactly 2 flushes — the re-flush from finally picked up msg2.
       // Without the inFlight guard in onUserTyping, a third flush could fire from
@@ -430,7 +431,8 @@ describe('MessageDebouncer', () => {
 
       // Release first flush
       resolveFirstFlush!();
-      await wait(50);
+      // Late arrivals now wait out a fresh debounce window before firing.
+      await wait(200);
 
       // Second batch should flush automatically
       expect(flushCalls.length).toBe(2);
@@ -623,5 +625,106 @@ describe('MessageDebouncer', () => {
 
       expect(debouncer.hasPending('inst-1', 'chat-1')).toBe(false);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mid-flight arrivals re-arm the window instead of flushing immediately
+// ---------------------------------------------------------------------------
+
+describe('messages arriving mid-flight', () => {
+  function fixedConfig(ms: number): DebounceConfig {
+    return {
+      mode: 'fixed',
+      minMs: ms,
+      maxMs: ms,
+      groupMs: null,
+      maxWaitMs: null,
+      restartOnTyping: false,
+    } as DebounceConfig;
+  }
+
+  it('waits the debounce window before answering them', async () => {
+    const flushes: BufferedMessage[][] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+
+    const d = new MessageDebouncer(async (_key, msgs) => {
+      flushes.push(msgs);
+      if (flushes.length === 1) await firstDone;
+    });
+
+    d.buffer('inst-1', 'chat-1', makeMessage('oi'), fixedConfig(20));
+    await Bun.sleep(35); // first batch flushes and blocks
+
+    // user keeps typing while the agent is still answering the first message
+    d.buffer('inst-1', 'chat-1', makeMessage('quero plano'), fixedConfig(20));
+    d.buffer('inst-1', 'chat-1', makeMessage('pra 2 pessoas'), fixedConfig(20));
+
+    releaseFirst?.();
+    await Bun.sleep(5);
+
+    // The old behaviour flushed on a setTimeout(0), so the second batch would
+    // already be out here — back to back with the first reply.
+    expect(flushes.length).toBe(1);
+
+    await Bun.sleep(30);
+    expect(flushes.length).toBe(2);
+    // and both messages are answered together, with full context
+    expect(flushes[1]!.length).toBe(2);
+  });
+
+  it('still answers them — re-arming must not strand the buffer', async () => {
+    const flushes: BufferedMessage[][] = [];
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const d = new MessageDebouncer(async (_key, msgs) => {
+      flushes.push(msgs);
+      if (flushes.length === 1) await gate;
+    });
+
+    d.buffer('inst-1', 'chat-2', makeMessage('a'), fixedConfig(15));
+    await Bun.sleep(25);
+    d.buffer('inst-1', 'chat-2', makeMessage('b'), fixedConfig(15));
+    release?.();
+
+    await Bun.sleep(60);
+    expect(flushes.length).toBe(2);
+    expect(flushes[1]![0]?.payload.content?.text).toBe('b');
+  });
+
+  it('re-arms even in fixed mode, where a live timer normally blocks restarts', async () => {
+    // `restartTimer` refuses to restart a fixed-window timer unless forced.
+    // After a flush there is no live timer, so the new batch must get its own
+    // window — otherwise it would never fire.
+    const flushes: BufferedMessage[][] = [];
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const d = new MessageDebouncer(async (_key, msgs) => {
+      flushes.push(msgs);
+      if (flushes.length === 1) await gate;
+    });
+
+    d.buffer('inst-1', 'chat-3', makeMessage('x'), fixedConfig(15));
+    await Bun.sleep(25);
+    d.buffer('inst-1', 'chat-3', makeMessage('y'), fixedConfig(15));
+    release?.();
+    await Bun.sleep(60);
+
+    expect(flushes.length).toBe(2);
+  });
+
+  it('does not leak config state once the chat drains', async () => {
+    const d = new MessageDebouncer(async () => {});
+    d.buffer('inst-1', 'chat-4', makeMessage('only'), fixedConfig(10));
+    await Bun.sleep(40);
+    // nothing pending, nothing scheduled — a further wait produces no flush
+    expect(d.hasPending('inst-1', 'chat-4')).toBe(false);
   });
 });

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -70,6 +70,12 @@ export class MessageDebouncer {
   private inFlight: Set<string> = new Set();
   /** Timestamp of the first buffered message per chat — anchors the maxWaitMs cap. */
   private firstBufferedAt: Map<string, number> = new Map();
+  /**
+   * Last debounce config seen for a chat. The flush-completion path needs it to
+   * re-arm the timer for messages that arrived mid-flight; without it the only
+   * option was to flush them immediately, ignoring the collection window.
+   */
+  private lastConfig: Map<string, DebounceConfig> = new Map();
   private onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>;
   /** Injectable clock — defaults to Date.now; overridable for deterministic tests. */
   private now: () => number;
@@ -92,6 +98,7 @@ export class MessageDebouncer {
     // Anchor the max-wait window on the first message of a fresh batch so the
     // cap survives any number of timer restarts (typing or new messages).
     if (!this.firstBufferedAt.has(chatKey)) this.firstBufferedAt.set(chatKey, this.now());
+    this.lastConfig.set(chatKey, config);
 
     // If this chat is currently being processed, just accumulate — don't start
     // a new timer. The flush completion handler will pick up these messages.
@@ -191,12 +198,29 @@ export class MessageDebouncer {
     } finally {
       this.inFlight.delete(chatKey);
 
-      // Check if new messages arrived while we were processing.
-      // If so, flush them now (they've been accumulating in the buffer).
+      // Messages that arrived while we were processing. Re-arm the debounce
+      // window instead of flushing right away: an immediate flush answers a
+      // half-typed thought, and — because the previous reply is landing at the
+      // same moment — the user gets two messages back to back, the first one
+      // answering something they had already moved on from.
+      //
+      // Re-arming keeps the same guarantee the first batch had: wait for the
+      // person to finish. `force` is required because 'fixed'/'presence' modes
+      // refuse to restart a live timer, and here there is no live timer at all
+      // — the window must start fresh for this new batch.
       const pending = this.buffers.get(chatKey);
       if (pending?.length) {
-        // Use setTimeout(0) to avoid deep recursion
-        setTimeout(() => this.flush(chatKey), 0);
+        const config = this.lastConfig.get(chatKey);
+        if (config) {
+          this.restartTimer(chatKey, config, true);
+        } else {
+          // No config recorded (should not happen — buffer() always records it).
+          // Falling back to the old immediate flush is better than stranding
+          // the messages with no timer at all.
+          setTimeout(() => this.flush(chatKey), 0);
+        }
+      } else {
+        this.lastConfig.delete(chatKey);
       }
     }
   }


### PR DESCRIPTION
Messages that arrive while a flush is in-flight were flushed **immediately** once that flush completed:

```ts
const pending = this.buffers.get(chatKey);
if (pending?.length) {
  setTimeout(() => this.flush(chatKey), 0);   // bypasses the collection window
}
```

Two symptoms, same cause:

1. **The reply answers a half-typed thought.** The user is still composing when it goes out.
2. **Two messages land back to back.** The previous reply arrives at that same moment, and the first one answers something the user had already moved on from.

## The fix

Re-arm the timer instead. This batch gets the same guarantee the first one had: wait for the person to finish.

`force` is required — `fixed`/`presence` refuse to restart a live timer, and after a flush there is no live timer at all, so the window has to start fresh. Without it the batch would sit with no timer and never fire.

The config is now recorded per chat in `buffer()`, since the flush-completion path needs it to re-arm, and dropped when the chat drains. If no config was recorded (should not happen), the old immediate flush still runs — stranding messages with no timer would be worse than answering early.

## Tests

The three existing in-flight tests **kept their assertions** (nothing is lost, no competing timer starts); only their waits grew to cover the window the batch now goes through.

Four tests added:

- late arrivals wait the window instead of firing immediately, and are answered **together**
- they are still answered — re-arming must not strand the buffer
- fixed mode re-arms (the case a missing `force` would break)
- no config state leaks once the chat drains

`bun test packages/api/src/plugins/__tests__/` → **429 pass, 0 fail**. `tsc --noEmit` clean on both touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message debouncing so messages arriving during processing are grouped into a new debounce window.
  * Prevented premature flushes and preserved expected behavior for fixed and presence-based modes.
  * Improved cleanup after all buffered messages are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->