### PR TITLE
fix(runtime): bind local services to loopback

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -98,7 +98,9 @@ import { resolveInstanceTenantId } from './ws/voice-instance-ownership';
 
 // Configuration
 const PORT = Number.parseInt(process.env.API_PORT ?? '8882', 10);
-const HOST = process.env.API_HOST ?? '0.0.0.0';
+// Fail closed for direct/local launches. Container and reverse-proxy
+// deployments that need a network listener must opt in with API_HOST.
+const HOST = process.env.API_HOST ?? '127.0.0.1';
 const NATS_URL = process.env.NATS_URL ?? 'nats://localhost:4222';
 
 import { VoiceStreamRegistry, authorizeVoiceApiKey, parseVoiceStreamParams, transcodeAudioFrame } from './ws/voice';

--- a/packages/cli/src/__tests__/runtime-env.test.ts
+++ b/packages/cli/src/__tests__/runtime-env.test.ts
@@ -147,6 +147,7 @@ describe('buildRuntimeEnv', () => {
 
     const env = buildRuntimeEnv(serverConfig, cliConfig);
 
+    expect(env.API_HOST).toBe('127.0.0.1');
     expect(env.API_PORT).toBe('8882');
     expect(env.DATABASE_URL).toBe(buildEmbeddedDatabaseUrl());
     expect(env.OMNI_API_KEY).toBe('omni_sk_test-key');

--- a/packages/cli/src/__tests__/start.test.ts
+++ b/packages/cli/src/__tests__/start.test.ts
@@ -163,7 +163,7 @@ describe('buildPm2StartArgs — nats launch', () => {
     kind: 'nats',
     script: '/tmp/nats-server',
     name: PM2_PROCESSES.nats,
-    scriptArgs: ['-js', '-sd', '/tmp/nats-data'],
+    scriptArgs: ['-a', '127.0.0.1', '-js', '-sd', '/tmp/nats-data'],
   });
 
   test('includes --max-memory-restart 1G for nats kind', () => {
@@ -191,7 +191,7 @@ describe('buildPm2StartArgs — nats launch', () => {
   test('forwards scriptArgs after a "--" separator', () => {
     const dashIdx = natsArgs.indexOf('--');
     expect(dashIdx).toBeGreaterThan(-1);
-    expect(natsArgs.slice(dashIdx + 1)).toEqual(['-js', '-sd', '/tmp/nats-data']);
+    expect(natsArgs.slice(dashIdx + 1)).toEqual(['-a', '127.0.0.1', '-js', '-sd', '/tmp/nats-data']);
   });
 
   test('does not include --interpreter when not provided', () => {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -237,7 +237,9 @@ async function startServices(
       kind: 'nats',
       script: NATS_BINARY_PATH,
       name: PM2_PROCESSES.nats,
-      scriptArgs: ['-js', '-sd', natsDataDir],
+      // NATS is an internal event bus for the local Omni runtime. Never
+      // make it remotely reachable as a side effect of `omni install`.
+      scriptArgs: ['-a', '127.0.0.1', '-js', '-sd', natsDataDir],
     });
     const natsCode = await runPm2(natsArgs);
     if (natsCode !== 0) natsSpinner.warn(`${PM2_PROCESSES.nats} failed to start — check NATS binary`);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -104,7 +104,9 @@ async function runStart(): Promise<void> {
       kind: 'nats',
       script: natsPath,
       name: PM2_PROCESSES.nats,
-      scriptArgs: ['-js', '-sd', natsDataDir],
+      // NATS is an internal event bus for the local Omni runtime. Never
+      // make it remotely reachable as a side effect of `omni start`.
+      scriptArgs: ['-a', '127.0.0.1', '-js', '-sd', natsDataDir],
     });
     const natsCode = await runPm2(natsArgs);
     if (natsCode !== 0) {

--- a/packages/cli/src/runtime-env.ts
+++ b/packages/cli/src/runtime-env.ts
@@ -46,6 +46,7 @@ import { resolveOmniEnforcedCredentials, resolveOmniScopedCredentials } from './
  * (and onward to the managed omni-api process).
  */
 export type RuntimeEnv = {
+  API_HOST: string;
   API_PORT: string;
   DATABASE_URL: string;
   // PGHOST / PGPORT: libpq-standard env vars consumed by postgres.js when
@@ -245,6 +246,10 @@ export function buildRuntimeEnv(serverConfig: ServerConfig, cliConfig: Config = 
   const scopedCreds =
     process.env.OMNI_DB_ENFORCEMENT === 'on' ? resolveOmniEnforcedCredentials() : resolveOmniScopedCredentials();
   return {
+    // A CLI-managed Omni runtime is a local transport bridge. Operators that
+    // intentionally expose the API must make that boundary explicit outside
+    // this installer (reverse proxy/TLS or an explicit API_HOST override).
+    API_HOST: '127.0.0.1',
     API_PORT: String(serverConfig.port),
     DATABASE_URL: applyScopedCredentials(resolveDatabaseUrl(serverConfig), scopedCreds),
     PGHOST: pgHost,


### PR DESCRIPTION
## Summary

- default the API listener to `127.0.0.1`; deployments that need a network listener can opt in with `API_HOST`
- bind CLI-managed NATS processes to `127.0.0.1` during both `omni install` and `omni start`
- cover the generated runtime environment and NATS launch arguments with focused tests

## Validation

- 48 focused CLI tests passed
- Biome check passed
- `git diff --check` passed
- full CI runs on the pull request