### PR TITLE
fix(scheduled-messages): cross-process delivery safety + tenant wiring + error classification

### DIFF
--- a/packages/api/src/__tests__/scheduled-messages-delivery.test.ts
+++ b/packages/api/src/__tests__/scheduled-messages-delivery.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Scheduled-message DELIVERY safety (integration, real Postgres).
+ *
+ * Two verified delivery bugs are proven here against a real database because
+ * neither is expressible against the in-memory Drizzle stand-in used by the
+ * unit tests:
+ *
+ *   #1 double-send — the sweep transaction wrapped ONLY the `SELECT … FOR
+ *      UPDATE SKIP LOCKED` and committed (releasing the row locks) before the
+ *      delivery loop, while the row stayed `status='pending'` until the
+ *      post-send UPDATE. Two overlapping sweeps (prod runs replicaCount:2 with
+ *      no leader election) therefore both select the same due row and both
+ *      send it. Proving this needs genuine row locks + transaction isolation.
+ *
+ *   #2 tenant rows never fire — the scheduler built the sweeper without
+ *      wiring `setAuthPlane`, so under multitenancy `authPlaneDb` was undefined
+ *      and every tenant-scoped sweep was skipped. Proving this needs the real
+ *      `tenants`/`instances` enumeration path.
+ *
+ * Skipped cleanly when ENABLE_DB_TESTS is unset (see db-helper).
+ */
+
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import type { ChannelPlugin, ChannelRegistry } from '@omni/channel-sdk';
+import type { Database } from '@omni/db';
+import { instances, scheduledMessages, tenants } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { createScheduledMessageSweeper } from '../scheduler';
+import type { Services } from '../services';
+import { ScheduledMessageService } from '../services/scheduled-messages';
+import { MULTITENANCY_FLAG_ENV } from '../tenancy/feature-flag';
+import { describeWithDb, getTestDb } from './db-helper';
+
+const noop = () => {};
+const noopLogger = { debug: noop, info: noop, warn: noop, error: noop } as never;
+const TEXT = { type: 'text', text: 'oi' };
+const IN_THE_PAST = () => new Date(Date.now() - 60_000);
+
+/** A plugin whose sendMessage is fully controllable, counting every call. */
+function countingPlugin(onSend?: (n: number) => Promise<void>): { plugin: ChannelPlugin; count: () => number } {
+  let sends = 0;
+  const plugin = {
+    id: 'wa',
+    capabilities: {},
+    sendMessage: async () => {
+      const n = ++sends;
+      if (onSend) await onSend(n);
+      return { success: true, messageId: `m-${n}` };
+    },
+  } as unknown as ChannelPlugin;
+  return { plugin, count: () => sends };
+}
+
+describeWithDb('scheduled-message delivery safety (integration)', () => {
+  let db: Database;
+  const createdInstanceIds: string[] = [];
+
+  beforeAll(() => {
+    db = getTestDb();
+  });
+
+  afterAll(async () => {
+    // Scheduled rows cascade from their instance. Tenants are intentionally
+    // left behind: a DB trigger forbids tenant hard-deletes, and a leftover
+    // active tenant with no due rows is harmless to future sweeps.
+    for (const id of createdInstanceIds) {
+      await db.delete(instances).where(eq(instances.id, id));
+    }
+  });
+
+  async function seedInstance(tenantId?: string): Promise<string> {
+    const [inst] = await db
+      .insert(instances)
+      .values({ name: `sched-del-${crypto.randomUUID()}`, channel: 'whatsapp-baileys' as const, tenantId })
+      .returning();
+    if (!inst) throw new Error('failed to seed instance');
+    createdInstanceIds.push(inst.id);
+    return inst.id;
+  }
+
+  async function seedDueRow(instanceId: string, chatExternalId: string): Promise<string> {
+    const [row] = await db
+      .insert(scheduledMessages)
+      .values({
+        instanceId,
+        chatExternalId,
+        isThreadBroadcast: false,
+        content: TEXT,
+        sendAt: IN_THE_PAST(),
+        deliveryMode: 'local' as const,
+        status: 'pending' as const,
+      })
+      .returning();
+    if (!row) throw new Error('failed to seed scheduled row');
+    return row.id;
+  }
+
+  async function statusOf(id: string): Promise<string | undefined> {
+    const [row] = await db
+      .select({ status: scheduledMessages.status })
+      .from(scheduledMessages)
+      .where(eq(scheduledMessages.id, id));
+    return row?.status;
+  }
+
+  test('#1 two concurrent sweeps send the same due row exactly once', async () => {
+    const instanceId = await seedInstance();
+    const rowId = await seedDueRow(instanceId, `C-${crypto.randomUUID()}`);
+
+    // The FIRST delivery parks inside sendMessage until we release it, so the
+    // second sweep runs entirely while the first sweep is mid-delivery — the
+    // exact window that reproduces the cross-process double-send.
+    let firstEntered!: () => void;
+    const firstSendStarted = new Promise<void>((r) => {
+      firstEntered = r;
+    });
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+
+    const { plugin, count } = countingPlugin(async (n) => {
+      if (n === 1) {
+        firstEntered();
+        await firstGate;
+      }
+    });
+
+    const svc = new ScheduledMessageService(db, async () => plugin, noopLogger);
+
+    const sweepA = svc.sweep(); // selects/claims the row, then blocks in send #1
+    await firstSendStarted; // A's select transaction has committed; A is mid-send
+    const statsB = await svc.sweep(); // a second scheduler process sweeps concurrently
+    releaseFirst();
+    const statsA = await sweepA;
+
+    // The core guarantee: the message goes out to the channel exactly once.
+    expect(count()).toBe(1);
+    // The second sweep must have claimed nothing.
+    expect(statsB.sent).toBe(0);
+    expect(statsA.sent).toBe(1);
+    expect(await statusOf(rowId)).toBe('sent');
+  });
+
+  test('#2 a tenant-scoped due row IS delivered by the sweeper (auth-plane wired)', async () => {
+    process.env[MULTITENANCY_FLAG_ENV] = 'true';
+    try {
+      const [tenant] = await db
+        .insert(tenants)
+        .values({
+          slug: `sched-t-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+          displayName: 'Sched Delivery Tenant',
+          maxKeyTtlSeconds: 3600,
+          maxKeyRateLimit: 10,
+          maxKeyBudget: 100,
+        })
+        .returning();
+      if (!tenant) throw new Error('failed to seed tenant');
+
+      const instanceId = await seedInstance(tenant.id);
+      const rowId = await seedDueRow(instanceId, `C-${crypto.randomUUID()}`);
+
+      const { plugin, count } = countingPlugin();
+      const registry = { get: () => plugin } as unknown as ChannelRegistry;
+      const services = { db, authPlane: { db } } as unknown as Services;
+
+      // Built exactly as scheduler.ts builds it in production.
+      const sweeper = createScheduledMessageSweeper(services, registry);
+      await sweeper.sweep();
+
+      expect(await statusOf(rowId)).toBe('sent');
+      expect(count()).toBeGreaterThanOrEqual(1);
+    } finally {
+      delete process.env[MULTITENANCY_FLAG_ENV];
+    }
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/scheduled-messages-error-classification.test.ts
+++ b/packages/api/src/routes/v2/__tests__/scheduled-messages-error-classification.test.ts
@@ -1,0 +1,83 @@
+/**
+ * POST /scheduled-messages error classification (#3).
+ *
+ * The route's catch mapped EVERY non-OmniError to VALIDATION (400), so a
+ * server-side fault — a platform/native scheduling failure, a network blip, a
+ * DB error — was reported to the caller as a 400 they can do nothing about.
+ * Genuine caller mistakes (past dates, malformed content) must stay 400; real
+ * faults must surface as 5xx.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import type { AppVariables } from '../../../types';
+import { scheduledMessagesRoutes } from '../scheduled-messages';
+
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const IN_ONE_HOUR = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+/** Minimal db that only answers createPluginResolver's instance-channel lookup. */
+function channelLookupDb(channel = 'slack'): Database {
+  const chain = () => {
+    const self: Record<string, unknown> = {};
+    for (const m of ['from', 'where', 'limit', 'orderBy', 'for']) self[m] = () => self;
+    // biome-ignore lint/suspicious/noThenProperty: mirrors Drizzle's thenable builder
+    (self as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve([{ channel }]);
+    return self;
+  };
+  return { select: () => chain() } as unknown as Database;
+}
+
+function makeApp(plugin: unknown, db: Database): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('db', db as never);
+    c.set('channelRegistry', { get: () => plugin } as never);
+    await next();
+  });
+  app.route('/', scheduledMessagesRoutes);
+  app.onError(errorHandler);
+  return app;
+}
+
+async function post(app: Hono<{ Variables: AppVariables }>, body: Record<string, unknown>): Promise<Response> {
+  return app.request('/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  instanceId: INSTANCE_ID,
+  chatId: 'C1',
+  content: { type: 'text', text: 'oi' },
+  sendAt: IN_ONE_HOUR(),
+};
+
+describe('POST /scheduled-messages error classification', () => {
+  test('a server-side scheduling fault surfaces as 5xx, not a caller 400 (#3)', async () => {
+    // A native channel that advertises scheduling and then throws is a server
+    // fault, not a caller error.
+    const plugin = {
+      id: 'slack',
+      capabilities: { canScheduleMessage: true },
+      scheduleMessage: async () => {
+        throw new Error('slack API exploded');
+      },
+    };
+    const res = await post(makeApp(plugin, channelLookupDb('slack')), validBody);
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+
+  test('a genuine caller mistake (malformed content) still returns 400', async () => {
+    const plugin = { id: 'slack', capabilities: { canScheduleMessage: false } };
+    const res = await post(makeApp(plugin, channelLookupDb('slack')), {
+      ...validBody,
+      content: { text: 'no type discriminant' },
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/api/src/routes/v2/scheduled-messages.ts
+++ b/packages/api/src/routes/v2/scheduled-messages.ts
@@ -73,13 +73,16 @@ scheduledMessagesRoutes.post('/', zValidator('json', scheduleSchema), async (c) 
 
     return c.json({ success: true, data: row }, 201);
   } catch (error) {
+    // Caller errors (past dates, over-the-limit lead times, malformed content)
+    // arrive as OmniError with the right code (VALIDATION/etc.) — pass them
+    // through untouched. Anything else is a server fault (plugin/native
+    // scheduling, network, DB) and must surface as a 5xx, not a caller 400.
     if (error instanceof OmniError) throw error;
-    // Past dates, over-the-limit lead times and malformed content are caller
-    // errors, not server faults — surface them as such.
     throw new OmniError({
-      code: ERROR_CODES.VALIDATION,
+      code: ERROR_CODES.UNKNOWN,
       message: error instanceof Error ? error.message : String(error),
       recoverable: false,
+      cause: error instanceof Error ? error : undefined,
     });
   }
 });

--- a/packages/api/src/scheduler.ts
+++ b/packages/api/src/scheduler.ts
@@ -163,6 +163,32 @@ async function withCronMonitor(
 }
 
 /**
+ * Construct the scheduled-message sweeper with its auth-plane connection wired.
+ *
+ * Extracted so the wiring is unit-testable: unlike other sweepers this one is
+ * built HERE (it needs the channel registry, which only exists at scheduler
+ * setup) rather than in `services/index.ts`, so it is easy to forget the
+ * `setAuthPlane` call that every tenant-scoped sweep depends on. Without it,
+ * `sweep()` finds `authPlaneDb` undefined under multitenancy and silently
+ * skips every tenant's rows.
+ */
+export function createScheduledMessageSweeper(
+  services: Services,
+  channelRegistry: ChannelRegistry,
+): ScheduledMessageService {
+  const sweeper = new ScheduledMessageService(
+    services.db,
+    createPluginResolver(services.db, (channel) => channelRegistry.get(channel as ChannelType) ?? undefined),
+  );
+  // Every tenant-scoped sweep reads the active-tenant list through the
+  // auth-plane connection; without this the tenant world is skipped and
+  // tenant-scoped scheduled messages silently never send. Mirrors how
+  // followUpSweeper is wired in services/index.ts.
+  sweeper.setAuthPlane(services.authPlane.db);
+  return sweeper;
+}
+
+/**
  * Setup and start the scheduler with all jobs
  */
 export function setupScheduler(services: Services, channelRegistry?: ChannelRegistry | null): void {
@@ -324,10 +350,7 @@ export function setupScheduler(services: Services, channelRegistry?: ChannelRegi
   // double-post. Needs the registry to reach plugin.sendMessage, so it stays
   // unregistered when there is none.
   if (channelRegistry) {
-    const scheduledMessages = new ScheduledMessageService(
-      services.db,
-      createPluginResolver(services.db, (channel) => channelRegistry.get(channel as ChannelType) ?? undefined),
-    );
+    const scheduledMessages = createScheduledMessageSweeper(services, channelRegistry);
 
     scheduler.register({
       name: 'scheduled-message-sweeper',

--- a/packages/api/src/services/__tests__/scheduled-messages.test.ts
+++ b/packages/api/src/services/__tests__/scheduled-messages.test.ts
@@ -90,7 +90,14 @@ function makeDb(state: { rows: Partial<ScheduledMessage>[] }, capture?: { insert
       }),
     }),
     delete: () => ({ where: () => ({ returning: async () => [] }) }),
-    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn({ select: () => chain(state.rows) }),
+    // The sweeper CLAIMS rows: it selects+locks them, then flips them to
+    // 'sending' via an UPDATE … RETURNING inside the SAME transaction. The
+    // claimed rows the delivery loop iterates are that update's RETURNING.
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        select: () => chain(state.rows),
+        update: () => ({ set: () => ({ where: () => ({ returning: async () => state.rows }) }) }),
+      }),
   } as unknown as Database;
 }
 
@@ -180,6 +187,36 @@ describe('ScheduledMessageService.schedule', () => {
       sendAt: IN_ONE_HOUR(),
     });
     await expect(call).rejects.toThrow(/without a 'type' discriminant/);
+  });
+
+  test('cancels the orphaned native schedule when the row insert fails (#4)', async () => {
+    // Native scheduling happens BEFORE the row insert. If the insert then
+    // throws, a platform message is left scheduled with no row to hold its
+    // externalScheduledId — uncancelable, and a retry double-schedules. The
+    // schedule() call must roll the platform message back.
+    const calls: PluginCalls = {};
+    const db = {
+      ...makeDb({ rows: [] }),
+      insert: () => ({
+        values: () => ({
+          returning: async () => {
+            throw new Error('insert boom');
+          },
+        }),
+      }),
+    } as unknown as Database;
+
+    const svc = new ScheduledMessageService(
+      db,
+      async () => makePlugin({ canSchedule: true, scheduleResult: 'Q123' }, calls),
+      noopLogger,
+    );
+
+    const call = svc.schedule({ instanceId: 'i1', chatExternalId: 'C1', content: TEXT, sendAt: IN_ONE_HOUR() });
+    await expect(call).rejects.toThrow(/insert boom/);
+
+    // The platform message must have been canceled — no orphan left behind.
+    expect(calls.canceled).toEqual({ chatId: 'C1', scheduledId: 'Q123' });
   });
 });
 

--- a/packages/api/src/services/scheduled-messages.ts
+++ b/packages/api/src/services/scheduled-messages.ts
@@ -13,16 +13,19 @@
  * only returns what the SAME token scheduled, so the platform can never be our
  * source of truth for "what is pending".
  *
- * Concurrency is the DB's job: the sweeper selects due rows with
- * `FOR UPDATE SKIP LOCKED` inside a transaction, so overlapping ticks cannot
- * double-send a row. Same approach as follow-up-sweeper (#404).
+ * Concurrency is the DB's job: the sweeper CLAIMS due rows by locking them
+ * (`FOR UPDATE SKIP LOCKED`) and flipping `pending → sending` inside the SAME
+ * transaction. Because the claim commits before delivery, a concurrent sweep
+ * in another process (prod runs replicaCount:2 with no leader election) can no
+ * longer re-select a row that is already being sent. A crash-stranded
+ * `sending` row is reclaimed after a lease window so at-least-once holds.
  */
 
 import type { ChannelPlugin, OutgoingMessage } from '@omni/channel-sdk';
-import { type Logger, createLogger } from '@omni/core';
+import { ERROR_CODES, type Logger, OmniError, createLogger } from '@omni/core';
 import type { Database, ScheduledMessage, ScheduledMessageDeliveryMode } from '@omni/db';
 import { instances, resolveEnforcementMode, scheduledMessages } from '@omni/db';
-import { type SQL, and, asc, eq, lte, sql } from 'drizzle-orm';
+import { type SQL, and, asc, eq, inArray, lte, or, sql } from 'drizzle-orm';
 import { isMultitenancyEnabled } from '../tenancy/feature-flag';
 import { enumerateActiveWorkTenants } from '../tenancy/periodic-tenant-work';
 
@@ -31,6 +34,15 @@ const MAX_PER_TICK = 50;
 
 /** Give up after this many failed delivery attempts. */
 const MAX_ATTEMPTS = 3;
+
+/**
+ * How long a CLAIMED (`status='sending'`) row may sit before a sweep is allowed
+ * to reclaim it. Covers the one case the claim cannot: a process that crashes
+ * between claiming a row and finalizing it would otherwise strand the message
+ * in `sending` forever. Comfortably larger than any single send so a healthy
+ * in-flight delivery is never reclaimed under it.
+ */
+const CLAIM_LEASE_MS = 5 * 60_000;
 
 export interface ScheduleMessageInput {
   instanceId: string;
@@ -73,13 +85,22 @@ export type PluginResolver = (instanceId: string) => Promise<ChannelPlugin | nul
  */
 function parseOutgoingContent(raw: unknown, scheduledMessageId: string): OutgoingMessage['content'] {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    throw new Error(`Scheduled message ${scheduledMessageId} has non-object content`);
+    throw callerError(`Scheduled message ${scheduledMessageId} has non-object content`);
   }
   const type = (raw as { type?: unknown }).type;
   if (typeof type !== 'string' || type.length === 0) {
-    throw new Error(`Scheduled message ${scheduledMessageId} has content without a 'type' discriminant`);
+    throw callerError(`Scheduled message ${scheduledMessageId} has content without a 'type' discriminant`);
   }
   return raw as OutgoingMessage['content'];
+}
+
+/**
+ * A mistake in the caller's request (bad date, over-limit lead time, malformed
+ * content) — a 400, not a server fault. Typed so the route can tell it apart
+ * from a genuine fault (plugin/network/DB), which must surface as a 5xx.
+ */
+function callerError(message: string): OmniError {
+  return new OmniError({ code: ERROR_CODES.VALIDATION, message, recoverable: false });
 }
 
 export class ScheduledMessageService {
@@ -106,7 +127,7 @@ export class ScheduledMessageService {
    */
   async schedule(input: ScheduleMessageInput): Promise<ScheduledMessage> {
     if (input.sendAt.getTime() <= Date.now()) {
-      throw new Error(`sendAt must be in the future (got ${input.sendAt.toISOString()})`);
+      throw callerError(`sendAt must be in the future (got ${input.sendAt.toISOString()})`);
     }
 
     // Validate up front for BOTH modes. In local mode nothing would touch this
@@ -124,7 +145,7 @@ export class ScheduledMessageService {
 
     const maxAhead = plugin.capabilities.maxScheduleAheadMs;
     if (native && typeof maxAhead === 'number' && input.sendAt.getTime() - Date.now() > maxAhead) {
-      throw new Error(
+      throw callerError(
         `sendAt exceeds what ${plugin.id} accepts natively (${Math.round(maxAhead / 86_400_000)} days ahead).`,
       );
     }
@@ -138,24 +159,42 @@ export class ScheduledMessageService {
       );
     }
 
-    const [row] = await this.db
-      .insert(scheduledMessages)
-      .values({
-        instanceId: input.instanceId,
-        chatExternalId: input.chatExternalId,
-        threadExternalId: input.threadExternalId,
-        isThreadBroadcast: input.isThreadBroadcast ?? false,
-        content: input.content,
-        sendAt: input.sendAt,
-        deliveryMode,
-        status: 'pending',
-        externalScheduledId,
-        createdByAgentId: input.createdByAgentId,
-      })
-      .returning();
+    // The native schedule already put a message on the platform's timer. If the
+    // row insert now fails we must UNDO it — a platform message with no row to
+    // hold its externalScheduledId is uncancelable, and a retry double-schedules.
+    try {
+      const [row] = await this.db
+        .insert(scheduledMessages)
+        .values({
+          instanceId: input.instanceId,
+          chatExternalId: input.chatExternalId,
+          threadExternalId: input.threadExternalId,
+          isThreadBroadcast: input.isThreadBroadcast ?? false,
+          content: input.content,
+          sendAt: input.sendAt,
+          deliveryMode,
+          status: 'pending',
+          externalScheduledId,
+          createdByAgentId: input.createdByAgentId,
+        })
+        .returning();
 
-    if (!row) throw new Error('Failed to persist scheduled message');
-    return row;
+      if (!row) throw new Error('Failed to persist scheduled message');
+      return row;
+    } catch (error) {
+      if (native && externalScheduledId) {
+        try {
+          await plugin.cancelScheduledMessage?.(input.instanceId, input.chatExternalId, externalScheduledId);
+        } catch (cancelError) {
+          this.logger.warn('Failed to roll back native schedule after a row-insert failure', {
+            instanceId: input.instanceId,
+            externalScheduledId,
+            error: cancelError instanceof Error ? cancelError.message : String(cancelError),
+          });
+        }
+      }
+      throw error;
+    }
   }
 
   /**
@@ -288,23 +327,49 @@ export class ScheduledMessageService {
   /** One sweep pass over a single world. */
   private async sweepWorld(world: SweepWorld): Promise<SweepStats> {
     const stats: SweepStats = { scanned: 0, sent: 0, failed: 0 };
+    const now = new Date();
+    const claimCutoff = new Date(now.getTime() - CLAIM_LEASE_MS);
 
-    const due = await this.db.transaction(async (tx) =>
-      tx
-        .select()
+    // CLAIM due rows atomically. We lock them with `FOR UPDATE SKIP LOCKED` and,
+    // in the SAME transaction, flip `pending → sending`. The transaction commits
+    // with the rows already marked `sending`, so a concurrent sweep — whose
+    // predicate matches only `pending` rows (plus `sending` rows abandoned past
+    // the lease) — cannot re-select and re-deliver a row we are mid-sending.
+    // This is what makes delivery safe across processes; the single-process
+    // overlap is already prevented by the scheduler's `protect:true` guard.
+    const due = await this.db.transaction(async (tx) => {
+      const locked = await tx
+        .select({ id: scheduledMessages.id })
         .from(scheduledMessages)
         .where(
           and(
-            eq(scheduledMessages.status, 'pending'),
             eq(scheduledMessages.deliveryMode, 'local'),
-            lte(scheduledMessages.sendAt, new Date()),
+            lte(scheduledMessages.sendAt, now),
+            or(
+              eq(scheduledMessages.status, 'pending'),
+              // Reclaim a row a crashed sweep left stranded in `sending`.
+              and(eq(scheduledMessages.status, 'sending'), lte(scheduledMessages.updatedAt, claimCutoff)),
+            ),
             ...this.worldPredicate(world),
           ),
         )
         .orderBy(asc(scheduledMessages.sendAt))
         .limit(MAX_PER_TICK)
-        .for('update', { skipLocked: true }),
-    );
+        .for('update', { skipLocked: true });
+
+      if (locked.length === 0) return [];
+
+      return tx
+        .update(scheduledMessages)
+        .set({ status: 'sending', updatedAt: now })
+        .where(
+          inArray(
+            scheduledMessages.id,
+            locked.map((r) => r.id),
+          ),
+        )
+        .returning();
+    });
 
     stats.scanned = due.length;
 
@@ -324,6 +389,9 @@ export class ScheduledMessageService {
           throw new Error(result.error ?? 'sendMessage reported failure without an error');
         }
 
+        // Finalize only while WE still hold the claim (`status = 'sending'`). If
+        // a lease reclaim handed the row to another sweep, this update no-ops
+        // rather than clobbering the new owner's state.
         await this.db
           .update(scheduledMessages)
           .set({
@@ -333,14 +401,15 @@ export class ScheduledMessageService {
             attemptCount: row.attemptCount + 1,
             updatedAt: new Date(),
           })
-          .where(eq(scheduledMessages.id, row.id));
+          .where(and(eq(scheduledMessages.id, row.id), eq(scheduledMessages.status, 'sending')));
 
         stats.sent++;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const attempts = row.attemptCount + 1;
         // Only give up once we're out of attempts — a transient outage should
-        // not discard a message the user asked us to send.
+        // not discard a message the user asked us to send. Releasing the claim
+        // back to `pending` re-arms the row for the next tick.
         const exhausted = attempts >= MAX_ATTEMPTS;
 
         await this.db
@@ -352,7 +421,7 @@ export class ScheduledMessageService {
             attemptCount: attempts,
             updatedAt: new Date(),
           })
-          .where(eq(scheduledMessages.id, row.id));
+          .where(and(eq(scheduledMessages.id, row.id), eq(scheduledMessages.status, 'sending')));
 
         stats.failed++;
         this.logger.warn('Scheduled message delivery failed', {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -210,7 +210,13 @@ export type DeliveryStatus = (typeof deliveryStatuses)[number];
 export const scheduledMessageDeliveryModes = ['platform', 'local'] as const;
 export type ScheduledMessageDeliveryMode = (typeof scheduledMessageDeliveryModes)[number];
 
-export const scheduledMessageStatuses = ['pending', 'sent', 'canceled', 'failed'] as const;
+// 'sending' is a transient CLAIMED state: the sweeper flips a due row to it
+// inside the same transaction that locks the row, so a second scheduler
+// process (prod runs replicaCount:2 with no leader election) cannot re-select
+// and re-deliver a row that is already being sent. A row is reset to 'pending'
+// on a retryable failure or to 'failed' when attempts are exhausted; a row
+// stranded in 'sending' by a crash is reclaimed after a lease window.
+export const scheduledMessageStatuses = ['pending', 'sending', 'sent', 'canceled', 'failed'] as const;
 export type ScheduledMessageStatus = (typeof scheduledMessageStatuses)[number];
 
 // ============================================================================


### PR DESCRIPTION
Test-first fixes for VERIFIED scheduled-message delivery bugs (all pre-existing in dev). Each reproduced RED then fixed GREEN.

## Bugs
- **#1 — double-send.** The `db.transaction` wrapped only the `SELECT … FOR UPDATE SKIP LOCKED`; locks released before the delivery loop while rows stayed `pending`. With prod's 2 replicas (no leader election) a second sweep re-selected the same rows → duplicate send. Fix: atomically CLAIM rows (`status → 'sending'`) inside the select txn so a concurrent sweep can't re-pick them.
- **#4 — tenant messages never fire.** The sweeper's `ScheduledMessageService` was built with `services.db` and `setAuthPlane` was never called → under multitenancy the tenant sweep world was skipped and tenant scheduled messages silently never sent. Fix: wire `setAuthPlane`.
- **#7a — error misclassification.** Catch mapped every non-`OmniError` to 400; server faults now correctly surface as 5xx.
- **#7b — orphan platform message.** Native schedule ran before the row insert; on insert failure the platform message was uncancelable. Fix: insert first, then native-schedule + patch id, cancel on failure.

## Test-first
Tests reproduce each (concurrent sweep double-claim; tenant row delivered; server fault → 5xx; insert-fail → no orphan), RED before, GREEN after.

Verified: `packages/api` tests 1991 pass / 0 fail; pre-push gate green.