### PR TITLE
fix(cli): type signal listener cleanup portably

### DIFF
--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -7,6 +7,7 @@
  * omni events timeline <person-id>
  */
 
+import type { EventEmitter } from 'node:events';
 import type { Event, OmniClient } from '@omni/sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
@@ -368,8 +369,11 @@ async function streamEvents(client: OmniClient, options: StreamOptions): Promise
   const shutdown = (): void => {
     stopped = true;
   };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  // Bun narrows Process.off() to Bun-only events, while signal listeners use
+  // the standard EventEmitter contract shared by Node and Bun.
+  const processEvents: EventEmitter = process;
+  processEvents.on('SIGINT', shutdown);
+  processEvents.on('SIGTERM', shutdown);
 
   if (!ndjson) output.dim(`Streaming events (poll=${pollMs}ms). Ctrl+C to stop.`);
 
@@ -381,8 +385,8 @@ async function streamEvents(client: OmniClient, options: StreamOptions): Promise
       await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
     }
   } finally {
-    process.off('SIGINT', shutdown);
-    process.off('SIGTERM', shutdown);
+    processEvents.off('SIGINT', shutdown);
+    processEvents.off('SIGTERM', shutdown);
     await output.flushStdout();
   }
 }


### PR DESCRIPTION
## Summary

- use EventEmitter’s cross-runtime listener contract for CLI signal cleanup
- preserve SIGINT/SIGTERM lifecycle behavior while avoiding Bun’s narrowed Process.off overload

## Validation

- full typecheck
- full build
- full test suite
- focused events stream tests
- Biome