### PR TITLE
fix(agent-replay): stop replaying turns answered via POST /api/v2/messages/send

### DIFF
--- a/packages/api/src/plugins/__tests__/message-persistence-sent.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-sent.test.ts
@@ -62,4 +62,41 @@ describe('message-persistence sent content mapping', () => {
       rawPayload: undefined,
     });
   });
+
+  test('systemNotice marks the stored rawPayload so replay skips it as an answer (#912)', () => {
+    const payload: MessageSentPayload = {
+      externalId: 'ACK-ID-1',
+      chatId: '5511999999999@s.whatsapp.net',
+      to: '5511999999999@s.whatsapp.net',
+      content: { type: 'text', text: 'Um momento, já te respondo!' },
+      systemNotice: true,
+    };
+
+    expect(buildSentMessageContentFields(payload).rawPayload).toEqual({ omniSystemNotice: true });
+  });
+
+  test('systemNotice merges into an existing rawPayload without dropping keys', () => {
+    const payload: MessageSentPayload = {
+      externalId: 'ACK-ID-2',
+      chatId: '5511999999999@s.whatsapp.net',
+      to: '5511999999999@s.whatsapp.net',
+      content: { type: 'text', text: 'Pode mandar de novo?' },
+      rawPayload: { isFromMe: true },
+      systemNotice: true,
+    };
+
+    expect(buildSentMessageContentFields(payload).rawPayload).toEqual({ isFromMe: true, omniSystemNotice: true });
+  });
+
+  test('absent systemNotice leaves rawPayload untouched', () => {
+    const payload: MessageSentPayload = {
+      externalId: 'TEXT-ID-2',
+      chatId: '5511999999999@s.whatsapp.net',
+      to: '5511999999999@s.whatsapp.net',
+      content: { type: 'text', text: 'a real reply' },
+      rawPayload: { isFromMe: true },
+    };
+
+    expect(buildSentMessageContentFields(payload).rawPayload).toEqual({ isFromMe: true });
+  });
 });

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -551,6 +551,7 @@ async function sendTextMessage(
   replyTo?: string,
   correlationId?: string,
   senderAgentId?: string,
+  systemNotice?: boolean,
 ): Promise<void> {
   const plugin = await getPlugin(channel);
   if (!plugin) throw new Error(`Channel plugin not found: ${channel}`);
@@ -563,7 +564,7 @@ async function sendTextMessage(
     to: chatId,
     content: { type: 'text', text: sanitized },
     replyTo,
-    metadata: { messageFormatMode, correlationId, senderAgentId },
+    metadata: { messageFormatMode, correlationId, senderAgentId, systemNotice },
   });
 }
 
