### PR TITLE
fix(api): make identity resolution idempotent to prevent orphan persons under concurrency

### DIFF
--- a/packages/api/src/__tests__/identity-idempotent-concurrency.test.ts
+++ b/packages/api/src/__tests__/identity-idempotent-concurrency.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Idempotency / race tests for PersonService.findOrCreateIdentity.
+ *
+ * Reproduces the concurrent first-contact race that used to create orphan
+ * phone-less persons and throw unhandled unique-violations:
+ *   - N simultaneous first-contact messages from the SAME new
+ *     (channel, instanceId, platformUserId) with NO phone must settle on
+ *     exactly ONE platform_identities row and exactly ONE persons row, with
+ *     every caller receiving the same identity + person and nobody throwing.
+ *
+ * Runs against the disposable test DB (describeWithDb / getTestDb). Real
+ * DB-level concurrency is exercised via the connection pool: each
+ * findOrCreateIdentity opens its own transaction on a separate pooled
+ * connection, so the ON CONFLICT DO NOTHING blocking is the real thing.
+ */
+
+import { afterEach, beforeAll, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { instances, persons, platformIdentities } from '@omni/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { PersonService } from '../services/persons';
+import { describeWithDb, getTestDb } from './db-helper';
+
+describeWithDb('Identity resolution idempotency (concurrency)', () => {
+  let db: Database;
+  let personService: PersonService;
+  let instanceId: string;
+  const createdInstanceIds: string[] = [];
+
+  beforeAll(async () => {
+    db = getTestDb();
+    personService = new PersonService(db, null);
+
+    const [instance] = await db
+      .insert(instances)
+      .values({ name: `idem-race-inst-${Date.now()}`, channel: 'whatsapp-baileys' as const })
+      .returning();
+    if (!instance) throw new Error('Failed to create test instance');
+    instanceId = instance.id;
+    createdInstanceIds.push(instance.id);
+  });
+
+  afterEach(async () => {
+    // Remove identities + persons for this instance so each test starts clean.
+    const identities = await db.select().from(platformIdentities).where(eq(platformIdentities.instanceId, instanceId));
+    const personIds = [...new Set(identities.map((i) => i.personId).filter((id): id is string => Boolean(id)))];
+    await db.delete(platformIdentities).where(eq(platformIdentities.instanceId, instanceId));
+    for (const personId of personIds) {
+      await db.delete(persons).where(eq(persons.id, personId));
+    }
+  });
+
+  test('N concurrent first-contact calls (no phone) yield one identity and one person', async () => {
+    const platformUserId = `5599${Date.now()}@s.whatsapp.net`;
+    const displayName = `idem-race-${Date.now()}`; // unique — used to detect orphan persons
+    const N = 8;
+
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        personService.findOrCreateIdentity(
+          {
+            channel: 'whatsapp-baileys',
+            instanceId,
+            platformUserId,
+            platformUsername: displayName,
+          },
+          {
+            createPerson: true,
+            displayName,
+            // No matchByPhone — this is the orphan-prone phone-less path.
+            matchByPlatformUserId: platformUserId,
+            matchByChannel: 'whatsapp-baileys',
+          },
+        ),
+      ),
+    );
+
+    // Nobody threw, everybody got a person and an identity.
+    for (const r of results) {
+      expect(r.identity).toBeDefined();
+      expect(r.person).not.toBeNull();
+    }
+
+    // All callers converged on the SAME identity and the SAME person.
+    const identityIds = new Set(results.map((r) => r.identity.id));
+    const personIdSet = new Set(results.map((r) => r.person?.id));
+    expect(identityIds.size).toBe(1);
+    expect(personIdSet.size).toBe(1);
+
+    // Exactly one identity row exists for the natural key.
+    const identityRows = await db
+      .select()
+      .from(platformIdentities)
+      .where(
+        and(
+          eq(platformIdentities.channel, 'whatsapp-baileys'),
+          eq(platformIdentities.instanceId, instanceId),
+          eq(platformIdentities.platformUserId, platformUserId),
+        ),
+      );
+    expect(identityRows.length).toBe(1);
+    expect(identityRows[0]?.personId).toBe([...personIdSet][0] ?? null);
+
+    // Exactly one person carries the unique display name — no orphans. (Before
+    // the fix, every writer that lost the race created its own phone-less person.)
+    const [{ n } = { n: 0 }] = (await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(persons)
+      .where(eq(persons.displayName, displayName))) as Array<{ n: number }>;
+    expect(n).toBe(1);
+  });
+
+  test('a repeat call for an existing identity returns it without a duplicate person', async () => {
+    const platformUserId = `5588${Date.now()}@s.whatsapp.net`;
+    const displayName = `idem-seq-${Date.now()}`;
+
+    const first = await personService.findOrCreateIdentity(
+      { channel: 'whatsapp-baileys', instanceId, platformUserId, platformUsername: displayName },
+      { createPerson: true, displayName },
+    );
+    const second = await personService.findOrCreateIdentity(
+      { channel: 'whatsapp-baileys', instanceId, platformUserId, platformUsername: displayName },
+      { createPerson: true, displayName },
+    );
+
+    expect(first.isNew).toBe(true);
+    expect(second.isNew).toBe(false); // existing-identity fast path
+    expect(second.identity.id).toBe(first.identity.id);
+    expect(second.person?.id).toBe(first.person?.id);
+
+    const [{ n } = { n: 0 }] = (await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(persons)
+      .where(eq(persons.displayName, displayName))) as Array<{ n: number }>;
+    expect(n).toBe(1);
+  });
+});

