### PR TITLE
fix(cli): enforce dependency-aware service readiness

### DIFF
--- a/packages/cli/src/__tests__/service-lifecycle.test.ts
+++ b/packages/cli/src/__tests__/service-lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { type Server, createServer } from 'node:net';
+import {
+  formatLifecycleFailure,
+  runServiceStartSequence,
+  waitForDatabaseReady,
+  waitForTcpReady,
+} from '../service-lifecycle.js';
+
+describe('runServiceStartSequence', () => {
+  test('runs dependencies before dependents', async () => {
+    const calls: string[] = [];
+    const pass = (name: string) => async () => {
+      calls.push(name);
+      return true;
+    };
+
+    const result = await runServiceStartSequence({
+      checkDatabase: pass('database'),
+      startNats: pass('nats-start'),
+      checkNats: pass('nats-ready'),
+      startApi: pass('api-start'),
+      checkApi: pass('api-health'),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual(['database', 'nats-start', 'nats-ready', 'api-start', 'api-health']);
+  });
+
+  test.each([
+    ['database', 'database'],
+    ['nats-start', 'nats-start'],
+    ['nats-ready', 'nats-ready'],
+    ['api-start', 'api-start'],
+    ['api-health', 'api-health'],
+  ] as const)('stops immediately when %s fails', async (failedCall, expectedPhase) => {
+    const calls: string[] = [];
+    const step = (name: string) => async () => {
+      calls.push(name);
+      return name !== failedCall;
+    };
+
+    const result = await runServiceStartSequence({
+      checkDatabase: step('database'),
+      startNats: step('nats-start'),
+      checkNats: step('nats-ready'),
+      startApi: step('api-start'),
+      checkApi: step('api-health'),
+    });
+
+    expect(result).toEqual({ ok: false, phase: expectedPhase });
+    expect(calls.at(-1)).toBe(failedCall);
+  });
+
+  test('formats an actionable message for every failure phase', () => {
+    for (const phase of ['database', 'nats-start', 'nats-ready', 'api-start', 'api-health'] as const) {
+      expect(formatLifecycleFailure({ ok: false, phase })).not.toBe('');
+    }
+  });
+
+  test('stops immediately when a phase throws', async () => {
+    const calls: string[] = [];
+    const result = await runServiceStartSequence({
+      checkDatabase: async () => {
+        calls.push('database');
+        return true;
+      },
+      startNats: async () => {
+        calls.push('nats-start');
+        throw new Error('pm2 failed');
+      },
+      checkNats: async () => {
+        calls.push('nats-ready');
+        return true;
+      },
+      startApi: async () => true,
+      checkApi: async () => true,
+    });
+
+    expect(result).toEqual({ ok: false, phase: 'nats-start' });
+    expect(calls).toEqual(['database', 'nats-start']);
+  });
+});
+
+describe('readiness probes', () => {
+  let server: Server | undefined;
+
+  afterEach(() => {
+    server?.close();
+    server = undefined;
+  });
+
+  test('TCP readiness succeeds only after a listener accepts connections', async () => {
+    server = createServer();
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected TCP address');
+
+    expect(await waitForTcpReady('127.0.0.1', address.port, 100)).toBe(true);
+  });
+
+  test('TCP readiness times out when no listener is present', async () => {
+    server = createServer();
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected TCP address');
+    const port = address.port;
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = undefined;
+
+    expect(await waitForTcpReady('127.0.0.1', port, 20)).toBe(false);
+  });
+
+  test('database readiness fails closed for an invalid URL', async () => {
+    expect(await waitForDatabaseReady({ databaseUrl: 'not-a-postgres-url' }, 10)).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -15,29 +15,24 @@
  *   6. Print an agent handoff block addressed TO the AI agent running this.
  */
 
-import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import ora from 'ora';
 import {
-  type Config,
   DEFAULT_SERVER_CONFIG,
-  type ServerConfig,
   getConfigPath,
   loadLocalRuntimeConfig,
   loadServerConfig,
   saveLocalRuntimeConfig,
   saveServerConfig,
 } from '../config.js';
-import { DEFAULT_API_PORT, HEALTH_TIMEOUT_MS, waitForHealth } from '../health.js';
-import { detectReinstall, installPm2Logrotate, writeSystemdUnit } from '../install-helpers.js';
+import { DEFAULT_API_PORT } from '../health.js';
+import { detectReinstall } from '../install-helpers.js';
+import { startInstallServices } from '../install-services.js';
 import { resolveCanonicalPgservePreference } from '../lib/canonical-pgserve.js';
-import { NATS_BINARY_PATH, ensureNats } from '../nats-install.js';
+import { ensureNats } from '../nats-install.js';
 import * as output from '../output.js';
-import { PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, isPm2Available, runPm2 } from '../pm2.js';
-import { buildEmbeddedDatabaseUrl, buildRuntimeEnv } from '../runtime-env.js';
-import { getServerBundlePath, getServerLauncherPath } from '../server-bundle.js';
+import { buildEmbeddedDatabaseUrl } from '../runtime-env.js';
 import { generateApiKey, maskApiKey } from '../utils/keys.js';
 import { VERSION } from '../version.js';
 
@@ -161,93 +156,6 @@ function resolveReinstallConfig(options: InstallOptions): ResolvedConfig {
   };
 }
 
-function buildInstallRuntimeEnv(
-  cfg: ResolvedConfig,
-  forceCleanup: boolean,
-  useCanonicalPgserve: boolean,
-): Record<string, string> {
-  const serverConfig: ServerConfig = {
-    ...DEFAULT_SERVER_CONFIG,
-    port: cfg.port,
-    databaseUrl: cfg.databaseUrl,
-    dataDir: cfg.dataDir,
-    useCanonicalPgserve,
-  };
-  const env = buildRuntimeEnv(serverConfig, { apiKey: cfg.apiKey } as Config) as Record<string, string>;
-  if (forceCleanup) env.OMNI_PGSERVE_FORCE_CLEANUP = 'true';
-  return env;
-}
-
-// ----------------------------------------------------------------------------
-// Service start
-// ----------------------------------------------------------------------------
-
-async function startServices(
-  cfg: ResolvedConfig,
-  forceCleanup: boolean,
-  forceSystemd: boolean,
-  useCanonicalPgserve: boolean,
-): Promise<boolean> {
-  if (forceSystemd) {
-    writeSystemdUnit(cfg.dataDir);
-    return false;
-  }
-
-  if (!(await isPm2Available())) {
-    output.warn('PM2 not found in PATH.\n  Install it with: bun add -g pm2\n  Then run: omni start');
-    return false;
-  }
-
-  const bundlePath = getServerBundlePath();
-  if (!existsSync(bundlePath)) {
-    output.warn(
-      `Server bundle not found at: ${bundlePath}\n  Install @automagik/omni from npm: bun add -g @automagik/omni\n  Or build locally: make cli-build-full`,
-    );
-    return false;
-  }
-
-  mkdirSync(getPm2LogDir(), { recursive: true });
-  await installPm2Logrotate();
-
-  const runtimeEnv = buildInstallRuntimeEnv(cfg, forceCleanup, useCanonicalPgserve);
-
-  // Delete existing processes so the new hardened flags take effect (reinstall path).
-  await runPm2(['delete', PM2_PROCESSES.api]);
-  await runPm2(['delete', PM2_PROCESSES.nats]);
-
-  const apiSpinner = ora(`Starting ${PM2_PROCESSES.api} on port ${cfg.port}...`).start();
-  const apiArgs = buildPm2StartArgs({
-    kind: 'api',
-    script: getServerLauncherPath(),
-    name: PM2_PROCESSES.api,
-    interpreter: 'bash',
-  });
-  const apiCode = await runPm2(apiArgs, runtimeEnv);
-  if (apiCode !== 0) {
-    apiSpinner.fail(`Failed to start ${PM2_PROCESSES.api} (pm2 exit code ${apiCode})`);
-    return false;
-  }
-  apiSpinner.succeed(`${PM2_PROCESSES.api} started`);
-
-  if (existsSync(NATS_BINARY_PATH)) {
-    const natsSpinner = ora(`Starting ${PM2_PROCESSES.nats}...`).start();
-    const natsDataDir = join(cfg.dataDir, 'nats');
-    mkdirSync(natsDataDir, { recursive: true });
-    const natsArgs = buildPm2StartArgs({
-      kind: 'nats',
-      script: NATS_BINARY_PATH,
-      name: PM2_PROCESSES.nats,
-      scriptArgs: ['-js', '-sd', natsDataDir],
-    });
-    const natsCode = await runPm2(natsArgs);
-    if (natsCode !== 0) natsSpinner.warn(`${PM2_PROCESSES.nats} failed to start — check NATS binary`);
-    else natsSpinner.succeed(`${PM2_PROCESSES.nats} started`);
-  } else {
-    output.warn(`NATS binary not found at ${NATS_BINARY_PATH} — skipping`);
-  }
-  return true;
-}
-
 // ----------------------------------------------------------------------------
 // Persistence, health, handoff
 // ----------------------------------------------------------------------------
@@ -268,14 +176,6 @@ function writeConfigFile(cfg: ResolvedConfig, useCanonicalPgserve: boolean): voi
     // commands honor it without operator passing flags or env vars.
     useCanonicalPgserve,
   });
-}
-
-async function checkHealth(port: number): Promise<boolean> {
-  const spinner = ora(`Checking health at http://localhost:${port}/api/v2/health...`).start();
-  const healthy = await waitForHealth(port);
-  if (healthy) spinner.succeed('Server is healthy');
-  else spinner.warn(`Health check failed after ${HEALTH_TIMEOUT_MS / 1000}s — check: omni logs --process api`);
-  return healthy;
 }
 
 /**
@@ -372,12 +272,14 @@ async function runInstall(options: InstallOptions): Promise<void> {
   const useCanonicalPgserve = await resolveCanonicalPgservePreference(signals.isReinstall, cfg);
 
   await ensureNats();
-  const servicesStarted = await startServices(cfg, forceCleanup, forceSystemd, useCanonicalPgserve);
+  const servicesStarted = await startInstallServices(cfg, forceCleanup, forceSystemd, useCanonicalPgserve);
+
+  if (!forceSystemd && !servicesStarted) {
+    output.error('Installation did not complete because the local services are not ready.', undefined, 1);
+  }
 
   writeConfigFile(cfg, useCanonicalPgserve);
   output.success(`Config written to ${getConfigPath()}`);
-
-  if (servicesStarted) await checkHealth(cfg.port);
 
   const apiKeyDisplay = apiKeyFreshlyGenerated ? cfg.apiKey : maskApiKey(cfg.apiKey);
   output.raw(buildAgentHandoffBlock(cfg, apiKeyDisplay));

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -17,6 +17,14 @@ import { getHealthCheckUrl, waitForHealth } from '../health.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, isPm2Available, pm2NotFoundError, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv } from '../runtime-env.js';
+import {
+  databaseTargetFromRuntimeEnv,
+  formatLifecycleFailure,
+  runServiceStartSequence,
+  tcpTargetFromUrl,
+  waitForDatabaseReady,
+  waitForTcpReady,
+} from '../service-lifecycle.js';
 
 // ============================================================================
 // CONSTANTS
@@ -39,25 +47,44 @@ async function runRestart(): Promise<void> {
   const cliConfig = loadLocalRuntimeConfig();
   const apiPort = serverConfig.port;
 
-  output.info('Restarting omni services...');
   // Build a hermetic env from config. We pass this so the pm2 CLI itself
   // runs in a sanitized environment (no leakage from the parent shell's
   // DATABASE_URL / OMNI_API_KEY).
   const env = buildRuntimeEnv(serverConfig, cliConfig);
-  const code = await runPm2(['restart', PM2_PROCESSES.api, PM2_PROCESSES.nats], env);
-  if (code !== 0) {
-    output.warn('Some services may not have restarted cleanly — check pm2 status');
+  const natsTarget = tcpTargetFromUrl(env.NATS_URL);
+  if (!natsTarget) {
+    output.error(`Invalid NATS URL in runtime configuration: ${env.NATS_URL}`, undefined, 1);
   }
 
-  // Wait for health check
   const healthUrl = getHealthCheckUrl(apiPort);
-  output.info(`Waiting for health check at ${healthUrl}...`);
-  const healthy = await waitForHealth(apiPort, RESTART_HEALTH_TIMEOUT_MS);
-  if (healthy) {
-    output.success('Server is healthy after restart');
-  } else {
-    output.warn(`Health check did not pass within ${RESTART_HEALTH_TIMEOUT_MS / 1000}s`);
+  const result = await runServiceStartSequence({
+    checkDatabase: async () => {
+      output.info('Waiting for database readiness...');
+      return waitForDatabaseReady(databaseTargetFromRuntimeEnv(env));
+    },
+    startNats: async () => {
+      output.info(`Restarting ${PM2_PROCESSES.nats}...`);
+      return (await runPm2(['restart', PM2_PROCESSES.nats], env)) === 0;
+    },
+    checkNats: async () => {
+      output.info(`Waiting for NATS at ${natsTarget.host}:${natsTarget.port}...`);
+      return waitForTcpReady(natsTarget.host, natsTarget.port);
+    },
+    startApi: async () => {
+      output.info(`Restarting ${PM2_PROCESSES.api}...`);
+      return (await runPm2(['restart', PM2_PROCESSES.api], env)) === 0;
+    },
+    checkApi: async () => {
+      output.info(`Waiting for health check at ${healthUrl}...`);
+      return waitForHealth(apiPort, RESTART_HEALTH_TIMEOUT_MS);
+    },
+  });
+
+  if (!result.ok) {
+    output.error(`${formatLifecycleFailure(result)}.`, undefined, 1);
   }
+
+  output.success('Server is healthy after restart');
 }
 
 // ============================================================================

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -15,6 +15,14 @@ import * as output from '../output.js';
 import { PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, isPm2Available, pm2NotFoundError, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv } from '../runtime-env.js';
 import { bundleNotFoundError, getServerBundlePath, getServerLauncherPath } from '../server-bundle.js';
+import {
+  databaseTargetFromRuntimeEnv,
+  formatLifecycleFailure,
+  runServiceStartSequence,
+  tcpTargetFromUrl,
+  waitForDatabaseReady,
+  waitForTcpReady,
+} from '../service-lifecycle.js';
 
 // ============================================================================
 // CONSTANTS
@@ -76,11 +84,14 @@ async function runStart(): Promise<void> {
   // Ensure hardened log directory exists before pm2 spawns.
   mkdirSync(getPm2LogDir(), { recursive: true });
 
-  // 3. Start omni-api via PM2 with complete env from config and hardened flags
-  output.info(`Starting ${PM2_PROCESSES.api} (port ${apiPort})...`);
   // LOCAL entry, never the active server — see runtime-env.ts rule 5.
   const cliConfig = loadLocalRuntimeConfig();
   const env = buildRuntimeEnv(serverConfig, cliConfig);
+  const natsTarget = tcpTargetFromUrl(env.NATS_URL);
+  if (!natsTarget) {
+    output.error(`Invalid NATS URL in runtime configuration: ${env.NATS_URL}`, undefined, 1);
+  }
+
   const launcherPath = getServerLauncherPath();
   const apiArgs = buildPm2StartArgs({
     kind: 'api',
@@ -88,41 +99,47 @@ async function runStart(): Promise<void> {
     name: PM2_PROCESSES.api,
     interpreter: 'bash',
   });
-  const apiCode = await runPm2(apiArgs, env);
-  if (apiCode !== 0) {
-    output.error(`Failed to start ${PM2_PROCESSES.api} (pm2 exit code ${apiCode})`, undefined, 1);
-    return;
-  }
-
-  // 4. Start omni-nats if binary exists
   const natsPath = join(homedir(), '.omni', 'nats-server');
-  if (existsSync(natsPath)) {
-    output.info(`Starting ${PM2_PROCESSES.nats}...`);
-    const natsDataDir = join(serverConfig.dataDir, 'nats');
-    mkdirSync(natsDataDir, { recursive: true });
-    const natsArgs = buildPm2StartArgs({
-      kind: 'nats',
-      script: natsPath,
-      name: PM2_PROCESSES.nats,
-      scriptArgs: ['-js', '-sd', natsDataDir],
-    });
-    const natsCode = await runPm2(natsArgs);
-    if (natsCode !== 0) {
-      output.warn(`${PM2_PROCESSES.nats} failed to start — run 'omni install' to download NATS first`);
-    }
-  } else {
-    output.warn(`NATS binary not found at ${natsPath} — skipping. Run 'omni install' to set it up.`);
+  const natsDataDir = join(serverConfig.dataDir, 'nats');
+  const natsArgs = buildPm2StartArgs({
+    kind: 'nats',
+    script: natsPath,
+    name: PM2_PROCESSES.nats,
+    scriptArgs: ['-js', '-sd', natsDataDir],
+  });
+  const healthUrl = getHealthCheckUrl(apiPort);
+
+  const result = await runServiceStartSequence({
+    checkDatabase: async () => {
+      output.info('Waiting for database readiness...');
+      return waitForDatabaseReady(databaseTargetFromRuntimeEnv(env));
+    },
+    startNats: async () => {
+      if (!existsSync(natsPath)) return false;
+      mkdirSync(natsDataDir, { recursive: true });
+      output.info(`Starting ${PM2_PROCESSES.nats}...`);
+      return (await runPm2(natsArgs)) === 0;
+    },
+    checkNats: async () => {
+      output.info(`Waiting for NATS at ${natsTarget.host}:${natsTarget.port}...`);
+      return waitForTcpReady(natsTarget.host, natsTarget.port);
+    },
+    startApi: async () => {
+      output.info(`Starting ${PM2_PROCESSES.api} (port ${apiPort})...`);
+      return (await runPm2(apiArgs, env)) === 0;
+    },
+    checkApi: async () => {
+      output.info(`Waiting for health check at ${healthUrl}...`);
+      return waitForHealth(apiPort, START_HEALTH_TIMEOUT_MS);
+    },
+  });
+
+  if (!result.ok) {
+    const hint = result.phase === 'nats-start' && !existsSync(natsPath) ? ` Run 'omni install' to install NATS.` : '';
+    output.error(`${formatLifecycleFailure(result)}.${hint}`, undefined, 1);
   }
 
-  // 5. Wait for health check
-  const healthUrl = getHealthCheckUrl(apiPort);
-  output.info(`Waiting for health check at ${healthUrl}...`);
-  const healthy = await waitForHealth(apiPort, START_HEALTH_TIMEOUT_MS);
-  if (healthy) {
-    output.success(`Server is healthy at ${healthUrl}`);
-  } else {
-    output.warn(`Health check did not pass within ${START_HEALTH_TIMEOUT_MS / 1000}s — server may still be starting`);
-  }
+  output.success(`Server is healthy at ${healthUrl}`);
 }
 
 // ============================================================================

--- a/packages/cli/src/install-services.ts
+++ b/packages/cli/src/install-services.ts
@@ -1,0 +1,124 @@
+/** PM2/systemd service materialization for `omni install`. */
+
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import ora from 'ora';
+import { type Config, DEFAULT_SERVER_CONFIG, type ServerConfig } from './config.js';
+import { waitForHealth } from './health.js';
+import { installPm2Logrotate, writeSystemdUnit } from './install-helpers.js';
+import { NATS_BINARY_PATH } from './nats-install.js';
+import * as output from './output.js';
+import { PM2_PROCESSES, buildPm2StartArgs, getPm2LogDir, isPm2Available, runPm2 } from './pm2.js';
+import { type RuntimeEnv, buildRuntimeEnv } from './runtime-env.js';
+import { getServerBundlePath, getServerLauncherPath } from './server-bundle.js';
+import {
+  databaseTargetFromRuntimeEnv,
+  formatLifecycleFailure,
+  runServiceStartSequence,
+  tcpTargetFromUrl,
+  waitForDatabaseReady,
+  waitForTcpReady,
+} from './service-lifecycle.js';
+
+export interface InstallServiceConfig {
+  port: number;
+  dataDir: string;
+  databaseUrl: string;
+  apiKey: string;
+}
+
+function buildInstallRuntimeEnv(
+  cfg: InstallServiceConfig,
+  forceCleanup: boolean,
+  useCanonicalPgserve: boolean,
+): RuntimeEnv & Record<string, string> {
+  const serverConfig: ServerConfig = {
+    ...DEFAULT_SERVER_CONFIG,
+    port: cfg.port,
+    databaseUrl: cfg.databaseUrl,
+    dataDir: cfg.dataDir,
+    useCanonicalPgserve,
+  };
+  const env: RuntimeEnv & Record<string, string> = {
+    ...buildRuntimeEnv(serverConfig, { apiKey: cfg.apiKey } as Config),
+  };
+  if (forceCleanup) env.OMNI_PGSERVE_FORCE_CLEANUP = 'true';
+  return env;
+}
+
+export async function startInstallServices(
+  cfg: InstallServiceConfig,
+  forceCleanup: boolean,
+  forceSystemd: boolean,
+  useCanonicalPgserve: boolean,
+): Promise<boolean> {
+  if (forceSystemd) {
+    writeSystemdUnit(cfg.dataDir);
+    return false;
+  }
+  if (!(await isPm2Available())) {
+    output.warn('PM2 not found in PATH.\n  Install it with: bun add -g pm2\n  Then run: omni start');
+    return false;
+  }
+
+  const bundlePath = getServerBundlePath();
+  if (!existsSync(bundlePath)) {
+    output.warn(
+      `Server bundle not found at: ${bundlePath}\n  Install @automagik/omni from npm: bun add -g @automagik/omni\n  Or build locally: make cli-build-full`,
+    );
+    return false;
+  }
+
+  mkdirSync(getPm2LogDir(), { recursive: true });
+  await installPm2Logrotate();
+  const runtimeEnv = buildInstallRuntimeEnv(cfg, forceCleanup, useCanonicalPgserve);
+  const natsTarget = tcpTargetFromUrl(runtimeEnv.NATS_URL);
+  if (!natsTarget) return false;
+
+  const natsDataDir = join(cfg.dataDir, 'nats');
+  const natsArgs = buildPm2StartArgs({
+    kind: 'nats',
+    script: NATS_BINARY_PATH,
+    name: PM2_PROCESSES.nats,
+    scriptArgs: ['-js', '-sd', natsDataDir],
+  });
+  const apiArgs = buildPm2StartArgs({
+    kind: 'api',
+    script: getServerLauncherPath(),
+    name: PM2_PROCESSES.api,
+    interpreter: 'bash',
+  });
+
+  const result = await runServiceStartSequence({
+    checkDatabase: () => waitForDatabaseReady(databaseTargetFromRuntimeEnv(runtimeEnv)),
+    startNats: async () => {
+      if (!existsSync(NATS_BINARY_PATH)) return false;
+      await runPm2(['delete', PM2_PROCESSES.api]);
+      await runPm2(['delete', PM2_PROCESSES.nats]);
+      mkdirSync(natsDataDir, { recursive: true });
+      const spinner = ora(`Starting ${PM2_PROCESSES.nats}...`).start();
+      const code = await runPm2(natsArgs);
+      if (code === 0) spinner.succeed(`${PM2_PROCESSES.nats} started`);
+      else spinner.fail(`Failed to start ${PM2_PROCESSES.nats} (pm2 exit code ${code})`);
+      return code === 0;
+    },
+    checkNats: () => waitForTcpReady(natsTarget.host, natsTarget.port),
+    startApi: async () => {
+      const spinner = ora(`Starting ${PM2_PROCESSES.api} on port ${cfg.port}...`).start();
+      const code = await runPm2(apiArgs, runtimeEnv);
+      if (code === 0) spinner.succeed(`${PM2_PROCESSES.api} started`);
+      else spinner.fail(`Failed to start ${PM2_PROCESSES.api} (pm2 exit code ${code})`);
+      return code === 0;
+    },
+    checkApi: async () => {
+      const spinner = ora(`Checking health at http://localhost:${cfg.port}/api/v2/health...`).start();
+      const healthy = await waitForHealth(cfg.port);
+      if (healthy) spinner.succeed('Server is healthy');
+      else spinner.fail('Server health check failed');
+      return healthy;
+    },
+  });
+
+  if (!result.ok) output.warn(formatLifecycleFailure(result));
+  return result.ok;
+}

--- a/packages/cli/src/lib/canonical-pgserve.ts
+++ b/packages/cli/src/lib/canonical-pgserve.ts
@@ -309,7 +309,7 @@ export async function setupCanonicalPgserve(): Promise<string | null> {
   if (!(await ensurePgserveBinary())) {
     // ensurePgserveBinary already emitted the actionable autopg
     // install.sh hint. Bare warn here just labels the abort surface.
-    output.warn('Canonical pgserve setup skipped — staying on embedded mode.');
+    output.warn('Canonical pgserve setup could not start.');
     return null;
   }
   if (!(await runPgserveInstall())) return null;
@@ -320,11 +320,11 @@ export async function setupCanonicalPgserve(): Promise<string | null> {
   // db-create + role connect races startup, silently no-ops (best-effort), and
   // the operator is left with omni-api crash-looping on a missing `omni` db
   // until they re-run `omni doctor --fix`.
-  await waitForCanonicalReady(port);
-  // Best-effort: db-create failure does not abort the install; operator
-  // can rerun `omni doctor --fix` later. The URL is still returned so
-  // the caller persists the correct port even when DB creation lags.
-  await ensureOmniDatabaseExists(port);
+  if (!(await waitForCanonicalReady(port))) {
+    output.warn(`Canonical pgserve did not become ready on port ${port}.`);
+    return null;
+  }
+  if (!(await ensureOmniDatabaseExists(port))) return null;
   // Provision the dedicated non-superuser role scoped to the omni DB.
   // Best-effort: failure logs a warning and falls back to legacy
   // postgres:postgres at omni-api startup via the sentinel-missing path
@@ -349,8 +349,8 @@ export async function setupCanonicalPgserve(): Promise<string | null> {
  * Semantics:
  *   - Fresh install → ALWAYS canonical (auto-installs `pgserve` globally
  *     when missing, runs `pgserve install`, reads `pgserve url`). If
- *     canonical setup completely fails, falls back to embedded with a warn
- *     — the install still completes.
+ *     canonical setup fails, the later dependency probe prevents service
+ *     installation from being reported as successful.
  *   - Reinstall → preserves the operator's existing
  *     `serverConfig.useCanonicalPgserve`. If `true`, re-runs setup
  *     (idempotent) to refresh the canonical url. If `false`/undefined,
@@ -377,9 +377,7 @@ export async function resolveCanonicalPgservePreference(
   output.raw('  Canonical pgserve mode (default for new installs)');
   const url = await setupCanonicalPgserve();
   if (!url) {
-    output.warn(
-      'Canonical pgserve setup did not complete — falling back to embedded pgserve. Run `omni doctor --fix` later to migrate.',
-    );
+    output.warn('Canonical pgserve setup did not complete.');
     output.raw('');
     return false;
   }

--- a/packages/cli/src/service-lifecycle.ts
+++ b/packages/cli/src/service-lifecycle.ts
@@ -1,0 +1,167 @@
+/**
+ * Dependency-aware Omni service startup.
+ *
+ * A process-manager state is not a readiness signal. This module keeps the
+ * dependency order explicit and exposes the data-plane probes shared by
+ * install, start, and restart.
+ */
+
+import { createConnection } from 'node:net';
+import postgres from 'postgres';
+
+export const DEPENDENCY_READY_TIMEOUT_MS = 15_000;
+const READINESS_POLL_INTERVAL_MS = 250;
+
+export type LifecycleFailurePhase = 'database' | 'nats-start' | 'nats-ready' | 'api-start' | 'api-health';
+
+export type LifecycleResult = { ok: true } | { ok: false; phase: LifecycleFailurePhase };
+
+export interface ServiceStartSteps {
+  checkDatabase: () => Promise<boolean>;
+  startNats: () => Promise<boolean>;
+  checkNats: () => Promise<boolean>;
+  startApi: () => Promise<boolean>;
+  checkApi: () => Promise<boolean>;
+}
+
+const PHASE_MESSAGES: Record<LifecycleFailurePhase, string> = {
+  database: 'Database is not ready; no Omni services were changed',
+  'nats-start': 'NATS failed to start',
+  'nats-ready': 'NATS started but did not become ready',
+  'api-start': 'Omni API failed to start',
+  'api-health': 'Omni API started but its health check did not pass',
+};
+
+export async function runServiceStartSequence(steps: ServiceStartSteps): Promise<LifecycleResult> {
+  const phases: Array<[LifecycleFailurePhase, () => Promise<boolean>]> = [
+    ['database', steps.checkDatabase],
+    ['nats-start', steps.startNats],
+    ['nats-ready', steps.checkNats],
+    ['api-start', steps.startApi],
+    ['api-health', steps.checkApi],
+  ];
+
+  for (const [phase, run] of phases) {
+    try {
+      if (!(await run())) return { ok: false, phase };
+    } catch {
+      return { ok: false, phase };
+    }
+  }
+
+  return { ok: true };
+}
+
+export function formatLifecycleFailure(result: Exclude<LifecycleResult, { ok: true }>): string {
+  return PHASE_MESSAGES[result.phase];
+}
+
+function probeTcp(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(ready);
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+  });
+}
+
+export async function waitForTcpReady(
+  host: string,
+  port: number,
+  timeoutMs = DEPENDENCY_READY_TIMEOUT_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  do {
+    const remaining = Math.max(1, deadline - Date.now());
+    if (await probeTcp(host, port, Math.min(remaining, 1_000))) return true;
+    if (Date.now() < deadline) {
+      await Bun.sleep(Math.min(READINESS_POLL_INTERVAL_MS, deadline - Date.now()));
+    }
+  } while (Date.now() < deadline);
+
+  return false;
+}
+
+export interface DatabaseReadinessTarget {
+  databaseUrl: string;
+  host?: string;
+  port?: number;
+}
+
+export async function waitForDatabaseReady(
+  target: DatabaseReadinessTarget,
+  timeoutMs = DEPENDENCY_READY_TIMEOUT_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  do {
+    let sql: ReturnType<typeof postgres> | undefined;
+    try {
+      const options: {
+        max: number;
+        connect_timeout: number;
+        idle_timeout: number;
+        prepare: boolean;
+        onnotice: () => void;
+        host?: string;
+        port?: number;
+      } = {
+        max: 1,
+        connect_timeout: 1,
+        idle_timeout: 1,
+        prepare: false,
+        onnotice: () => {},
+      };
+      if (target.host) options.host = target.host;
+      if (target.port) options.port = target.port;
+
+      sql = postgres(target.databaseUrl, options);
+      await sql`SELECT 1`;
+      return true;
+    } catch {
+      // Retry until the bounded deadline. Callers surface the failure phase.
+    } finally {
+      await sql?.end({ timeout: 1 }).catch(() => {});
+    }
+
+    if (Date.now() < deadline) {
+      await Bun.sleep(Math.min(READINESS_POLL_INTERVAL_MS, deadline - Date.now()));
+    }
+  } while (Date.now() < deadline);
+
+  return false;
+}
+
+export function databaseTargetFromRuntimeEnv(env: {
+  DATABASE_URL: string;
+  PGHOST?: string;
+  PGPORT?: string;
+}): DatabaseReadinessTarget {
+  const parsedPort = Number.parseInt(env.PGPORT ?? '', 10);
+  return {
+    databaseUrl: env.DATABASE_URL,
+    host: env.PGHOST || undefined,
+    port: Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : undefined,
+  };
+}
+
+export function tcpTargetFromUrl(rawUrl: string): { host: string; port: number } | null {
+  try {
+    const url = new URL(rawUrl);
+    const port = Number.parseInt(url.port, 10);
+    if (!url.hostname || !Number.isInteger(port) || port < 1 || port > 65_535) return null;
+    return { host: url.hostname, port };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- probe the configured database before mutating local services
- start NATS before the API and require data-plane readiness at each phase
- make `omni start`, `omni restart`, and PM2-backed install fail when the resulting stack is unhealthy
- stop canonical database setup from being persisted when PostgreSQL or database provisioning never becomes ready

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- pre-push gates: 5,683 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated service startup and restart checks for the database, NATS, and API.
  * Added readiness and health checks with bounded wait times and cleanup handling.
  * Added support for starting services through systemd or PM2 during installation.
* **Bug Fixes**
  * Invalid service URLs and failed dependencies now produce clear errors instead of warnings.
  * Canonical database setup failures now correctly prevent successful installation reporting.
* **Tests**
  * Added coverage for dependency ordering, readiness timeouts, startup failures, cleanup, and invalid configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->