### PR TITLE
fix(api): wire hermes credentials through instance create/connect/reconnect

### DIFF
--- a/packages/api/src/plugins/instance-monitor.ts
+++ b/packages/api/src/plugins/instance-monitor.ts
@@ -196,6 +196,11 @@ function buildInstanceConnectOptions(instance: {
   metaApiVersion?: string | null;
   metaDisplayPhoneNumber?: string | null;
   metaConnectionMethod?: string | null;
+  hermesBaseUrl?: string | null;
+  hermesUsername?: string | null;
+  hermesPassword?: string | null;
+  hermesMediaId?: string | null;
+  hermesTemplateNamespace?: string | null;
 }): Record<string, unknown> {
   const options: Record<string, unknown> = {};
   if (instance.telegramBotToken) options.token = instance.telegramBotToken;
@@ -216,7 +221,32 @@ function buildInstanceConnectOptions(instance: {
   if (instance.channel === 'whatsapp-business') {
     applyWhatsAppBusinessOptions(options, instance);
   }
+  if (instance.channel === 'hermes') {
+    applyHermesOptions(options, instance);
+  }
   return options;
+}
+
+/**
+ * hermes reconnect credentials — the plugin's `connect()` reads these from
+ * `config.options` (same keys as `config.credentials` in the manual connect
+ * route). Persisted on `instances` by the create/connect/PATCH routes.
+ */
+function applyHermesOptions(
+  options: Record<string, unknown>,
+  instance: {
+    hermesBaseUrl?: string | null;
+    hermesUsername?: string | null;
+    hermesPassword?: string | null;
+    hermesMediaId?: string | null;
+    hermesTemplateNamespace?: string | null;
+  },
+): void {
+  if (instance.hermesBaseUrl) options.hermesBaseUrl = instance.hermesBaseUrl;
+  if (instance.hermesUsername) options.hermesUsername = instance.hermesUsername;
+  if (instance.hermesPassword) options.hermesPassword = instance.hermesPassword;
+  if (instance.hermesMediaId) options.hermesMediaId = instance.hermesMediaId;
+  if (instance.hermesTemplateNamespace) options.hermesTemplateNamespace = instance.hermesTemplateNamespace;
 }
 
 /**

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -178,6 +178,11 @@ const createInstanceSchema = z.object({
     .nullable()
     .describe('Public Twilio inbound webhook URL for signature validation'),
   twilioValidateSignature: z.boolean().default(true).describe('Validate X-Twilio-Signature on webhooks'),
+  hermesBaseUrl: z.string().optional().nullable().describe('Hermes API base URL (e.g. https://waap-api.h3rmes.com)'),
+  hermesUsername: z.string().optional().nullable().describe('Hermes account username'),
+  hermesPassword: z.string().optional().nullable().describe('Hermes account password'),
+  hermesMediaId: z.string().optional().nullable().describe('Hermes line UUID (media_id) — required on every send'),
+  hermesTemplateNamespace: z.string().optional().nullable().describe('Meta template namespace for HSM sends'),
   readReceipts: z
     .enum(['on', 'off', 'exclude-self'])
     .default('on')
@@ -412,6 +417,7 @@ const SENSITIVE_INSTANCE_FIELDS = [
   'gupshupAuthToken',
   'webhookVerifyToken',
   'twilioAuthToken',
+  'hermesPassword',
 ] as const;
 
 /** Strip secret tokens from an instance before returning it in API responses */
@@ -493,6 +499,11 @@ type InstanceConnectionOptionsInput = {
   twilioStatusCallbackUrl?: string | null;
   twilioWebhookUrl?: string | null;
   twilioValidateSignature?: boolean | null;
+  hermesBaseUrl?: string | null;
+  hermesUsername?: string | null;
+  hermesPassword?: string | null;
+  hermesMediaId?: string | null;
+  hermesTemplateNamespace?: string | null;
 };
 
 function applyTelegramConnectionOptions(options: Record<string, unknown>, input: InstanceConnectionOptionsInput): void {
@@ -527,6 +538,14 @@ function applyTwilioWhatsAppConnectionOptions(
   }
 }
 
+function applyHermesConnectionOptions(options: Record<string, unknown>, input: InstanceConnectionOptionsInput): void {
+  if (input.hermesBaseUrl) options.hermesBaseUrl = input.hermesBaseUrl;
+  if (input.hermesUsername) options.hermesUsername = input.hermesUsername;
+  if (input.hermesPassword) options.hermesPassword = input.hermesPassword;
+  if (input.hermesMediaId) options.hermesMediaId = input.hermesMediaId;
+  if (input.hermesTemplateNamespace) options.hermesTemplateNamespace = input.hermesTemplateNamespace;
+}
+
 function applyChannelSpecificConnectionOptions(
   options: Record<string, unknown>,
   input: InstanceConnectionOptionsInput,
@@ -543,6 +562,9 @@ function applyChannelSpecificConnectionOptions(
       return;
     case 'twilio-whatsapp':
       applyTwilioWhatsAppConnectionOptions(options, input);
+      return;
+    case 'hermes':
+      applyHermesConnectionOptions(options, input);
       return;
   }
 }
@@ -770,6 +792,11 @@ instancesRoutes.post('/', zValidator('json', createInstanceSchema), async (c) =>
     twilioStatusCallbackUrl: instance.twilioStatusCallbackUrl,
     twilioWebhookUrl: instance.twilioWebhookUrl,
     twilioValidateSignature: instance.twilioValidateSignature,
+    hermesBaseUrl: instance.hermesBaseUrl,
+    hermesUsername: instance.hermesUsername,
+    hermesPassword: instance.hermesPassword,
+    hermesMediaId: instance.hermesMediaId,
+    hermesTemplateNamespace: instance.hermesTemplateNamespace,
   });
 
   // Wire: load guild config overrides into plugin before connection
@@ -1112,6 +1139,11 @@ const connectInstanceSchema = z.object({
   twilioStatusCallbackUrl: z.string().optional().describe('Twilio outbound status callback URL'),
   twilioWebhookUrl: z.string().optional().describe('Public Twilio inbound webhook URL for signature validation'),
   twilioValidateSignature: z.boolean().optional().describe('Validate X-Twilio-Signature on webhooks'),
+  hermesBaseUrl: z.string().optional().describe('Hermes API base URL'),
+  hermesUsername: z.string().optional().describe('Hermes account username'),
+  hermesPassword: z.string().optional().describe('Hermes account password'),
+  hermesMediaId: z.string().optional().describe('Hermes line UUID (media_id)'),
+  hermesTemplateNamespace: z.string().optional().describe('Meta template namespace for HSM sends'),
   whatsapp: z
     .object({
       syncFullHistory: z.boolean().optional().describe('Sync full message history on connect (default: true)'),
@@ -1148,6 +1180,11 @@ function buildConnectConnectionOptions(
     twilioStatusCallbackUrl: body.twilioStatusCallbackUrl ?? instance.twilioStatusCallbackUrl,
     twilioWebhookUrl: body.twilioWebhookUrl ?? instance.twilioWebhookUrl,
     twilioValidateSignature: body.twilioValidateSignature ?? instance.twilioValidateSignature,
+    hermesBaseUrl: body.hermesBaseUrl ?? instance.hermesBaseUrl,
+    hermesUsername: body.hermesUsername ?? instance.hermesUsername,
+    hermesPassword: body.hermesPassword ?? instance.hermesPassword,
+    hermesMediaId: body.hermesMediaId ?? instance.hermesMediaId,
+    hermesTemplateNamespace: body.hermesTemplateNamespace ?? instance.hermesTemplateNamespace,
   });
 }
 
@@ -1181,17 +1218,30 @@ function buildConnectPersistUpdates(instance: InstanceRecord, body: ConnectInsta
     ...buildTokenPersistUpdates(instance.channel, body),
   };
 
-  if (instance.channel !== 'twilio-whatsapp') return updates;
+  if (instance.channel === 'twilio-whatsapp') {
+    return {
+      ...updates,
+      twilioAccountSid: body.twilioAccountSid ?? instance.twilioAccountSid,
+      twilioFrom: body.twilioFrom ?? instance.twilioFrom,
+      twilioMessagingServiceSid: body.twilioMessagingServiceSid ?? instance.twilioMessagingServiceSid,
+      twilioStatusCallbackUrl: body.twilioStatusCallbackUrl ?? instance.twilioStatusCallbackUrl,
+      twilioWebhookUrl: body.twilioWebhookUrl ?? instance.twilioWebhookUrl,
+      twilioValidateSignature: body.twilioValidateSignature ?? instance.twilioValidateSignature,
+    };
+  }
 
-  return {
-    ...updates,
-    twilioAccountSid: body.twilioAccountSid ?? instance.twilioAccountSid,
-    twilioFrom: body.twilioFrom ?? instance.twilioFrom,
-    twilioMessagingServiceSid: body.twilioMessagingServiceSid ?? instance.twilioMessagingServiceSid,
-    twilioStatusCallbackUrl: body.twilioStatusCallbackUrl ?? instance.twilioStatusCallbackUrl,
-    twilioWebhookUrl: body.twilioWebhookUrl ?? instance.twilioWebhookUrl,
-    twilioValidateSignature: body.twilioValidateSignature ?? instance.twilioValidateSignature,
-  };
+  if (instance.channel === 'hermes') {
+    return {
+      ...updates,
+      hermesBaseUrl: body.hermesBaseUrl ?? instance.hermesBaseUrl,
+      hermesUsername: body.hermesUsername ?? instance.hermesUsername,
+      hermesPassword: body.hermesPassword ?? instance.hermesPassword,
+      hermesMediaId: body.hermesMediaId ?? instance.hermesMediaId,
+      hermesTemplateNamespace: body.hermesTemplateNamespace ?? instance.hermesTemplateNamespace,
+    };
+  }
+
+  return updates;
 }
 
 /**


### PR DESCRIPTION
## Problema

O plugin do canal `hermes` exige `hermesBaseUrl`/`hermesUsername`/`hermesPassword`/`hermesMediaId` nas options do connect — mas **nenhuma rota da API carregava esses campos**:

- create/PATCH: Zod strippava os campos (não estavam no schema)
- `POST /instances/:id/connect`: schema sem os campos, builder não os passava
- instance-monitor (boot reconnect): `buildInstanceConnectOptions` sem mapeamento hermes

Resultado: instância hermes **impossível de configurar via API** (a de prod hv-cx está criada porém com credenciais todas `null` — PATCH retorna 200 e ignora).

## Fix (padrão twilio/whatsapp-business)

- `createInstanceSchema` (+ PATCH via `.partial()`): aceita e persiste `hermes*`
- `connectInstanceSchema`: aceita `hermes*` como override, persiste no connect (`buildConnectPersistUpdates`)
- `buildInstanceConnectionOptions`: `applyHermesConnectionOptions` (create + connect + restart)
- instance-monitor: `applyHermesOptions` no boot auto-reconnect (mesmo padrão do `applyWhatsAppBusinessOptions`)
- `hermesPassword` adicionado a `SENSITIVE_INSTANCE_FIELDS` (não vaza mais no GET)

Nota: `metaAccessToken` também não está em SENSITIVE_INSTANCE_FIELDS — deixei fora do escopo, mas vale um follow-up.

## Testes
- typecheck ✅ · biome ✅
- `packages/api` plugins: 370 pass / 0 fail · rotas v2: 281 pass / 0 fail

## Contexto
Necessário pra ativar a linha Hermes (Mutant) da Hapvida em prod — media_id real recebido e validado hoje contra a API deles.