### PR TITLE
feat(instances): per-instance agent dispatch error message (#737)

### DIFF
--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -570,8 +570,8 @@ async function sendTextMessage(
 /**
  * Built-in dispatch-failure message (#737). Kept in English for backwards
  * compatibility — non-English deployments override it globally via the
- * `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env var (a per-instance override tier is
- * a planned follow-up; see {@link resolveDispatchErrorMessage}).
+ * `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env var or per instance via the
+ * `agentErrorMessage` column (see {@link resolveDispatchErrorMessage}).
  */
 export const DEFAULT_DISPATCH_ERROR_MESSAGE = '⚠️ Sorry, I ran into an issue processing your message. Please try again.';
 
@@ -581,13 +581,6 @@ export const DEFAULT_DISPATCH_ERROR_MESSAGE = '⚠️ Sorry, I ran into an issue
  *   2. `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env (global override),
  *   3. {@link DEFAULT_DISPATCH_ERROR_MESSAGE}.
  * Blank/whitespace-only values are ignored so they fall through to the next tier.
- *
- * NOTE: the per-instance tier is wired through the first argument but no
- * `instances` column exists yet — callers pass `null` today and rely on the
- * env override. The column is a follow-up, deferred until the Drizzle snapshot
- * drift in `packages/db` is reconciled (re-adding it now would re-propose
- * already-migrated columns and crash auto-migrate). The tier is kept here +
- * tested so dropping the column in is a one-line call-site change.
  */
 export function resolveDispatchErrorMessage(
   instanceErrorMessage: string | null | undefined,
@@ -815,9 +808,13 @@ async function handleDispatchFailure(
     trustedTenantId,
   );
   if (handedOff) return;
-  // Per-instance override tier is null until the `agentErrorMessage` column
-  // lands (see resolveDispatchErrorMessage note) — env + default for now.
-  await sendErrorFeedback(channel, instance.id, chatId, error, resolveDispatchErrorMessage(null)).catch(() => {});
+  await sendErrorFeedback(
+    channel,
+    instance.id,
+    chatId,
+    error,
+    resolveDispatchErrorMessage(instance.agentErrorMessage),
+  ).catch(() => {});
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -59,6 +59,13 @@ const createInstanceSchema = z.object({
   channel: ChannelTypeSchema.describe('Channel type (e.g., whatsapp-baileys, discord)'),
   agentId: z.string().uuid().nullable().optional().describe('Agent UUID referencing agents table'),
   agentTimeout: z.number().int().positive().default(600).describe('Agent timeout in seconds'),
+  agentErrorMessage: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      'Customer-facing reply sent when agent dispatch fails (null = fall through to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
+    ),
   agentStreamMode: z.boolean().default(false).describe('Enable streaming responses'),
   agentReplyFilter: agentReplyFilterSchema.optional().nullable().describe('When agent should reply'),
   agentSessionStrategy: z
@@ -256,6 +263,7 @@ const createInstanceSchema = z.object({
 const updateInstanceSchema = createInstanceSchema.partial().extend({
   // Nullable fields in DB - can be set to null
   agentId: z.string().uuid().nullable().optional(),
+  agentErrorMessage: z.string().nullable().optional(),
   agentReplyFilter: agentReplyFilterSchema.nullable().optional(),
   triggerEvents: z.array(z.string()).nullable().optional(),
   telegramBotToken: z.string().nullable().optional(),

--- a/packages/api/src/schemas/openapi/instances.ts
+++ b/packages/api/src/schemas/openapi/instances.ts
@@ -22,6 +22,11 @@ export const InstanceSchema = z.object({
   agentId: z.string().uuid().nullable().optional().openapi({ description: 'Agent UUID (agents table)' }),
   agentProviderId: z.string().uuid().nullable().optional().openapi({ description: 'Provider ID (agent provider)' }),
   agentTimeout: z.number().openapi({ description: 'Agent timeout in seconds' }),
+  agentErrorMessage: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({ description: 'Customer-facing reply sent when agent dispatch fails (null = env/default fallback)' }),
   agentStreamMode: z.boolean().openapi({ description: 'Whether streaming is enabled' }),
   createdAt: z.string().datetime().openapi({ description: 'Creation timestamp' }),
   updatedAt: z.string().datetime().openapi({ description: 'Last update timestamp' }),
@@ -35,6 +40,11 @@ export const CreateInstanceSchema = z.object({
   channel: ChannelTypeSchema.openapi({ description: 'Channel type' }),
   agentId: z.string().uuid().nullable().optional().openapi({ description: 'Agent UUID (agents table)' }),
   agentTimeout: z.number().int().positive().default(600).openapi({ description: 'Agent timeout in seconds' }),
+  agentErrorMessage: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({ description: 'Customer-facing reply sent when agent dispatch fails (null = env/default fallback)' }),
   agentStreamMode: z.boolean().default(false).openapi({ description: 'Enable streaming responses' }),
   isDefault: z.boolean().default(false).openapi({ description: 'Set as default instance for channel' }),
   token: z.string().optional().openapi({ description: 'Bot token for Discord instances' }),

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -55,6 +55,7 @@ function applyAgentFields(body: Record<string, unknown>, opts: Record<string, un
   // agentFkId (--agent-fk-id) is now the primary way to set the agent (maps to agentId in DB)
   setVal(body, 'agentId', opts.agentFkId);
   if (opts.agentTimeout !== undefined) body.agentTimeout = opts.agentTimeout;
+  setVal(body, 'agentErrorMessage', opts.agentErrorMessage);
   setBool(body, 'agentStreamMode', opts.agentStreamMode);
   setVal(body, 'agentSessionStrategy', opts.agentSessionStrategy);
   setBool(body, 'agentPrefixSenderName', opts.agentPrefixSenderName);
@@ -304,6 +305,10 @@ export function createInstancesCommand(): Command {
     .option('--agent <id>', 'Agent ID')
     .option('--agent-type <type>', 'Agent type: agent, team, or workflow')
     .option('--agent-timeout <seconds>', 'Agent timeout in seconds', (v) => Number.parseInt(v, 10))
+    .option(
+      '--agent-error-message <text>',
+      'Customer-facing reply when agent dispatch fails (use "null" to clear; falls back to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
+    )
     .option('--agent-stream-mode', 'Enable streaming responses')
     .option('--agent-session-strategy <strategy>', 'Session strategy: per_user, per_chat, per_user_per_chat')
     .option('--agent-prefix-sender-name', 'Prefix messages with sender name')
@@ -905,6 +910,10 @@ export function createInstancesCommand(): Command {
     .option('--agent <id>', 'Agent ID (use "null" to clear)')
     .option('--agent-type <type>', 'Agent type: agent, team, or workflow')
     .option('--agent-timeout <seconds>', 'Agent timeout in seconds', (v) => Number.parseInt(v, 10))
+    .option(
+      '--agent-error-message <text>',
+      'Customer-facing reply when agent dispatch fails (use "null" to clear; falls back to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
+    )
     .option('--agent-stream-mode', 'Enable streaming responses')
     .option('--no-agent-stream-mode', 'Disable streaming responses')
     .option('--agent-session-strategy <strategy>', 'Session strategy: per_user, per_chat, per_user_per_chat')

--- a/packages/db/drizzle/0044_instance_agent_error_message.sql
+++ b/packages/db/drizzle/0044_instance_agent_error_message.sql
@@ -1,0 +1,17 @@
+-- Per-instance dispatch-failure message (#737).
+--
+-- Adds `agent_error_message` to `instances`: the customer-facing text sent
+-- when agent dispatch fails on a non-handoff channel. NULL falls through to
+-- the `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env var, then the built-in default
+-- (see resolveDispatchErrorMessage in packages/api agent-dispatcher).
+--
+-- Hand-written following the 0043_hermes_channel precedent (additive,
+-- idempotent, no rewrite: ADD COLUMN with no default does not rewrite the
+-- table).
+
+-- NOTE: no explicit BEGIN/COMMIT — the boot migrator executes this file on a
+-- pooled postgres-js connection, which rejects raw transaction control
+-- (UNSAFE_TRANSACTION). Single idempotent statement.
+
+ALTER TABLE "instances"
+  ADD COLUMN IF NOT EXISTS "agent_error_message" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1784300000000,
       "tag": "0043_hermes_channel",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784400000000,
+      "tag": "0044_instance_agent_error_message",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -765,6 +765,8 @@ export const instances = pgTable(
     // ---- Agent Configuration (Instance Override) ----
     agentTimeout: integer('agent_timeout').notNull().default(600),
     agentStreamMode: boolean('agent_stream_mode').notNull().default(false),
+    /** Customer-facing reply when agent dispatch fails (null = OMNI_AGENT_DISPATCH_ERROR_MESSAGE env / built-in default, #737) */
+    agentErrorMessage: text('agent_error_message'),
     /** When agent should reply to messages */
     agentReplyFilter: jsonb('agent_reply_filter').$type<AgentReplyFilter>(),
     /** Session strategy for agent memory */

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2615,7 +2615,7 @@ export interface components {
              * @description Channel type
              * @enum {string}
              */
-            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
             /** @description Whether instance is active */
             isActive: boolean;
             /** @description Whether this is the default instance for channel */
@@ -2638,6 +2638,8 @@ export interface components {
             agentProviderId?: string | null;
             /** @description Agent timeout in seconds */
             agentTimeout: number;
+            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+            agentErrorMessage?: string | null;
             /** @description Whether streaming is enabled */
             agentStreamMode: boolean;
             /**
@@ -2658,7 +2660,7 @@ export interface components {
              * @description Channel type
              * @enum {string}
              */
-            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
             /**
              * Format: uuid
              * @description Agent UUID (agents table)
@@ -2669,6 +2671,8 @@ export interface components {
              * @default 600
              */
             agentTimeout: number;
+            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+            agentErrorMessage?: string | null;
             /**
              * @description Enable streaming responses
              * @default false
@@ -2753,7 +2757,7 @@ export interface components {
              * @description Channel type ID
              * @enum {string}
              */
-            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
             /** @description Human-readable channel name */
             name: string;
             /** @description Plugin version */
@@ -2865,6 +2869,8 @@ export interface components {
                  */
                 url?: string;
             }[];
+            /** @description Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text) */
+            requestLocation?: boolean;
         };
         TTSVoice: {
             /** @description ElevenLabs voice ID */
@@ -6096,7 +6102,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -6119,6 +6125,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
+                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+                            agentErrorMessage?: string | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -6159,7 +6167,7 @@ export interface operations {
                      * @description Channel type
                      * @enum {string}
                      */
-                    channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                    channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                     /**
                      * Format: uuid
                      * @description Agent UUID (agents table)
@@ -6170,6 +6178,8 @@ export interface operations {
                      * @default 600
                      */
                     agentTimeout?: number;
+                    /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+                    agentErrorMessage?: string | null;
                     /**
                      * @description Enable streaming responses
                      * @default false
@@ -6205,7 +6215,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -6228,6 +6238,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
+                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+                            agentErrorMessage?: string | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -6288,7 +6300,7 @@ export interface operations {
                              * @description Channel type ID
                              * @enum {string}
                              */
-                            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                            id: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                             /** @description Human-readable channel name */
                             name: string;
                             /** @description Plugin version */
@@ -6337,7 +6349,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -6360,6 +6372,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
+                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+                            agentErrorMessage?: string | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -6465,7 +6479,7 @@ export interface operations {
                      * @description Channel type
                      * @enum {string}
                      */
-                    channel?: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                    channel?: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                     /**
                      * Format: uuid
                      * @description Agent UUID (agents table)
@@ -6476,6 +6490,8 @@ export interface operations {
                      * @default 600
                      */
                     agentTimeout?: number;
+                    /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+                    agentErrorMessage?: string | null;
                     /**
                      * @description Enable streaming responses
                      * @default false
@@ -6511,7 +6527,7 @@ export interface operations {
                              * @description Channel type
                              * @enum {string}
                              */
-                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "twilio-whatsapp" | "internal";
+                            channel: "whatsapp-baileys" | "whatsapp-cloud" | "discord" | "slack" | "telegram" | "a2a" | "gupshup" | "hermes" | "twilio-whatsapp" | "internal";
                             /** @description Whether instance is active */
                             isActive: boolean;
                             /** @description Whether this is the default instance for channel */
@@ -6534,6 +6550,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
+                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
+                            agentErrorMessage?: string | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -7426,6 +7444,8 @@ export interface operations {
                          */
                         url?: string;
                     }[];
+                    /** @description Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text) */
+                    requestLocation?: boolean;
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Adds the `agent_error_message` column to `instances` (migration `0044`, hand-written per the `0043_hermes_channel` precedent — drizzle snapshot drift since 0027 makes `drizzle-kit generate` interactive).
- Wires the already-implemented-and-tested per-instance tier of `resolveDispatchErrorMessage` (#737): **instance override → `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env → built-in default** (blank values fall through).
- Exposes the field on instance create/update (routes + OpenAPI schemas) and on the CLI as `--agent-error-message <text>` (`"null"` clears).
- Regenerates the TS SDK types (also picks up pending `hermes` channel enum + `requestLocation` drift from #878).

## What the customer sees on dispatch failure now
1. Native-handoff channels (Gupshup): unchanged — handoff message + agent pause.
2. Other channels: the instance's `agentErrorMessage` if set, else env override, else the built-in English default.

## Test plan
- `make typecheck` + `make lint` green.
- `bun test packages apps/ui`: 6166 tests, 0 fail (pre-push gate).
- Precedence covered by existing `agent-dispatch-error-message.test.ts`.