@@ -614,7 +615,9 @@ async function sendErrorFeedback(
 ): Promise<void> {
   const errorMsg = error instanceof Error ? error.message : String(error);
   log.error('agent_dispatch_error', { channel, instanceId, chatId, error: errorMsg });
-  await sendTextMessage(channel, instanceId, chatId, message);
+  // systemNotice: the dispatch FAILED — this apology must not count as "the
+  // turn was answered" or replay-on-reconnect would never retry it (#912)
+  await sendTextMessage(channel, instanceId, chatId, message, 'convert', undefined, undefined, undefined, true);
 }
 
 /**
@@ -4032,7 +4035,19 @@ async function processAgentResponse(
       await sendTypingPresence(channel, instance.id, chatId, 'composing');
       try {
         if (agentAckMessage) {
-          sendTextMessage(channel, instance.id, chatId, agentAckMessage).catch((err) => {
+          // systemNotice: the ack precedes the real reply — it must not count
+          // as "the turn was answered" for agent replay (#912 review)
+          sendTextMessage(
+            channel,
+            instance.id,
+            chatId,
+            agentAckMessage,
+            'convert',
+            undefined,
+            undefined,
+            undefined,
+            true,
+          ).catch((err) => {
             log.warn('Failed to send agent ack message', { instanceId: instance.id, chatId, error: String(err) });
           });
         }

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -297,6 +297,7 @@ export function buildSentMessageContentFields(payload: MessageSentPayload): {
   mediaMetadata?: Record<string, unknown>;
   rawPayload?: Record<string, unknown>;
 } {
+  const sanitizedRawPayload = payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined;
   return {
     textContent: sanitizeText(payload.content.text ?? payload.content.caption),
     hasMedia: isSentMediaContent(payload.content),
@@ -304,7 +305,10 @@ export function buildSentMessageContentFields(payload: MessageSentPayload): {
     mediaUrl: payload.content.mediaUrl,
     mediaLocalPath: payload.content.localPath,
     mediaMetadata: buildSentMediaMetadata(payload.content, payload.rawPayload),
-    rawPayload: payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined,
+    // omniSystemNotice: queried by AgentReplayService's answered-turn guard —
+    // a procedural courtesy send (auto-ack, error feedback) must not look
+    // like an answer to the turn (#912 review)
+    rawPayload: payload.systemNotice ? { ...(sanitizedRawPayload ?? {}), omniSystemNotice: true } : sanitizedRawPayload,
   };
 }
 

--- a/packages/api/src/routes/v2/__tests__/messages-send-sent-by.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-send-sent-by.test.ts
@@ -1,0 +1,159 @@
+/**
+ * POST /messages/send + /messages/send/media — `sentBy: 'agent'` authorship (#912).
+ *
+ * Agent integrations that answer a turn out-of-band (interactive lists, media)
+ * previously had no way to mark their outbound as agent-authored: the routes
+ * never set `metadata.senderAgentId`, the row landed with
+ * `sender_agent_id = NULL`, and follow-up scheduling never armed. `sentBy:
+ * 'agent'` resolves the instance's configured agent SERVER-SIDE (the column is
+ * an FK — caller-provided ids are not accepted) and threads it into
+ * `OutgoingMessage.metadata.senderAgentId`, which channel plugins echo into
+ * the `message.sent` payload for persistence.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { messagesRoutes } from '../messages';
+
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const AGENT_ID = '22222222-2222-4222-8222-222222222222';
+
+type MountOptions = {
+  agentId?: string | null;
+};
+
+function mountMessagesRoutes(options: MountOptions = {}): {
+  app: Hono<{ Variables: AppVariables }>;
+  sendMessage: ReturnType<typeof mock>;
+} {
+  const sendMessage = mock(async (_instanceId: string, _message: unknown) => ({
+    success: true,
+    messageId: 'SENT-MSG-ID',
+    timestamp: 123,
+  }));
+
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async (id: string) => ({
+          id,
+          channel: 'whatsapp-business',
+          agentId: options.agentId === undefined ? AGENT_ID : options.agentId,
+        })),
+      },
+      persons: {
+        getIdentityForChannel: mock(async () => null),
+      },
+      chats: {
+        findByExternalIdSmart: mock(async () => null),
+      },
+    } as never);
+    c.set('channelRegistry', {
+      get: mock(() => ({
+        capabilities: { canSendText: true, canSendMedia: true },
+        sendMessage,
+      })),
+    } as never);
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+    await next();
+  });
+  app.route('/messages', messagesRoutes);
+  return { app, sendMessage };
+}
+
+async function postJson(app: Hono<{ Variables: AppVariables }>, path: string, body: Record<string, unknown>) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function sentMetadata(sendMessage: ReturnType<typeof mock>): Record<string, unknown> {
+  const [, message] = sendMessage.mock.calls[0] as [string, { metadata?: Record<string, unknown> }];
+  return message.metadata ?? {};
+}
+
+describe('POST /messages/send with sentBy', () => {
+  const textBody = { instanceId: INSTANCE_ID, to: '5511999998888', text: 'Pick one' };
+
+  test("sentBy: 'agent' resolves the instance agent into metadata.senderAgentId", async () => {
+    const { app, sendMessage } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send', { ...textBody, sentBy: 'agent' });
+
+    expect(res.status).toBe(201);
+    expect(sentMetadata(sendMessage).senderAgentId).toBe(AGENT_ID);
+  });
+
+  test('omitted sentBy leaves metadata unattributed', async () => {
+    const { app, sendMessage } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send', textBody);
+
+    expect(res.status).toBe(201);
+    expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
+  });
+
+  test("sentBy: 'user' leaves metadata unattributed", async () => {
+    const { app, sendMessage } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send', { ...textBody, sentBy: 'user' });
+
+    expect(res.status).toBe(201);
+    expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
+  });
+
+  test("sentBy: 'agent' on an instance without an agent stays unattributed", async () => {
+    const { app, sendMessage } = mountMessagesRoutes({ agentId: null });
+
+    const res = await postJson(app, '/messages/send', { ...textBody, sentBy: 'agent' });
+
+    expect(res.status).toBe(201);
+    expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
+  });
+
+  test('rejects an unknown sentBy value', async () => {
+    const { app, sendMessage } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send', { ...textBody, sentBy: 'operator' });
+
+    expect(res.status).toBe(400);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /messages/send/media with sentBy', () => {
+  const mediaBody = {
+    instanceId: INSTANCE_ID,
+    to: '5511999998888',
+    type: 'image',
+    url: 'https://example.com/photo.jpg',
+  };
+
+  test("sentBy: 'agent' resolves the instance agent into metadata.senderAgentId", async () => {
+    const { app, sendMessage } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send/media', { ...mediaBody, sentBy: 'agent' });
+
+    expect(res.status).toBe(201);
+    expect(sentMetadata(sendMessage).senderAgentId).toBe(AGENT_ID);
+  });
+
+  test('omitted sentBy leaves metadata unattributed', async () => {
+    const { app, sendMessage } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send/media', mediaBody);
+
+    expect(res.status).toBe(201);
+    expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/messages-send-sent-by.test.ts
+++ b/packages/api/src/routes/v2/__tests__/messages-send-sent-by.test.ts
@@ -52,7 +52,14 @@ function mountMessagesRoutes(options: MountOptions = {}): {
     } as never);
     c.set('channelRegistry', {
       get: mock(() => ({
-        capabilities: { canSendText: true, canSendMedia: true },
+        capabilities: {
+          canSendText: true,
+          canSendMedia: true,
+          canSendSticker: true,
+          canSendContact: true,
+          canSendLocation: true,
+          canSendPoll: true,
+        },
         sendMessage,
       })),
     } as never);
@@ -92,6 +99,9 @@ describe('POST /messages/send with sentBy', () => {
 
     expect(res.status).toBe(201);
     expect(sentMetadata(sendMessage).senderAgentId).toBe(AGENT_ID);
+    // Response echoes the resolved attribution so callers can verify it
+    const body = (await res.json()) as { data: { senderAgentId?: string | null } };
+    expect(body.data.senderAgentId).toBe(AGENT_ID);
   });
 
   test('omitted sentBy leaves metadata unattributed', async () => {
@@ -112,13 +122,26 @@ describe('POST /messages/send with sentBy', () => {
     expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
   });
 
-  test("sentBy: 'agent' on an instance without an agent stays unattributed", async () => {
+  test("sentBy: 'agent' on an instance without an agent stays unattributed — response reports null", async () => {
     const { app, sendMessage } = mountMessagesRoutes({ agentId: null });
 
     const res = await postJson(app, '/messages/send', { ...textBody, sentBy: 'agent' });
 
     expect(res.status).toBe(201);
     expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
+    // The caller can detect that attribution did not happen (#912 review)
+    const body = (await res.json()) as { data: { senderAgentId?: string | null } };
+    expect(body.data.senderAgentId).toBeNull();
+  });
+
+  test('response omits senderAgentId entirely when sentBy was not requested', async () => {
+    const { app } = mountMessagesRoutes();
+
+    const res = await postJson(app, '/messages/send', textBody);
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: Record<string, unknown> };
+    expect('senderAgentId' in body.data).toBe(false);
   });
 
   test('rejects an unknown sentBy value', async () => {
@@ -156,4 +179,31 @@ describe('POST /messages/send/media with sentBy', () => {
     expect(res.status).toBe(201);
     expect('senderAgentId' in sentMetadata(sendMessage)).toBe(false);
   });
+});
+
+describe('sentBy on the remaining send routes (#912 review)', () => {
+  const base = { instanceId: INSTANCE_ID, to: '5511999998888', sentBy: 'agent' };
+
+  const cases: Array<{ path: string; body: Record<string, unknown> }> = [
+    { path: '/messages/send/sticker', body: { ...base, url: 'https://example.com/sticker.webp' } },
+    { path: '/messages/send/contact', body: { ...base, contact: { name: 'Ada Lovelace' } } },
+    { path: '/messages/send/location', body: { ...base, latitude: -23.55, longitude: -46.63 } },
+    {
+      path: '/messages/send/poll',
+      body: { ...base, question: 'Best slot?', answers: ['10:00', '11:00'] },
+    },
+  ];
+
+  for (const { path, body } of cases) {
+    test(`${path} threads senderAgentId and echoes it in the response`, async () => {
+      const { app, sendMessage } = mountMessagesRoutes();
+
+      const res = await postJson(app, path, body);
+
+      expect(res.status).toBe(201);
+      expect(sentMetadata(sendMessage).senderAgentId).toBe(AGENT_ID);
+      const parsed = (await res.json()) as { data: { senderAgentId?: string | null } };
+      expect(parsed.data.senderAgentId).toBe(AGENT_ID);
+    });
+  }
 });

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -623,6 +623,12 @@ const sendTextSchema = z.object({
     .boolean()
     .optional()
     .describe('Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text)'),
+  sentBy: z
+    .enum(['agent', 'user'])
+    .optional()
+    .describe(
+      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered (#912). Default: unattributed.",
+    ),
 });
 
 // Send media schema
@@ -640,6 +646,12 @@ const sendMediaSchema = z.object({
     .describe('MIME type of the media (e.g. image/gif enables GIF playback for video type)'),
   voiceNote: z.boolean().optional().describe('Send audio as voice note'),
   threadId: z.string().optional().describe('Thread/topic ID (e.g. Telegram forum topic)'),
+  sentBy: z
+    .enum(['agent', 'user'])
+    .optional()
+    .describe(
+      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered (#912). Default: unattributed.",
+    ),
 });
 
 function normalizeSendMediaMimeType(data: z.infer<typeof sendMediaSchema>): string {
@@ -648,6 +660,19 @@ function normalizeSendMediaMimeType(data: z.infer<typeof sendMediaSchema>): stri
     return 'audio/ogg; codecs=opus';
   }
   return inferred;
+}
+
+/**
+ * Resolve `sentBy: 'agent'` to the instance's configured agent (#912).
+ * Server-side on purpose: `messages.sender_agent_id` is an FK, so
+ * caller-provided agent ids are not accepted.
+ */
+function resolveSentByAgentId(
+  sentBy: 'agent' | 'user' | undefined,
+  instance: { agentId?: string | null },
+): string | undefined {
+  if (sentBy !== 'agent') return undefined;
+  return instance.agentId ?? undefined;
 }
 
 function buildSendMediaMetadata(data: z.infer<typeof sendMediaSchema>): Record<string, unknown> {
@@ -1187,7 +1212,7 @@ messagesRoutes.post('/send', async (c) => {
     return c.json({ error: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } }, 400);
   }
 
-  const { instanceId, to, replyTo, threadId, mentions, buttons, list, requestLocation } = parsed.data;
+  const { instanceId, to, replyTo, threadId, mentions, buttons, list, requestLocation, sentBy } = parsed.data;
   // Strip internal routing headers and agent directives before sending (GH #300)
   const text = sanitizeOutboundText(parsed.data.text);
   if (!text) {
@@ -1214,6 +1239,8 @@ messagesRoutes.post('/send', async (c) => {
   // Get reply context if replying
   const replyContext = replyTo ? await getReplyContext(services, instanceId, resolvedTo, replyTo) : {};
 
+  const senderAgentId = resolveSentByAgentId(sentBy, instance);
+
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
     threadId,
@@ -1224,7 +1251,7 @@ messagesRoutes.post('/send', async (c) => {
       ...(list ? { list } : {}),
     } as OutgoingContent,
     replyTo,
-    metadata: { ...(mentions ? { mentions } : {}), ...replyContext },
+    metadata: { ...(mentions ? { mentions } : {}), ...replyContext, ...(senderAgentId ? { senderAgentId } : {}) },
   };
 
   // T8: API processed the send request
@@ -1318,6 +1345,8 @@ messagesRoutes.post('/send/media', zValidator('json', sendMediaSchema), async (c
 
   const mediaMimeType = normalizeSendMediaMimeType(data);
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   // Build outgoing message
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -1329,7 +1358,7 @@ messagesRoutes.post('/send/media', zValidator('json', sendMediaSchema), async (c
       filename: data.filename,
       mimeType: mediaMimeType,
     } as OutgoingContent,
-    metadata: buildSendMediaMetadata(data),
+    metadata: { ...buildSendMediaMetadata(data), ...(senderAgentId ? { senderAgentId } : {}) },
   };
 
   // T8: API processed the send request

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -577,6 +577,15 @@ const updateDeliveryStatusSchema = z.object({
   latestEventId: z.string().uuid().optional(),
 });
 
+// Shared authorship marker for all send routes (#912). 'agent' resolves the
+// instance's configured agent server-side — see resolveSentByAgentId.
+const sentByField = z
+  .enum(['agent', 'user'])
+  .optional()
+  .describe(
+    "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered (#912). The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.",
+  );
+
 // Mention schema - supports both WhatsApp and Discord formats
 const MentionSchema = z.object({
   id: z.string().min(1).describe('User/role ID to mention'),
@@ -623,12 +632,7 @@ const sendTextSchema = z.object({
     .boolean()
     .optional()
     .describe('Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text)'),
-  sentBy: z
-    .enum(['agent', 'user'])
-    .optional()
-    .describe(
-      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered (#912). Default: unattributed.",
-    ),
+  sentBy: sentByField,
 });
 
 // Send media schema
@@ -646,12 +650,7 @@ const sendMediaSchema = z.object({
     .describe('MIME type of the media (e.g. image/gif enables GIF playback for video type)'),
   voiceNote: z.boolean().optional().describe('Send audio as voice note'),
   threadId: z.string().optional().describe('Thread/topic ID (e.g. Telegram forum topic)'),
-  sentBy: z
-    .enum(['agent', 'user'])
-    .optional()
-    .describe(
-      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered (#912). Default: unattributed.",
-    ),
+  sentBy: sentByField,
 });
 
 function normalizeSendMediaMimeType(data: z.infer<typeof sendMediaSchema>): string {
@@ -666,13 +665,35 @@ function normalizeSendMediaMimeType(data: z.infer<typeof sendMediaSchema>): stri
  * Resolve `sentBy: 'agent'` to the instance's configured agent (#912).
  * Server-side on purpose: `messages.sender_agent_id` is an FK, so
  * caller-provided agent ids are not accepted.
+ *
+ * When the instance has no configured agent (e.g. routing lives in
+ * agent_routes), the send still goes out — failing it would break the
+ * integration harder than missing attribution does — but the miss is logged
+ * here and surfaced to the caller via `sentByResponseFields`.
  */
 function resolveSentByAgentId(
   sentBy: 'agent' | 'user' | undefined,
-  instance: { agentId?: string | null },
+  instance: { id: string; agentId?: string | null },
 ): string | undefined {
   if (sentBy !== 'agent') return undefined;
-  return instance.agentId ?? undefined;
+  if (!instance.agentId) {
+    log.warn('sentBy=agent could not be attributed: instance has no configured agent', { instanceId: instance.id });
+    return undefined;
+  }
+  return instance.agentId;
+}
+
+/**
+ * Response fields reporting how `sentBy: 'agent'` resolved: `senderAgentId`
+ * is the attributed agent, or null when the instance has no configured agent
+ * (so callers can detect that attribution silently did not happen). Empty for
+ * sends that did not request agent attribution.
+ */
+function sentByResponseFields(
+  sentBy: 'agent' | 'user' | undefined,
+  senderAgentId: string | undefined,
+): { senderAgentId?: string | null } {
+  return sentBy === 'agent' ? { senderAgentId: senderAgentId ?? null } : {};
 }
 
 function buildSendMediaMetadata(data: z.infer<typeof sendMediaSchema>): Record<string, unknown> {
@@ -696,6 +717,7 @@ const sendStickerSchema = z.object({
   to: z.string().min(1).describe('Recipient'),
   url: z.string().url().optional().describe('Sticker URL'),
   base64: z.string().optional().describe('Base64 encoded sticker'),
+  sentBy: sentByField,
 });
 
 // Send contact schema
@@ -708,6 +730,7 @@ const sendContactSchema = z.object({
     email: z.string().email().optional().describe('Email address'),
     organization: z.string().optional().describe('Organization'),
   }),
+  sentBy: sentByField,
 });
 
 // Send location schema
@@ -718,6 +741,7 @@ const sendLocationSchema = z.object({
   longitude: z.number().describe('Longitude'),
   name: z.string().optional().describe('Location name'),
   address: z.string().optional().describe('Address'),
+  sentBy: sentByField,
 });
 
 const sendHandoffSchema = z.object({
@@ -1281,6 +1305,7 @@ messagesRoutes.post('/send', async (c) => {
         instanceId: instance.id,
         to,
         timestamp: result.timestamp,
+        ...sentByResponseFields(sentBy, senderAgentId),
       },
     },
     201,
@@ -1404,6 +1429,7 @@ messagesRoutes.post('/send/media', zValidator('json', sendMediaSchema), async (c
         to: data.to,
         mediaType: data.type,
         timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
       },
     },
     201,
@@ -1553,6 +1579,8 @@ messagesRoutes.post('/send/sticker', zValidator('json', sendStickerSchema), asyn
   // Resolve recipient (handles person ID to platform ID resolution)
   const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   // Build outgoing message for sticker
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -1562,6 +1590,7 @@ messagesRoutes.post('/send/sticker', zValidator('json', sendStickerSchema), asyn
     } as OutgoingContent,
     metadata: {
       base64: data.base64,
+      ...(senderAgentId ? { senderAgentId } : {}),
     },
   };
 
@@ -1589,6 +1618,7 @@ messagesRoutes.post('/send/sticker', zValidator('json', sendStickerSchema), asyn
         externalMessageId: result.messageId,
         status: 'sent',
         timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
       },
     },
     201,
@@ -1639,6 +1669,8 @@ messagesRoutes.post('/send/contact', zValidator('json', sendContactSchema), asyn
   // Resolve recipient (handles person ID to platform ID resolution)
   const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   // Build outgoing message for contact
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -1646,6 +1678,7 @@ messagesRoutes.post('/send/contact', zValidator('json', sendContactSchema), asyn
       type: 'contact',
       contact: data.contact,
     } as OutgoingContent,
+    ...(senderAgentId ? { metadata: { senderAgentId } } : {}),
   };
 
   // Send via channel plugin
@@ -1672,6 +1705,7 @@ messagesRoutes.post('/send/contact', zValidator('json', sendContactSchema), asyn
         externalMessageId: result.messageId,
         status: 'sent',
         timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
       },
     },
     201,
@@ -1722,6 +1756,8 @@ messagesRoutes.post('/send/location', zValidator('json', sendLocationSchema), as
   // Resolve recipient (handles person ID to platform ID resolution)
   const resolvedTo = await resolveRecipient(data.to, instance.channel, services);
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   // Build outgoing message for location
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -1734,6 +1770,7 @@ messagesRoutes.post('/send/location', zValidator('json', sendLocationSchema), as
         address: data.address,
       },
     } as OutgoingContent,
+    ...(senderAgentId ? { metadata: { senderAgentId } } : {}),
   };
 
   // Send via channel plugin
@@ -1760,6 +1797,7 @@ messagesRoutes.post('/send/location', zValidator('json', sendLocationSchema), as
         externalMessageId: result.messageId,
         status: 'sent',
         timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
       },
     },
     201,
@@ -2163,6 +2201,7 @@ const sendTtsSchema = z.object({
     .max(30000)
     .optional()
     .describe('Custom recording presence duration in ms (default: match audio duration)'),
+  sentBy: sentByField,
 });
 
 /**
@@ -2212,6 +2251,8 @@ messagesRoutes.post('/send/tts', zValidator('json', sendTtsSchema), async (c) =>
     }
   }
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   // Build outgoing voice note message
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -2222,6 +2263,7 @@ messagesRoutes.post('/send/tts', zValidator('json', sendTtsSchema), async (c) =>
     metadata: {
       audioBuffer: ttsResult.buffer,
       ptt: true,
+      ...(senderAgentId ? { senderAgentId } : {}),
     },
   };
 
@@ -2253,6 +2295,7 @@ messagesRoutes.post('/send/tts', zValidator('json', sendTtsSchema), async (c) =>
         audioSizeKb: ttsResult.sizeKb,
         durationMs: ttsResult.durationMs,
         timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
       },
     },
     201,
@@ -2269,6 +2312,7 @@ const forwardMessageSchema = z.object({
   to: z.string().min(1).describe('Recipient to forward to'),
   messageId: z.string().min(1).describe('External message ID to forward'),
   fromChatId: z.string().min(1).describe('Chat ID where the message is from'),
+  sentBy: sentByField,
 });
 
 /**
@@ -2278,7 +2322,7 @@ const forwardMessageSchema = z.object({
  * This ensures the "Forwarded" label appears correctly.
  */
 messagesRoutes.post('/send/forward', zValidator('json', forwardMessageSchema), async (c) => {
-  const { instanceId, to, messageId, fromChatId } = c.req.valid('json');
+  const { instanceId, to, messageId, fromChatId, sentBy } = c.req.valid('json');
   const services = c.get('services');
   const channelRegistry = c.get('channelRegistry');
   checkInstanceAccess(c.get('apiKey'), instanceId);
@@ -2349,6 +2393,8 @@ messagesRoutes.post('/send/forward', zValidator('json', forwardMessageSchema), a
   // Resolve recipient
   const resolvedTo = await resolveRecipient(to, instance.channel, services);
 
+  const senderAgentId = resolveSentByAgentId(sentBy, instance);
+
   // Build outgoing message for forward with the full rawPayload
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
@@ -2362,6 +2408,7 @@ messagesRoutes.post('/send/forward', zValidator('json', forwardMessageSchema), a
         fromChatId,
         rawPayload: originalMessage.rawPayload, // Pass full message for proper forwarding
       },
+      ...(senderAgentId ? { senderAgentId } : {}),
     },
   };
 
@@ -2388,6 +2435,7 @@ messagesRoutes.post('/send/forward', zValidator('json', forwardMessageSchema), a
         messageId: result.messageId,
         status: 'sent',
         timestamp: result.timestamp,
+        ...sentByResponseFields(sentBy, senderAgentId),
       },
     },
     201,
@@ -2707,6 +2755,7 @@ const sendPollSchema = z.object({
   durationHours: z.number().int().min(1).max(168).optional().describe('Poll duration in hours (default 24, max 168)'),
   multiSelect: z.boolean().optional().describe('Allow multiple selections'),
   replyTo: z.string().optional().describe('Message ID to reply to'),
+  sentBy: sentByField,
 });
 
 // Send embed schema (Discord only)
@@ -2747,6 +2796,7 @@ const sendEmbedSchema = z.object({
     .optional()
     .describe('Embed fields'),
   replyTo: z.string().optional().describe('Message ID to reply to'),
+  sentBy: sentByField,
 });
 
 // Edit message via channel schema
@@ -2784,6 +2834,8 @@ messagesRoutes.post('/send/poll', zValidator('json', sendPollSchema), async (c) 
   // Get reply context if replying
   const replyContext = data.replyTo ? await getReplyContext(services, data.instanceId, resolvedTo, data.replyTo) : {};
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   const outgoingMessage: OutgoingMessage = {
     to: resolvedTo,
     content: { type: 'poll', text: data.question } as OutgoingContent,
@@ -2795,6 +2847,7 @@ messagesRoutes.post('/send/poll', zValidator('json', sendPollSchema), async (c) 
         multiSelect: data.multiSelect ?? false,
       },
       ...replyContext,
+      ...(senderAgentId ? { senderAgentId } : {}),
     },
     replyTo: data.replyTo,
   };
@@ -2802,7 +2855,17 @@ messagesRoutes.post('/send/poll', zValidator('json', sendPollSchema), async (c) 
   const result = await plugin.sendMessage(data.instanceId, outgoingMessage);
   handleSendResult(result, { channelType: instance.channel, instanceId: data.instanceId, operation: 'send poll' });
 
-  return c.json({ data: { messageId: result.messageId, status: 'sent', timestamp: result.timestamp } }, 201);
+  return c.json(
+    {
+      data: {
+        messageId: result.messageId,
+        status: 'sent',
+        timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
+      },
+    },
+    201,
+  );
 });
 
 /**
@@ -2863,6 +2926,8 @@ messagesRoutes.post('/send/embed', zValidator('json', sendEmbedSchema), async (c
     }
   }
 
+  const senderAgentId = resolveSentByAgentId(data.sentBy, instance);
+
   // Build outgoing message for embed
   // Note: We use 'text' type but pass embed data in metadata
   // The Discord plugin checks for metadata.embed and handles accordingly
@@ -2887,6 +2952,7 @@ messagesRoutes.post('/send/embed', zValidator('json', sendEmbedSchema), async (c
       },
       ...(replyToFromMe !== undefined ? { replyToFromMe } : {}),
       ...(replyToRawPayload ? { replyToRawPayload } : {}),
+      ...(senderAgentId ? { senderAgentId } : {}),
     },
     replyTo: data.replyTo,
   };
@@ -2914,6 +2980,7 @@ messagesRoutes.post('/send/embed', zValidator('json', sendEmbedSchema), async (c
         messageId: result.messageId,
         status: 'sent',
         timestamp: result.timestamp,
+        ...sentByResponseFields(data.sentBy, senderAgentId),
       },
     },
     201,

--- a/packages/api/src/schemas/openapi/messages.ts
+++ b/packages/api/src/schemas/openapi/messages.ts
@@ -56,6 +56,10 @@ export const SendTextSchema = z.object({
   requestLocation: z.boolean().optional().openapi({
     description: 'Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text)',
   }),
+  sentBy: z.enum(['agent', 'user']).optional().openapi({
+    description:
+      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.",
+  }),
 });
 
 // Send media request
@@ -68,6 +72,10 @@ export const SendMediaSchema = z.object({
   filename: z.string().optional().openapi({ description: 'Filename for documents' }),
   caption: z.string().optional().openapi({ description: 'Caption for media' }),
   voiceNote: z.boolean().optional().openapi({ description: 'Send audio as voice note' }),
+  sentBy: z.enum(['agent', 'user']).optional().openapi({
+    description:
+      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.",
+  }),
 });
 
 // Send reaction request

--- a/packages/api/src/schemas/openapi/messages.ts
+++ b/packages/api/src/schemas/openapi/messages.ts
@@ -6,6 +6,12 @@ import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import { z } from '../../lib/zod-openapi';
 import { ErrorSchema, SuccessSchema } from './common';
 
+// Shared authorship marker for send requests (#912)
+const SentByField = z.enum(['agent', 'user']).optional().openapi({
+  description:
+    "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.",
+});
+
 // Message response schema
 export const MessageResponseSchema = z.object({
   messageId: z.string().openapi({ description: 'Internal message ID' }),
@@ -14,6 +20,10 @@ export const MessageResponseSchema = z.object({
   instanceId: z.string().uuid().optional().openapi({ description: 'Instance UUID' }),
   to: z.string().optional().openapi({ description: 'Recipient' }),
   mediaType: z.string().optional().openapi({ description: 'Media type if applicable' }),
+  senderAgentId: z.string().uuid().nullable().optional().openapi({
+    description:
+      "Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)",
+  }),
 });
 
 // Send text request
@@ -56,10 +66,7 @@ export const SendTextSchema = z.object({
   requestLocation: z.boolean().optional().openapi({
     description: 'Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text)',
   }),
-  sentBy: z.enum(['agent', 'user']).optional().openapi({
-    description:
-      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.",
-  }),
+  sentBy: SentByField,
 });
 
 // Send media request
@@ -72,10 +79,7 @@ export const SendMediaSchema = z.object({
   filename: z.string().optional().openapi({ description: 'Filename for documents' }),
   caption: z.string().optional().openapi({ description: 'Caption for media' }),
   voiceNote: z.boolean().optional().openapi({ description: 'Send audio as voice note' }),
-  sentBy: z.enum(['agent', 'user']).optional().openapi({
-    description:
-      "Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.",
-  }),
+  sentBy: SentByField,
 });
 
 // Send reaction request
@@ -92,6 +96,7 @@ export const SendStickerSchema = z.object({
   to: z.string().min(1).openapi({ description: 'Recipient' }),
   url: z.string().url().optional().openapi({ description: 'Sticker URL' }),
   base64: z.string().optional().openapi({ description: 'Base64 encoded sticker' }),
+  sentBy: SentByField,
 });
 
 // Send contact request
@@ -104,6 +109,7 @@ export const SendContactSchema = z.object({
     email: z.string().email().optional().openapi({ description: 'Email address' }),
     organization: z.string().optional().openapi({ description: 'Organization' }),
   }),
+  sentBy: SentByField,
 });
 
 // Send location request
@@ -114,6 +120,7 @@ export const SendLocationSchema = z.object({
   longitude: z.number().openapi({ description: 'Longitude' }),
   name: z.string().optional().openapi({ description: 'Location name' }),
   address: z.string().optional().openapi({ description: 'Address' }),
+  sentBy: SentByField,
 });
 
 // Send presence request
@@ -214,6 +221,7 @@ export const SendTtsSchema = z.object({
     .max(30000)
     .optional()
     .openapi({ description: 'Recording presence duration in ms' }),
+  sentBy: SentByField,
 });
 
 // TTS response

--- a/packages/api/src/services/__tests__/agent-replay.test.ts
+++ b/packages/api/src/services/__tests__/agent-replay.test.ts
@@ -431,6 +431,11 @@ describe('AgentReplayService', () => {
       const guard = rendered.slice(notExistsIdx);
       expect(guard).toContain('reply.is_from_me = true');
       expect(guard).not.toContain('reply.sender_agent_id');
+      // Procedural courtesy sends (auto-ack, dispatch-error feedback) are
+      // persisted with rawPayload.omniSystemNotice=true and must NOT count as
+      // an answer — otherwise a crash between the ack and the real reply
+      // permanently drops the turn (#912 review).
+      expect(guard).toContain("COALESCE((reply.raw_payload ->> 'omniSystemNotice')::boolean, false) = false");
     });
 
     test('uses cutoff when since is undefined', async () => {

--- a/packages/api/src/services/__tests__/agent-replay.test.ts
+++ b/packages/api/src/services/__tests__/agent-replay.test.ts
@@ -8,6 +8,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { EventBus } from '@omni/core';
 import type { Database } from '@omni/db';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { AgentReplayService } from '../agent-replay';
 
 // ---------------------------------------------------------------------------
@@ -398,6 +400,37 @@ describe('AgentReplayService', () => {
       expect(eventBus.publish).toHaveBeenCalledTimes(1003);
       // until should be now (the query upper bound), not last-row timestamp
       expect(result.until.getTime()).toBeGreaterThan(page2Timestamp.getTime());
+    });
+
+    test('answered-turn guard is provenance-agnostic — keyed on is_from_me, not sender_agent_id (#912)', async () => {
+      // Turns answered out-of-band via POST /api/v2/messages/send are stored
+      // with sender_agent_id = NULL. The guard must treat ANY outbound row
+      // after the inbound as "answered", or those turns replay on every
+      // reconnect. Capture the messages-query where clause and render it.
+      let capturedWhere: SQL | undefined;
+      const mockSelect = mock(() => ({
+        from: mock(() => ({
+          innerJoin: mock(() => ({
+            where: mock((condition: SQL) => {
+              capturedWhere = condition;
+              return { orderBy: mock(() => ({ limit: mock(() => Promise.resolve([])) })) };
+            }),
+          })),
+        })),
+      }));
+      const db = { select: mockSelect } as unknown as Database;
+
+      const service = new AgentReplayService(db, eventBus);
+      await service.replayMissedMessages({ instanceId: 'inst-1' });
+
+      expect(capturedWhere).toBeDefined();
+      const rendered = new PgDialect().sqlToQuery(capturedWhere as SQL).sql;
+
+      const notExistsIdx = rendered.indexOf('NOT EXISTS');
+      expect(notExistsIdx).toBeGreaterThan(-1);
+      const guard = rendered.slice(notExistsIdx);
+      expect(guard).toContain('reply.is_from_me = true');
+      expect(guard).not.toContain('reply.sender_agent_id');
     });
 
     test('uses cutoff when since is undefined', async () => {

--- a/packages/api/src/services/agent-replay.ts
+++ b/packages/api/src/services/agent-replay.ts
@@ -210,12 +210,16 @@ export class AgentReplayService {
               sql`${messages.senderAgentId} IS NULL`,
               // Only active messages
               sql`${messages.deletedAt} IS NULL`,
-              // Skip messages that already have an agent reply after them in the same chat
-              // — means the agent already handled this message before the restart
+              // Skip messages with ANY outbound reply after them in the same chat
+              // — the turn was answered, regardless of who sent the answer.
+              // Provenance-agnostic on purpose (#912): answers sent out-of-band
+              // through POST /api/v2/messages/send land with
+              // sender_agent_id = NULL, and a guard keyed on that column
+              // re-dispatched every such turn on every reconnect.
               sql`NOT EXISTS (
               SELECT 1 FROM ${messages} AS reply
               WHERE reply.chat_id = ${messages.chatId}
-                AND reply.sender_agent_id IS NOT NULL
+                AND reply.is_from_me = true
                 AND reply.platform_timestamp > ${messages.platformTimestamp}
                 AND reply.deleted_at IS NULL
             )`,

--- a/packages/api/src/services/agent-replay.ts
+++ b/packages/api/src/services/agent-replay.ts
@@ -210,16 +210,21 @@ export class AgentReplayService {
               sql`${messages.senderAgentId} IS NULL`,
               // Only active messages
               sql`${messages.deletedAt} IS NULL`,
-              // Skip messages with ANY outbound reply after them in the same chat
-              // — the turn was answered, regardless of who sent the answer.
-              // Provenance-agnostic on purpose (#912): answers sent out-of-band
-              // through POST /api/v2/messages/send land with
+              // Skip messages with ANY substantive outbound reply after them in
+              // the same chat — the turn was answered, regardless of who sent
+              // the answer. Provenance-agnostic on purpose (#912): answers sent
+              // out-of-band through POST /api/v2/messages/send land with
               // sender_agent_id = NULL, and a guard keyed on that column
               // re-dispatched every such turn on every reconnect.
+              // Procedural courtesy sends (pre-dispatch auto-ack, dispatch-error
+              // feedback) are excluded via the omniSystemNotice marker: they
+              // precede or replace the real reply, so counting them would
+              // permanently drop turns whose dispatch died mid-flight.
               sql`NOT EXISTS (
               SELECT 1 FROM ${messages} AS reply
               WHERE reply.chat_id = ${messages.chatId}
                 AND reply.is_from_me = true
+                AND COALESCE((reply.raw_payload ->> 'omniSystemNotice')::boolean, false) = false
                 AND reply.platform_timestamp > ${messages.platformTimestamp}
                 AND reply.deleted_at IS NULL
             )`,

--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -714,6 +714,7 @@ export class DiscordPlugin extends BaseChannelPlugin {
         content: { type: message.content.type, text: message.content.text },
         replyToId: message.replyTo,
         senderAgentId: message.metadata?.senderAgentId as string | undefined,
+        systemNotice: message.metadata?.systemNotice as boolean | undefined,
       });
 
       return { success: true, messageId, timestamp: Date.now() };

--- a/packages/channel-gupshup/src/plugin.ts
+++ b/packages/channel-gupshup/src/plugin.ts
@@ -247,6 +247,7 @@ export class GupshupPlugin extends BaseChannelPlugin {
           gupshupProviderAliases: providerAliases,
         },
         senderAgentId: message.metadata?.senderAgentId as string | undefined,
+        systemNotice: message.metadata?.systemNotice as boolean | undefined,
       });
 
       return { success: true, messageId, timestamp: Date.now() };

--- a/packages/channel-hermes/src/plugin.ts
+++ b/packages/channel-hermes/src/plugin.ts
@@ -223,6 +223,7 @@ export class HermesPlugin extends BaseChannelPlugin {
         },
         replyToId: replyTo,
         senderAgentId: metadata?.senderAgentId as string | undefined,
+        systemNotice: metadata?.systemNotice as boolean | undefined,
       });
 
       return { success: true, messageId, timestamp: Date.now() };

--- a/packages/channel-sdk/src/helpers/events.ts
+++ b/packages/channel-sdk/src/helpers/events.ts
@@ -105,6 +105,13 @@ export interface EmitMessageSentParams {
 
   /** agents.id UUID — set by agent-dispatcher when agent sends */
   senderAgentId?: string;
+
+  /**
+   * Procedural courtesy send (pre-dispatch auto-ack, dispatch-error feedback)
+   * rather than a substantive reply. Echo `metadata?.systemNotice` here so
+   * agent replay does not treat the row as evidence a turn was answered.
+   */
+  systemNotice?: boolean;
 }
 
 /**

--- a/packages/channel-sdk/src/types/messaging.ts
+++ b/packages/channel-sdk/src/types/messaging.ts
@@ -107,6 +107,14 @@ export interface MessageMetadata {
    */
   isThreadBroadcast?: boolean;
 
+  /**
+   * Procedural courtesy send (pre-dispatch auto-ack, dispatch-error feedback)
+   * rather than a substantive reply. Plugins echo this into the
+   * `message.sent` payload so agent replay does not treat the row as evidence
+   * a turn was answered.
+   */
+  systemNotice?: boolean;
+
   /** Additional plugin-specific metadata */
   [key: string]: unknown;
 }

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -405,6 +405,7 @@ export class SlackPlugin extends BaseChannelPlugin {
         content: { type: message.content.type, text: message.content.text },
         replyToId: message.replyTo,
         senderAgentId: message.metadata?.senderAgentId as string | undefined,
+        systemNotice: message.metadata?.systemNotice as boolean | undefined,
       });
 
       return { success: true, messageId, timestamp: Date.now() };

--- a/packages/channel-telegram/src/plugin.ts
+++ b/packages/channel-telegram/src/plugin.ts
@@ -496,6 +496,7 @@ export class TelegramPlugin extends BaseChannelPlugin {
         },
         replyToId: message.replyTo,
         senderAgentId: message.metadata?.senderAgentId as string | undefined,
+        systemNotice: message.metadata?.systemNotice as boolean | undefined,
       });
 
       return {

--- a/packages/channel-twilio-whatsapp/src/plugin.ts
+++ b/packages/channel-twilio-whatsapp/src/plugin.ts
@@ -253,6 +253,7 @@ export class TwilioWhatsAppPlugin extends BaseChannelPlugin {
         },
         replyToId: message.replyTo,
         senderAgentId: message.metadata?.senderAgentId as string | undefined,
+        systemNotice: message.metadata?.systemNotice as boolean | undefined,
       });
 
       return { success: true, messageId, timestamp: Date.now() };

--- a/packages/channel-whatsapp-business/src/plugin.ts
+++ b/packages/channel-whatsapp-business/src/plugin.ts
@@ -302,6 +302,7 @@ export class WhatsAppBusinessPlugin extends BaseChannelPlugin {
         },
         replyToId: replyTo,
         senderAgentId: metadata?.senderAgentId as string | undefined,
+        systemNotice: metadata?.systemNotice as boolean | undefined,
       });
 
       return { success: true, messageId, timestamp: Date.now() };

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -1471,6 +1471,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       replyToId: originalMessage.replyTo,
       rawPayload: this.buildSentRawPayload(externalId, originalMessage, processedMessage),
       senderAgentId: originalMessage.metadata?.senderAgentId as string | undefined,
