### PR TITLE
feat(whatsapp-flows): API-first flow CRUD + encrypted data_exchange endpoint

### DIFF
--- a/docs/channels/whatsapp-flows.md
+++ b/docs/channels/whatsapp-flows.md
@@ -1,0 +1,158 @@
+# WhatsApp Flows
+
+WhatsApp Flows are in-chat interactive forms/screens (Meta Cloud API channel
+only). Omni supports the full lifecycle: create/update/publish flows via API,
+send them as interactive messages, receive completions, and — for **dynamic
+flows** — host Meta's encrypted data-exchange endpoint so screens can be
+resolved server-side mid-flow.
+
+## Two flavors
+
+| | Static (`navigate`) | Dynamic (`data_exchange`) |
+|---|---|---|
+| Screens | All in Flow JSON, resolved on-device | Decided per-step by omni's data endpoint |
+| Server calls during the flow | None | `INIT` → screen, each submit → next screen |
+| Requirements | Published/draft flow | + encryption keys + `META_FLOWS_PUBLIC_BASE_URL` + a registered resolver |
+| Result delivery | `nfm_reply` webhook at completion | Same, plus per-step `flow.data_exchange` events |
+
+## Management API
+
+All routes live under `/api/v2/instances/:id/whatsapp-flows` (scope:
+`instances:read`/`instances:write`).
+
+```
+GET    /                       list flows
+POST   /                       create  { name, categories, flowJson?, publish?, dynamic? }
+GET    /:flowId                status + validationErrors + endpointUri + preview
+PUT    /:flowId                update  { flowJson?, name?, categories?, dynamic? }
+DELETE /:flowId                delete (DRAFT only)
+POST   /:flowId/publish        publish
+POST   /:flowId/deprecate      retire a published flow
+GET    /:flowId/preview        browser preview URL
+POST   /send                   send  { to, flowId|flowName, cta, bodyText, ..., flowAction? }
+POST   /keys                   generate + register encryption keys (repeat = rotate)
+GET    /keys                   key status (local presence + Meta signature_status)
+```
+
+Create/update run **local Flow JSON validation** (`validateFlowJson` in
+`@omni/core`) before contacting Meta — catching the errors Meta reports only
+after an upload round-trip (or not at all) — and always return Meta's
+`validationErrors` in the response.
+
+### Flow JSON gotchas (enforced locally)
+
+- `RichText.text` must be a **string** (arrays fail v6.3 validation).
+- `RichText` must be **alone on its screen** (Footer excepted).
+- `data_api_version` ⇔ dynamic: a flow with `data_api_version` but no
+  registered `endpoint_uri` shows **"an error occurred"** on open, with no
+  webhook trace. `dynamic: true` wires the endpoint and requires
+  `data_api_version: '3.0'`; static flows must omit it.
+- At least one `terminal: true` screen; `routing_model` / `navigate` targets
+  must reference declared screens.
+
+### Authoring DX
+
+Use the SDK's fluent builder (`@omni/sdk` → `flow()`) instead of hand-writing
+JSON — it enforces the same rules at `build()` time:
+
+```typescript
+import { flow } from '@omni/sdk';
+
+const { flowJson } = flow({ version: '6.3' })
+  .screen('INTRO', { title: 'Welcome' }, (s) => {
+    s.image(base64Png, { height: 240 });
+    s.heading('Hi there!');
+    s.footerNavigate('Start', 'FORM');
+  })
+  .screen('FORM', { title: 'About you', terminal: true }, (s) => {
+    s.form('form', (f) => {
+      f.textInput('name', 'Your name', { required: true });
+      f.dropdown('channel', 'Channel', [{ id: 'wa', title: 'WhatsApp' }]);
+      f.footerComplete('Submit', { name: '${form.name}', channel: '${form.channel}' });
+    });
+  })
+  .build();
+```
+
+## Sending + receiving
+
+`POST .../send` dispatches through the channel plugin (`content.type: 'flow'`)
+and returns `{ messageId, flowToken }`. The token is echoed back verbatim in
+the completion webhook — persist it to correlate. When omitted, omni generates
+a **structured token** `omni.<flowId>.<uuid>` (this is how the data endpoint
+knows which flow it is serving — Meta's decrypted payload has no flow id).
+
+Completion arrives as a normal inbound message with
+`interactive.type: 'nfm_reply'`; the answers are in
+`nfm_reply.response_json` (preserved in `rawPayload`, surfaced to the timeline
+as text). Multi-select fields arrive as arrays, OptIn as boolean, DatePicker
+as `YYYY-MM-DD`.
+
+## Dynamic flows (data_exchange)
+
+Setup, once per instance:
+
+1. Set `META_FLOWS_PUBLIC_BASE_URL` (public HTTPS base, e.g. the ngrok URL in
+   dev). The data endpoint is
+   `POST {base}/api/v2/channels/whatsapp-cloud/flows/data/:instanceId`
+   (auth-exempt; authenticated by Meta's HMAC signature + the fact that only
+   the registered key can decrypt).
+2. `POST .../whatsapp-flows/keys` — generates a 2048-bit RSA keypair, uploads
+   the public half to Meta (`whatsapp_business_encryption`), stores the
+   private half sealed (`whatsapp_flow_keys` table). POST again to rotate.
+   `GET .../keys` reports Meta's `signature_status` — **MISMATCH means Meta
+   encrypts with a key you no longer hold → endless 421s → rotate.**
+3. Create the flow with `dynamic: true` (Flow JSON must carry
+   `data_api_version: '3.0'`; screens submitted with `footerDataExchange`).
+4. Register a resolver (in-process — must answer within ~8s):
+
+```typescript
+import plugin from '@omni/channel-whatsapp-cloud';
+
+plugin.flowResolvers.register('<flowId>', {
+  resolve: async ({ action, screen, data, flowToken }) => {
+    if (action === 'INIT') return { screen: 'STEP_1', data: { options: [...] } };
+    if (screen === 'STEP_1') return { screen: 'STEP_2', data: { summary: ... } };
+    return {
+      screen: 'SUCCESS',
+      data: { extension_message_response: { params: { flow_token: flowToken, outcome: 'done' } } },
+    };
+  },
+});
+```
+
+`registerInstanceDefault(instanceId, resolver)` catches flows sent with
+caller-supplied (opaque) tokens. Send dynamic flows with
+`flowAction: 'data_exchange'`.
+
+Every endpoint hit (except pings) also publishes a **`flow.data_exchange`**
+event (instanceId, flowId, flowToken, action, screen, data, responseScreen,
+durationMs) for observability/async consumers.
+
+### Endpoint status codes (Meta contract)
+
+| Code | Meaning | Client behavior |
+|---|---|---|
+| 200 | Encrypted next-screen response | renders screen |
+| 404 | Unknown instance in URL | generic error |
+| 421 | Can't decrypt (missing/rotated key) | re-fetches public key, retries |
+| 427 | Bad/absent flow token | tells user to re-open the flow |
+| 432 | HMAC signature verification failed | drops request |
+
+Resolver errors/timeouts degrade to an in-screen `error_message` snackbar —
+the endpoint never hangs and never 5xxs for resolver failures.
+
+## Key files
+
+| Piece | Path |
+|---|---|
+| Local Flow JSON validator | `packages/core/src/schemas/whatsapp-flows.ts` |
+| Management routes | `packages/api/src/routes/v2/whatsapp-flows.ts` |
+| Public data endpoint mount | `packages/api/src/app.ts` (flows/data) |
+| Crypto (RSA-OAEP + AES-GCM) | `packages/channel-whatsapp-cloud/src/utils/flow-crypto.ts` |
+| Endpoint handler | `packages/channel-whatsapp-cloud/src/handlers/flow-data.ts` |
+| Resolver registry + tokens | `packages/channel-whatsapp-cloud/src/flows/resolver.ts` |
+| Flow sender | `packages/channel-whatsapp-cloud/src/senders/flow.ts` |
+| Graph API client (flows section) | `packages/channel-whatsapp-cloud/src/client.ts` |
+| SDK builder | `packages/sdk/src/flow-builder.ts` |
+| Key storage | `packages/db/src/schema.ts` (`whatsapp_flow_keys`) |

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5,14 +5,17 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import type { ChannelRegistry } from '@omni/channel-sdk';
+import type { WhatsAppCloudPlugin } from '@omni/channel-whatsapp-cloud';
 import { type EventBus, createLogger } from '@omni/core';
-import type { Database, Instance } from '@omni/db';
+import { type Database, type Instance, whatsappFlowKeys } from '@omni/db';
+import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { serveStatic } from 'hono/bun';
 import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
 import { timing } from 'hono/timing';
+import { openCredentialField } from './tenancy/sealed-credentials';
 
 const httpLog = createLogger('http');
 
@@ -350,6 +353,53 @@ export function createApp(
     }
 
     return plugin.handleWebhook(c.req.raw);
+  });
+
+  // Public WhatsApp Flows data-exchange endpoint — auth-exempt sibling of the
+  // webhook above. Authenticated by X-Hub-Signature-256 + payload encryption
+  // (only the instance's registered private key can decrypt). `:instanceId`
+  // selects the keypair; the whatsapp-flows routes set this URL as the flow's
+  // `endpoint_uri` when created/updated with `dynamic: true`.
+  //
+  // Instance lookup + private-key unsealing happen HERE (the API owns DB and
+  // sealing); signature/crypto/screen-resolution happen in the plugin
+  // (`handleFlowData` → handlers/flow-data.ts). Status codes are part of
+  // Meta's contract: 404 unknown instance, 421 undecryptable (client
+  // re-fetches the public key), 427 bad flow token, 432 bad signature.
+  app.post('/api/v2/channels/whatsapp-cloud/flows/data/:instanceId', async (c) => {
+    const channelRegistry = c.get('channelRegistry');
+
+    if (!channelRegistry) {
+      return c.json({ error: { code: 'NO_REGISTRY', message: 'Channel registry not available' } }, 503);
+    }
+
+    const plugin = channelRegistry.get('whatsapp-cloud') as WhatsAppCloudPlugin | undefined;
+    if (!plugin?.handleFlowData) {
+      return c.json({ error: { code: 'PLUGIN_NOT_FOUND', message: 'WhatsApp Cloud plugin not loaded' } }, 503);
+    }
+
+    const instanceId = c.req.param('instanceId');
+    const services = c.get('services');
+    const instance = await services.instances.getById(instanceId).catch(() => null);
+    if (!instance || instance.channel !== 'whatsapp-cloud') {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'Unknown instance' } }, 404);
+    }
+
+    const db = c.get('db');
+    const [keyRow] = await db
+      .select()
+      .from(whatsappFlowKeys)
+      .where(eq(whatsappFlowKeys.instanceId, instanceId))
+      .limit(1);
+    // No key row, or sealed under a key we can't open → 421: Meta re-fetches
+    // the public key and ops gets a signal instead of a silent decrypt loop.
+    const privateKeyPem = keyRow ? openCredentialField(instance.tenantId, keyRow.privateKeyPem) : null;
+    if (!privateKeyPem) {
+      httpLog.warn('Flow data request without usable private key', { instanceId, hasKeyRow: Boolean(keyRow) });
+      return c.body(null, 421);
+    }
+
+    return plugin.handleFlowData(c.req.raw, { instanceId, privateKeyPem });
   });
 
   // Public Twilio WhatsApp webhook endpoint - auth-exempt, verified by X-Twilio-Signature in the plugin.

--- a/packages/api/src/constants/scopes.ts
+++ b/packages/api/src/constants/scopes.ts
@@ -354,7 +354,13 @@ export const SCOPE_MAP: Record<string, string> = {
   // --- whatsapp-flows (mounted at root: /instances/:id/whatsapp-flows/...) ---
   'GET /instances/:id/whatsapp-flows': 'instances:read',
   'POST /instances/:id/whatsapp-flows': 'instances:write',
+  'GET /instances/:id/whatsapp-flows/keys': 'instances:read',
+  'POST /instances/:id/whatsapp-flows/keys': 'instances:write',
+  'GET /instances/:id/whatsapp-flows/:flowId': 'instances:read',
+  'PUT /instances/:id/whatsapp-flows/:flowId': 'instances:write',
+  'DELETE /instances/:id/whatsapp-flows/:flowId': 'instances:write',
   'POST /instances/:id/whatsapp-flows/:flowId/publish': 'instances:write',
+  'POST /instances/:id/whatsapp-flows/:flowId/deprecate': 'instances:write',
   'GET /instances/:id/whatsapp-flows/:flowId/preview': 'instances:read',
   'POST /instances/:id/whatsapp-flows/send': 'instances:write',
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -214,6 +214,23 @@ async function initializeChannelPlugins(db: Database, eventBus: EventBus): Promi
     pluginLog.warn('Some channel plugins failed to load', { failed: result.failed });
   }
 
+  // Smoke-test harness for the WhatsApp Flows data-exchange path: register the
+  // reference resolver as the given instance's default. Env-gated — set
+  // META_FLOWS_DEMO_INSTANCE=<instanceId> in dev only; without it nothing is
+  // registered and unresolved flows degrade to an in-screen error message.
+  const flowsDemoInstance = process.env.META_FLOWS_DEMO_INSTANCE;
+  if (flowsDemoInstance) {
+    const waCloud = result.registry.get('whatsapp-cloud');
+    if (waCloud && 'flowResolvers' in waCloud) {
+      const { createDemoFlowResolver } = await import('@omni/channel-whatsapp-cloud');
+      (waCloud as import('@omni/channel-whatsapp-cloud').WhatsAppCloudPlugin).flowResolvers.registerInstanceDefault(
+        flowsDemoInstance,
+        createDemoFlowResolver(),
+      );
+      pluginLog.info('WhatsApp Flows demo resolver registered', { instanceId: flowsDemoInstance });
+    }
+  }
+
   // Auto-reconnect previously active instances.
   //
   // G5 (ADR-0008/ADR-0003): the startup reconnect is a whole-table `instances`

--- a/packages/api/src/routes/openapi.ts
+++ b/packages/api/src/routes/openapi.ts
@@ -46,6 +46,7 @@ import { registerProviderSchemas } from '../schemas/openapi/providers';
 import { registerSettingsSchemas } from '../schemas/openapi/settings';
 import { registerVoiceSchemas } from '../schemas/openapi/voice';
 import { registerWebhookSchemas } from '../schemas/openapi/webhooks';
+import { registerWhatsappFlowsSchemas } from '../schemas/openapi/whatsapp-flows';
 
 // Register all schemas
 registerAgentSchemas(registry);
@@ -71,6 +72,7 @@ registerJourneySchemas(registry);
 registerConversationSchemas(registry);
 registerFollowUpSchemas(registry);
 registerVoiceSchemas(registry);
+registerWhatsappFlowsSchemas(registry);
 // Flag-gated, but still documented: "no REST endpoints without OpenAPI docs"
 // has no exception for a surface that 404s when the flag is off.
 registerPlatformTenantSchemas(registry);