--- a/packages/api/src/plugins/__tests__/person-dedup.test.ts
+++ b/packages/api/src/plugins/__tests__/person-dedup.test.ts
@@ -109,23 +109,25 @@ function mockPersonInsert(opts: MockDbOpts) {
 }
 
 function mockIdentityInsert() {
+  const buildRows = (data: Record<string, unknown>) => [
+    makeIdentity({
+      id: `new-identity-${Date.now()}`,
+      personId: data.personId as string | undefined,
+      channel: data.channel as PlatformIdentity['channel'],
+      instanceId: data.instanceId as string,
+      platformUserId: data.platformUserId as string,
+      platformUsername: data.platformUsername as string | null,
+      linkedBy: data.linkedBy as string | null,
+      confidence: (data.confidence as number) ?? 100,
+      linkReason: data.linkReason as string | null,
+    }),
+  ];
   return {
+    // findOrCreateIdentity secures the identity with onConflictDoNothing (idempotent
+    // upsert). The mock models the winning insert: it always returns a row.
     values: mock((data: Record<string, unknown>) => ({
-      returning: mock(() =>
-        Promise.resolve([
-          makeIdentity({
-            id: `new-identity-${Date.now()}`,
-            personId: data.personId as string | undefined,
-            channel: data.channel as PlatformIdentity['channel'],
-            instanceId: data.instanceId as string,
-            platformUserId: data.platformUserId as string,
-            platformUsername: data.platformUsername as string | null,
-            linkedBy: data.linkedBy as string | null,
-            confidence: (data.confidence as number) ?? 100,
-            linkReason: data.linkReason as string | null,
-          }),
-        ]),
-      ),
+      onConflictDoNothing: mock(() => ({ returning: mock(() => Promise.resolve(buildRows(data))) })),
+      returning: mock(() => Promise.resolve(buildRows(data))),
     })),
   };
 }
@@ -161,6 +163,10 @@ function createMockDb(opts: MockDbOpts) {
       })),
     })),
   };
+
+  // findOrCreateIdentity now secures the identity + defers person creation inside
+  // a single transaction. The mock runs the callback against the same handle.
+  (db as { transaction?: unknown }).transaction = mock((cb: (tx: unknown) => unknown) => cb(db));
 
   return db as unknown as Database;
 }

