### PR TITLE
feat(hermes): dispatch content.buttons as Cloud API interactive + markdown conversion

### DIFF
--- a/packages/channel-hermes/src/__tests__/plugin.test.ts
+++ b/packages/channel-hermes/src/__tests__/plugin.test.ts
@@ -102,6 +102,138 @@ describe('HermesPlugin', () => {
     });
   });
 
+  it('renders content.buttons (≤3, no descriptions) as an interactive button envelope', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({ message: { id: HERMES_UUID } }));
+
+    const result = await plugin.sendMessage(instanceId, {
+      to: '5511999998888',
+      content: {
+        type: 'text',
+        text: 'Qual cadastro deseja usar?',
+        buttons: [
+          { text: 'João', data: 'cad_1' },
+          { text: 'Maria', data: 'cad_2' },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const envelope = sentEnvelope(fetchSpy, 1) as { message: Record<string, unknown> };
+    expect(envelope.message).toMatchObject({
+      type: 'interactive',
+      interactive: {
+        type: 'button',
+        body: { text: 'Qual cadastro deseja usar?' },
+        action: {
+          buttons: [
+            { type: 'reply', reply: { id: 'cad_1', title: 'João' } },
+            { type: 'reply', reply: { id: 'cad_2', title: 'Maria' } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('renders 4+ buttons as an interactive list with the buttonLabel', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({ message: { id: HERMES_UUID } }));
+
+    const result = await plugin.sendMessage(instanceId, {
+      to: '5511999998888',
+      content: {
+        type: 'text',
+        text: 'Escolha um horário:',
+        buttons: [
+          { text: '08:30', data: 's1', description: 'Unidade Centro' },
+          { text: '09:15', data: 's2' },
+          { text: '14:00', data: 's3' },
+          { text: '16:40', data: 's4' },
+        ],
+        list: { buttonLabel: 'Ver horários', sectionTitle: 'Quinta 06/08' },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    const envelope = sentEnvelope(fetchSpy, 1) as { message: { interactive: Record<string, unknown> } };
+    expect(envelope.message.interactive).toMatchObject({
+      type: 'list',
+      action: {
+        button: 'Ver horários',
+        sections: [
+          {
+            title: 'Quinta 06/08',
+            rows: [
+              { id: 's1', title: '08:30', description: 'Unidade Centro' },
+              { id: 's2', title: '09:15' },
+              { id: 's3', title: '14:00' },
+              { id: 's4', title: '16:40' },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders a single URL button as cta_url', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({ message: { id: HERMES_UUID } }));
+
+    await plugin.sendMessage(instanceId, {
+      to: '5511999998888',
+      content: {
+        type: 'text',
+        text: 'Sua carteirinha está no app.',
+        buttons: [{ text: 'Abrir o app', url: 'https://app.example.com' }],
+      },
+    });
+
+    const envelope = sentEnvelope(fetchSpy, 1) as { message: { interactive: Record<string, unknown> } };
+    expect(envelope.message.interactive).toMatchObject({
+      type: 'cta_url',
+      action: { name: 'cta_url', parameters: { display_text: 'Abrir o app', url: 'https://app.example.com' } },
+    });
+  });
+
+  it('converts markdown to WhatsApp syntax on text sends (messageFormatMode default)', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({ message: { id: HERMES_UUID } }));
+
+    await plugin.sendMessage(instanceId, {
+      to: '5511999998888',
+      content: { type: 'text', text: 'me informe seu **CPF** e **data de nascimento**' },
+    });
+
+    const envelope = sentEnvelope(fetchSpy, 1) as { message: Record<string, unknown> };
+    expect(envelope.message.text).toBe('me informe seu *CPF* e *data de nascimento*');
+  });
+
+  it('honors messageFormatMode=passthrough (raw markdown untouched)', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({ message: { id: HERMES_UUID } }));
+
+    await plugin.sendMessage(instanceId, {
+      to: '5511999998888',
+      content: { type: 'text', text: '**raw**' },
+      metadata: { messageFormatMode: 'passthrough' },
+    });
+
+    const envelope = sentEnvelope(fetchSpy, 1) as { message: Record<string, unknown> };
+    expect(envelope.message.text).toBe('**raw**');
+  });
+
+  it('dispatches location_request as the location_request_message interactive', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({ message: { id: HERMES_UUID } }));
+
+    const result = await plugin.sendMessage(instanceId, {
+      to: '5511999998888',
+      content: { type: 'location_request', text: 'Compartilhe sua localização 📍' },
+    });
+
+    expect(result.success).toBe(true);
+    const envelope = sentEnvelope(fetchSpy, 1) as { message: { interactive: Record<string, unknown> } };
+    expect(envelope.message.interactive).toEqual({
+      type: 'location_request_message',
+      body: { text: 'Compartilhe sua localização 📍' },
+      action: { name: 'send_location' },
+    });
+  });
+
   it('fails fast (no message.failed) for unsupported content types', async () => {
     const result = await plugin.sendMessage(instanceId, {
       to: '5511999998888',

--- a/packages/channel-hermes/src/__tests__/senders.test.ts
+++ b/packages/channel-hermes/src/__tests__/senders.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it, spyOn } from 'bun:test';
 
 import { HermesClient } from '../client';
 import { sendContact } from '../senders/contact';
-import { sendInteractiveButtons, sendInteractiveList } from '../senders/interactive';
+import {
+  sendInteractiveButtons,
+  sendInteractiveList,
+  sendLocationRequest,
+  sendPlannedInteractive,
+} from '../senders/interactive';
 import { sendLocation } from '../senders/location';
 import { resolveHermesMediaType, sendMedia } from '../senders/media';
 import { sendReaction } from '../senders/reaction';
@@ -243,6 +248,44 @@ describe('sendTemplate', () => {
 });
 
 describe('interactive senders', () => {
+  it('sendPlannedInteractive wraps a pre-built interactive object verbatim', async () => {
+    const client = makeClient();
+    const spy = spyOn(client, 'sendMessage').mockResolvedValueOnce(OK_RESPONSE);
+
+    const interactive = {
+      type: 'cta_url',
+      body: { text: 'See dates' },
+      action: { name: 'cta_url', parameters: { display_text: 'Open', url: 'https://x.example' } },
+    };
+    await sendPlannedInteractive(client, '+55 11 99999-8888', interactive, 'wamid.reply');
+
+    expect(spy).toHaveBeenCalledWith({
+      to: '5511999998888',
+      recipient_type: 'individual',
+      type: 'interactive',
+      interactive,
+      context: { message_id: 'wamid.reply' },
+    });
+  });
+
+  it('sendLocationRequest produces the location_request_message shape', async () => {
+    const client = makeClient();
+    const spy = spyOn(client, 'sendMessage').mockResolvedValueOnce(OK_RESPONSE);
+
+    await sendLocationRequest(client, '5511999998888', 'Share your location');
+
+    expect(spy).toHaveBeenCalledWith({
+      to: '5511999998888',
+      recipient_type: 'individual',
+      type: 'interactive',
+      interactive: {
+        type: 'location_request_message',
+        body: { text: 'Share your location' },
+        action: { name: 'send_location' },
+      },
+    });
+  });
+
   it('produces the interactive button shape from the spec', async () => {
     const client = makeClient();
     const spy = spyOn(client, 'sendMessage').mockResolvedValueOnce(OK_RESPONSE);

--- a/packages/channel-hermes/src/plugin.ts
+++ b/packages/channel-hermes/src/plugin.ts
@@ -16,7 +16,13 @@
  * username/password) + dedupe cache keyed by `wamid`.
  */
 
-import { BaseChannelPlugin, createDownloadGuard, createInboundDedupeCache, sanitizeMessage } from '@omni/channel-sdk';
+import {
+  BaseChannelPlugin,
+  createDownloadGuard,
+  createInboundDedupeCache,
+  planInteractive,
+  sanitizeMessage,
+} from '@omni/channel-sdk';
 import type {
   ChannelCapabilities,
   DedupeCache,
@@ -29,6 +35,7 @@ import type {
   PluginContext,
   SendResult,
 } from '@omni/channel-sdk';
+import { markdownToWhatsApp } from '@omni/core';
 import type { Logger } from '@omni/core';
 import type { HermesContact, MetaInboundMessage, MetaWebhookStatusEntry } from '@omni/core/schemas';
 import type { ChannelType, ContentType } from '@omni/core/types';
@@ -36,7 +43,16 @@ import type { ChannelType, ContentType } from '@omni/core/types';
 import { HERMES_CAPABILITIES } from './capabilities';
 import { HermesClient } from './client';
 import { handleHermesWebhookRequest } from './handlers/webhook';
-import { sendContact, sendLocation, sendMedia, sendReaction, sendTemplate, sendText } from './senders';
+import {
+  sendContact,
+  sendLocation,
+  sendLocationRequest,
+  sendMedia,
+  sendPlannedInteractive,
+  sendReaction,
+  sendTemplate,
+  sendText,
+} from './senders';
 import type { HermesConfig, HermesSendResponse } from './types';
 import { HermesApiError, HermesErrorCode } from './utils/errors';
 
@@ -176,7 +192,7 @@ export class HermesPlugin extends BaseChannelPlugin {
     if (correlationId) this.captureT10(correlationId);
 
     try {
-      const dispatched = await dispatchOutbound(state, message);
+      const dispatched = await dispatchOutbound(state, message, this.logger);
       if (!dispatched.ok) {
         return { success: false, error: dispatched.error, retryable: false, timestamp: Date.now() };
       }
@@ -571,12 +587,19 @@ type OutboundDispatchResult = { ok: true; response: HermesSendResponse } | { ok:
  * without emitting `message.failed` (nothing was attempted against the
  * Hermes API). Sender failures propagate as thrown `HermesApiError`s.
  */
-async function dispatchOutbound(state: HermesInstanceState, message: OutgoingMessage): Promise<OutboundDispatchResult> {
+async function dispatchOutbound(
+  state: HermesInstanceState,
+  message: OutgoingMessage,
+  logger?: Logger,
+): Promise<OutboundDispatchResult> {
   const { client } = state;
   const { content, to, replyTo } = message;
 
   if (content.type === 'text') {
-    return { ok: true, response: await sendText(client, to, content.text ?? '', replyTo) };
+    return dispatchOutboundText(client, message, logger);
+  }
+  if (content.type === 'location_request') {
+    return { ok: true, response: await sendLocationRequest(client, to, resolveOutboundText(message), replyTo) };
   }
   if (HERMES_MEDIA_TYPES.has(content.type)) {
     return dispatchOutboundMedia(client, message);
@@ -607,6 +630,52 @@ async function dispatchOutbound(state: HermesInstanceState, message: OutgoingMes
     return dispatchOutboundTemplate(state, message);
   }
   return { ok: false, error: `Unsupported content.type=${content.type} for hermes` };
+}
+
+/**
+ * Markdown → WhatsApp syntax, honoring the instance's `messageFormatMode`
+ * (same contract as the whatsapp-business and baileys channels — without it
+ * the agent's `**bold**` reaches the device raw and WhatsApp pairs the
+ * asterisks wrong).
+ */
+function resolveOutboundText(message: OutgoingMessage): string {
+  const formatMode = (message.metadata?.messageFormatMode as 'convert' | 'passthrough') ?? 'convert';
+  const text = message.content.text ?? '';
+  return formatMode === 'passthrough' ? text : markdownToWhatsApp(text);
+}
+
+/**
+ * Text content — plain send, or the best-fitting Cloud API interactive type
+ * when `content.buttons` is present (shared `planInteractive` mapper: reply
+ * buttons ≤3, list 4-10, cta_url for a single URL button). Overflow beyond
+ * the 10-row list limit is dropped with a warn log — never silently.
+ */
+async function dispatchOutboundText(
+  client: HermesClient,
+  message: OutgoingMessage,
+  logger?: Logger,
+): Promise<OutboundDispatchResult> {
+  const { content, to, replyTo } = message;
+  const formatted = resolveOutboundText(message);
+
+  if (!content.buttons?.length) {
+    return { ok: true, response: await sendText(client, to, formatted, replyTo) };
+  }
+
+  const plan = planInteractive(formatted, content.buttons, content.list?.buttonLabel ?? 'Options', {
+    sectionTitle: content.list?.sectionTitle,
+    forceList: content.list?.forceList,
+  });
+  if (plan.droppedRows > 0) {
+    logger?.warn('[hermes] interactive list capped at 10 rows — extra buttons dropped', {
+      to,
+      droppedRows: plan.droppedRows,
+    });
+  }
+  const response = plan.interactive
+    ? await sendPlannedInteractive(client, to, plan.interactive, replyTo)
+    : await sendText(client, to, plan.body, replyTo);
+  return { ok: true, response };
 }
 
 /**

--- a/packages/channel-hermes/src/senders/index.ts
+++ b/packages/channel-hermes/src/senders/index.ts
@@ -16,6 +16,8 @@ export { sendTemplate, type SendTemplateOptions } from './template';
 export {
   sendInteractiveButtons,
   sendInteractiveList,
+  sendLocationRequest,
+  sendPlannedInteractive,
   type InteractiveButton,
   type InteractiveListSection,
   type SendInteractiveListOptions,

--- a/packages/channel-hermes/src/senders/interactive.ts
+++ b/packages/channel-hermes/src/senders/interactive.ts
@@ -10,6 +10,7 @@ import type { HermesClient } from '../client';
 import type {
   HermesInteractiveButtonPayload,
   HermesInteractiveListPayload,
+  HermesInteractivePayload,
   HermesOutboundMessage,
   HermesSendResponse,
 } from '../types';
@@ -53,6 +54,51 @@ export async function sendInteractiveButtons(
     recipient_type: 'individual',
     type: 'interactive',
     interactive,
+  };
+  if (replyTo) payload.context = { message_id: replyTo };
+  return client.sendMessage(payload);
+}
+
+/**
+ * Send a pre-built Cloud API `interactive` object (the output of the shared
+ * `planInteractive` mapper) — button, list, or cta_url.
+ */
+export async function sendPlannedInteractive(
+  client: HermesClient,
+  to: string,
+  interactive: Record<string, unknown>,
+  replyTo?: string,
+): Promise<HermesSendResponse> {
+  const payload: HermesOutboundMessage = {
+    to: toHermesPhone(to),
+    recipient_type: 'individual',
+    type: 'interactive',
+    interactive: interactive as unknown as HermesInteractivePayload,
+  };
+  if (replyTo) payload.context = { message_id: replyTo };
+  return client.sendMessage(payload);
+}
+
+/**
+ * Ask the user to share their location — renders WhatsApp's native
+ * "Send location" button under the body text. The shared location arrives
+ * as a regular inbound `location` message on the webhook.
+ */
+export async function sendLocationRequest(
+  client: HermesClient,
+  to: string,
+  bodyText: string,
+  replyTo?: string,
+): Promise<HermesSendResponse> {
+  const payload: HermesOutboundMessage = {
+    to: toHermesPhone(to),
+    recipient_type: 'individual',
+    type: 'interactive',
+    interactive: {
+      type: 'location_request_message',
+      body: { text: bodyText },
+      action: { name: 'send_location' },
+    },
   };
   if (replyTo) payload.context = { message_id: replyTo };
   return client.sendMessage(payload);

--- a/packages/channel-hermes/src/types.ts
+++ b/packages/channel-hermes/src/types.ts
@@ -85,7 +85,30 @@ export interface HermesInteractiveListPayload {
   };
 }
 
-export type HermesInteractivePayload = HermesInteractiveButtonPayload | HermesInteractiveListPayload;
+export interface HermesInteractiveCtaUrlPayload {
+  type: 'cta_url';
+  header?: { type: 'image'; image: { link: string } };
+  body: { text: string };
+  footer?: { text: string };
+  action: { name: 'cta_url'; parameters: { display_text: string; url: string } };
+}
+
+/**
+ * Not in the published Postman collection, but Hermes proxies the Cloud API
+ * shape verbatim — accepted live on 2026-08-04 (renders WhatsApp's native
+ * "Send location" button).
+ */
+export interface HermesInteractiveLocationRequestPayload {
+  type: 'location_request_message';
+  body: { text: string };
+  action: { name: 'send_location' };
+}
+
+export type HermesInteractivePayload =
+  | HermesInteractiveButtonPayload
+  | HermesInteractiveListPayload
+  | HermesInteractiveCtaUrlPayload
+  | HermesInteractiveLocationRequestPayload;
 
 /**
  * Inner `message` object POSTed to /api/v2/messages — WITHOUT `media_id`,

--- a/packages/channel-sdk/src/index.ts
+++ b/packages/channel-sdk/src/index.ts
@@ -93,6 +93,9 @@ export type { SanitizeOptions, SanitizeResult } from './sanitize';
 export { createDownloadGuard, DownloadTooLargeError } from './download-guard';
 export type { DownloadGuard, DownloadGuardConfig, DownloadGuardContext } from './download-guard';
 
+export { planInteractive } from './interactive-plan';
+export type { InteractiveButton, InteractiveListOptions, InteractivePlan } from './interactive-plan';
+
 // ─────────────────────────────────────────────────────────────
 // Media storage backends (shared by @omni/api and channel plugins)
 // ─────────────────────────────────────────────────────────────

--- a/packages/channel-sdk/src/interactive-plan.ts
+++ b/packages/channel-sdk/src/interactive-plan.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared planner for the channel-agnostic `content.buttons` contract onto the
+ * WhatsApp Cloud API `interactive` object. Meta's constraints drive the shape:
+ *   - `interactive.button` — up to 3 reply buttons (title ≤ 20 chars, id ≤ 256)
+ *   - `interactive.list`   — 4-10 options become a single-section list
+ *                            (row title ≤ 24 chars, row description ≤ 72,
+ *                            section title ≤ 24); >10 rows is a Meta hard
+ *                            limit, the overflow is dropped (caller logs)
+ *   - a list is also chosen for ≤3 options when the caller asks for one
+ *     (`forceList`) or supplies presentation that only lists can render
+ *     (a row `description`, or a `sectionTitle`) — rendering reply buttons
+ *     there would drop that content silently
+ *   - `interactive.cta_url`— exactly one URL button (session messages cannot
+ *                            carry arbitrary URL buttons; cta_url is the only
+ *                            in-session link affordance)
+ *   - URL buttons that cannot be expressed (mixed with reply buttons, or more
+ *     than one) are appended to the body as `label: url` lines so no
+ *     information is silently lost.
+ *
+ * Consumed by every channel that speaks the Cloud API interactive dialect:
+ * whatsapp-business talks to Meta directly, hermes through the Mutant gateway
+ * (which proxies the same payload shape). Interactive messages only deliver
+ * inside the 24h customer-service window — outside it Meta rejects them (use
+ * an HSM template with buttons instead).
+ */
+
+export interface InteractiveButton {
+  text: string;
+  /** Callback payload (becomes the reply button / list row id). */
+  data?: string;
+  /** Link button URL — expressed via cta_url when it is the only button. */
+  url?: string;
+  /**
+   * Secondary line under the row title. Lists only — Meta's reply buttons
+   * have no description affordance, so supplying one promotes the message to
+   * a list (see `planInteractive`).
+   */
+  description?: string;
+}
+
+/** List-specific presentation, ignored when the plan renders reply buttons. */
+export interface InteractiveListOptions {
+  /** Section header above the rows. */
+  sectionTitle?: string;
+  /** Render a list even with ≤3 options (default: count decides). */
+  forceList?: boolean;
+}
+
+const MAX_REPLY_BUTTONS = 3;
+const MAX_LIST_ROWS = 10;
+const MAX_BUTTON_TITLE = 20;
+const MAX_ROW_TITLE = 24;
+const MAX_ROW_DESCRIPTION = 72;
+const MAX_SECTION_TITLE = 24;
+const MAX_ID = 256;
+
+const truncate = (s: string, max: number): string => (s.length <= max ? s : `${s.slice(0, max - 1)}…`);
+
+function buttonId(btn: InteractiveButton, index: number): string {
+  return (btn.data ?? btn.text ?? `btn_${index}`).slice(0, MAX_ID);
+}
+
+/** Result of mapping the agnostic buttons onto a Cloud API interactive payload. */
+export interface InteractivePlan {
+  interactive: Record<string, unknown> | null;
+  /** Body text, possibly extended with URL fallback lines. */
+  body: string;
+  /** Rows dropped beyond Meta's list limit — caller should log these. */
+  droppedRows: number;
+}
+
+/**
+ * Pure mapping step — exported for tests and for plugins to log drops.
+ */
+export function planInteractive(
+  bodyText: string,
+  buttons: InteractiveButton[],
+  listButtonLabel: string,
+  listOptions: InteractiveListOptions = {},
+): InteractivePlan {
+  const replyButtons = buttons.filter((b) => !b.url);
+  const urlButtons = buttons.filter((b) => b.url);
+
+  // Single URL button and nothing else → cta_url is the exact fit.
+  const soleCta = replyButtons.length === 0 && urlButtons.length === 1 ? urlButtons[0] : undefined;
+  if (soleCta) {
+    return {
+      interactive: {
+        type: 'cta_url',
+        body: { text: bodyText },
+        action: {
+          name: 'cta_url',
+          parameters: { display_text: truncate(soleCta.text, MAX_BUTTON_TITLE), url: soleCta.url },
+        },
+      },
+      body: bodyText,
+      droppedRows: 0,
+    };
+  }
+
+  // Any other URL buttons cannot render in-session — fold them into the body.
+  let body = bodyText;
+  if (urlButtons.length > 0) {
+    const lines = urlButtons.map((b) => `${b.text}: ${b.url}`);
+    body = body ? `${body}\n\n${lines.join('\n')}` : lines.join('\n');
+  }
+
+  if (replyButtons.length === 0) {
+    return { interactive: null, body, droppedRows: 0 };
+  }
+
+  // Descriptions and section titles only exist on lists, so asking for either
+  // implies a list — rendering reply buttons instead would drop them silently,
+  // which this module deliberately avoids (see the URL-button fallback above).
+  const wantsList =
+    listOptions.forceList === true ||
+    listOptions.sectionTitle !== undefined ||
+    replyButtons.some((b) => b.description !== undefined);
+
+  if (replyButtons.length <= MAX_REPLY_BUTTONS && !wantsList) {
+    return {
+      interactive: {
+        type: 'button',
+        body: { text: body },
+        action: {
+          buttons: replyButtons.map((b, i) => ({
+            type: 'reply',
+            reply: { id: buttonId(b, i), title: truncate(b.text, MAX_BUTTON_TITLE) },
+          })),
+        },
+      },
+      body,
+      droppedRows: 0,
+    };
+  }
+
+  const rows = replyButtons.slice(0, MAX_LIST_ROWS);
+  return {
+    interactive: {
+      type: 'list',
+      body: { text: body },
+      action: {
+        button: truncate(listButtonLabel, MAX_BUTTON_TITLE),
+        sections: [
+          {
+            ...(listOptions.sectionTitle ? { title: truncate(listOptions.sectionTitle, MAX_SECTION_TITLE) } : {}),
+            rows: rows.map((b, i) => ({
+              id: buttonId(b, i),
+              title: truncate(b.text, MAX_ROW_TITLE),
+              ...(b.description ? { description: truncate(b.description, MAX_ROW_DESCRIPTION) } : {}),
+            })),
+          },
+        ],
+      },
+    },
+    body,
+    droppedRows: replyButtons.length - rows.length,
+  };
+}

--- a/packages/channel-whatsapp-business/src/senders/interactive.ts
+++ b/packages/channel-whatsapp-business/src/senders/interactive.ts
@@ -28,139 +28,18 @@ import type { MetaWhatsAppClient } from '../client';
 import type { MetaOutboundMessage, MetaSendResponse } from '../types';
 import { toMetaPhone } from '../utils/identity';
 
-export interface InteractiveButton {
-  text: string;
-  /** Callback payload (becomes the reply button / list row id). */
-  data?: string;
-  /** Link button URL — expressed via cta_url when it is the only button. */
-  url?: string;
-  /**
-   * Secondary line under the row title. Lists only — Meta's reply buttons
-   * have no description affordance, so supplying one promotes the message to
-   * a list (see `planInteractive`).
-   */
-  description?: string;
-}
+import {
+  type InteractiveButton,
+  type InteractiveListOptions,
+  type InteractivePlan,
+  planInteractive,
+} from '@omni/channel-sdk';
 
-/** List-specific presentation, ignored when the plan renders reply buttons. */
-export interface InteractiveListOptions {
-  /** Section header above the rows. */
-  sectionTitle?: string;
-  /** Render a list even with ≤3 options (default: count decides). */
-  forceList?: boolean;
-}
-
-const MAX_REPLY_BUTTONS = 3;
-const MAX_LIST_ROWS = 10;
-const MAX_BUTTON_TITLE = 20;
-const MAX_ROW_TITLE = 24;
-const MAX_ROW_DESCRIPTION = 72;
-const MAX_SECTION_TITLE = 24;
-const MAX_ID = 256;
-
-const truncate = (s: string, max: number): string => (s.length <= max ? s : `${s.slice(0, max - 1)}…`);
-
-function buttonId(btn: InteractiveButton, index: number): string {
-  return (btn.data ?? btn.text ?? `btn_${index}`).slice(0, MAX_ID);
-}
-
-/** Result of mapping the agnostic buttons onto a Meta interactive payload. */
-export interface InteractivePlan {
-  interactive: Record<string, unknown> | null;
-  /** Body text, possibly extended with URL fallback lines. */
-  body: string;
-  /** Rows dropped beyond Meta's list limit — caller should log these. */
-  droppedRows: number;
-}
-
-/**
- * Pure mapping step — exported for tests and for the plugin to log drops.
- */
-export function planInteractive(
-  bodyText: string,
-  buttons: InteractiveButton[],
-  listButtonLabel: string,
-  listOptions: InteractiveListOptions = {},
-): InteractivePlan {
-  const replyButtons = buttons.filter((b) => !b.url);
-  const urlButtons = buttons.filter((b) => b.url);
-
-  // Single URL button and nothing else → cta_url is the exact fit.
-  const soleCta = replyButtons.length === 0 && urlButtons.length === 1 ? urlButtons[0] : undefined;
-  if (soleCta) {
-    return {
-      interactive: {
-        type: 'cta_url',
-        body: { text: bodyText },
-        action: {
-          name: 'cta_url',
-          parameters: { display_text: truncate(soleCta.text, MAX_BUTTON_TITLE), url: soleCta.url },
-        },
-      },
-      body: bodyText,
-      droppedRows: 0,
-    };
-  }
-
-  // Any other URL buttons cannot render in-session — fold them into the body.
-  let body = bodyText;
-  if (urlButtons.length > 0) {
-    const lines = urlButtons.map((b) => `${b.text}: ${b.url}`);
-    body = body ? `${body}\n\n${lines.join('\n')}` : lines.join('\n');
-  }
-
-  if (replyButtons.length === 0) {
-    return { interactive: null, body, droppedRows: 0 };
-  }
-
-  // Descriptions and section titles only exist on lists, so asking for either
-  // implies a list — rendering reply buttons instead would drop them silently,
-  // which this module deliberately avoids (see the URL-button fallback above).
-  const wantsList =
-    listOptions.forceList === true ||
-    listOptions.sectionTitle !== undefined ||
-    replyButtons.some((b) => b.description !== undefined);
-
-  if (replyButtons.length <= MAX_REPLY_BUTTONS && !wantsList) {
-    return {
-      interactive: {
-        type: 'button',
-        body: { text: body },
-        action: {
-          buttons: replyButtons.map((b, i) => ({
-            type: 'reply',
-            reply: { id: buttonId(b, i), title: truncate(b.text, MAX_BUTTON_TITLE) },
-          })),
-        },
-      },
-      body,
-      droppedRows: 0,
-    };
-  }
-
-  const rows = replyButtons.slice(0, MAX_LIST_ROWS);
-  return {
-    interactive: {
-      type: 'list',
-      body: { text: body },
-      action: {
-        button: truncate(listButtonLabel, MAX_BUTTON_TITLE),
-        sections: [
-          {
-            ...(listOptions.sectionTitle ? { title: truncate(listOptions.sectionTitle, MAX_SECTION_TITLE) } : {}),
-            rows: rows.map((b, i) => ({
-              id: buttonId(b, i),
-              title: truncate(b.text, MAX_ROW_TITLE),
-              ...(b.description ? { description: truncate(b.description, MAX_ROW_DESCRIPTION) } : {}),
-            })),
-          },
-        ],
-      },
-    },
-    body,
-    droppedRows: replyButtons.length - rows.length,
-  };
-}
+// The planner moved to @omni/channel-sdk (shared with channel-hermes, which
+// proxies the same Cloud API interactive shapes through the Mutant gateway).
+// Re-exported here so existing importers and tests keep their paths.
+export { planInteractive };
+export type { InteractiveButton, InteractiveListOptions, InteractivePlan };
 
 /**
  * Ask the user to share their location — renders WhatsApp's native


### PR DESCRIPTION
## Problema

O canal hermes declara `canSendButtons: true` e tem os senders interativos implementados — mas o `dispatchOutbound` nunca os chamava: `content.buttons` era **silenciosamente descartado** e saía texto puro. Além disso o texto saía com markdown cru (`**negrito**` chegava com asteriscos errados no aparelho — mesmo bug já corrigido no whatsapp-business em #886).

## Mudanças

**`@omni/channel-sdk`** — `planInteractive` promovido pra cá (mapper puro do contrato `content.buttons`: reply buttons ≤3 / list 4–10 / cta_url pra botão-URL único, truncagens, droppedRows). O Hermes proxya os shapes da Cloud API verbatim, então o mapper é idêntico pros dois canais.

**`channel-whatsapp-business`** — importa o planner do SDK e re-exporta (paths existentes e testes intactos).

**`channel-hermes`**
- `dispatchOutboundText`: planeja `content.buttons` → button/list/cta_url (`sendPlannedInteractive`); overflow >10 rows dropado com warn
- `content.type === 'location_request'` → `location_request_message` (não está no Postman publicado da Mutant, mas foi **aceito ao vivo em 2026-08-04** — Hermes repassa o shape pra Meta)
- texto honra `messageFormatMode` via `markdownToWhatsApp`
- types: `cta_url` + `location_request_message` entram na union

## Testes
- 8 novos (6 dispatch no plugin + 2 senders)
- hermes 55 ✅ · whatsapp-business 131 ✅ · channel-sdk 388 ✅ (compliance incluso)
- typecheck workspace 23/23 ✅ · knip ✅ · biome ✅

## Contexto
Linha Hermes (Mutant) da Hapvida ativa em prod desde hoje; widgets validados ao vivo direto na API (bateria de 22 envios). Falta análogo no hv-scheduling: adicionar `hermes` ao `INTERACTIVE_CHANNELS`.