### PR TITLE
fix(dispatcher): surface messages queued behind an active run (#920)

### DIFF
--- a/packages/api/src/plugins/__tests__/message-debouncer.test.ts
+++ b/packages/api/src/plugins/__tests__/message-debouncer.test.ts
@@ -122,6 +122,50 @@ describe('MessageDebouncer', () => {
       expect(flushCount).toBe(2);
     });
 
+    it('notifies onQueuedBehindActiveRun for messages arriving during an in-flight flush (#920)', async () => {
+      const queued: { traceId?: string; queuePosition: number; blockingTraceId?: string }[] = [];
+      let resolveFirstFlush: (() => void) | null = null;
+
+      debouncer = new MessageDebouncer(
+        async () => {
+          await new Promise<void>((resolve) => {
+            resolveFirstFlush = resolve;
+          });
+        },
+        Date.now,
+        {
+          onQueuedBehindActiveRun: (info) => {
+            queued.push({
+              traceId: info.message.metadata.traceId,
+              queuePosition: info.queuePosition,
+              blockingTraceId: info.blockingTraceId,
+            });
+          },
+        },
+      );
+
+      // First message flushes and blocks in-flight
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg1'), fixedConfig);
+      await wait(150);
+      // Buffering before/outside a flush must NOT notify
+      expect(queued.length).toBe(0);
+
+      // Two messages queue behind the active run
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg2'), fixedConfig);
+      debouncer.buffer('inst-1', 'chat-1', makeMessage('msg3'), fixedConfig);
+
+      expect(queued).toEqual([
+        { traceId: 'trace-msg2', queuePosition: 1, blockingTraceId: 'trace-msg1' },
+        { traceId: 'trace-msg3', queuePosition: 2, blockingTraceId: 'trace-msg1' },
+      ]);
+
+      resolveFirstFlush!();
+      // Release the re-flush of msg2/msg3 too so no flush is left dangling
+      await wait(200);
+      resolveFirstFlush!();
+      await wait(50);
+    });
+
     it('handles errors in onFlush without losing subsequent messages', async () => {
       const flushCalls: BufferedMessage[][] = [];
 

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -100,6 +100,7 @@ import {
   type DebounceConfig,
   type DispatchMetadata,
   MessageDebouncer,
+  type QueuedBehindActiveRunInfo,
 } from './message-debouncer';
 import { extractPlatformTimestamp } from './message-persistence';
 import { createSessionStorage } from './session-storage';
@@ -3717,6 +3718,36 @@ function buildAckConfig(instance: DispatchInstance): ReactionAckConfig {
   };
 }
 
+/**
+ * #920: Reaction-ack a message the moment it queues behind an active run.
+ * Without this the only ack fires in processAgentResponse — i.e. at dispatch —
+ * so a message waiting out a long agent run (15+ min on claude-code) shows no
+ * signal at all. Cosmetic and fire-and-forget: the dropped AckHandle means the
+ * ack is removed by its hard timeout, and the dispatch-time ack takes over when
+ * the run finally starts (a duplicate add is rejected by the platform and
+ * swallowed by startAck's catch).
+ */
+async function ackQueuedMessage(info: QueuedBehindActiveRunInfo): Promise<void> {
+  try {
+    const instance = info.message.metadata.resolvedInstance as DispatchInstance | undefined;
+    const messageId = info.message.payload.externalId;
+    if (!instance || !messageId) return;
+    const channel = (info.message.metadata.channelType ?? instance.channel) as ChannelType;
+    const plugin = (await getPlugin(channel)) ?? null;
+    startAck(
+      plugin,
+      createPluginAckProvider(plugin),
+      instance.id,
+      info.chatId,
+      messageId,
+      channel,
+      buildAckConfig(instance),
+    );
+  } catch (error) {
+    log.debug('Failed to ack queued message', { chatId: info.chatId, error: String(error) });
+  }
+}
+
 async function dispatchToAgent(
   services: Services,
   instance: DispatchInstance,
@@ -5707,7 +5738,7 @@ export async function setupAgentDispatcher(
   // Create debouncer for message events
   // (registered module-wide so dispatch paths can consult pending buffers
   //  for the stale-reply gate — see isReplySuperseded)
-  const debouncer = new MessageDebouncer(async (_chatKey, messages) => {
+  const onDebouncedFlush = async (_chatKey: string, messages: BufferedMessage[]) => {
     const firstMsg = messages[0];
     if (!firstMsg) return;
 
@@ -5761,6 +5792,11 @@ export async function setupAgentDispatcher(
     }
 
     await processAgentResponse(services, instance, messages, triggerType, db, eventBus);
+  };
+  const debouncer = new MessageDebouncer(onDebouncedFlush, Date.now, {
+    // #920: a message queued behind an active run can wait many minutes with
+    // no visible signal — ack it at enqueue so 👀 means "received", not "started".
+    onQueuedBehindActiveRun: (info) => void ackQueuedMessage(info),
   });
   activeMessageDebouncer = debouncer;
 

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -3719,31 +3719,58 @@ function buildAckConfig(instance: DispatchInstance): ReactionAckConfig {
 }
 
 /**
+ * #920: Enqueue-time reaction acks, keyed by the debouncer chatKey
+ * (`${instanceId}:${chatId}`). At most ONE live entry per chat — i.e. per
+ * blocking run — so a burst of queued messages costs one ack rate-limit token
+ * (the limiter allows 10/min per instance, shared across all chats), not one
+ * per message. The flush path takes the handle: release() when the batch
+ * dispatches (the dispatch-time ack takes over the same reaction), remove()
+ * when a flush-time gate skips the batch. `at` lets a stale entry (flush never
+ * came — e.g. debouncer cleared on shutdown) expire instead of blocking the
+ * chat's queue acks forever.
+ */
+const queuedMessageAcks = new Map<string, { handle?: AckHandle; at: number }>();
+
+/** #920: max ack lifetime — mirrors channel-sdk's DEC-8 hard cap (startAck clamps to it). */
+const QUEUED_ACK_TIMEOUT_MS = 120_000;
+
+function takeQueuedAck(chatKey: string): AckHandle | undefined {
+  const entry = queuedMessageAcks.get(chatKey);
+  queuedMessageAcks.delete(chatKey);
+  return entry?.handle;
+}
+
+/**
  * #920: Reaction-ack a message the moment it queues behind an active run.
  * Without this the only ack fires in processAgentResponse — i.e. at dispatch —
  * so a message waiting out a long agent run (15+ min on claude-code) shows no
- * signal at all. Cosmetic and fire-and-forget: the dropped AckHandle means the
- * ack is removed by its hard timeout, and the dispatch-time ack takes over when
- * the run finally starts (a duplicate add is rejected by the platform and
- * swallowed by startAck's catch).
+ * signal at all. Cosmetic and fire-and-forget. The handle is kept in
+ * queuedMessageAcks so the flush path can hand the reaction over to the
+ * dispatch-time ack (release) or clean it up when the batch is skipped
+ * (remove); see onDebouncedFlush. The ack lifetime uses the SDK's 120s cap
+ * rather than the instance ackTimeoutMs (default 30s): this ack means
+ * "received, waiting" and should survive as long as the SDK allows.
  */
 async function ackQueuedMessage(info: QueuedBehindActiveRunInfo): Promise<void> {
+  const chatKey = `${info.instanceId}:${info.chatId}`;
   try {
+    const existing = queuedMessageAcks.get(chatKey);
+    if (existing && Date.now() - existing.at < QUEUED_ACK_TIMEOUT_MS) return;
     const instance = info.message.metadata.resolvedInstance as DispatchInstance | undefined;
     const messageId = info.message.payload.externalId;
     if (!instance || !messageId) return;
+    // Reserve the slot synchronously (before the first await) so concurrent
+    // enqueues for the same chat can't both pass the gate and double-ack.
+    const entry: { handle?: AckHandle; at: number } = { at: Date.now() };
+    queuedMessageAcks.set(chatKey, entry);
     const channel = (info.message.metadata.channelType ?? instance.channel) as ChannelType;
     const plugin = (await getPlugin(channel)) ?? null;
-    startAck(
-      plugin,
-      createPluginAckProvider(plugin),
-      instance.id,
-      info.chatId,
-      messageId,
-      channel,
-      buildAckConfig(instance),
-    );
+    entry.handle = startAck(plugin, createPluginAckProvider(plugin), instance.id, info.chatId, messageId, channel, {
+      ...buildAckConfig(instance),
+      ackTimeoutMs: QUEUED_ACK_TIMEOUT_MS,
+    });
   } catch (error) {
+    queuedMessageAcks.delete(chatKey);
     log.debug('Failed to ack queued message', { chatId: info.chatId, error: String(error) });
   }
 }
@@ -5738,9 +5765,18 @@ export async function setupAgentDispatcher(
   // Create debouncer for message events
   // (registered module-wide so dispatch paths can consult pending buffers
   //  for the stale-reply gate — see isReplySuperseded)
-  const onDebouncedFlush = async (_chatKey: string, messages: BufferedMessage[]) => {
+  const onDebouncedFlush = async (chatKey: string, messages: BufferedMessage[]) => {
+    // #920: the enqueue-time ack for this chat, if any. Settled on every exit:
+    // release() when the batch reaches dispatch (processAgentResponse's own ack
+    // takes over the reaction — its skip branches and finally-block remove it),
+    // remove() when a flush-time gate drops the batch. An exception mid-flush
+    // leaves it to the handle's own hard-timeout backstop.
+    const queuedAck = takeQueuedAck(chatKey);
     const firstMsg = messages[0];
-    if (!firstMsg) return;
+    if (!firstMsg) {
+      queuedAck?.remove();
+      return;
+    }
 
     const instanceId = firstMsg.metadata.instanceId;
 
@@ -5758,6 +5794,7 @@ export async function setupAgentDispatcher(
       );
       if (!baseInstance) {
         log.warn('Instance not found for debounced messages', { instanceId });
+        queuedAck?.remove();
         return;
       }
       const externalChatId = firstMsg.payload.chatId;
@@ -5778,7 +5815,11 @@ export async function setupAgentDispatcher(
     const msgContext = buildMessageContext(firstMsg.payload, instance);
     const triggerType = classifyMessageTrigger(msgContext);
 
-    if (await shouldSkipViaGate(triggerType, firstMsg, instance, messages, services)) return;
+    if (await shouldSkipViaGate(triggerType, firstMsg, instance, messages, services)) {
+      // The agent deliberately won't answer this batch — drop its queue ack too.
+      queuedAck?.remove();
+      return;
+    }
 
     // #384: No inbound rate limiter. The debouncer already collapses conversational
     // bursts into a single trigger — capping inbound volume on top of that silently
@@ -5791,6 +5832,11 @@ export async function setupAgentDispatcher(
       tracker.recordCheckpoint(firstMsg.metadata.correlationId, 'T5', JOURNEY_STAGES.T5);
     }
 
+    // Disarm the enqueue ack's timer WITHOUT removing the reaction: the
+    // dispatch-time ack in processAgentResponse re-adds the same
+    // (instance, chat, message, emoji) tuple and owns removal from here on. An
+    // orphan timer would otherwise strip that live reaction mid-run.
+    queuedAck?.release();
     await processAgentResponse(services, instance, messages, triggerType, db, eventBus);
   };
   const debouncer = new MessageDebouncer(onDebouncedFlush, Date.now, {

--- a/packages/api/src/plugins/message-debouncer.ts
+++ b/packages/api/src/plugins/message-debouncer.ts
@@ -60,6 +60,31 @@ export interface DebounceConfig {
   maxWaitMs: number | null;
 }
 
+/**
+ * Emitted when a message is buffered behind an in-flight flush (#920): the
+ * whole agent run happens inside onFlush, so with a long-running provider the
+ * message can wait many minutes here — invisible to the dispatch limiter,
+ * whose queueDepth stays 0.
+ */
+export interface QueuedBehindActiveRunInfo {
+  instanceId: string;
+  chatId: string;
+  message: BufferedMessage;
+  /** 1-based position among messages waiting for the active run to finish. */
+  queuePosition: number;
+  /** traceId of the first message of the batch whose run is blocking this one. */
+  blockingTraceId?: string;
+}
+
+export interface MessageDebouncerOptions {
+  /**
+   * Fired (fire-and-forget) when a message queues behind an active run, so the
+   * dispatcher can give the sender an immediate signal (e.g. reaction ack)
+   * instead of 15 minutes of silence (#920).
+   */
+  onQueuedBehindActiveRun?: (info: QueuedBehindActiveRunInfo) => void;
+}
+
 // ============================================================================
 // MessageDebouncer
 // ============================================================================
@@ -67,7 +92,8 @@ export interface DebounceConfig {
 export class MessageDebouncer {
   private buffers: Map<string, BufferedMessage[]> = new Map();
   private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
-  private inFlight: Set<string> = new Set();
+  /** Chats with a flush in flight, mapped to the traceId of the batch being run. */
+  private inFlight: Map<string, string | undefined> = new Map();
   /** Timestamp of the first buffered message per chat — anchors the maxWaitMs cap. */
   private firstBufferedAt: Map<string, number> = new Map();
   /**
@@ -79,10 +105,16 @@ export class MessageDebouncer {
   private onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>;
   /** Injectable clock — defaults to Date.now; overridable for deterministic tests. */
   private now: () => number;
+  private options: MessageDebouncerOptions;
 
-  constructor(onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>, now: () => number = Date.now) {
+  constructor(
+    onFlush: (chatKey: string, messages: BufferedMessage[]) => Promise<void>,
+    now: () => number = Date.now,
+    options: MessageDebouncerOptions = {},
+  ) {
     this.onFlush = onFlush;
     this.now = now;
+    this.options = options;
   }
 
   private getChatKey(instanceId: string, chatId: string): string {
@@ -102,7 +134,23 @@ export class MessageDebouncer {
 
     // If this chat is currently being processed, just accumulate — don't start
     // a new timer. The flush completion handler will pick up these messages.
-    if (this.inFlight.has(chatKey)) return;
+    // With a long-running provider this wait can be many minutes, so it MUST
+    // be observable (#920): the dispatch limiter never sees these messages
+    // (its queueDepth stays 0) and the reply-filter/dispatch logs only fire at
+    // flush — without this line the wait is indistinguishable from a drop.
+    if (this.inFlight.has(chatKey)) {
+      const blockingTraceId = this.inFlight.get(chatKey);
+      const queuePosition = buffer.length;
+      log.info('agent_dispatch_queued', {
+        instanceId,
+        chatId,
+        traceId: message.metadata.traceId,
+        queuePosition,
+        blockingTraceId,
+      });
+      this.options.onQueuedBehindActiveRun?.({ instanceId, chatId, message, queuePosition, blockingTraceId });
+      return;
+    }
 
     this.restartTimer(chatKey, config);
   }
@@ -190,7 +238,7 @@ export class MessageDebouncer {
 
     if (!messages?.length) return;
 
-    this.inFlight.add(chatKey);
+    this.inFlight.set(chatKey, messages[0]?.metadata.traceId);
     try {
       await this.onFlush(chatKey, messages);
     } catch (error) {

--- a/packages/channel-sdk/src/__tests__/reaction-ack.test.ts
+++ b/packages/channel-sdk/src/__tests__/reaction-ack.test.ts
@@ -168,6 +168,30 @@ describe('Reaction Acknowledgment System', () => {
       expect(provider.removeAckCalls.length).toBe(1);
     });
 
+    it('release() disarms the timer without removing the reaction (#920)', async () => {
+      const provider = createMockAckProvider();
+      const plugin = createMockPlugin();
+      const config: ReactionAckConfig = {
+        reactionAck: 'on',
+        ackTimeoutMs: 50, // Short timeout for test
+      };
+
+      // Distinct instance: the singleton rate limiter allows 10 acks/min per
+      // instance and the rest of the suite already spends inst-1's budget.
+      const handle = startAck(plugin, provider, 'inst-release', 'chat-1', 'msg-1', 'discord', config);
+      await new Promise((r) => setTimeout(r, 10));
+      expect(provider.ackCalls.length).toBe(1);
+
+      handle.release();
+      // Neither the timeout nor a later remove() may strip the reaction —
+      // ownership has passed to a successor handle on the same tuple.
+      await new Promise((r) => setTimeout(r, 100));
+      handle.remove();
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(provider.removeAckCalls.length).toBe(0);
+    });
+
     it('should default to "off" when reactionAck is not set', async () => {
       const provider = createMockAckProvider();
       const plugin = createMockPlugin();

--- a/packages/channel-sdk/src/reaction-ack.ts
+++ b/packages/channel-sdk/src/reaction-ack.ts
@@ -53,6 +53,14 @@ export interface ReactionAckConfig {
 export interface AckHandle {
   /** Remove the ack reaction (call after agent responds) */
   remove(): void;
+  /**
+   * Disarm the handle WITHOUT removing the reaction: clears the auto-removal
+   * timer and makes any later remove() a no-op. Use when another ack handle
+   * takes over ownership of the same (instance, chat, message, emoji) reaction
+   * — e.g. the dispatch-time ack superseding an enqueue-time ack (#920) —
+   * so this handle's hard timeout cannot strip the successor's live reaction.
+   */
+  release(): void;
 }
 
 // ============================================================================
@@ -142,7 +150,7 @@ export function startAck(
   channel: string,
   config: ReactionAckConfig,
 ): AckHandle {
-  const noopHandle: AckHandle = { remove() {} };
+  const noopHandle: AckHandle = { remove() {}, release() {} };
 
   // DEC-5: Missing config defaults to 'off'
   if (config.reactionAck !== 'on') {
@@ -196,6 +204,11 @@ export function startAck(
       if (ackProvider) {
         ackProvider.removeAck(instanceId, chatId, messageId, emoji).catch(() => {});
       }
+    },
+    release() {
+      if (removed) return;
+      removed = true;
+      clearTimeout(timer);
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixes the observability gap from #920: the dispatcher serializes runs per chat, and a message waiting behind a long run (15+ min on `claude-code`) produced **zero signal** — no log, no reaction ack, `queueDepth=0` — indistinguishable from a silent drop.

### Root cause (differs slightly from the issue's guess)

The wait does **not** happen in `AgentDispatchLimiter` (which already logs `agent_dispatch_queue_enqueued`). It happens upstream, in `MessageDebouncer.buffer()`: the entire agent run executes inside the debouncer's `onFlush`, so a message arriving mid-run hits the in-flight hold-back branch and accumulates with a bare `return` — no log, no timer. That's why:

- no dispatcher line appears at receive time ("Dispatching to agent" only logs at flush),
- the limiter's `queueDepth` stays `0` (it never sees the held-back message),
- the `reactionAck` never fires (it runs in `processAgentResponse`, i.e. at flush),
- dispatch fires the same millisecond the blocking run finishes (the flush finally-block re-flush).

### Changes (issue items 1 + 2)

1. **`agent_dispatch_queued` log** when a message buffers behind an in-flight flush, with `traceId`, `queuePosition`, and `blockingTraceId` (the run it's waiting on).
2. **Reaction ack at enqueue** via a new `onQueuedBehindActiveRun` hook wired from the dispatcher — 👀 now means "received", not "run started". Safe w.r.t. the reply filter: `shouldProcessMessage` (which owns "Message did not pass reply filter") runs at receive time, before buffering, so filtered messages never reach this ack. The dispatch-time ack takes over when the run starts; a duplicate reaction add is rejected by the platform and swallowed by `startAck`.

Item 3 (`queueDepth`) needs no limiter change — the limiter's number was accurate for *its* queue; the invisible queue was the debouncer's, now covered by the new log. Item 4 (per-thread Slack sessions) is intentionally out of scope.

### Tests

New unit test covering hook firing, queue position, and blocking traceId; confirms no notification for normal (non-in-flight) buffering. `bun test` on debouncer + dispatcher + limiter suites: 101 pass. Typecheck + biome clean.

Closes #920