### PR TITLE
feat(cli,ui): multi-server management — named server entries, switcher, per-invocation override

### DIFF
--- a/.genie/wishes/multi-server-management/WISH.md
+++ b/.genie/wishes/multi-server-management/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | APPROVED |
+| **Status** | IN_PROGRESS |
 | **Slug** | `multi-server-management` |
 | **Date** | 2026-07-31 |
 | **Author** | Felipe Rosa |
@@ -111,7 +111,7 @@ Groups 3 and 4 must merge together in one PR: `make check` runs knip dead-code d
 **Deliverables:**
 1. `servers` config block in `packages/cli/src/config.ts`: `{ active: string, list: Record<name, { url: string, apiKey?: string }> }`, with a Zod schema validating it on load (invalid entries dropped with a warning, never a crash).
 2. Lazy migration in `loadConfig()`: when `servers` is absent and flat `apiUrl`/`apiKey` exist, lift them into a `default` entry and set it active; effective `config.apiUrl`/`config.apiKey` are derived from the active entry for client-facing paths. The `--server` override is transported via `process.env` (same mechanism and bundler-duplication rationale as `setRuntimeFormat`, `config.ts:249-255`).
-3. Non-resolving accessor `loadLocalRuntimeConfig()` for local-runtime paths: `runtime-env.ts` (`buildRuntimeEnv`), `commands/start.ts`, `restart.ts`, `update.ts`, `install.ts`, `doctor.ts`, and `auth recover` read the local `default` entry regardless of the active server; `doctor`/`update` health probes (`doctor.ts:357,388`, `update.ts:387`) keep targeting `http://localhost:<apiPort>`.
+3. Non-resolving accessor `loadLocalRuntimeConfig()` for local-runtime paths: `runtime-env.ts` (`buildRuntimeEnv`), `commands/start.ts`, `restart.ts`, `update.ts`, `install.ts`, `doctor.ts`, and `auth recover` read the local `default` entry regardless of the active server; `doctor`/`update` health probes (`doctor.ts:357,388`, `update.ts:387`) resolve from the local `default` entry, never the active one (reviewer-corrected wording: hardcoding `localhost:<apiPort>` would break legitimate non-default local installs).
 4. `config list` shows one read-only, masked active-server row; `config get/set/delete` reject `servers.*` keys with a pointer to `omni server` (per Decision 10 — no dynamic `ConfigKey` entries).
 5. Unit tests in `packages/cli/src/__tests__/config.test.ts` covering migration, resolution, override, invalid-entry fallback, and the `buildRuntimeEnv` isolation guarantee — sandboxed via `OMNI_CONFIG_DIR` with `beforeEach`/`afterEach` env save-restore. Fix the stale header comment (`config.test.ts:4-6`) claiming import-time path caching (false — `getConfigDir()` reads the env on every call), and sandbox the existing `loadServerConfig()` test that currently reads the developer's real `~/.omni`.
 
@@ -301,6 +301,17 @@ All seven blocking/major findings from the first pass verified genuinely closed 
 | 11 | minor | Simplicity Case "simplest complete design" bullet describes only the registry; auth-mode bullet claims minimality that ignores omni's existing machinery | Rewrite after 1–4 resolve |
 
 **Path forward per reviewer:** dispatch Waves 1–2 now; re-plan Groups 5–7 against the real surface (existing flag/posture, chosen chain position, renamed role concept, Bearer discriminator, sequencing agreed with `omni-full-multitenancy`); re-review required. Findings 8–11 follow Groups 5–7 wherever they live.
+
+### Execution reviews — 2026-07-31 — all four groups closed after fix loops
+
+Each group: independent reviewer (≠ engineer) ran the validation personally; FIX-FIRST findings fixed by a separate fixer (one loop each); orchestrator re-validated before `genie task done`.
+
+| Group | Verdict → outcome | Notable findings fixed |
+|-------|-------------------|------------------------|
+| 1 (CLI config) | FIX-FIRST → done (40 config tests, 499-sweep) | HIGH: flat `apiUrl`/`apiKey` mirror tracked the *active* (possibly remote) entry — now mirrors `default` only, and `projectEntry`'s missing-entry branch returns safe defaults instead of inheriting the mirror (closes the remote-key-into-PM2 leak plus the older-CLI-build face of it). Also: knip unused export; `config unset apiUrl` silent no-op; warning emission now asserted. Accepted judgment call: doctor/update probes resolve from the `default` entry rather than hardcoded localhost (AC wording corrected in Group 1 deliverable 3). |
+| 3 (UI registry) | FIX-FIRST → done (19 UI tests) | HIGH: two literal NUL bytes in `sdk.ts` made the file binary to git (undiffable/unmergeable) — replaced with ` ` escapes; MEDIUM: `crypto.randomUUID()` undefined on non-secure origins (http://<remote-ip>) — guarded fallback with a negative-control test. Reviewer also confirmed the old `usePersons` `baseUrl` reach-in was always `undefined` (silently same-origin-only). |
+| 2 (CLI commands) | FIX-FIRST → done (93 cli tests, 567-sweep) | BLOCKER (empirically proven by reviewer): re-handshake overwrote the single `hostId` with the new server's UUID, hard-401ing the previously bound server — `boundServers` is now `Array<{url, hostId}>` with per-URL id selection in `loadSigningContextForServer` and legacy coercion; tests assert per-origin ids on the wire, not just header presence. Also: knip export; duplicate `--server` rejected; `add` trims names; keyless add probes health credential-free (no `'unset'` placeholder on the wire); `syncEffectiveIntoEntry` normalizes URLs so `auth login --api-url` can't desync an entry from its signing binding. |
+| 4 (UI switcher) | FIX-FIRST → done (19 UI tests, knip clean for apps/ui) | MAJOR: first-ever `apps/ui` test file missing from knip entry globs (CI gate) — `src/**/*.test.ts` added; dialog gained a staleness token so a hung validation resolving after close can't persist/activate; `removeServer` cache-discipline contract documented; last-entry removal tested. Wave-1 carried findings all closed: `switchServer(id, queryClient)` required arg, unknown-id no-op, dangling-pointer correction persisted. |
 
 ---
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@omni/sdk": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
@@ -28,7 +29,8 @@
     "react-router-dom": "^7.13.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
-    "use-debounce": "^10.1.0"
+    "use-debounce": "^10.1.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/apps/ui/src/components/layout/AddServerDialog.tsx
+++ b/apps/ui/src/components/layout/AddServerDialog.tsx
@@ -1,0 +1,274 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { addServer } from '@/lib/servers';
+import { createOmniClient } from '@omni/sdk';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+
+interface AddServerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the id of the newly added server once it validated and was saved. */
+  onAdded: (serverId: string) => void;
+}
+
+/**
+ * A validation failure the user can act on.
+ *
+ * `hint` carries the operator-facing remedy — notably the CORS one, which is
+ * the single most common reason a perfectly good URL and key still fail from a
+ * browser.
+ */
+interface ValidationFailure {
+  message: string;
+  hint?: string;
+}
+
+/** Trim, add a scheme if the user omitted it, and reject anything not a URL. */
+function normalizeBaseUrl(raw: string): string | null {
+  const trimmed = raw.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return null;
+  }
+
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const url = new URL(withScheme);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    return withScheme;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify a failure from the candidate server's `auth.validate`.
+ *
+ * A `TypeError` from fetch is indistinguishable at the JS level from a CORS
+ * rejection — the browser hides the response on purpose — so both land here and
+ * must NOT be reported as a bad key: telling an operator their key is invalid
+ * when the real problem is `OMNI_CORS_ORIGINS` sends them to rotate a
+ * perfectly good credential.
+ */
+function classifyValidationError(error: unknown, baseUrl: string): ValidationFailure {
+  if (error instanceof TypeError) {
+    return {
+      message: `Could not reach ${baseUrl}.`,
+      hint: `The request never got a response, which means the server is unreachable OR it rejected this dashboard's origin (${globalThis.window?.location.origin ?? 'this origin'}). Set OMNI_CORS_ORIGINS on the target server to include this origin, then try again.`,
+    };
+  }
+
+  if (error instanceof SyntaxError) {
+    // The SDK parses the body before checking the status, so a non-Omni host
+    // answering with HTML surfaces as a JSON parse error rather than a status.
+    return { message: `${baseUrl} answered, but not with an Omni API response.` };
+  }
+
+  const status = (error as { status?: number } | null)?.status;
+  if (status === 401 || status === 403) {
+    return { message: 'The server rejected this API key.' };
+  }
+  if (status === 404) {
+    return { message: `${baseUrl} responded, but has no /api/v2/auth/validate endpoint. Is it an Omni server?` };
+  }
+  if (typeof status === 'number') {
+    return { message: `The server returned HTTP ${status}.` };
+  }
+
+  return { message: error instanceof Error ? error.message : 'Could not validate this server.' };
+}
+
+/**
+ * Add a server to the registry — but only after proving the URL and key work.
+ *
+ * The candidate is validated with a throwaway SDK client built for the entered
+ * URL and key, so nothing touches the registry or the active client until the
+ * server answers. Failures leave the registry untouched.
+ */
+export function AddServerDialog({ open, onClose, onAdded }: AddServerDialogProps) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [failure, setFailure] = useState<ValidationFailure | null>(null);
+
+  /**
+   * Attempt token. Incremented on every submit AND on every close, so a
+   * validation the user walked away from can never come back and persist —
+   * let alone activate — a server behind a dialog that is no longer open.
+   * The SDK's `auth.validate()` takes no arguments, so the in-flight request
+   * cannot be aborted; the token is what makes its late resolution inert.
+   */
+  const attemptRef = useRef(0);
+
+  const reset = () => {
+    setName('');
+    setUrl('');
+    setApiKey('');
+    setFailure(null);
+    setIsValidating(false);
+  };
+
+  const handleClose = () => {
+    // Orphan any validation still in flight before the state it would write to
+    // is torn down.
+    attemptRef.current += 1;
+    reset();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    setFailure(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setFailure({ message: 'Give this server a name.' });
+      return;
+    }
+
+    const baseUrl = normalizeBaseUrl(url);
+    if (!baseUrl) {
+      setFailure({ message: 'Enter a valid http(s) URL, for example https://omni.example.com.' });
+      return;
+    }
+
+    const trimmedKey = apiKey.trim();
+    if (!trimmedKey) {
+      setFailure({ message: 'An API key is required to validate this server.' });
+      return;
+    }
+
+    const attempt = attemptRef.current + 1;
+    attemptRef.current = attempt;
+    const isStale = () => attemptRef.current !== attempt;
+
+    setIsValidating(true);
+    try {
+      // Throwaway client: the candidate is proven before anything is persisted,
+      // and the singleton in lib/sdk keeps pointing at the current server.
+      const candidate = createOmniClient({ baseUrl, apiKey: trimmedKey });
+      const result = await candidate.auth.validate();
+      // Checked before the write, not just before the UI update: a dialog the
+      // user closed mid-validation must not persist or activate a server.
+      if (isStale()) {
+        return;
+      }
+      if (!result.valid) {
+        setFailure({ message: 'The server rejected this API key.' });
+        return;
+      }
+
+      const entry = addServer({ name: trimmedName, baseUrl, apiKey: trimmedKey });
+      // Data from the previous server must not survive the activation that
+      // follows in the parent.
+      queryClient.clear();
+      reset();
+      onAdded(entry.id);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setFailure(classifyValidationError(error, baseUrl));
+    } finally {
+      if (!isStale()) {
+        setIsValidating(false);
+      }
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          handleClose();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add server</DialogTitle>
+          <DialogDescription>
+            Connect this dashboard to another Omni API. The URL and key are checked before the server is saved.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="server-name">Name *</Label>
+            <Input
+              id="server-name"
+              placeholder="Production"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={isValidating}
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="server-url">URL *</Label>
+            <Input
+              id="server-url"
+              placeholder="https://omni.example.com"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              disabled={isValidating}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="server-key">API key *</Label>
+            <Input
+              id="server-key"
+              type="password"
+              placeholder="omni_..."
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              disabled={isValidating}
+              autoComplete="off"
+            />
+          </div>
+
+          {failure && (
+            <div
+              role="alert"
+              className="flex gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="space-y-1">
+                <p className="font-medium">{failure.message}</p>
+                {failure.hint && <p className="text-destructive/80 text-xs leading-relaxed">{failure.hint}</p>}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isValidating}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isValidating}>
+            {isValidating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isValidating ? 'Validating…' : 'Validate & add'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/layout/ServerSwitcher.tsx
+++ b/apps/ui/src/components/layout/ServerSwitcher.tsx
@@ -1,0 +1,230 @@
+import { AddServerDialog } from '@/components/layout/AddServerDialog';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { resetClient, switchServer } from '@/lib/sdk';
+import { type ServerEntry, getActiveServer, listServers, removeServer, resolveBaseUrl } from '@/lib/servers';
+import { cn } from '@/lib/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { ChevronsUpDown, KeyRound, Plus, Server, Trash2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface ServerSwitcherProps {
+  collapsed: boolean;
+}
+
+/**
+ * Short, human-scannable form of an entry's endpoint. Same-origin entries are
+ * resolved through `resolveBaseUrl`, so the row shows the host actually used.
+ */
+function describeEntry(entry: ServerEntry): string {
+  const url = resolveBaseUrl(entry);
+  if (!url) {
+    return 'This origin';
+  }
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Active-server switcher for the sidebar.
+ *
+ * The registry lives in localStorage, which is not reactive, so the component
+ * re-reads it whenever the menu opens or a mutation lands. `getActiveServer()`
+ * (not the raw pointer) is the source of truth for what is checked: it is the
+ * same resolution the SDK client uses, including the dangling-pointer
+ * correction, so the checkmark can never disagree with the server being talked
+ * to.
+ */
+export function ServerSwitcher({ collapsed }: ServerSwitcherProps) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [servers, setServers] = useState<ServerEntry[]>(() => listServers());
+  const [activeId, setActiveId] = useState<string | null>(() => getActiveServer()?.id ?? null);
+  const [addOpen, setAddOpen] = useState(false);
+
+  const refresh = useCallback(() => {
+    setServers(listServers());
+    setActiveId(getActiveServer()?.id ?? null);
+  }, []);
+
+  const active = servers.find((server) => server.id === activeId) ?? null;
+
+  /** Land on the newly active server, or send the user to log into it. */
+  const settleOnActiveServer = useCallback(() => {
+    const next = getActiveServer();
+    refresh();
+    if (!next?.apiKey) {
+      // No credential for the server we just landed on (or none left at all).
+      window.location.href = '/login';
+      return;
+    }
+    // Resource ids in the current route belong to the previous server.
+    navigate('/');
+  }, [navigate, refresh]);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      if (id === activeId) {
+        return;
+      }
+      // Always hand over the query client: a switch that keeps the previous
+      // server's cached data is a correctness bug, not a performance detail.
+      if (!switchServer(id, queryClient)) {
+        // Unknown id — the registry changed under this menu. Re-read it.
+        refresh();
+        return;
+      }
+      settleOnActiveServer();
+    },
+    [activeId, queryClient, refresh, settleOnActiveServer],
+  );
+
+  const handleRemove = useCallback(
+    (entry: ServerEntry) => {
+      if (!confirm(`Remove "${entry.name}"? Its stored API key will be deleted from this browser.`)) {
+        return;
+      }
+
+      const wasActive = entry.id === activeId;
+      removeServer(entry.id);
+
+      if (!wasActive) {
+        refresh();
+        return;
+      }
+
+      // The active connection just went away: drop the cached client and any
+      // data it produced before resolving the fallback entry.
+      resetClient();
+      queryClient.clear();
+      settleOnActiveServer();
+    },
+    [activeId, queryClient, refresh, settleOnActiveServer],
+  );
+
+  const handleAdded = useCallback(
+    (serverId: string) => {
+      setAddOpen(false);
+      refresh();
+      if (switchServer(serverId, queryClient)) {
+        settleOnActiveServer();
+      }
+    },
+    [queryClient, refresh, settleOnActiveServer],
+  );
+
+  const label = active?.name ?? 'No server';
+
+  const trigger = (
+    <DropdownMenuTrigger
+      className={cn(
+        'group flex items-center rounded-md text-sm font-medium text-muted-foreground transition-colors',
+        'hover:bg-white/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
+        'data-[state=open]:bg-white/5 data-[state=open]:text-foreground',
+        collapsed ? 'h-9 w-9 justify-center' : 'h-9 w-full gap-2 px-3',
+      )}
+      aria-label={`Active server: ${label}. Switch server`}
+    >
+      <Server className="h-4 w-4 shrink-0" />
+      {!collapsed && (
+        <>
+          <span className="flex-1 truncate text-left text-foreground">{label}</span>
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-60" />
+        </>
+      )}
+    </DropdownMenuTrigger>
+  );
+
+  return (
+    <>
+      <DropdownMenu onOpenChange={(open) => open && refresh()}>
+        {collapsed ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+            <TooltipContent side="right">{label}</TooltipContent>
+          </Tooltip>
+        ) : (
+          trigger
+        )}
+
+        <DropdownMenuContent align="start" side={collapsed ? 'right' : 'bottom'} className="w-64">
+          <DropdownMenuLabel>Servers</DropdownMenuLabel>
+
+          {servers.length === 0 && (
+            <div className="px-2 py-1.5 text-sm text-muted-foreground">No servers registered.</div>
+          )}
+
+          {servers.map((entry) => (
+            <div key={entry.id} className="group/server relative">
+              <DropdownMenuCheckboxItem
+                checked={entry.id === activeId}
+                onSelect={() => handleSelect(entry.id)}
+                // Radix keeps arrow keys, typeahead and Escape; Delete/Backspace
+                // is added as the keyboard path to remove, because the remove
+                // button overlaying the row is not tab-reachable inside a menu.
+                onKeyDown={(event) => {
+                  if (event.key === 'Delete' || event.key === 'Backspace') {
+                    event.preventDefault();
+                    handleRemove(entry);
+                  }
+                }}
+                aria-keyshortcuts="Delete"
+                className="pr-9"
+              >
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="flex items-center gap-1.5 truncate text-foreground">
+                    {entry.name}
+                    {!entry.apiKey && (
+                      <KeyRound className="h-3 w-3 shrink-0 text-amber-500" role="img" aria-label="No API key" />
+                    )}
+                  </span>
+                  <span className="truncate text-xs text-muted-foreground">{describeEntry(entry)}</span>
+                </span>
+              </DropdownMenuCheckboxItem>
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleRemove(entry);
+                }}
+                className={cn(
+                  'absolute right-1.5 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md',
+                  // Always visible (not hover-only): inside a menu this button is
+                  // not tab-reachable, so hiding it until hover would leave touch
+                  // users with no remove affordance at all.
+                  'text-muted-foreground/60 transition-colors hover:bg-destructive/10 hover:text-destructive',
+                  'group-hover/server:text-muted-foreground',
+                )}
+                aria-label={`Remove ${entry.name}`}
+                tabIndex={-1}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setAddOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Add server…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AddServerDialog open={addOpen} onClose={() => setAddOpen(false)} onAdded={handleAdded} />
+    </>
+  );
+}

