### PR TITLE
fix(api): make reconcile --apply atomic per group and keep oldest person in backfill

### DIFF
--- a/packages/api/scripts/__tests__/reconcile-identity-fragmentation-postgres.test.ts
+++ b/packages/api/scripts/__tests__/reconcile-identity-fragmentation-postgres.test.ts
@@ -36,6 +36,83 @@ const INSTANCE = '55555555-5555-4555-8555-5555555555b1';
 const PERSON_BARE = '99999999-9999-4999-8999-9999999999b1';
 const PERSON_SUFFIXED = '99999999-9999-4999-8999-9999999999b2';
 const PERSON_LID = '99999999-9999-4999-8999-9999999999b3';
+const PERSON_PHONE = '99999999-9999-4999-8999-9999999999b4';
+
+/** Every migration SQL file concatenated, applied to a fresh database. */
+function loadMigrations(): string {
+  return readdirSync(drizzleDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+    .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
+    .join('\n');
+}
+
+/**
+ * Create + migrate a fresh disposable database, returning a handle and a
+ * cleanup that closes the pool and drops the database. Each apply-mode scenario
+ * gets its own database so a write in one never bleeds into another.
+ */
+async function provisionDatabase(): Promise<{
+  db: Database;
+  seed: (script: string) => void;
+  cleanup: () => Promise<void>;
+}> {
+  const dbName = `omni_p0_recon_${crypto.randomUUID().replaceAll('-', '')}`;
+  const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
+  if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+  const dbUrl = urlFor(superUrl, dbName);
+  const migrated = runSqlOn(dbUrl, loadMigrations());
+  if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
+  const handle = createDbHandle({ url: dbUrl, maxConnections: 2 });
+  return {
+    db: handle.db,
+    seed: (script: string) => {
+      const res = runSqlOn(dbUrl, script);
+      if (res.exitCode !== 0) throw new Error(`seed failed: ${res.stderr}`);
+    },
+    cleanup: async () => {
+      await handle.close().catch(() => undefined);
+      runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+    },
+  };
+}
+
+/**
+ * Wrap a database handle so a `DELETE FROM platform_identities` throws — a fault
+ * injected into the SECOND phase of a group's mutation (`absorbIdentity`), i.e.
+ * AFTER the first phase (`mergePersons`, which deletes the merged-away person)
+ * has already run to completion. That placement is deliberate: it proves the
+ * whole per-group sequence is atomic, not merely each helper in isolation —
+ * without the group-level transaction the committed person merge survives the
+ * later failure, leaving the group half-processed. The wrapper re-wraps the
+ * transaction handle drizzle hands to `db.transaction`, so the fault lands
+ * whether the mutation runs on the pool (buggy) or inside a transaction (fixed).
+ */
+function wrapWithDeleteFault(handle: object): object {
+  return new Proxy(handle, {
+    get(target, prop, receiver) {
+      if (prop === 'delete') {
+        const del = Reflect.get(target, prop, receiver) as (table: unknown) => unknown;
+        return (table: unknown) => {
+          if (table === platformIdentities) {
+            throw new Error('injected fault: platform_identities delete disabled mid-reconcile');
+          }
+          return del.call(target, table);
+        };
+      }
+      if (prop === 'transaction') {
+        const tx = Reflect.get(target, prop, receiver) as (
+          fn: (t: object) => Promise<unknown>,
+          config?: unknown,
+        ) => Promise<unknown>;
+        return (fn: (t: object) => Promise<unknown>, config?: unknown) =>
+          tx.call(target, (inner: object) => fn(wrapWithDeleteFault(inner)), config);
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+    },
+  });
+}
 
 function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
   const file = join(tmpdir(), `omni-p0-recon-${crypto.randomUUID()}.sql`);
@@ -140,4 +217,85 @@ postgresDescribe('reconciliation script dry-run mutates nothing (real PostgreSQL
     const userIds = identitiesAfter.map((i) => i.platformUserId).sort();
     expect(userIds).toEqual(['5511777770000', '5511777770000@s.whatsapp.net', '54958418317348@lid'].sort());
   }, 60_000);
+});
+
+/** A stable, order-independent snapshot of the rows a group mutation touches. */
+async function snapshot(db: Database): Promise<string> {
+  const ids = (await db.select().from(platformIdentities))
+    .map((i) => `${i.id}|${i.platformUserId}|${i.personId}|${i.updatedAt?.toISOString() ?? ''}`)
+    .sort();
+  const ps = (await db.select().from(persons))
+    .map((p) => `${p.id}|${p.primaryPhone}|${p.displayName}|${p.updatedAt?.toISOString() ?? ''}`)
+    .sort();
+  return JSON.stringify({ ids, ps });
+}
+
+postgresDescribe('reconciliation script --apply write-path safety (real PostgreSQL)', () => {
+  // Bug #1: a mid-group failure must roll back the WHOLE group, all-or-nothing.
+  test('group reconciliation is atomic: a mid-mutation failure leaves the group unchanged', async () => {
+    const { db, seed, cleanup } = await provisionDatabase();
+    try {
+      // A fragmented number: bare (older) + suffixed (younger), two persons.
+      seed(`
+        INSERT INTO instances (id, name, channel, created_at)
+          VALUES ('${INSTANCE}', 'inst-recon', 'whatsapp-baileys', now());
+        INSERT INTO persons (id, primary_phone, created_at) VALUES
+          ('${PERSON_BARE}',     '+5511777770000', '2026-01-01 00:00:00+00'),
+          ('${PERSON_SUFFIXED}', NULL,             '2026-01-02 00:00:00+00');
+        INSERT INTO platform_identities (channel, instance_id, platform_user_id, person_id, created_at) VALUES
+          ('whatsapp-baileys', '${INSTANCE}', '5511777770000',                '${PERSON_BARE}',     '2026-01-01 00:00:00+00'),
+          ('whatsapp-baileys', '${INSTANCE}', '5511777770000@s.whatsapp.net', '${PERSON_SUFFIXED}', '2026-01-02 00:00:00+00');
+      `);
+
+      const before = await snapshot(db);
+
+      // Run apply-mode with a fault injected into the group's SECOND phase
+      // (absorbIdentity's platform_identities DELETE), after the person merge
+      // has already committed. Only a group-level transaction can undo that.
+      const faulted = wrapWithDeleteFault(db) as unknown as Database;
+      await expect(reconcile(faulted, { apply: true })).rejects.toThrow('injected fault');
+
+      // All-or-nothing: the failed group must be byte-identical to before.
+      // Without a transaction the pre-DELETE UPDATEs (person coalesce + identity
+      // re-point) have already committed, so this snapshot differs.
+      const after = await snapshot(db);
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  }, 120_000);
+
+  // Bug #2: Step-2 backfill must keep the OLDEST person (oldest-survives),
+  // even when the older person is the phone-less @lid one.
+  test('step-2 backfill keeps the OLDER @lid person as survivor', async () => {
+    const { db, seed, cleanup } = await provisionDatabase();
+    try {
+      // @lid person is OLDER than the existing phone-person it will merge with.
+      seed(`
+        INSERT INTO instances (id, name, channel, created_at)
+          VALUES ('${INSTANCE}', 'inst-recon', 'whatsapp-baileys', now());
+        INSERT INTO persons (id, primary_phone, created_at) VALUES
+          ('${PERSON_LID}',   NULL,             '2026-01-01 00:00:00+00'),  -- older
+          ('${PERSON_PHONE}', '+5511666660000', '2026-01-02 00:00:00+00');  -- younger
+        INSERT INTO platform_identities (channel, instance_id, platform_user_id, person_id, created_at) VALUES
+          ('whatsapp-baileys', '${INSTANCE}', '54958418317348@lid', '${PERSON_LID}', '2026-01-01 00:00:00+00');
+        INSERT INTO chat_id_mappings (instance_id, lid_id, phone_id) VALUES
+          ('${INSTANCE}', '54958418317348@lid', '5511666660000@s.whatsapp.net');
+      `);
+
+      await reconcile(db, { apply: true });
+
+      const survivors = await db.select().from(persons);
+      const survivorIds = survivors.map((p) => p.id).sort();
+
+      // Oldest survives: the @lid person stays, the younger phone-person is merged
+      // away. The buggy version keeps the phone-person and DELETES the older @lid.
+      expect(survivorIds).toEqual([PERSON_LID]);
+      const [survivor] = survivors;
+      expect(survivor?.id).toBe(PERSON_LID);
+      expect(survivor?.primaryPhone).toBe('+5511666660000');
+    } finally {
+      await cleanup();
+    }
+  }, 120_000);
 });

--- a/packages/api/scripts/reconcile-identity-fragmentation.ts
+++ b/packages/api/scripts/reconcile-identity-fragmentation.ts
@@ -57,6 +57,16 @@ const sampleLimit = 10;
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
+/**
+ * A pool handle OR an open transaction. Drizzle's `db.transaction(fn)` hands the
+ * callback a distinct tx handle whose type differs from the pool's, yet both
+ * expose the same query-builder surface these helpers use. Typing the mutation
+ * helpers against this union lets the per-group work run atomically inside a
+ * transaction without duplicating them.
+ */
+type TxHandle = Parameters<Parameters<Database['transaction']>[0]>[0];
+type DbHandle = Database | TxHandle;
+
 interface IdentityRow {
   id: string;
   channel: string;
@@ -90,46 +100,58 @@ function sample(line: string): void {
 // ── Person merge (coalesce fields, oldest survives) ─────────────────────────
 
 /**
- * Merge `sourceId` into `targetId`: coalesce person fields onto the target
- * (never dropping a phone/name/email/avatar the source had and the target
- * lacked), move every FK reference, then delete the source. No-op when equal.
+ * Merge `sourceId` into `targetId`: move every FK reference off the source,
+ * delete it, then coalesce its fields onto the target (never dropping a
+ * phone/name/email/avatar the source had and the target lacked). No-op when
+ * equal.
+ *
+ * ORDER MATTERS. The coalesce write must land AFTER the source row is gone:
+ * `persons.primary_phone` carries a unique index, so setting the target's phone
+ * to the source's value while the source still holds it would trip a transient
+ * unique violation. The whole merge runs in one transaction — a savepoint when
+ * the caller already gave us a transaction handle — so it is atomic whether
+ * invoked standalone (Step 2) or inside a group's transaction (Step 1).
  */
-async function mergePersons(db: Database, sourceId: string, targetId: string, reason: string): Promise<void> {
+async function mergePersons(db: DbHandle, sourceId: string, targetId: string, reason: string): Promise<void> {
   if (sourceId === targetId) return;
 
   const [source] = await db.select().from(persons).where(eq(persons.id, sourceId)).limit(1);
   const [target] = await db.select().from(persons).where(eq(persons.id, targetId)).limit(1);
   if (!source || !target) return;
 
-  // Coalesce: keep the target's value, fall back to the source's.
-  await db
-    .update(persons)
-    .set({
-      displayName: target.displayName ?? source.displayName,
-      primaryPhone: target.primaryPhone ?? source.primaryPhone,
-      primaryEmail: target.primaryEmail ?? source.primaryEmail,
-      avatarUrl: target.avatarUrl ?? source.avatarUrl,
-      updatedAt: new Date(),
-    })
-    .where(eq(persons.id, targetId));
+  await db.transaction(async (tx) => {
+    // Move platform identities, participants, messages, events off the source.
+    await tx
+      .update(platformIdentities)
+      .set({ personId: targetId, linkedBy: 'manual', linkReason: reason, updatedAt: new Date() })
+      .where(eq(platformIdentities.personId, sourceId));
+    await tx
+      .update(chatParticipants)
+      .set({ personId: targetId, updatedAt: new Date() })
+      .where(eq(chatParticipants.personId, sourceId));
+    await tx.update(messages).set({ senderPersonId: targetId }).where(eq(messages.senderPersonId, sourceId));
+    await tx.update(omniEvents).set({ personId: targetId }).where(eq(omniEvents.personId, sourceId));
 
-  // Move platform identities, participants, messages, events off the source.
-  await db
-    .update(platformIdentities)
-    .set({ personId: targetId, linkedBy: 'manual', linkReason: reason, updatedAt: new Date() })
-    .where(eq(platformIdentities.personId, sourceId));
-  await db
-    .update(chatParticipants)
-    .set({ personId: targetId, updatedAt: new Date() })
-    .where(eq(chatParticipants.personId, sourceId));
-  await db.update(messages).set({ senderPersonId: targetId }).where(eq(messages.senderPersonId, sourceId));
-  await db.update(omniEvents).set({ personId: targetId }).where(eq(omniEvents.personId, sourceId));
+    // Delete the source BEFORE writing coalesced values onto the target, so the
+    // unique columns (primary_phone) are never held by two rows at once.
+    await tx.delete(persons).where(eq(persons.id, sourceId));
 
-  await db.delete(persons).where(eq(persons.id, sourceId));
+    // Coalesce: keep the target's value, fall back to the source's.
+    await tx
+      .update(persons)
+      .set({
+        displayName: target.displayName ?? source.displayName,
+        primaryPhone: target.primaryPhone ?? source.primaryPhone,
+        primaryEmail: target.primaryEmail ?? source.primaryEmail,
+        avatarUrl: target.avatarUrl ?? source.avatarUrl,
+        updatedAt: new Date(),
+      })
+      .where(eq(persons.id, targetId));
+  });
 }
 
 /** Re-point an identity's messages/participants/events, then delete it. */
-async function absorbIdentity(db: Database, loserId: string, survivorId: string): Promise<void> {
+async function absorbIdentity(db: DbHandle, loserId: string, survivorId: string): Promise<void> {
   await db
     .update(messages)
     .set({ senderPlatformIdentityId: survivorId })
@@ -143,7 +165,7 @@ async function absorbIdentity(db: Database, loserId: string, survivorId: string)
 }
 
 /** The oldest person id among a set, or undefined when none have persons. */
-async function oldestPersonId(db: Database, personIds: string[]): Promise<string | undefined> {
+async function oldestPersonId(db: DbHandle, personIds: string[]): Promise<string | undefined> {
   const ids = [...new Set(personIds)];
   if (ids.length === 0) return undefined;
   const rows = await db
@@ -174,7 +196,7 @@ function groupByCanonical(rows: IdentityRow[]): Map<string, IdentityRow[]> {
   return groups;
 }
 
-async function reconcileGroup(db: Database, key: string, group: IdentityRow[]): Promise<void> {
+async function reconcileGroup(db: Database, key: string, group: IdentityRow[], applyMode: boolean): Promise<void> {
   const [channel, , canonicalId] = key.split('|');
   // Survivor identity: the one already in canonical form, else the oldest.
   const sorted = [...group].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
@@ -188,38 +210,52 @@ async function reconcileGroup(db: Database, key: string, group: IdentityRow[]): 
   stats.fragmentGroups++;
   sample(`group ${channel}/${canonicalId}: ${group.length} identities → 1 (persons: ${new Set(personIds).size})`);
 
-  if (dryRun) {
+  if (!applyMode) {
     stats.identitiesMerged += group.length - 1;
     if (new Set(personIds).size > 1) stats.personsMerged += new Set(personIds).size - 1;
     return;
   }
 
-  // Merge every other person into the surviving person first.
-  if (survivingPersonId) {
-    for (const pid of new Set(personIds)) {
-      if (pid !== survivingPersonId) {
-        await mergePersons(db, pid, survivingPersonId, `identity fragmentation dedupe: ${channel}/${canonicalId}`);
-        stats.personsMerged++;
+  // ATOMICITY: the whole per-group mutation — every person merge, every identity
+  // absorb, and the survivor's canonicalization — runs in ONE transaction. A
+  // mid-way failure must roll the entire group back: idempotency here depends on
+  // the fragmentation signal (`length > 1 && spellings > 1`), so a partially
+  // applied group (some losers already deleted) would no longer be detected on a
+  // re-run, stranding the survivor half-merged / non-canonical forever.
+  // Stats are tallied locally and committed only after the transaction succeeds,
+  // so a rolled-back group leaves the counters untouched too.
+  let personsMerged = 0;
+  let identitiesMerged = 0;
+  await db.transaction(async (tx) => {
+    // Merge every other person into the surviving person first.
+    if (survivingPersonId) {
+      for (const pid of new Set(personIds)) {
+        if (pid !== survivingPersonId) {
+          await mergePersons(tx, pid, survivingPersonId, `identity fragmentation dedupe: ${channel}/${canonicalId}`);
+          personsMerged++;
+        }
       }
     }
-  }
 
-  // Absorb every non-survivor identity into the survivor.
-  for (const loser of group) {
-    if (loser.id !== survivor.id) {
-      await absorbIdentity(db, loser.id, survivor.id);
-      stats.identitiesMerged++;
+    // Absorb every non-survivor identity into the survivor.
+    for (const loser of group) {
+      if (loser.id !== survivor.id) {
+        await absorbIdentity(tx, loser.id, survivor.id);
+        identitiesMerged++;
+      }
     }
-  }
 
-  // Canonicalize the survivor's handle + person link.
-  await db
-    .update(platformIdentities)
-    .set({ platformUserId: canonicalId, personId: survivingPersonId ?? survivor.personId, updatedAt: new Date() })
-    .where(eq(platformIdentities.id, survivor.id));
+    // Canonicalize the survivor's handle + person link.
+    await tx
+      .update(platformIdentities)
+      .set({ platformUserId: canonicalId, personId: survivingPersonId ?? survivor.personId, updatedAt: new Date() })
+      .where(eq(platformIdentities.id, survivor.id));
+  });
+  stats.personsMerged += personsMerged;
+  stats.identitiesMerged += identitiesMerged;
 }
 
-async function dedupeFragmentedIdentities(db: Database): Promise<void> {
+async function dedupeFragmentedIdentities(db: Database, applyMode: boolean): Promise<void> {
   process.stdout.write('Step 1: dedupe fragmented identities\n');
   process.stdout.write(`${'-'.repeat(40)}\n`);
 
@@ -245,7 +281,7 @@ async function dedupeFragmentedIdentities(db: Database): Promise<void> {
     return;
   }
   process.stdout.write(`  Found ${fragmented.length} fragmented group(s).\n`);
-  for (const [key, group] of fragmented) await reconcileGroup(db, key, group);
+  for (const [key, group] of fragmented) await reconcileGroup(db, key, group, applyMode);
   process.stdout.write('\n');
 }
 
@@ -257,7 +293,7 @@ function phoneFromJid(phoneJid: string): string | undefined {
   return /^\d{7,15}$/.test(digits) ? `+${digits}` : undefined;
 }
 
-async function backfillPhonelessPersons(db: Database): Promise<void> {
+async function backfillPhonelessPersons(db: Database, applyMode: boolean): Promise<void> {
   process.stdout.write('Step 2: backfill phone-less persons from chat_id_mappings\n');
   process.stdout.write(`${'-'.repeat(40)}\n`);
 
@@ -296,13 +332,19 @@ async function backfillPhonelessPersons(db: Database): Promise<void> {
     const [existingPhonePerson] = await db.select().from(persons).where(eq(persons.primaryPhone, phone)).limit(1);
 
     if (existingPhonePerson && existingPhonePerson.id !== person.id) {
-      sample(`backfill: person ${person.id} (@lid) merges into phone-person ${existingPhonePerson.id} (${phone})`);
+      // Oldest survives — same rule as Step 1. Merge the YOUNGER of the two into
+      // the OLDER, rather than always keeping the phone-person: keeping the
+      // phone-person regardless of age would delete an older @lid person and
+      // rewrite its createdAt/id, contradicting Step 1's oldest-survives choice.
+      const survivorId = (await oldestPersonId(db, [person.id, existingPhonePerson.id])) ?? existingPhonePerson.id;
+      const loserId = survivorId === person.id ? existingPhonePerson.id : person.id;
+      sample(`backfill: person ${loserId} merges into older person ${survivorId} (${phone})`);
       stats.phonelessMergedIntoPhonePerson++;
-      if (apply) await mergePersons(db, person.id, existingPhonePerson.id, `lid phone backfill merge ${phone}`);
+      if (applyMode) await mergePersons(db, loserId, survivorId, `lid phone backfill merge ${phone}`);
     } else {
       sample(`backfill: set person ${person.id}.primary_phone = ${phone}`);
       stats.phonesBackfilled++;
-      if (apply)
+      if (applyMode)
         await db.update(persons).set({ primaryPhone: phone, updatedAt: new Date() }).where(eq(persons.id, person.id));
     }
   }
@@ -337,10 +379,23 @@ function printReport(): void {
 
 // ── Main ──────────────────────────────────────────────────────────────────
 
-/** Exported for the dry-run test; runs both passes against the given handle. */
-export async function reconcile(db: Database): Promise<Stats> {
-  await dedupeFragmentedIdentities(db);
-  await backfillPhonelessPersons(db);
+/** Options for {@link reconcile}. `apply` defaults to the process-level flag. */
+export interface ReconcileOptions {
+  /** When true, perform writes; when false (default outside `--apply`), dry-run. */
+  apply?: boolean;
+}
+
+/**
+ * Exported for tests; runs both passes against the given handle.
+ *
+ * `apply` defaults to the module-level flag derived from `--apply`, so `main()`
+ * behaves exactly as before. Tests pass `{ apply: true }` explicitly to exercise
+ * the write path against a disposable database.
+ */
+export async function reconcile(db: Database, opts: ReconcileOptions = {}): Promise<Stats> {
+  const applyMode = opts.apply ?? apply;
+  await dedupeFragmentedIdentities(db, applyMode);
+  await backfillPhonelessPersons(db, applyMode);
   return stats;
 }
 


### PR DESCRIPTION
## Why

Two verified safety bugs in `packages/api/scripts/reconcile-identity-fragmentation.ts` gate our ability to run the script with `--apply` against real data. Both are on the write path only (dry-run, the default, is unaffected). Fixed test-first: each bug reproduced with a failing real-PostgreSQL test, confirmed red, then fixed to green.

## Bug 1 — non-atomic group reconciliation (`reconcileGroup`)

In `--apply` mode the per-group mutation ran `mergePersons` (multi-UPDATE + DELETE), `absorbIdentity` (multi-UPDATE + DELETE), and the canonical-handle UPDATE **directly on the pool with no transaction**. A mid-way failure left partial state — and because dedupe detection depends on the fragmentation signal (`group.length > 1 && spellings > 1`), once some losers are deleted a re-run no longer detects the group, so the survivor is stranded **permanently half-merged / non-canonical**.

**Fix:** the whole per-group mutation now runs in one `db.transaction`. The `tx` handle is threaded through `mergePersons` / `absorbIdentity` / the canonical UPDATE (their signatures widened from `Database` to a `DbHandle = Database | TxHandle` union, where `TxHandle` is derived from the transaction-callback param type). Stats are tallied into locals inside the callback and only added to the module totals after the transaction commits, so a rolled-back group leaves the counters untouched too.

**Red evidence (before fix):** the test seeds a fragmented number (bare + suffixed → two persons), then injects a fault into the group's *second* phase — `absorbIdentity`'s `platform_identities` DELETE, i.e. after the person merge has already committed — and asserts the group is byte-identical to before. Pre-fix the snapshot differed: the suffixed identity's `person_id` had been re-pointed `…b2 → …b1` and the merged-away person was gone, i.e. a partially-applied group that a re-run can no longer detect:

```
error: expect(received).toBe(expected)
- …|5511777770000@s.whatsapp.net|…b2|…   (before: suffixed → person b2)
+ …|5511777770000@s.whatsapp.net|…b1|…   (after:  suffixed re-pointed to b1, merge committed)
```

I also verified the test specifically guards the *group-level* transaction: temporarily reverting only the outer `reconcileGroup` transaction (leaving `mergePersons`'s own transaction in place) turns it red again, because the committed person-merge survives the later `absorbIdentity` failure.

## Bug 2 — wrong survivor in Step-2 backfill

Step-2 called `mergePersons(db, person.id, existingPhonePerson.id)` — always keeping the phone-person as survivor and deleting the `@lid` person **even when the `@lid` person was older**, contradicting Step-1's `oldestPersonId` "oldest survives" rule. Coalescing prevents field loss, so it was a `createdAt` / `id` inconsistency rather than data loss, but it's fixed for consistency.

**Fix:** the survivor is now chosen via `oldestPersonId([person.id, existingPhonePerson.id])` and the younger person merges into the older.

**Red evidence (before fix):** the test seeds a Step-2 case where the `@lid` person is older (`2026-01-01`) than the existing phone-person (`2026-01-02`) and asserts the older `@lid` person survives. Pre-fix the older `@lid` person was deleted and the younger phone-person survived:

```
error: expect(received).toEqual(expected)
- "…b3"   (expected: older @lid survives)
+ "…b4"   (actual:   younger phone-person survived, older @lid deleted)
```

## Supporting change — `mergePersons` ordering

The oldest-survivor direction surfaced a latent ordering bug: `persons.primary_phone` carries a unique index (`persons_phone_idx`), so coalescing the source's phone onto the target *while the source still held it* tripped a transient `23505` unique violation. `mergePersons` now moves FK references off the source and **deletes the source before** writing the coalesced fields onto the target, wrapped in its own (nested-safe) transaction so it is atomic whether invoked standalone (Step 2) or inside a group's transaction (Step 1).

`reconcile()` also gains an `{ apply }` option (defaulting to the process `--apply` flag) so tests can exercise the write path against a disposable database; `main()` behaves exactly as before.

## Tests & governance

- New tests live in the existing `reconcile-identity-fragmentation-postgres.test.ts` (no new `*-postgres.test.ts` file → pg-gate file-set unchanged), each provisioning its own disposable database so writes don't bleed across scenarios.
- The pre-existing **dry-run test still passes** (dry-run still mutates nothing).
- The changes add/remove no DB access sites or tables, so the db-access-guard / writer-coverage registries needed no edits; both governance suites stay green (`tenancy-db-access-guard.test.ts` + `tenancy-writer-coverage.test.ts`: 30 pass).
- `make typecheck` green; `biome check` clean on touched files.
- **Pre-push gate passed**: `make typecheck` + full `bun test packages apps/ui` → `5800 pass, 627 skip, 0 fail` (postgres suites skip without a cluster URL, as designed).

## Safety note

This PR **gates any `--apply` run.** Beyond these two, one thing to flag for a live apply: the script has no top-level transaction *across* groups — each group is now individually atomic, but an apply that dies between groups still leaves earlier groups committed. That's acceptable because each group is independently idempotent once atomic, but a real `--apply` should still be run against a backup with an approved plan (as the script header already warns).