--- a/packages/api/src/routes/v2/__tests__/whatsapp-flows.test.ts
+++ b/packages/api/src/routes/v2/__tests__/whatsapp-flows.test.ts
@@ -144,7 +144,7 @@ describe('POST /instances/:id/whatsapp-flows', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(await res.json()).toEqual({ data: { id: 'FLOW-NEW' } });
+    expect(await res.json()).toEqual({ data: { id: 'FLOW-NEW', endpointUri: null, validationErrors: [] } });
     expect(calls[0]?.url).toContain('/WABA-1/flows');
     expect(calls[0]?.method).toBe('POST');
     expect(calls[0]?.body).toEqual({ name: 'Onboarding', categories: ['SIGN_UP'], publish: false });

--- a/packages/api/src/routes/v2/__tests__/whatsapp-flows.test.ts
+++ b/packages/api/src/routes/v2/__tests__/whatsapp-flows.test.ts
@@ -228,7 +228,8 @@ describe('POST /instances/:id/whatsapp-flows/send', () => {
     expect(res.status).toBe(201);
     const json = (await res.json()) as { messageId: string; flowToken: string };
     expect(json.messageId).toBe('wamid.SENT-FLOW');
-    expect(json.flowToken).toMatch(/^[0-9a-f-]{36}$/);
+    // Structured token: omni.<flowRef>.<uuid> — the data endpoint parses the ref out.
+    expect(json.flowToken).toMatch(/^omni\.FLOW-1\.[0-9a-f-]{36}$/);
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const [instanceId, message] = sendMessage.mock.calls[0] as [

--- a/packages/api/src/routes/v2/whatsapp-flows.ts
+++ b/packages/api/src/routes/v2/whatsapp-flows.ts
@@ -15,7 +15,7 @@
  */
 
 import { zValidator } from '@hono/zod-validator';
-import { MetaWhatsAppClient, generateFlowKeyPair } from '@omni/channel-whatsapp-cloud';
+import { MetaWhatsAppClient, buildFlowToken, generateFlowKeyPair } from '@omni/channel-whatsapp-cloud';
 import { createLogger } from '@omni/core';
 import { WhatsAppFlowSendSchema, validateFlowJson } from '@omni/core/schemas';
 import { whatsappFlowKeys } from '@omni/db';
@@ -521,8 +521,10 @@ whatsappFlowsRoutes.post(
     }
 
     // Generate the correlation token here so it can be returned to the caller
-    // — the nfm_reply webhook echoes it back verbatim.
-    const flowToken = flow.flowToken ?? crypto.randomUUID();
+    // — the nfm_reply webhook echoes it back verbatim. Structured
+    // (`omni.<flowRef>.<uuid>`) so the data-exchange endpoint can recover
+    // which flow it is serving; caller-supplied tokens pass through opaque.
+    const flowToken = flow.flowToken ?? buildFlowToken(flow.flowId ?? flow.flowName ?? 'unknown');
 
     const result = await plugin.sendMessage(instanceId, {
       to,

--- a/packages/api/src/routes/v2/whatsapp-flows.ts
+++ b/packages/api/src/routes/v2/whatsapp-flows.ts
@@ -15,12 +15,15 @@
  */
 
 import { zValidator } from '@hono/zod-validator';
-import { MetaWhatsAppClient } from '@omni/channel-whatsapp-cloud';
+import { MetaWhatsAppClient, generateFlowKeyPair } from '@omni/channel-whatsapp-cloud';
 import { createLogger } from '@omni/core';
-import { WhatsAppFlowSendSchema } from '@omni/core/schemas';
+import { WhatsAppFlowSendSchema, validateFlowJson } from '@omni/core/schemas';
+import { whatsappFlowKeys } from '@omni/db';
+import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { requireInstanceAccess } from '../../middleware/auth';
+import { sealCredentialField } from '../../tenancy/sealed-credentials';
 import type { AppVariables } from '../../types';
 import { ensureWhatsAppCloud } from './whatsapp-cloud';
 
@@ -62,7 +65,26 @@ const createBodySchema = z.object({
   flowJson: z.string().min(1).optional(),
   /** Publish immediately after creation (requires valid flowJson). */
   publish: z.boolean().optional(),
+  /**
+   * Endpoint-backed (data_exchange) flow: the server registers this omni
+   * install's public flows-data URL as the flow's `endpoint_uri`. Requires
+   * META_FLOWS_PUBLIC_BASE_URL and a Flow JSON with data_api_version '3.0'.
+   */
+  dynamic: z.boolean().optional(),
 });
+
+const updateBodySchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    categories: z.array(FlowCategorySchema).min(1).optional(),
+    /** Replaces the flow's screens (POST /{flow_id}/assets). */
+    flowJson: z.string().min(1).optional(),
+    /** Re-point (or newly point) the flow at this install's data endpoint. */
+    dynamic: z.boolean().optional(),
+  })
+  .refine((v) => v.name || v.categories || v.flowJson || v.dynamic !== undefined, {
+    message: 'Provide at least one of name, categories, flowJson, dynamic',
+  });
 
 const sendBodySchema = WhatsAppFlowSendSchema.and(
   z.object({
@@ -108,7 +130,7 @@ function readMetaConfig(instance: {
 }
 
 type FlowsClientResolution =
-  | { ok: true; client: MetaWhatsAppClient }
+  | { ok: true; client: MetaWhatsAppClient; instance: { id: string; tenantId: string | null } }
   | { ok: false; payload: { error: { code: string; message: string } } };
 
 /**
@@ -131,7 +153,29 @@ async function resolveFlowsClient(
     { accessToken: cfg.accessToken, phoneNumberId: cfg.phoneNumberId, apiVersion: cfg.apiVersion },
     cfg.wabaId,
   );
-  return { ok: true, client };
+  return { ok: true, client, instance: { id: instance.id, tenantId: instance.tenantId ?? null } };
+}
+
+/**
+ * Public flows-data URL for `instanceId` — becomes the flow's `endpoint_uri`
+ * for dynamic flows. Null when META_FLOWS_PUBLIC_BASE_URL is unset (dynamic
+ * flows are rejected with a clear error instead of registering a dead URL).
+ */
+function flowsDataEndpointUri(instanceId: string): string | null {
+  const base = process.env.META_FLOWS_PUBLIC_BASE_URL?.replace(/\/+$/, '');
+  if (!base) return null;
+  return `${base}/api/v2/channels/whatsapp-cloud/flows/data/${instanceId}`;
+}
+
+/** 422 payload for local Flow JSON validation failures (pre-Meta feedback). */
+function flowJsonInvalid(issues: ReturnType<typeof validateFlowJson>['issues']) {
+  return {
+    error: {
+      code: 'INVALID_FLOW_JSON',
+      message: 'Flow JSON failed local validation (checked before contacting Meta)',
+    },
+    issues,
+  } as const;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -173,13 +217,243 @@ whatsappFlowsRoutes.post(
     const resolved = await resolveFlowsClient(c.get('services'), instanceId);
     if (!resolved.ok) return c.json(resolved.payload, 400);
 
+    let endpointUri: string | undefined;
+    if (body.dynamic) {
+      const uri = flowsDataEndpointUri(instanceId);
+      if (!uri) {
+        return c.json(
+          jsonError('dynamic flows require META_FLOWS_PUBLIC_BASE_URL to be configured', 'NOT_CONFIGURED'),
+          400,
+        );
+      }
+      endpointUri = uri;
+    }
+
+    // Local validation catches the silent killers (data_api_version without an
+    // endpoint, RichText placement) before any Graph API round-trip.
+    if (body.flowJson) {
+      const local = validateFlowJson(body.flowJson, { dynamic: body.dynamic });
+      if (!local.valid) return c.json(flowJsonInvalid(local.issues), 422);
+    }
+
     const result = await resolved.client.createFlow({
       name: body.name,
       categories: body.categories,
       flowJson: body.flowJson,
       publish: body.publish,
+      endpointUri,
     });
-    return c.json({ data: { id: result.id } }, 201);
+    return c.json(
+      {
+        data: {
+          id: result.id,
+          endpointUri: endpointUri ?? null,
+          // Meta-side validation errors — a flow can be created and still be unopenable.
+          validationErrors: result.validation_errors ?? [],
+        },
+      },
+      201,
+    );
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data-endpoint encryption keys — registered BEFORE the :flowId routes so
+// the literal 'keys' segment never matches as a flow id.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// POST /instances/:id/whatsapp-flows/keys — generate + register (or rotate)
+whatsappFlowsRoutes.post(
+  '/instances/:id/whatsapp-flows/keys',
+  instanceAccess,
+  zValidator('param', idParamSchema),
+  async (c) => {
+    const { id: instanceId } = c.req.valid('param');
+    const resolved = await resolveFlowsClient(c.get('services'), instanceId);
+    if (!resolved.ok) return c.json(resolved.payload, 400);
+
+    const { privateKeyPem, publicKeyPem } = await generateFlowKeyPair();
+    await resolved.client.uploadBusinessPublicKey(publicKeyPem);
+
+    // Sealed under the owning instance's tenant — the public data route
+    // unseals with instance.tenantId, so the pair stays symmetric.
+    const sealedPrivateKey = sealCredentialField(resolved.instance.tenantId, privateKeyPem);
+    const now = new Date();
+    const db = c.get('db');
+    await db
+      .insert(whatsappFlowKeys)
+      .values({
+        instanceId,
+        privateKeyPem: sealedPrivateKey,
+        publicKeyPem,
+        uploadedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: whatsappFlowKeys.instanceId,
+        set: {
+          privateKeyPem: sealedPrivateKey,
+          publicKeyPem,
+          uploadedAt: now,
+          updatedAt: now,
+        },
+      });
+
+    const status = await resolved.client.getBusinessPublicKey().catch(() => null);
+    log.info('flow encryption key registered', { instanceId });
+    return c.json(
+      {
+        data: {
+          uploaded: true,
+          signatureStatus: status?.business_public_key_signature_status ?? null,
+          endpointUri: flowsDataEndpointUri(instanceId),
+        },
+      },
+      201,
+    );
+  },
+);
+
+// GET /instances/:id/whatsapp-flows/keys — local presence + Meta signature status
+whatsappFlowsRoutes.get(
+  '/instances/:id/whatsapp-flows/keys',
+  instanceAccess,
+  zValidator('param', idParamSchema),
+  async (c) => {
+    const { id: instanceId } = c.req.valid('param');
+    const resolved = await resolveFlowsClient(c.get('services'), instanceId);
+    if (!resolved.ok) return c.json(resolved.payload, 400);
+
+    const db = c.get('db');
+    const [keyRow] = await db
+      .select({ uploadedAt: whatsappFlowKeys.uploadedAt, createdAt: whatsappFlowKeys.createdAt })
+      .from(whatsappFlowKeys)
+      .where(eq(whatsappFlowKeys.instanceId, instanceId))
+      .limit(1);
+
+    const remote = await resolved.client.getBusinessPublicKey().catch(() => null);
+    return c.json({
+      data: {
+        hasLocalKey: Boolean(keyRow),
+        uploadedAt: keyRow?.uploadedAt ?? null,
+        // MISMATCH → Meta encrypts with a key we no longer hold → 421 loop; rotate via POST.
+        signatureStatus: remote?.business_public_key_signature_status ?? null,
+        endpointUri: flowsDataEndpointUri(instanceId),
+      },
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /instances/:id/whatsapp-flows/:flowId — status + validation + endpoint
+// ─────────────────────────────────────────────────────────────────────────────
+
+whatsappFlowsRoutes.get(
+  '/instances/:id/whatsapp-flows/:flowId',
+  instanceAccess,
+  zValidator('param', flowIdParamSchema),
+  async (c) => {
+    const { id: instanceId, flowId } = c.req.valid('param');
+    const resolved = await resolveFlowsClient(c.get('services'), instanceId);
+    if (!resolved.ok) return c.json(resolved.payload, 400);
+
+    const flow = await resolved.client.getFlow(flowId);
+    return c.json({
+      data: {
+        id: flow.id,
+        name: flow.name,
+        status: flow.status,
+        categories: flow.categories,
+        validationErrors: flow.validation_errors ?? [],
+        endpointUri: flow.endpoint_uri ?? null,
+        preview: flow.preview ?? null,
+      },
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PUT /instances/:id/whatsapp-flows/:flowId — update screens and/or properties
+// ─────────────────────────────────────────────────────────────────────────────
+
+whatsappFlowsRoutes.put(
+  '/instances/:id/whatsapp-flows/:flowId',
+  instanceAccess,
+  zValidator('param', flowIdParamSchema),
+  zValidator('json', updateBodySchema),
+  async (c) => {
+    const { id: instanceId, flowId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const resolved = await resolveFlowsClient(c.get('services'), instanceId);
+    if (!resolved.ok) return c.json(resolved.payload, 400);
+
+    let endpointUri: string | undefined;
+    if (body.dynamic) {
+      const uri = flowsDataEndpointUri(instanceId);
+      if (!uri) {
+        return c.json(
+          jsonError('dynamic flows require META_FLOWS_PUBLIC_BASE_URL to be configured', 'NOT_CONFIGURED'),
+          400,
+        );
+      }
+      endpointUri = uri;
+    }
+
+    if (body.flowJson) {
+      const local = validateFlowJson(body.flowJson, { dynamic: body.dynamic });
+      if (!local.valid) return c.json(flowJsonInvalid(local.issues), 422);
+    }
+
+    if (body.name || body.categories || endpointUri) {
+      await resolved.client.updateFlowMetadata(flowId, {
+        name: body.name,
+        categories: body.categories,
+        endpointUri,
+      });
+    }
+
+    let validationErrors: unknown[] = [];
+    if (body.flowJson) {
+      const result = await resolved.client.updateFlowAssets(flowId, body.flowJson);
+      validationErrors = result.validation_errors ?? [];
+    }
+
+    return c.json({ data: { id: flowId, endpointUri: endpointUri ?? null, validationErrors } });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /instances/:id/whatsapp-flows/:flowId — draft-only delete
+// ─────────────────────────────────────────────────────────────────────────────
+
+whatsappFlowsRoutes.delete(
+  '/instances/:id/whatsapp-flows/:flowId',
+  instanceAccess,
+  zValidator('param', flowIdParamSchema),
+  async (c) => {
+    const { id: instanceId, flowId } = c.req.valid('param');
+    const resolved = await resolveFlowsClient(c.get('services'), instanceId);
+    if (!resolved.ok) return c.json(resolved.payload, 400);
+
+    const result = await resolved.client.deleteFlow(flowId);
+    return c.json({ success: result.success, flowId });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /instances/:id/whatsapp-flows/:flowId/deprecate — retire a published flow
+// ─────────────────────────────────────────────────────────────────────────────
+
+whatsappFlowsRoutes.post(
+  '/instances/:id/whatsapp-flows/:flowId/deprecate',
+  instanceAccess,
+  zValidator('param', flowIdParamSchema),
+  async (c) => {
+    const { id: instanceId, flowId } = c.req.valid('param');
+    const resolved = await resolveFlowsClient(c.get('services'), instanceId);
+    if (!resolved.ok) return c.json(resolved.payload, 400);
+
+    const result = await resolved.client.deprecateFlow(flowId);
+    return c.json({ success: result.success, flowId });
   },
 );
 

--- a/packages/api/src/schemas/openapi/whatsapp-flows.ts
+++ b/packages/api/src/schemas/openapi/whatsapp-flows.ts
@@ -1,0 +1,329 @@
+/**
+ * OpenAPI schemas for WhatsApp Flows management routes
+ * (packages/api/src/routes/v2/whatsapp-flows.ts).
+ *
+ * The public Meta-facing data-exchange endpoint
+ * (POST /channels/whatsapp-cloud/flows/data/:instanceId) is deliberately NOT
+ * registered — like the channel webhooks, it is not a customer-SDK surface.
+ */
+
+import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { z } from '../../lib/zod-openapi';
+import { ErrorSchema } from './common';
+
+const FlowCategorySchema = z
+  .enum([
+    'SIGN_UP',
+    'SIGN_IN',
+    'APPOINTMENT_BOOKING',
+    'LEAD_GENERATION',
+    'CONTACT_US',
+    'CUSTOMER_SUPPORT',
+    'SURVEY',
+    'OTHER',
+  ])
+  .openapi({ description: "Meta's fixed flow category set" });
+
+export const FlowValidationErrorSchema = z.object({
+  error: z.string().openapi({ description: 'Error code (e.g. INVALID_PROPERTY_TYPE)' }),
+  error_type: z.string().openapi({ description: 'Error class (e.g. FLOW_JSON_ERROR)' }),
+  message: z.string().openapi({ description: 'Human-readable explanation' }),
+  line_start: z.number().optional(),
+  line_end: z.number().optional(),
+  column_start: z.number().optional(),
+  column_end: z.number().optional(),
+  pointers: z
+    .array(z.object({ path: z.string().openapi({ description: 'JSON path of the offending node' }) }).passthrough())
+    .optional(),
+});
+
+export const FlowSummarySchema = z.object({
+  id: z.string().openapi({ description: 'Meta flow id' }),
+  name: z.string(),
+  status: z.string().openapi({ description: 'DRAFT | PUBLISHED | DEPRECATED | BLOCKED | THROTTLED' }),
+  categories: z.array(z.string()),
+});
+
+export const FlowDetailSchema = FlowSummarySchema.extend({
+  validationErrors: z
+    .array(FlowValidationErrorSchema)
+    .openapi({ description: 'Meta-side Flow JSON validation errors' }),
+  endpointUri: z.string().nullable().openapi({ description: 'Registered data-exchange endpoint (dynamic flows)' }),
+  preview: z
+    .object({ preview_url: z.string(), expires_at: z.string() })
+    .nullable()
+    .openapi({ description: 'Browser preview (valid ~30 days)' }),
+});
+
+export const CreateFlowRequestSchema = z.object({
+  name: z.string().min(1).max(200).openapi({ description: 'Flow name (shown in WhatsApp Manager)' }),
+  categories: z.array(FlowCategorySchema).min(1),
+  flowJson: z.string().optional().openapi({ description: 'Stringified Flow JSON (screens/layout)' }),
+  publish: z.boolean().optional().openapi({ description: 'Publish immediately (requires valid flowJson)' }),
+  dynamic: z.boolean().optional().openapi({
+    description:
+      "Endpoint-backed (data_exchange) flow: registers this omni install's flows-data URL as endpoint_uri. Requires META_FLOWS_PUBLIC_BASE_URL and Flow JSON with data_api_version '3.0'.",
+  }),
+});
+
+export const UpdateFlowRequestSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  categories: z.array(FlowCategorySchema).min(1).optional(),
+  flowJson: z.string().optional().openapi({ description: 'Replaces the flow screens (asset upload)' }),
+  dynamic: z.boolean().optional().openapi({ description: "Point the flow at this install's data endpoint" }),
+});
+
+export const FlowMutationResponseSchema = z.object({
+  data: z.object({
+    id: z.string(),
+    endpointUri: z.string().nullable(),
+    validationErrors: z.array(FlowValidationErrorSchema),
+  }),
+});
+
+export const SendFlowRequestSchema = z.object({
+  to: z.string().min(1).openapi({ description: 'Recipient phone (E.164 or digits)' }),
+  flowId: z.string().optional().openapi({ description: 'Meta flow id (exactly one of flowId/flowName)' }),
+  flowName: z.string().optional(),
+  cta: z.string().min(1).max(30).openapi({ description: 'Button label that opens the flow' }),
+  bodyText: z.string().min(1).max(1024),
+  headerText: z.string().max(60).optional(),
+  footerText: z.string().max(60).optional(),
+  screen: z.string().optional().openapi({ description: 'Entry screen (navigate flows)' }),
+  data: z.record(z.string(), z.unknown()).optional().openapi({ description: 'Prefill data for the first screen' }),
+  flowToken: z.string().optional().openapi({ description: 'Correlation token; generated when omitted' }),
+  draft: z.boolean().optional().openapi({ description: 'Send an unpublished flow (mode: draft)' }),
+  flowAction: z
+    .enum(['navigate', 'data_exchange'])
+    .optional()
+    .openapi({ description: "'data_exchange' opens the flow against the data endpoint (INIT decides screen 1)" }),
+});
+
+export const FlowKeysStatusSchema = z.object({
+  data: z.object({
+    hasLocalKey: z.boolean().openapi({ description: 'Private key stored for this instance' }),
+    uploadedAt: z.string().nullable(),
+    signatureStatus: z
+      .string()
+      .nullable()
+      .openapi({ description: 'Meta-side status: VALID | MISMATCH (MISMATCH → rotate via POST)' }),
+    endpointUri: z.string().nullable(),
+  }),
+});
+
+export function registerWhatsappFlowsSchemas(registry: OpenAPIRegistry): void {
+  registry.register('FlowSummary', FlowSummarySchema);
+  registry.register('FlowDetail', FlowDetailSchema);
+  registry.register('FlowValidationError', FlowValidationErrorSchema);
+  registry.register('CreateFlowRequest', CreateFlowRequestSchema);
+  registry.register('UpdateFlowRequest', UpdateFlowRequestSchema);
+  registry.register('SendFlowRequest', SendFlowRequestSchema);
+
+  const idParam = z.object({ id: z.string().uuid().openapi({ description: 'Instance UUID' }) });
+  const flowIdParams = z.object({
+    id: z.string().uuid().openapi({ description: 'Instance UUID' }),
+    flowId: z.string().openapi({ description: 'Meta flow id' }),
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/instances/{id}/whatsapp-flows',
+    operationId: 'listWhatsappFlows',
+    tags: ['WhatsApp Flows'],
+    summary: 'List flows',
+    description: "List the WABA's WhatsApp Flows with status and categories.",
+    request: { params: idParam },
+    responses: {
+      200: {
+        description: 'Flows on the WABA',
+        content: {
+          'application/json': {
+            schema: z.object({ items: z.array(FlowSummarySchema), meta: z.object({ count: z.number() }) }),
+          },
+        },
+      },
+      400: {
+        description: 'Not a whatsapp-cloud instance / not connected',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/instances/{id}/whatsapp-flows',
+    operationId: 'createWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Create flow',
+    description:
+      'Create a flow (optionally dynamic/endpoint-backed). Flow JSON is validated locally before contacting Meta; Meta-side validation_errors are always returned.',
+    request: { params: idParam, body: { content: { 'application/json': { schema: CreateFlowRequestSchema } } } },
+    responses: {
+      201: { description: 'Flow created', content: { 'application/json': { schema: FlowMutationResponseSchema } } },
+      400: {
+        description: 'Bad request / missing META_FLOWS_PUBLIC_BASE_URL',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
+      422: {
+        description: 'Flow JSON failed local validation',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/instances/{id}/whatsapp-flows/{flowId}',
+    operationId: 'getWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Get flow',
+    description: 'Status, categories, Meta validation errors, endpoint_uri and preview URL.',
+    request: { params: flowIdParams },
+    responses: {
+      200: {
+        description: 'Flow detail',
+        content: { 'application/json': { schema: z.object({ data: FlowDetailSchema }) } },
+      },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'put',
+    path: '/instances/{id}/whatsapp-flows/{flowId}',
+    operationId: 'updateWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Update flow',
+    description:
+      'Update screens (flowJson → asset upload) and/or properties (name, categories, dynamic → endpoint_uri).',
+    request: { params: flowIdParams, body: { content: { 'application/json': { schema: UpdateFlowRequestSchema } } } },
+    responses: {
+      200: { description: 'Flow updated', content: { 'application/json': { schema: FlowMutationResponseSchema } } },
+      400: { description: 'Bad request', content: { 'application/json': { schema: ErrorSchema } } },
+      422: {
+        description: 'Flow JSON failed local validation',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'delete',
+    path: '/instances/{id}/whatsapp-flows/{flowId}',
+    operationId: 'deleteWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Delete flow (draft only)',
+    description: 'Deletes a DRAFT flow. Published flows must be deprecated instead.',
+    request: { params: flowIdParams },
+    responses: {
+      200: {
+        description: 'Deleted',
+        content: { 'application/json': { schema: z.object({ success: z.boolean(), flowId: z.string() }) } },
+      },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/instances/{id}/whatsapp-flows/{flowId}/publish',
+    operationId: 'publishWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Publish flow',
+    description: 'Publish a draft flow (requires zero validation errors).',
+    request: { params: flowIdParams },
+    responses: {
+      200: {
+        description: 'Published',
+        content: { 'application/json': { schema: z.object({ success: z.boolean(), flowId: z.string() }) } },
+      },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/instances/{id}/whatsapp-flows/{flowId}/deprecate',
+    operationId: 'deprecateWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Deprecate flow',
+    description: 'Retire a PUBLISHED flow.',
+    request: { params: flowIdParams },
+    responses: {
+      200: {
+        description: 'Deprecated',
+        content: { 'application/json': { schema: z.object({ success: z.boolean(), flowId: z.string() }) } },
+      },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/instances/{id}/whatsapp-flows/{flowId}/preview',
+    operationId: 'getWhatsappFlowPreview',
+    tags: ['WhatsApp Flows'],
+    summary: 'Get flow preview URL',
+    description: 'Browser preview URL for the flow (valid ~30 days).',
+    request: { params: flowIdParams },
+    responses: {
+      200: {
+        description: 'Preview URL',
+        content: {
+          'application/json': { schema: z.object({ previewUrl: z.string(), expiresAt: z.string() }) },
+        },
+      },
+      404: { description: 'No preview available', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/instances/{id}/whatsapp-flows/send',
+    operationId: 'sendWhatsappFlow',
+    tags: ['WhatsApp Flows'],
+    summary: 'Send flow message',
+    description:
+      "Send an interactive flow message through the channel plugin. Returns the flowToken echoed back on the completion webhook (nfm_reply). Use flowAction 'data_exchange' for endpoint-backed flows.",
+    request: { params: idParam, body: { content: { 'application/json': { schema: SendFlowRequestSchema } } } },
+    responses: {
+      201: {
+        description: 'Flow message sent',
+        content: {
+          'application/json': { schema: z.object({ messageId: z.string().optional(), flowToken: z.string() }) },
+        },
+      },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+      500: { description: 'Send failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/instances/{id}/whatsapp-flows/keys',
+    operationId: 'registerWhatsappFlowKeys',
+    tags: ['WhatsApp Flows'],
+    summary: 'Generate + register data-endpoint encryption keys',
+    description:
+      'Generates a 2048-bit RSA keypair, registers the public key with Meta (whatsapp_business_encryption) and stores the private key sealed. Calling again rotates the key.',
+    request: { params: idParam },
+    responses: {
+      201: { description: 'Key registered', content: { 'application/json': { schema: FlowKeysStatusSchema } } },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/instances/{id}/whatsapp-flows/keys',
+    operationId: 'getWhatsappFlowKeysStatus',
+    tags: ['WhatsApp Flows'],
+    summary: 'Data-endpoint key status',
+    description: 'Local key presence + Meta-side signature status (MISMATCH explains 421 loops).',
+    request: { params: idParam },
+    responses: {
+      200: { description: 'Key status', content: { 'application/json': { schema: FlowKeysStatusSchema } } },
+      400: { description: 'Channel guard failed', content: { 'application/json': { schema: ErrorSchema } } },
+    },
+  });
+}

--- a/packages/api/src/tenancy/route-ownership.ts
+++ b/packages/api/src/tenancy/route-ownership.ts
@@ -295,6 +295,19 @@ const PUBLIC_PRIVACY_CONTRACTS: readonly RouteOwnershipDeclaration[] = [
       'claim. Responses are fixed acks (200/401) and carry no row data; unknown phone_number_id still acks 200 ' +
       'so the surface is not a resource-existence oracle.',
   },
+  {
+    route: 'POST /api/v2/channels/whatsapp-cloud/flows/data/:instanceId',
+    class: 'public-by-contract',
+    justification:
+      "WhatsApp Flows data-exchange endpoint. Auth-exempt for Meta's servers; authenticity is double: the " +
+      'X-Hub-Signature-256 HMAC verified against the server-held META_APP_SECRET over the raw body (432 on ' +
+      'mismatch), and RSA-OAEP payload encryption — only the private key registered for the :instanceId row can ' +
+      'decrypt the request (421 otherwise), so a forged path yields nothing. The tenant comes from the ' +
+      'server-side instance record addressed by the path (the Gupshup/Twilio per-instance precedent); the ' +
+      'private key is unsealed server-side via openCredentialField under that record’s tenant. Responses are ' +
+      'AES-GCM-encrypted screen payloads readable only by the requesting WhatsApp client, or bare status codes ' +
+      '(404/421/427/432) that reveal no row data.',
+  },
 ];
 
 /**
@@ -358,6 +371,7 @@ const TENANT_SCOPED_ROUTES: readonly RouteKey[] = [
   'DELETE /api/v2/follow-up/chats/:id',
   'DELETE /api/v2/follow-up/instances/:id',
   'DELETE /api/v2/instances/:id',
+  'DELETE /api/v2/instances/:id/whatsapp-flows/:flowId',
   'DELETE /api/v2/instances/:id/block',
   'DELETE /api/v2/instances/:id/guilds/:guildId/config',
   'DELETE /api/v2/instances/:id/profile/picture',
@@ -447,7 +461,9 @@ const TENANT_SCOPED_ROUTES: readonly RouteKey[] = [
   'GET /api/v2/instances/:id/whatsapp-cloud/profile',
   'GET /api/v2/instances/:id/whatsapp-cloud/quality',
   'GET /api/v2/instances/:id/whatsapp-flows',
+  'GET /api/v2/instances/:id/whatsapp-flows/:flowId',
   'GET /api/v2/instances/:id/whatsapp-flows/:flowId/preview',
+  'GET /api/v2/instances/:id/whatsapp-flows/keys',
   'GET /api/v2/instances/:id/whatsapp-templates',
   'GET /api/v2/instances/:id/whatsapp-templates/:templateId',
   'GET /api/v2/instances/:instanceId/routes',
@@ -579,7 +595,9 @@ const TENANT_SCOPED_ROUTES: readonly RouteKey[] = [
   'POST /api/v2/instances/:id/whatsapp-cloud/register',
   'POST /api/v2/instances/:id/whatsapp-cloud/subscribe-app',
   'POST /api/v2/instances/:id/whatsapp-flows',
+  'POST /api/v2/instances/:id/whatsapp-flows/:flowId/deprecate',
   'POST /api/v2/instances/:id/whatsapp-flows/:flowId/publish',
+  'POST /api/v2/instances/:id/whatsapp-flows/keys',
   'POST /api/v2/instances/:id/whatsapp-flows/send',
   'POST /api/v2/instances/:id/whatsapp-templates',
   'POST /api/v2/instances/:id/whatsapp-templates/:templateId/send-test',
@@ -638,6 +656,7 @@ const TENANT_SCOPED_ROUTES: readonly RouteKey[] = [
   'PUT /api/v2/instances/:id/profile/name',
   'PUT /api/v2/instances/:id/profile/picture',
   'PUT /api/v2/instances/:id/whatsapp-cloud/profile',
+  'PUT /api/v2/instances/:id/whatsapp-flows/:flowId',
   'PUT /api/v2/instances/:id/profile/status',
   'PUT /api/v2/payload-config/:eventType',
   'PUT /api/v2/settings/:key',

--- a/packages/channel-whatsapp-cloud/CLAUDE.md
+++ b/packages/channel-whatsapp-cloud/CLAUDE.md
@@ -39,13 +39,18 @@ src/
 │   ├── location.ts
 │   ├── contact.ts
 │   ├── reaction.ts
-│   └── template.ts
+│   ├── template.ts
+│   └── flow.ts                  # interactive.flow (navigate + data_exchange, structured flow tokens)
+├── flows/
+│   └── resolver.ts              # FlowResolverRegistry + buildFlowToken/parseFlowToken
 ├── handlers/
-│   └── webhook.ts               # handleVerifyChallenge + handleMetaWebhook
+│   ├── webhook.ts               # handleVerifyChallenge + handleMetaWebhook
+│   └── flow-data.ts             # encrypted Flows data-exchange endpoint (200/421/427/432)
 ├── utils/
 │   ├── identity.ts              # toMetaPhone (digits-only), toE164, phonesEqual
 │   ├── errors.ts                # MetaApiError + MetaErrorCode taxonomy
-│   └── signature.ts             # verifyMetaSignature (HMAC-SHA256, timing-safe)
+│   ├── signature.ts             # verifyMetaSignature (HMAC-SHA256, timing-safe)
+│   └── flow-crypto.ts           # RSA-OAEP unwrap + AES-128-GCM (flipped-IV response), keygen
 └── __tests__/                   # bun:test
     ├── senders.test.ts
     ├── webhook.test.ts
@@ -89,6 +94,16 @@ Inbound `wamid` values must be deduped via `createInboundDedupeCache` (shared wi
 ### Signature verification
 
 `X-Hub-Signature-256: sha256=<hex>` over the **raw request body** using HMAC-SHA256 with `META_APP_SECRET`. Compare using a constant-time check (Web Crypto `crypto.subtle` + manual constant-time byte compare). Reject with 401 + warn-log on mismatch — do not include any token diff in the log.
+
+### WhatsApp Flows
+
+Full guide: `docs/channels/whatsapp-flows.md`. Package-side pieces: the flow
+sender emits structured tokens `omni.<flowId>.<uuid>` (the data endpoint's only
+way to know which flow it serves); `handlers/flow-data.ts` owns the encrypted
+data-exchange contract (421 = can't decrypt → check key `signature_status`,
+427 = bad token, 432 = bad HMAC); screen logic registers on
+`plugin.flowResolvers` and must resolve within ~8s. Private keys are unsealed
+by the API route (`app.ts`), never read here.
 
 ### 24h window enforcement
 

--- a/packages/channel-whatsapp-cloud/src/__tests__/flow-crypto.test.ts
+++ b/packages/channel-whatsapp-cloud/src/__tests__/flow-crypto.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  FlowDecryptError,
+  decryptFlowRequest,
+  encryptFlowResponse,
+  generateFlowKeyPair,
+  importFlowPrivateKey,
+} from '../utils/flow-crypto';
+
+const b64 = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes));
+
+/** Encrypt a payload exactly the way Meta's client does (the inverse of our endpoint). */
+async function metaEncryptRequest(
+  payload: unknown,
+  publicKeyPem: string,
+): Promise<{
+  body: { encrypted_flow_data: string; encrypted_aes_key: string; initial_vector: string };
+  aesRaw: Uint8Array;
+  iv: Uint8Array;
+}> {
+  const der = Uint8Array.from(
+    atob(publicKeyPem.replace(/-----(BEGIN|END)[A-Z ]+-----/g, '').replace(/\s+/g, '')),
+    (c) => c.charCodeAt(0),
+  );
+  const publicKey = await crypto.subtle.importKey(
+    'spki',
+    der.buffer as ArrayBuffer,
+    { name: 'RSA-OAEP', hash: 'SHA-256' },
+    false,
+    ['encrypt'],
+  );
+
+  const aesRaw = crypto.getRandomValues(new Uint8Array(16)); // AES-128
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const aesKey = await crypto.subtle.importKey('raw', aesRaw.buffer as ArrayBuffer, { name: 'AES-GCM' }, false, [
+    'encrypt',
+  ]);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+    aesKey,
+    new TextEncoder().encode(JSON.stringify(payload)).buffer as ArrayBuffer,
+  );
+  const wrappedKey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, aesRaw.buffer as ArrayBuffer);
+
+  return {
+    body: {
+      encrypted_flow_data: b64(new Uint8Array(ciphertext)),
+      encrypted_aes_key: b64(new Uint8Array(wrappedKey)),
+      initial_vector: b64(iv),
+    },
+    aesRaw,
+    iv,
+  };
+}
+
+describe('flow-crypto', () => {
+  test('decrypts a Meta-shaped request and encrypts a response Meta can read', async () => {
+    const { privateKeyPem, publicKeyPem } = await generateFlowKeyPair();
+    const privateKey = await importFlowPrivateKey(privateKeyPem);
+
+    const request = {
+      version: '3.0',
+      action: 'data_exchange' as const,
+      screen: 'CADASTRO',
+      data: { nome: 'Cezar' },
+      flow_token: 'omni.123.abc',
+    };
+    const { body, aesRaw, iv } = await metaEncryptRequest(request, publicKeyPem);
+
+    const decrypted = await decryptFlowRequest(body, privateKey);
+    expect(decrypted.payload).toEqual(request);
+
+    // Response round-trip: decrypt with the same AES key + flipped IV (Meta's side).
+    const response = { screen: 'SUCCESS', data: { ok: true } };
+    const encryptedResponse = await encryptFlowResponse(response, decrypted.aesKey, decrypted.iv);
+
+    const flippedIv = iv.map((byte) => byte ^ 0xff);
+    const aesKey = await crypto.subtle.importKey('raw', aesRaw.buffer as ArrayBuffer, { name: 'AES-GCM' }, false, [
+      'decrypt',
+    ]);
+    const roundTripped = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: flippedIv.buffer as ArrayBuffer },
+      aesKey,
+      Uint8Array.from(atob(encryptedResponse), (c) => c.charCodeAt(0)).buffer as ArrayBuffer,
+    );
+    expect(JSON.parse(new TextDecoder().decode(roundTripped))).toEqual(response);
+  });
+
+  test('throws FlowDecryptError when the AES key was wrapped for a different keypair', async () => {
+    const ours = await generateFlowKeyPair();
+    const theirs = await generateFlowKeyPair();
+    const privateKey = await importFlowPrivateKey(ours.privateKeyPem);
+
+    const { body } = await metaEncryptRequest({ version: '3.0', action: 'ping' }, theirs.publicKeyPem);
+    expect(decryptFlowRequest(body, privateKey)).rejects.toBeInstanceOf(FlowDecryptError);
+  });
+
+  test('throws FlowDecryptError on tampered ciphertext (GCM auth failure)', async () => {
+    const { privateKeyPem, publicKeyPem } = await generateFlowKeyPair();
+    const privateKey = await importFlowPrivateKey(privateKeyPem);
+    const { body } = await metaEncryptRequest({ version: '3.0', action: 'ping' }, publicKeyPem);
+
+    const bytes = Uint8Array.from(atob(body.encrypted_flow_data), (c) => c.charCodeAt(0));
+    bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+    const tampered = { ...body, encrypted_flow_data: b64(bytes) };
+    expect(decryptFlowRequest(tampered, privateKey)).rejects.toBeInstanceOf(FlowDecryptError);
+  });
+
+  test('generateFlowKeyPair produces importable PEM halves', async () => {
+    const { privateKeyPem, publicKeyPem } = await generateFlowKeyPair();
+    expect(privateKeyPem).toStartWith('-----BEGIN PRIVATE KEY-----');
+    expect(publicKeyPem).toStartWith('-----BEGIN PUBLIC KEY-----');
+    await importFlowPrivateKey(privateKeyPem); // does not throw
+  });
+});

--- a/packages/channel-whatsapp-cloud/src/__tests__/flow-data.test.ts
+++ b/packages/channel-whatsapp-cloud/src/__tests__/flow-data.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from 'bun:test';
+import type { EventPayloadMap, Logger } from '@omni/core';
+import { FlowResolverRegistry, buildFlowToken } from '../flows/resolver';
+import { type FlowDataHandlerContext, handleFlowDataRequest } from '../handlers/flow-data';
+import { generateFlowKeyPair } from '../utils/flow-crypto';
+
+const APP_SECRET = 'test-app-secret';
+
+const noopLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+const b64 = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes));
+
+async function hmacHex(body: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = new Uint8Array(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body)));
+  return Array.from(sig)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function signedRequest(body: string, opts: { badSignature?: boolean } = {}): Promise<Request> {
+  const signature = opts.badSignature ? 'deadbeef' : await hmacHex(body, APP_SECRET);
+  return new Request('http://localhost/flows/data/inst-1', {
+    method: 'POST',
+    headers: { 'x-hub-signature-256': `sha256=${signature}` },
+    body,
+  });
+}
+
+/** Meta-side encryption (mirrors the client): wrap AES key with RSA, AES-GCM the payload. */
+async function metaEncrypt(
+  payload: unknown,
+  publicKeyPem: string,
+): Promise<{ body: string; aesRaw: Uint8Array; iv: Uint8Array }> {
+  const der = Uint8Array.from(
+    atob(publicKeyPem.replace(/-----(BEGIN|END)[A-Z ]+-----/g, '').replace(/\s+/g, '')),
+    (c) => c.charCodeAt(0),
+  );
+  const publicKey = await crypto.subtle.importKey(
+    'spki',
+    der.buffer as ArrayBuffer,
+    { name: 'RSA-OAEP', hash: 'SHA-256' },
+    false,
+    ['encrypt'],
+  );
+  const aesRaw = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const aesKey = await crypto.subtle.importKey('raw', aesRaw.buffer as ArrayBuffer, { name: 'AES-GCM' }, false, [
+    'encrypt',
+  ]);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+    aesKey,
+    new TextEncoder().encode(JSON.stringify(payload)).buffer as ArrayBuffer,
+  );
+  const wrapped = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, aesRaw.buffer as ArrayBuffer);
+  return {
+    body: JSON.stringify({
+      encrypted_flow_data: b64(new Uint8Array(ciphertext)),
+      encrypted_aes_key: b64(new Uint8Array(wrapped)),
+      initial_vector: b64(iv),
+    }),
+    aesRaw,
+    iv,
+  };
+}
+
+/** Decrypt the handler's encrypted 200 body from Meta's perspective. */
+async function metaDecryptResponse(responseB64: string, aesRaw: Uint8Array, iv: Uint8Array): Promise<unknown> {
+  const flipped = iv.map((byte) => byte ^ 0xff);
+  const aesKey = await crypto.subtle.importKey('raw', aesRaw.buffer as ArrayBuffer, { name: 'AES-GCM' }, false, [
+    'decrypt',
+  ]);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: flipped.buffer as ArrayBuffer },
+    aesKey,
+    Uint8Array.from(atob(responseB64), (c) => c.charCodeAt(0)).buffer as ArrayBuffer,
+  );
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+interface HarnessOptions {
+  registry?: FlowResolverRegistry;
+  privateKeyPem?: string;
+}
+
+async function makeContext(opts: HarnessOptions = {}): Promise<{
+  ctx: FlowDataHandlerContext;
+  publicKeyPem: string;
+  events: EventPayloadMap['flow.data_exchange'][];
+}> {
+  const { privateKeyPem, publicKeyPem } = await generateFlowKeyPair();
+  const events: EventPayloadMap['flow.data_exchange'][] = [];
+  const ctx: FlowDataHandlerContext = {
+    instanceId: 'inst-1',
+    channelType: 'whatsapp-cloud',
+    privateKeyPem: opts.privateKeyPem ?? privateKeyPem,
+    appSecret: APP_SECRET,
+    registry: opts.registry ?? new FlowResolverRegistry(),
+    logger: noopLogger,
+    publishEvent: async (payload) => {
+      events.push(payload);
+    },
+  };
+  return { ctx, publicKeyPem, events };
+}
+
+describe('handleFlowDataRequest', () => {
+  test('432 on bad signature', async () => {
+    const { ctx } = await makeContext();
+    const res = await handleFlowDataRequest(await signedRequest('{}', { badSignature: true }), ctx);
+    expect(res.status).toBe(432);
+  });
+
+  test('200 plain JSON for plain-text ping', async () => {
+    const { ctx } = await makeContext();
+    const res = await handleFlowDataRequest(
+      await signedRequest(JSON.stringify({ version: '3.0', action: 'ping' })),
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { status: 'active' } });
+  });
+
+  test('421 on undecryptable payload (wrong keypair)', async () => {
+    const { ctx } = await makeContext();
+    const other = await generateFlowKeyPair();
+    const { body } = await metaEncrypt({ version: '3.0', action: 'INIT', flow_token: 'omni.1.x' }, other.publicKeyPem);
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(421);
+  });
+
+  test('421 on non-encrypted garbage body', async () => {
+    const { ctx } = await makeContext();
+    const res = await handleFlowDataRequest(await signedRequest(JSON.stringify({ hello: 'world' })), ctx);
+    expect(res.status).toBe(421);
+  });
+
+  test('427 when the payload has no flow_token', async () => {
+    const { ctx, publicKeyPem } = await makeContext();
+    const { body } = await metaEncrypt({ version: '3.0', action: 'INIT' }, publicKeyPem);
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(427);
+  });
+
+  test('encrypted ping gets an encrypted active response and no event', async () => {
+    const { ctx, publicKeyPem, events } = await makeContext();
+    const { body, aesRaw, iv } = await metaEncrypt({ version: '3.0', action: 'ping' }, publicKeyPem);
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(200);
+    expect(await metaDecryptResponse(await res.text(), aesRaw, iv)).toEqual({ data: { status: 'active' } });
+    expect(events).toHaveLength(0);
+  });
+
+  test('error notification is acknowledged, not resolved', async () => {
+    const { ctx, publicKeyPem, events } = await makeContext();
+    const { body, aesRaw, iv } = await metaEncrypt(
+      {
+        version: '3.0',
+        action: 'data_exchange',
+        flow_token: buildFlowToken('123'),
+        data: { error: 'INVALID_SCREEN', error_message: 'bad screen' },
+      },
+      publicKeyPem,
+    );
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(200);
+    expect(await metaDecryptResponse(await res.text(), aesRaw, iv)).toEqual({ data: { acknowledged: true } });
+    expect(events).toHaveLength(0);
+  });
+
+  test('resolves via flow-ref registry (structured token) and publishes the event', async () => {
+    const registry = new FlowResolverRegistry();
+    registry.register('4242', {
+      resolve: (resolveCtx) => ({
+        screen: 'STEP_2',
+        data: { echo: resolveCtx.data?.value, action: resolveCtx.action },
+      }),
+    });
+    const { ctx, publicKeyPem, events } = await makeContext({ registry });
+
+    const token = buildFlowToken('4242');
+    const { body, aesRaw, iv } = await metaEncrypt(
+      { version: '3.0', action: 'data_exchange', screen: 'STEP_1', data: { value: 42 }, flow_token: token },
+      publicKeyPem,
+    );
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(200);
+    expect(await metaDecryptResponse(await res.text(), aesRaw, iv)).toEqual({
+      screen: 'STEP_2',
+      data: { echo: 42, action: 'data_exchange' },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      instanceId: 'inst-1',
+      flowId: '4242',
+      flowToken: token,
+      action: 'data_exchange',
+      screen: 'STEP_1',
+      responseScreen: 'STEP_2',
+    });
+  });
+
+  test('opaque token falls back to the instance default resolver', async () => {
+    const registry = new FlowResolverRegistry();
+    registry.registerInstanceDefault('inst-1', { resolve: () => ({ screen: 'DEFAULT' }) });
+    const { ctx, publicKeyPem } = await makeContext({ registry });
+
+    const { body, aesRaw, iv } = await metaEncrypt(
+      { version: '3.0', action: 'INIT', flow_token: 'caller-supplied-opaque-token' },
+      publicKeyPem,
+    );
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(await metaDecryptResponse(await res.text(), aesRaw, iv)).toEqual({ screen: 'DEFAULT' });
+  });
+
+  test('no resolver → encrypted error screen (still 200, never a hang)', async () => {
+    const { ctx, publicKeyPem } = await makeContext();
+    const { body, aesRaw, iv } = await metaEncrypt(
+      { version: '3.0', action: 'data_exchange', screen: 'S1', flow_token: buildFlowToken('999') },
+      publicKeyPem,
+    );
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(200);
+    const decrypted = (await metaDecryptResponse(await res.text(), aesRaw, iv)) as {
+      screen: string;
+      data: { error_message?: string };
+    };
+    expect(decrypted.screen).toBe('S1');
+    expect(decrypted.data.error_message).toBeTruthy();
+  });
+
+  test('throwing resolver → encrypted error screen', async () => {
+    const registry = new FlowResolverRegistry();
+    registry.register('boom', {
+      resolve: () => {
+        throw new Error('resolver exploded');
+      },
+    });
+    const { ctx, publicKeyPem } = await makeContext({ registry });
+    const { body, aesRaw, iv } = await metaEncrypt(
+      { version: '3.0', action: 'data_exchange', screen: 'S1', flow_token: buildFlowToken('boom') },
+      publicKeyPem,
+    );
+    const res = await handleFlowDataRequest(await signedRequest(body), ctx);
+    expect(res.status).toBe(200);
+    const decrypted = (await metaDecryptResponse(await res.text(), aesRaw, iv)) as { data: { error_message?: string } };
+    expect(decrypted.data.error_message).toBeTruthy();
+  });
+});

--- a/packages/channel-whatsapp-cloud/src/__tests__/flow-resolver.test.ts
+++ b/packages/channel-whatsapp-cloud/src/__tests__/flow-resolver.test.ts
@@ -3,9 +3,9 @@ import { FlowResolverRegistry, buildFlowToken, parseFlowToken } from '../flows/r
 
 describe('flow token', () => {
   test('build → parse round-trips the flow ref', () => {
-    const token = buildFlowToken('1381873504009404');
-    expect(token.startsWith('omni.1381873504009404.')).toBe(true);
-    expect(parseFlowToken(token)).toBe('1381873504009404');
+    const token = buildFlowToken('1234567890123456');
+    expect(token.startsWith('omni.1234567890123456.')).toBe(true);
+    expect(parseFlowToken(token)).toBe('1234567890123456');
   });
 
   test('refs containing dots survive (uuid is always the last segment)', () => {

--- a/packages/channel-whatsapp-cloud/src/__tests__/flow-resolver.test.ts
+++ b/packages/channel-whatsapp-cloud/src/__tests__/flow-resolver.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { FlowResolverRegistry, buildFlowToken, parseFlowToken } from '../flows/resolver';
+
+describe('flow token', () => {
+  test('build → parse round-trips the flow ref', () => {
+    const token = buildFlowToken('1381873504009404');
+    expect(token.startsWith('omni.1381873504009404.')).toBe(true);
+    expect(parseFlowToken(token)).toBe('1381873504009404');
+  });
+
+  test('refs containing dots survive (uuid is always the last segment)', () => {
+    expect(parseFlowToken(buildFlowToken('my.flow.name'))).toBe('my.flow.name');
+  });
+
+  test('foreign/opaque tokens parse to null', () => {
+    expect(parseFlowToken('caller-supplied-token')).toBeNull();
+    expect(parseFlowToken('omni.x')).toBeNull(); // too few segments
+    expect(parseFlowToken(undefined)).toBeNull();
+    expect(parseFlowToken('')).toBeNull();
+  });
+});
+
+describe('FlowResolverRegistry', () => {
+  const flowResolver = { resolve: () => ({ screen: 'BY_REF' }) };
+  const instanceResolver = { resolve: () => ({ screen: 'BY_INSTANCE' }) };
+
+  test('flow-ref match wins over instance default', () => {
+    const registry = new FlowResolverRegistry();
+    registry.register('42', flowResolver);
+    registry.registerInstanceDefault('inst-1', instanceResolver);
+    expect(registry.lookup({ instanceId: 'inst-1', flowRef: '42' })).toBe(flowResolver);
+  });
+
+  test('falls back to instance default when ref is unknown or null', () => {
+    const registry = new FlowResolverRegistry();
+    registry.registerInstanceDefault('inst-1', instanceResolver);
+    expect(registry.lookup({ instanceId: 'inst-1', flowRef: 'unknown' })).toBe(instanceResolver);
+    expect(registry.lookup({ instanceId: 'inst-1', flowRef: null })).toBe(instanceResolver);
+  });
+
+  test('returns null when nothing matches; unregister removes the ref', () => {
+    const registry = new FlowResolverRegistry();
+    expect(registry.lookup({ instanceId: 'inst-1', flowRef: '42' })).toBeNull();
+    registry.register('42', flowResolver);
+    registry.unregister('42');
+    expect(registry.lookup({ instanceId: 'inst-1', flowRef: '42' })).toBeNull();
+  });
+});

--- a/packages/channel-whatsapp-cloud/src/client.ts
+++ b/packages/channel-whatsapp-cloud/src/client.ts
@@ -18,6 +18,18 @@ import { MetaApiError as MetaApiErrorClass, MetaErrorCode, mapHttpStatusToMetaEr
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+/** One entry of Meta's `validation_errors` array on flow create/update/get. */
+export interface MetaFlowValidationError {
+  error: string;
+  error_type: string;
+  message: string;
+  line_start?: number;
+  line_end?: number;
+  column_start?: number;
+  column_end?: number;
+  pointers?: Array<{ path: string; line_start?: number; line_end?: number }>;
+}
+
 type MetaTemplateComponent = NonNullable<MetaTemplatePayload['components']>[number];
 type MetaTemplateParameter = NonNullable<MetaTemplateComponent['parameters']>[number];
 
@@ -140,6 +152,8 @@ export class MetaWhatsAppClient {
   /**
    * POST /{waba_id}/flows — create a flow (optionally publishing immediately).
    * `flowJson` is the stringified Flow JSON (screens/layout definition).
+   * Meta returns `validation_errors` inline when `flow_json` is provided —
+   * always surface them (a flow that "creates fine" can still be unopenable).
    */
   async createFlow(input: {
     name: string;
@@ -147,7 +161,7 @@ export class MetaWhatsAppClient {
     flowJson?: string;
     publish?: boolean;
     endpointUri?: string;
-  }): Promise<{ id: string }> {
+  }): Promise<{ id: string; success?: boolean; validation_errors?: MetaFlowValidationError[] }> {
     this.requireWaba('createFlow');
     return this.post(`/${this.wabaId}/flows`, {
       name: input.name,
@@ -158,9 +172,60 @@ export class MetaWhatsAppClient {
     });
   }
 
+  /**
+   * POST /{flow_id}/assets — replace the flow's Flow JSON (multipart upload,
+   * `asset_type: FLOW_JSON`). The only way to update screens on an existing
+   * flow; DRAFT flows update in place, published flows require a new draft.
+   */
+  async updateFlowAssets(
+    flowId: string,
+    flowJson: string,
+  ): Promise<{ success: boolean; validation_errors?: MetaFlowValidationError[] }> {
+    const form = new FormData();
+    form.append('name', 'flow.json');
+    form.append('asset_type', 'FLOW_JSON');
+    form.append('file', new Blob([flowJson], { type: 'application/json' }), 'flow.json');
+    return this.postForm(`/${flowId}/assets`, form);
+  }
+
+  /**
+   * POST /{flow_id} — update flow properties. `endpoint_uri` lives here (it is
+   * a flow property, NOT part of Flow JSON in v6+): this is the only way to
+   * point an existing flow at a data-exchange endpoint.
+   */
+  async updateFlowMetadata(
+    flowId: string,
+    input: { name?: string; categories?: string[]; endpointUri?: string; applicationId?: string },
+  ): Promise<{ success: boolean }> {
+    return this.post(`/${flowId}`, {
+      ...(input.name ? { name: input.name } : {}),
+      ...(input.categories ? { categories: input.categories } : {}),
+      ...(input.endpointUri !== undefined ? { endpoint_uri: input.endpointUri } : {}),
+      ...(input.applicationId ? { application_id: input.applicationId } : {}),
+    });
+  }
+
+  /** GET /{flow_id} — status, validation errors, endpoint_uri and preview in one call. */
+  async getFlow(flowId: string): Promise<{
+    id: string;
+    name: string;
+    status: string;
+    categories: string[];
+    validation_errors: MetaFlowValidationError[];
+    endpoint_uri?: string;
+    preview?: { preview_url: string; expires_at: string };
+  }> {
+    return this.get(`/${flowId}?fields=id,name,status,categories,validation_errors,endpoint_uri,preview`);
+  }
+
   /** POST /{flow_id}/publish — requires zero validation errors. */
   async publishFlow(flowId: string): Promise<{ success: boolean }> {
     return this.post(`/${flowId}/publish`, {});
+  }
+
+  /** POST /{flow_id}/deprecate — retires a PUBLISHED flow (drafts use deleteFlow). */
+  async deprecateFlow(flowId: string): Promise<{ success: boolean }> {
+    return this.post(`/${flowId}/deprecate`, {});
   }
 
   /** DELETE /{flow_id} — only while the flow is still DRAFT. */
@@ -171,6 +236,33 @@ export class MetaWhatsAppClient {
   /** GET /{flow_id}?fields=preview — browser preview URL (valid ~30 days). */
   async getFlowPreview(flowId: string): Promise<{ preview?: { preview_url: string; expires_at: string } }> {
     return this.get(`/${flowId}?fields=preview.invalidate(false)`);
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Flows data-endpoint encryption keys
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * POST /{phone_number_id}/whatsapp_business_encryption — register the
+   * 2048-bit RSA public key Meta uses to wrap the per-request AES key.
+   * Re-posting replaces the key (rotation).
+   */
+  async uploadBusinessPublicKey(publicKeyPem: string): Promise<{ success: boolean }> {
+    const form = new FormData();
+    form.append('business_public_key', publicKeyPem);
+    return this.postForm(`/${this.phoneNumberId}/whatsapp_business_encryption`, form);
+  }
+
+  /**
+   * GET /{phone_number_id}/whatsapp_business_encryption — the registered key +
+   * `business_public_key_signature_status` (VALID | MISMATCH). MISMATCH means
+   * Meta will keep calling the endpoint with a key we can't decrypt → 421 loop.
+   */
+  async getBusinessPublicKey(): Promise<{
+    business_public_key?: string;
+    business_public_key_signature_status?: 'VALID' | 'MISMATCH';
+  }> {
+    return this.get(`/${this.phoneNumberId}/whatsapp_business_encryption`);
   }
 
   private requireWaba(operation: string): void {
@@ -278,6 +370,18 @@ export class MetaWhatsAppClient {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify(body),
+    });
+    if (!res.ok) throw await this.errorFromResponse(res, `POST ${path}`);
+    const text = await res.text();
+    return (text ? JSON.parse(text) : {}) as T;
+  }
+
+  /** Multipart POST — fetch sets the boundary Content-Type from the FormData. */
+  private async postForm<T = unknown>(path: string, form: FormData): Promise<T> {
+    const res = await this.fetchWithTimeout(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+      body: form,
     });
     if (!res.ok) throw await this.errorFromResponse(res, `POST ${path}`);
     const text = await res.text();

--- a/packages/channel-whatsapp-cloud/src/flows/demo-resolver.ts
+++ b/packages/channel-whatsapp-cloud/src/flows/demo-resolver.ts
@@ -1,0 +1,50 @@
+/**
+ * Reference resolver for validating the Flows data-exchange path end-to-end.
+ *
+ * Serves a two-step demo flow (screens START → CONFIRM → SUCCESS):
+ *   INIT                         → START (empty data)
+ *   data_exchange from START     → CONFIRM with a summary composed of the
+ *                                  submitted fields (echoed back so the
+ *                                  terminal screen can template them)
+ *   data_exchange from CONFIRM   → SUCCESS terminating the flow; the params
+ *                                  land on the nfm_reply webhook
+ *
+ * Wire it env-gated from the API bootstrap (META_FLOWS_DEMO_INSTANCE) as the
+ * instance default — it is a smoke-test harness, not product logic. It is
+ * intentionally screen-name agnostic beyond the START/CONFIRM contract.
+ */
+
+import type { FlowResolveContext, FlowResolver, FlowScreenResponse } from './resolver';
+
+export function createDemoFlowResolver(): FlowResolver {
+  return {
+    resolve(ctx: FlowResolveContext): FlowScreenResponse {
+      if (ctx.action === 'INIT' || ctx.action === 'BACK') {
+        return { screen: 'START', data: {} };
+      }
+
+      if (ctx.screen === 'START') {
+        const data = ctx.data ?? {};
+        const fields = Object.entries(data)
+          .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : String(value)}`)
+          .join(' · ');
+        return {
+          screen: 'CONFIRM',
+          data: { ...data, resumo: fields || '(nada preenchido)' },
+        };
+      }
+
+      // CONFIRM (or anything else) → terminate; echo everything to the webhook.
+      // Meta only accepts STRING values in extension_message_response.params —
+      // a boolean/number silently prevents the client from closing the flow.
+      const params: Record<string, string> = { flow_token: ctx.flowToken };
+      for (const [key, value] of Object.entries(ctx.data ?? {})) {
+        params[key] = Array.isArray(value) ? value.join(',') : String(value);
+      }
+      return {
+        screen: 'SUCCESS',
+        data: { extension_message_response: { params } },
+      };
+    },
+  };
+}

--- a/packages/channel-whatsapp-cloud/src/flows/resolver.ts
+++ b/packages/channel-whatsapp-cloud/src/flows/resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * WhatsApp Flows data-exchange resolver.
+ *
+ * The data endpoint must answer synchronously inside Meta's timeout, so
+ * resolution is an in-process registry lookup — no queue hop. Resolvers are
+ * keyed by flow ref (Meta flow id or flow name), with an optional
+ * per-instance default as fallback.
+ *
+ * flowId discovery: the decrypted payload carries NO flow id, only the
+ * flow_token echoed from the send. `sendFlow` therefore emits structured
+ * tokens (`omni.<flowRef>.<uuid>`) unless the caller supplied their own —
+ * `parseFlowToken` recovers the ref; opaque tokens fall through to the
+ * instance default resolver.
+ */
+
+export interface FlowResolveContext {
+  instanceId: string;
+  /** Parsed from a structured flow token; null for caller-supplied opaque tokens. */
+  flowRef: string | null;
+  flowToken: string;
+  action: 'INIT' | 'data_exchange' | 'BACK';
+  /** Screen the user submitted from (undefined on INIT). */
+  screen?: string;
+  /** User-submitted key-value pairs for this step. */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * What the endpoint sends back (pre-encryption). `screen: 'SUCCESS'` with an
+ * `extension_message_response` terminates the flow and routes `params` to the
+ * nfm_reply webhook.
+ */
+export interface FlowScreenResponse {
+  screen: string;
+  data?: Record<string, unknown>;
+}
+
+export interface FlowResolver {
+  resolve(ctx: FlowResolveContext): Promise<FlowScreenResponse> | FlowScreenResponse;
+}
+
+const FLOW_TOKEN_PREFIX = 'omni';
+
+/** Build a structured flow token: `omni.<flowRef>.<uuid>`. */
+export function buildFlowToken(flowRef: string): string {
+  return `${FLOW_TOKEN_PREFIX}.${flowRef}.${crypto.randomUUID()}`;
+}
+
+/** Recover the flow ref from a structured token; null for foreign formats. */
+export function parseFlowToken(flowToken: string | undefined): string | null {
+  if (!flowToken) return null;
+  const parts = flowToken.split('.');
+  if (parts.length < 3 || parts[0] !== FLOW_TOKEN_PREFIX) return null;
+  // The uuid is the last segment; the ref may itself contain dots.
+  const ref = parts.slice(1, -1).join('.');
+  return ref.length > 0 ? ref : null;
+}
+
+/** Registry: flow-ref resolvers + per-instance defaults. */
+export class FlowResolverRegistry {
+  private readonly byFlowRef = new Map<string, FlowResolver>();
+  private readonly byInstance = new Map<string, FlowResolver>();
+
+  register(flowRef: string, resolver: FlowResolver): void {
+    this.byFlowRef.set(flowRef, resolver);
+  }
+
+  registerInstanceDefault(instanceId: string, resolver: FlowResolver): void {
+    this.byInstance.set(instanceId, resolver);
+  }
+
+  unregister(flowRef: string): void {
+    this.byFlowRef.delete(flowRef);
+  }
+
+  /** flow-ref match first, then the instance default, else null (caller error-screens). */
+  lookup(ctx: Pick<FlowResolveContext, 'instanceId' | 'flowRef'>): FlowResolver | null {
+    if (ctx.flowRef) {
+      const byRef = this.byFlowRef.get(ctx.flowRef);
+      if (byRef) return byRef;
+    }
+    return this.byInstance.get(ctx.instanceId) ?? null;
+  }
+}
+
+/**
+ * Fallback response when no resolver matches or resolution fails: an error
+ * snackbar on the screen the user is on (INIT gets a bare SUCCESS-less
+ * terminal error via the same shape — Meta renders `error_message` inline).
+ */
+export function errorScreenResponse(ctx: Pick<FlowResolveContext, 'screen'>, message: string): FlowScreenResponse {
+  return {
+    screen: ctx.screen ?? 'SUCCESS',
+    data: { error_message: message },
+  };
+}

--- a/packages/channel-whatsapp-cloud/src/handlers/flow-data.ts
+++ b/packages/channel-whatsapp-cloud/src/handlers/flow-data.ts
@@ -1,0 +1,200 @@
+/**
+ * WhatsApp Flows data-exchange endpoint handler.
+ *
+ * Meta calls this for endpoint-backed flows on INIT (flow opened with
+ * flow_action data_exchange), data_exchange (screen submitted), BACK
+ * (refresh_on_back screens) and ping (health check). The response must be
+ * synchronous — screens are resolved in-process via FlowResolverRegistry.
+ *
+ * Status-code contract (Meta client behavior depends on these):
+ *   200 — encrypted response body (or plain JSON for plain-text pings)
+ *   404 — unknown instance (bad URL)
+ *   421 — cannot decrypt → client re-fetches the business public key
+ *   427 — flow token rejected → client tells the user to re-open the flow
+ *   432 — request signature verification failed
+ */
+
+import type { EventPayloadMap, Logger } from '@omni/core';
+import type { FlowResolveContext, FlowResolverRegistry, FlowScreenResponse } from '../flows/resolver';
+import { errorScreenResponse, parseFlowToken } from '../flows/resolver';
+import type { DecryptedFlowRequest, EncryptedFlowRequestBody } from '../utils/flow-crypto';
+import { FlowDecryptError, decryptFlowRequest, encryptFlowResponse, importFlowPrivateKey } from '../utils/flow-crypto';
+import { verifyMetaSignature } from '../utils/signature';
+
+/** Resolver time budget — Meta aborts slow endpoints, so never exceed this. */
+const RESOLVE_TIMEOUT_MS = 8_000;
+
+export interface FlowDataHandlerContext {
+  instanceId: string;
+  channelType: string;
+  /** Unsealed PKCS#8 PEM. The caller (API route) owns unsealing. */
+  privateKeyPem: string;
+  appSecret: string;
+  registry: FlowResolverRegistry;
+  logger: Logger;
+  /** Observability hook — fired after the response is resolved (never for ping). */
+  publishEvent: (payload: EventPayloadMap['flow.data_exchange']) => Promise<unknown>;
+}
+
+/** Either an early HTTP response (ping/errors) or the decrypted request to resolve. */
+type IntakeResult = { response: Response } | { decrypted: DecryptedFlowRequest };
+
+function isEncryptedBody(
+  parsed: Record<string, unknown>,
+): parsed is Record<string, unknown> & EncryptedFlowRequestBody {
+  return (
+    typeof parsed.encrypted_flow_data === 'string' &&
+    typeof parsed.encrypted_aes_key === 'string' &&
+    typeof parsed.initial_vector === 'string'
+  );
+}
+
+/** Signature check, plain-ping short-circuit, and decryption. */
+async function intake(request: Request, ctx: FlowDataHandlerContext): Promise<IntakeResult> {
+  const rawBody = await request.text();
+
+  const signature = request.headers.get('x-hub-signature-256');
+  if (!ctx.appSecret || !signature || !(await verifyMetaSignature(rawBody, signature, ctx.appSecret))) {
+    ctx.logger.warn('[whatsapp-cloud] flow data request failed signature verification', {
+      instanceId: ctx.instanceId,
+      hasSignature: Boolean(signature),
+    });
+    return { response: new Response(null, { status: 432 }) };
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(rawBody) as Record<string, unknown>;
+  } catch {
+    return { response: new Response(null, { status: 421 }) };
+  }
+
+  // Plain-text health check (docs describe unencrypted pings; be liberal —
+  // encrypted pings take the normal decrypt path below).
+  if (parsed.action === 'ping') {
+    return { response: Response.json({ data: { status: 'active' } }) };
+  }
+
+  if (!isEncryptedBody(parsed)) {
+    return { response: new Response(null, { status: 421 }) };
+  }
+
+  try {
+    const privateKey = await importFlowPrivateKey(ctx.privateKeyPem);
+    return { decrypted: await decryptFlowRequest(parsed, privateKey) };
+  } catch (err) {
+    ctx.logger.warn('[whatsapp-cloud] flow data decrypt failed — responding 421', {
+      instanceId: ctx.instanceId,
+      error: err instanceof FlowDecryptError ? err.message : String(err),
+    });
+    return { response: new Response(null, { status: 421 }) };
+  }
+}
+
+/** Registry lookup + resolution under the timeout budget; always yields a screen. */
+async function resolveScreen(ctx: FlowDataHandlerContext, resolveCtx: FlowResolveContext): Promise<FlowScreenResponse> {
+  const resolver = ctx.registry.lookup(resolveCtx);
+  if (!resolver) {
+    ctx.logger.warn('[whatsapp-cloud] no flow resolver registered — responding with error screen', {
+      instanceId: ctx.instanceId,
+      flowRef: resolveCtx.flowRef,
+    });
+    return errorScreenResponse(resolveCtx, 'This flow is not available right now. Please try again later.');
+  }
+
+  try {
+    return await Promise.race([
+      Promise.resolve(resolver.resolve(resolveCtx)),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`flow resolver timed out after ${RESOLVE_TIMEOUT_MS}ms`)),
+          RESOLVE_TIMEOUT_MS,
+        ),
+      ),
+    ]);
+  } catch (err) {
+    ctx.logger.error('[whatsapp-cloud] flow resolver failed', {
+      instanceId: ctx.instanceId,
+      flowRef: resolveCtx.flowRef,
+      action: resolveCtx.action,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return errorScreenResponse(resolveCtx, 'Something went wrong. Please try again.');
+  }
+}
+
+async function publishExchangeEvent(
+  ctx: FlowDataHandlerContext,
+  resolveCtx: FlowResolveContext,
+  responseScreen: string,
+  durationMs: number,
+): Promise<void> {
+  try {
+    await ctx.publishEvent({
+      instanceId: ctx.instanceId,
+      channelType: ctx.channelType as EventPayloadMap['flow.data_exchange']['channelType'],
+      flowId: resolveCtx.flowRef,
+      flowToken: resolveCtx.flowToken,
+      action: resolveCtx.action,
+      screen: resolveCtx.screen,
+      data: resolveCtx.data,
+      responseScreen,
+      durationMs,
+    });
+  } catch (err) {
+    // Observability must never break the synchronous response.
+    ctx.logger.warn('[whatsapp-cloud] flow.data_exchange event publish failed', {
+      instanceId: ctx.instanceId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export async function handleFlowDataRequest(request: Request, ctx: FlowDataHandlerContext): Promise<Response> {
+  const authenticated = await intake(request, ctx);
+  if ('response' in authenticated) return authenticated.response;
+
+  const { payload, aesKey, iv } = authenticated.decrypted;
+  const respond = async (body: unknown): Promise<Response> =>
+    new Response(await encryptFlowResponse(body, aesKey, iv), {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+  if (payload.action === 'ping') {
+    return respond({ data: { status: 'active' } });
+  }
+
+  // Async error notification from the client (e.g. we returned an invalid
+  // screen earlier) — acknowledge, don't resolve.
+  const dataBag = (payload.data ?? {}) as Record<string, unknown>;
+  if (dataBag.error != null || dataBag.error_message != null) {
+    ctx.logger.warn('[whatsapp-cloud] flow client error notification', {
+      instanceId: ctx.instanceId,
+      flowToken: payload.flow_token,
+      error: dataBag.error,
+      errorMessage: dataBag.error_message,
+    });
+    return respond({ data: { acknowledged: true } });
+  }
+
+  if (!payload.flow_token) {
+    // Without a token there is nothing to correlate or resolve against.
+    return new Response(null, { status: 427 });
+  }
+
+  const resolveCtx: FlowResolveContext = {
+    instanceId: ctx.instanceId,
+    flowRef: parseFlowToken(payload.flow_token),
+    flowToken: payload.flow_token,
+    action: payload.action,
+    screen: payload.screen,
+    data: payload.data,
+  };
+
+  const startedAt = performance.now();
+  const screenResponse = await resolveScreen(ctx, resolveCtx);
+  await publishExchangeEvent(ctx, resolveCtx, screenResponse.screen, Math.round(performance.now() - startedAt));
+
+  return respond(screenResponse);
+}

--- a/packages/channel-whatsapp-cloud/src/handlers/flow-data.ts
+++ b/packages/channel-whatsapp-cloud/src/handlers/flow-data.ts
@@ -194,7 +194,16 @@ export async function handleFlowDataRequest(request: Request, ctx: FlowDataHandl
 
   const startedAt = performance.now();
   const screenResponse = await resolveScreen(ctx, resolveCtx);
-  await publishExchangeEvent(ctx, resolveCtx, screenResponse.screen, Math.round(performance.now() - startedAt));
+  const durationMs = Math.round(performance.now() - startedAt);
+  ctx.logger.info('[whatsapp-cloud] flow data exchange resolved', {
+    instanceId: ctx.instanceId,
+    flowRef: resolveCtx.flowRef,
+    action: resolveCtx.action,
+    screen: resolveCtx.screen,
+    responseScreen: screenResponse.screen,
+    durationMs,
+  });
+  await publishExchangeEvent(ctx, resolveCtx, screenResponse.screen, durationMs);
 
   return respond(screenResponse);
 }

--- a/packages/channel-whatsapp-cloud/src/index.ts
+++ b/packages/channel-whatsapp-cloud/src/index.ts
@@ -65,6 +65,7 @@ export {
   parseFlowToken,
   errorScreenResponse,
 } from './flows/resolver';
+export { createDemoFlowResolver } from './flows/demo-resolver';
 export type { FlowResolver, FlowResolveContext, FlowScreenResponse } from './flows/resolver';
 export { generateFlowKeyPair } from './utils/flow-crypto';
 export type { MetaFlowValidationError } from './client';

--- a/packages/channel-whatsapp-cloud/src/index.ts
+++ b/packages/channel-whatsapp-cloud/src/index.ts
@@ -56,6 +56,19 @@ export type {
 export { sendFlow } from './senders/flow';
 export type { SendFlowResult } from './senders/flow';
 
+// WhatsApp Flows data-exchange endpoint pieces — resolver registry (register
+// screen logic per flow), token helpers, and crypto/keygen used by the keys
+// REST route (`POST /instances/:id/whatsapp-flows/keys`).
+export {
+  FlowResolverRegistry,
+  buildFlowToken,
+  parseFlowToken,
+  errorScreenResponse,
+} from './flows/resolver';
+export type { FlowResolver, FlowResolveContext, FlowScreenResponse } from './flows/resolver';
+export { generateFlowKeyPair } from './utils/flow-crypto';
+export type { MetaFlowValidationError } from './client';
+
 // Embedded Signup OAuth helpers — pure functions consumed by the REST surface
 // at `packages/api/src/routes/v2/whatsapp-cloud.ts` (Group 5).
 export {

--- a/packages/channel-whatsapp-cloud/src/plugin.ts
+++ b/packages/channel-whatsapp-cloud/src/plugin.ts
@@ -31,6 +31,8 @@ import type { ChannelType, ContentType } from '@omni/core/types';
 
 import { WHATSAPP_CLOUD_CAPABILITIES } from './capabilities';
 import { MetaWhatsAppClient } from './client';
+import { FlowResolverRegistry } from './flows/resolver';
+import { handleFlowDataRequest } from './handlers/flow-data';
 import { handleMetaWebhook } from './handlers/webhook';
 import {
   type SendTemplateButton,
@@ -336,6 +338,35 @@ export class WhatsAppCloudPlugin extends BaseChannelPlugin {
     }
 
     return handleMetaWebhook(request, this, appSecret, verifyToken);
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // WhatsApp Flows data-exchange endpoint
+  // ─────────────────────────────────────────────────────────────
+
+  /** Screen resolvers for endpoint-backed flows (see flows/resolver.ts). */
+  readonly flowResolvers = new FlowResolverRegistry();
+
+  /**
+   * Handle one encrypted data-exchange request for `instanceId`. The caller
+   * (API public route) owns instance lookup and private-key unsealing — this
+   * method owns signature verification, crypto and screen resolution.
+   */
+  async handleFlowData(request: Request, opts: { instanceId: string; privateKeyPem: string }): Promise<Response> {
+    return handleFlowDataRequest(request, {
+      instanceId: opts.instanceId,
+      channelType: this.id,
+      privateKeyPem: opts.privateKeyPem,
+      appSecret: process.env.META_APP_SECRET ?? '',
+      registry: this.flowResolvers,
+      logger: this.logger,
+      publishEvent: (payload) =>
+        this.eventBus.publish('flow.data_exchange', payload, {
+          instanceId: opts.instanceId,
+          channelType: this.id,
+          source: `channel:${this.id}`,
+        }),
+    });
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/packages/channel-whatsapp-cloud/src/senders/flow.ts
+++ b/packages/channel-whatsapp-cloud/src/senders/flow.ts
@@ -6,13 +6,14 @@
  * come back on the webhook as `interactive.nfm_reply` with `response_json`,
  * correlated by the `flow_token` echoed back verbatim.
  *
- * Only `flow_action: navigate` is supported — `data_exchange` flows require a
- * business-hosted encrypted data endpoint, which is out of this channel's
- * scope for now.
+ * Supports both `flow_action: navigate` (static flows) and `data_exchange`
+ * (endpoint-backed dynamic flows — the omni-hosted encrypted data endpoint
+ * resolves each screen; see handlers/flow-data.ts).
  */
 
 import type { WhatsAppFlowSend } from '@omni/core/schemas';
 import type { MetaWhatsAppClient } from '../client';
+import { buildFlowToken } from '../flows/resolver';
 import type { MetaOutboundMessage, MetaSendResponse } from '../types';
 import { toMetaPhone } from '../utils/identity';
 
@@ -28,17 +29,24 @@ export async function sendFlow(
   flow: WhatsAppFlowSend,
   replyTo?: string,
 ): Promise<SendFlowResult> {
-  const flowToken = flow.flowToken ?? crypto.randomUUID();
+  // Structured token (`omni.<flowRef>.<uuid>`) — the data endpoint recovers
+  // the flow ref from it, since Meta's decrypted payload has no flow id.
+  // Caller-supplied tokens pass through opaque.
+  const flowRef = flow.flowId ?? flow.flowName ?? 'unknown';
+  const flowToken = flow.flowToken ?? buildFlowToken(flowRef);
+  const flowAction = flow.flowAction ?? 'navigate';
 
   const parameters: Record<string, unknown> = {
     flow_message_version: '3',
     flow_token: flowToken,
     flow_cta: flow.cta,
-    flow_action: 'navigate',
+    flow_action: flowAction,
     ...(flow.flowId ? { flow_id: flow.flowId } : { flow_name: flow.flowName }),
     ...(flow.draft ? { mode: 'draft' } : {}),
   };
-  if (flow.screen) {
+  // navigate: entry screen is required client-side; data_exchange: the INIT
+  // call to the endpoint decides the first screen, so no payload is sent.
+  if (flow.screen && flowAction === 'navigate') {
     parameters.flow_action_payload = {
       screen: flow.screen,
       ...(flow.data && Object.keys(flow.data).length > 0 ? { data: flow.data } : {}),

--- a/packages/channel-whatsapp-cloud/src/utils/flow-crypto.ts
+++ b/packages/channel-whatsapp-cloud/src/utils/flow-crypto.ts
@@ -1,0 +1,156 @@
+/**
+ * WhatsApp Flows data-endpoint crypto (Meta data API v3.0).
+ *
+ * Request:  Meta wraps a fresh 128-bit AES key with the business's 2048-bit
+ *           RSA public key (RSA-OAEP, SHA-256 hash + SHA-256 MGF1) and
+ *           encrypts the JSON payload with AES-128-GCM. The 16-byte GCM tag
+ *           is appended to the ciphertext — exactly the layout Web Crypto's
+ *           `decrypt` expects.
+ * Response: encrypted with the SAME AES key but the IV bitwise-inverted
+ *           (each byte XOR 0xFF), then base64'd as the raw HTTP body.
+ *
+ * Pure functions — no fetch, no DB — so the whole contract is unit-testable
+ * as an encrypt→decrypt inverse without Meta in the loop.
+ */
+
+export interface EncryptedFlowRequestBody {
+  encrypted_flow_data: string;
+  encrypted_aes_key: string;
+  initial_vector: string;
+}
+
+/** Decrypted request plus the material needed to encrypt the response. */
+export interface DecryptedFlowRequest {
+  payload: FlowDataExchangeRequest;
+  aesKey: CryptoKey;
+  iv: Uint8Array;
+}
+
+/** The decrypted data-exchange payload (action drives the dispatch). */
+export interface FlowDataExchangeRequest {
+  version: string;
+  action: 'ping' | 'INIT' | 'data_exchange' | 'BACK';
+  screen?: string;
+  data?: Record<string, unknown>;
+  flow_token?: string;
+}
+
+/** Thrown for any failure that must map to HTTP 421 (Meta re-fetches the key). */
+export class FlowDecryptError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'FlowDecryptError';
+    this.cause = cause;
+  }
+}
+
+const b64decode = (value: string): Uint8Array => Uint8Array.from(atob(value), (c) => c.charCodeAt(0));
+const b64encode = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes));
+
+/** Strip PEM armor and return the DER bytes. */
+function pemToDer(pem: string): Uint8Array {
+  const base64 = pem.replace(/-----(BEGIN|END)[A-Z ]+-----/g, '').replace(/\s+/g, '');
+  return b64decode(base64);
+}
+
+/** Import a PKCS#8 RSA private key PEM for OAEP-SHA256 unwrapping. */
+export async function importFlowPrivateKey(privateKeyPem: string): Promise<CryptoKey> {
+  try {
+    const der = pemToDer(privateKeyPem);
+    return await crypto.subtle.importKey(
+      'pkcs8',
+      der.buffer as ArrayBuffer,
+      { name: 'RSA-OAEP', hash: 'SHA-256' },
+      false,
+      ['decrypt'],
+    );
+  } catch (err) {
+    throw new FlowDecryptError('failed to import flow private key', err);
+  }
+}
+
+/**
+ * Decrypt an inbound data-exchange request. Any failure (bad base64, wrong
+ * key, GCM auth failure, non-JSON plaintext) throws FlowDecryptError → the
+ * caller must answer HTTP 421.
+ */
+export async function decryptFlowRequest(
+  body: EncryptedFlowRequestBody,
+  privateKey: CryptoKey,
+): Promise<DecryptedFlowRequest> {
+  let aesKeyBytes: ArrayBuffer;
+  try {
+    const wrapped = b64decode(body.encrypted_aes_key);
+    aesKeyBytes = await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, privateKey, wrapped.buffer as ArrayBuffer);
+  } catch (err) {
+    throw new FlowDecryptError('RSA unwrap of AES key failed', err);
+  }
+
+  try {
+    const aesKey = await crypto.subtle.importKey('raw', aesKeyBytes, { name: 'AES-GCM' }, false, [
+      'encrypt',
+      'decrypt',
+    ]);
+    const iv = b64decode(body.initial_vector);
+    const ciphertext = b64decode(body.encrypted_flow_data);
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+      aesKey,
+      ciphertext.buffer as ArrayBuffer,
+    );
+    const payload = JSON.parse(new TextDecoder().decode(plaintext)) as FlowDataExchangeRequest;
+    return { payload, aesKey, iv };
+  } catch (err) {
+    if (err instanceof FlowDecryptError) throw err;
+    throw new FlowDecryptError('AES-GCM decrypt of flow data failed', err);
+  }
+}
+
+/**
+ * Encrypt the response payload with the request's AES key and the inverted
+ * IV. Returns the base64 string Meta expects as the raw response body.
+ */
+export async function encryptFlowResponse(
+  response: unknown,
+  aesKey: CryptoKey,
+  requestIv: Uint8Array,
+): Promise<string> {
+  const flippedIv = requestIv.map((byte) => byte ^ 0xff);
+  const plaintext = new TextEncoder().encode(JSON.stringify(response));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: flippedIv.buffer as ArrayBuffer },
+    aesKey,
+    plaintext.buffer as ArrayBuffer,
+  );
+  return b64encode(new Uint8Array(ciphertext));
+}
+
+/**
+ * Generate a 2048-bit RSA-OAEP keypair for the flows endpoint. Returns both
+ * halves as PEM: the public side goes to Meta
+ * (`uploadBusinessPublicKey`), the private side is sealed and stored.
+ */
+export async function generateFlowKeyPair(): Promise<{ privateKeyPem: string; publicKeyPem: string }> {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: 'RSA-OAEP',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+  const privateDer = new Uint8Array(await crypto.subtle.exportKey('pkcs8', pair.privateKey));
+  const publicDer = new Uint8Array(await crypto.subtle.exportKey('spki', pair.publicKey));
+  return {
+    privateKeyPem: derToPem(privateDer, 'PRIVATE KEY'),
+    publicKeyPem: derToPem(publicDer, 'PUBLIC KEY'),
+  };
+}
+
+function derToPem(der: Uint8Array, label: string): string {
+  const base64 = b64encode(der);
+  const lines = base64.match(/.{1,64}/g) ?? [];
+  return `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----\n`;
+}

--- a/packages/core/src/events/nats/__tests__/streams.test.ts
+++ b/packages/core/src/events/nats/__tests__/streams.test.ts
@@ -40,9 +40,19 @@ describe('streams', () => {
       expect(config.subjects).toEqual(['custom.>']);
     });
 
-    test('SYSTEM stream captures system.>, sync.>, batch-job.>, presence.>, chat.>, and follow_up.> subjects', () => {
+    test('SYSTEM stream captures system/sync/batch-job/presence/chat/follow_up/flow/template/channel subjects', () => {
       const config = STREAM_CONFIGS.SYSTEM;
-      expect(config.subjects).toEqual(['system.>', 'sync.>', 'batch-job.>', 'presence.>', 'chat.>', 'follow_up.>']);
+      expect(config.subjects).toEqual([
+        'system.>',
+        'sync.>',
+        'batch-job.>',
+        'presence.>',
+        'chat.>',
+        'follow_up.>',
+        'flow.>',
+        'template.>',
+        'channel.>',
+      ]);
     });
   });
 

--- a/packages/core/src/events/nats/streams.ts
+++ b/packages/core/src/events/nats/streams.ts
@@ -106,11 +106,24 @@ export const STREAM_CONFIGS: Record<StreamName, Partial<StreamConfig>> = {
   },
   [STREAM_NAMES.SYSTEM]: {
     name: STREAM_NAMES.SYSTEM,
-    subjects: ['system.>', 'sync.>', 'batch-job.>', 'presence.>', 'chat.>', 'follow_up.>'],
+    subjects: [
+      'system.>',
+      'sync.>',
+      'batch-job.>',
+      'presence.>',
+      'chat.>',
+      'follow_up.>',
+      // Channel-ops events. template./channel. had NO stream before (publishes
+      // failed with 503 no-responders); flow. added with the Flows feature.
+      'flow.>',
+      'template.>',
+      'channel.>',
+    ],
     max_age: daysToNs(7),
     storage: NATS_STORAGE_FILE,
     retention: NATS_RETENTION_LIMITS,
-    description: 'Internal system events (dead_letter, replay, health, sync, batch-job, presence, chat, follow_up)',
+    description:
+      'Internal system events (dead_letter, replay, health, sync, batch-job, presence, chat, follow_up, flow, template, channel)',
   },
   [STREAM_NAMES.AGENT]: {
     name: STREAM_NAMES.AGENT,
@@ -143,6 +156,9 @@ export function getStreamForEventType(eventType: string): StreamName {
     presence: STREAM_NAMES.SYSTEM,
     chat: STREAM_NAMES.SYSTEM,
     follow_up: STREAM_NAMES.SYSTEM,
+    flow: STREAM_NAMES.SYSTEM,
+    template: STREAM_NAMES.SYSTEM,
+    channel: STREAM_NAMES.SYSTEM,
     agent: STREAM_NAMES.AGENT,
   };
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -105,6 +105,9 @@ export const CORE_EVENT_TYPES = [
   // Channel-side operator alerts (Meta WABA quality drops, account flags, etc.)
   // Single event; consumers filter on payload.alertType.
   'channel.alert',
+  // WhatsApp Flows — one event per data-exchange endpoint hit (INIT/data_exchange/BACK).
+  // Observability + async consumers; the synchronous screen response is resolved in-process.
+  'flow.data_exchange',
 ] as const;
 
 export type CoreEventType = (typeof CORE_EVENT_TYPES)[number];
@@ -958,6 +961,32 @@ export interface TemplateStatusChangedPayload {
   rejectionReason?: string;
 }
 
+// ─── WhatsApp Flows data exchange ─────────────────────────────────────────
+
+/**
+ * Emitted once per WhatsApp Flows data-endpoint hit (after the synchronous
+ * encrypted response has been resolved in-process). Never emitted for `ping`
+ * health checks. `flowId` is parsed from structured flow tokens
+ * (`omni.<flowId>.<uuid>`) and is null for caller-supplied opaque tokens.
+ */
+export interface FlowDataExchangePayload {
+  instanceId: string;
+  channelType: ChannelType;
+  /** Meta flow id when derivable from the flow token, else null. */
+  flowId: string | null;
+  /** Echoed verbatim from the send — correlates endpoint hits to the send. */
+  flowToken: string;
+  action: 'INIT' | 'data_exchange' | 'BACK';
+  /** Screen the user was on (empty for INIT). */
+  screen?: string;
+  /** Decrypted user-submitted data for this step. */
+  data?: Record<string, unknown>;
+  /** Screen the resolver responded with (SUCCESS terminates the flow). */
+  responseScreen?: string;
+  /** Wall-clock time spent resolving the response. */
+  durationMs: number;
+}
+
 /**
  * Event type map for type-safe event handling (core events only)
  */
@@ -1031,6 +1060,7 @@ export interface EventPayloadMap {
   'voice.user_left_channel': VoiceUserChannelPayload;
   'template.status_changed': TemplateStatusChangedPayload;
   'channel.alert': ChannelAlertPayload;
+  'flow.data_exchange': FlowDataExchangePayload;
 }
 
 /**

--- a/packages/core/src/schemas/__tests__/whatsapp-flows.test.ts
+++ b/packages/core/src/schemas/__tests__/whatsapp-flows.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { validateFlowJson } from '../whatsapp-flows';
+
+/** The rich flow we drove live (INTRO with image → CADASTRO form) — must pass. */
+const validStaticFlow = {
+  version: '6.3',
+  routing_model: { INTRO: ['CADASTRO'], CADASTRO: [] },
+  screens: [
+    {
+      id: 'INTRO',
+      title: 'Khal AI',
+      layout: {
+        type: 'SingleColumnLayout',
+        children: [
+          { type: 'Image', src: 'aGVsbG8=', height: 240 },
+          { type: 'TextHeading', text: 'Bem-vindo' },
+          { type: 'TextBody', text: 'Demo' },
+          {
+            type: 'Footer',
+            label: 'Começar',
+            'on-click-action': { name: 'navigate', next: { type: 'screen', name: 'CADASTRO' }, payload: {} },
+          },
+        ],
+      },
+    },
+    {
+      id: 'CADASTRO',
+      title: 'Seus dados',
+      terminal: true,
+      layout: {
+        type: 'SingleColumnLayout',
+        children: [
+          {
+            type: 'Form',
+            name: 'form',
+            children: [
+              { type: 'TextInput', name: 'nome', label: 'Nome', 'input-type': 'text', required: true },
+              {
+                type: 'Dropdown',
+                name: 'canal',
+                label: 'Canal',
+                'data-source': [{ id: 'wa', title: 'WhatsApp' }],
+              },
+              {
+                type: 'Footer',
+                label: 'Enviar',
+                'on-click-action': { name: 'complete', payload: { nome: '${form.nome}' } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('validateFlowJson', () => {
+  test('accepts the live-tested rich static flow (object and string forms)', () => {
+    expect(validateFlowJson(validStaticFlow).valid).toBe(true);
+    expect(validateFlowJson(JSON.stringify(validStaticFlow)).valid).toBe(true);
+  });
+
+  test('rejects data_api_version on a non-dynamic flow (the live "an error occurred" bug)', () => {
+    const result = validateFlowJson({ ...validStaticFlow, data_api_version: '3.0' });
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.path === 'data_api_version')).toBe(true);
+  });
+
+  test('requires data_api_version when dynamic: true', () => {
+    const result = validateFlowJson(validStaticFlow, { dynamic: true });
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.path === 'data_api_version')).toBe(true);
+
+    expect(validateFlowJson({ ...validStaticFlow, data_api_version: '3.0' }, { dynamic: true }).valid).toBe(true);
+  });
+
+  test('rejects RichText.text as array (Meta v6.3 INVALID_PROPERTY_TYPE)', () => {
+    const doc = structuredClone(validStaticFlow) as Record<string, unknown>;
+    (doc.screens as Array<{ layout: { children: unknown[] } }>)[0]!.layout.children = [
+      { type: 'RichText', text: ['**bold**', 'line 2'] },
+    ];
+    expect(validateFlowJson(doc).valid).toBe(false);
+  });
+
+  test('rejects RichText sharing a screen with non-Footer components', () => {
+    const doc = structuredClone(validStaticFlow) as Record<string, unknown>;
+    (doc.screens as Array<{ layout: { children: unknown[] } }>)[0]!.layout.children = [
+      { type: 'RichText', text: '**ok**' },
+      { type: 'TextBody', text: 'not allowed next to RichText' },
+    ];
+    const result = validateFlowJson(doc);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.message.includes('RichText'))).toBe(true);
+  });
+
+  test('allows RichText alone or with only a Footer', () => {
+    const doc = structuredClone(validStaticFlow) as Record<string, unknown>;
+    (doc.screens as Array<{ layout: { children: unknown[] } }>)[0]!.layout.children = [
+      { type: 'RichText', text: '**ok**' },
+      {
+        type: 'Footer',
+        label: 'Ir',
+        'on-click-action': { name: 'navigate', next: { type: 'screen', name: 'CADASTRO' }, payload: {} },
+      },
+    ];
+    expect(validateFlowJson(doc).valid).toBe(true);
+  });
+
+  test('rejects navigate to an undeclared screen and routing_model drift', () => {
+    const badNavigate = structuredClone(validStaticFlow) as Record<string, unknown>;
+    const introChildren = (badNavigate.screens as Array<{ layout: { children: Array<Record<string, unknown>> } }>)[0]!
+      .layout.children;
+    (introChildren[3]!['on-click-action'] as { next: { name: string } }).next.name = 'NOPE';
+    expect(validateFlowJson(badNavigate).valid).toBe(false);
+
+    const badRouting = { ...validStaticFlow, routing_model: { INTRO: ['GHOST'] } };
+    expect(validateFlowJson(badRouting).valid).toBe(false);
+  });
+
+  test('requires at least one terminal screen and unique screen ids', () => {
+    const noTerminal = structuredClone(validStaticFlow) as { screens: Array<{ terminal?: boolean }> };
+    for (const screen of noTerminal.screens) screen.terminal = undefined;
+    expect(validateFlowJson(noTerminal).valid).toBe(false);
+
+    const duplicated = structuredClone(validStaticFlow) as { screens: Array<{ id: string }> };
+    duplicated.screens[1]!.id = 'INTRO';
+    expect(validateFlowJson(duplicated).valid).toBe(false);
+  });
+
+  test('rejects non-JSON strings with a clear issue', () => {
+    const result = validateFlowJson('{not json');
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.message).toContain('not valid JSON');
+  });
+});

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -14,4 +14,5 @@ export * from './instance';
 export * from './message';
 export * from './person';
 export * from './whatsapp-cloud';
+export * from './whatsapp-flows';
 export * from './hermes';

--- a/packages/core/src/schemas/whatsapp-cloud.ts
+++ b/packages/core/src/schemas/whatsapp-cloud.ts
@@ -376,6 +376,12 @@ export const WhatsAppFlowSendSchema = z
     /** Correlates the nfm_reply back to this send; generated when omitted. */
     flowToken: z.string().optional(),
     draft: z.boolean().optional(),
+    /**
+     * 'navigate' (default): static flow, screens resolved client-side.
+     * 'data_exchange': endpoint-backed flow — opening it calls the data
+     * endpoint with INIT; requires the flow to have a registered endpoint_uri.
+     */
+    flowAction: z.enum(['navigate', 'data_exchange']).optional(),
   })
   .refine((v) => Boolean(v.flowId) !== Boolean(v.flowName), {
     message: 'Provide exactly one of flowId or flowName',

--- a/packages/core/src/schemas/whatsapp-flows.ts
+++ b/packages/core/src/schemas/whatsapp-flows.ts
@@ -1,0 +1,309 @@
+/**
+ * WhatsApp Flow JSON validation (Meta Flow JSON v6.x, data API v3.0).
+ *
+ * Meta only reports `validation_errors` *after* an asset upload round-trip.
+ * This schema encodes the structural rules — including the ones that fail
+ * silently or cryptically in production — so callers get fast local feedback
+ * before any Graph API call:
+ *
+ *   - `RichText.text` must be a string (Meta rejects arrays in v6.3+).
+ *   - `RichText` must be the only component on its screen (Footer excepted).
+ *   - `data_api_version` marks a flow as endpoint-backed; sending one without
+ *     a registered `endpoint_uri` makes the client show "an error occurred"
+ *     on open with no webhook trace. The pairing is enforced via
+ *     `validateFlowJson(..., { dynamic })` because `endpoint_uri` is a flow
+ *     *property* (set via Graph API), not part of the Flow JSON itself.
+ *   - At least one `terminal: true` screen; `routing_model` and `navigate`
+ *     actions may only reference declared screen ids.
+ *
+ * Unknown component types are allowed to pass through (Meta ships new
+ * components frequently) — rules apply to the known set only.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+/** `on-click-action` / `on-select-action` object on Footer and interactive components. */
+export const FlowActionSchema = z
+  .object({
+    name: z.enum(['navigate', 'complete', 'data_exchange', 'open_url', 'update_data']),
+    next: z
+      .object({
+        type: z.enum(['screen', 'plugin']),
+        name: z.string().min(1),
+      })
+      .optional(),
+    payload: z.record(z.string(), z.unknown()).optional(),
+    url: z.string().optional(),
+  })
+  .passthrough();
+
+const dataSourceEntry = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+  })
+  .passthrough();
+
+/**
+ * Known component shapes. Each entry validates the fields the rules below
+ * depend on; everything else passes through. Unknown `type` values fall into
+ * the generic branch so new Meta components don't hard-fail local validation.
+ */
+export const FlowComponentSchema: z.ZodType<Record<string, unknown>> = z.lazy(() =>
+  z.union([
+    z
+      .object({
+        type: z.literal('RichText'),
+        // Meta v6.3 rejects arrays here — the docs' examples are misleading.
+        text: z.string().min(1),
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.literal('Image'),
+        /** Base64-encoded image bytes (not a URL). */
+        src: z.string().min(1),
+        height: z.number().int().positive().optional(),
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.literal('Footer'),
+        label: z.string().min(1),
+        'on-click-action': FlowActionSchema,
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.literal('Form'),
+        name: z.string().min(1),
+        children: z.array(FlowComponentSchema),
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.enum(['Dropdown', 'RadioButtonsGroup', 'CheckboxGroup', 'ChipsSelector']),
+        name: z.string().min(1),
+        'data-source': z.array(dataSourceEntry).min(1),
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.enum(['TextInput', 'TextArea', 'DatePicker', 'OptIn']),
+        name: z.string().min(1),
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.enum(['TextHeading', 'TextSubheading', 'TextBody', 'TextCaption']),
+        text: z.string().min(1),
+      })
+      .passthrough(),
+    // Generic fallback: any other component type Meta may introduce.
+    z
+      .object({ type: z.string().min(1) })
+      .passthrough()
+      .refine(
+        (c) =>
+          ![
+            'RichText',
+            'Image',
+            'Footer',
+            'Form',
+            'Dropdown',
+            'RadioButtonsGroup',
+            'CheckboxGroup',
+            'ChipsSelector',
+            'TextInput',
+            'TextArea',
+            'DatePicker',
+            'OptIn',
+            'TextHeading',
+            'TextSubheading',
+            'TextBody',
+            'TextCaption',
+          ].includes(c.type as string),
+        { message: 'known component failed its specific shape' },
+      ),
+  ]),
+);
+
+// ---------------------------------------------------------------------------
+// Screens + document
+// ---------------------------------------------------------------------------
+
+export const FlowScreenSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().optional(),
+    terminal: z.boolean().optional(),
+    /** Screen-level dynamic data contract (endpoint-backed flows). */
+    data: z.record(z.string(), z.unknown()).optional(),
+    refresh_on_back: z.boolean().optional(),
+    layout: z
+      .object({
+        type: z.literal('SingleColumnLayout'),
+        children: z.array(FlowComponentSchema),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+type RefineCtx = z.RefinementCtx;
+type FlowDoc = {
+  routing_model?: Record<string, string[]>;
+  screens: Array<z.infer<typeof FlowScreenSchema>>;
+};
+
+function addIssue(ctx: RefineCtx, path: (string | number)[], message: string): void {
+  ctx.addIssue({ code: z.ZodIssueCode.custom, path, message });
+}
+
+function checkScreenIdentity(flow: FlowDoc, idSet: Set<string>, ctx: RefineCtx): void {
+  if (idSet.size !== flow.screens.length) {
+    addIssue(ctx, ['screens'], 'screen ids must be unique');
+  }
+  if (!flow.screens.some((s) => s.terminal === true)) {
+    addIssue(ctx, ['screens'], 'at least one screen must set terminal: true');
+  }
+}
+
+function checkRoutingModel(flow: FlowDoc, idSet: Set<string>, ctx: RefineCtx): void {
+  for (const [from, targets] of Object.entries(flow.routing_model ?? {})) {
+    if (!idSet.has(from)) {
+      addIssue(ctx, ['routing_model', from], `routing_model references unknown screen '${from}'`);
+    }
+    for (const target of targets) {
+      if (!idSet.has(target)) {
+        addIssue(ctx, ['routing_model', from], `routing_model routes '${from}' to unknown screen '${target}'`);
+      }
+    }
+  }
+}
+
+function checkRichTextIsolation(screen: FlowDoc['screens'][number], screenIdx: number, ctx: RefineCtx): void {
+  const children = screen.layout.children as Array<Record<string, unknown>>;
+  const hasRichText = children.some((c) => c.type === 'RichText');
+  if (hasRichText && children.some((c) => c.type !== 'RichText' && c.type !== 'Footer')) {
+    addIssue(
+      ctx,
+      ['screens', screenIdx, 'layout', 'children'],
+      `screen '${screen.id}': RichText must be the only component on the screen (Footer excepted)`,
+    );
+  }
+}
+
+/** Recursively verify that every navigate action targets a declared screen. */
+function checkNavigateTargets(
+  node: unknown,
+  path: (string | number)[],
+  screen: FlowDoc['screens'][number],
+  screenIdx: number,
+  idSet: Set<string>,
+  ctx: RefineCtx,
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((child, i) => checkNavigateTargets(child, [...path, i], screen, screenIdx, idSet, ctx));
+    return;
+  }
+  if (node === null || typeof node !== 'object') return;
+  const obj = node as Record<string, unknown>;
+  const action = obj['on-click-action'] as Record<string, unknown> | undefined;
+  if (action?.name === 'navigate') {
+    const next = action.next as Record<string, unknown> | undefined;
+    if (next?.type === 'screen' && typeof next.name === 'string' && !idSet.has(next.name)) {
+      addIssue(
+        ctx,
+        ['screens', screenIdx, ...path],
+        `screen '${screen.id}': navigate targets unknown screen '${next.name}'`,
+      );
+    }
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'object' && value !== null) {
+      checkNavigateTargets(value, [...path, key], screen, screenIdx, idSet, ctx);
+    }
+  }
+}
+
+export const FlowJsonSchema = z
+  .object({
+    version: z.string().min(1),
+    /** Present ⇔ the flow is endpoint-backed (see validateFlowJson pairing). */
+    data_api_version: z.literal('3.0').optional(),
+    routing_model: z.record(z.string(), z.array(z.string())).optional(),
+    screens: z.array(FlowScreenSchema).min(1),
+  })
+  .passthrough()
+  .superRefine((flow, ctx) => {
+    const idSet = new Set(flow.screens.map((s) => s.id));
+    checkScreenIdentity(flow, idSet, ctx);
+    checkRoutingModel(flow, idSet, ctx);
+    flow.screens.forEach((screen, screenIdx) => {
+      checkRichTextIsolation(screen, screenIdx, ctx);
+      checkNavigateTargets(screen.layout.children, ['layout', 'children'], screen, screenIdx, idSet, ctx);
+    });
+  });
+
+export type FlowJson = z.infer<typeof FlowJsonSchema>;
+
+// ---------------------------------------------------------------------------
+// Full validation (schema + endpoint pairing)
+// ---------------------------------------------------------------------------
+
+export interface FlowJsonIssue {
+  path: string;
+  message: string;
+}
+
+export interface ValidateFlowJsonResult {
+  valid: boolean;
+  issues: FlowJsonIssue[];
+}
+
+/**
+ * Validate a Flow JSON document (object or stringified) against the schema
+ * *and* the endpoint pairing rule that Meta itself does not check:
+ *
+ *   - `dynamic: true` (an `endpoint_uri` will be registered) requires
+ *     `data_api_version: '3.0'`.
+ *   - `data_api_version` without `dynamic` produces a flow that errors on
+ *     open — the exact failure we hit live.
+ */
+export function validateFlowJson(flowJson: unknown, opts: { dynamic?: boolean } = {}): ValidateFlowJsonResult {
+  let doc: unknown = flowJson;
+  if (typeof flowJson === 'string') {
+    try {
+      doc = JSON.parse(flowJson);
+    } catch {
+      return { valid: false, issues: [{ path: '', message: 'flowJson is not valid JSON' }] };
+    }
+  }
+
+  const parsed = FlowJsonSchema.safeParse(doc);
+  const issues: FlowJsonIssue[] = parsed.success
+    ? []
+    : parsed.error.issues.map((issue) => ({ path: issue.path.join('.'), message: issue.message }));
+
+  const hasDataApiVersion =
+    typeof doc === 'object' && doc !== null && 'data_api_version' in (doc as Record<string, unknown>);
+  if (opts.dynamic && !hasDataApiVersion) {
+    issues.push({
+      path: 'data_api_version',
+      message: "dynamic (endpoint-backed) flows must set data_api_version: '3.0'",
+    });
+  }
+  if (!opts.dynamic && hasDataApiVersion) {
+    issues.push({
+      path: 'data_api_version',
+      message:
+        "data_api_version is set but the flow is not dynamic — without a registered endpoint_uri the flow fails on open ('an error occurred'). Remove it or create/update the flow with dynamic: true",
+    });
+  }
+
+  return { valid: issues.length === 0, issues };
+}

--- a/packages/db/drizzle/0046_whatsapp_flow_keys.sql
+++ b/packages/db/drizzle/0046_whatsapp_flow_keys.sql
@@ -1,0 +1,39 @@
+-- WhatsApp Flows data-endpoint encryption keys (whatsapp-flows feature).
+--
+-- One active RSA keypair per instance: the public key is registered with Meta
+-- (POST /{phone_number_id}/whatsapp_business_encryption) and the private key
+-- decrypts inbound flow data-exchange requests. `private_key_pem` is sealed
+-- at rest via sealCredentialField when tenancy + master key are configured
+-- (legacy plaintext otherwise — same codec as instance credential columns).
+-- Rotation replaces the row (unique on instance_id).
+--
+-- Tenancy derives via instance_id (the whatsapp_templates precedent) — no
+-- denormalized tenant_id column, so the table stays outside the RLS
+-- tenant-table manifest by construction.
+--
+-- Hand-written following the 0044/0045 precedent (snapshot drift keeps
+-- drizzle-kit generate interactive). Additive + idempotent statements.
+
+-- NOTE: no explicit BEGIN/COMMIT — the boot migrator executes this file on a
+-- pooled postgres-js connection, which rejects raw transaction control
+-- (UNSAFE_TRANSACTION).
+
+CREATE TABLE IF NOT EXISTS "whatsapp_flow_keys" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "instance_id" uuid NOT NULL,
+  "private_key_pem" text NOT NULL,
+  "public_key_pem" text NOT NULL,
+  "uploaded_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+  ALTER TABLE "whatsapp_flow_keys"
+    ADD CONSTRAINT "whatsapp_flow_keys_instance_id_instances_id_fk"
+    FOREIGN KEY ("instance_id") REFERENCES "instances"("id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_wa_flow_keys_instance"
+  ON "whatsapp_flow_keys" ("instance_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1784500000000,
       "tag": "0045_agent_error_messages_list",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1784600000000,
+      "tag": "0046_whatsapp_flow_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1052,6 +1052,41 @@ export const whatsappTemplates = pgTable(
 export type WhatsappTemplate = typeof whatsappTemplates.$inferSelect;
 export type NewWhatsappTemplate = typeof whatsappTemplates.$inferInsert;
 
+/**
+ * WhatsApp Flows data-endpoint encryption keys (one active keypair per
+ * instance). The public key is registered with Meta via
+ * POST /{phone_number_id}/whatsapp_business_encryption; the private key
+ * decrypts inbound data-exchange requests.
+ *
+ * `privateKeyPem` is sealed at rest via sealCredentialField (tenant-secret
+ * envelope) under the owning instance's tenant when tenancy + master key are
+ * configured; legacy plaintext otherwise — same codec as the credential
+ * columns on `instances`. Tenancy derives via `instance_id` (the
+ * whatsapp_templates precedent) — no denormalized tenant_id column.
+ * Rotation replaces the row (upsert on instance_id).
+ */
+export const whatsappFlowKeys = pgTable(
+  'whatsapp_flow_keys',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    instanceId: uuid('instance_id')
+      .notNull()
+      .references(() => instances.id, { onDelete: 'cascade' }),
+    privateKeyPem: text('private_key_pem').notNull(),
+    publicKeyPem: text('public_key_pem').notNull(),
+    /** Set when the public key was accepted by Meta; null = generated but not registered. */
+    uploadedAt: timestamp('uploaded_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    instanceUnique: uniqueIndex('idx_wa_flow_keys_instance').on(t.instanceId),
+  }),
+);
+
+export type WhatsappFlowKey = typeof whatsappFlowKeys.$inferSelect;
+export type NewWhatsappFlowKey = typeof whatsappFlowKeys.$inferInsert;
+
 // ============================================================================
 // PERSONS (Identity Graph Root)
 // ============================================================================

--- a/packages/sdk/src/__tests__/flow-builder.test.ts
+++ b/packages/sdk/src/__tests__/flow-builder.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { FlowBuilderError, flow } from '../flow-builder';
+
+function richTwoScreenFlow() {
+  return flow({ version: '6.3' })
+    .screen('INTRO', { title: 'Khal AI' }, (s) => {
+      s.image('aGVsbG8=', { height: 240, scaleType: 'cover', altText: 'Banner' });
+      s.heading('Bem-vindo ✨');
+      s.body('Demo de flow.');
+      s.footerNavigate('Começar', 'CADASTRO');
+    })
+    .screen('CADASTRO', { title: 'Seus dados', terminal: true }, (s) => {
+      s.form('form', (f) => {
+        f.textInput('nome', 'Nome completo', { required: true });
+        f.textInput('email', 'E-mail', { inputType: 'email', required: true });
+        f.radioButtons('plano', 'Plano', [
+          { id: 'free', title: 'Free' },
+          { id: 'pro', title: 'Pro' },
+        ]);
+        f.checkboxGroup('interesses', 'Interesses', [
+          { id: 'wa', title: 'WhatsApp' },
+          { id: 'tg', title: 'Telegram' },
+        ]);
+        f.dropdown('origem', 'Origem', [{ id: 'social', title: 'Redes sociais' }]);
+        f.datePicker('nascimento', 'Nascimento');
+        f.optIn('aceite', 'Aceito contato', { required: true });
+        f.footerComplete('Enviar', { nome: '${form.nome}', email: '${form.email}' });
+      });
+    });
+}
+
+describe('flow builder', () => {
+  test('builds the rich two-screen flow with derived routing_model', () => {
+    const { json, flowJson } = richTwoScreenFlow().build();
+    expect(JSON.parse(flowJson)).toEqual(json);
+    expect(json.version).toBe('6.3');
+    expect(json.data_api_version).toBeUndefined();
+    expect(json.routing_model).toEqual({ INTRO: ['CADASTRO'], CADASTRO: [] });
+
+    const screens = json.screens as Array<{ id: string; terminal?: boolean; layout: { children: unknown[] } }>;
+    expect(screens.map((s) => s.id)).toEqual(['INTRO', 'CADASTRO']);
+    expect(screens[1]!.terminal).toBe(true);
+  });
+
+  test('dynamic flows emit data_api_version 3.0', () => {
+    const { json } = flow({ dynamic: true })
+      .screen('ONLY', { terminal: true }, (s) => s.footerDataExchange('Enviar'))
+      .build();
+    expect(json.data_api_version).toBe('3.0');
+  });
+
+  test('rejects navigate to unknown screen at build time', () => {
+    const builder = flow().screen('A', { terminal: true }, (s) => s.footerNavigate('Go', 'MISSING'));
+    expect(() => builder.build()).toThrow(FlowBuilderError);
+  });
+
+  test('rejects flows without a terminal screen', () => {
+    const builder = flow().screen('A', (s) => s.body('hi'));
+    expect(() => builder.build()).toThrow(/terminal/);
+  });
+
+  test('rejects RichText next to non-Footer components', () => {
+    const builder = flow().screen('A', { terminal: true }, (s) => {
+      s.richText('**hi**');
+      s.body('not allowed');
+    });
+    expect(() => builder.build()).toThrow(/RichText/);
+  });
+
+  test('rejects duplicate screen ids and double Footers in a form', () => {
+    expect(() =>
+      flow()
+        .screen('A', { terminal: true }, (s) => s.body('1'))
+        .screen('A', (s) => s.body('2')),
+    ).toThrow(/duplicate/);
+
+    expect(() =>
+      flow().screen('A', { terminal: true }, (s) =>
+        s.form('f', (f) => {
+          f.footerComplete('One', {});
+          f.footerComplete('Two', {});
+        }),
+      ),
+    ).toThrow(/one Footer/);
+  });
+});

--- a/packages/sdk/src/flow-builder.ts
+++ b/packages/sdk/src/flow-builder.ts
@@ -1,0 +1,311 @@
+/**
+ * Fluent WhatsApp Flow JSON builder.
+ *
+ * Hand-authored (not generated): produces Meta Flow JSON v6.x for the
+ * whatsapp-flows routes (`POST /instances/{id}/whatsapp-flows` with the
+ * built `flowJson`). `build()` enforces the structural rules Meta reports
+ * late (or not at all) so mistakes fail at authoring time:
+ *
+ *   - RichText must be alone on its screen (Footer excepted)
+ *   - navigate targets must be declared screens
+ *   - at least one terminal screen
+ *   - `dynamic` flows get `data_api_version: '3.0'`; static flows must not
+ *     carry it (an endpoint-less data_api_version flow errors on open)
+ *
+ * The API re-validates server-side with the authoritative schema — this
+ * builder exists so you rarely get that far with an invalid document.
+ *
+ * @example
+ * ```typescript
+ * const { flowJson } = flow({ version: '6.3' })
+ *   .screen('INTRO', { title: 'Welcome' }, (s) => {
+ *     s.image(base64Png, { height: 240 });
+ *     s.heading('Hello!');
+ *     s.footerNavigate('Start', 'FORM');
+ *   })
+ *   .screen('FORM', { title: 'About you', terminal: true }, (s) => {
+ *     s.form('form', (f) => {
+ *       f.textInput('name', 'Your name', { required: true });
+ *       f.dropdown('channel', 'Favorite channel', [{ id: 'wa', title: 'WhatsApp' }]);
+ *       f.footerComplete('Submit', { name: '${form.name}', channel: '${form.channel}' });
+ *     });
+ *   })
+ *   .build();
+ * ```
+ */
+
+export type FlowComponent = Record<string, unknown>;
+
+export interface DataSourceItem {
+  id: string;
+  title: string;
+}
+
+export interface ScreenOptions {
+  title?: string;
+  terminal?: boolean;
+  /** Dynamic-flow screens: declared data contract for endpoint-provided values. */
+  data?: Record<string, unknown>;
+  /** Call the data endpoint with BACK when the user navigates back here. */
+  refreshOnBack?: boolean;
+}
+
+export interface FlowOptions {
+  /** Flow JSON version. Default '6.3'. */
+  version?: string;
+  /** Endpoint-backed flow: emits data_api_version '3.0'. Pair with the route's `dynamic: true`. */
+  dynamic?: boolean;
+}
+
+export class FlowBuilderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FlowBuilderError';
+  }
+}
+
+interface InputOptions {
+  required?: boolean;
+  [key: string]: unknown;
+}
+
+/** Builds the component list of one Form. */
+export class FormBuilder {
+  readonly components: FlowComponent[] = [];
+  private footerSet = false;
+
+  textInput(name: string, label: string, opts: InputOptions & { inputType?: string } = {}): this {
+    const { inputType, ...rest } = opts;
+    this.components.push({ type: 'TextInput', name, label, 'input-type': inputType ?? 'text', ...rest });
+    return this;
+  }
+
+  textArea(name: string, label: string, opts: InputOptions = {}): this {
+    this.components.push({ type: 'TextArea', name, label, ...opts });
+    return this;
+  }
+
+  datePicker(name: string, label: string, opts: InputOptions = {}): this {
+    this.components.push({ type: 'DatePicker', name, label, ...opts });
+    return this;
+  }
+
+  optIn(name: string, label: string, opts: InputOptions = {}): this {
+    this.components.push({ type: 'OptIn', name, label, ...opts });
+    return this;
+  }
+
+  dropdown(name: string, label: string, dataSource: DataSourceItem[], opts: InputOptions = {}): this {
+    this.components.push({ type: 'Dropdown', name, label, 'data-source': dataSource, ...opts });
+    return this;
+  }
+
+  radioButtons(name: string, label: string, dataSource: DataSourceItem[], opts: InputOptions = {}): this {
+    this.components.push({ type: 'RadioButtonsGroup', name, label, 'data-source': dataSource, ...opts });
+    return this;
+  }
+
+  checkboxGroup(name: string, label: string, dataSource: DataSourceItem[], opts: InputOptions = {}): this {
+    this.components.push({ type: 'CheckboxGroup', name, label, 'data-source': dataSource, ...opts });
+    return this;
+  }
+
+  /** Terminal submit: completes the flow, `payload` reaches the nfm_reply webhook. */
+  footerComplete(label: string, payload: Record<string, unknown>): this {
+    this.footer(label, { name: 'complete', payload });
+    return this;
+  }
+
+  /** Submit this screen to the data endpoint (dynamic flows) — it decides what's next. */
+  footerDataExchange(label: string, payload: Record<string, unknown> = {}): this {
+    this.footer(label, { name: 'data_exchange', payload });
+    return this;
+  }
+
+  footerNavigate(label: string, nextScreen: string, payload: Record<string, unknown> = {}): this {
+    this.footer(label, { name: 'navigate', next: { type: 'screen', name: nextScreen }, payload });
+    return this;
+  }
+
+  /** Escape hatch for components the builder doesn't model. */
+  raw(component: FlowComponent): this {
+    this.components.push(component);
+    return this;
+  }
+
+  private footer(label: string, action: Record<string, unknown>): void {
+    if (this.footerSet) throw new FlowBuilderError('a Form can only have one Footer');
+    this.footerSet = true;
+    this.components.push({ type: 'Footer', label, 'on-click-action': action });
+  }
+}
+
+export class ScreenBuilder {
+  readonly components: FlowComponent[] = [];
+
+  constructor(readonly id: string) {}
+
+  heading(text: string): this {
+    this.components.push({ type: 'TextHeading', text });
+    return this;
+  }
+
+  subheading(text: string): this {
+    this.components.push({ type: 'TextSubheading', text });
+    return this;
+  }
+
+  body(text: string): this {
+    this.components.push({ type: 'TextBody', text });
+    return this;
+  }
+
+  caption(text: string): this {
+    this.components.push({ type: 'TextCaption', text });
+    return this;
+  }
+
+  /**
+   * Markdown-ish rich text. Meta requires RichText to be ALONE on its screen
+   * (Footer excepted) and `text` to be a single string — both enforced at build.
+   */
+  richText(text: string): this {
+    this.components.push({ type: 'RichText', text });
+    return this;
+  }
+
+  /** `src` is base64-encoded image bytes (not a URL). */
+  image(src: string, opts: { height?: number; scaleType?: 'cover' | 'contain'; altText?: string } = {}): this {
+    this.components.push({
+      type: 'Image',
+      src,
+      ...(opts.height !== undefined ? { height: opts.height } : {}),
+      ...(opts.scaleType ? { 'scale-type': opts.scaleType } : {}),
+      ...(opts.altText ? { 'alt-text': opts.altText } : {}),
+    });
+    return this;
+  }
+
+  form(name: string, define: (form: FormBuilder) => void): this {
+    const builder = new FormBuilder();
+    define(builder);
+    this.components.push({ type: 'Form', name, children: builder.components });
+    return this;
+  }
+
+  footerNavigate(label: string, nextScreen: string, payload: Record<string, unknown> = {}): this {
+    this.components.push({
+      type: 'Footer',
+      label,
+      'on-click-action': { name: 'navigate', next: { type: 'screen', name: nextScreen }, payload },
+    });
+    return this;
+  }
+
+  footerComplete(label: string, payload: Record<string, unknown>): this {
+    this.components.push({ type: 'Footer', label, 'on-click-action': { name: 'complete', payload } });
+    return this;
+  }
+
+  footerDataExchange(label: string, payload: Record<string, unknown> = {}): this {
+    this.components.push({ type: 'Footer', label, 'on-click-action': { name: 'data_exchange', payload } });
+    return this;
+  }
+
+  /** Escape hatch for components the builder doesn't model. */
+  raw(component: FlowComponent): this {
+    this.components.push(component);
+    return this;
+  }
+}
+
+interface ScreenDefinition {
+  id: string;
+  options: ScreenOptions;
+  components: FlowComponent[];
+}
+
+export class FlowBuilder {
+  private readonly screens: ScreenDefinition[] = [];
+
+  constructor(private readonly options: FlowOptions = {}) {}
+
+  screen(id: string, options: ScreenOptions, define: (screen: ScreenBuilder) => void): this;
+  screen(id: string, define: (screen: ScreenBuilder) => void): this;
+  screen(
+    id: string,
+    optionsOrDefine: ScreenOptions | ((screen: ScreenBuilder) => void),
+    maybeDefine?: (screen: ScreenBuilder) => void,
+  ): this {
+    const options = typeof optionsOrDefine === 'function' ? {} : optionsOrDefine;
+    const define = typeof optionsOrDefine === 'function' ? optionsOrDefine : maybeDefine;
+    if (!define) throw new FlowBuilderError(`screen '${id}' needs a definition callback`);
+    if (this.screens.some((s) => s.id === id)) throw new FlowBuilderError(`duplicate screen id '${id}'`);
+
+    const builder = new ScreenBuilder(id);
+    define(builder);
+    this.screens.push({ id, options, components: builder.components });
+    return this;
+  }
+
+  /** Validate and produce the document + its stringified form for the API. */
+  build(): { json: Record<string, unknown>; flowJson: string } {
+    if (this.screens.length === 0) throw new FlowBuilderError('a flow needs at least one screen');
+
+    const ids = new Set(this.screens.map((s) => s.id));
+    if (!this.screens.some((s) => s.options.terminal)) {
+      throw new FlowBuilderError('at least one screen must be terminal: true');
+    }
+
+    const routingModel: Record<string, string[]> = {};
+    for (const screen of this.screens) {
+      // RichText isolation rule.
+      const hasRichText = screen.components.some((c) => c.type === 'RichText');
+      if (hasRichText && screen.components.some((c) => c.type !== 'RichText' && c.type !== 'Footer')) {
+        throw new FlowBuilderError(
+          `screen '${screen.id}': RichText must be the only component on the screen (Footer excepted)`,
+        );
+      }
+
+      // Collect navigate edges (screen-level and inside forms) + target check.
+      const targets: string[] = [];
+      const visit = (component: FlowComponent): void => {
+        const action = component['on-click-action'] as Record<string, unknown> | undefined;
+        if (action?.name === 'navigate') {
+          const next = action.next as { type?: string; name?: string } | undefined;
+          if (next?.type === 'screen' && next.name) {
+            if (!ids.has(next.name)) {
+              throw new FlowBuilderError(`screen '${screen.id}': navigate targets unknown screen '${next.name}'`);
+            }
+            targets.push(next.name);
+          }
+        }
+        const children = component.children as FlowComponent[] | undefined;
+        if (Array.isArray(children)) for (const child of children) visit(child);
+      };
+      for (const component of screen.components) visit(component);
+      routingModel[screen.id] = targets;
+    }
+
+    const json: Record<string, unknown> = {
+      version: this.options.version ?? '6.3',
+      ...(this.options.dynamic ? { data_api_version: '3.0' } : {}),
+      routing_model: routingModel,
+      screens: this.screens.map((screen) => ({
+        id: screen.id,
+        ...(screen.options.title ? { title: screen.options.title } : {}),
+        ...(screen.options.terminal ? { terminal: true } : {}),
+        ...(screen.options.data ? { data: screen.options.data } : {}),
+        ...(screen.options.refreshOnBack ? { refresh_on_back: true } : {}),
+        layout: { type: 'SingleColumnLayout', children: screen.components },
+      })),
+    };
+
+    return { json, flowJson: JSON.stringify(json) };
+  }
+}
+
+/** Entry point: `flow().screen(...).build()`. */
+export function flow(options: FlowOptions = {}): FlowBuilder {
+  return new FlowBuilder(options);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -155,5 +155,15 @@ export type {
 // Errors
 export { OmniApiError, OmniConfigError, type ApiErrorDetails } from './errors';
 
+// WhatsApp Flow JSON builder (hand-authored — not OpenAPI-generated)
+export {
+  flow,
+  FlowBuilder,
+  ScreenBuilder,
+  FormBuilder,
+  FlowBuilderError,
+} from './flow-builder';
+export type { FlowOptions, ScreenOptions, DataSourceItem, FlowComponent } from './flow-builder';
+
 // Generated types (for advanced usage)
 export type { paths, components, operations } from './types.generated';

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2152,6 +2152,162 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/instances/{id}/whatsapp-flows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List flows
+         * @description List the WABA's WhatsApp Flows with status and categories.
+         */
+        get: operations["listWhatsappFlows"];
+        put?: never;
+        /**
+         * Create flow
+         * @description Create a flow (optionally dynamic/endpoint-backed). Flow JSON is validated locally before contacting Meta; Meta-side validation_errors are always returned.
+         */
+        post: operations["createWhatsappFlow"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instances/{id}/whatsapp-flows/{flowId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get flow
+         * @description Status, categories, Meta validation errors, endpoint_uri and preview URL.
+         */
+        get: operations["getWhatsappFlow"];
+        /**
+         * Update flow
+         * @description Update screens (flowJson → asset upload) and/or properties (name, categories, dynamic → endpoint_uri).
+         */
+        put: operations["updateWhatsappFlow"];
+        post?: never;
+        /**
+         * Delete flow (draft only)
+         * @description Deletes a DRAFT flow. Published flows must be deprecated instead.
+         */
+        delete: operations["deleteWhatsappFlow"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instances/{id}/whatsapp-flows/{flowId}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Publish flow
+         * @description Publish a draft flow (requires zero validation errors).
+         */
+        post: operations["publishWhatsappFlow"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instances/{id}/whatsapp-flows/{flowId}/deprecate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Deprecate flow
+         * @description Retire a PUBLISHED flow.
+         */
+        post: operations["deprecateWhatsappFlow"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instances/{id}/whatsapp-flows/{flowId}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get flow preview URL
+         * @description Browser preview URL for the flow (valid ~30 days).
+         */
+        get: operations["getWhatsappFlowPreview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instances/{id}/whatsapp-flows/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send flow message
+         * @description Send an interactive flow message through the channel plugin. Returns the flowToken echoed back on the completion webhook (nfm_reply). Use flowAction 'data_exchange' for endpoint-backed flows.
+         */
+        post: operations["sendWhatsappFlow"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instances/{id}/whatsapp-flows/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Data-endpoint key status
+         * @description Local key presence + Meta-side signature status (MISMATCH explains 421 loops).
+         */
+        get: operations["getWhatsappFlowKeysStatus"];
+        put?: never;
+        /**
+         * Generate + register data-endpoint encryption keys
+         * @description Generates a 2048-bit RSA keypair, registers the public key with Meta (whatsapp_business_encryption) and stores the private key sealed. Calling again rotates the key.
+         */
+        post: operations["registerWhatsappFlowKeys"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/platform/tenants": {
         parameters: {
             query?: never;
@@ -5103,6 +5259,108 @@ export interface components {
         VoiceLeaveRequest: {
             /** @description Voice session ID to leave */
             sessionId: string;
+        };
+        FlowSummary: {
+            /** @description Meta flow id */
+            id: string;
+            name: string;
+            /** @description DRAFT | PUBLISHED | DEPRECATED | BLOCKED | THROTTLED */
+            status: string;
+            categories: string[];
+        };
+        FlowDetail: {
+            /** @description Meta flow id */
+            id: string;
+            name: string;
+            /** @description DRAFT | PUBLISHED | DEPRECATED | BLOCKED | THROTTLED */
+            status: string;
+            categories: string[];
+            /** @description Meta-side Flow JSON validation errors */
+            validationErrors: {
+                /** @description Error code (e.g. INVALID_PROPERTY_TYPE) */
+                error: string;
+                /** @description Error class (e.g. FLOW_JSON_ERROR) */
+                error_type: string;
+                /** @description Human-readable explanation */
+                message: string;
+                line_start?: number;
+                line_end?: number;
+                column_start?: number;
+                column_end?: number;
+                pointers?: {
+                    /** @description JSON path of the offending node */
+                    path: string;
+                }[];
+            }[];
+            /** @description Registered data-exchange endpoint (dynamic flows) */
+            endpointUri: string | null;
+            /** @description Browser preview (valid ~30 days) */
+            preview: {
+                preview_url: string;
+                expires_at: string;
+            } | null;
+        };
+        FlowValidationError: {
+            /** @description Error code (e.g. INVALID_PROPERTY_TYPE) */
+            error: string;
+            /** @description Error class (e.g. FLOW_JSON_ERROR) */
+            error_type: string;
+            /** @description Human-readable explanation */
+            message: string;
+            line_start?: number;
+            line_end?: number;
+            column_start?: number;
+            column_end?: number;
+            pointers?: {
+                /** @description JSON path of the offending node */
+                path: string;
+            }[];
+        };
+        CreateFlowRequest: {
+            /** @description Flow name (shown in WhatsApp Manager) */
+            name: string;
+            categories: ("SIGN_UP" | "SIGN_IN" | "APPOINTMENT_BOOKING" | "LEAD_GENERATION" | "CONTACT_US" | "CUSTOMER_SUPPORT" | "SURVEY" | "OTHER")[];
+            /** @description Stringified Flow JSON (screens/layout) */
+            flowJson?: string;
+            /** @description Publish immediately (requires valid flowJson) */
+            publish?: boolean;
+            /** @description Endpoint-backed (data_exchange) flow: registers this omni install's flows-data URL as endpoint_uri. Requires META_FLOWS_PUBLIC_BASE_URL and Flow JSON with data_api_version '3.0'. */
+            dynamic?: boolean;
+        };
+        UpdateFlowRequest: {
+            name?: string;
+            categories?: ("SIGN_UP" | "SIGN_IN" | "APPOINTMENT_BOOKING" | "LEAD_GENERATION" | "CONTACT_US" | "CUSTOMER_SUPPORT" | "SURVEY" | "OTHER")[];
+            /** @description Replaces the flow screens (asset upload) */
+            flowJson?: string;
+            /** @description Point the flow at this install's data endpoint */
+            dynamic?: boolean;
+        };
+        SendFlowRequest: {
+            /** @description Recipient phone (E.164 or digits) */
+            to: string;
+            /** @description Meta flow id (exactly one of flowId/flowName) */
+            flowId?: string;
+            flowName?: string;
+            /** @description Button label that opens the flow */
+            cta: string;
+            bodyText: string;
+            headerText?: string;
+            footerText?: string;
+            /** @description Entry screen (navigate flows) */
+            screen?: string;
+            /** @description Prefill data for the first screen */
+            data?: {
+                [key: string]: unknown;
+            };
+            /** @description Correlation token; generated when omitted */
+            flowToken?: string;
+            /** @description Send an unpublished flow (mode: draft) */
+            draft?: boolean;
+            /**
+             * @description 'data_exchange' opens the flow against the data endpoint (INIT decides screen 1)
+             * @enum {string}
+             */
+            flowAction?: "navigate" | "data_exchange";
         };
         PlatformTenant: {
             /**
@@ -17474,6 +17732,723 @@ export interface operations {
                             code: string;
                             /** @description Error message */
                             message: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    listWhatsappFlows: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Flows on the WABA */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: {
+                            /** @description Meta flow id */
+                            id: string;
+                            name: string;
+                            /** @description DRAFT | PUBLISHED | DEPRECATED | BLOCKED | THROTTLED */
+                            status: string;
+                            categories: string[];
+                        }[];
+                        meta: {
+                            count: number;
+                        };
+                    };
+                };
+            };
+            /** @description Not a whatsapp-cloud instance / not connected */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    createWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Flow name (shown in WhatsApp Manager) */
+                    name: string;
+                    categories: ("SIGN_UP" | "SIGN_IN" | "APPOINTMENT_BOOKING" | "LEAD_GENERATION" | "CONTACT_US" | "CUSTOMER_SUPPORT" | "SURVEY" | "OTHER")[];
+                    /** @description Stringified Flow JSON (screens/layout) */
+                    flowJson?: string;
+                    /** @description Publish immediately (requires valid flowJson) */
+                    publish?: boolean;
+                    /** @description Endpoint-backed (data_exchange) flow: registers this omni install's flows-data URL as endpoint_uri. Requires META_FLOWS_PUBLIC_BASE_URL and Flow JSON with data_api_version '3.0'. */
+                    dynamic?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Flow created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            id: string;
+                            endpointUri: string | null;
+                            validationErrors: {
+                                /** @description Error code (e.g. INVALID_PROPERTY_TYPE) */
+                                error: string;
+                                /** @description Error class (e.g. FLOW_JSON_ERROR) */
+                                error_type: string;
+                                /** @description Human-readable explanation */
+                                message: string;
+                                line_start?: number;
+                                line_end?: number;
+                                column_start?: number;
+                                column_end?: number;
+                                pointers?: {
+                                    /** @description JSON path of the offending node */
+                                    path: string;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Bad request / missing META_FLOWS_PUBLIC_BASE_URL */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Flow JSON failed local validation */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    getWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                flowId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Flow detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Meta flow id */
+                            id: string;
+                            name: string;
+                            /** @description DRAFT | PUBLISHED | DEPRECATED | BLOCKED | THROTTLED */
+                            status: string;
+                            categories: string[];
+                            /** @description Meta-side Flow JSON validation errors */
+                            validationErrors: {
+                                /** @description Error code (e.g. INVALID_PROPERTY_TYPE) */
+                                error: string;
+                                /** @description Error class (e.g. FLOW_JSON_ERROR) */
+                                error_type: string;
+                                /** @description Human-readable explanation */
+                                message: string;
+                                line_start?: number;
+                                line_end?: number;
+                                column_start?: number;
+                                column_end?: number;
+                                pointers?: {
+                                    /** @description JSON path of the offending node */
+                                    path: string;
+                                }[];
+                            }[];
+                            /** @description Registered data-exchange endpoint (dynamic flows) */
+                            endpointUri: string | null;
+                            /** @description Browser preview (valid ~30 days) */
+                            preview: {
+                                preview_url: string;
+                                expires_at: string;
+                            } | null;
+                        };
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    updateWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                flowId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    categories?: ("SIGN_UP" | "SIGN_IN" | "APPOINTMENT_BOOKING" | "LEAD_GENERATION" | "CONTACT_US" | "CUSTOMER_SUPPORT" | "SURVEY" | "OTHER")[];
+                    /** @description Replaces the flow screens (asset upload) */
+                    flowJson?: string;
+                    /** @description Point the flow at this install's data endpoint */
+                    dynamic?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Flow updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            id: string;
+                            endpointUri: string | null;
+                            validationErrors: {
+                                /** @description Error code (e.g. INVALID_PROPERTY_TYPE) */
+                                error: string;
+                                /** @description Error class (e.g. FLOW_JSON_ERROR) */
+                                error_type: string;
+                                /** @description Human-readable explanation */
+                                message: string;
+                                line_start?: number;
+                                line_end?: number;
+                                column_start?: number;
+                                column_end?: number;
+                                pointers?: {
+                                    /** @description JSON path of the offending node */
+                                    path: string;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Flow JSON failed local validation */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    deleteWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                flowId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        flowId: string;
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    publishWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                flowId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Published */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        flowId: string;
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    deprecateWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                flowId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deprecated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        flowId: string;
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    getWhatsappFlowPreview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                flowId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Preview URL */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        previewUrl: string;
+                        expiresAt: string;
+                    };
+                };
+            };
+            /** @description No preview available */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    sendWhatsappFlow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Recipient phone (E.164 or digits) */
+                    to: string;
+                    /** @description Meta flow id (exactly one of flowId/flowName) */
+                    flowId?: string;
+                    flowName?: string;
+                    /** @description Button label that opens the flow */
+                    cta: string;
+                    bodyText: string;
+                    headerText?: string;
+                    footerText?: string;
+                    /** @description Entry screen (navigate flows) */
+                    screen?: string;
+                    /** @description Prefill data for the first screen */
+                    data?: {
+                        [key: string]: unknown;
+                    };
+                    /** @description Correlation token; generated when omitted */
+                    flowToken?: string;
+                    /** @description Send an unpublished flow (mode: draft) */
+                    draft?: boolean;
+                    /**
+                     * @description 'data_exchange' opens the flow against the data endpoint (INIT decides screen 1)
+                     * @enum {string}
+                     */
+                    flowAction?: "navigate" | "data_exchange";
+                };
+            };
+        };
+        responses: {
+            /** @description Flow message sent */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        messageId?: string;
+                        flowToken: string;
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Send failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    getWhatsappFlowKeysStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Key status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Private key stored for this instance */
+                            hasLocalKey: boolean;
+                            uploadedAt: string | null;
+                            /** @description Meta-side status: VALID | MISMATCH (MISMATCH → rotate via POST) */
+                            signatureStatus: string | null;
+                            endpointUri: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    registerWhatsappFlowKeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Key registered */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Private key stored for this instance */
+                            hasLocalKey: boolean;
+                            uploadedAt: string | null;
+                            /** @description Meta-side status: VALID | MISMATCH (MISMATCH → rotate via POST) */
+                            signatureStatus: string | null;
+                            endpointUri: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Channel guard failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
                         };
                     };
                 };


### PR DESCRIPTION
## Summary

Ships the full WhatsApp Flows lifecycle over the API, including the dynamic (endpoint-backed) mode that was explicitly out of scope until now (`senders/flow.ts` used to say so).

Born from a live debugging session on `khal-ai-demo`: we drove navigate flows end-to-end via the Graph API, hit every silent Flow JSON pitfall (`data_api_version` without endpoint = "an error occurred" with no trace; `RichText` placement/type rules), and turned the findings into API surface, local validation and tests.

### A. Navigate CRUD DX
- New routes: `GET/PUT/DELETE /instances/:id/whatsapp-flows/:flowId`, `POST .../:flowId/deprecate`
- `create`/`update` **always surface Meta's `validation_errors`** (previously swallowed)
- **Local Zod validation** (`FlowJsonSchema` + `validateFlowJson` in `@omni/core`) rejects the known killers before any Graph API round-trip (422 with precise issues)
- Client: `updateFlowAssets` (multipart), `updateFlowMetadata` (`endpoint_uri` is a flow *property*, not Flow JSON), `getFlow`, `deprecateFlow`

### B. data_exchange (send/receive mid-flow)
- Public endpoint `POST /api/v2/channels/whatsapp-cloud/flows/data/:instanceId` with Meta's full contract: HMAC check (**432**), RSA-OAEP + AES-128-GCM decrypt (**421**), bad token (**427**), flipped-IV encrypted responses, plain+encrypted ping, error-notification ack
- **Keys**: `whatsapp_flow_keys` table (migration 0046; private key sealed via `sealCredentialField` under the instance's tenant), `POST/GET .../whatsapp-flows/keys` to generate/rotate/register with Meta and surface `signature_status` (MISMATCH = the 421-loop explainer)
- **Resolver**: in-process `FlowResolverRegistry` (synchronous by design — NATS has no request/reply), 8s budget, degrades to an in-screen error, never hangs; `flow.data_exchange` core event for observability
- **Structured flow tokens** `omni.<flowId>.<uuid>` from `sendFlow` — the decrypted payload carries no flow id, the token is how the endpoint knows which flow it serves

### C. DX + docs
- `@omni/sdk`: hand-authored fluent Flow JSON builder (`flow().screen(...).build()`) enforcing the same rules at build time
- OpenAPI registration for all flows routes; `types.generated.ts` regenerated
- `docs/channels/whatsapp-flows.md` (lifecycle, gotchas, key setup, status-code table)

## Verification
- 6200+ tests green (pre-push full suite): crypto round-trip vs a Meta-shaped client, handler status codes (200/404/421/427/432 + ping + error-notification), validator accept/reject on the live-tested flow, resolver token fallback, route/scope/ownership/RLS gates
- `make typecheck` (23/23) + biome clean
- Migration applied on a disposable database (47/47) and dropped
- Live drive of the dynamic path (keys → dynamic flow → INIT/data_exchange via ngrok) pending an API restart — follow-up on the session

## Notes for review
- Public route declared `public-by-contract` in route-ownership (double-authenticated: HMAC + only the registered key decrypts)
- `whatsapp_flow_keys` has **no** `tenant_id` column on purpose — tenancy derives via `instance_id` (the `whatsapp_templates` precedent); sealing still uses the instance's tenant
- Migration 0046 hand-written per the 0044/0045 precedent (snapshot drift keeps drizzle-kit generate interactive)