--- a/packages/api/src/services/persons.ts
+++ b/packages/api/src/services/persons.ts
@@ -164,8 +164,8 @@ export class PersonService {
   /**
    * Get person by ID
    */
-  async getById(id: string): Promise<Person> {
-    const [result] = await this.db.select().from(persons).where(eq(persons.id, id)).limit(1);
+  async getById(id: string, handle: Database = this.db): Promise<Person> {
+    const [result] = await handle.select().from(persons).where(eq(persons.id, id)).limit(1);
 
     if (!result) {
       throw new NotFoundError('Person', id);
@@ -289,8 +289,11 @@ export class PersonService {
   /**
    * Find existing person by phone (used for conflict resolution)
    */
-  private async findPersonByPhone(phone: string): Promise<{ personId: string; wasLinked: true } | null> {
-    const [existing] = await this.db.select().from(persons).where(eq(persons.primaryPhone, phone)).limit(1);
+  private async findPersonByPhone(
+    phone: string,
+    handle: Database = this.db,
+  ): Promise<{ personId: string; wasLinked: true } | null> {
+    const [existing] = await handle.select().from(persons).where(eq(persons.primaryPhone, phone)).limit(1);
     return existing ? { personId: existing.id, wasLinked: true } : null;
   }
 
@@ -354,13 +357,16 @@ export class PersonService {
    * Create a person with conflict handling for the UNIQUE phone constraint.
    * If insert conflicts (phone already exists), find and return the existing person.
    */
-  private async createPersonWithConflictHandling(linkOptions: {
-    matchByPhone?: string;
-    matchByEmail?: string;
-    displayName?: string;
-  }): Promise<{ personId?: string; wasLinked: boolean }> {
+  private async createPersonWithConflictHandling(
+    linkOptions: {
+      matchByPhone?: string;
+      matchByEmail?: string;
+      displayName?: string;
+    },
+    handle: Database = this.db,
+  ): Promise<{ personId?: string; wasLinked: boolean }> {
     try {
-      const [newPerson] = await this.db
+      const [newPerson] = await handle
         .insert(persons)
         .values({
           displayName: linkOptions.displayName,
@@ -374,12 +380,12 @@ export class PersonService {
 
       // Insert was skipped due to conflict — find and return existing person by phone
       if (linkOptions.matchByPhone) {
-        return (await this.findPersonByPhone(linkOptions.matchByPhone)) ?? { wasLinked: false };
+        return (await this.findPersonByPhone(linkOptions.matchByPhone, handle)) ?? { wasLinked: false };
       }
     } catch {
       // Fallback: re-query on any insert error (race condition safety)
       if (linkOptions.matchByPhone) {
-        return (await this.findPersonByPhone(linkOptions.matchByPhone)) ?? { wasLinked: false };
+        return (await this.findPersonByPhone(linkOptions.matchByPhone, handle)) ?? { wasLinked: false };
       }
     }
 
@@ -392,8 +398,9 @@ export class PersonService {
   private async updateExistingIdentity(
     existing: PlatformIdentity,
     data: Omit<NewPlatformIdentity, 'id' | 'personId' | 'createdAt' | 'updatedAt'>,
+    handle: Database = this.db,
   ): Promise<{ identity: PlatformIdentity; person: Person | null; isNew: boolean; wasLinked: boolean }> {
-    const [updated] = await this.db
+    const [updated] = await handle
       .update(platformIdentities)
       .set({
         platformUsername: data.platformUsername ?? existing.platformUsername,
@@ -411,7 +418,7 @@ export class PersonService {
 
     let person: Person | null = null;
     if (updated.personId) {
-      person = await this.getById(updated.personId);
+      person = await this.getById(updated.personId, handle);
     }
 
     return { identity: updated, person, isNew: false, wasLinked: false };
@@ -461,14 +468,16 @@ export class PersonService {
       return this.updateExistingIdentity(existing[0], data);
     }
 
-    // Try to find a person to link to
+    // Try to find an EXISTING person to link to. Person *creation* is deferred
+    // into secureIdentity() below, gated on winning the identity insert, so a
+    // lost first-contact race can never leave an orphan phone-less person.
     let personId: string | undefined = data.personId;
     let wasLinked = false;
+    let resolvedLinkOptions = linkOptions;
 
     if (!personId && linkOptions) {
       // Smart @lid→phone resolution: if this is a @lid identity with no phone match,
       // check chatIdMappings for a known phone JID and use it for person matching
-      let resolvedLinkOptions = linkOptions;
       if (!linkOptions.matchByPhone && data.platformUserId.endsWith('@lid') && instanceId) {
         const phoneFromLid = await this.resolvePhoneFromLid(instanceId, data.platformUserId);
         if (phoneFromLid) {
@@ -478,37 +487,137 @@ export class PersonService {
         }
       }
 
-      const linkResult = await this.findPersonToLink({ ...resolvedLinkOptions, instanceId });
+      // createPerson: false — only resolve an already-existing person here.
+      const linkResult = await this.findPersonToLink({ ...resolvedLinkOptions, instanceId, createPerson: false });
       personId = linkResult.personId;
       wasLinked = linkResult.wasLinked;
     }
 
-    // Create the identity
+    // Preserve the pre-existing linkedBy/confidence semantics of the create path.
+    // NOTE: matchType intentionally reads the caller's original linkOptions (not
+    // the @lid-resolved ones), exactly as before this change.
     const matchType = linkOptions?.matchByPhone ? 'phone' : linkOptions?.matchByEmail ? 'email' : 'platform_id';
     const linkedBy = wasLinked ? `${matchType}_match` : personId ? 'initial' : undefined;
     const linkReason = wasLinked ? `Matched by ${matchType}` : undefined;
 
-    const [created] = await this.db
-      .insert(platformIdentities)
-      .values({
-        ...data,
-        personId,
-        linkedBy,
-        confidence: wasLinked ? 90 : 100,
-        linkReason,
-      })
-      .returning();
+    // A new person may only be created when there is no existing person to link
+    // AND the caller asked for one; the resolved (possibly @lid-derived) phone is
+    // what the person is created with, matching the prior behaviour.
+    const createPersonOptions =
+      !personId && resolvedLinkOptions?.createPerson
+        ? {
+            matchByPhone: resolvedLinkOptions.matchByPhone,
+            matchByEmail: resolvedLinkOptions.matchByEmail,
+            displayName: resolvedLinkOptions.displayName,
+          }
+        : undefined;
 
-    if (!created) {
-      throw new Error('Failed to create identity');
-    }
+    return this.secureIdentity({
+      data,
+      personId,
+      wasLinked,
+      linkedBy,
+      linkReason,
+      confidence: wasLinked ? 90 : 100,
+      createPersonOptions,
+    });
+  }
 
-    let person: Person | null = null;
-    if (personId) {
-      person = await this.getById(personId);
-    }
+  /**
+   * Idempotently secure the `platform_identities` row for a first-contact sender
+   * and, only if this call actually inserted it, create the person it needs.
+   *
+   * Concurrency contract (why this is a transaction):
+   *   Two first-contact messages from the same new (channel, instanceId,
+   *   platformUserId) can both miss the SELECT above and race to INSERT. The
+   *   unique index `platform_identities_channel_user_idx` lets exactly one win.
+   *   `onConflictDoNothing` turns the loser's INSERT from an unhandled
+   *   unique-violation into a no-op that BLOCKS until the winner's transaction
+   *   commits, then returns no row. Because the winner creates and links its
+   *   person inside this same transaction, by the time the loser re-reads the
+   *   row the person link is already there — so the loser reuses it instead of
+   *   creating a duplicate. Result: exactly one identity, exactly one person, no
+   *   throw, and every caller gets the same rows.
+   *
+   * The non-racing path is behaviourally identical to the previous bare INSERT:
+   * the winner inserts, optionally creates its person, and returns isNew: true.
+   */
+  private async secureIdentity(params: {
+    data: Omit<NewPlatformIdentity, 'id' | 'personId' | 'createdAt' | 'updatedAt'> & { personId?: string };
+    personId?: string;
+    wasLinked: boolean;
+    linkedBy?: string;
+    linkReason?: string;
+    confidence: number;
+    createPersonOptions?: { matchByPhone?: string; matchByEmail?: string; displayName?: string };
+  }): Promise<{ identity: PlatformIdentity; person: Person | null; isNew: boolean; wasLinked: boolean }> {
+    const { data, personId, wasLinked, linkedBy, linkReason, confidence, createPersonOptions } = params;
+    const { instanceId, channel, platformUserId } = data;
 
-    return { identity: created, person, isNew: true, wasLinked };
+    return this.db.transaction(async (tx) => {
+      // The transaction handle runs the same query builder as the pooled handle;
+      // treat it as a `Database` (mirrors `scopedHandle`) so the identity insert,
+      // person creation, and person link all share one atomic transaction.
+      const txDb = tx as unknown as Database;
+
+      const [inserted] = await txDb
+        .insert(platformIdentities)
+        .values({
+          ...data,
+          personId,
+          linkedBy,
+          confidence,
+          linkReason,
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      // Lost the race: the winning writer's transaction has committed (our
+      // onConflictDoNothing waited on it), so its identity — and any person it
+      // linked — is now visible. Re-read and refresh benign fields, exactly like
+      // the "identity already exists" fast path.
+      if (!inserted) {
+        const [existing] = await txDb
+          .select()
+          .from(platformIdentities)
+          .where(
+            and(
+              eq(platformIdentities.channel, channel),
+              eq(platformIdentities.instanceId, instanceId ?? ''),
+              eq(platformIdentities.platformUserId, platformUserId),
+            ),
+          )
+          .limit(1);
+
+        if (!existing) {
+          throw new Error('Failed to resolve identity after conflict');
+        }
+
+        return this.updateExistingIdentity(existing, data, txDb);
+      }
+
+      // We won the insert. If it already has a person (an existing match or an
+      // explicit personId), we are done. Otherwise create the person now — this
+      // only ever runs for the race winner, so no orphan can be produced.
+      if (inserted.personId || !createPersonOptions) {
+        const person = inserted.personId ? await this.getById(inserted.personId, txDb) : null;
+        return { identity: inserted, person, isNew: true, wasLinked };
+      }
+
+      const created = await this.createPersonWithConflictHandling(createPersonOptions, txDb);
+      if (!created.personId) {
+        return { identity: inserted, person: null, isNew: true, wasLinked };
+      }
+
+      const [linked] = await txDb
+        .update(platformIdentities)
+        .set({ personId: created.personId, linkedBy: 'initial', confidence: 100, updatedAt: new Date() })
+        .where(eq(platformIdentities.id, inserted.id))
+        .returning();
+
+      const person = await this.getById(created.personId, txDb);
+      return { identity: linked ?? inserted, person, isNew: true, wasLinked: created.wasLinked };
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem

Concurrent first-contact messages from the same new sender `(channel, instanceId, platformUserId)` race inside `PersonService.findOrCreateIdentity`:

1. Both miss the existence `SELECT`, then both `INSERT` the identity. The bare insert had **no `onConflict` handling**, so the DB unique index (`platform_identities_channel_user_idx`) blocked the loser with an **unhandled unique-violation** — the message then persisted with **null identity FKs** (tenant-degrade path) or the error propagated (legacy path).
2. Each racer created its **own phone-less `persons` row before** the identity insert. A phone-less person has no natural key to dedupe on (the person insert's `onConflictDoNothing` can't help), so the losing racer left an **orphan person** — the exact rows `packages/api/scripts/fix-person-duplicates.ts` exists to clean in prod.

## Fix (race-fix only)

Secure the `platform_identities` row idempotently, and **defer person creation until the identity is won**, all inside one transaction:

- Identity insert now uses **`onConflictDoNothing`** on the existing unique index `(channel, instance_id, platform_user_id)`. The loser's insert blocks until the winner commits, then returns no row; we re-read and refresh the winner's row instead of throwing. Always returns a valid identity, never a unique-violation.
- **Person creation moved after** the identity is secured and **gated on winning the insert**. Because the winner creates + links its person in the same transaction, the loser sees the linked person on re-read and reuses it. A lost race can no longer orphan a person.
- **Non-racing path is behaviourally identical**: same `findPersonToLink` matching, same `linkedBy`/`confidence` semantics, same return shape. Existing-identity fast path untouched.
- **No schema change** — relies on the existing unique index.

## Test

New real-DB test `packages/api/src/__tests__/identity-idempotent-concurrency.test.ts`:
- Fires **N=8 concurrent** phone-less `findOrCreateIdentity` calls for the same new key → asserts exactly **one** `platform_identities` row, exactly **one** `persons` row (unique display-name probe → no orphans), every caller gets the same identity + person, nobody throws.
- Sequential idempotency: a repeat call returns the existing identity with no duplicate person.

Verified the test genuinely catches the regression: it **fails** (unhandled unique-violation) against the pre-fix bare insert, and passes with the fix. Existing `person-dedup.test.ts`, `persons.test.ts`, and `multi-instance-isolation.test.ts` still pass (mock harness updated for the new `.transaction()`/`.onConflictDoNothing()` surface; assertions unchanged). Typecheck + biome clean; pre-push suite green.

## Scope

Race-fix only. Normalization of `platformUserId`, backfill, and cross-channel/LID-first matching are **separate follow-up phases** of the identity rework — intentionally not touched here.