--- a/apps/ui/src/components/layout/Sidebar.tsx
+++ b/apps/ui/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
+import { ServerSwitcher } from '@/components/layout/ServerSwitcher';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { clearApiKey } from '@/lib/sdk';
+import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
 import {
   Activity,
@@ -84,6 +85,9 @@ interface SidebarProps {
 }
 
 export function Sidebar({ collapsed: controlledCollapsed, onCollapsedChange }: SidebarProps = {}) {
+  // Single logout path: useAuth clears the active server's key, the query cache,
+  // and redirects.
+  const { logout: handleLogout } = useAuth();
   const [internalCollapsed, setInternalCollapsed] = useState(() => {
     if (typeof window === 'undefined') return false;
     return localStorage.getItem(STORAGE_KEY) === 'true';
@@ -106,11 +110,6 @@ export function Sidebar({ collapsed: controlledCollapsed, onCollapsedChange }: S
       setInternalCollapsed(stored === 'true');
     }
   }, []);
-
-  const handleLogout = () => {
-    clearApiKey();
-    window.location.href = '/login';
-  };
 
   const toggleCollapse = () => setCollapsed(!collapsed);
 
@@ -144,6 +143,11 @@ export function Sidebar({ collapsed: controlledCollapsed, onCollapsedChange }: S
           >
             {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
           </button>
+        </div>
+
+        {/* Active server */}
+        <div className={cn('flex border-b border-border/30 px-3 py-3', collapsed && 'justify-center')}>
+          <ServerSwitcher collapsed={collapsed} />
         </div>
 
         {/* Navigation */}

--- a/apps/ui/src/components/ui/dropdown-menu.tsx
+++ b/apps/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,106 @@
+import { cn } from '@/lib/utils';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { Check } from 'lucide-react';
+import { forwardRef } from 'react';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuContent = forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[12rem] overflow-hidden rounded-xl border border-border/30 bg-popover/95 p-1 text-popover-foreground shadow-xl shadow-black/20 backdrop-blur-xl',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & { inset?: boolean }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none transition-colors',
+      'focus:bg-white/5 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    checked={checked}
+    className={cn(
+      'relative flex cursor-pointer select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none transition-colors',
+      'focus:bg-white/5 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4 text-primary" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuLabel = forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & { inset?: boolean }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      'px-2 py-1.5 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/60',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator ref={ref} className={cn('-mx-1 my-1 h-px bg-border/30', className)} {...props} />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/apps/ui/src/hooks/useAuth.ts
+++ b/apps/ui/src/hooks/useAuth.ts
@@ -23,7 +23,8 @@ export function useAuth() {
   // Login mutation
   const loginMutation = useMutation({
     mutationFn: async (apiKey: string) => {
-      // Set the key first
+      // Store the key on the active server entry first (creating the default
+      // same-origin entry when the registry is still empty)
       setApiKey(apiKey);
       // Then validate it
       const result = await getClient().auth.validate();
@@ -42,7 +43,9 @@ export function useAuth() {
     },
   });
 
-  // Logout function
+  // Logout: drops the active server's key (the entry itself is kept) and wipes
+  // the cache so no data survives into the next session. Single logout path for
+  // the whole app — the sidebar calls this too.
   const logout = () => {
     clearApiKey();
     queryClient.clear();

--- a/apps/ui/src/hooks/usePersons.ts
+++ b/apps/ui/src/hooks/usePersons.ts
@@ -1,5 +1,5 @@
 import { queryKeys } from '@/lib/query';
-import { getClient } from '@/lib/sdk';
+import { apiFetch, getClient } from '@/lib/sdk';
 import type { SearchPersonsParams } from '@omni/sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -44,14 +44,8 @@ export function useLinkIdentities() {
 
   return useMutation({
     mutationFn: async ({ identityA, identityB }: { identityA: string; identityB: string }) => {
-      const client = getClient();
-      const baseUrl = (client as unknown as { baseUrl: string }).baseUrl || '';
-      const response = await fetch(`${baseUrl}/api/v2/persons/link`, {
+      const response = await apiFetch('/persons/link', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${localStorage.getItem('omni-api-key') || ''}`,
-        },
         body: JSON.stringify({ identityA, identityB }),
       });
       if (!response.ok) {
@@ -74,14 +68,8 @@ export function useUnlinkIdentity() {
 
   return useMutation({
     mutationFn: async ({ identityId, reason }: { identityId: string; reason: string }) => {
-      const client = getClient();
-      const baseUrl = (client as unknown as { baseUrl: string }).baseUrl || '';
-      const response = await fetch(`${baseUrl}/api/v2/persons/unlink`, {
+      const response = await apiFetch('/persons/unlink', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${localStorage.getItem('omni-api-key') || ''}`,
-        },
         body: JSON.stringify({ identityId, reason }),
       });
       if (!response.ok) {
@@ -112,14 +100,8 @@ export function useMergePersons() {
       targetPersonId: string;
       reason?: string;
     }) => {
-      const client = getClient();
-      const baseUrl = (client as unknown as { baseUrl: string }).baseUrl || '';
-      const response = await fetch(`${baseUrl}/api/v2/persons/merge`, {
+      const response = await apiFetch('/persons/merge', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${localStorage.getItem('omni-api-key') || ''}`,
-        },
         body: JSON.stringify({ sourcePersonId, targetPersonId, reason }),
       });
       if (!response.ok) {

--- a/apps/ui/src/lib/__tests__/servers.test.ts
+++ b/apps/ui/src/lib/__tests__/servers.test.ts
@@ -1,0 +1,368 @@
+/// <reference types="bun-types" />
+/**
+ * Server registry unit tests.
+ *
+ * These run under `bun test`, where neither `localStorage` nor `window` exist,
+ * so both are stubbed on `globalThis` per test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { apiFetch, getApiKey, getBaseUrl, getClient, isAuthenticated, resetClient, switchServer } from '@/lib/sdk';
+import {
+  ACTIVE_SERVER_STORAGE_KEY,
+  DEFAULT_SERVER_ID,
+  SERVERS_STORAGE_KEY,
+  type ServerEntry,
+  addServer,
+  clearActiveApiKey,
+  getActiveApiKey,
+  getActiveServer,
+  getActiveServerId,
+  listServers,
+  removeServer,
+  resolveBaseUrl,
+  setActiveApiKey,
+  updateServer,
+} from '@/lib/servers';
+
+const LEGACY_API_KEY_STORAGE_KEY = 'omni-api-key';
+
+class FakeStorage implements Storage {
+  private data = new Map<string, string>();
+
+  get length(): number {
+    return this.data.size;
+  }
+
+  clear(): void {
+    this.data.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.data.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, String(value));
+  }
+}
+
+let storage: FakeStorage;
+
+function setOrigin(origin: string): void {
+  Object.defineProperty(globalThis, 'window', {
+    value: { location: { origin } },
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** `switchServer` requires a cache to clear; most tests don't assert on it. */
+function noopQueryClient(): { clear: () => void } {
+  return { clear: () => undefined };
+}
+
+function seedRegistry(servers: ServerEntry[], activeId?: string): void {
+  storage.setItem(SERVERS_STORAGE_KEY, JSON.stringify(servers));
+  if (activeId) {
+    storage.setItem(ACTIVE_SERVER_STORAGE_KEY, activeId);
+  }
+}
+
+beforeEach(() => {
+  storage = new FakeStorage();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+  setOrigin('https://omni.local');
+  resetClient();
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'localStorage');
+  Reflect.deleteProperty(globalThis, 'window');
+  resetClient();
+});
+
+describe('legacy migration', () => {
+  test('moves the legacy omni-api-key into a default entry on first read', () => {
+    storage.setItem(LEGACY_API_KEY_STORAGE_KEY, 'omni_legacy_key');
+
+    const servers = listServers();
+
+    expect(servers).toEqual([{ id: DEFAULT_SERVER_ID, name: 'Default', baseUrl: null, apiKey: 'omni_legacy_key' }]);
+    expect(getActiveServerId()).toBe(DEFAULT_SERVER_ID);
+    expect(getActiveApiKey()).toBe('omni_legacy_key');
+    expect(isAuthenticated()).toBe(true);
+    // The legacy item is consumed, not left behind as a stray credential.
+    expect(storage.getItem(LEGACY_API_KEY_STORAGE_KEY)).toBeNull();
+  });
+
+  test('creates an unauthenticated default entry when there is no legacy key', () => {
+    const servers = listServers();
+
+    expect(servers).toEqual([{ id: DEFAULT_SERVER_ID, name: 'Default', baseUrl: null, apiKey: null }]);
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  test('does not re-migrate once a registry exists', () => {
+    seedRegistry([{ id: DEFAULT_SERVER_ID, name: 'Default', baseUrl: null, apiKey: null }], DEFAULT_SERVER_ID);
+    storage.setItem(LEGACY_API_KEY_STORAGE_KEY, 'omni_stale_key');
+
+    expect(getActiveApiKey()).toBeNull();
+    expect(storage.getItem(LEGACY_API_KEY_STORAGE_KEY)).toBe('omni_stale_key');
+  });
+});
+
+describe('same-origin sentinel', () => {
+  test('resolves the migrated entry against the current origin at call time', () => {
+    storage.setItem(LEGACY_API_KEY_STORAGE_KEY, 'omni_legacy_key');
+    listServers();
+
+    expect(getBaseUrl()).toBe('https://omni.local');
+
+    // Host/port change (dev server moved, deployed behind another domain).
+    setOrigin('http://localhost:5173');
+    expect(getBaseUrl()).toBe('http://localhost:5173');
+  });
+
+  test('keeps the absolute URL of an explicitly added server', () => {
+    listServers();
+    const added = addServer({ name: 'Prod', baseUrl: 'https://api.example.com', apiKey: 'omni_prod' });
+
+    expect(resolveBaseUrl(added)).toBe('https://api.example.com');
+    setOrigin('http://localhost:5173');
+    expect(resolveBaseUrl(added)).toBe('https://api.example.com');
+  });
+
+  test('falls back to an empty base URL when there is no window', () => {
+    Reflect.deleteProperty(globalThis, 'window');
+
+    expect(resolveBaseUrl(null)).toBe('');
+  });
+});
+
+describe('corrupt localStorage', () => {
+  test('falls back to an empty registry when the payload is not JSON', () => {
+    storage.setItem(SERVERS_STORAGE_KEY, '{not json');
+
+    expect(listServers()).toEqual([]);
+    expect(getActiveServer()).toBeNull();
+    // No active server -> ProtectedRoute sends the user to /login.
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  test('falls back to an empty registry when the payload fails schema validation', () => {
+    storage.setItem(SERVERS_STORAGE_KEY, JSON.stringify([{ id: 'x', name: 'X', baseUrl: 'not-a-url', apiKey: null }]));
+
+    expect(listServers()).toEqual([]);
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  test('recovers by recreating the default entry when a key is stored after corruption', () => {
+    storage.setItem(SERVERS_STORAGE_KEY, '[[[');
+
+    setActiveApiKey('omni_recovered');
+
+    expect(listServers()).toEqual([
+      { id: DEFAULT_SERVER_ID, name: 'Default', baseUrl: null, apiKey: 'omni_recovered' },
+    ]);
+    expect(isAuthenticated()).toBe(true);
+  });
+});
+
+describe('registry CRUD', () => {
+  test('logout clears only the active key and keeps the entry', () => {
+    storage.setItem(LEGACY_API_KEY_STORAGE_KEY, 'omni_legacy_key');
+    listServers();
+
+    clearActiveApiKey();
+
+    expect(listServers()).toEqual([{ id: DEFAULT_SERVER_ID, name: 'Default', baseUrl: null, apiKey: null }]);
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  test('update and remove keep the active pointer coherent', () => {
+    listServers();
+    const staging = addServer({ name: 'Staging', baseUrl: 'https://staging.example.com' });
+
+    expect(updateServer(staging.id, { name: 'Staging 2' })?.name).toBe('Staging 2');
+    expect(updateServer('missing', { name: 'nope' })).toBeNull();
+
+    switchServer(staging.id, noopQueryClient());
+    expect(getActiveServerId()).toBe(staging.id);
+
+    removeServer(staging.id);
+    expect(listServers().map((s) => s.id)).toEqual([DEFAULT_SERVER_ID]);
+    // Pointer moved off the deleted entry instead of dangling.
+    expect(getActiveServer()?.id).toBe(DEFAULT_SERVER_ID);
+  });
+
+  test('removing the last entry clears the active pointer instead of dangling it', () => {
+    seedRegistry([{ id: 'only', name: 'Only', baseUrl: 'https://only.example.com', apiKey: 'omni_only' }], 'only');
+
+    removeServer('only');
+
+    expect(listServers()).toEqual([]);
+    // The pointer is *removed*, not left pointing at a deleted entry: a stale
+    // id would survive the next server being added under a different id.
+    expect(storage.getItem(ACTIVE_SERVER_STORAGE_KEY)).toBeNull();
+    expect(getActiveServerId()).toBeNull();
+    expect(getActiveServer()).toBeNull();
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  test('addServer still mints an id without crypto.randomUUID (insecure context)', () => {
+    // Plain-http dashboards (http://<remote-ip>) are not secure contexts, so
+    // `crypto.randomUUID` is undefined there.
+    // `randomUUID` lives on Crypto.prototype, so shadow it with an own
+    // undefined property rather than deleting it.
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      listServers();
+      const added = addServer({ name: 'Remote', baseUrl: 'http://10.0.0.5:8080' });
+
+      expect(added.id).toMatch(/^srv_/);
+      expect(listServers().map((s) => s.id)).toEqual([DEFAULT_SERVER_ID, added.id]);
+      // The minted id is a usable registry key, not just a non-empty string.
+      switchServer(added.id, noopQueryClient());
+      expect(getActiveServer()?.id).toBe(added.id);
+    } finally {
+      // Dropping the shadow re-exposes the prototype implementation.
+      Reflect.deleteProperty(globalThis.crypto, 'randomUUID');
+    }
+  });
+});
+
+describe('switchServer', () => {
+  test('swaps baseUrl + key, resets the SDK singleton and clears the query cache', () => {
+    seedRegistry(
+      [
+        { id: 'a', name: 'A', baseUrl: 'https://a.example.com', apiKey: 'omni_a' },
+        { id: 'b', name: 'B', baseUrl: 'https://b.example.com', apiKey: 'omni_b' },
+      ],
+      'a',
+    );
+
+    const clientA = getClient();
+    expect(getBaseUrl()).toBe('https://a.example.com');
+    expect(getApiKey()).toBe('omni_a');
+    expect(getClient()).toBe(clientA); // cached while the active entry is unchanged
+
+    let cleared = 0;
+    switchServer('b', { clear: () => cleared++ });
+
+    expect(cleared).toBe(1);
+    expect(getActiveServerId()).toBe('b');
+    expect(getBaseUrl()).toBe('https://b.example.com');
+    expect(getApiKey()).toBe('omni_b');
+    expect(getClient()).not.toBe(clientA);
+  });
+
+  test('apiFetch targets the newly active server with its own key', async () => {
+    seedRegistry(
+      [
+        { id: 'a', name: 'A', baseUrl: 'https://a.example.com', apiKey: 'omni_a' },
+        { id: 'b', name: 'B', baseUrl: 'https://b.example.com', apiKey: 'omni_b' },
+      ],
+      'a',
+    );
+
+    const calls: Array<{ url: string; apiKey: string | undefined }> = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      calls.push({ url: String(input), apiKey: headers.get('x-api-key') ?? undefined });
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      await apiFetch('/persons/link', { method: 'POST' });
+      switchServer('b', noopQueryClient());
+      await apiFetch('/persons/link', { method: 'POST' });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(calls).toEqual([
+      { url: 'https://a.example.com/api/v2/persons/link', apiKey: 'omni_a' },
+      { url: 'https://b.example.com/api/v2/persons/link', apiKey: 'omni_b' },
+    ]);
+  });
+
+  test('getClient throws when the active server has no key', () => {
+    seedRegistry([{ id: 'a', name: 'A', baseUrl: 'https://a.example.com', apiKey: null }], 'a');
+
+    expect(() => getClient()).toThrow('Not authenticated');
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  test('is a no-op for an id that is not in the registry', () => {
+    seedRegistry(
+      [
+        { id: 'a', name: 'A', baseUrl: 'https://a.example.com', apiKey: 'omni_a' },
+        { id: 'b', name: 'B', baseUrl: 'https://b.example.com', apiKey: 'omni_b' },
+      ],
+      'a',
+    );
+
+    const clientA = getClient();
+    let cleared = 0;
+
+    // A stale switcher entry, or an entry another tab just removed.
+    expect(switchServer('ghost', { clear: () => cleared++ })).toBe(false);
+
+    // Nothing moved: pointer, client and cache are all untouched.
+    expect(cleared).toBe(0);
+    expect(getActiveServerId()).toBe('a');
+    expect(getBaseUrl()).toBe('https://a.example.com');
+    expect(getClient()).toBe(clientA);
+
+    expect(switchServer('b', { clear: () => cleared++ })).toBe(true);
+    expect(cleared).toBe(1);
+  });
+});
+
+describe('dangling active pointer', () => {
+  test('persists the fallback so the pointer and the resolved server agree', () => {
+    seedRegistry(
+      [
+        { id: 'a', name: 'A', baseUrl: 'https://a.example.com', apiKey: 'omni_a' },
+        { id: 'b', name: 'B', baseUrl: 'https://b.example.com', apiKey: 'omni_b' },
+      ],
+      // Points at an entry that no longer exists (removed in another tab).
+      'gone',
+    );
+
+    expect(getActiveServer()?.id).toBe('a');
+    // The correction is written back, so every later reader — including a
+    // switcher rendering its checkmark from the id — sees the same server.
+    expect(getActiveServerId()).toBe('a');
+    expect(storage.getItem(ACTIVE_SERVER_STORAGE_KEY)).toBe('a');
+    expect(getBaseUrl()).toBe('https://a.example.com');
+  });
+
+  test('leaves no pointer behind when the registry is empty', () => {
+    seedRegistry([], 'gone');
+
+    expect(getActiveServer()).toBeNull();
+    // Nothing to fall back to: the pointer is left alone and the app redirects.
+    expect(getActiveServerId()).toBe('gone');
+    expect(isAuthenticated()).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/sdk.ts
+++ b/apps/ui/src/lib/sdk.ts
@@ -1,67 +1,129 @@
 /**
  * SDK Client singleton for UI
  *
- * Creates and manages the Omni SDK client instance.
+ * Creates and manages the Omni SDK client instance for the *active* server in
+ * the registry (see `@/lib/servers`). The singleton is keyed by the active
+ * entry, so switching servers can never serve a cached client pointed at the
+ * previous host or holding the previous key.
  */
 
 import { type OmniClient, createOmniClient } from '@omni/sdk';
+import {
+  type ServerEntry,
+  clearActiveApiKey,
+  getActiveServer,
+  listServers,
+  resolveBaseUrl,
+  setActiveApiKey,
+  setActiveServerId,
+} from './servers';
 
 let client: OmniClient | null = null;
+let clientSignature: string | null = null;
 
-const API_KEY_STORAGE_KEY = 'omni-api-key';
+/** Identity of the connection a cached client was built for. */
+function signatureOf(entry: ServerEntry, baseUrl: string): string {
+  return `${entry.id}\u0000${baseUrl}\u0000${entry.apiKey ?? ''}`;
+}
 
 /**
- * Get the API key from storage
+ * Drop the cached client. The next `getClient()` rebuilds it from the active
+ * registry entry.
+ */
+export function resetClient(): void {
+  client = null;
+  clientSignature = null;
+}
+
+/**
+ * Get the API key of the active server
  */
 export function getApiKey(): string | null {
-  return localStorage.getItem(API_KEY_STORAGE_KEY);
+  return getActiveServer()?.apiKey ?? null;
 }
 
 /**
- * Set the API key in storage
+ * Store the API key on the active server (creating the default entry if the
+ * registry is still empty)
  */
 export function setApiKey(apiKey: string): void {
-  localStorage.setItem(API_KEY_STORAGE_KEY, apiKey);
-  client = null; // Reset client to recreate with new key
+  setActiveApiKey(apiKey);
+  resetClient();
 }
 
 /**
- * Clear the API key and reset the client
+ * Clear the API key of the active server and reset the client.
+ * The server entry itself is retained.
  */
 export function clearApiKey(): void {
-  localStorage.removeItem(API_KEY_STORAGE_KEY);
-  client = null;
+  clearActiveApiKey();
+  resetClient();
 }
 
 /**
- * Check if the user is authenticated (has an API key)
+ * Check if the user is authenticated (the active server has an API key)
  */
 export function isAuthenticated(): boolean {
   return !!getApiKey();
 }
 
 /**
- * Get or create the Omni SDK client
+ * Base URL of the active server.
+ *
+ * For migrated / same-origin entries this resolves lazily:
+ * in dev, Vite proxies /api to the API server; in prod the API serves the UI on
+ * the same origin. The SDK appends /api/v2, so this is an origin only.
+ */
+export function getBaseUrl(): string {
+  return resolveBaseUrl(getActiveServer());
+}
+
+/**
+ * Switch the dashboard to another registered server.
+ *
+ * Resets the SDK singleton and clears the query cache so no data from the
+ * previous server survives the switch — the same cache discipline as logout in
+ * `useAuth`. `queryClient` is REQUIRED: an optional cache wipe is a cache wipe
+ * that eventually gets forgotten at a call site, and the failure mode (one
+ * server's chats rendered under another server's key) is silent.
+ *
+ * Unknown ids are a no-op: pointing the registry at an id it does not contain
+ * would leave `getActiveServerId()` dangling, so a stale switcher entry or a
+ * concurrent removal cannot desync the pointer from the registry.
+ *
+ * @returns `true` when the active server changed, `false` for an unknown id.
+ */
+export function switchServer(id: string, queryClient: { clear: () => void }): boolean {
+  if (!listServers().some((server) => server.id === id)) {
+    return false;
+  }
+
+  setActiveServerId(id);
+  resetClient();
+  queryClient.clear();
+  return true;
+}
+
+/**
+ * Get or create the Omni SDK client for the active server
  *
  * @throws Error if not authenticated
  */
 export function getClient(): OmniClient {
-  const apiKey = getApiKey();
-  if (!apiKey) {
+  const entry = getActiveServer();
+  if (!entry?.apiKey) {
     throw new Error('Not authenticated');
   }
 
-  if (!client) {
-    // In dev, Vite proxies /api to the API server (localhost:5173/api -> localhost:8882/api)
-    // In prod, the API serves the UI and /api/v2 is on the same origin
-    // SDK appends /api/v2 to baseUrl, so baseUrl should be origin only (empty for same-origin)
-    // Using window.location.origin as fallback since SDK requires non-empty baseUrl
-    const baseUrl = import.meta.env.VITE_API_URL || window.location.origin;
+  const baseUrl = resolveBaseUrl(entry);
+  const signature = signatureOf(entry, baseUrl);
 
+  if (!client || clientSignature !== signature) {
     client = createOmniClient({
       baseUrl,
-      apiKey,
+      apiKey: entry.apiKey,
     });
+    clientSignature = signature;
   }
 
   return client;
@@ -79,23 +141,22 @@ export function getClientOrNull(): OmniClient | null {
 }
 
 /**
- * Make an authenticated API fetch call.
+ * Make an authenticated API fetch call against the active server.
  * Used for endpoints not yet in the auto-generated SDK.
  */
 export async function apiFetch(path: string, options?: RequestInit): Promise<Response> {
-  const apiKey = getApiKey();
-  if (!apiKey) {
+  const entry = getActiveServer();
+  if (!entry?.apiKey) {
     throw new Error('Not authenticated');
   }
 
-  const baseUrl = import.meta.env.VITE_API_URL || window.location.origin;
-  const url = `${baseUrl}/api/v2${path}`;
+  const url = `${resolveBaseUrl(entry)}/api/v2${path}`;
 
   return fetch(url, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
-      'x-api-key': apiKey,
+      'x-api-key': entry.apiKey,
       ...options?.headers,
     },
   });

--- a/apps/ui/src/lib/servers.ts
+++ b/apps/ui/src/lib/servers.ts
@@ -1,0 +1,264 @@
+/**
+ * Server registry
+ *
+ * The dashboard can talk to more than one Omni API. Every known server lives in
+ * a localStorage-backed registry (`omni-servers`) and a pointer (`omni-active-server`)
+ * selects the one the SDK client currently resolves from.
+ *
+ * This module is the ONLY place allowed to read the legacy `omni-api-key` item:
+ * the first read of the registry lazily migrates it into a `default` entry.
+ *
+ * Every read and write is validated with Zod. A corrupt payload degrades to an
+ * empty registry (no active server -> the app redirects to /login) instead of
+ * throwing somewhere deep in a render.
+ */
+
+import { z } from 'zod';
+
+export const SERVERS_STORAGE_KEY = 'omni-servers';
+export const ACTIVE_SERVER_STORAGE_KEY = 'omni-active-server';
+/** Legacy single-server key. Read once during migration, then removed. */
+const LEGACY_API_KEY_STORAGE_KEY = 'omni-api-key';
+
+export const DEFAULT_SERVER_ID = 'default';
+const DEFAULT_SERVER_NAME = 'Default';
+
+/**
+ * A registered server.
+ *
+ * `baseUrl: null` is the same-origin sentinel: the URL is resolved at call time
+ * from `VITE_API_URL` / `window.location.origin` so the entry keeps working when
+ * the dashboard is served from a different host or port. Only explicitly added
+ * servers store an absolute URL.
+ */
+export const ServerEntrySchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  baseUrl: z.string().url().nullable(),
+  apiKey: z.string().nullable(),
+});
+
+export type ServerEntry = z.infer<typeof ServerEntrySchema>;
+
+export const ServerRegistrySchema = z.array(ServerEntrySchema);
+
+export type ServerRegistry = z.infer<typeof ServerRegistrySchema>;
+
+/**
+ * localStorage is absent outside the browser (SSR, unit tests). Callers get a
+ * null store and the registry behaves as if it were empty.
+ */
+function getStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the effective base URL for an entry.
+ *
+ * The same-origin sentinel is resolved lazily, on every call, so a migrated
+ * entry survives a host or port change.
+ */
+export function resolveBaseUrl(entry: ServerEntry | null): string {
+  if (entry?.baseUrl) {
+    return entry.baseUrl;
+  }
+  return import.meta.env.VITE_API_URL || globalThis.window?.location.origin || '';
+}
+
+/**
+ * Registry-local id. `crypto.randomUUID` is undefined outside secure contexts,
+ * which is exactly where these dashboards run (plain-http remote IPs), so fall
+ * back to a time-and-random string. These ids key local storage entries only —
+ * they are not security tokens and need no cryptographic strength.
+ */
+function newServerId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ?? `srv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+  );
+}
+
+function writeRegistry(servers: ServerRegistry): ServerRegistry {
+  const parsed = ServerRegistrySchema.parse(servers);
+  getStorage()?.setItem(SERVERS_STORAGE_KEY, JSON.stringify(parsed));
+  return parsed;
+}
+
+/**
+ * Build the `default` entry from the legacy single-key setup. Runs once: the
+ * legacy item is dropped as soon as the registry is written.
+ */
+function migrateLegacyKey(storage: Storage): ServerRegistry {
+  const legacyKey = storage.getItem(LEGACY_API_KEY_STORAGE_KEY);
+  const migrated = writeRegistry([
+    {
+      id: DEFAULT_SERVER_ID,
+      name: DEFAULT_SERVER_NAME,
+      // Same-origin sentinel: never freeze the origin at migration time.
+      baseUrl: null,
+      apiKey: legacyKey,
+    },
+  ]);
+  storage.setItem(ACTIVE_SERVER_STORAGE_KEY, DEFAULT_SERVER_ID);
+  storage.removeItem(LEGACY_API_KEY_STORAGE_KEY);
+  return migrated;
+}
+
+/**
+ * All registered servers.
+ *
+ * Migrates the legacy key when no registry exists yet. Returns an empty
+ * registry when the stored payload is missing, unparseable, or fails schema
+ * validation.
+ */
+export function listServers(): ServerRegistry {
+  const storage = getStorage();
+  if (!storage) {
+    return [];
+  }
+
+  const raw = storage.getItem(SERVERS_STORAGE_KEY);
+  if (raw === null) {
+    return migrateLegacyKey(storage);
+  }
+
+  try {
+    const result = ServerRegistrySchema.safeParse(JSON.parse(raw));
+    return result.success ? result.data : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getActiveServerId(): string | null {
+  return getStorage()?.getItem(ACTIVE_SERVER_STORAGE_KEY) ?? null;
+}
+
+/**
+ * The active server, or `null` when the registry is empty.
+ *
+ * Falls back to the first entry when the pointer is missing or dangling, so a
+ * stale pointer never locks the dashboard out of a registry that has servers.
+ * The correction is *persisted*: otherwise `getActiveServerId()` would keep
+ * reporting the dangling id while `getActiveServer()` served another entry, and
+ * a switcher rendering the checked item from the id would disagree with the
+ * server the SDK actually talks to.
+ */
+export function getActiveServer(): ServerEntry | null {
+  const servers = listServers();
+  if (servers.length === 0) {
+    return null;
+  }
+
+  const activeId = getActiveServerId();
+  const active = servers.find((server) => server.id === activeId);
+  if (active) {
+    return active;
+  }
+
+  const fallback = servers[0] ?? null;
+  if (fallback) {
+    setActiveServerId(fallback.id);
+  }
+  return fallback;
+}
+
+export function setActiveServerId(id: string): void {
+  getStorage()?.setItem(ACTIVE_SERVER_STORAGE_KEY, id);
+}
+
+export function addServer(input: { name: string; baseUrl: string; apiKey?: string | null }): ServerEntry {
+  const entry = ServerEntrySchema.parse({
+    id: newServerId(),
+    name: input.name,
+    baseUrl: input.baseUrl,
+    apiKey: input.apiKey ?? null,
+  });
+  writeRegistry([...listServers(), entry]);
+  return entry;
+}
+
+export function updateServer(id: string, patch: Partial<Omit<ServerEntry, 'id'>>): ServerEntry | null {
+  const servers = listServers();
+  const existing = servers.find((server) => server.id === id);
+  if (!existing) {
+    return null;
+  }
+
+  const updated = ServerEntrySchema.parse({ ...existing, ...patch, id });
+  writeRegistry(servers.map((server) => (server.id === id ? updated : server)));
+  return updated;
+}
+
+/**
+ * Remove an entry from the registry.
+ *
+ * When the removed entry was the active one, the pointer is moved to the first
+ * remaining server (or cleared when none remain). That move happens *inside*
+ * storage only — unlike `switchServer`, which takes a query client precisely so
+ * that no pointer change can land without the SDK singleton and the cache being
+ * dropped with it.
+ *
+ * Callers that observe an active-pointer change here MUST therefore reset the
+ * SDK client and clear the query cache themselves, or the dashboard will keep
+ * serving the removed server's client and its cached data under the new
+ * pointer. See `ServerSwitcher.tsx` (`resetClient()` + `queryClient.clear()`
+ * right after the `removeServer` call) for the canonical handling.
+ */
+export function removeServer(id: string): void {
+  const remaining = listServers().filter((server) => server.id !== id);
+  writeRegistry(remaining);
+
+  if (getActiveServerId() === id) {
+    const next = remaining[0];
+    if (next) {
+      setActiveServerId(next.id);
+    } else {
+      getStorage()?.removeItem(ACTIVE_SERVER_STORAGE_KEY);
+    }
+  }
+}
+
+/** API key of the active server, if any. */
+export function getActiveApiKey(): string | null {
+  return getActiveServer()?.apiKey ?? null;
+}
+
+/**
+ * Store a validated key on the active server.
+ *
+ * When the registry is empty (fresh install, or recovery from a corrupt
+ * payload) the default same-origin entry is created on the spot.
+ */
+export function setActiveApiKey(apiKey: string): ServerEntry {
+  const servers = listServers();
+  const active = getActiveServer();
+
+  if (!active) {
+    const entry = ServerEntrySchema.parse({
+      id: DEFAULT_SERVER_ID,
+      name: DEFAULT_SERVER_NAME,
+      baseUrl: null,
+      apiKey,
+    });
+    writeRegistry([entry]);
+    setActiveServerId(entry.id);
+    return entry;
+  }
+
+  const updated: ServerEntry = { ...active, apiKey };
+  writeRegistry(servers.map((server) => (server.id === active.id ? updated : server)));
+  return updated;
+}
+
+/** Log out of the active server: the entry is kept, only its key is dropped. */
+export function clearActiveApiKey(): void {
+  const active = getActiveServer();
+  if (!active) {
+    return;
+  }
+  writeRegistry(listServers().map((server) => (server.id === active.id ? { ...server, apiKey: null } : server)));
+}

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "dependencies": {
         "@omni/sdk": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -37,6 +38,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "use-debounce": "^10.1.0",
+        "zod": "^3.24.1",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -288,6 +290,7 @@
         "postgres": "^3.4.5",
         "qrcode-terminal": "^0.12.0",
         "sharp": "^0.34.5",
+        "zod": "^3.24.1",
       },
       "devDependencies": {
         "@omni/api": "workspace:*",
@@ -920,7 +923,7 @@
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
-    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.15", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
@@ -932,11 +935,15 @@
 
     "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
 
+    "@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.24", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-menu": "2.1.24", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-controllable-state": "1.2.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g=="],
+
     "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-menu": ["@radix-ui/react-menu@2.1.24", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-roving-focus": "1.1.19", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-callback-ref": "1.1.4", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA=="],
 
     "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
 
@@ -963,6 +970,8 @@
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
@@ -2436,6 +2445,58 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
+    "@radix-ui/react-collection/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-effect-event": "0.0.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.6", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.16", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper": ["@radix-ui/react-popper@1.3.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-rect": "1.1.4", "@radix-ui/react-use-size": "1.1.4", "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.17", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.10", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
+
     "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "@sentry/node/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
@@ -2762,6 +2823,36 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-dismissable-layer/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.15", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.4", "", { "dependencies": { "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/rect": ["@radix-ui/rect@1.1.3", "", {}, "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-portal/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-roving-focus/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
     "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "@sentry/node-core/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
@@ -2929,6 +3020,10 @@
     "@omni/media-processing/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@omni/voice-client/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-dismissable-layer/@radix-ui/react-use-effect-event/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
 
     "@redocly/openapi-core/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/knip.json
+++ b/knip.json
@@ -73,7 +73,14 @@
       "project": ["src/**/*.ts"]
     },
     "apps/ui": {
-      "entry": ["src/pages/*.tsx", "src/components/ui/*.tsx", "src/hooks/*.ts", "src/lib/*.ts", "src/types/*.ts"],
+      "entry": [
+        "src/pages/*.tsx",
+        "src/components/ui/*.tsx",
+        "src/hooks/*.ts",
+        "src/lib/*.ts",
+        "src/types/*.ts",
+        "src/**/*.test.ts"
+      ],
       "project": ["src/**/*.{ts,tsx}"],
       "ignoreDependencies": ["tailwindcss"]
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,8 @@
     "pdf-parse": "^1.1.1",
     "postgres": "^3.4.5",
     "qrcode-terminal": "^0.12.0",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@omni/api": "workspace:*",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -8,11 +8,19 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'bun';
-import { MOCK_API_KEY, startMockApi, stopMockApi } from './mock-api';
+import {
+  MOCK_API_KEY,
+  type MockApiHandle,
+  clearRecordedRequests,
+  getRecordedRequests,
+  startMockApi,
+  startMockApiInstance,
+  stopMockApi,
+} from './mock-api';
 
 /**
  * Pre-suite guard (#413): fail fast if a prior test run leaked a PM2 god
@@ -1051,6 +1059,395 @@ describe('CLI Integration Tests', () => {
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain('No message type');
+    });
+  });
+});
+
+// ── Multi-server registry tests (wish: multi-server-management, Group 2) ──
+//
+// Fully isolated from the suites above: its own HOME (so its own
+// `~/.omni/config.json` AND `~/.omni/keys/`) and its own two mock servers, so
+// the trust-handshake tests can bind a keypair without leaking signing headers
+// into the single-server suites.
+//
+// The tests inside are ordered as a narrative — `add` seeds the entries that
+// the later `use` / `remove` / handshake cases operate on.
+describe('CLI Multi-Server Tests', () => {
+  let MS_HOME = '';
+  let serverA: MockApiHandle;
+  let serverB: MockApiHandle;
+
+  /** Run the CLI against the multi-server HOME. */
+  async function ms(args: string[], env: Record<string, string> = {}): Promise<CliResult> {
+    const proc = spawn({
+      cmd: ['bun', CLI_PATH, ...args],
+      env: { ...process.env, HOME: MS_HOME, PM2_HOME: join(MS_HOME, '.pm2'), ...env },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  async function msJson<T>(args: string[]): Promise<T> {
+    const result = await ms([...args, '--json']);
+    if (result.exitCode !== 0) {
+      throw new Error(`CLI failed (${result.exitCode}): ${result.stderr || result.stdout}`);
+    }
+    return JSON.parse(result.stdout) as T;
+  }
+
+  interface ServerRow {
+    name: string;
+    url: string;
+    apiKey: string;
+    active: boolean;
+  }
+
+  function hostJson(): {
+    pubkey: string;
+    hostId: string;
+    boundServers?: Array<{ url: string; hostId: string }>;
+  } {
+    return JSON.parse(readFileSync(join(MS_HOME, '.omni', 'keys', 'host.json'), 'utf-8'));
+  }
+
+  beforeAll(() => {
+    MS_HOME = mkdtempSync(join(tmpdir(), '.omni-multiserver-'));
+    mkdirSync(join(MS_HOME, '.omni'), { recursive: true });
+    serverA = startMockApiInstance();
+    serverB = startMockApiInstance();
+
+    writeFileSync(
+      join(MS_HOME, '.omni', 'config.json'),
+      JSON.stringify(
+        {
+          apiUrl: serverA.url,
+          apiKey: MOCK_API_KEY,
+          format: 'human',
+          servers: {
+            active: 'default',
+            list: { default: { url: serverA.url, apiKey: MOCK_API_KEY } },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
+  afterAll(() => {
+    serverA?.close();
+    serverB?.close();
+    if (MS_HOME && existsSync(MS_HOME)) {
+      rmSync(MS_HOME, { recursive: true, force: true });
+    }
+  });
+
+  describe('server add', () => {
+    test('add verifies the target and persists it', async () => {
+      const result = await ms(['server', 'add', 'prod', serverB.url, '--api-key', MOCK_API_KEY]);
+
+      assertSuccess(result, 'server add prod');
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      const prod = rows.find((r) => r.name === 'prod');
+      expect(prod).toBeDefined();
+      expect(prod?.url).toBe(serverB.url);
+      // Added, not activated — `--use` / `server use` is the explicit switch.
+      expect(prod?.active).toBe(false);
+    });
+
+    test('add aborts with an unreachable error when the URL does not answer', async () => {
+      const result = await ms(['server', 'add', 'dead', 'http://127.0.0.1:1', '--api-key', MOCK_API_KEY]);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('unreachable');
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      expect(rows.find((r) => r.name === 'dead')).toBeUndefined();
+    });
+
+    test('add aborts with an unauthorized error when the key is rejected', async () => {
+      const result = await ms(['server', 'add', 'badkey', serverA.url, '--api-key', 'not-a-real-key']);
+
+      expect(result.exitCode).not.toBe(0);
+      // Distinct from the unreachable path — the server answered, the key did not.
+      expect(result.stderr).toContain('unauthorized');
+      expect(result.stderr).not.toContain('unreachable');
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      expect(rows.find((r) => r.name === 'badkey')).toBeUndefined();
+    });
+
+    test('add stores the trimmed name so lookups can reach it', async () => {
+      const result = await ms(['server', 'add', '  padded  ', serverB.url, '--api-key', MOCK_API_KEY]);
+      assertSuccess(result, 'server add "  padded  "');
+
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      expect(rows.find((r) => r.name === 'padded')).toBeDefined();
+      expect(rows.find((r) => r.name === '  padded  ')).toBeUndefined();
+
+      assertSuccess(await ms(['server', 'current', '--server', 'padded']), 'target the trimmed entry');
+      await ms(['server', 'remove', 'padded']);
+    });
+
+    test('add --skip-verify persists without probing', async () => {
+      const result = await ms(['server', 'add', 'offline', 'http://127.0.0.1:1', '--skip-verify']);
+
+      assertSuccess(result, 'server add --skip-verify');
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      expect(rows.find((r) => r.name === 'offline')?.url).toBe('http://127.0.0.1:1');
+
+      await ms(['server', 'remove', 'offline']);
+    });
+  });
+
+  describe('server list masking', () => {
+    test('list masks API keys in human and JSON output', async () => {
+      const human = await ms(['server', 'list']);
+      assertSuccess(human, 'server list');
+      expect(human.stdout).not.toContain(MOCK_API_KEY);
+
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      for (const row of rows) {
+        expect(row.apiKey).not.toBe(MOCK_API_KEY);
+      }
+      expect(rows.find((r) => r.name === 'default')?.apiKey).toBe(`${MOCK_API_KEY.slice(0, 12)}...`);
+    });
+
+    test('list --reveal prints full API keys', async () => {
+      const rows = await msJson<ServerRow[]>(['server', 'list', '--reveal']);
+      expect(rows.find((r) => r.name === 'default')?.apiKey).toBe(MOCK_API_KEY);
+    });
+  });
+
+  describe('--server flag', () => {
+    test('one-shot --server targets an entry without persisting it', async () => {
+      const overridden = await msJson<{ name: string; active: string; overridden: boolean }>([
+        'server',
+        'current',
+        '--server',
+        'prod',
+      ]);
+      expect(overridden.name).toBe('prod');
+      expect(overridden.active).toBe('default');
+      expect(overridden.overridden).toBe(true);
+
+      // The very next invocation is back on the persisted active entry.
+      const after = await msJson<{ name: string; active: string; overridden: boolean }>(['server', 'current']);
+      expect(after.name).toBe('default');
+      expect(after.active).toBe('default');
+      expect(after.overridden).toBe(false);
+    });
+
+    test('--server=<name> form works too', async () => {
+      const current = await msJson<{ name: string }>(['server', 'current', '--server=prod']);
+      expect(current.name).toBe('prod');
+    });
+
+    test('--server routes the request to that server', async () => {
+      clearRecordedRequests();
+      const result = await ms(['instances', 'list', '--server', 'prod']);
+
+      assertSuccess(result, 'instances list --server prod');
+      const origins = getRecordedRequests().map((r) => r.origin);
+      expect(origins).toContain(serverB.url);
+      expect(origins).not.toContain(serverA.url);
+    });
+
+    test('unknown --server exits non-zero listing known entries', async () => {
+      const result = await ms(['--server', 'nope', 'server', 'list']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("Unknown server 'nope'");
+      expect(result.stderr).toContain('default');
+      expect(result.stderr).toContain('prod');
+    });
+
+    test('--server without a value exits non-zero', async () => {
+      const result = await ms(['server', 'list', '--server']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--server requires a server name');
+    });
+
+    test('repeating --server exits non-zero instead of corrupting argv', async () => {
+      const result = await ms(['instances', 'list', '--server', 'prod', '--server', 'default']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('duplicate --server flag');
+    });
+
+    test('--server with a flag-like value exits non-zero', async () => {
+      const result = await ms(['server', 'list', '--server', '--json']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--server requires a server name');
+    });
+  });
+
+  describe('server use / remove / current', () => {
+    test('use switches the persisted active entry', async () => {
+      const result = await ms(['server', 'use', 'prod']);
+      assertSuccess(result, 'server use prod');
+
+      const current = await msJson<{ name: string; active: string }>(['server', 'current']);
+      expect(current.name).toBe('prod');
+      expect(current.active).toBe('prod');
+
+      await ms(['server', 'use', 'default']);
+    });
+
+    test('use with an unknown name exits non-zero listing known entries', async () => {
+      const result = await ms(['server', 'use', 'ghost']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("Unknown server 'ghost'");
+      expect(result.stderr).toContain('default');
+    });
+
+    test('remove refuses to drop the active entry without --force', async () => {
+      const result = await ms(['server', 'remove', 'default']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('active server');
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      expect(rows.find((r) => r.name === 'default')).toBeDefined();
+    });
+
+    test('remove --force drops the active entry and falls back to another', async () => {
+      await ms(['server', 'add', 'scratch', serverB.url, '--api-key', MOCK_API_KEY, '--use']);
+      expect((await msJson<{ active: string }>(['server', 'current'])).active).toBe('scratch');
+
+      const refused = await ms(['server', 'remove', 'scratch']);
+      expect(refused.exitCode).not.toBe(0);
+
+      const forced = await ms(['server', 'remove', 'scratch', '--force']);
+      assertSuccess(forced, 'server remove --force');
+
+      const current = await msJson<{ active: string }>(['server', 'current']);
+      expect(current.active).toBe('default');
+      const rows = await msJson<ServerRow[]>(['server', 'list']);
+      expect(rows.find((r) => r.name === 'scratch')).toBeUndefined();
+    });
+  });
+
+  describe('auth scoping', () => {
+    test('a keyless entry errors with the --server-scoped login hint', async () => {
+      await ms(['server', 'add', 'keyless', serverB.url]);
+
+      const result = await ms(['instances', 'list', '--server', 'keyless']);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('keyless');
+      expect(result.stderr).toContain('omni auth login --server keyless');
+    });
+
+    test('auth login --server writes the key into that entry only', async () => {
+      const result = await ms(['auth', 'login', '--server', 'keyless', '--api-key', MOCK_API_KEY]);
+      assertSuccess(result, 'auth login --server keyless');
+
+      const rows = await msJson<ServerRow[]>(['server', 'list', '--reveal']);
+      expect(rows.find((r) => r.name === 'keyless')?.apiKey).toBe(MOCK_API_KEY);
+      // Untargeted entries keep whatever they had.
+      expect(rows.find((r) => r.name === 'default')?.apiKey).toBe(MOCK_API_KEY);
+      expect(rows.find((r) => r.name === 'keyless')?.url).toBe(serverB.url);
+    });
+
+    test('auth logout --server clears only that entry key', async () => {
+      const result = await ms(['auth', 'logout', '--server', 'keyless']);
+      assertSuccess(result, 'auth logout --server keyless');
+
+      const rows = await msJson<ServerRow[]>(['server', 'list', '--reveal']);
+      expect(rows.find((r) => r.name === 'keyless')?.apiKey).toBe('-');
+      expect(rows.find((r) => r.name === 'default')?.apiKey).toBe(MOCK_API_KEY);
+      expect(rows.find((r) => r.name === 'prod')?.apiKey).toBe(MOCK_API_KEY);
+    });
+
+    test('auth status names the targeted server', async () => {
+      const result = await ms(['auth', 'status']);
+      assertSuccess(result, 'auth status');
+      expect(result.stdout).toContain('authenticated');
+      expect(result.stdout).toContain('default');
+    });
+  });
+
+  describe('trust handshake server binding', () => {
+    test('handshake binds the targeted server only', async () => {
+      const result = await ms(['trust', 'handshake']);
+      assertSuccess(result, 'trust handshake');
+
+      const meta = hostJson();
+      expect(meta.boundServers).toEqual([{ url: serverA.url, hostId: meta.hostId }]);
+    });
+
+    test('requests to a non-bound server are sent unsigned and still succeed', async () => {
+      clearRecordedRequests();
+      const result = await ms(['instances', 'list', '--server', 'prod']);
+
+      assertSuccess(result, 'instances list --server prod (unsigned)');
+      const toB = getRecordedRequests().filter((r) => r.origin === serverB.url);
+      expect(toB.length).toBeGreaterThan(0);
+      expect(toB.every((r) => r.signed === false)).toBe(true);
+    });
+
+    test('requests to the bound server stay signed', async () => {
+      clearRecordedRequests();
+      const result = await ms(['instances', 'list']);
+
+      assertSuccess(result, 'instances list (signed)');
+      const toA = getRecordedRequests().filter((r) => r.origin === serverA.url);
+      expect(toA.length).toBeGreaterThan(0);
+      expect(toA.every((r) => r.signed === true)).toBe(true);
+      expect(toA[0].hostId).toBe(hostJson().hostId);
+    });
+
+    test('re-handshaking against another server binds it without rotating', async () => {
+      const before = hostJson();
+
+      const result = await ms(['trust', 'handshake', '--server', 'prod']);
+      assertSuccess(result, 'trust handshake --server prod');
+      expect(result.stdout).toContain('no rotation');
+
+      const after = hostJson();
+      expect(after.pubkey).toBe(before.pubkey);
+      // The top-level id belongs to the FIRST server (A) and must survive
+      // binding B: stamping B's id here made every later request to A carry an
+      // id A never issued → 401 unknown host.
+      expect(after.hostId).toBe(before.hostId);
+
+      const bindings = after.boundServers ?? [];
+      expect(bindings.map((b) => b.url)).toEqual([serverA.url, serverB.url]);
+      // Each server issues its own row, so the ids differ.
+      const idForA = bindings[0].hostId;
+      const idForB = bindings[1].hostId;
+      expect(idForA).toBe(before.hostId);
+      expect(idForB).not.toBe(idForA);
+
+      // Both servers now sign — binding B did not unbind A — and each request
+      // carries the id THAT server issued.
+      clearRecordedRequests();
+      assertSuccess(await ms(['instances', 'list', '--server', 'prod']), 'signed against prod');
+      assertSuccess(await ms(['instances', 'list']), 'signed against default');
+      const recorded = getRecordedRequests().filter((r) => r.path === '/api/v2/instances');
+      expect(recorded.length).toBeGreaterThanOrEqual(2);
+      expect(recorded.every((r) => r.signed === true)).toBe(true);
+
+      const toA = recorded.filter((r) => r.origin === serverA.url);
+      const toB = recorded.filter((r) => r.origin === serverB.url);
+      expect(toA.length).toBeGreaterThan(0);
+      expect(toB.length).toBeGreaterThan(0);
+      expect(toA.every((r) => r.hostId === idForA)).toBe(true);
+      expect(toB.every((r) => r.hostId === idForB)).toBe(true);
+    });
+
+    test('an already-bound handshake reports the bound servers', async () => {
+      const result = await ms(['trust', 'handshake']);
+
+      assertSuccess(result, 'trust handshake (already bound)');
+      expect(result.stdout).toContain('Already handshook');
+      expect(result.stdout).toContain(serverA.url);
+      expect(result.stdout).toContain(serverB.url);
+      expect(result.stdout).toContain('UNSIGNED');
     });
   });
 });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,23 +1,112 @@
 /**
  * Config Module Unit Tests
  *
- * Note: File-based config operations are tested via CLI integration tests
- * because the config module caches paths at import time.
- * These tests focus on pure functions and validation logic.
+ * File-based tests are sandboxed with `OMNI_CONFIG_DIR`, which
+ * `getConfigDir()` reads on EVERY call — nothing is cached at import time —
+ * so pointing it at a temp dir per test fully isolates these tests from the
+ * developer's real `~/.omni`. Every test that touches the filesystem must go
+ * through `withSandbox()`; without it, `loadServerConfig()` and friends read
+ * (and `save*` would write) the real user config.
  */
 
-import { describe, expect, test } from 'bun:test';
-import { homedir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
   CONFIG_KEYS,
+  type Config,
   type ConfigKey,
   DEFAULT_SERVER_CONFIG,
+  DEFAULT_SERVER_NAME,
   type ServerConfig,
+  clearRuntimeServer,
+  deleteConfigValue,
+  describeActiveServer,
+  getConfigPath,
+  isServersConfigKey,
   isValidConfigKey,
+  loadConfig,
+  loadLocalRuntimeConfig,
   loadServerConfig,
+  maskConfigApiKey,
+  resetConfigWarnings,
+  saveConfig,
+  saveLocalRuntimeConfig,
+  setConfigValue,
+  setRuntimeServer,
 } from '../config.js';
+import { buildRuntimeEnv } from '../runtime-env.js';
+
+// ----------------------------------------------------------------------------
+// Sandbox: temp OMNI_CONFIG_DIR + full env save/restore
+// ----------------------------------------------------------------------------
+
+/** Env vars mutated by these tests — saved before and restored after each. */
+const MANAGED_ENV = ['OMNI_CONFIG_DIR', '__OMNI_RUNTIME_SERVER', 'OMNI_DB_ENFORCEMENT'] as const;
+
+let savedEnv: Record<string, string | undefined> = {};
+let sandboxDir: string | undefined;
+
+function withSandbox(): void {
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of MANAGED_ENV) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    sandboxDir = mkdtempSync(join(tmpdir(), 'omni-config-test-'));
+    process.env.OMNI_CONFIG_DIR = sandboxDir;
+    // The warning dedupe set is module-global and never expires — reset it so
+    // one test's warning is not swallowed for every test that follows.
+    resetConfigWarnings();
+  });
+
+  afterEach(() => {
+    if (sandboxDir) {
+      rmSync(sandboxDir, { recursive: true, force: true });
+      sandboxDir = undefined;
+    }
+    for (const key of MANAGED_ENV) {
+      const previous = savedEnv[key];
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  });
+}
+
+/** Write a raw config.json into the sandbox. */
+function writeRawConfig(raw: unknown): void {
+  writeFileSync(getConfigPath(), JSON.stringify(raw, null, 2));
+}
+
+/** Read the raw config.json back from the sandbox. */
+function readRawConfigFile(): Record<string, unknown> {
+  return JSON.parse(readFileSync(getConfigPath(), 'utf-8')) as Record<string, unknown>;
+}
+
+const LOCAL_KEY = 'omni_sk_localaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const REMOTE_KEY = 'omni_sk_remotebbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/** Two-entry registry with the REMOTE entry active. */
+function writeTwoServerConfig(): void {
+  writeRawConfig({
+    apiUrl: 'http://localhost:8882',
+    apiKey: LOCAL_KEY,
+    format: 'human',
+    servers: {
+      active: 'prod',
+      list: {
+        [DEFAULT_SERVER_NAME]: { url: 'http://localhost:8882', apiKey: LOCAL_KEY },
+        prod: { url: 'https://omni.example.com', apiKey: REMOTE_KEY },
+      },
+    },
+  });
+}
 
 describe('Config Validation', () => {
   describe('isValidConfigKey', () => {
@@ -82,6 +171,10 @@ describe('Config Key Types', () => {
 });
 
 describe('ServerConfig', () => {
+  // `loadServerConfig()` below hits the filesystem — sandbox it so it never
+  // reads the developer's real ~/.omni/config.json.
+  withSandbox();
+
   test('ServerConfig type has all required fields', () => {
     // Compile-time check - if it compiles, the type is correct
     const config: ServerConfig = {
@@ -142,5 +235,350 @@ describe('Server Config Keys', () => {
     expect(isValidConfigKey('server.dataDir')).toBe(true);
     expect(isValidConfigKey('server.logLevel')).toBe(true);
     expect(isValidConfigKey('server.nodeEnv')).toBe(true);
+  });
+});
+
+// ============================================================================
+// Multi-server registry
+// ============================================================================
+
+describe('Server registry keys are not config keys', () => {
+  test('isServersConfigKey matches the registry namespace only', () => {
+    expect(isServersConfigKey('servers')).toBe(true);
+    expect(isServersConfigKey('servers.prod.apiKey')).toBe(true);
+    expect(isServersConfigKey('servers.foo.apiKey')).toBe(true);
+    expect(isServersConfigKey('server.port')).toBe(false);
+    expect(isServersConfigKey('apiKey')).toBe(false);
+  });
+
+  test('servers.* keys are rejected by the closed ConfigKey union', () => {
+    // `omni config set servers.foo.apiKey x` must not be routable — the
+    // command layer turns this into an error pointing at `omni server`.
+    expect(isValidConfigKey('servers.foo.apiKey')).toBe(false);
+    expect(isValidConfigKey('servers')).toBe(false);
+    expect(Object.keys(CONFIG_KEYS).some((k) => k.startsWith('servers'))).toBe(false);
+  });
+
+  test('maskConfigApiKey never returns the full key', () => {
+    expect(maskConfigApiKey(LOCAL_KEY)).toBe(`${LOCAL_KEY.slice(0, 12)}...`);
+    expect(maskConfigApiKey(LOCAL_KEY)).not.toContain(LOCAL_KEY);
+    // Short keys collapse entirely rather than being echoed.
+    expect(maskConfigApiKey('short')).toBe('***');
+    expect(maskConfigApiKey(undefined)).toBe('-');
+  });
+});
+
+describe('Server registry migration', () => {
+  withSandbox();
+
+  test('lifts legacy flat apiUrl/apiKey into a default entry', () => {
+    writeRawConfig({ apiUrl: 'http://legacy.local:9000', apiKey: LOCAL_KEY, format: 'human' });
+
+    const config = loadConfig();
+
+    expect(config.servers?.active).toBe(DEFAULT_SERVER_NAME);
+    expect(config.servers?.list[DEFAULT_SERVER_NAME]).toEqual({
+      url: 'http://legacy.local:9000',
+      apiKey: LOCAL_KEY,
+    });
+    // Effective values are unchanged for the ~30 call sites reading them.
+    expect(config.apiUrl).toBe('http://legacy.local:9000');
+    expect(config.apiKey).toBe(LOCAL_KEY);
+  });
+
+  test('a flat config round-trips through load -> save -> load unchanged', () => {
+    writeRawConfig({ apiUrl: 'http://legacy.local:9000', apiKey: LOCAL_KEY, format: 'human' });
+
+    const first = loadConfig();
+    saveConfig(first);
+    const second = loadConfig();
+
+    expect(second.apiUrl).toBe(first.apiUrl);
+    expect(second.apiKey).toBe(first.apiKey);
+    expect(second.servers).toEqual(first.servers);
+    // The migration is now persisted, and the flat fields stay as a mirror
+    // for older CLI builds reading the same file.
+    const onDisk = readRawConfigFile();
+    expect(onDisk.servers).toBeDefined();
+    expect(onDisk.apiUrl).toBe('http://legacy.local:9000');
+  });
+
+  test('a config with no file at all still yields a default entry', () => {
+    const config = loadConfig();
+    expect(config.servers?.active).toBe(DEFAULT_SERVER_NAME);
+    expect(config.apiUrl).toBe('http://localhost:8882');
+    expect(config.apiKey).toBeUndefined();
+  });
+
+  test('migration is idempotent — an existing block is preserved', () => {
+    writeTwoServerConfig();
+    const config = loadConfig();
+    expect(config.servers?.active).toBe('prod');
+    expect(Object.keys(config.servers?.list ?? {}).sort()).toEqual(['default', 'prod']);
+  });
+});
+
+describe('Server registry resolution', () => {
+  withSandbox();
+
+  test('resolves the active entry into effective apiUrl/apiKey', () => {
+    writeTwoServerConfig();
+    const config = loadConfig();
+    expect(config.apiUrl).toBe('https://omni.example.com');
+    expect(config.apiKey).toBe(REMOTE_KEY);
+  });
+
+  test('the env-transported override wins for one invocation and is never persisted', () => {
+    writeTwoServerConfig();
+    setRuntimeServer(DEFAULT_SERVER_NAME);
+
+    const overridden = loadConfig();
+    expect(overridden.apiUrl).toBe('http://localhost:8882');
+    expect(overridden.apiKey).toBe(LOCAL_KEY);
+    // The persisted pointer is untouched, even after a save.
+    saveConfig(overridden);
+    expect((readRawConfigFile().servers as { active: string }).active).toBe('prod');
+
+    clearRuntimeServer();
+    expect(loadConfig().apiKey).toBe(REMOTE_KEY);
+  });
+
+  test('an unknown override falls back to the persisted active entry', () => {
+    writeTwoServerConfig();
+    setRuntimeServer('nope');
+    expect(loadConfig().apiKey).toBe(REMOTE_KEY);
+  });
+
+  test('saving writes credentials into the targeted entry, not just the flat fields', () => {
+    writeTwoServerConfig();
+    const config = loadConfig();
+    config.apiKey = 'omni_sk_rotatedccccccccccccccccccccccccc';
+    saveConfig(config);
+
+    const servers = readRawConfigFile().servers as { list: Record<string, { apiKey?: string }> };
+    expect(servers.list.prod.apiKey).toBe('omni_sk_rotatedccccccccccccccccccccccccc');
+    // The local entry is untouched by a save made against the active remote.
+    expect(servers.list.default.apiKey).toBe(LOCAL_KEY);
+  });
+
+  test('describeActiveServer reports the active entry with a masked key', () => {
+    writeTwoServerConfig();
+    const active = describeActiveServer();
+    expect(active.name).toBe('prod');
+    expect(active.url).toBe('https://omni.example.com');
+    expect(active.maskedKey).not.toBe(REMOTE_KEY);
+    expect(active.maskedKey).toBe(`${REMOTE_KEY.slice(0, 12)}...`);
+  });
+});
+
+describe('Server registry validation fallback', () => {
+  withSandbox();
+
+  test('a non-object servers block falls back to the legacy flat fields', () => {
+    writeRawConfig({ apiUrl: 'http://legacy.local:9000', apiKey: LOCAL_KEY, servers: 'not-an-object' });
+
+    const config = loadConfig();
+
+    expect(config.apiUrl).toBe('http://legacy.local:9000');
+    expect(config.apiKey).toBe(LOCAL_KEY);
+    expect(config.servers?.active).toBe(DEFAULT_SERVER_NAME);
+  });
+
+  test('individual malformed entries are dropped, valid ones survive', () => {
+    writeRawConfig({
+      apiUrl: 'http://localhost:8882',
+      servers: {
+        active: 'good',
+        list: {
+          good: { url: 'https://good.example.com', apiKey: LOCAL_KEY },
+          missingUrl: { apiKey: REMOTE_KEY },
+          wrongType: { url: 1234 },
+        },
+      },
+    });
+
+    const config = loadConfig();
+
+    expect(Object.keys(config.servers?.list ?? {})).toEqual(['good']);
+    expect(config.apiUrl).toBe('https://good.example.com');
+  });
+
+  test('an active pointer naming a dropped entry falls back to a surviving one', () => {
+    writeRawConfig({
+      servers: { active: 'ghost', list: { [DEFAULT_SERVER_NAME]: { url: 'http://localhost:8882' } } },
+    });
+
+    const config = loadConfig();
+
+    expect(config.servers?.active).toBe(DEFAULT_SERVER_NAME);
+    expect(config.apiUrl).toBe('http://localhost:8882');
+  });
+
+  test('unparseable JSON falls back to defaults instead of crashing', () => {
+    writeFileSync(getConfigPath(), '{ this is not json');
+    const config = loadConfig();
+    expect(config.apiUrl).toBe('http://localhost:8882');
+    expect(config.servers?.active).toBe(DEFAULT_SERVER_NAME);
+  });
+});
+
+describe('Local runtime isolation', () => {
+  withSandbox();
+
+  test('loadLocalRuntimeConfig reads the default entry while a remote is active', () => {
+    writeTwoServerConfig();
+
+    expect(loadConfig().apiKey).toBe(REMOTE_KEY);
+    expect(loadLocalRuntimeConfig().apiKey).toBe(LOCAL_KEY);
+    expect(loadLocalRuntimeConfig().apiUrl).toBe('http://localhost:8882');
+  });
+
+  test('buildRuntimeEnv never hands the active remote key to the local process', () => {
+    writeTwoServerConfig();
+
+    // Default parameter — the structural guarantee: a caller that passes no
+    // cliConfig still gets the LOCAL entry.
+    expect(buildRuntimeEnv(loadServerConfig()).OMNI_API_KEY).toBe(LOCAL_KEY);
+    // Explicit accessor — how every call site is wired.
+    expect(buildRuntimeEnv(loadServerConfig(), loadLocalRuntimeConfig()).OMNI_API_KEY).toBe(LOCAL_KEY);
+    expect(buildRuntimeEnv(loadServerConfig()).OMNI_API_KEY).not.toBe(REMOTE_KEY);
+  });
+
+  test('the server.* local runtime namespace is untouched by the registry', () => {
+    writeRawConfig({
+      apiUrl: 'http://localhost:8882',
+      apiKey: LOCAL_KEY,
+      server: { port: 9999, logLevel: 'debug' },
+      servers: {
+        active: 'prod',
+        list: {
+          [DEFAULT_SERVER_NAME]: { url: 'http://localhost:9999', apiKey: LOCAL_KEY },
+          prod: { url: 'https://omni.example.com', apiKey: REMOTE_KEY },
+        },
+      },
+    });
+
+    const serverConfig = loadServerConfig();
+    expect(serverConfig.port).toBe(9999);
+    expect(serverConfig.logLevel).toBe('debug');
+    expect(buildRuntimeEnv(serverConfig).API_PORT).toBe('9999');
+    // Saving through the client-facing accessor must not rewrite server.*
+    saveConfig(loadConfig());
+    expect(readRawConfigFile().server).toEqual({ port: 9999, logLevel: 'debug' });
+  });
+
+  test('saveLocalRuntimeConfig writes to the default entry while a remote is active', () => {
+    writeTwoServerConfig();
+
+    const local: Config = loadLocalRuntimeConfig();
+    local.apiKey = 'omni_sk_recoveredddddddddddddddddddddddd';
+    saveLocalRuntimeConfig(local);
+
+    const servers = readRawConfigFile().servers as { active: string; list: Record<string, { apiKey?: string }> };
+    expect(servers.list.default.apiKey).toBe('omni_sk_recoveredddddddddddddddddddddddd');
+    expect(servers.list.prod.apiKey).toBe(REMOTE_KEY);
+    expect(servers.active).toBe('prod');
+  });
+});
+
+describe('Flat back-compat mirror never carries remote credentials', () => {
+  withSandbox();
+
+  test('saving against an active remote leaves the flat fields mirroring default', () => {
+    writeTwoServerConfig();
+
+    // A save made through the client-facing accessor while `prod` is active.
+    saveConfig(loadConfig());
+
+    const onDisk = readRawConfigFile();
+    expect(onDisk.apiKey).toBe(LOCAL_KEY);
+    expect(onDisk.apiKey).not.toBe(REMOTE_KEY);
+    expect(onDisk.apiUrl).toBe('http://localhost:8882');
+    // And the local accessor still resolves the local entry.
+    expect(loadLocalRuntimeConfig().apiKey).toBe(LOCAL_KEY);
+  });
+
+  test('rotating the active remote key does not leak it into the flat mirror', () => {
+    writeTwoServerConfig();
+    const config = loadConfig();
+    config.apiKey = 'omni_sk_rotatedccccccccccccccccccccccccc';
+    saveConfig(config);
+
+    const onDisk = readRawConfigFile();
+    expect(onDisk.apiKey).toBe(LOCAL_KEY);
+    expect(onDisk.apiUrl).toBe('http://localhost:8882');
+  });
+
+  test('a registry without a default entry yields no local credential at all', () => {
+    // Reachable by hand-editing config.json today, and by `omni server remove
+    // default` once that command lands.
+    writeRawConfig({
+      apiUrl: 'https://omni.example.com',
+      apiKey: REMOTE_KEY,
+      servers: { active: 'prod', list: { prod: { url: 'https://omni.example.com', apiKey: REMOTE_KEY } } },
+    });
+
+    const local = loadLocalRuntimeConfig();
+    expect(local.apiUrl).toBe('http://localhost:8882');
+    expect(local.apiKey).toBeUndefined();
+    expect(buildRuntimeEnv(loadServerConfig()).OMNI_API_KEY).toBe('');
+  });
+});
+
+describe('config unset', () => {
+  withSandbox();
+
+  test('unset apiUrl reverts the effective URL to the default', () => {
+    setConfigValue('apiUrl', 'http://custom.local:9100');
+    expect(loadConfig().apiUrl).toBe('http://custom.local:9100');
+
+    deleteConfigValue('apiUrl');
+
+    expect(loadConfig().apiUrl).toBe('http://localhost:8882');
+    const servers = readRawConfigFile().servers as { list: Record<string, { url: string }> };
+    expect(servers.list.default.url).toBe('http://localhost:8882');
+  });
+
+  test('unset apiKey still clears the key', () => {
+    setConfigValue('apiKey', LOCAL_KEY);
+    expect(loadConfig().apiKey).toBe(LOCAL_KEY);
+
+    deleteConfigValue('apiKey');
+
+    expect(loadConfig().apiKey).toBeUndefined();
+    expect(readRawConfigFile().apiKey).toBeUndefined();
+  });
+});
+
+describe('Config warnings', () => {
+  withSandbox();
+
+  test('a malformed server entry is reported on stderr', () => {
+    writeRawConfig({
+      apiUrl: 'http://localhost:8882',
+      servers: {
+        active: 'good',
+        list: {
+          good: { url: 'https://good.example.com' },
+          broken: { apiKey: REMOTE_KEY },
+        },
+      },
+    });
+
+    const original = process.stderr.write.bind(process.stderr);
+    const captured: string[] = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      loadConfig();
+    } finally {
+      process.stderr.write = original;
+    }
+
+    expect(captured.join('')).toContain('dropping invalid server entry "broken"');
+    // The dropped entry's key is never echoed in the warning.
+    expect(captured.join('')).not.toContain(REMOTE_KEY);
   });
 });

--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -466,11 +466,70 @@ function handleRecentLogs(req: Request): Response {
   });
 }
 
+// ── Trust / handshake fixtures ──
+
+/**
+ * Registered pubkeys, keyed by `${origin}|${pubkey}`.
+ *
+ * Mirrors the real route's idempotency: the same pubkey posted twice to one
+ * server yields the same host id, and the SAME pubkey posted to a second
+ * server registers there independently. Both properties are what the
+ * multi-server binding tests assert against.
+ */
+const registeredHosts = new Map<string, { id: string; pubkey: string; hostname: string }>();
+
+async function handleTrustHandshake(req: Request): Promise<Response> {
+  const origin = new URL(req.url).origin;
+  const body = (await req.json()) as { pubkey?: string; hostname?: string };
+  const pubkey = body.pubkey ?? '';
+  const mapKey = `${origin}|${pubkey}`;
+  const existing = registeredHosts.get(mapKey);
+  if (existing) return json({ data: existing });
+  const host = { id: crypto.randomUUID(), pubkey, hostname: body.hostname ?? 'unknown' };
+  registeredHosts.set(mapKey, host);
+  return json({ data: host }, 201);
+}
+
+// ── Request recording (signature assertions) ──
+
+export interface RecordedRequest {
+  origin: string;
+  method: string;
+  path: string;
+  /** True when the request carried the X-Genie-* operator-signing headers. */
+  signed: boolean;
+  hostId: string | null;
+}
+
+let recordedRequests: RecordedRequest[] = [];
+
+/** Requests seen since the last {@link clearRecordedRequests}, oldest first. */
+export function getRecordedRequests(): RecordedRequest[] {
+  return [...recordedRequests];
+}
+
+export function clearRecordedRequests(): void {
+  recordedRequests = [];
+}
+
+function recordRequest(req: Request, path: string): void {
+  const hostId = req.headers.get('x-genie-host-id');
+  recordedRequests.push({
+    origin: new URL(req.url).origin,
+    method: req.method,
+    path,
+    signed: hostId !== null && req.headers.get('x-genie-signature') !== null,
+    hostId,
+  });
+}
+
 // ── Auth middleware ──
 
 function checkAuth(req: Request, path: string): Response | null {
   if (!path.startsWith('/api/v2') || path.endsWith('/health')) return null;
-  const key = req.headers.get('x-api-key');
+  // Accept either header style: the SDK sends x-api-key, while the raw-fetch
+  // trust command sends `Authorization: Bearer`.
+  const key = req.headers.get('x-api-key') ?? req.headers.get('authorization')?.replace(/^Bearer\s+/i, '');
   if (key === MOCK_API_KEY) return null;
   return json({ error: { code: 'UNAUTHORIZED', message: 'Invalid API key' } }, 401);
 }
@@ -505,6 +564,8 @@ const staticRoutes: Record<RouteKey, (req: Request) => Response | Promise<Respon
   'GET /api/v2/agents': () => json({ items: dynamicAgents }),
   'POST /api/v2/agents': handleCreateAgent,
   'GET /api/v2/logs/recent': handleRecentLogs,
+  'POST /api/v2/trust/handshake': handleTrustHandshake,
+  'GET /api/v2/trust/hosts': () => json(EMPTY_ITEMS),
 };
 
 /** Pattern routes: regex-matched paths */
@@ -555,6 +616,8 @@ async function handleRequest(req: Request): Promise<Response> {
   const path = url.pathname;
   const method = req.method;
 
+  recordRequest(req, path);
+
   // Auth check
   const authError = checkAuth(req, path);
   if (authError) return authError;
@@ -575,13 +638,31 @@ async function handleRequest(req: Request): Promise<Response> {
 
 // ── Server lifecycle ──
 
-interface MockApiHandle {
+export interface MockApiHandle {
   url: string;
   port: number;
   close: () => void;
 }
 
 let handle: MockApiHandle | null = null;
+
+/**
+ * Start an ADDITIONAL mock API on its own random port.
+ *
+ * Unlike {@link startMockApi} this is not a singleton and does not reset the
+ * shared fixtures — multi-server tests need two live servers at once, and
+ * resetting would clobber the suite that is already running against the
+ * singleton. Callers must close the handle themselves.
+ */
+export function startMockApiInstance(): MockApiHandle {
+  const server = Bun.serve({ port: 0, fetch: handleRequest });
+  const port = server.port ?? 0;
+  return {
+    url: `http://localhost:${port}`,
+    port,
+    close: () => server.stop(true),
+  };
+}
 
 /**
  * Start the mock API server on a random available port.

--- a/packages/cli/src/__tests__/signing.test.ts
+++ b/packages/cli/src/__tests__/signing.test.ts
@@ -24,7 +24,9 @@ import {
   _paths,
   canonicalSigningInput,
   generateAndStoreKeypair,
+  loadHostMetadata,
   loadSigningContext,
+  loadSigningContextForServer,
   signRequest,
   writeHostMetadata,
 } from '../signing';
@@ -170,6 +172,60 @@ describe('generateAndStoreKeypair → loadSigningContext round-trip', () => {
       registeredAt: '2026-04-30T12:00:00.000Z',
     });
     expect(loadSigningContext()).toBeNull();
+  });
+
+  test('per-server bindings sign with the id THAT server issued', () => {
+    const { pubkeyB64Url } = generateAndStoreKeypair();
+    writeHostMetadata({
+      hostId: 'id-from-a',
+      pubkey: pubkeyB64Url,
+      hostname: 'test-machine',
+      registeredAt: '2026-04-30T12:00:00.000Z',
+      boundServers: [
+        { url: 'https://a.example.com', hostId: 'id-from-a' },
+        { url: 'https://b.example.com', hostId: 'id-from-b' },
+      ],
+    });
+
+    expect(loadSigningContextForServer('https://a.example.com')?.hostId).toBe('id-from-a');
+    // Trailing slash is normalized away before the lookup.
+    expect(loadSigningContextForServer('https://b.example.com/')?.hostId).toBe('id-from-b');
+    // Unbound server → unsigned.
+    expect(loadSigningContextForServer('https://c.example.com')).toBeNull();
+  });
+
+  test('legacy string[] boundServers coerce to the top-level hostId', () => {
+    const { pubkeyB64Url } = generateAndStoreKeypair();
+    require('node:fs').writeFileSync(
+      _paths.hostJson(),
+      JSON.stringify({
+        hostId: 'legacy-id',
+        pubkey: pubkeyB64Url,
+        hostname: 'test-machine',
+        registeredAt: '2026-04-30T12:00:00.000Z',
+        boundServers: ['https://a.example.com/', 'https://b.example.com'],
+      }),
+    );
+
+    expect(loadHostMetadata()?.boundServers).toEqual([
+      { url: 'https://a.example.com', hostId: 'legacy-id' },
+      { url: 'https://b.example.com', hostId: 'legacy-id' },
+    ]);
+    expect(loadSigningContextForServer('https://b.example.com')?.hostId).toBe('legacy-id');
+  });
+
+  test('absent boundServers coerce to the local default URL', () => {
+    const { pubkeyB64Url } = generateAndStoreKeypair();
+    writeHostMetadata({
+      hostId: 'legacy-id',
+      pubkey: pubkeyB64Url,
+      hostname: 'test-machine',
+      registeredAt: '2026-04-30T12:00:00.000Z',
+    });
+
+    expect(loadHostMetadata()?.boundServers).toEqual([{ url: 'http://localhost:8882', hostId: 'legacy-id' }]);
+    expect(loadSigningContextForServer('http://localhost:8882')?.hostId).toBe('legacy-id');
+    expect(loadSigningContextForServer('https://remote.example.com')).toBeNull();
   });
 
   test('private key file gets 0600 perms (no group/other read)', () => {

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -5,13 +5,34 @@
  */
 
 import { type OmniClient, createOmniClient } from '@omni/sdk';
-import { hasAuth, loadConfig } from './config.js';
+import { describeActiveServer, hasAuth, loadConfig } from './config.js';
 import * as output from './output.js';
-import { type SigningContext, loadSigningContext } from './signing.js';
+import { type SigningContext, loadSigningContextForServer } from './signing.js';
 import { VERSION } from './version.js';
 
 /** Cached client instance */
 let cachedClient: OmniClient | null = null;
+
+const DEFAULT_API_URL = 'http://localhost:8882';
+
+/**
+ * Abort with a not-authenticated error naming the server entry the command was
+ * targeting.
+ *
+ * With multiple entries in the registry, a bare "run omni auth login" is
+ * actively misleading: it would write the key into whichever entry is active,
+ * which may not be the one that just failed. The hint is therefore always
+ * `--server`-scoped.
+ */
+export function exitNotAuthenticated(): never {
+  const target = describeActiveServer();
+  return output.error(
+    `Not authenticated for server "${target.name}" (${target.url}). ` +
+      `Run: omni auth login --server ${target.name} --api-key <key>`,
+    undefined,
+    2,
+  );
+}
 
 /**
  * Get an authenticated SDK client.
@@ -23,21 +44,22 @@ export function getClient(): OmniClient {
   }
 
   if (!hasAuth()) {
-    output.error('Not authenticated. Run: omni auth login --api-key <key>', undefined, 2);
+    exitNotAuthenticated();
   }
 
   const config = loadConfig();
 
   // hasAuth() already verified apiKey exists, but we check again for type safety
   if (!config.apiKey) {
-    output.error('API key not configured', undefined, 2);
+    exitNotAuthenticated();
   }
 
+  const baseUrl = config.apiUrl ?? DEFAULT_API_URL;
   cachedClient = createOmniClient({
-    baseUrl: config.apiUrl ?? 'http://localhost:8882',
+    baseUrl,
     apiKey: config.apiKey,
     cliVersion: VERSION,
-    signRequest: signRequestIfHandshook(),
+    signRequest: signRequestIfHandshook(baseUrl),
   });
 
   return cachedClient;
@@ -63,11 +85,12 @@ export function getOptionalClient(): OmniClient | null {
     return null;
   }
 
+  const baseUrl = config.apiUrl ?? DEFAULT_API_URL;
   cachedClient = createOmniClient({
-    baseUrl: config.apiUrl ?? 'http://localhost:8882',
+    baseUrl,
     apiKey: config.apiKey,
     cliVersion: VERSION,
-    signRequest: signRequestIfHandshook(),
+    signRequest: signRequestIfHandshook(baseUrl),
   });
 
   return cachedClient;
@@ -75,18 +98,25 @@ export function getOptionalClient(): OmniClient | null {
 
 /**
  * Build the SDK's `signRequest` callback when the operator has run
- * `omni trust handshake`. Returns undefined otherwise — the SDK falls
- * back to bearer-only, identical to behavior before P0b.
+ * `omni trust handshake` AGAINST THIS SERVER. Returns undefined otherwise —
+ * the SDK falls back to bearer-only, identical to behavior before P0b.
+ *
+ * The binding check matters once more than one server is registered: only the
+ * server that saw the handshake knows this pubkey, so signing headers sent
+ * elsewhere are noise the verifier may reject outright.
  *
  * Cached at module level: re-loading the keypair from disk on every
- * client creation is wasted I/O.
+ * client creation is wasted I/O. Keyed by URL because a single invocation can
+ * legitimately build clients for different servers.
  */
-let _cachedSigningCtx: SigningContext | null | undefined;
-function signRequestIfHandshook() {
-  if (_cachedSigningCtx === undefined) {
-    _cachedSigningCtx = loadSigningContext();
+const _signingCtxByUrl = new Map<string, SigningContext | null>();
+function signRequestIfHandshook(baseUrl: string) {
+  let ctx = _signingCtxByUrl.get(baseUrl);
+  if (ctx === undefined) {
+    ctx = loadSigningContextForServer(baseUrl);
+    _signingCtxByUrl.set(baseUrl, ctx);
   }
-  if (!_cachedSigningCtx) return undefined;
-  const ctx = _cachedSigningCtx;
-  return (method: string, path: string, body: string) => ctx.signRequest(method, path, body);
+  if (!ctx) return undefined;
+  const bound = ctx;
+  return (method: string, path: string, body: string) => bound.signRequest(method, path, body);
 }

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -9,7 +9,17 @@
 
 import { createOmniClient } from '@omni/sdk';
 import { Command } from 'commander';
-import { deleteConfigValue, getConfigDir, getConfigPath, loadConfig, loadServerConfig, saveConfig } from '../config.js';
+import {
+  deleteConfigValue,
+  getConfigDir,
+  getConfigPath,
+  getTargetServerName,
+  loadConfig,
+  loadLocalRuntimeConfig,
+  loadServerConfig,
+  saveConfig,
+  saveLocalRuntimeConfig,
+} from '../config.js';
 import { credentialStatusFields } from '../lib/credential-status.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, capturePm2, isPm2Available, runPm2 } from '../pm2.js';
@@ -100,7 +110,9 @@ async function restartApiWithNewKey(newKey: string): Promise<{ success: boolean;
     // newly generated key. The other fields (DATABASE_URL, PGSERVE_DATA, etc.)
     // come from `~/.omni/config.json`, NOT from the calling shell.
     const serverConfig = loadServerConfig();
-    const cliConfig = loadConfig();
+    // `auth recover` repairs the LOCAL runtime — read the `default` entry, not
+    // whichever remote entry is active (see runtime-env.ts rule 5).
+    const cliConfig = loadLocalRuntimeConfig();
     const runtimeEnv = { ...buildRuntimeEnv(serverConfig, cliConfig), OMNI_API_KEY: newKey };
 
     // Persist the key via `pm2 set` and bounce the process. We intentionally
@@ -134,14 +146,19 @@ async function validateKey(apiUrl: string, apiKey: string): Promise<boolean> {
 // HELPERS - OUTPUT
 // ============================================================================
 
-/** Update CLI config with a new API key (and optional URL). */
-function updateConfig(apiKey: string, apiUrl?: string): void {
-  const config = loadConfig();
+/**
+ * Update the LOCAL server entry with a recovered/rotated API key (and optional
+ * URL). Only used by `auth recover`, which repairs the locally supervised
+ * omni-api — the key it recovers comes from the local PM2 process, so it must
+ * land in the `default` entry regardless of the active server.
+ */
+function updateLocalConfig(apiKey: string, apiUrl?: string): void {
+  const config = loadLocalRuntimeConfig();
   config.apiKey = apiKey;
   if (apiUrl) {
     config.apiUrl = apiUrl;
   }
-  saveConfig(config);
+  saveLocalRuntimeConfig(config);
 }
 
 /** Print manual recovery instructions when automation fails. */
@@ -191,7 +208,7 @@ async function tryRecoverFromPm2Env(apiUrl: string, apiUrlOverride?: string): Pr
     return false;
   }
 
-  updateConfig(found.key, apiUrlOverride);
+  updateLocalConfig(found.key, apiUrlOverride);
   output.success('API key recovered successfully!', {
     keyPrefix: maskApiKey(found.key),
     configPath: getConfigPath(),
@@ -210,7 +227,7 @@ function handleRotationFailure(newKey: string, processName: string | null, apiUr
     output.warn(`Failed to restart ${processName} with new key.`);
   }
   printManualInstructions(newKey);
-  updateConfig(newKey, apiUrlOverride);
+  updateLocalConfig(newKey, apiUrlOverride);
   output.warn(`Config updated with new key (${maskApiKey(newKey)}) but API restart failed.`);
   output.raw('  After fixing the DB and restarting the API, run: omni status');
   output.raw('');
@@ -237,7 +254,7 @@ async function handleRotationSuccess(
       output.raw(`  Attempt ${attempt + 1} failed, retrying...`);
     }
   }
-  updateConfig(newKey, apiUrlOverride);
+  updateLocalConfig(newKey, apiUrlOverride);
 
   if (valid) {
     output.success('API key rotated and recovered successfully!', {
@@ -294,11 +311,24 @@ export function createAuthCommand(): Command {
   // omni auth login
   auth
     .command('login')
-    .description('Save API credentials')
+    .description('Save API credentials into the targeted server entry')
     .requiredOption('--api-key <key>', 'API key for authentication')
-    .option('--api-url <url>', 'API base URL (default: http://localhost:8882)')
+    .option('--api-url <url>', 'API base URL (default: the targeted server entry URL)')
+    .addHelpText(
+      'after',
+      `
+Credentials are written to the server entry this command targets — the active
+one, or the entry named by the global flag:
+  omni auth login --server prod --api-key <key>
+`,
+    )
     .action(async (options: { apiKey: string; apiUrl?: string }) => {
+      // `loadConfig()` has already resolved the targeted entry (active, or the
+      // one named by the global `--server` flag) into apiUrl/apiKey, and
+      // `saveConfig()` writes back into that same entry — so login is
+      // multi-server aware without any explicit plumbing here.
       const config = loadConfig();
+      const serverName = getTargetServerName();
       config.apiKey = options.apiKey;
 
       if (options.apiUrl) {
@@ -322,7 +352,8 @@ export function createAuthCommand(): Command {
         // Save config
         saveConfig(config);
 
-        output.success('Logged in successfully', {
+        output.success(`Logged in successfully (server: ${serverName})`, {
+          server: serverName,
           apiUrl: config.apiUrl,
           keyName: result.keyName,
           keyPrefix: result.keyPrefix,
@@ -341,9 +372,14 @@ export function createAuthCommand(): Command {
     .description('Show current authentication status')
     .action(async () => {
       const config = loadConfig();
+      const serverName = getTargetServerName();
 
       if (!config.apiKey) {
-        output.error('Not logged in. Run: omni auth login --api-key <key>', undefined, 2);
+        output.error(
+          `Not logged in for server "${serverName}". Run: omni auth login --server ${serverName} --api-key <key>`,
+          undefined,
+          2,
+        );
       }
 
       // Type guard: output.error is never, so apiKey is guaranteed here
@@ -363,6 +399,7 @@ export function createAuthCommand(): Command {
 
         output.data({
           status: 'authenticated',
+          server: serverName,
           apiUrl: config.apiUrl,
           keyName: result.keyName,
           keyPrefix: result.keyPrefix,
@@ -380,10 +417,16 @@ export function createAuthCommand(): Command {
   // omni auth logout
   auth
     .command('logout')
-    .description('Clear stored credentials')
+    .description('Clear stored credentials for the targeted server entry')
     .action(() => {
+      // Scoped by construction: `deleteConfigValue` round-trips through
+      // loadConfig/saveConfig, both of which resolve the SAME targeted entry —
+      // every other entry keeps its key.
+      const serverName = getTargetServerName();
       deleteConfigValue('apiKey');
-      output.success('Logged out successfully');
+      output.success(`Logged out of server "${serverName}" (other server entries keep their keys)`, {
+        server: serverName,
+      });
     });
 
   // omni auth recover
@@ -393,7 +436,7 @@ export function createAuthCommand(): Command {
     .option('--api-url <url>', 'API base URL (default: http://localhost:8882)')
     .option('--rotate', 'Generate a new key instead of recovering the existing one')
     .action(async (options: { apiUrl?: string; rotate?: boolean }) => {
-      const config = loadConfig();
+      const config = loadLocalRuntimeConfig();
       const apiUrl = options.apiUrl ?? config.apiUrl ?? 'http://localhost:8882';
       const shouldRotate = options.rotate === true;
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -11,11 +11,29 @@ import {
   CONFIG_KEYS,
   type ConfigKey,
   deleteConfigValue,
+  describeActiveServer,
   getConfigValue,
+  isServersConfigKey,
   isValidConfigKey,
+  maskConfigApiKey,
   setConfigValue,
 } from '../config.js';
 import * as output from '../output.js';
+
+/**
+ * Reject `servers` / `servers.*` keys with a pointer to `omni server`.
+ *
+ * The registry is deliberately NOT part of `ConfigKey`: that union is closed
+ * and its masking is keyed on the literal `apiKey`, so dynamic
+ * `servers.<name>.apiKey` keys would print credentials unmasked. Exits the
+ * process (via `output.error`) when the key belongs to the registry.
+ */
+function rejectServersKey(key: string): void {
+  if (!isServersConfigKey(key)) return;
+  output.error(`Config key '${key}' is managed by 'omni server', not 'omni config'`, {
+    use: ['omni server list', 'omni server add <name> <url> --api-key <key>', 'omni server use <name>'],
+  });
+}
 
 /** Handle config set with value */
 function handleSetWithValue(key: ConfigKey, value: string): void {
@@ -61,21 +79,24 @@ export function createConfigCommand(): Command {
     .description('List all configuration values')
     .action(() => {
       const items = Object.entries(CONFIG_KEYS).map(([key, meta]) => {
-        let value: string = getConfigValue(key as ConfigKey) ?? '-';
-
-        // Mask API key for security (show first 12 chars and last 4)
-        if (key === 'apiKey' && typeof value === 'string' && value !== '-') {
-          const len = value.length;
-          if (len > 16) {
-            value = `${value.slice(0, 12)}****${value.slice(-4)}`;
-          }
-        }
+        const raw: string = getConfigValue(key as ConfigKey) ?? '-';
+        // Mask API key for security — never echo a full key, however short.
+        const value = key === 'apiKey' && raw !== '-' ? maskConfigApiKey(raw) : raw;
 
         return {
           key,
           value,
           description: meta.description,
         };
+      });
+
+      // Read-only view of the remote-server registry (Decision 10): one row,
+      // key masked, managed exclusively by `omni server`.
+      const active = describeActiveServer();
+      items.push({
+        key: 'servers.active',
+        value: `${active.name} (${active.url}) key=${active.maskedKey}`,
+        description: 'Active server entry (read-only — manage with: omni server)',
       });
 
       output.data(items);
@@ -87,6 +108,7 @@ export function createConfigCommand(): Command {
     .description('Get a configuration value')
     .option('--raw', 'Output only the value (no key label, no formatting)')
     .action((key: string, options: { raw?: boolean }) => {
+      rejectServersKey(key);
       if (!isValidConfigKey(key)) {
         output.error(`Unknown config key: ${key}`, {
           availableKeys: Object.keys(CONFIG_KEYS),
@@ -112,6 +134,7 @@ export function createConfigCommand(): Command {
     .command('set <key> [value]')
     .description('Set or unset a configuration value')
     .action((key: string, value?: string) => {
+      rejectServersKey(key);
       if (!isValidConfigKey(key)) {
         output.error(`Unknown config key: ${key}`, {
           availableKeys: Object.keys(CONFIG_KEYS),
@@ -131,6 +154,7 @@ export function createConfigCommand(): Command {
     .command('unset <key>')
     .description('Remove a configuration value')
     .action((key: string) => {
+      rejectServersKey(key);
       if (!isValidConfigKey(key)) {
         output.error(`Unknown config key: ${key}`, {
           availableKeys: Object.keys(CONFIG_KEYS),

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -52,9 +52,9 @@ import { Command } from 'commander';
 import {
   type Config,
   type ServerConfig,
-  loadConfig,
+  loadLocalRuntimeConfig,
   loadServerConfig,
-  saveConfig,
+  saveLocalRuntimeConfig,
   saveServerConfig,
 } from '../config.js';
 import { getHealthCheckUrl } from '../health.js';
@@ -352,7 +352,9 @@ function productionDeps(): DoctorDeps {
       }
     },
     validateStoredKey: async (apiPort: number) => {
-      const cliConfig = loadConfig();
+      // doctor diagnoses the LOCAL runtime: always the `default` server entry,
+      // never the active remote one (see runtime-env.ts rule 5).
+      const cliConfig = loadLocalRuntimeConfig();
       if (!cliConfig.apiKey) return false;
       const baseUrl = cliConfig.apiUrl ?? `http://localhost:${apiPort}`;
       try {
@@ -365,11 +367,11 @@ function productionDeps(): DoctorDeps {
     },
     loadState: () => ({
       serverConfig: loadServerConfig(),
-      cliConfig: loadConfig(),
+      cliConfig: loadLocalRuntimeConfig(),
     }),
     runPm2,
-    saveCliConfig: saveConfig,
-    reloadCliConfig: loadConfig,
+    saveCliConfig: saveLocalRuntimeConfig,
+    reloadCliConfig: loadLocalRuntimeConfig,
     generateApiKey,
     sleepMs: (ms: number) => Bun.sleep(ms),
     capturePm2Conf: async () => {
@@ -378,7 +380,7 @@ function productionDeps(): DoctorDeps {
       return stdout;
     },
     listLockedInstances: async () => {
-      const cliConfig = loadConfig();
+      const cliConfig = loadLocalRuntimeConfig();
       // Without a stored CLI key we can't even reach /instances. Fall
       // back to "no locked instances visible" rather than crash; the
       // cli-key-valid check already FAILs and surfaces the real problem.

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -25,9 +25,9 @@ import {
   DEFAULT_SERVER_CONFIG,
   type ServerConfig,
   getConfigPath,
-  loadConfig,
+  loadLocalRuntimeConfig,
   loadServerConfig,
-  saveConfig,
+  saveLocalRuntimeConfig,
   saveServerConfig,
 } from '../config.js';
 import { DEFAULT_API_PORT, HEALTH_TIMEOUT_MS, waitForHealth } from '../health.js';
@@ -134,7 +134,9 @@ function resolveFreshConfig(options: InstallOptions): ResolvedConfig {
  * flag overrides (`--port`, `--database-url`, `--api-key`) change values.
  */
 function resolveReinstallConfig(options: InstallOptions): ResolvedConfig {
-  const cliConfig = loadConfig();
+  // `omni install` provisions the LOCAL server — read/write the `default`
+  // entry, never whichever remote entry happens to be active.
+  const cliConfig = loadLocalRuntimeConfig();
   const serverConfig = loadServerConfig();
 
   let databaseUrl = serverConfig.databaseUrl;
@@ -251,8 +253,8 @@ async function startServices(
 // ----------------------------------------------------------------------------
 
 function writeConfigFile(cfg: ResolvedConfig, useCanonicalPgserve: boolean): void {
-  const existing = loadConfig();
-  saveConfig({
+  const existing = loadLocalRuntimeConfig();
+  saveLocalRuntimeConfig({
     ...existing,
     apiUrl: `http://localhost:${cfg.port}`,
     apiKey: cfg.apiKey,

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -12,7 +12,7 @@
  */
 
 import { Command } from 'commander';
-import { loadConfig, loadServerConfig } from '../config.js';
+import { loadLocalRuntimeConfig, loadServerConfig } from '../config.js';
 import { getHealthCheckUrl, waitForHealth } from '../health.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, isPm2Available, pm2NotFoundError, runPm2 } from '../pm2.js';
@@ -35,7 +35,8 @@ async function runRestart(): Promise<void> {
   }
 
   const serverConfig = loadServerConfig();
-  const cliConfig = loadConfig();
+  // LOCAL entry, never the active server — see runtime-env.ts rule 5.
+  const cliConfig = loadLocalRuntimeConfig();
   const apiPort = serverConfig.port;
 
   output.info('Restarting omni services...');

--- a/packages/cli/src/commands/server.ts
+++ b/packages/cli/src/commands/server.ts
@@ -1,0 +1,318 @@
+/**
+ * Server Commands — manage the REMOTE server registry.
+ *
+ *   omni server add <name> <url> [--api-key <key>]   Register a server
+ *   omni server list [--reveal]                      List registered servers
+ *   omni server use <name>                           Switch the active server
+ *   omni server remove <name> [--force]              Drop a server
+ *   omni server current                              Show the targeted server
+ *
+ * Wish: multi-server-management, Group 2.
+ *
+ * NAMING TRAP: this command manages the servers the CLI TALKS TO. The
+ * unrelated `omni config set server.*` namespace configures the LOCAL
+ * omni-api runtime this machine supervises (port, database, data dir). They
+ * are never the same thing — see `ServerEntry` vs `ServerConfig` in config.ts.
+ *
+ * There is deliberately no `omni server health`: reachability is verified as
+ * part of `add`, and live status for the targeted server is `omni status`.
+ */
+
+import { createOmniClient } from '@omni/sdk';
+import { Command } from 'commander';
+import {
+  DEFAULT_SERVER_NAME,
+  type ServerEntry,
+  type ServersConfig,
+  describeActiveServer,
+  hasRuntimeServerOverride,
+  loadServers,
+  maskConfigApiKey,
+  saveServers,
+} from '../config.js';
+import * as output from '../output.js';
+import { normalizeServerUrl } from '../signing.js';
+import { VERSION } from '../version.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Sorted entry names — used in every "unknown server" error. */
+function knownNames(servers: ServersConfig): string[] {
+  return Object.keys(servers.list).sort();
+}
+
+/** Abort naming the entries that DO exist. Guessing a name is the #1 error. */
+function exitUnknownServer(name: string, servers: ServersConfig): never {
+  return output.error(`Unknown server '${name}'`, { knownServers: knownNames(servers) });
+}
+
+/** Row shape for `list` / `current`, with the key masked unless revealed. */
+function toRow(
+  name: string,
+  entry: ServerEntry,
+  servers: ServersConfig,
+  reveal: boolean,
+): Record<string, string | boolean> {
+  return {
+    name,
+    url: entry.url,
+    apiKey: reveal ? (entry.apiKey ?? '-') : maskConfigApiKey(entry.apiKey),
+    active: name === servers.active,
+  };
+}
+
+/**
+ * Outcome of probing a candidate server before it is persisted.
+ *
+ * `unreachable` and `unauthorized` are kept distinct because the operator fix
+ * is completely different: a wrong URL / down server versus a wrong key.
+ */
+type VerifyResult = { ok: true } | { ok: false; kind: 'unreachable' | 'unauthorized'; detail: string };
+
+/**
+ * Probe a candidate server: reachability via the (auth-exempt) health endpoint
+ * first, then key validity. Ordering matters — a dead host would otherwise
+ * surface as "unauthorized" and send the operator hunting for the wrong bug.
+ */
+/**
+ * Reachability probe against the auth-exempt health endpoint, with NO
+ * credentials attached.
+ *
+ * Raw fetch rather than the SDK client on purpose: the client demands a
+ * non-empty apiKey, so a keyless `add` used to hand it the literal placeholder
+ * 'unset'. It also surfaces every non-2xx as a throw, which flattened an
+ * auth-gated health route into "unreachable" and sent the operator hunting for
+ * a network problem instead of a key problem.
+ */
+async function probeHealth(url: string): Promise<VerifyResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${url}/api/v2/health`, {
+      // Accept-Encoding: identity mirrors the SDK — Bun/Hono gzip interop.
+      headers: { 'Accept-Encoding': 'identity', 'x-omni-cli-version': VERSION },
+    });
+  } catch (err) {
+    return { ok: false, kind: 'unreachable', detail: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    return { ok: false, kind: 'unauthorized', detail: `the health endpoint requires credentials (HTTP ${res.status})` };
+  }
+  if (!res.ok) {
+    return { ok: false, kind: 'unreachable', detail: `health check returned HTTP ${res.status} ${res.statusText}` };
+  }
+  return { ok: true };
+}
+
+async function verifyServer(url: string, apiKey: string | undefined): Promise<VerifyResult> {
+  const reachable = await probeHealth(url);
+  if (!reachable.ok) {
+    return reachable;
+  }
+
+  if (!apiKey) {
+    return { ok: true };
+  }
+
+  // Key validity still goes through the SDK, which is the authority on how the
+  // CLI authenticates for real requests.
+  const client = createOmniClient({ baseUrl: url, apiKey, cliVersion: VERSION });
+
+  try {
+    const result = await client.auth.validate();
+    if (!result.valid) {
+      return { ok: false, kind: 'unauthorized', detail: 'the API reported the key as invalid' };
+    }
+  } catch (err) {
+    return { ok: false, kind: 'unauthorized', detail: err instanceof Error ? err.message : String(err) };
+  }
+
+  return { ok: true };
+}
+
+/** Abort with a message that distinguishes "wrong URL" from "wrong key". */
+function exitVerificationFailed(name: string, url: string, failure: Extract<VerifyResult, { ok: false }>): never {
+  const message =
+    failure.kind === 'unreachable'
+      ? `Server '${name}' is unreachable at ${url}: ${failure.detail}`
+      : `Server '${name}' rejected the API key (unauthorized): ${failure.detail}`;
+  return output.error(message, {
+    hint: 'Fix the value, or pass --skip-verify to register the entry anyway.',
+  });
+}
+
+// ============================================================================
+// Subcommand actions
+// ============================================================================
+
+interface AddOptions {
+  apiKey?: string;
+  skipVerify?: boolean;
+  use?: boolean;
+}
+
+async function handleAdd(rawName: string, url: string, options: AddOptions): Promise<void> {
+  // Trim BEFORE both validation and persistence: storing the untrimmed spelling
+  // while validating the trimmed one creates an entry whose name no lookup
+  // (`--server`, `use`, `remove`) can ever type.
+  const name = rawName.trim();
+  if (name.length === 0) {
+    output.error('Server name must not be empty');
+  }
+
+  const servers = loadServers();
+  const normalized = normalizeServerUrl(url);
+
+  if (!options.skipVerify) {
+    const verified = await verifyServer(normalized, options.apiKey);
+    if (!verified.ok) {
+      exitVerificationFailed(name, normalized, verified);
+    }
+  }
+
+  const entry: ServerEntry = { url: normalized };
+  if (options.apiKey) entry.apiKey = options.apiKey;
+
+  const existed = servers.list[name] !== undefined;
+  const next: ServersConfig = {
+    active: options.use ? name : servers.active,
+    list: { ...servers.list, [name]: entry },
+  };
+  saveServers(next);
+
+  if (!options.apiKey) {
+    output.warn(`No API key stored for '${name}'. Run: omni auth login --server ${name} --api-key <key>`);
+  }
+
+  output.success(existed ? `Updated server '${name}'` : `Added server '${name}'`, {
+    name,
+    url: normalized,
+    apiKey: maskConfigApiKey(entry.apiKey),
+    verified: options.skipVerify !== true,
+    active: next.active === name,
+  });
+}
+
+function handleList(options: { reveal?: boolean }): void {
+  const servers = loadServers();
+  const rows = knownNames(servers).map((name) => toRow(name, servers.list[name], servers, options.reveal === true));
+  // No `rawData`: the masked rows ARE the machine-readable payload. Handing
+  // `output.list` the raw entries would leak full keys in --json mode.
+  output.list(rows, { emptyMessage: 'No servers registered. Add one with: omni server add <name> <url>' });
+}
+
+function handleUse(name: string): void {
+  const servers = loadServers();
+  if (!servers.list[name]) {
+    exitUnknownServer(name, servers);
+  }
+
+  saveServers({ active: name, list: servers.list });
+  const entry = servers.list[name];
+  output.success(`Active server is now '${name}' (${entry.url})`, {
+    name,
+    url: entry.url,
+    apiKey: maskConfigApiKey(entry.apiKey),
+  });
+}
+
+/** Pick the entry to fall back to when the ACTIVE one is force-removed. */
+function pickFallbackActive(remaining: Record<string, ServerEntry>): string {
+  if (remaining[DEFAULT_SERVER_NAME]) return DEFAULT_SERVER_NAME;
+  return Object.keys(remaining).sort()[0];
+}
+
+function handleRemove(name: string, options: { force?: boolean }): void {
+  const servers = loadServers();
+  if (!servers.list[name]) {
+    exitUnknownServer(name, servers);
+  }
+
+  const remaining = { ...servers.list };
+  delete remaining[name];
+
+  // Removing the last entry would leave the registry empty and force the next
+  // load to re-derive one from the legacy flat fields, emitting a warning on
+  // every command. Refuse instead — `omni server add` can replace it in place.
+  if (Object.keys(remaining).length === 0) {
+    output.error(`Cannot remove '${name}': it is the only registered server`, {
+      hint: `Point it somewhere else instead: omni server add ${name} <url>`,
+    });
+  }
+
+  if (name === servers.active && !options.force) {
+    output.error(`Cannot remove '${name}': it is the active server`, {
+      hint: `Switch first (omni server use <name>), or pass --force to remove it and fall back to '${pickFallbackActive(remaining)}'.`,
+    });
+  }
+
+  const active = name === servers.active ? pickFallbackActive(remaining) : servers.active;
+  saveServers({ active, list: remaining });
+
+  if (name === DEFAULT_SERVER_NAME) {
+    output.warn(
+      `Removed the '${DEFAULT_SERVER_NAME}' entry — local runtime commands (start/restart/doctor) fall back to http://localhost:8882 with no API key.`,
+    );
+  }
+
+  output.success(`Removed server '${name}'`, { removed: name, active });
+}
+
+function handleCurrent(): void {
+  const servers = loadServers();
+  const target = describeActiveServer();
+  output.data({
+    name: target.name,
+    url: target.url,
+    apiKey: target.maskedKey,
+    // The persisted pointer, which a `--server` override does NOT change.
+    active: servers.active,
+    overridden: hasRuntimeServerOverride(),
+  });
+}
+
+// ============================================================================
+// Command factory
+// ============================================================================
+
+export function createServerCommand(): Command {
+  const server = new Command('server').description('Manage the registry of Omni servers this CLI talks to').addHelpText(
+    'after',
+    `
+Not to be confused with 'omni config set server.*', which configures the LOCAL
+omni-api runtime (port, database, data dir) this machine supervises.
+
+Target one entry for a single command with the global flag:
+  omni --server <name> instances list
+`,
+  );
+
+  server
+    .command('add <name> <url>')
+    .description('Register a server (verifies reachability and key before saving)')
+    .option('--api-key <key>', 'API key for this server')
+    .option('--skip-verify', 'Save the entry without probing the server first')
+    .option('--use', 'Also make this the active server')
+    .action(handleAdd);
+
+  server
+    .command('list')
+    .description('List registered servers (API keys masked)')
+    .option('--reveal', 'Print full API keys instead of masked prefixes')
+    .action(handleList);
+
+  server.command('use <name>').description('Set the active server for subsequent commands').action(handleUse);
+
+  server
+    .command('remove <name>')
+    .alias('rm')
+    .description('Remove a registered server')
+    .option('--force', 'Remove even when it is the active server (falls back to another entry)')
+    .action(handleRemove);
+
+  server.command('current').description('Show the server commands are currently targeting').action(handleCurrent);
+
+  return server;
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import { loadConfig, loadServerConfig } from '../config.js';
+import { loadLocalRuntimeConfig, loadServerConfig } from '../config.js';
 import { getHealthCheckUrl, waitForHealth } from '../health.js';
 import { EMBEDDED_PGSERVE_DATA_DIR, readDataDirMajor } from '../lib/embedded-canonical-migration.js';
 import * as output from '../output.js';
@@ -78,7 +78,8 @@ async function runStart(): Promise<void> {
 
   // 3. Start omni-api via PM2 with complete env from config and hardened flags
   output.info(`Starting ${PM2_PROCESSES.api} (port ${apiPort})...`);
-  const cliConfig = loadConfig();
+  // LOCAL entry, never the active server — see runtime-env.ts rule 5.
+  const cliConfig = loadLocalRuntimeConfig();
   const env = buildRuntimeEnv(serverConfig, cliConfig);
   const launcherPath = getServerLauncherPath();
   const apiArgs = buildPm2StartArgs({

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -17,9 +17,20 @@
 
 import { hostname as osHostname } from 'node:os';
 import { Command } from 'commander';
-import { hasAuth, loadConfig } from '../config.js';
+import { exitNotAuthenticated } from '../client.js';
+import { getTargetServerName, hasAuth, loadConfig } from '../config.js';
 import * as output from '../output.js';
-import { type OmniHostMetadata, generateAndStoreKeypair, loadSigningContext, writeHostMetadata } from '../signing.js';
+import {
+  type OmniHostMetadata,
+  bindingForServer,
+  boundServerBindings,
+  boundServerUrls,
+  generateAndStoreKeypair,
+  loadHostMetadata,
+  loadSigningContextForServer,
+  normalizeServerUrl,
+  writeHostMetadata,
+} from '../signing.js';
 
 interface TrustHost {
   id: string;
@@ -37,13 +48,16 @@ interface TrustHost {
 // Helpers
 // ============================================================================
 
+/** Base URL of the server this invocation targets (active entry or `--server`). */
+function targetBaseUrl(): string {
+  return normalizeServerUrl(loadConfig().apiUrl ?? 'http://localhost:8882');
+}
+
 function trustEndpoint(path: string): string {
   if (!hasAuth()) {
-    output.error('Not authenticated. Run: omni auth login --api-key <key>', undefined, 2);
+    exitNotAuthenticated();
   }
-  const config = loadConfig();
-  const baseUrl = (config.apiUrl ?? 'http://localhost:8882').replace(/\/+$/, '');
-  return `${baseUrl}/api/v2/trust${path}`;
+  return `${targetBaseUrl()}/api/v2/trust${path}`;
 }
 
 function authHeaders(): Record<string, string> {
@@ -56,19 +70,21 @@ function authHeaders(): Record<string, string> {
 }
 
 /**
- * If the operator has run `omni trust handshake`, this returns the
- * signing context that adds the X-Genie-* headers to every call. When no
- * keypair exists locally, it returns null and we go bearer-only — matches
- * the behavior before P0b shipped, no surprise lockout for operators
- * who haven't migrated yet.
+ * If the operator has run `omni trust handshake` AGAINST THE TARGET SERVER,
+ * this returns the signing context that adds the X-Genie-* headers to every
+ * call. When no keypair exists locally — or the target server has never seen
+ * this pubkey — it returns null and we go bearer-only, matching the behavior
+ * before P0b shipped.
  *
  * Pulled out as a module-level lazy cache so we don't re-read the key
- * file on every API call within a single CLI invocation.
+ * file on every API call within a single CLI invocation. The target server
+ * cannot change mid-invocation (`--server` is resolved once, pre-Commander),
+ * so a single-slot cache is sound.
  */
-let _cachedSigningContext: ReturnType<typeof loadSigningContext> | undefined;
-function getSigningContextOnce(): ReturnType<typeof loadSigningContext> {
+let _cachedSigningContext: ReturnType<typeof loadSigningContextForServer> | undefined;
+function getSigningContextOnce(): ReturnType<typeof loadSigningContextForServer> {
   if (_cachedSigningContext === undefined) {
-    _cachedSigningContext = loadSigningContext();
+    _cachedSigningContext = loadSigningContextForServer(targetBaseUrl());
   }
   return _cachedSigningContext;
 }
@@ -156,59 +172,102 @@ async function handleUpdate(id: string, options: { scope: string }): Promise<voi
   }
 }
 
+/**
+ * POST the pubkey to the target server's handshake route.
+ *
+ * We DO NOT sign this request — the server-side handshake route is auth-exempt
+ * by design (it's how new hosts bootstrap) and idempotent, so re-posting an
+ * existing pubkey to a second server registers it there without rotating.
+ */
+async function registerPubkey(
+  pubkey: string,
+  hostname: string,
+): Promise<{ id: string; pubkey: string; hostname: string }> {
+  try {
+    const res = await callApi<{ data: { id: string; pubkey: string; hostname: string } }>('POST', '/handshake', {
+      pubkey,
+      hostname,
+      capabilities: {
+        client: 'omni-cli',
+        platform: process.platform,
+        nodeVersion: process.version,
+      },
+    });
+    return res.data;
+  } catch (err) {
+    return output.error(`Handshake failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 async function handleHandshake(options: { rotate?: boolean; hostname?: string }): Promise<void> {
-  // Refuse to clobber an existing handshake unless --rotate. Quietly
-  // re-using the existing one is the right behavior — handshakes are
-  // idempotent on the server side too — but we want operators to know
-  // when nothing changed.
-  const existing = loadSigningContext();
+  const targetUrl = targetBaseUrl();
+  const serverName = getTargetServerName();
+  const existing = loadHostMetadata();
+
   if (existing && !options.rotate) {
-    output.success(`Already handshook as host ${existing.hostId}. Pass --rotate to issue a new keypair.`);
+    const bindings = boundServerBindings(existing);
+    const bound = boundServerUrls(existing);
+    const alreadyBound = bindingForServer(existing, targetUrl);
+
+    // Already bound to THIS server — nothing to do. Say which servers are
+    // covered: signing is per-server, so an operator with several entries must
+    // know that the rest are still going out bearer-only.
+    if (alreadyBound) {
+      output.success(
+        `Already handshook as host ${alreadyBound.hostId} for server '${serverName}' (${targetUrl}). Bound servers: ${bound.join(', ')} (each with its own host id). Requests to any other server entry are sent UNSIGNED (bearer only) — run \`omni trust handshake --server <name>\` there to bind it. Pass --rotate to issue a new keypair.`,
+      );
+      return;
+    }
+
+    // New server, existing key: register the SAME pubkey. Rotating here would
+    // invalidate the keypair on every server already bound to it. The id this
+    // server issues is stored ON THE BINDING — the top-level `hostId` belongs
+    // to the first server and stamping this one over it would make every
+    // request to the servers already bound 401 as an unknown host.
+    const registered = await registerPubkey(existing.pubkey, options.hostname ?? existing.hostname);
+    const meta: OmniHostMetadata = {
+      ...existing,
+      pubkey: registered.pubkey,
+      boundServers: [...bindings, { url: targetUrl, hostId: registered.id }],
+    };
+    writeHostMetadata(meta);
+
+    output.success(`Bound existing host key to server '${serverName}' (${targetUrl}) — no rotation.`);
+    output.data({
+      hostId: registered.id,
+      hostname: meta.hostname,
+      pubkey: meta.pubkey,
+      boundServers: meta.boundServers,
+      rotated: false,
+    });
     return;
   }
 
   // Generate the keypair (overwrites prior keys when --rotate is set —
   // intentional; rotation is "revoke + re-register with a new key" per
-  // the wish's decision record).
+  // the wish's decision record). Rotation resets the binding list: servers
+  // bound to the OLD key have never seen this one.
   const { pubkeyB64Url } = generateAndStoreKeypair();
   const hostname = options.hostname ?? osHostname();
-  const capabilities = {
-    client: 'omni-cli',
-    platform: process.platform,
-    nodeVersion: process.version,
-  };
-
-  // Hit the handshake endpoint. Note we DO NOT sign this request — the
-  // server-side handshake route is auth-exempt by design (it's how new
-  // hosts bootstrap), and we don't yet have a host_id to put in the
-  // signing headers.
-  let registered: { id: string; pubkey: string; hostname: string };
-  try {
-    registered = await callApi<{ data: { id: string; pubkey: string; hostname: string } }>('POST', '/handshake', {
-      pubkey: pubkeyB64Url,
-      hostname,
-      capabilities,
-    }).then((r) => r.data);
-  } catch (err) {
-    output.error(`Handshake failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
+  const registered = await registerPubkey(pubkeyB64Url, hostname);
 
   const meta: OmniHostMetadata = {
     hostId: registered.id,
     pubkey: registered.pubkey,
     hostname: registered.hostname,
     registeredAt: new Date().toISOString(),
+    boundServers: [{ url: targetUrl, hostId: registered.id }],
   };
   writeHostMetadata(meta);
 
-  output.success(`Operator-host registered: ${meta.hostId}`);
+  output.success(`Operator-host registered: ${meta.hostId} (server: ${serverName})`);
   output.data({
     hostId: meta.hostId,
     hostname: meta.hostname,
     pubkey: meta.pubkey,
+    boundServers: meta.boundServers,
     keysDir: '~/.omni/keys/',
-    nextStep:
-      'Future omni CLI calls will sign requests automatically. Run `omni trust list` to verify (lastSeenAt should advance after subsequent calls).',
+    nextStep: `Calls to '${serverName}' will now be signed automatically; other server entries stay bearer-only until you run \`omni trust handshake --server <name>\` against them. Run \`omni trust list\` to verify (lastSeenAt should advance after subsequent calls).`,
   });
 }
 
@@ -232,9 +291,17 @@ export function createTrustCommand(): Command {
   trust
     .command('handshake')
     .description(
-      'Register THIS omni CLI as a host (mints ed25519 keypair in ~/.omni/keys/, future API calls auto-sign).',
+      'Register THIS omni CLI as a host with the targeted server (mints ed25519 keypair in ~/.omni/keys/ on first run; later servers reuse it).',
     )
-    .option('--rotate', 'Issue a new keypair even if one already exists')
+    .addHelpText(
+      'after',
+      `
+Signing is per-server: only servers you have handshaken against recognize this
+keypair, so calls to other entries stay bearer-only. Bind another one with:
+  omni trust handshake --server <name>
+`,
+    )
+    .option('--rotate', 'Issue a new keypair even if one already exists (unbinds every previously bound server)')
     .option('--hostname <name>', 'Override the hostname reported to omni (defaults to os.hostname())')
     .action(handleHandshake);
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -28,7 +28,7 @@ import { createOmniClient } from '@omni/sdk';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
-import { type Config, loadConfig, loadServerConfig, saveConfig } from '../config.js';
+import { type Config, loadConfig, loadLocalRuntimeConfig, loadServerConfig, saveConfig } from '../config.js';
 import { getHealthCheckUrl } from '../health.js';
 import { type CleanupReport, cleanupLegacyArtifacts } from '../legacy-cleanup.js';
 import * as output from '../output.js';
@@ -217,7 +217,8 @@ async function installLatest(channel: UpdateChannel): Promise<boolean> {
  */
 async function restartPm2Services(processNames: Pm2ProcessName[]): Promise<boolean> {
   const serverConfig = loadServerConfig();
-  const cliConfig = loadConfig();
+  // LOCAL entry, never the active server — see runtime-env.ts rule 5.
+  const cliConfig = loadLocalRuntimeConfig();
   const runtimeEnv = buildRuntimeEnv(serverConfig, cliConfig);
 
   let allSucceeded = true;
@@ -380,7 +381,9 @@ async function fetchHealthBody(apiPort: number, timeoutMs: number): Promise<Heal
  * what to do on failure (typically exit non-zero and point at `omni doctor`).
  */
 async function validateStoredKey(apiPort: number): Promise<boolean> {
-  const cliConfig = loadConfig();
+  // Probes the LOCAL server that was just restarted — must not follow the
+  // active remote entry (see runtime-env.ts rule 5).
+  const cliConfig = loadLocalRuntimeConfig();
   if (!cliConfig.apiKey) {
     return false;
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,6 +7,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { z } from 'zod';
 
 /** Command visibility categories */
 export type CommandCategory = 'core' | 'standard' | 'advanced' | 'debug';
@@ -46,6 +47,42 @@ export type ConfigKey =
   | 'server.logLevel'
   | 'server.nodeEnv';
 
+/**
+ * A single named REMOTE target (an Omni API server the CLI talks to).
+ *
+ * NOTE the naming trap: `ServerEntry` / the `servers` block is the *remote
+ * target registry*. The unrelated `ServerConfig` / `server.*` namespace above
+ * is the **local** omni-api runtime (port, database, data dir) that gets fed
+ * to PM2 by `runtime-env.ts`. They must never be conflated — restarting the
+ * local API with a remote server's API key is the failure mode this split
+ * exists to prevent.
+ */
+export interface ServerEntry {
+  url: string;
+  apiKey?: string;
+}
+
+/** Named remote-server registry plus the active pointer */
+export interface ServersConfig {
+  active: string;
+  list: Record<string, ServerEntry>;
+}
+
+/** Name of the entry that always maps to the LOCAL omni-api runtime */
+export const DEFAULT_SERVER_NAME = 'default';
+
+/** Zod schema for a single server entry (config.json is user-editable) */
+const ServerEntrySchema = z.object({
+  url: z.string().min(1),
+  apiKey: z.string().optional(),
+});
+
+/** Zod schema for the whole `servers` block */
+const ServersConfigSchema = z.object({
+  active: z.string().min(1),
+  list: z.record(z.string(), ServerEntrySchema),
+});
+
 /** Config file structure */
 export interface Config {
   apiUrl?: string;
@@ -56,11 +93,21 @@ export interface Config {
   telemetry?: string; // 'true' or 'false' — error telemetry via Sentry
   updateChannel?: 'latest' | 'next';
   server?: Partial<ServerConfig>;
+  /**
+   * Remote-server registry. Managed exclusively by `omni server` — never by
+   * `omni config set` (see {@link isServersConfigKey}), because `ConfigKey` is
+   * a closed union whose masking rules are literal-keyed and dynamic
+   * `servers.<name>.apiKey` entries would print unmasked.
+   */
+  servers?: ServersConfig;
 }
+
+/** Default API base URL — the locally managed omni-api */
+const DEFAULT_API_URL = 'http://localhost:8882';
 
 /** Default config values */
 const DEFAULT_CONFIG: Config = {
-  apiUrl: 'http://localhost:8882',
+  apiUrl: DEFAULT_API_URL,
   format: 'human',
 };
 
@@ -122,8 +169,137 @@ function ensureConfigDir(): void {
   }
 }
 
-/** Load config from file */
-export function loadConfig(): Config {
+// ----------------------------------------------------------------------------
+// Server registry: validation, migration, resolution
+// ----------------------------------------------------------------------------
+
+/**
+ * Env key carrying the per-invocation `--server <name>` override.
+ *
+ * Uses `process.env` rather than a module-level variable for the same reason
+ * as {@link setRuntimeFormat}: the CLI is bundled and this module can end up
+ * duplicated, so a module-scoped value set by the entrypoint would not be seen
+ * by the copy a command imports.
+ */
+const RUNTIME_SERVER_ENV = '__OMNI_RUNTIME_SERVER';
+
+/** Warnings are emitted at most once per process — `loadConfig()` is hot. */
+const warnedMessages = new Set<string>();
+
+/**
+ * Clear the once-per-process warning dedupe set.
+ *
+ * Test-only: the set is module-global, so without this a warning asserted by
+ * one test is swallowed in every later test in the same process.
+ */
+export function resetConfigWarnings(): void {
+  warnedMessages.clear();
+}
+
+/**
+ * Emit a config warning on stderr.
+ *
+ * Deliberately does NOT use `output.ts`: `output.ts` imports `getOutputFormat`
+ * from this module, so importing it here would be a cycle. stderr keeps
+ * `--json` stdout parseable.
+ */
+function warnConfig(message: string): void {
+  if (warnedMessages.has(message)) return;
+  warnedMessages.add(message);
+  process.stderr.write(`omni: config warning — ${message}\n`);
+}
+
+/**
+ * Validate the raw `servers` block, dropping individual invalid entries rather
+ * than failing the whole load. Returns undefined when nothing salvageable is
+ * left, in which case the caller falls back to the legacy flat fields.
+ */
+function sanitizeServers(raw: unknown): ServersConfig | undefined {
+  if (raw === undefined || raw === null) return undefined;
+
+  const whole = ServersConfigSchema.safeParse(raw);
+  if (whole.success && whole.data.list[whole.data.active]) {
+    return whole.data;
+  }
+
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    warnConfig('"servers" is not an object — ignoring it and using the legacy apiUrl/apiKey fields');
+    return undefined;
+  }
+
+  const rec = raw as { active?: unknown; list?: unknown };
+  const list: Record<string, ServerEntry> = {};
+  if (rec.list && typeof rec.list === 'object' && !Array.isArray(rec.list)) {
+    for (const [name, entry] of Object.entries(rec.list as Record<string, unknown>)) {
+      const parsed = ServerEntrySchema.safeParse(entry);
+      if (name.length > 0 && parsed.success) {
+        list[name] = parsed.data;
+      } else {
+        warnConfig(`dropping invalid server entry "${name}" from ~/.omni/config.json`);
+      }
+    }
+  }
+
+  const names = Object.keys(list);
+  if (names.length === 0) {
+    warnConfig('"servers" has no valid entries — falling back to the legacy apiUrl/apiKey fields');
+    return undefined;
+  }
+
+  if (typeof rec.active === 'string' && list[rec.active]) {
+    return { active: rec.active, list };
+  }
+  const active = list[DEFAULT_SERVER_NAME] ? DEFAULT_SERVER_NAME : names[0];
+  warnConfig(`active server "${String(rec.active)}" is unknown — falling back to "${active}"`);
+  return { active, list };
+}
+
+/**
+ * Lazy migration: derive the `servers` block from a config that predates it by
+ * lifting the flat `apiUrl`/`apiKey` into a `default` entry. Idempotent — an
+ * already-migrated config is returned as-is.
+ */
+function deriveServers(config: Config): ServersConfig {
+  if (config.servers?.list[config.servers.active]) {
+    return config.servers;
+  }
+  const entry: ServerEntry = { url: config.apiUrl ?? DEFAULT_API_URL };
+  if (config.apiKey) entry.apiKey = config.apiKey;
+  return { active: DEFAULT_SERVER_NAME, list: { [DEFAULT_SERVER_NAME]: entry } };
+}
+
+/** Set the per-invocation server override (from the global `--server` flag) */
+export function setRuntimeServer(name: string): void {
+  process.env[RUNTIME_SERVER_ENV] = name;
+}
+
+/** Read the per-invocation server override, if any (internal to this module) */
+function getRuntimeServer(): string | undefined {
+  const name = process.env[RUNTIME_SERVER_ENV];
+  return name && name.length > 0 ? name : undefined;
+}
+
+/** Clear the per-invocation server override (tests / long-lived processes) */
+export function clearRuntimeServer(): void {
+  delete process.env[RUNTIME_SERVER_ENV];
+}
+
+/**
+ * Name of the entry commands should talk to: the `--server` override when it
+ * names a known entry, otherwise the persisted active pointer. The override is
+ * never written back to disk.
+ */
+function resolveActiveName(servers: ServersConfig): string {
+  const override = getRuntimeServer();
+  if (override) {
+    if (servers.list[override]) return override;
+    warnConfig(`unknown server "${override}" — using the active entry "${servers.active}" instead`);
+  }
+  return servers.list[servers.active] ? servers.active : DEFAULT_SERVER_NAME;
+}
+
+/** Read + parse the config file with defaults merged. No server resolution. */
+function readRawConfig(): Config {
   const configPath = getConfigPath();
 
   if (!existsSync(configPath)) {
@@ -133,17 +309,202 @@ export function loadConfig(): Config {
   try {
     const content = readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(content) as Config;
-    return { ...DEFAULT_CONFIG, ...parsed };
+    const merged: Config = { ...DEFAULT_CONFIG, ...parsed };
+    const servers = sanitizeServers((parsed as { servers?: unknown }).servers);
+    if (servers) {
+      merged.servers = servers;
+    } else {
+      merged.servers = undefined;
+    }
+    return merged;
   } catch {
     return { ...DEFAULT_CONFIG };
   }
 }
 
-/** Save config to file */
-export function saveConfig(config: Config): void {
+/** Project the named entry onto the effective flat `apiUrl`/`apiKey` fields. */
+function projectEntry(raw: Config, servers: ServersConfig, name: string): Config {
+  const entry = servers.list[name];
+  if (!entry) {
+    // Only reachable for the LOCAL accessor when `default` was removed. The
+    // on-disk flat fields are not trustworthy here (an older file may mirror
+    // whatever entry was active when it was written), so fall back to the
+    // local defaults with NO credential rather than risk handing a remote key
+    // to the local runtime.
+    return { ...raw, servers, apiUrl: DEFAULT_API_URL, apiKey: undefined };
+  }
+  return { ...raw, servers, apiUrl: entry.url, apiKey: entry.apiKey };
+}
+
+/**
+ * Load config with the ACTIVE server entry resolved into `apiUrl`/`apiKey`.
+ *
+ * This is the accessor for every client-facing path: the ~30 call sites that
+ * read `config.apiUrl` / `config.apiKey` directly become multi-server-aware
+ * without changing. Local-runtime paths must use
+ * {@link loadLocalRuntimeConfig} instead.
+ */
+export function loadConfig(): Config {
+  const raw = readRawConfig();
+  const servers = deriveServers(raw);
+  return projectEntry(raw, servers, resolveActiveName(servers));
+}
+
+/**
+ * Load config with the LOCAL (`default`) entry resolved into
+ * `apiUrl`/`apiKey`, regardless of which server is active.
+ *
+ * Use this for anything that configures or probes the locally managed
+ * omni-api process — `buildRuntimeEnv`, `start`, `restart`, `update`,
+ * `install`, `doctor`, `auth recover`. Resolving the active entry there would
+ * bake a remote server's key into the local PM2 process and make doctor's
+ * env-drift check report permanent drift.
+ */
+export function loadLocalRuntimeConfig(): Config {
+  const raw = readRawConfig();
+  const servers = deriveServers(raw);
+  return projectEntry(raw, servers, DEFAULT_SERVER_NAME);
+}
+
+/**
+ * Canonical form of a server base URL: trimmed, trailing slashes removed.
+ *
+ * Duplicated from `signing.ts:normalizeServerUrl` on purpose — `signing.ts`
+ * imports THIS module (`loadLocalRuntimeConfig`), so importing back would be a
+ * cycle. The two must stay byte-identical in behavior: signing looks a server
+ * up by its normalized URL, so an entry saved with a different spelling
+ * (`https://api.example.com/` vs `…com`) silently stops being signed.
+ */
+function normalizeEntryUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+/** Write the effective `apiUrl`/`apiKey` back into the named server entry. */
+function syncEffectiveIntoEntry(config: Config, name: string): Config {
+  const servers = deriveServers(config);
+  const previous = servers.list[name];
+  // `omni config unset apiUrl` DELETES the key (see {@link deleteConfigValue}),
+  // and an absent key is an explicit clear: reverting to `previous.url` here
+  // would silently restore the value the operator just unset.
+  const cleared = !('apiUrl' in config);
+  const entry: ServerEntry = {
+    url: normalizeEntryUrl(cleared ? DEFAULT_API_URL : (config.apiUrl ?? previous?.url ?? DEFAULT_API_URL)),
+  };
+  if (config.apiKey) entry.apiKey = config.apiKey;
+  const list = { ...servers.list, [name]: entry };
+  // The flat fields are a back-compat mirror for older CLI builds — which feed
+  // them straight into the LOCAL runtime — so they must always mirror the
+  // `default` entry and never a remote one, whatever entry this save targeted.
+  const local = list[DEFAULT_SERVER_NAME];
+  return {
+    ...config,
+    apiUrl: local?.url ?? DEFAULT_API_URL,
+    apiKey: local?.apiKey,
+    // `active` is intentionally carried over untouched: a `--server` override
+    // targets an entry for one invocation and must never be persisted.
+    servers: { active: servers.active, list },
+  };
+}
+
+function writeConfigFile(config: Config): void {
   ensureConfigDir();
   const configPath = getConfigPath();
   writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+/**
+ * Save config, mirroring the effective `apiUrl`/`apiKey` into the entry the
+ * command was targeting (active entry, or the `--server` override). The flat
+ * fields are kept on disk as a back-compat mirror for older CLI builds — of
+ * the `default` (local) entry only, never of a remote one.
+ */
+export function saveConfig(config: Config): void {
+  const servers = deriveServers(config);
+  writeConfigFile(syncEffectiveIntoEntry(config, resolveActiveName(servers)));
+}
+
+/**
+ * Save config, mirroring `apiUrl`/`apiKey` into the LOCAL (`default`) entry.
+ * Counterpart of {@link loadLocalRuntimeConfig} — used by `install` and
+ * `doctor`'s key rotation, which configure the local runtime and must not
+ * write to whichever remote server happens to be active.
+ */
+export function saveLocalRuntimeConfig(config: Config): void {
+  writeConfigFile(syncEffectiveIntoEntry(config, DEFAULT_SERVER_NAME));
+}
+
+/**
+ * Read the remote-server registry (sanitized, with the legacy flat fields
+ * lifted into a `default` entry when the config predates the block).
+ *
+ * Accessor for `omni server` — every other path should go through
+ * {@link loadConfig} / {@link loadLocalRuntimeConfig}.
+ */
+export function loadServers(): ServersConfig {
+  return deriveServers(readRawConfig());
+}
+
+/**
+ * Persist the remote-server registry wholesale.
+ *
+ * Counterpart of {@link loadServers}, used by `omni server add/use/remove`.
+ * Mirrors the flat `apiUrl`/`apiKey` fields from the `default` entry only —
+ * same back-compat contract as {@link saveConfig}, so a remote key can never
+ * leak into the local runtime.
+ */
+export function saveServers(servers: ServersConfig): void {
+  const raw = readRawConfig();
+  const local = servers.list[DEFAULT_SERVER_NAME];
+  writeConfigFile({
+    ...raw,
+    apiUrl: local?.url ?? DEFAULT_API_URL,
+    apiKey: local?.apiKey,
+    servers,
+  });
+}
+
+/**
+ * Name of the entry commands are currently targeting — the `--server`
+ * override when set, otherwise the persisted active pointer.
+ */
+export function getTargetServerName(): string {
+  return resolveActiveName(loadServers());
+}
+
+/** True when a `--server` override is in effect for this invocation. */
+export function hasRuntimeServerOverride(): boolean {
+  return getRuntimeServer() !== undefined;
+}
+
+/**
+ * Mask an API key for display. Never returns the full key: values too short to
+ * carry a recognizable prefix collapse to `***` rather than being echoed.
+ */
+export function maskConfigApiKey(key: string | undefined): string {
+  if (!key) return '-';
+  if (key.length <= 12) return '***';
+  return `${key.slice(0, 12)}...`;
+}
+
+/** Active server entry with its key masked — for read-only display. */
+export function describeActiveServer(): { name: string; url: string; maskedKey: string } {
+  const raw = readRawConfig();
+  const servers = deriveServers(raw);
+  const name = resolveActiveName(servers);
+  const entry = servers.list[name];
+  return {
+    name,
+    url: entry?.url ?? DEFAULT_API_URL,
+    maskedKey: maskConfigApiKey(entry?.apiKey),
+  };
+}
+
+/**
+ * True for keys that belong to the remote-server registry. These are rejected
+ * by `omni config get/set/unset` — see {@link Config.servers}.
+ */
+export function isServersConfigKey(key: string): boolean {
+  return key === 'servers' || key.startsWith('servers.');
 }
 
 /** Get a single config value */
@@ -160,7 +521,7 @@ export function getConfigValue(key: ConfigKey): string | undefined {
     return String(DEFAULT_SERVER_CONFIG[field]);
   }
 
-  return config[key as keyof Omit<Config, 'server'>];
+  return config[key as keyof Omit<Config, 'server' | 'servers'>];
 }
 
 /** Set a server.* config field */
@@ -236,7 +597,10 @@ export function deleteConfigValue(key: ConfigKey): void {
     return;
   }
 
-  (config as Record<string, unknown>)[key] = undefined;
+  // DELETE rather than assign undefined: `syncEffectiveIntoEntry` treats an
+  // absent `apiUrl` key as an explicit clear (an assigned-undefined key is
+  // indistinguishable from "not provided" and would be restored from the entry).
+  delete (config as Record<string, unknown>)[key];
   saveConfig(config);
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,6 +53,7 @@ import { createResyncCommand } from './commands/resync.js';
 import { createSayCommand } from './commands/say.js';
 import { createSeeCommand } from './commands/see.js';
 import { createSendCommand } from './commands/send.js';
+import { createServerCommand } from './commands/server.js';
 import { createSettingsCommand } from './commands/settings.js';
 import { createSpeakCommand } from './commands/speak.js';
 import { createStartCommand } from './commands/start.js';
@@ -66,9 +67,9 @@ import { createUseCommand } from './commands/use.js';
 import { createVoiceCommand } from './commands/voice.js';
 import { createWebhooksCommand } from './commands/webhooks.js';
 import { createWhereCommand } from './commands/where.js';
-import { type CommandCategory, loadConfig, setRuntimeFormat } from './config.js';
+import { type CommandCategory, loadConfig, loadServers, setRuntimeFormat, setRuntimeServer } from './config.js';
 import { type CommandInfo, formatCommandGroups, formatExamples } from './help.js';
-import { areColorsEnabled, disableColors, flushStdout } from './output.js';
+import { areColorsEnabled, disableColors, error as exitWithError, flushStdout } from './output.js';
 
 // Handle --json flag early (before Commander) so it works anywhere in argv
 if (process.argv.includes('--json')) {
@@ -77,6 +78,59 @@ if (process.argv.includes('--json')) {
   const idx = process.argv.indexOf('--json');
   process.argv.splice(idx, 1);
 }
+
+/**
+ * Handle the global `--server <name>` / `--server=<name>` flag before
+ * Commander sees argv — same mechanism as `--json` above, and for the same
+ * reason: the flag must work in any position, including after a subcommand,
+ * without every subcommand declaring it.
+ *
+ * Order matters. This runs before ANY `loadConfig()` / `getClient()` call so
+ * the override is already in place by the time a command resolves its target.
+ */
+function applyServerFlag(): void {
+  const occurrences: number[] = [];
+  for (const [i, arg] of process.argv.entries()) {
+    if (arg === '--server' || arg.startsWith('--server=')) occurrences.push(i);
+  }
+  // A second occurrence would leave the first flag (or its value) in argv after
+  // the single splice below, and Commander would then choke on a stray token.
+  // Reject instead of silently targeting one of the two servers.
+  if (occurrences.length > 1) {
+    exitWithError('duplicate --server flag: pass it at most once');
+  }
+  const idx = occurrences[0] ?? -1;
+  if (idx === -1) return;
+
+  const arg = process.argv[idx];
+  let name: string | undefined;
+  if (arg.startsWith('--server=')) {
+    name = arg.slice('--server='.length);
+    process.argv.splice(idx, 1);
+  } else {
+    // Two-element splice: the flag AND its value. Removing only the flag would
+    // leave a bare server name in argv for Commander to treat as an argument.
+    name = process.argv[idx + 1];
+    process.argv.splice(idx, 2);
+  }
+
+  // A flag-like value means the operator forgot the name (`--server --json`);
+  // treating it as a server name would produce a baffling "unknown server".
+  if (!name || name.length === 0 || name.startsWith('-')) {
+    exitWithError('--server requires a server name (e.g. --server prod)', {
+      knownServers: Object.keys(loadServers().list).sort(),
+    });
+  }
+
+  const servers = loadServers();
+  if (!servers.list[name]) {
+    exitWithError(`Unknown server '${name}'`, { knownServers: Object.keys(servers.list).sort() });
+  }
+
+  setRuntimeServer(name);
+}
+
+applyServerFlag();
 import { selfHealManifestPin } from './manifest-pin.js';
 import { getConfigSummary, getInlineStatus } from './status.js';
 import { captureCliError, flushTelemetry } from './telemetry.js';
@@ -322,6 +376,12 @@ const COMMANDS: CommandDef[] = [
   },
   { create: createEventsCommand, category: 'standard', helpGroup: 'System', helpDescription: 'Query message history' },
   { create: createAuthCommand, category: 'core', helpGroup: 'System', helpDescription: 'Authentication management' },
+  {
+    create: createServerCommand,
+    category: 'core',
+    helpGroup: 'System',
+    helpDescription: 'Registry of Omni servers to talk to (add, use, list)',
+  },
   { create: createSettingsCommand, category: 'standard', helpGroup: 'System', helpDescription: 'Server settings' },
   { create: createBatchCommand, category: 'standard', helpGroup: 'System', helpDescription: 'Batch operations' },
   {
@@ -558,8 +618,9 @@ ${c().bold('Quick Start')}:
   omni events list --limit 10
 
 ${c().bold('Global Flags')}:
-  --json         Output in JSON format (works with any command)
-  --no-color     Disable colored output
+  --json           Output in JSON format (works with any command)
+  --server <name>  Target one registered server for this command only (omni server list)
+  --no-color       Disable colored output
 `;
   return quickStart;
 });

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -24,10 +24,15 @@
  *      when the stored value is the legacy 5432 default.
  *   4. Always include `OMNI_PACKAGES_DIR` (drift-fix between install.ts and
  *      restart.ts) and honor the dynamic `nodeEnv` / `logLevel` from config.
+ *   5. NEVER derive `OMNI_API_KEY` from the *active* server entry. The
+ *      multi-server registry (`config.servers`) lets an operator point the CLI
+ *      at a remote Omni API; the locally supervised process must keep using the
+ *      LOCAL (`default`) entry, so `cliConfig` must always come from
+ *      `loadLocalRuntimeConfig()` — which is also this module's default.
  */
 
 import { join } from 'node:path';
-import type { Config, ServerConfig } from './config.js';
+import { type Config, type ServerConfig, loadLocalRuntimeConfig } from './config.js';
 import {
   CANONICAL_PG_PORT,
   buildDatabaseUrlForTransport,
@@ -212,8 +217,12 @@ function applyScopedCredentials(url: string, creds: { username: string; password
  * `useCanonicalPgserve: false` triggers a one-shot warning surfaced by
  * `omni doctor --fix` (which rewrites the config). The env keys remain
  * in {@link RuntimeEnv} until a future major bumps the env contract.
+ *
+ * `cliConfig` defaults to {@link loadLocalRuntimeConfig} — the LOCAL
+ * (`default`) server entry — so the local process can never inherit a remote
+ * server's API key even if a caller forgets to pass one (see rule 5 above).
  */
-export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config): RuntimeEnv {
+export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config = loadLocalRuntimeConfig()): RuntimeEnv {
   const pgservePort = resolvePgservePort(serverConfig);
   // When the canonical Unix socket is live, also publish PGHOST/PGPORT so
   // postgres.js routes through the socket. See PGHOST doc on RuntimeEnv

--- a/packages/cli/src/signing.ts
+++ b/packages/cli/src/signing.ts
@@ -26,17 +26,54 @@
 import { type KeyObject, createHash, createPrivateKey, sign as edSign, generateKeyPairSync } from 'node:crypto';
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getConfigDir } from './config.js';
+import { getConfigDir, loadLocalRuntimeConfig } from './config.js';
 
 const KEY_FILENAME_PRIV = 'omni-cli.ed25519';
 const KEY_FILENAME_PUB = 'omni-cli.ed25519.pub';
 const HOST_JSON_FILENAME = 'host.json';
 
+/**
+ * One server this keypair is registered with, and the host id THAT server
+ * issued for it.
+ *
+ * The id is per-server: each omni instance mints its own row (its own UUID)
+ * when the pubkey is handshaken there. Carrying a single id across servers
+ * makes every request to the other servers 401 "unknown host", which is why
+ * bindings are (url, hostId) pairs rather than bare urls.
+ */
+export interface ServerBinding {
+  url: string;
+  hostId: string;
+}
+
 export interface OmniHostMetadata {
+  /**
+   * The host id issued by the FIRST server this keypair was registered with.
+   * Kept as the legacy/default id (older CLIs read only this field, and
+   * {@link loadSigningContext} still uses it); never overwritten by binding an
+   * additional server — only a `--rotate` handshake replaces it.
+   */
   hostId: string;
   pubkey: string;
   hostname: string;
   registeredAt: string;
+  /**
+   * Servers this keypair is registered with, each with the host id that server
+   * issued. URLs are normalized by {@link normalizeServerUrl}.
+   *
+   * A handshake registers the pubkey with ONE server; other servers in the
+   * registry have never seen it, so signing headers sent to them are at best
+   * ignored and at worst rejected. Requests therefore carry X-Genie-* headers
+   * only for bound servers — everything else goes bearer-only.
+   *
+   * Legacy shapes are coerced on load (see {@link loadHostMetadata}):
+   *   - ABSENT (host.json written before multi-server support) → bound to the
+   *     local `default` entry, the only server those installs could have
+   *     handshaken against, with the top-level `hostId`.
+   *   - `string[]` (written before per-server ids) → each url paired with the
+   *     top-level `hostId`.
+   */
+  boundServers?: ServerBinding[];
 }
 
 export interface SigningHeaders {
@@ -106,26 +143,115 @@ export function signRequest(opts: {
 }
 
 /**
+ * Canonical form of a server base URL for binding comparisons: trimmed, with
+ * trailing slashes removed. Deliberately conservative — host casing and port
+ * are left alone so `localhost` and `127.0.0.1` stay distinct entries.
+ */
+export function normalizeServerUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Read `~/.omni/keys/host.json`, or null when this CLI has never handshaken.
+ *
+ * Requires the private key to exist too: metadata without a key cannot sign,
+ * and treating that state as "handshook" would make every caller fail later
+ * with a confusing crypto error instead of falling back to bearer-only.
+ */
+export function loadHostMetadata(): OmniHostMetadata | null {
+  const hostJsonFile = hostJsonPath();
+  if (!existsSync(hostJsonFile) || !existsSync(privateKeyPath())) {
+    return null;
+  }
+  const raw = JSON.parse(readFileSync(hostJsonFile, 'utf-8')) as Omit<OmniHostMetadata, 'boundServers'> & {
+    boundServers?: Array<string | ServerBinding>;
+  };
+  return { ...raw, boundServers: coerceBindings(raw.hostId, raw.boundServers) };
+}
+
+/**
+ * Normalize the on-disk `boundServers` value into (url, hostId) pairs.
+ *
+ * Both legacy shapes predate per-server ids, so they can only be attributed to
+ * the top-level `hostId` — which is exactly the id those installs were signing
+ * with, so the coercion is behavior-preserving.
+ */
+function coerceBindings(hostId: string, raw: Array<string | ServerBinding> | undefined): ServerBinding[] {
+  if (!raw || raw.length === 0) {
+    // Absent: legacy install, bound to the LOCAL `default` entry — never the
+    // active one, since a legacy handshake could only have targeted the local API.
+    return [{ url: normalizeServerUrl(loadLocalRuntimeConfig().apiUrl ?? 'http://localhost:8882'), hostId }];
+  }
+  return raw.map((entry) =>
+    typeof entry === 'string'
+      ? { url: normalizeServerUrl(entry), hostId }
+      : { url: normalizeServerUrl(entry.url), hostId: entry.hostId },
+  );
+}
+
+/** Bindings of loaded metadata — always populated by {@link loadHostMetadata}. */
+export function boundServerBindings(meta: OmniHostMetadata): ServerBinding[] {
+  return coerceBindings(meta.hostId, meta.boundServers);
+}
+
+/** Base URLs of the servers this keypair is registered with. */
+export function boundServerUrls(meta: OmniHostMetadata): string[] {
+  return boundServerBindings(meta).map((b) => b.url);
+}
+
+/** The binding for `url`, or undefined when that server has never seen this key. */
+export function bindingForServer(meta: OmniHostMetadata, url: string): ServerBinding | undefined {
+  const normalized = normalizeServerUrl(url);
+  return boundServerBindings(meta).find((b) => b.url === normalized);
+}
+
+/**
+ * Signing context for a specific target server, or null when requests to that
+ * server must go out unsigned (no keypair at all, or a keypair the target
+ * server has never seen).
+ *
+ * Uses the host id THAT server issued — not the top-level one, which belongs to
+ * whichever server was handshaken first.
+ */
+export function loadSigningContextForServer(url: string): SigningContext | null {
+  const meta = loadHostMetadata();
+  if (!meta) {
+    return null;
+  }
+  const binding = bindingForServer(meta, url);
+  if (!binding) {
+    return null;
+  }
+  return buildSigningContext(binding.hostId);
+}
+
+/**
  * Load the operator's signing context from `~/.omni/keys/`. Returns null
  * when no keypair is present (the CLI then continues bearer-only — same
  * behavior as before this module existed).
+ *
+ * Ignores server binding — callers that put headers on the wire should use
+ * {@link loadSigningContextForServer} instead.
  *
  * Errors loading an existing keypair (file unreadable, malformed JSON,
  * etc.) bubble up — silently falling back to bearer would mask a key
  * file that was tampered with or partially written.
  */
 export function loadSigningContext(): SigningContext | null {
-  const hostJsonFile = hostJsonPath();
-  const privKeyFile = privateKeyPath();
-  if (!existsSync(hostJsonFile) || !existsSync(privKeyFile)) {
+  const meta = loadHostMetadata();
+  if (!meta) {
     return null;
   }
-  const meta = JSON.parse(readFileSync(hostJsonFile, 'utf-8')) as OmniHostMetadata;
-  const privKeyBuf = readFileSync(privKeyFile);
+  return buildSigningContext(meta.hostId);
+}
+
+/** Read the private key off disk and bind it to one host id. */
+function buildSigningContext(hostId: string): SigningContext {
+  const privKeyBuf = readFileSync(privateKeyPath());
   const privateKey = createPrivateKey({ key: privKeyBuf });
   return {
-    hostId: meta.hostId,
-    signRequest: (method, path, body) => signRequest({ hostId: meta.hostId, privateKey, method, path, body }),
+    hostId,
+    signRequest: (method, path, body) => signRequest({ hostId, privateKey, method, path, body }),
   };
 }
 

--- a/packages/cli/src/status.ts
+++ b/packages/cli/src/status.ts
@@ -5,7 +5,7 @@
  */
 
 import chalk, { Chalk, type ChalkInstance } from 'chalk';
-import { loadConfig } from './config.js';
+import { describeActiveServer, loadConfig } from './config.js';
 import { areColorsEnabled } from './output.js';
 
 /** Get chalk instance (respects color setting) */
@@ -19,36 +19,39 @@ function c(): ChalkInstance {
 /**
  * Get inline status string for help display (synchronous).
  *
- * Returns config-based status:
- * - "configured (instance-name)" if API key and instance configured
- * - "configured (no default instance)" if API key but no instance
- * - "not configured" if no API key
+ * Returns config-based status, always naming the server entry it describes —
+ * with a registry of several servers, "configured" alone is ambiguous:
+ * - "server=prod, configured (instance-name)" if API key and instance configured
+ * - "server=prod, configured (no default instance)" if API key but no instance
+ * - "server=prod, not configured" if that entry has no API key
  *
  * Note: For live connection status, use `omni status` command.
  */
 export function getInlineStatus(): string {
   const config = loadConfig();
+  const server = `server=${describeActiveServer().name}, `;
 
   if (!config.apiKey) {
-    return c().dim('not configured');
+    return `${server}${c().dim('not configured')}`;
   }
 
   const instance = config.defaultInstance;
   if (instance) {
-    return c().green(`configured (${instance})`);
+    return `${server}${c().green(`configured (${instance})`)}`;
   }
 
-  return c().yellow('configured (no default instance)');
+  return `${server}${c().yellow('configured (no default instance)')}`;
 }
 
 /**
  * Get config summary for help footer.
  *
- * Returns: "instance=name, format=human" or similar
+ * Returns: "server=default, instance=name, format=human" or similar
  */
 export function getConfigSummary(): string {
   const config = loadConfig();
-  const parts: string[] = [];
+  const active = describeActiveServer();
+  const parts: string[] = [`server=${active.name} (${active.url})`];
 
   if (config.defaultInstance) {
     parts.push(`instance=${config.defaultInstance}`);


### PR DESCRIPTION
Implements wish `multi-server-management` (Groups 1–4, all independently reviewed + fix-looped).

## CLI
- `servers` registry in `~/.omni/config.json`: Zod-validated named entries, lazy migration of legacy flat `apiUrl`/`apiKey` into a `default` entry — existing installs upgrade with zero action.
- `omni server add|list|use|remove|current`: add-time verification (reachable vs unauthorized, `--skip-verify`), masked keys (`--reveal` opt-in), active-entry removal protection.
- Global `--server <name>` / `--server=<name>` one-shot override (pre-commander stripping; never persisted).
- Trust-handshake bindings are now per-server `{url, hostId}` pairs: one keypair, per-origin host ids, so binding server B never 401s server A; unbound servers are sent unsigned.
- Local-runtime isolation: `start`/`restart`/`update`/`install`/`doctor`/`auth recover` read a non-resolving `loadLocalRuntimeConfig()` and the flat mirror tracks `default` only — a remote active entry can never leak its key into the local PM2 process (unit-tested).

## UI
- localStorage server registry (`omni-servers` + `omni-active-server`) with legacy `omni-api-key` migration and a same-origin sentinel that keeps resolving `window.location.origin` at call time.
- `switchServer(id, queryClient)` — cache clearing is compiler-enforced; sidebar `ServerSwitcher` dropdown (new shadcn-style `dropdown-menu` primitive) with collapsed-state support; `AddServerDialog` validates against the candidate server before saving and distinguishes CORS/network failures (with an `OMNI_CORS_ORIGINS` hint) from invalid keys.
- `usePersons` raw fetches rewired through the SDK client (the old `baseUrl` reach-in was silently same-origin-only).

## Verification
- 567 CLI tests / 19 UI tests green; typecheck 23/23; biome clean; knip clean for this scope.
- Each group: independent execution review (FIX-FIRST → fixed → re-validated). Highlights fixed during review: flat-mirror remote-key leak, NUL bytes making `sdk.ts` binary to git, re-handshake hostId clobbering (empirically proven), knip entry glob for the first `apps/ui` test file.

Operator note: reaching a **remote** server from the dashboard requires `OMNI_CORS_ORIGINS` on that server (production default is an empty allow-list); the dialog surfaces this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)