+      systemNotice: originalMessage.metadata?.systemNotice as boolean | undefined,
     };
   }
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -270,6 +270,12 @@ export interface MessageSentPayload {
   rawPayload?: Record<string, unknown>;
   /** agents.id UUID — set by agent-dispatcher when agent sends */
   senderAgentId?: string;
+  /**
+   * Procedural courtesy send (pre-dispatch auto-ack, dispatch-error feedback)
+   * rather than a substantive reply. Agent replay must not treat these as
+   * evidence that a turn was answered (#912 review).
+   */
+  systemNotice?: boolean;
 }
 
 export interface MessageDeliveredPayload {

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -3038,6 +3038,11 @@ export interface components {
             };
             /** @description Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text) */
             requestLocation?: boolean;
+            /**
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+             * @enum {string}
+             */
+            sentBy?: "agent" | "user";
         };
         TTSVoice: {
             /** @description ElevenLabs voice ID */
@@ -3121,6 +3126,11 @@ export interface components {
             caption?: string;
             /** @description Send audio as voice note */
             voiceNote?: boolean;
+            /**
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+             * @enum {string}
+             */
+            sentBy?: "agent" | "user";
         };
         SendReactionRequest: {
             /**
@@ -7726,6 +7736,11 @@ export interface operations {
                     };
                     /** @description Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text) */
                     requestLocation?: boolean;
+                    /**
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+                     * @enum {string}
+                     */
+                    sentBy?: "agent" | "user";
                 };
             };
         };
