### PR TITLE
feat(hooks): retire the SessionStart 300s health hook (hooks-v2#retire)

### DIFF
--- a/.genie/wishes/omni-plugin-revamp/WISH.md
+++ b/.genie/wishes/omni-plugin-revamp/WISH.md
@@ -33,7 +33,9 @@ encodes that shape in CI gates so it cannot silently rot again.
   `omni-feature-implementor`
 - Fold `plugins/omni/rules/omni-agent.md` into the omni-agent skill; delete it
 - Simplify the SessionStart hook to a probe (no auto-install); shrink
-  `omni-runner.js` to ≤ 80 lines
+  `omni-runner.js` to ≤ 80 lines — SUPERSEDED (2026-08-13): hooks-v2#retire
+  removed the SessionStart hook entirely; the health probe moved to
+  `genie doctor` (genie PR #2780, omni PR #905)
 - Enrich `plugin.json`: repository, license, keywords; no `mcpServers` key
 - CI anti-rot gates: skills lint (size, frontmatter, grammar) + fresh-install
   smoke that builds the CLI from source and checks every named subcommand
@@ -60,7 +62,7 @@ encodes that shape in CI gates so it cannot silently rot again.
 | # | Decision | Rationale |
 |---|----------|-----------|
 | 1 | Delete all 11 slash commands | User decision. Genie ships zero; removes ~280 lines duplicating references 1:1. |
-| 2 | SessionStart hook: probe only, no auto-install | User decision. Keeps the signal, drops a 430-line shim that installs software silently. |
+| 2 | SessionStart hook: probe only, no auto-install | User decision. Keeps the signal, drops a 430-line shim that installs software silently. **SUPERSEDED (2026-08-13): hooks-v2#retire removed the SessionStart hook; the health probe moved to `genie doctor` (genie PR #2780, omni PR #905) — do not re-add the hook here.** |
 | 3 | CLI-only: no MCP, now or planned | User decision after learning `packages/mcp` does not exist. One surface is the simpler contract. |
 | 4 | Single skill location + CI gates, no mirror sync | Omni skills have exactly one consumer. |
 | 5 | Fold the two pointer-agents; keep `omni-feature-implementor` | The first two point into omni-ops; the third covers repo-internal dev no skill does. |

--- a/plugins/omni/hooks/hooks.json
+++ b/plugins/omni/hooks/hooks.json
@@ -1,17 +1,4 @@
 {
-  "description": "Omni plugin hooks — auto-install CLI + health check on session start",
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup|clear|compact",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/omni-runner.js\" health",
-            "timeout": 300
-          }
-        ]
-      }
-    ]
-  }
+  "description": "Omni plugin hooks — the SessionStart health hook was retired (hooks-v2#retire); the probe now lives in `genie doctor`",
+  "hooks": {}
 }

--- a/plugins/omni/scripts/omni-runner.js
+++ b/plugins/omni/scripts/omni-runner.js
@@ -10,8 +10,10 @@
  *   health - Ensure omni is installed, check server health, auto-recover
  *   run    - Forward args to omni CLI (only subcommand that may exit non-zero)
  *
- * The health subcommand is the primary entry point — it runs on SessionStart
- * and handles both first-time installation and ongoing health checks.
+ * The SessionStart hook that invoked `health` was retired (hooks-v2#retire):
+ * the health probe now lives in `genie doctor` as its `omni bridge health`
+ * check. Nothing fires this runner automatically on session start anymore;
+ * the subcommands below remain for explicit operator use.
  *
  * Usage: node omni-runner.js <setup|health|run> [args...]
  */


### PR DESCRIPTION
## hooks-v2#retire — omni leg

Retires the plugin's SessionStart health hook (`omni-runner.js health`, `timeout: 300`) that auto-installed omni and auto-recovered the bridge on every session start.

The health probe moves to `genie doctor` (companion genie PR, automagik-dev/genie — the two land together). The hooks file stays as an empty `hooks: {}` so plugin packaging keeps its shape.

**OPEN-ONLY — never merge from the worker side; the installed-marketplace re-sync is a separate morning follow-up after this merges.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Omni plugin’s automatic health check at session startup.
  * Health diagnostics are now handled through the `genie doctor` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->