### PR TITLE
fix(channel-slack): fail fast on unresolved acting user + add files:write user scope

### DIFF
--- a/packages/channel-slack/src/__tests__/auth-mode.test.ts
+++ b/packages/channel-slack/src/__tests__/auth-mode.test.ts
@@ -44,6 +44,14 @@ describe('buildSlackManifest — user scopes', () => {
     expect(manifest.oauth_config.scopes.bot).not.toContain('search:read');
   });
 
+  it('requests files:write so user-mode media uploads work (files.uploadV2)', () => {
+    // In user mode sendMediaContent uploads via the xoxp acting client, which
+    // needs files:write — without it every user-mode media send fails with
+    // missing_scope. Bot mode already has it via REQUIRED_BOT_SCOPES.
+    const manifest = buildSlackManifest({ includeUserScopes: true });
+    expect(manifest.oauth_config.scopes.user).toContain('files:write');
+  });
+
   it('requests im:write so DMs can be opened, and subscribes to user events', () => {
     const manifest = buildSlackManifest({ includeUserScopes: true });
     expect(manifest.oauth_config.scopes.user).toContain('im:write');

--- a/packages/channel-slack/src/__tests__/bolt-client-user-mode.test.ts
+++ b/packages/channel-slack/src/__tests__/bolt-client-user-mode.test.ts
@@ -1,0 +1,99 @@
+/**
+ * User-mode startup safety (#889).
+ *
+ * In user mode the acting-user id MUST be resolved before the app starts.
+ * Self-filtering (shouldSkipMessage) compares the human's own typing against
+ * the acting-user id; if that id is undefined the check silently no-ops and the
+ * agent answers the operator's OWN messages — the exact failure the resolve was
+ * added to prevent. So an unresolved acting-user id in user mode must FAIL FAST
+ * rather than start the app in that broken state.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { BoltConnection } from '../connection/bolt-client';
+import { startBoltConnection } from '../connection/bolt-client';
+import { shouldSkipMessage } from '../handlers/messages';
+
+const noop = () => {};
+const noopLogger = { debug: noop, info: noop, warn: noop, error: noop };
+
+/** Build a minimal fake connection whose app.start() is observable. */
+function makeConnection(overrides: Partial<BoltConnection> = {}): {
+  conn: BoltConnection;
+  started: () => number;
+} {
+  let startCount = 0;
+  const conn = {
+    app: {
+      client: {
+        auth: {
+          test: async () => ({ user_id: 'U0BOT', user: 'bot', team_id: 'T1', team: 'team' }),
+        },
+      },
+      start: async () => {
+        startCount++;
+      },
+    },
+    client: {},
+    actingClient: {},
+    botToken: 'xoxb-fake',
+    mode: 'socket',
+    ...overrides,
+  } as unknown as BoltConnection;
+  return { conn, started: () => startCount };
+}
+
+describe('startBoltConnection — user mode acting-user invariant', () => {
+  it('throws (does not start) when the user token resolve fails', async () => {
+    const { conn, started } = makeConnection({
+      userClient: {
+        auth: {
+          test: async () => {
+            throw new Error('invalid_auth');
+          },
+        },
+      } as unknown as BoltConnection['userClient'],
+    });
+
+    await expect(startBoltConnection(conn, noopLogger as never)).rejects.toThrow();
+    expect(started()).toBe(0);
+  });
+
+  it('throws (does not start) when the user token resolves without a user_id', async () => {
+    const { conn, started } = makeConnection({
+      userClient: {
+        auth: { test: async () => ({ ok: true }) },
+      } as unknown as BoltConnection['userClient'],
+    });
+
+    await expect(startBoltConnection(conn, noopLogger as never)).rejects.toThrow();
+    expect(started()).toBe(0);
+  });
+
+  it('starts normally in user mode once the acting-user id resolves', async () => {
+    const { conn, started } = makeConnection({
+      userClient: {
+        auth: { test: async () => ({ user_id: 'U0HUMAN', user: 'human' }) },
+      } as unknown as BoltConnection['userClient'],
+    });
+
+    await startBoltConnection(conn, noopLogger as never);
+    expect(conn.actingUserId).toBe('U0HUMAN');
+    expect(started()).toBe(1);
+  });
+
+  it('starts normally in bot mode (no userClient)', async () => {
+    const { conn, started } = makeConnection();
+    await startBoltConnection(conn, noopLogger as never);
+    expect(started()).toBe(1);
+  });
+
+  it('documents the downstream harm: without the acting-user id, self-filtering no-ops', () => {
+    // If start were allowed with actingUserId undefined, this is what happens:
+    // the human's own typing (no bot_id, their own user id) is NOT skipped.
+    const HUMAN = 'U0HUMAN';
+    expect(shouldSkipMessage({ user: HUMAN }, ['U0BOT', undefined])).toBe(false);
+    // With the id present, it is correctly skipped.
+    expect(shouldSkipMessage({ user: HUMAN }, ['U0BOT', HUMAN])).toBe(true);
+  });
+});

--- a/packages/channel-slack/src/connection/bolt-client.ts
+++ b/packages/channel-slack/src/connection/bolt-client.ts
@@ -327,6 +327,17 @@ export async function startBoltConnection(connection: BoltConnection, logger: Lo
     });
   }
 