@@ -7836,6 +7851,11 @@ export interface operations {
                     caption?: string;
                     /** @description Send audio as voice note */
                     voiceNote?: boolean;
+                    /**
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+                     * @enum {string}
+                     */
+                    sentBy?: "agent" | "user";
                 };
             };
         };

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -3000,6 +3000,11 @@ export interface components {
             to?: string;
             /** @description Media type if applicable */
             mediaType?: string;
+            /**
+             * Format: uuid
+             * @description Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)
+             */
+            senderAgentId?: string | null;
         };
         SendTextRequest: {
             /**
@@ -3039,7 +3044,7 @@ export interface components {
             /** @description Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text) */
             requestLocation?: boolean;
             /**
-             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
              * @enum {string}
              */
             sentBy?: "agent" | "user";
@@ -3080,6 +3085,11 @@ export interface components {
             similarityBoost?: number;
             /** @description Recording presence duration in ms */
             presenceDelay?: number;
+            /**
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+             * @enum {string}
+             */
+            sentBy?: "agent" | "user";
         };
         TtsResponse: {
             /** @description Internal message ID */
@@ -3127,7 +3137,7 @@ export interface components {
             /** @description Send audio as voice note */
             voiceNote?: boolean;
             /**
-             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
              * @enum {string}
              */
             sentBy?: "agent" | "user";
@@ -3160,6 +3170,11 @@ export interface components {
             url?: string;
             /** @description Base64 encoded sticker */
             base64?: string;
+            /**
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+             * @enum {string}
+             */
+            sentBy?: "agent" | "user";
         };
         SendContactRequest: {
             /**
@@ -3182,6 +3197,11 @@ export interface components {
                 /** @description Organization */
                 organization?: string;
             };
+            /**
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+             * @enum {string}
+             */
+            sentBy?: "agent" | "user";
         };
         SendLocationRequest: {
             /**
@@ -3199,6 +3219,11 @@ export interface components {
             name?: string;
             /** @description Address */
             address?: string;
+            /**
+             * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+             * @enum {string}
+             */
+            sentBy?: "agent" | "user";
         };
         SendPresenceRequest: {
             /**
@@ -7737,7 +7762,7 @@ export interface operations {
                     /** @description Ask the user to share their location (WhatsApp Cloud: native "Send location" button under the text) */
                     requestLocation?: boolean;
                     /**
-                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
                      * @enum {string}
                      */
                     sentBy?: "agent" | "user";
@@ -7768,6 +7793,11 @@ export interface operations {
                             to?: string;
                             /** @description Media type if applicable */
                             mediaType?: string;
+                            /**
+                             * Format: uuid
+                             * @description Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)
+                             */
+                            senderAgentId?: string | null;
                         };
                     };
                 };
@@ -7852,7 +7882,7 @@ export interface operations {
                     /** @description Send audio as voice note */
                     voiceNote?: boolean;
                     /**
-                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. Default: unattributed.
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
                      * @enum {string}
                      */
                     sentBy?: "agent" | "user";
@@ -7883,6 +7913,11 @@ export interface operations {
                             to?: string;
                             /** @description Media type if applicable */
                             mediaType?: string;
+                            /**
+                             * Format: uuid
+                             * @description Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)
+                             */
+                            senderAgentId?: string | null;
                         };
                     };
                 };
