### PR TITLE
fix(channel-whatsapp): extract bot-sent interactive messages instead of "Unknown message type"

### DIFF
--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -226,4 +226,79 @@ describe('extractContent — bot-interactive messages (omni#902)', () => {
     expect(content?.type).toBe('text');
     expect(content?.text).toBe('Oi\n[Ok]');
   });
+
+  it('classifies a buttonsMessage with an image header as image + button transcript caption', () => {
+    const content = extractContent(
+      wrap({
+        buttonsMessage: {
+          contentText: 'Confira a oferta',
+          imageMessage: {
+            url: 'https://mmg.whatsapp.net/v/t62.7118-24/offer.enc?oe=9',
+            mimetype: 'image/jpeg',
+          },
+          buttons: [{ buttonId: 'b1', buttonText: { displayText: 'Comprar' } }],
+        },
+      }),
+    );
+    expect(content?.type).toBe('image');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7118-24/offer.enc?oe=9');
+    expect(content?.mimeType).toBe('image/jpeg');
+    expect(content?.caption).toBe('Confira a oferta\n[Comprar]');
+  });
+
+  it('classifies an interactiveMessage with a document header as document + body caption', () => {
+    const content = extractContent(
+      wrap({
+        interactiveMessage: {
+          body: { text: 'Segue seu contrato' },
+          header: {
+            title: 'Contrato',
+            documentMessage: {
+              url: 'https://mmg.whatsapp.net/v/t62.7119-24/contract.enc?oe=10',
+              mimetype: 'application/pdf',
+              fileName: 'contrato.pdf',
+            },
+          },
+          nativeFlowMessage: { buttons: [{ name: 'review_and_pay', buttonParamsJson: '{}' }] },
+        },
+      }),
+    );
+    expect(content?.type).toBe('document');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7119-24/contract.enc?oe=10');
+    expect(content?.filename).toBe('contrato.pdf');
+    expect(content?.mimeType).toBe('application/pdf');
+    expect(content?.caption).toBe('Contrato\nSegue seu contrato\n[review_and_pay]');
+  });
+
+  it('classifies a hydrated templateMessage with a video header as video + transcript caption', () => {
+    const content = extractContent(
+      wrap({
+        templateMessage: {
+          hydratedTemplate: {
+            hydratedContentText: 'Assista ao tutorial',
+            videoMessage: {
+              url: 'https://mmg.whatsapp.net/v/t62.7161-24/tutorial.enc?oe=11',
+              mimetype: 'video/mp4',
+            },
+            hydratedButtons: [{ index: 0, quickReplyButton: { displayText: 'Entendi', id: 'q1' } }],
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('video');
+    expect(content?.mediaUrl).toBe('https://mmg.whatsapp.net/v/t62.7161-24/tutorial.enc?oe=11');
+    expect(content?.mimeType).toBe('video/mp4');
+    expect(content?.caption).toBe('Assista ao tutorial\n[Entendi]');
+  });
+
+  it('keeps a buttonsMessage WITHOUT a media header as plain text', () => {
+    const content = extractContent(
+      wrap({
+        buttonsMessage: { contentText: 'Sem mídia', buttons: [{ buttonId: 'b1', buttonText: { displayText: 'Ok' } }] },
+      }),
+    );
+    expect(content?.type).toBe('text');
+    expect(content?.mediaUrl).toBeUndefined();
+    expect(content?.text).toBe('Sem mídia\n[Ok]');
+  });
 });

--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -115,3 +115,115 @@ describe('extractContent — mediaUrl hoist (omni#500)', () => {
     expect(content?.mediaUrl).toBeUndefined();
   });
 });
+
+/**
+ * Bot-sent interactive messages (issue #902): list menus, quick-reply buttons,
+ * and the modern nativeFlow / template variants must flatten to a readable text
+ * transcript instead of falling through to `"Unknown message type: …"`.
+ */
+describe('extractContent — bot-interactive messages (omni#902)', () => {
+  it('flattens listMessage (title + description + rows) to text', () => {
+    const content = extractContent(
+      wrap({
+        listMessage: {
+          title: 'Menu principal',
+          description: 'Escolha uma opção',
+          buttonText: 'Ver opções',
+          sections: [
+            {
+              title: 'Atendimento',
+              rows: [
+                { title: 'Falar com humano', rowId: 'r1' },
+                { title: 'Suporte', rowId: 'r2' },
+              ],
+            },
+            { title: 'Financeiro', rows: [{ title: '2ª via de boleto', rowId: 'r3' }] },
+          ],
+          footerText: 'Sinapse',
+        },
+      }),
+    );
+    expect(content?.type).toBe('text');
+    expect(content?.text).toBe(
+      'Menu principal\nEscolha uma opção\n• Falar com humano\n• Suporte\n• 2ª via de boleto\nSinapse',
+    );
+  });
+
+  it('flattens buttonsMessage (contentText + button labels) to text', () => {
+    const content = extractContent(
+      wrap({
+        buttonsMessage: {
+          contentText: 'Deseja continuar?',
+          footerText: 'Bot',
+          buttons: [
+            { buttonId: 'b1', buttonText: { displayText: 'Sim' } },
+            { buttonId: 'b2', buttonText: { displayText: 'Não' } },
+          ],
+        },
+      }),
+    );
+    expect(content?.type).toBe('text');
+    expect(content?.text).toBe('Deseja continuar?\nBot\n[Sim] [Não]');
+  });
+
+  it('flattens modern interactiveMessage (nativeFlow) to text', () => {
+    const content = extractContent(
+      wrap({
+        interactiveMessage: {
+          header: { title: 'Confirmação' },
+          body: { text: 'Confirma o agendamento?' },
+          footer: { text: 'Clínica' },
+          nativeFlowMessage: {
+            buttons: [
+              { name: 'single_select', buttonParamsJson: '{}' },
+              { name: 'cta_url', buttonParamsJson: '{}' },
+            ],
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('text');
+    expect(content?.text).toBe('Confirmação\nConfirma o agendamento?\nClínica\n[single_select] [cta_url]');
+  });
+
+  it('flattens hydrated templateMessage (title/content + hydrated buttons) to text', () => {
+    const content = extractContent(
+      wrap({
+        templateMessage: {
+          hydratedTemplate: {
+            hydratedTitleText: 'Sua fatura',
+            hydratedContentText: 'Fatura de agosto disponível',
+            hydratedFooterText: 'Financeiro',
+            hydratedButtons: [
+              { index: 0, quickReplyButton: { displayText: 'Pagar agora', id: 'q1' } },
+              { index: 1, urlButton: { displayText: 'Ver online', url: 'https://x' } },
+            ],
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('text');
+    expect(content?.text).toBe('Sua fatura\nFatura de agosto disponível\nFinanceiro\n[Pagar agora] [Ver online]');
+  });
+
+  it('no longer falls through to "Unknown message type" for listMessage', () => {
+    const content = extractContent(wrap({ listMessage: { title: 'X', sections: [] } }));
+    expect(content?.type).toBe('text');
+    expect(content?.text).not.toContain('Unknown message type');
+  });
+
+  it('re-extracts an interactive message nested inside a deviceSentMessage wrapper', () => {
+    const content = extractContent(
+      wrap({
+        deviceSentMessage: {
+          destinationJid: '5511999998888@s.whatsapp.net',
+          message: {
+            buttonsMessage: { contentText: 'Oi', buttons: [{ buttonId: 'b1', buttonText: { displayText: 'Ok' } }] },
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('text');
+    expect(content?.text).toBe('Oi\n[Ok]');
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -91,6 +91,57 @@ interface ExtractedContent {
 type MessageContent = proto.IMessage;
 type ContentExtractor = (message: MessageContent) => ExtractedContent | null;
 
+/** Join non-empty, trimmed parts with newlines; undefined when nothing survives. */
+function joinLines(...parts: Array<string | null | undefined>): string | undefined {
+  const text = parts.filter((p): p is string => typeof p === 'string' && p.trim().length > 0).join('\n');
+  return text.length > 0 ? text : undefined;
+}
+
+/** Render visible button labels as `[A] [B]`; undefined when there are none. */
+function bracketButtons(labels: Array<string | null | undefined>): string | undefined {
+  const clean = labels.filter((l): l is string => typeof l === 'string' && l.trim().length > 0);
+  return clean.length > 0 ? clean.map((l) => `[${l.trim()}]`).join(' ') : undefined;
+}
+
+/**
+ * Bot-interactive message flattening (issue #902).
+ *
+ * WhatsApp's native interactive UX — list menus, quick-reply buttons, and the
+ * modern nativeFlow / template variants — is what a bot SENDS, so it has no
+ * response handler and previously fell through to `extractUnknownContent`,
+ * landing in the DB as `"Unknown message type: listMessage"`. These formatters
+ * flatten each into a readable text transcript (title / body / footer + the
+ * visible option labels) so chat history, audit logs, and QA tooling see the
+ * actual bot output instead of a placeholder.
+ */
+function extractListMessageText(list: proto.Message.IListMessage): string | undefined {
+  const rows = (list.sections ?? []).flatMap((s) => (s.rows ?? []).map((r) => (r.title ? `• ${r.title}` : '')));
+  return joinLines(list.title, list.description, ...rows, list.footerText);
+}
+
+function extractButtonsMessageText(bm: proto.Message.IButtonsMessage): string | undefined {
+  const labels = bracketButtons((bm.buttons ?? []).map((b) => b.buttonText?.displayText));
+  return joinLines(bm.contentText ?? bm.text, bm.footerText, labels);
+}
+
+function extractInteractiveMessageText(im: proto.Message.IInteractiveMessage): string | undefined {
+  const labels = bracketButtons((im.nativeFlowMessage?.buttons ?? []).map((b) => b.name));
+  return joinLines(im.header?.title, im.header?.subtitle, im.body?.text, im.footer?.text, labels);
+}
+
+function extractTemplateMessageText(tpl: proto.Message.ITemplateMessage): string | undefined {
+  const hydrated = tpl.hydratedTemplate ?? tpl.hydratedFourRowTemplate;
+  if (hydrated) {
+    const labels = bracketButtons(
+      (hydrated.hydratedButtons ?? []).map(
+        (b) => b.quickReplyButton?.displayText ?? b.urlButton?.displayText ?? b.callButton?.displayText,
+      ),
+    );
+    return joinLines(hydrated.hydratedTitleText, hydrated.hydratedContentText, hydrated.hydratedFooterText, labels);
+  }
+  return tpl.interactiveMessageTemplate ? extractInteractiveMessageText(tpl.interactiveMessageTemplate) : undefined;
+}
+
 /**
  * Content extractors for each message type
  * Each extractor handles one specific message type
@@ -328,6 +379,41 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
     extract: (m) => ({
       type: 'text' as ContentType,
       text: m.buttonsResponseMessage?.selectedDisplayText ?? m.buttonsResponseMessage?.selectedButtonId ?? undefined,
+    }),
+  },
+  // Bot-sent interactive list menu (issue #902) — flatten to a text transcript.
+  // Must stay BEFORE the trailing wrapper extractors so the slice(0, -N) offsets
+  // below keep pointing at the wrappers (and so deviceSent/ephemeral/viewOnce
+  // re-extraction reaches these interactive types).
+  {
+    check: (m) => !!m.listMessage,
+    extract: (m) => ({
+      type: 'text' as ContentType,
+      text: m.listMessage ? extractListMessageText(m.listMessage) : undefined,
+    }),
+  },
+  // Bot-sent quick-reply buttons (legacy buttonsMessage) — issue #902
+  {
+    check: (m) => !!m.buttonsMessage,
+    extract: (m) => ({
+      type: 'text' as ContentType,
+      text: m.buttonsMessage ? extractButtonsMessageText(m.buttonsMessage) : undefined,
+    }),
+  },
+  // Bot-sent modern interactive message (nativeFlow / flows) — issue #902
+  {
+    check: (m) => !!m.interactiveMessage,
+    extract: (m) => ({
+      type: 'text' as ContentType,
+      text: m.interactiveMessage ? extractInteractiveMessageText(m.interactiveMessage) : undefined,
+    }),
+  },
+  // Bot-sent template message (hydrated four-row / interactive template) — issue #902
+  {
+    check: (m) => !!m.templateMessage,
+    extract: (m) => ({
+      type: 'text' as ContentType,
+      text: m.templateMessage ? extractTemplateMessageText(m.templateMessage) : undefined,
     }),
   },
   // Sender key distribution - internal E2E encryption, ignore

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -143,6 +143,72 @@ function extractTemplateMessageText(tpl: proto.Message.ITemplateMessage): string
 }
 
 /**
+ * A bot-interactive container (buttonsMessage, interactiveMessage.header, a
+ * hydrated template) can carry a media header — an image/video/document shown
+ * above the buttons. When present, classify the message as that media so the
+ * bytes are downloaded like any other media (mediaUrl hoisted, see omni#500),
+ * and fold the interactive text transcript into the caption. Returns null when
+ * the container has no media header (caller falls back to a text message).
+ */
+interface InteractiveMediaContainer {
+  imageMessage?: proto.Message.IImageMessage | null;
+  videoMessage?: proto.Message.IVideoMessage | null;
+  documentMessage?: proto.Message.IDocumentMessage | null;
+}
+
+function extractInteractiveMediaHeader(
+  container: InteractiveMediaContainer,
+  caption: string | undefined,
+): ExtractedContent | null {
+  if (container.imageMessage) {
+    return {
+      type: 'image',
+      caption: caption ?? container.imageMessage.caption ?? undefined,
+      mimeType: container.imageMessage.mimetype ?? 'image/jpeg',
+      mediaUrl: container.imageMessage.url ?? undefined,
+    };
+  }
+  if (container.videoMessage) {
+    return {
+      type: 'video',
+      caption: caption ?? container.videoMessage.caption ?? undefined,
+      mimeType: container.videoMessage.mimetype ?? 'video/mp4',
+      mediaUrl: container.videoMessage.url ?? undefined,
+    };
+  }
+  if (container.documentMessage) {
+    return {
+      type: 'document',
+      filename: container.documentMessage.fileName ?? undefined,
+      caption: caption ?? container.documentMessage.caption ?? undefined,
+      mimeType: container.documentMessage.mimetype ?? 'application/octet-stream',
+      mediaUrl: container.documentMessage.url ?? undefined,
+    };
+  }
+  return null;
+}
+
+/** buttonsMessage → media header (if any) with the button transcript as caption, else text. */
+function extractButtonsMessage(bm: proto.Message.IButtonsMessage): ExtractedContent {
+  const text = extractButtonsMessageText(bm);
+  return extractInteractiveMediaHeader(bm, text) ?? { type: 'text', text };
+}
+
+/** interactiveMessage → media header (if any) with the body transcript as caption, else text. */
+function extractInteractiveMessage(im: proto.Message.IInteractiveMessage): ExtractedContent {
+  const text = extractInteractiveMessageText(im);
+  return extractInteractiveMediaHeader(im.header ?? {}, text) ?? { type: 'text', text };
+}
+
+/** templateMessage → media header on the hydrated template (if any) with transcript as caption, else text. */
+function extractTemplateMessage(tpl: proto.Message.ITemplateMessage): ExtractedContent {
+  const text = extractTemplateMessageText(tpl);
+  const hydrated = tpl.hydratedTemplate ?? tpl.hydratedFourRowTemplate;
+  const media = hydrated ? extractInteractiveMediaHeader(hydrated, text) : null;
+  return media ?? { type: 'text', text };
+}
+
+/**
  * Content extractors for each message type
  * Each extractor handles one specific message type
  */
@@ -392,29 +458,22 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
       text: m.listMessage ? extractListMessageText(m.listMessage) : undefined,
     }),
   },
-  // Bot-sent quick-reply buttons (legacy buttonsMessage) — issue #902
+  // Bot-sent quick-reply buttons (legacy buttonsMessage) — issue #902.
+  // A media header (image/video/document above the buttons) is classified as
+  // that media with the button transcript as caption; otherwise a text message.
   {
     check: (m) => !!m.buttonsMessage,
-    extract: (m) => ({
-      type: 'text' as ContentType,
-      text: m.buttonsMessage ? extractButtonsMessageText(m.buttonsMessage) : undefined,
-    }),
+    extract: (m) => (m.buttonsMessage ? extractButtonsMessage(m.buttonsMessage) : null),
   },
   // Bot-sent modern interactive message (nativeFlow / flows) — issue #902
   {
     check: (m) => !!m.interactiveMessage,
-    extract: (m) => ({
-      type: 'text' as ContentType,
-      text: m.interactiveMessage ? extractInteractiveMessageText(m.interactiveMessage) : undefined,
-    }),
+    extract: (m) => (m.interactiveMessage ? extractInteractiveMessage(m.interactiveMessage) : null),
   },
   // Bot-sent template message (hydrated four-row / interactive template) — issue #902
   {
     check: (m) => !!m.templateMessage,
-    extract: (m) => ({
-      type: 'text' as ContentType,
-      text: m.templateMessage ? extractTemplateMessageText(m.templateMessage) : undefined,
-    }),
+    extract: (m) => (m.templateMessage ? extractTemplateMessage(m.templateMessage) : null),
   },
   // Sender key distribution - internal E2E encryption, ignore
   {


### PR DESCRIPTION
Fixes #902

## Problem

When a WhatsApp bot sends a `listMessage` (interactive list/menu) or `buttonsMessage` (quick-reply buttons), these aren't recognized by `contentExtractors` in `packages/channel-whatsapp/src/handlers/messages.ts` and fall through to `extractUnknownContent`, so they're stored as:

```
textContent: "Unknown message type: listMessage"
textContent: "Unknown message type: buttonsMessage"
```

The array only handled the **response (user) side** (`listResponseMessage`, `buttonsResponseMessage`) — never the **outgoing bot-message side**. Chat history, audit logs, and QA tooling saw placeholder garbage instead of the actual bot output (discovered via QA on the Hapvida/Sinapse bot).

## Fix

Add extractors that flatten each bot-interactive type into a readable text transcript (title / description / body / footer + visible option labels):

| Type | Direction | Now handled |
|---|---|---|
| `listMessage` | bot sends list menu | ✅ title + description + `• row` lines + footer |
| `buttonsMessage` | bot sends quick-reply buttons | ✅ contentText + footer + `[label]` buttons |
| `interactiveMessage` | bot sends modern nativeFlow / flows | ✅ header/body/footer + nativeFlow button names |
| `templateMessage` | bot sends hydrated four-row / interactive template | ✅ hydrated title/content/footer + hydrated buttons |

The issue asked for the first two; I also covered `interactiveMessage` and `templateMessage` because they're the modern equivalents that would otherwise hit the exact same "Unknown message type" fall-through.

### Media headers (2nd commit)

A `buttonsMessage` / `interactiveMessage` / hydrated `templateMessage` can carry a **media header** — an image/video/document shown above the buttons. Instead of dropping it, when a media header is present the message is classified as that media type (so the bytes download like any other media, `mediaUrl` hoisted per #500) and the interactive text transcript is folded into the **caption**. No media header → text, as before. `listMessage` has no media header and stays text-only.

### Placement detail

The new extractors are inserted **before** the trailing wrapper handlers (`deviceSentMessage` / `ephemeralMessage` / `viewOnceMessage`). Those wrappers re-run extraction on their inner message via `contentExtractors.slice(0, -3)` / `.slice(0, -1)` — position-dependent offsets that count from the end. Inserting before the wrappers keeps those offsets valid **and** means an interactive message nested inside a wrapper now extracts correctly too (covered by a test).

## Tests

Extended `extract-content.test.ts` (10 new cases):
- each of the four interactive types flattens to the expected transcript;
- regression guard that `listMessage` no longer yields `"Unknown message type"`;
- deviceSentMessage-wrapper re-extraction;
- media headers on buttons/interactive/template (image/document/video) → correct media type + `mediaUrl` + transcript caption;
- header-less `buttonsMessage` stays plain text.

Full scoped suite green: **6318 tests, 0 fail**. typecheck + biome clean.