### PR TITLE
feat(instances): randomized list of agent dispatch error messages

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatch-error-message.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for resolveDispatchErrorMessage — issue #737.
  *
- * Precedence: per-instance `agentErrorMessage` → `OMNI_AGENT_DISPATCH_ERROR_MESSAGE`
- * env → built-in default. Blank/whitespace values fall through to the next tier.
+ * Precedence: per-instance `agentErrorMessages` (random pick among variants) →
+ * `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env → built-in default. Blank/whitespace
+ * values fall through to the next tier.
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -25,28 +26,49 @@ describe('resolveDispatchErrorMessage', () => {
   it('falls back to the built-in default when nothing is configured', () => {
     expect(resolveDispatchErrorMessage(null, {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
     expect(resolveDispatchErrorMessage(undefined, {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+    expect(resolveDispatchErrorMessage([], {})).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
   });
 
-  it('uses the env override when no per-instance value is set', () => {
+  it('ships a pt-BR built-in default', () => {
+    expect(DEFAULT_DISPATCH_ERROR_MESSAGE).toContain('Opa, tive um probleminha');
+  });
+
+  it('uses the env override when no per-instance list is set', () => {
     const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'Estamos com um problema, tente novamente.' };
     expect(resolveDispatchErrorMessage(null, env)).toBe('Estamos com um problema, tente novamente.');
   });
 
-  it('prefers the per-instance value over env and default', () => {
+  it('prefers the per-instance list over env and default', () => {
     const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env message' };
-    expect(resolveDispatchErrorMessage('instance message', env)).toBe('instance message');
+    expect(resolveDispatchErrorMessage(['instance message'], env)).toBe('instance message');
   });
 
-  it('ignores blank/whitespace-only values and falls through', () => {
+  it('picks a variant by the injected random source', () => {
+    const variants = ['first', 'second', 'third'];
+    expect(resolveDispatchErrorMessage(variants, {}, () => 0)).toBe('first');
+    expect(resolveDispatchErrorMessage(variants, {}, () => 0.5)).toBe('second');
+    expect(resolveDispatchErrorMessage(variants, {}, () => 0.99)).toBe('third');
+  });
+
+  it('only ever picks from the configured variants with real randomness', () => {
+    const variants = ['a', 'b'];
+    for (let i = 0; i < 50; i++) {
+      expect(variants).toContain(resolveDispatchErrorMessage(variants, {}));
+    }
+  });
+
+  it('ignores blank/whitespace-only entries and falls through', () => {
     const env = { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: '  ' };
-    // Blank instance + blank env → default.
-    expect(resolveDispatchErrorMessage('   ', env)).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
-    // Blank instance + valid env → env.
-    expect(resolveDispatchErrorMessage('  ', { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env msg' })).toBe('env msg');
+    // Blank-only list + blank env → default.
+    expect(resolveDispatchErrorMessage(['   '], env)).toBe(DEFAULT_DISPATCH_ERROR_MESSAGE);
+    // Blank-only list + valid env → env.
+    expect(resolveDispatchErrorMessage(['  '], { OMNI_AGENT_DISPATCH_ERROR_MESSAGE: 'env msg' })).toBe('env msg');
+    // Blank entries are dropped BEFORE the pick, so a valid entry always wins.
+    expect(resolveDispatchErrorMessage(['  ', 'valid'], {}, () => 0)).toBe('valid');
   });
 
   it('trims surrounding whitespace from the resolved value', () => {
-    expect(resolveDispatchErrorMessage('  hi there  ', {})).toBe('hi there');
+    expect(resolveDispatchErrorMessage(['  hi there  '], {})).toBe('hi there');
   });
 });
 

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -568,26 +568,32 @@ async function sendTextMessage(
 }
 
 /**
- * Built-in dispatch-failure message (#737). Kept in English for backwards
- * compatibility — non-English deployments override it globally via the
- * `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env var or per instance via the
- * `agentErrorMessage` column (see {@link resolveDispatchErrorMessage}).
+ * Built-in dispatch-failure message (#737). Defaults to pt-BR (the deployments
+ * this flow serves), matching the other customer-facing defaults
+ * (`DEFAULT_ERROR_HANDOFF_MESSAGE`, `SAFE_PROVIDER_ERROR_MESSAGE`). Other
+ * locales override globally via the `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env
+ * var or per instance via the `agentErrorMessages` column (see
+ * {@link resolveDispatchErrorMessage}).
  */
-export const DEFAULT_DISPATCH_ERROR_MESSAGE = '⚠️ Sorry, I ran into an issue processing your message. Please try again.';
+export const DEFAULT_DISPATCH_ERROR_MESSAGE = 'Opa, tive um probleminha aqui 😅 Pode mandar de novo?';
 
 /**
  * Resolve the customer-facing dispatch-failure message (#737). Precedence:
- *   1. per-instance override (localized per deployment),
+ *   1. per-instance `agentErrorMessages` — a list of variants, one picked at
+ *      random per failure so repeated errors don't read like a bot loop,
  *   2. `OMNI_AGENT_DISPATCH_ERROR_MESSAGE` env (global override),
  *   3. {@link DEFAULT_DISPATCH_ERROR_MESSAGE}.
- * Blank/whitespace-only values are ignored so they fall through to the next tier.
+ * Blank/whitespace-only entries are ignored so they fall through to the next
+ * tier. `random` is injectable for deterministic tests.
  */
 export function resolveDispatchErrorMessage(
-  instanceErrorMessage: string | null | undefined,
+  instanceErrorMessages: readonly string[] | null | undefined,
   env: Record<string, string | undefined> = process.env,
+  random: () => number = Math.random,
 ): string {
-  const instanceMsg = instanceErrorMessage?.trim();
-  if (instanceMsg) return instanceMsg;
+  const variants = (instanceErrorMessages ?? []).map((m) => m.trim()).filter(Boolean);
+  const picked = variants[Math.floor(random() * variants.length)];
+  if (picked) return picked;
   const envMsg = env.OMNI_AGENT_DISPATCH_ERROR_MESSAGE?.trim();
   if (envMsg) return envMsg;
   return DEFAULT_DISPATCH_ERROR_MESSAGE;
@@ -813,7 +819,7 @@ async function handleDispatchFailure(
     instance.id,
     chatId,
     error,
-    resolveDispatchErrorMessage(instance.agentErrorMessage),
+    resolveDispatchErrorMessage(instance.agentErrorMessages),
   ).catch(() => {});
 }
 

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -59,12 +59,12 @@ const createInstanceSchema = z.object({
   channel: ChannelTypeSchema.describe('Channel type (e.g., whatsapp-baileys, discord)'),
   agentId: z.string().uuid().nullable().optional().describe('Agent UUID referencing agents table'),
   agentTimeout: z.number().int().positive().default(600).describe('Agent timeout in seconds'),
-  agentErrorMessage: z
-    .string()
+  agentErrorMessages: z
+    .array(z.string())
     .optional()
     .nullable()
     .describe(
-      'Customer-facing reply sent when agent dispatch fails (null = fall through to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
+      'Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = fall through to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
     ),
   agentStreamMode: z.boolean().default(false).describe('Enable streaming responses'),
   agentReplyFilter: agentReplyFilterSchema.optional().nullable().describe('When agent should reply'),
@@ -263,7 +263,7 @@ const createInstanceSchema = z.object({
 const updateInstanceSchema = createInstanceSchema.partial().extend({
   // Nullable fields in DB - can be set to null
   agentId: z.string().uuid().nullable().optional(),
-  agentErrorMessage: z.string().nullable().optional(),
+  agentErrorMessages: z.array(z.string()).nullable().optional(),
   agentReplyFilter: agentReplyFilterSchema.nullable().optional(),
   triggerEvents: z.array(z.string()).nullable().optional(),
   telegramBotToken: z.string().nullable().optional(),

--- a/packages/api/src/schemas/openapi/instances.ts
+++ b/packages/api/src/schemas/openapi/instances.ts
@@ -22,11 +22,10 @@ export const InstanceSchema = z.object({
   agentId: z.string().uuid().nullable().optional().openapi({ description: 'Agent UUID (agents table)' }),
   agentProviderId: z.string().uuid().nullable().optional().openapi({ description: 'Provider ID (agent provider)' }),
   agentTimeout: z.number().openapi({ description: 'Agent timeout in seconds' }),
-  agentErrorMessage: z
-    .string()
-    .nullable()
-    .optional()
-    .openapi({ description: 'Customer-facing reply sent when agent dispatch fails (null = env/default fallback)' }),
+  agentErrorMessages: z.array(z.string()).nullable().optional().openapi({
+    description:
+      'Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback)',
+  }),
   agentStreamMode: z.boolean().openapi({ description: 'Whether streaming is enabled' }),
   createdAt: z.string().datetime().openapi({ description: 'Creation timestamp' }),
   updatedAt: z.string().datetime().openapi({ description: 'Last update timestamp' }),
@@ -40,11 +39,10 @@ export const CreateInstanceSchema = z.object({
   channel: ChannelTypeSchema.openapi({ description: 'Channel type' }),
   agentId: z.string().uuid().nullable().optional().openapi({ description: 'Agent UUID (agents table)' }),
   agentTimeout: z.number().int().positive().default(600).openapi({ description: 'Agent timeout in seconds' }),
-  agentErrorMessage: z
-    .string()
-    .nullable()
-    .optional()
-    .openapi({ description: 'Customer-facing reply sent when agent dispatch fails (null = env/default fallback)' }),
+  agentErrorMessages: z.array(z.string()).nullable().optional().openapi({
+    description:
+      'Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback)',
+  }),
   agentStreamMode: z.boolean().default(false).openapi({ description: 'Enable streaming responses' }),
   isDefault: z.boolean().default(false).openapi({ description: 'Set as default instance for channel' }),
   token: z.string().optional().openapi({ description: 'Bot token for Discord instances' }),

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -55,7 +55,10 @@ function applyAgentFields(body: Record<string, unknown>, opts: Record<string, un
   // agentFkId (--agent-fk-id) is now the primary way to set the agent (maps to agentId in DB)
   setVal(body, 'agentId', opts.agentFkId);
   if (opts.agentTimeout !== undefined) body.agentTimeout = opts.agentTimeout;
-  setVal(body, 'agentErrorMessage', opts.agentErrorMessage);
+  if (Array.isArray(opts.agentErrorMessage)) {
+    const messages = opts.agentErrorMessage as string[];
+    body.agentErrorMessages = messages.length === 1 && messages[0] === 'null' ? null : messages;
+  }
   setBool(body, 'agentStreamMode', opts.agentStreamMode);
   setVal(body, 'agentSessionStrategy', opts.agentSessionStrategy);
   setBool(body, 'agentPrefixSenderName', opts.agentPrefixSenderName);
@@ -307,7 +310,8 @@ export function createInstancesCommand(): Command {
     .option('--agent-timeout <seconds>', 'Agent timeout in seconds', (v) => Number.parseInt(v, 10))
     .option(
       '--agent-error-message <text>',
-      'Customer-facing reply when agent dispatch fails (use "null" to clear; falls back to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
+      'Customer-facing reply when agent dispatch fails; repeat the flag for multiple variants (one is picked at random per failure). Use "null" to clear; falls back to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default',
+      (value: string, previous: string[] = []) => [...previous, value],
     )
     .option('--agent-stream-mode', 'Enable streaming responses')
     .option('--agent-session-strategy <strategy>', 'Session strategy: per_user, per_chat, per_user_per_chat')
@@ -912,7 +916,8 @@ export function createInstancesCommand(): Command {
     .option('--agent-timeout <seconds>', 'Agent timeout in seconds', (v) => Number.parseInt(v, 10))
     .option(
       '--agent-error-message <text>',
-      'Customer-facing reply when agent dispatch fails (use "null" to clear; falls back to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default)',
+      'Customer-facing reply when agent dispatch fails; repeat the flag for multiple variants (one is picked at random per failure). Use "null" to clear; falls back to OMNI_AGENT_DISPATCH_ERROR_MESSAGE env, then built-in default',
+      (value: string, previous: string[] = []) => [...previous, value],
     )
     .option('--agent-stream-mode', 'Enable streaming responses')
     .option('--no-agent-stream-mode', 'Disable streaming responses')

--- a/packages/db/drizzle/0045_agent_error_messages_list.sql
+++ b/packages/db/drizzle/0045_agent_error_messages_list.sql
@@ -1,0 +1,24 @@
+-- Per-instance dispatch-failure messages, plural (#737 follow-up).
+--
+-- Replaces the single-text `agent_error_message` (added in 0044) with a jsonb
+-- string array `agent_error_messages`: operators can configure several
+-- variants and the dispatcher picks one at random per failure. Any value
+-- already stored in the old column is carried over as a one-element array.
+--
+-- Hand-written following the 0043/0044 precedent (snapshot drift keeps
+-- drizzle-kit generate interactive). Additive + idempotent statements.
+
+-- NOTE: no explicit BEGIN/COMMIT — the boot migrator executes this file on a
+-- pooled postgres-js connection, which rejects raw transaction control
+-- (UNSAFE_TRANSACTION).
+
+ALTER TABLE "instances"
+  ADD COLUMN IF NOT EXISTS "agent_error_messages" jsonb;
+
+UPDATE "instances"
+  SET "agent_error_messages" = to_jsonb(ARRAY["agent_error_message"])
+  WHERE "agent_error_message" IS NOT NULL
+    AND "agent_error_messages" IS NULL;
+
+ALTER TABLE "instances"
+  DROP COLUMN IF EXISTS "agent_error_message";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1784400000000,
       "tag": "0044_instance_agent_error_message",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1784500000000,
+      "tag": "0045_agent_error_messages_list",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -765,8 +765,8 @@ export const instances = pgTable(
     // ---- Agent Configuration (Instance Override) ----
     agentTimeout: integer('agent_timeout').notNull().default(600),
     agentStreamMode: boolean('agent_stream_mode').notNull().default(false),
-    /** Customer-facing reply when agent dispatch fails (null = OMNI_AGENT_DISPATCH_ERROR_MESSAGE env / built-in default, #737) */
-    agentErrorMessage: text('agent_error_message'),
+    /** Customer-facing replies when agent dispatch fails; one is picked at random per failure (null/empty = OMNI_AGENT_DISPATCH_ERROR_MESSAGE env / built-in default, #737) */
+    agentErrorMessages: jsonb('agent_error_messages').$type<string[]>(),
     /** When agent should reply to messages */
     agentReplyFilter: jsonb('agent_reply_filter').$type<AgentReplyFilter>(),
     /** Session strategy for agent memory */

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2638,8 +2638,8 @@ export interface components {
             agentProviderId?: string | null;
             /** @description Agent timeout in seconds */
             agentTimeout: number;
-            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-            agentErrorMessage?: string | null;
+            /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+            agentErrorMessages?: string[] | null;
             /** @description Whether streaming is enabled */
             agentStreamMode: boolean;
             /**
@@ -2671,8 +2671,8 @@ export interface components {
              * @default 600
              */
             agentTimeout: number;
-            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-            agentErrorMessage?: string | null;
+            /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+            agentErrorMessages?: string[] | null;
             /**
              * @description Enable streaming responses
              * @default false
@@ -6125,8 +6125,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
-                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-                            agentErrorMessage?: string | null;
+                            /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+                            agentErrorMessages?: string[] | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -6178,8 +6178,8 @@ export interface operations {
                      * @default 600
                      */
                     agentTimeout?: number;
-                    /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-                    agentErrorMessage?: string | null;
+                    /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+                    agentErrorMessages?: string[] | null;
                     /**
                      * @description Enable streaming responses
                      * @default false
@@ -6238,8 +6238,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
-                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-                            agentErrorMessage?: string | null;
+                            /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+                            agentErrorMessages?: string[] | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -6372,8 +6372,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
-                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-                            agentErrorMessage?: string | null;
+                            /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+                            agentErrorMessages?: string[] | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**
@@ -6490,8 +6490,8 @@ export interface operations {
                      * @default 600
                      */
                     agentTimeout?: number;
-                    /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-                    agentErrorMessage?: string | null;
+                    /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+                    agentErrorMessages?: string[] | null;
                     /**
                      * @description Enable streaming responses
                      * @default false
@@ -6550,8 +6550,8 @@ export interface operations {
                             agentProviderId?: string | null;
                             /** @description Agent timeout in seconds */
                             agentTimeout: number;
-                            /** @description Customer-facing reply sent when agent dispatch fails (null = env/default fallback) */
-                            agentErrorMessage?: string | null;
+                            /** @description Customer-facing replies sent when agent dispatch fails; one is picked at random per failure (null/empty = env/default fallback) */
+                            agentErrorMessages?: string[] | null;
                             /** @description Whether streaming is enabled */
                             agentStreamMode: boolean;
                             /**


### PR DESCRIPTION
## Summary
Follow-up to #881 (merged today, not yet promoted to main):

- `agent_error_message` (text) → **`agent_error_messages` (jsonb `string[]`)**: operators can configure one or several customer-facing variants; the dispatcher **picks one at random per failure** so repeated errors don't read like a bot loop. Migration `0045` adds the new column, carries any existing single value over as a one-element array, and drops the old column.
- **Built-in default is now pt-BR**: `'Opa, tive um probleminha aqui 😅 Pode mandar de novo?'` — consistent with the other customer-facing defaults (`DEFAULT_ERROR_HANDOFF_MESSAGE`, `SAFE_PROVIDER_ERROR_MESSAGE`). Other locales override via `OMNI_AGENT_DISPATCH_ERROR_MESSAGE`.
- Precedence unchanged: instance list (random pick, blanks filtered) → env → default.
- API/OpenAPI: `agentErrorMessages: string[] | null` on create/update + response; SDK types regenerated.
- CLI: `--agent-error-message` is now **repeatable** (`--agent-error-message "a" --agent-error-message "b"`); a single `"null"` clears.

## Test plan
- New deterministic tests for the random pick (injectable RNG), blank filtering, empty-list fallthrough, and the pt-BR default.
- `make typecheck` + `make lint` green; `bun test packages apps/ui` 0 fail (pre-push gate).