@@ -8038,6 +8073,11 @@ export interface operations {
                     url?: string;
                     /** @description Base64 encoded sticker */
                     base64?: string;
+                    /**
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+                     * @enum {string}
+                     */
+                    sentBy?: "agent" | "user";
                 };
             };
         };
@@ -8065,6 +8105,11 @@ export interface operations {
                             to?: string;
                             /** @description Media type if applicable */
                             mediaType?: string;
+                            /**
+                             * Format: uuid
+                             * @description Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)
+                             */
+                            senderAgentId?: string | null;
                         };
                     };
                 };
@@ -8143,6 +8188,11 @@ export interface operations {
                         /** @description Organization */
                         organization?: string;
                     };
+                    /**
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+                     * @enum {string}
+                     */
+                    sentBy?: "agent" | "user";
                 };
             };
         };
@@ -8170,6 +8220,11 @@ export interface operations {
                             to?: string;
                             /** @description Media type if applicable */
                             mediaType?: string;
+                            /**
+                             * Format: uuid
+                             * @description Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)
+                             */
+                            senderAgentId?: string | null;
                         };
                     };
                 };
@@ -8243,6 +8298,11 @@ export interface operations {
                     name?: string;
                     /** @description Address */
                     address?: string;
+                    /**
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+                     * @enum {string}
+                     */
+                    sentBy?: "agent" | "user";
                 };
             };
         };
