### PR TITLE
fix(api): enforce instance access on permalink and Slack routes (cross-instance leak)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/messages-permalink-authz.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-permalink-authz.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import type { AppVariables } from '../../../types';
+import { messagesRoutes } from '../messages';
+
+// Instance the API key is scoped to.
+const ALLOWED_INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+// Instance the API key must NOT be able to read — a different tenant's instance.
+const OTHER_INSTANCE_ID = '99999999-9999-4999-8999-999999999999';
+const CHANNEL_ID = 'C0000000000';
+const MESSAGE_EXTERNAL_ID = 'p1700000000.000100';
+const OMNI_CHAT_ID = '22222222-2222-4222-8222-222222222222';
+const LEAKED_PERMALINK = 'https://acme.slack.com/archives/C0000000000/p1700000000000100';
+
+/**
+ * Mount the messages routes with an API key scoped ONLY to ALLOWED_INSTANCE_ID.
+ * The channel plugin resolves a permalink for any instance — the route is
+ * responsible for refusing to call it for an instance the key cannot access.
+ */
+function mountMessagesRoutes(getPermalink: ReturnType<typeof mock>): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async (id: string) => ({ id, channel: 'slack' })),
+      },
+      chats: {
+        // Chat exists for the (other) instance.
+        getByExternalId: mock(async (_instanceId: string, _channelId: string) => ({
+          id: OMNI_CHAT_ID,
+          externalId: CHANNEL_ID,
+        })),
+      },
+      messages: {
+        // No cached permalink → route proceeds to the plugin.
+        getByExternalId: mock(async () => null),
+        setPermalink: mock(async () => {}),
+      },
+    } as never);
+    c.set('channelRegistry', {
+      get: mock(() => ({ getPermalink })),
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: [ALLOWED_INSTANCE_ID],
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/messages', messagesRoutes);
+  return app;
+}
+
+describe('GET /messages/:id/permalink cross-instance authorization', () => {
+  test('rejects reading a permalink for an instance the API key cannot access', async () => {
+    const getPermalink = mock(async () => LEAKED_PERMALINK);
+    const app = mountMessagesRoutes(getPermalink);
+
+    const res = await app.request(
+      `/messages/${MESSAGE_EXTERNAL_ID}/permalink?instanceId=${OTHER_INSTANCE_ID}&channelId=${CHANNEL_ID}`,
+    );
+
+    // The key is scoped to ALLOWED_INSTANCE_ID, so a permalink for
+    // OTHER_INSTANCE_ID must be refused before the plugin is ever consulted.
+    expect(res.status).toBe(403);
+    expect(getPermalink).not.toHaveBeenCalled();
+  });
+
+  test('allows reading a permalink for an instance the API key can access', async () => {
+    const getPermalink = mock(async () => LEAKED_PERMALINK);
+    const app = mountMessagesRoutes(getPermalink);
+
+    const res = await app.request(
+      `/messages/${MESSAGE_EXTERNAL_ID}/permalink?instanceId=${ALLOWED_INSTANCE_ID}&channelId=${CHANNEL_ID}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(getPermalink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/slack-authz.test.ts
+++ b/packages/api/src/routes/v2/__tests__/slack-authz.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import type { AppVariables } from '../../../types';
+import { slackRoutes } from '../slack';
+
+// Instance the API key is scoped to.
+const ALLOWED_INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+// A different tenant's Slack instance the key must NOT reach.
+const OTHER_INSTANCE_ID = '99999999-9999-4999-8999-999999999999';
+
+/**
+ * Mount the Slack routes with an API key scoped ONLY to ALLOWED_INSTANCE_ID.
+ * Both plugin methods succeed for any instance — the routes are responsible
+ * for refusing an instance the key cannot access.
+ */
+function mountSlackRoutes(plugin: Record<string, unknown>): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async (id: string) => ({ id, channel: 'slack' })),
+      },
+    } as never);
+    c.set('channelRegistry', {
+      get: mock(() => plugin),
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: [ALLOWED_INSTANCE_ID],
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/slack', slackRoutes);
+  return app;
+}
+
+describe('Slack routes cross-instance authorization', () => {
+  test('GET /slack/search rejects an instance the API key cannot access', async () => {
+    const searchMessages = mock(async () => [{ text: 'secret cross-tenant message' }]);
+    const app = mountSlackRoutes({ searchMessages });
+
+    const res = await app.request(`/slack/search?instanceId=${OTHER_INSTANCE_ID}&query=secret`);
+
+    expect(res.status).toBe(403);
+    expect(searchMessages).not.toHaveBeenCalled();
+  });
+
+  test('POST /slack/dm/open rejects an instance the API key cannot access', async () => {
+    const openDirectMessage = mock(async () => 'D0000000000');
+    const app = mountSlackRoutes({ openDirectMessage });
+
+    const res = await app.request('/slack/dm/open', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: OTHER_INSTANCE_ID, userId: 'U0000000000' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(openDirectMessage).not.toHaveBeenCalled();
+  });
+
+  test('GET /slack/search allows an instance the API key can access', async () => {
+    const searchMessages = mock(async () => [{ text: 'ok' }]);
+    const app = mountSlackRoutes({ searchMessages });
+
+    const res = await app.request(`/slack/search?instanceId=${ALLOWED_INSTANCE_ID}&query=hello`);
+
+    expect(res.status).toBe(200);
+    expect(searchMessages).toHaveBeenCalledTimes(1);
+  });
+
+  test('POST /slack/dm/open allows an instance the API key can access', async () => {
+    const openDirectMessage = mock(async () => 'D0000000000');
+    const app = mountSlackRoutes({ openDirectMessage });
+
+    const res = await app.request('/slack/dm/open', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instanceId: ALLOWED_INSTANCE_ID, userId: 'U0000000000' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(openDirectMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -266,6 +266,7 @@ const permalinkQuerySchema = z.object({
 messagesRoutes.get('/:id/permalink', zValidator('query', permalinkQuerySchema), async (c) => {
   const messageId = c.req.param('id');
   const { instanceId, channelId } = c.req.valid('query');
+  checkInstanceAccess(c.get('apiKey'), instanceId);
   const services = c.get('services');
 
   const chat = await services.chats.getByExternalId(instanceId, channelId);

--- a/packages/api/src/routes/v2/slack.ts
+++ b/packages/api/src/routes/v2/slack.ts
@@ -15,7 +15,8 @@ import type { ChannelType } from '@omni/core';
 import { ERROR_CODES, OmniError } from '@omni/core';
 import { Hono } from 'hono';
 import { z } from 'zod';
-import type { AppVariables } from '../../types';
+import { ApiKeyService } from '../../services/api-keys';
+import type { ApiKeyData, AppVariables } from '../../types';
 
 export const slackRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -40,11 +41,28 @@ interface SlackCapablePlugin {
   ) => Promise<unknown[]>;
 }
 
+/**
+ * Check if an API key has access to a specific instance.
+ * Throws FORBIDDEN error if access is denied.
+ */
+function checkInstanceAccess(apiKey: ApiKeyData | undefined, instanceId: string): void {
+  if (apiKey && !ApiKeyService.instanceAllowed(apiKey.instanceIds, instanceId)) {
+    throw new OmniError({
+      code: ERROR_CODES.FORBIDDEN,
+      message: 'API key does not have access to this instance',
+      context: { instanceId },
+      recoverable: false,
+    });
+  }
+}
+
 /** Resolve the Slack plugin, refusing early when the instance is not Slack. */
 async function getSlackPlugin(
-  c: { get: (k: 'services' | 'channelRegistry') => unknown },
+  c: { get: (k: 'services' | 'channelRegistry' | 'apiKey') => unknown },
   instanceId: string,
 ): Promise<SlackCapablePlugin> {
+  checkInstanceAccess(c.get('apiKey') as ApiKeyData | undefined, instanceId);
+
   const services = c.get('services') as { instances: { getById: (id: string) => Promise<{ channel: string }> } };
   const registry = c.get('channelRegistry') as { get: (ch: ChannelType) => unknown } | null | undefined;
 


### PR DESCRIPTION
Test-first fixes for two VERIFIED cross-instance authorization leaks (a scoped API key could read data from instances outside its scope). Both reproduced with a failing test first, then fixed.

## Bugs
- **#2 — permalink handler (`routes/v2/messages.ts`)** resolved the message and called `plugin.getPermalink(instanceId,…)` **without** `checkInstanceAccess`, unlike ~24 sibling handlers. A key scoped to instance A could read instance B's messages/permalinks.
- **#3 — Slack routes (`routes/v2/slack.ts`, `/dm/open` + `/search`)** neither called `checkInstanceAccess`; `/search` returned message content cross-instance.

## Test-first
Added tests: a key scoped to instance A requesting instance B's permalink / Slack search is **rejected (403)** — RED before the fix (the leak returned data), GREEN after adding `checkInstanceAccess` to both.

Scope: authz enforcement only. Verified: `packages/api` tests 1994 pass / 0 fail; pre-push gate green.