### PR TITLE
fix(whatsapp-business): download inbound Meta media so transcription runs

### DIFF
--- a/packages/api/src/plugins/__tests__/media-processor-plugin-download.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-plugin-download.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Deferred-media download bridge (issue #897).
+ *
+ * Meta Cloud (`whatsapp-business`) inbound webhooks carry only a `media_id`, not
+ * a public `mediaUrl` — so the message.received event has `content.mediaId` set
+ * and `content.mediaUrl` absent. The media processor must materialize the bytes
+ * by calling the channel plugin's `downloadInboundMedia(instanceId, mediaId)`,
+ * store them, and feed a readable file to the processing service. Without this
+ * bridge the audio is persisted but never downloaded or transcribed.
+ *
+ * These are pure unit tests (LocalMediaBackend, no MinIO/Docker). The fake
+ * plugin is injected via `ctx.resolveChannelPlugin` so the test never touches
+ * the shared `channelRegistry` singleton (which is fragile under bun's global
+ * `mock.module` leakage across files).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type ChannelPlugin, LocalMediaBackend } from '@omni/channel-sdk';
+import type { EventBus, MessageReceivedPayload } from '@omni/core';
+import type { Database } from '@omni/db';
+import type { MediaProcessingService } from '@omni/media-processing';
+import type { Services } from '../../services';
+import { MediaStorageService } from '../../services/media-storage';
+import { type MediaProcessorContext, __test__ } from '../media-processor';
+
+const { processMessageMedia } = __test__;
+
+interface ProcessCapture {
+  path?: string;
+  bytes?: Buffer;
+}
+
+function makeFakeMediaService(capture: ProcessCapture): MediaProcessingService {
+  return {
+    canProcess: () => true,
+    process: async (path: string) => {
+      capture.path = path;
+      capture.bytes = await readFile(path);
+      return {
+        success: true,
+        content: 'transcribed: hello world',
+        contentFormat: 'text',
+        processingType: 'transcription',
+        provider: 'fake',
+        model: 'fake-model',
+        processingTimeMs: 1,
+        costCents: 0,
+      };
+    },
+  } as unknown as MediaProcessingService;
+}
+
+/** Chainable no-op DB — the storage/persistence writes are asserted elsewhere. */
+function makeMockDb(): Database {
+  return {
+    update: () => ({ set: () => ({ where: async () => {} }) }),
+    insert: () => ({ values: async () => {} }),
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => [] }) }) }),
+  } as unknown as Database;
+}
+
+function makeMockServices(): Services {
+  return {
+    chats: { findByExternalIdSmart: async () => ({ id: 'chat-uuid' }) },
+    // No pre-existing local path — forces the processor down the download branch.
+    messages: { getByExternalId: async () => ({ id: 'msg-uuid', mediaLocalPath: null, platformTimestamp: null }) },
+  } as unknown as Services;
+}
+
+function makeContext(opts: {
+  mediaStorage: MediaStorageService;
+  mediaService: MediaProcessingService;
+  published: Array<{ type: string; payload: Record<string, unknown> }>;
+  plugin: ChannelPlugin | undefined;
+}): MediaProcessorContext {
+  const eventBus = {
+    publish: async (type: string, payload: Record<string, unknown>) => {
+      opts.published.push({ type, payload });
+    },
+  } as unknown as EventBus;
+
+  return {
+    db: makeMockDb(),
+    eventBus,
+    services: makeMockServices(),
+    mediaService: opts.mediaService,
+    mediaStorage: opts.mediaStorage,
+    defaultLanguage: 'pt',
+    promptOverrides: {},
+    resolveChannelPlugin: async () => opts.plugin,
+  };
+}
+
+/** Inbound Meta audio: mediaId set, NO mediaUrl (the defining shape of #897). */
+const metaAudioPayload: MessageReceivedPayload = {
+  externalId: 'wamid.meta-audio-1',
+  chatId: '5511999999999',
+  content: { type: 'audio', mimeType: 'audio/ogg; codecs=opus', mediaId: 'META_MEDIA_123' },
+} as unknown as MessageReceivedPayload;
+
+/** Distinctive bytes so a stored-vs-processed match can't be coincidental. */
+const audioBytes = Buffer.from([0x4f, 0x67, 0x67, 0x53, 0xde, 0xad, 0xbe, 0xef]);
+
+function makeFakePlugin(
+  overrides: Partial<ChannelPlugin>,
+  calls: Array<{ instanceId: string; mediaRef: string }>,
+): ChannelPlugin {
+  return {
+    id: 'whatsapp-business',
+    name: 'Fake WA Business',
+    version: '0.0.0-test',
+    capabilities: {},
+    initialize: async () => {},
+    destroy: async () => {},
+    connect: async () => {},
+    disconnect: async () => {},
+    getStatus: async () => 'connected',
+    getConnectedInstances: () => [],
+    sendMessage: async () => ({ success: true }),
+    downloadInboundMedia: async (instanceId: string, mediaRef: string) => {
+      calls.push({ instanceId, mediaRef });
+      return { buffer: audioBytes, mimeType: 'audio/ogg' };
+    },
+    ...overrides,
+  } as unknown as ChannelPlugin;
+}
+
+describe('media-processor deferred plugin download (issue #897)', () => {
+  it('materializes Meta media via downloadInboundMedia, stores bytes, and transcribes', async () => {
+    const tempBase = await mkdtemp(join(tmpdir(), 'omni-plugin-dl-'));
+    try {
+      const storage = new MediaStorageService(makeMockDb(), tempBase, new LocalMediaBackend(tempBase));
+
+      const calls: Array<{ instanceId: string; mediaRef: string }> = [];
+      const capture: ProcessCapture = {};
+      const published: Array<{ type: string; payload: Record<string, unknown> }> = [];
+      const ctx = makeContext({
+        mediaStorage: storage,
+        mediaService: makeFakeMediaService(capture),
+        published,
+        plugin: makeFakePlugin({}, calls),
+      });
+
+      await processMessageMedia(
+        ctx,
+        metaAudioPayload,
+        { instanceId: 'inst-wab-1', channelType: 'whatsapp-business' },
+        { metadata: { correlationId: 'legacy' } },
+      );
+
+      // The plugin was asked for the exact Meta media id, scoped to the instance.
+      expect(calls).toEqual([{ instanceId: 'inst-wab-1', mediaRef: 'META_MEDIA_123' }]);
+
+      // The processing service received a readable file holding the plugin bytes.
+      expect(capture.path).toBeDefined();
+      expect(Array.from(capture.bytes!)).toEqual(Array.from(audioBytes));
+
+      // Transcription ran and was published.
+      const processed = published.find((e) => e.type === 'media.processed');
+      expect(processed).toBeDefined();
+      expect(processed?.payload.content).toBe('transcribed: hello world');
+    } finally {
+      await rm(tempBase, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op (no transcription) when the plugin cannot download inbound media', async () => {
+    const tempBase = await mkdtemp(join(tmpdir(), 'omni-plugin-dl-'));
+    try {
+      const storage = new MediaStorageService(makeMockDb(), tempBase, new LocalMediaBackend(tempBase));
+
+      const capture: ProcessCapture = {};
+      const published: Array<{ type: string; payload: Record<string, unknown> }> = [];
+      const ctx = makeContext({
+        mediaStorage: storage,
+        mediaService: makeFakeMediaService(capture),
+        published,
+        // Plugin without downloadInboundMedia — the bridge must bail cleanly.
+        plugin: makeFakePlugin({ downloadInboundMedia: undefined }, []),
+      });
+
+      await processMessageMedia(
+        ctx,
+        metaAudioPayload,
+        { instanceId: 'inst-wab-1', channelType: 'whatsapp-business' },
+        { metadata: { correlationId: 'legacy' } },
+      );
+
+      expect(capture.path).toBeUndefined();
+      expect(published.find((e) => e.type === 'media.processed')).toBeUndefined();
+    } finally {
+      await rm(tempBase, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -16,6 +16,7 @@
  * @see media-processing-realtime wish
  */
 
+import type { ChannelPlugin } from '@omni/channel-sdk';
 import type { ChannelType, EventBus, MessageReceivedPayload, OmniEvent } from '@omni/core';
 import { classifyEnvelope, createLogger, isValidUuid } from '@omni/core';
 import type { Database } from '@omni/db';
@@ -32,6 +33,7 @@ import type { Services } from '../services';
 import { MediaStorageService } from '../services/media-storage';
 import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 import { runConsumerInTenantContext, runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
+import { getPlugin } from './loader';
 
 const log = createLogger('media-processor');
 
@@ -156,6 +158,12 @@ interface MediaProcessorContext {
     video?: string;
     document?: string;
   };
+  /**
+   * Resolve a channel plugin by id — used to materialize deferred inbound media
+   * (channels that emit a `content.mediaId` but no URL). Defaults to the global
+   * registry's `getPlugin`; injectable so tests avoid the shared singleton.
+   */
+  resolveChannelPlugin?: (id: ChannelType) => Promise<ChannelPlugin | undefined>;
 }
 
 /**
@@ -236,6 +244,59 @@ async function downloadMediaFromUrl(
 }
 
 /**
+ * Materialize inbound media whose bytes live behind the channel plugin's own
+ * authenticated fetch rather than a public URL.
+ *
+ * Meta Cloud (`whatsapp-business`) inbound webhooks carry only a `media_id`
+ * (surfaced on `content.mediaId`) — the bytes require a two-step Graph call the
+ * plugin implements as `downloadInboundMedia`. We invoke it, store the returned
+ * buffer via `storeFromBuffer` (the URL path's `storeFromUrl` can't fetch an
+ * authenticated, short-lived Graph URL), and record the stored reference on the
+ * message row. Returns the stored path on success, null on failure.
+ */
+async function downloadMediaViaPlugin(
+  ctx: MediaProcessorContext,
+  instanceId: string,
+  messageId: string,
+  channelType: ChannelType,
+  mediaRef: string,
+  fallbackMimeType: string,
+  platformTimestamp: Date | undefined,
+  trustedTenantId?: string,
+): Promise<string | null> {
+  const plugin = await (ctx.resolveChannelPlugin ?? getPlugin)(channelType);
+  if (!plugin?.downloadInboundMedia) {
+    log.warn('Channel plugin cannot materialize deferred media', { channelType, messageId });
+    return null;
+  }
+  try {
+    const { buffer, mimeType } = await plugin.downloadInboundMedia(instanceId, mediaRef);
+    // `storeFromBuffer` is a discrete DB block and gets its own short worker
+    // scope (G5, ADR-0008); the plugin download above is NETWORK I/O and must
+    // never be held inside a worker transaction. A legacy envelope (undefined
+    // `trustedTenantId`) writes ambient, byte-identical to pre-G5.
+    const result = await ctx.mediaStorage.storeFromBuffer(
+      instanceId,
+      messageId,
+      buffer,
+      mimeType || fallbackMimeType,
+      platformTimestamp,
+      trustedTenantId,
+    );
+    await runMediaDb(ctx, trustedTenantId, () => ctx.mediaStorage.updateMessageLocalPath(messageId, result.localPath));
+    log.debug('Downloaded inbound media via plugin', { messageId, channelType, filePath: result.localPath });
+    return result.localPath;
+  } catch (error) {
+    log.error('Failed to download inbound media via plugin', {
+      error: String(error),
+      channelType,
+      messageId,
+    });
+    return null;
+  }
+}
+
+/**
  * Resolve media file path for a message
  * Handles both local paths and URL downloads
  */
@@ -290,6 +351,22 @@ async function resolveMediaPath(
       mimeType,
       message.platformTimestamp ?? undefined,
       channelType,
+      trustedTenantId,
+    );
+    if (!filePath) return null;
+  }
+
+  // Channel-native deferred media (e.g. Meta Cloud `media_id`): no public URL,
+  // so materialize the bytes through the plugin's authenticated download.
+  if (!filePath && content.mediaId && channelType) {
+    filePath = await downloadMediaViaPlugin(
+      ctx,
+      instanceId,
+      message.id,
+      channelType,
+      content.mediaId,
+      mimeType,
+      message.platformTimestamp ?? undefined,
       trustedTenantId,
     );
     if (!filePath) return null;
@@ -776,6 +853,7 @@ export const __test__ = {
   resolveSafeMediaContentEventId,
   processMessageMedia,
   downloadMediaFromUrl,
+  downloadMediaViaPlugin,
 };
 
 export type { MediaProcessorContext };

--- a/packages/channel-sdk/src/helpers/events.ts
+++ b/packages/channel-sdk/src/helpers/events.ts
@@ -38,6 +38,12 @@ export interface EmitMessageReceivedParams {
     type: ContentType;
     text?: string;
     mediaUrl?: string;
+    /**
+     * Channel-native media handle for deferred downloads (e.g. a Meta Cloud
+     * `media_id`). Set when the bytes are not available via a public `mediaUrl`
+     * and must be materialized through the plugin's own `downloadInboundMedia`.
+     */
+    mediaId?: string;
     localPath?: string;
     mimeType?: string;
     isVoiceNote?: boolean;

--- a/packages/channel-sdk/src/types/plugin.ts
+++ b/packages/channel-sdk/src/types/plugin.ts
@@ -203,6 +203,21 @@ export interface ChannelPlugin {
   sendTyping?(instanceId: string, chatId: string, duration?: number): Promise<void>;
 
   /**
+   * Materialize inbound media bytes from a channel-native handle.
+   *
+   * Optional — implement for channels whose inbound webhooks defer the download
+   * and carry only a media reference (e.g. a Meta Cloud `media_id`) rather than
+   * a public `mediaUrl`. The realtime media pipeline invokes this when a
+   * `message.received` content has a `mediaId` but no `mediaUrl`/local path, so
+   * the bytes can be stored and processed (transcription, OCR, …).
+   *
+   * @param instanceId - Instance the media belongs to
+   * @param mediaRef - Channel-native media handle (as set on `content.mediaId`)
+   * @returns The downloaded bytes and their resolved MIME type
+   */
+  downloadInboundMedia?(instanceId: string, mediaRef: string): Promise<{ buffer: Buffer; mimeType: string }>;
+
+  /**
    * Mark messages as read
    *
    * Optional - only implement if canReceiveReadReceipts capability is true.

--- a/packages/channel-whatsapp-business/src/__tests__/inbound-media.test.ts
+++ b/packages/channel-whatsapp-business/src/__tests__/inbound-media.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Inbound media emission (issue #897).
+ *
+ * Meta Cloud defers the media download: an inbound audio/image/video/document
+ * webhook carries only a `media_id`, never a public URL. The plugin must surface
+ * that id on the emitted `message.received` `content.mediaId` so the media
+ * pipeline can materialize the bytes via `downloadInboundMedia`. Before the fix
+ * the id lived only in `rawPayload.mediaId`, `content.mediaId` was undefined, and
+ * the media processor skipped the message — audio was persisted but never
+ * transcribed.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import type { Logger, PluginContext, PluginStorage } from '@omni/channel-sdk';
+import type { EventBus, PublishResult, Subscription } from '@omni/core/events';
+import type { MetaInboundMessage } from '@omni/core/schemas';
+import { WhatsAppBusinessPlugin } from '../plugin';
+
+const instanceId = '00000000-0000-4000-8000-000000000001';
+const PHONE_NUMBER_ID = '999888777';
+const CUSTOMER = '5511987654321';
+const META_MEDIA_ID = '1234567890123456';
+
+class MockLogger implements Logger {
+  debug() {}
+  info() {}
+  warn() {}
+  error() {}
+  child(): Logger {
+    return this;
+  }
+}
+
+class MockStorage implements PluginStorage {
+  private readonly data = new Map<string, unknown>();
+  async get<T>(key: string): Promise<T | null> {
+    return (this.data.get(key) as T) ?? null;
+  }
+  async set<T>(key: string, value: T): Promise<void> {
+    this.data.set(key, value);
+  }
+  async delete(key: string): Promise<boolean> {
+    return this.data.delete(key);
+  }
+  async has(key: string): Promise<boolean> {
+    return this.data.has(key);
+  }
+  async keys(): Promise<string[]> {
+    return Array.from(this.data.keys());
+  }
+}
+
+class MockEventBus implements EventBus {
+  published: Array<{ type: string; payload: unknown; metadata?: unknown }> = [];
+  async connect(): Promise<void> {}
+  async publish(type: string, payload: unknown, metadata?: unknown): Promise<PublishResult> {
+    this.published.push({ type, payload, metadata });
+    return { id: 'test-id', sequence: 1, stream: 'test-stream' };
+  }
+  async publishGeneric(type: string, payload: unknown, metadata?: unknown): Promise<PublishResult> {
+    return this.publish(type, payload, metadata);
+  }
+  async subscribe(): Promise<Subscription> {
+    return { id: 'sub-1', pattern: '*', unsubscribe: async () => {} };
+  }
+  async subscribePattern(): Promise<Subscription> {
+    return { id: 'sub-2', pattern: '*', unsubscribe: async () => {} };
+  }
+  async subscribeMany(): Promise<Subscription> {
+    return { id: 'sub-3', pattern: '*', unsubscribe: async () => {} };
+  }
+  async subscribeAll(): Promise<Subscription> {
+    return { id: 'sub-4', pattern: '*', unsubscribe: async () => {} };
+  }
+  async close(): Promise<void> {}
+  isConnected(): boolean {
+    return true;
+  }
+}
+
+function createContext(eventBus: MockEventBus): PluginContext {
+  return {
+    eventBus,
+    storage: new MockStorage(),
+    logger: new MockLogger(),
+    config: {
+      env: 'development',
+      apiBaseUrl: 'http://localhost:3000',
+      webhookBaseUrl: 'http://localhost:3000/webhooks',
+      mediaStorage: { type: 'local', basePath: '/tmp/media' },
+    },
+    db: { execute: async () => [], getDrizzle: () => null },
+  };
+}
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function inboundAudio(): MetaInboundMessage {
+  return {
+    id: 'wamid.audio-1',
+    from: CUSTOMER,
+    timestamp: '1785245000',
+    type: 'audio',
+    audio: { id: META_MEDIA_ID, mime_type: 'audio/ogg; codecs=opus', voice: true },
+  } as MetaInboundMessage;
+}
+
+type ReceivedContent = { type: string; mediaId?: string; mediaUrl?: string; mimeType?: string; isVoiceNote?: boolean };
+
+describe('WhatsAppBusinessPlugin inbound media emission', () => {
+  let plugin: WhatsAppBusinessPlugin;
+  let bus: MockEventBus;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    bus = new MockEventBus();
+    plugin = new WhatsAppBusinessPlugin();
+    await plugin.initialize(createContext(bus));
+    // connect() validates the token via GET /{phone_number_id}.
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(okResponse({ id: PHONE_NUMBER_ID }));
+    await plugin.connect(instanceId, {
+      instanceId,
+      credentials: { metaAccessToken: 'EAAtest', metaPhoneNumberId: PHONE_NUMBER_ID, metaWabaId: '111222333' },
+    });
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  test('surfaces the Meta media id on content.mediaId (not just rawPayload)', async () => {
+    const state = plugin.getInstanceState(instanceId);
+    if (!state) throw new Error('instance not connected in test setup');
+    await plugin.handleInboundMessage(instanceId, inboundAudio(), undefined, state.dedupeCache);
+
+    const received = bus.published.find((e) => e.type === 'message.received');
+    expect(received).toBeDefined();
+    const payload = received?.payload as { content: ReceivedContent; rawPayload?: { mediaId?: string } };
+
+    // The defining assertion for #897: the media pipeline reads content.mediaId.
+    expect(payload.content.type).toBe('audio');
+    expect(payload.content.mediaId).toBe(META_MEDIA_ID);
+    expect(payload.content.mimeType).toBe('audio/ogg; codecs=opus');
+    expect(payload.content.isVoiceNote).toBe(true);
+    // No public URL is available for deferred Meta media.
+    expect(payload.content.mediaUrl).toBeUndefined();
+    // Still mirrored in the raw record for debugging.
+    expect(payload.rawPayload?.mediaId).toBe(META_MEDIA_ID);
+  });
+});

--- a/packages/channel-whatsapp-business/src/plugin.ts
+++ b/packages/channel-whatsapp-business/src/plugin.ts
@@ -648,6 +648,12 @@ export class WhatsAppBusinessPlugin extends BaseChannelPlugin {
         type: content.type,
         text: content.text ?? content.caption,
         mediaUrl: content.mediaUrl,
+        // Meta Cloud defers the media download — the webhook carries only a
+        // `media_id`, not a public URL (see `extractMediaContent`). Surface it
+        // on the event so the media pipeline can materialize the bytes via
+        // `downloadInboundMedia`; without this, inbound audio/image/video/doc
+        // is persisted but never downloaded or transcribed.
+        mediaId: content.mediaId,
         mimeType: content.mimeType,
         isVoiceNote: content.isVoiceNote,
       },

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -234,6 +234,14 @@ export interface MessageReceivedPayload {
     type: ContentType;
     text?: string;
     mediaUrl?: string;
+    /**
+     * Channel-native media handle for deferred downloads (e.g. a Meta Cloud
+     * `media_id`). Set when the bytes are NOT available via a public `mediaUrl`
+     * and must be materialized through the channel plugin's own authenticated
+     * `downloadInboundMedia(instanceId, mediaId)` fetch. Distinct from the
+     * persisted `messages.mediaId` UUID.
+     */
+    mediaId?: string;
     mimeType?: string;
     localPath?: string;
     isVoiceNote?: boolean;


### PR DESCRIPTION
Fixes #897

## Problem

On a `whatsapp-business` (Meta Cloud) instance, inbound audio/voice (and image/video/document) messages are received and persisted, but the **media bytes are never downloaded**, so `MediaProcessingService` never runs transcription. The event ends with `transcription: null` and empty text, the agent-dispatcher finishes the turn without invoking the agent, and from the user's side "nothing happens" when they send a voice note. Text on the same instance works.

## Root cause

Meta Cloud **defers** the media download: the inbound webhook carries only a `media_id`, never a public URL (the bytes live behind a two-step authenticated Graph call). But:

- The plugin routed that `media_id` only into `rawPayload.mediaId` — `content.mediaId` was never set on the `message.received` event.
- The realtime media processor (`resolveMediaPath`) only knows how to download from a `content.mediaUrl`, so with no URL and no local path it logs *"No media file path available"* and returns null → transcription never runs.
- The plugin already had a working `downloadInboundMedia(instanceId, mediaId)` (the Graph two-step), but **nothing ever called it** (dead code on both `whatsapp-business` and `hermes`).

Baileys works because it downloads eagerly before emitting; hermes works because it sets `content.mediaUrl` to a direct S3 link. Only `whatsapp-business` was affected.

## Fix

Bridge the deferred `media_id` model to the media processor's eager expectation, keeping the webhook handler synchronous (no Graph roundtrip on Meta's 2xx path):

- **core**: carry a channel-native `content.mediaId` on `MessageReceivedPayload` (distinct from the internal `messages.mediaId` UUID).
- **channel-sdk**: mirror `mediaId` on `EmitMessageReceivedParams.content`; declare optional `downloadInboundMedia?` on the `ChannelPlugin` interface (both `whatsapp-business` and `hermes` already implement it).
- **channel-whatsapp-business**: surface the Meta media id on `content.mediaId`.
- **api / media-processor**: `resolveMediaPath` falls back to the plugin's authenticated download (`storeFromBuffer`) when there is a `mediaId` but no URL/local path. The plugin resolver is injectable via `MediaProcessorContext.resolveChannelPlugin` (defaults to the global `getPlugin`) for clean test isolation.

This transparently fixes image/video/document on the same channel too.

## Tests

- `media-processor-plugin-download.test.ts` — end-to-end (LocalMediaBackend, no Docker): a Meta audio event with `content.mediaId` and no `mediaUrl` now materializes bytes via `downloadInboundMedia`, feeds a readable file to the processor, and emits `media.processed` with the transcript; plus the clean-bail path when a plugin can't download.
- `inbound-media.test.ts` (whatsapp-business) — the real `handleInboundMessage` surfaces the Meta media id on `content.mediaId` (not just `rawPayload`).

Full scoped suite green: **5695 pass / 0 fail**. typecheck + biome clean.