@@ -8270,6 +8330,11 @@ export interface operations {
                             to?: string;
                             /** @description Media type if applicable */
                             mediaType?: string;
+                            /**
+                             * Format: uuid
+                             * @description Present when the request set sentBy: 'agent' — the agent the send was attributed to, or null when the instance has no configured agent (attribution did not happen)
+                             */
+                            senderAgentId?: string | null;
                         };
                     };
                 };
@@ -8796,6 +8861,11 @@ export interface operations {
                     similarityBoost?: number;
                     /** @description Recording presence duration in ms */
                     presenceDelay?: number;
+                    /**
+                     * @description Authorship of this send. 'agent' attributes the message to the instance's configured agent (persists sender_agent_id), so agent replay and follow-up scheduling treat the turn as agent-answered. The response echoes the resolved senderAgentId (null when the instance has no configured agent). Default: unattributed.
+                     * @enum {string}
+                     */
+                    sentBy?: "agent" | "user";
                 };
             };
         };


### PR DESCRIPTION
Fixes #912.

## Problem

`AgentReplayService` decided a turn was "missed" by looking for a later reply with `sender_agent_id IS NOT NULL` — a field only the dispatcher's own reply path sets. Turns answered out-of-band through `POST /api/v2/messages/send` (the only route that can produce interactive list/button messages) land with `sender_agent_id = NULL`, so they looked permanently unanswered and the inbound was re-dispatched to the agent on **every** reconnect for 24h, re-sending stale, time-sensitive answers.