+  // User mode (#889) MUST NOT start without a resolved acting-user id. Self-
+  // filtering compares the human's own typing against actingUserId; when it is
+  // undefined the check in shouldSkipMessage silently no-ops and the agent
+  // answers the operator's OWN messages. Fail fast rather than start broken.
+  if (connection.userClient && !connection.actingUserId) {
+    throw new SlackError(
+      SlackErrorCode.CONNECTION_FAILED,
+      'User mode requires a resolved acting user id, but it could not be determined from the user token. Refusing to start.',
+    );
+  }
+
   if (connection.mode === 'http') {
     // HTTP mode: start Bolt's built-in HTTP server so inbound Slack events are received.
     // Bolt's HTTPReceiver listens on the given port and routes requests to registered handlers.

--- a/packages/channel-slack/src/manifest.ts
+++ b/packages/channel-slack/src/manifest.ts
@@ -65,6 +65,7 @@ const USER_SCOPES = [
   'channels:history',
   'channels:read',
   'chat:write',
+  'files:write',
   'groups:history',
   'groups:read',
   'im:history',


### PR DESCRIPTION
## Two verified Slack user-mode bugs (#889)

### Bug 1 — user mode starts without a resolved \`actingUserId\`
In \`startBoltConnection\` (bolt-client.ts) the user-token auth resolve was inside a \`try\` whose \`catch\` only \`warn\`ed and let execution continue to \`app.start\`. So user mode could start with \`actingUserId=undefined\`. Downstream, \`shouldSkipMessage\`'s acting-user check \`selfUserIds.some(id => id && id === userId)\` silently no-ops when the id is undefined, so the agent replies to the human operator's OWN messages — exactly what the resolve was added to prevent.

**Fix:** after the identity-resolve block, if \`connection.userClient\` is present but \`actingUserId\` is unresolved, throw \`SlackError(CONNECTION_FAILED)\` — fail fast instead of starting broken.

### Bug 2 — \`USER_SCOPES\` missing \`files:write\`
In user mode \`connection.actingClient\` is the \`xoxp\` user client, and \`sendMediaContent\` uploads via \`files.uploadV2\`, which requires \`files:write\`. \`USER_SCOPES\` omitted it, so every user-mode media send failed with \`missing_scope\` (bot mode was fine — \`REQUIRED_BOT_SCOPES\` already had it).

**Fix:** add \`files:write\` to \`USER_SCOPES\`.

## Test-first
- New \`__tests__/bolt-client-user-mode.test.ts\`: asserts \`startBoltConnection\` throws and never calls \`app.start\` when the user token resolve fails or returns no \`user_id\`; still starts normally once resolved and in bot mode; documents the self-filter no-op consequence. Red before fix (resolved instead of rejecting), green after.
- Extended \`__tests__/auth-mode.test.ts\`: user scopes must contain \`files:write\`. Red before, green after.

## Verification
- \`bun test packages/channel-slack\` — 240 pass, 0 fail
- \`make typecheck\` — green
- \`bunx biome check --write\` on touched files — clean
- Full pre-push suite — 5806 pass, 0 fail