## Changes

Both suggested fixes from the issue (they compose):

**1. Provenance-agnostic replay guard** (`services/agent-replay.ts`)
The `NOT EXISTS` guard now keys on `reply.is_from_me = true` instead of `reply.sender_agent_id IS NOT NULL`: any outbound message after the inbound is evidence the turn was handled, regardless of who sent the answer. This alone fixes the replay storm, including for existing rows already in the 24h window at deploy time.

**2. Send routes can carry agent authorship** (`routes/v2/messages.ts`)
`POST /messages/send` and `/messages/send/media` accept an optional `sentBy: 'agent' | 'user'`. `'agent'` resolves the instance's configured agent **server-side** (`sender_agent_id` is an FK to `agents`, so caller-provided ids are not accepted) and threads it into `OutgoingMessage.metadata.senderAgentId`, which channel plugins already echo into the `message.sent` payload for persistence. Beyond replay, this arms the follow-up lifecycle for out-of-band answers (`follow-up-hooks.ts` only arms on agent-authored sends) and fixes attribution in analytics. OpenAPI schemas updated and SDK types regenerated.

## Tests

- `agent-replay.test.ts`: renders the actual messages-query WHERE clause via `PgDialect` and asserts the guard keys on `reply.is_from_me` and no longer references `reply.sender_agent_id`.
- `messages-send-sent-by.test.ts` (new): `sentBy: 'agent'` resolves the instance agent into `metadata.senderAgentId` on both routes; omitted/`'user'`/agent-less instance stay unattributed; unknown values are rejected.

`make typecheck`, `make lint`, and the full `packages/api` suite (2005 pass, 0 fail) are green.