### PR TITLE
fix(automations): dispatch call_agent to local claude-code providers

### DIFF
--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -223,6 +223,7 @@ export function buildAutomationEngineDeps(
       const result = await services.agentRunner.runOrStream({
         instance: runInstance,
         chatId: resolvedChatId,
+        threadId: ctx.threadId,
         senderId: resolvedSenderId,
         senderName: ctx.senderName,
         chatType: 'dm',

--- a/packages/api/src/services/__tests__/agent-runner-claude-code.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner-claude-code.test.ts
@@ -1,0 +1,267 @@
+/**
+ * `call_agent` must be able to dispatch to local claude-code providers (#929).
+ *
+ * The automation `call_agent` action lands on `AgentRunnerService`, which used
+ * to (1) require a non-empty `apiKey` unconditionally and (2) build every
+ * client through the HTTP factory path without `schemaConfig` — so a
+ * `local://claude-code` provider that answers chats fine via message routing
+ * failed with "Provider … has no API key configured" when an automation
+ * invoked it.
+ *
+ * These tests pin the fix:
+ *   * `getClient` builds a claude-code client with NO api key, from
+ *     `schemaConfig` (projectPath), instead of throwing;
+ *   * a sealed-but-unopenable credential still fails closed, even for
+ *     claude-code;
+ *   * `run()`/`stream()` map the strategy-computed session key to the
+ *     provider's own session UUID through the same per-provider session store
+ *     the message-routing dispatcher uses, so automations resume the very
+ *     session the chat conversation runs in.
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as omniCoreReal from '@omni/core';
+import type { IAgentClient, ProviderResponse, StreamChunk } from '@omni/core';
+import { setTenantSecretMasterKey } from '@omni/core';
+import type { Database } from '@omni/db';
+import { sealCredentialField } from '../../tenancy/sealed-credentials';
+import { runInTenantScope } from '../../tenancy/tenant-scope';
+import { buildWorkerTenantContext } from '../../tenancy/worker-tenant-context';
+import { type AgentRunContext, AgentRunnerService, type RunInstance } from '../agent-runner';
+
+const PROVIDER_ID = 'cc-provider-1';
+const CLAUDE_SESSION_UUID = '99999999-9999-4999-8999-999999999999';
+const TENANT_A = '11111111-1111-4111-8111-11111111111a';
+const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+
+/**
+ * What `getClient` hands the provider-client factory — the point the #929 fix
+ * changes. Recorded through a module mock because bun's `mock.module` is
+ * process-wide and sibling suites (`plugins/__tests__/agent-dispatcher*.test.ts`)
+ * already replace `createProviderClient` with stubs; asserting on the RETURNED
+ * client would depend on which suite's mock happens to be active. The mock
+ * returns an inert client — no test in this file executes the built client.
+ */
+const factoryCalls: Array<{ schema: string; apiKey: string; schemaConfig?: Record<string, unknown> }> = [];
+mock.module('@omni/core', () => ({
+  ...omniCoreReal,
+  createProviderClient: (config: { schema: string; apiKey: string; schemaConfig?: Record<string, unknown> }) => {
+    factoryCalls.push(config);
+    return { run: async () => ({}), stream: async function* () {} } as unknown as IAgentClient;
+  },
+}));
+
+afterEach(() => {
+  factoryCalls.length = 0;
+});
+
+/** A one-row `agent_providers` stand-in for a local claude-code provider. */
+function providerDb(apiKey: string | null): Database {
+  const row = {
+    id: PROVIDER_ID,
+    name: 'local claude',
+    schema: 'claude-code',
+    baseUrl: 'local://claude-code',
+    apiKey,
+    defaultTimeout: 600,
+    isActive: true,
+    schemaConfig: { projectPath: '/tmp/cc-project' },
+  };
+  const db: Record<string, unknown> = {
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(db),
+    execute: async () => undefined,
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [row],
+        }),
+      }),
+    }),
+  };
+  return db as unknown as Database;
+}
+
+/**
+ * A db stand-in for the SESSION-STORE reads/writes `run()`/`stream()` issue
+ * (the provider row is bypassed by stubbing `getClient`). Serves `stored` on
+ * select and records every upsert.
+ */
+function sessionDb(
+  stored: { sessionId: string } | null,
+  upserts: Array<{ instanceId: string; sessionKey: string; sessionId: unknown }>,
+): Database {
+  const row = stored
+    ? { providerSessionData: { sessionId: stored.sessionId }, lastUsedAt: new Date(), expiresAt: null }
+    : null;
+  const db: Record<string, unknown> = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (row ? [row] : []),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (values: { instanceId: string; sessionKey: string; providerSessionData: { sessionId: unknown } }) => ({
+        onConflictDoUpdate: async () => {
+          upserts.push({
+            instanceId: values.instanceId,
+            sessionKey: values.sessionKey,
+            sessionId: values.providerSessionData.sessionId,
+          });
+        },
+      }),
+    }),
+  };
+  return db as unknown as Database;
+}
+
+/** `getClient` is private; the run path reaches it, and so does this. */
+function getClient(service: AgentRunnerService, providerId: string): Promise<{ client: IAgentClient; schema: string }> {
+  return (
+    service as unknown as { getClient: (id: string) => Promise<{ client: IAgentClient; schema: string }> }
+  ).getClient(providerId);
+}
+
+/** Stub the private client resolution so run()/stream() exercise only the session flow. */
+function stubClient(service: AgentRunnerService, client: IAgentClient): void {
+  (service as unknown as { getClient: () => Promise<{ client: IAgentClient; schema: string }> }).getClient =
+    async () => ({
+      client,
+      schema: 'claude-code',
+    });
+}
+
+function runContext(): AgentRunContext {
+  const instance = {
+    id: 'inst-1',
+    tenantId: null,
+    agentProviderId: PROVIDER_ID,
+    agentInternalId: 'claude-code',
+    agentSessionStrategy: 'per_chat',
+  } as unknown as RunInstance;
+  return {
+    instance,
+    chatId: '5511999999999@s.whatsapp.net',
+    senderId: '5511999999999@s.whatsapp.net',
+    chatType: 'dm',
+    messages: ['pong'],
+  };
+}
+
+describe('agent-runner — claude-code providers dispatch without an API key (#929)', () => {
+  test('getClient builds a client for a keyless local claude-code provider (was: 401)', async () => {
+    const service = new AgentRunnerService(providerDb(null));
+    const resolved = await getClient(service, PROVIDER_ID);
+    expect(resolved.schema).toBe('claude-code');
+    // The factory receives the schemaConfig it needs to build a ClaudeCodeClient
+    // (projectPath), and no bearer credential is fabricated.
+    expect(factoryCalls).toHaveLength(1);
+    expect(factoryCalls[0]?.schema).toBe('claude-code');
+    expect(factoryCalls[0]?.apiKey).toBe('');
+    expect(factoryCalls[0]?.schemaConfig).toEqual({ projectPath: '/tmp/cc-project' });
+  });
+
+  test('a plaintext api key is still forwarded to the client config', async () => {
+    // The key becomes the SDK's ANTHROPIC_API_KEY override.
+    const service = new AgentRunnerService(providerDb('sk-ant-test'));
+    await getClient(service, PROVIDER_ID);
+    expect(factoryCalls[0]?.apiKey).toBe('sk-ant-test');
+  });
+
+  test('a sealed credential that cannot be opened still fails CLOSED', async () => {
+    setTenantSecretMasterKey(Buffer.alloc(32, 7));
+    try {
+      const sealed = sealCredentialField(TENANT_A, 'sk-ant-test');
+      const db = providerDb(sealed);
+      const service = new AgentRunnerService(db);
+      await expect(
+        runInTenantScope(db, buildWorkerTenantContext(TENANT_B), () => getClient(service, PROVIDER_ID)),
+      ).rejects.toThrow(/not available/i);
+      expect(factoryCalls).toHaveLength(0);
+    } finally {
+      setTenantSecretMasterKey(null);
+    }
+  });
+});
+
+describe('agent-runner — claude-code session continuity with the dispatch path', () => {
+  test('run() starts fresh when no session is stored, then persists the provider session UUID', async () => {
+    const upserts: Array<{ instanceId: string; sessionKey: string; sessionId: unknown }> = [];
+    const service = new AgentRunnerService(sessionDb(null, upserts));
+    const seen: Array<{ sessionId?: string; mcpUrlParams?: Record<string, string> }> = [];
+    stubClient(service, {
+      run: mock(async (request: { sessionId?: string; mcpUrlParams?: Record<string, string> }) => {
+        seen.push({ sessionId: request.sessionId, mcpUrlParams: request.mcpUrlParams });
+        return {
+          content: 'pong',
+          runId: 'run-1',
+          sessionId: CLAUDE_SESSION_UUID,
+          status: 'completed',
+        } as ProviderResponse;
+      }),
+    } as unknown as IAgentClient);
+
+    const result = await service.run(runContext());
+
+    // No stored session → the client must NOT receive the strategy key as a
+    // resume target (Claude Code resumes only by its own UUID).
+    expect(seen[0]?.sessionId).toBeUndefined();
+    // Parity with the dispatcher: HTTP MCP servers get the chat identifier.
+    expect(seen[0]?.mcpUrlParams).toEqual({ chat_id: '5511999999999@s.whatsapp.net' });
+    // The returned UUID is persisted under the strategy key for the NEXT call.
+    expect(upserts).toEqual([
+      {
+        instanceId: 'inst-1',
+        sessionKey: `provider:${PROVIDER_ID}:session:5511999999999@s.whatsapp.net`,
+        sessionId: CLAUDE_SESSION_UUID,
+      },
+    ]);
+    expect(result.parts).toEqual(['pong']);
+  });
+
+  test('run() resumes the stored provider session UUID', async () => {
+    const upserts: Array<{ instanceId: string; sessionKey: string; sessionId: unknown }> = [];
+    const service = new AgentRunnerService(sessionDb({ sessionId: CLAUDE_SESSION_UUID }, upserts));
+    const seen: Array<{ sessionId?: string }> = [];
+    stubClient(service, {
+      run: mock(async (request: { sessionId?: string }) => {
+        seen.push({ sessionId: request.sessionId });
+        return {
+          content: 'pong',
+          runId: 'run-2',
+          sessionId: CLAUDE_SESSION_UUID,
+          status: 'completed',
+        } as ProviderResponse;
+      }),
+    } as unknown as IAgentClient);
+
+    await service.run(runContext());
+
+    expect(seen[0]?.sessionId).toBe(CLAUDE_SESSION_UUID);
+  });
+
+  test('stream() captures the provider session UUID from chunks and persists it', async () => {
+    const upserts: Array<{ instanceId: string; sessionKey: string; sessionId: unknown }> = [];
+    const service = new AgentRunnerService(sessionDb(null, upserts));
+    stubClient(service, {
+      stream: async function* (): AsyncGenerator<StreamChunk> {
+        yield { event: 'RunStarted', isComplete: false, sessionId: CLAUDE_SESSION_UUID };
+        yield { event: 'RunCompleted', isComplete: true, fullContent: 'pong', sessionId: CLAUDE_SESSION_UUID };
+      },
+    } as unknown as IAgentClient);
+
+    const parts: string[] = [];
+    for await (const part of service.stream(runContext())) {
+      parts.push(part);
+    }
+
+    expect(upserts).toEqual([
+      {
+        instanceId: 'inst-1',
+        sessionKey: `provider:${PROVIDER_ID}:session:5511999999999@s.whatsapp.net`,
+        sessionId: CLAUDE_SESSION_UUID,
+      },
+    ]);
+  });
+});

--- a/packages/api/src/services/__tests__/agent-runner-claude-code.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner-claude-code.test.ts
@@ -117,10 +117,16 @@ function sessionDb(
 }
 
 /** `getClient` is private; the run path reaches it, and so does this. */
-function getClient(service: AgentRunnerService, providerId: string): Promise<{ client: IAgentClient; schema: string }> {
+function getClient(
+  service: AgentRunnerService,
+  providerId: string,
+  openedForTenantId?: string | null,
+): Promise<{ client: IAgentClient; schema: string }> {
   return (
-    service as unknown as { getClient: (id: string) => Promise<{ client: IAgentClient; schema: string }> }
-  ).getClient(providerId);
+    service as unknown as {
+      getClient: (id: string, openedForTenantId?: string | null) => Promise<{ client: IAgentClient; schema: string }>;
+    }
+  ).getClient(providerId, openedForTenantId);
 }
 
 /** Stub the private client resolution so run()/stream() exercise only the session flow. */
@@ -132,13 +138,13 @@ function stubClient(service: AgentRunnerService, client: IAgentClient): void {
     });
 }
 
-function runContext(): AgentRunContext {
+function runContext(overrides: Partial<AgentRunContext> = {}, sessionStrategy = 'per_chat'): AgentRunContext {
   const instance = {
     id: 'inst-1',
     tenantId: null,
     agentProviderId: PROVIDER_ID,
     agentInternalId: 'claude-code',
-    agentSessionStrategy: 'per_chat',
+    agentSessionStrategy: sessionStrategy,
   } as unknown as RunInstance;
   return {
     instance,
@@ -146,6 +152,7 @@ function runContext(): AgentRunContext {
     senderId: '5511999999999@s.whatsapp.net',
     chatType: 'dm',
     messages: ['pong'],
+    ...overrides,
   };
 }
 
@@ -179,6 +186,23 @@ describe('agent-runner — claude-code providers dispatch without an API key (#9
         runInTenantScope(db, buildWorkerTenantContext(TENANT_B), () => getClient(service, PROVIDER_ID)),
       ).rejects.toThrow(/not available/i);
       expect(factoryCalls).toHaveLength(0);
+    } finally {
+      setTenantSecretMasterKey(null);
+    }
+  });
+
+  test("a sealed credential OPENS under the instance's persisted tenant with NO scope active", async () => {
+    // The call_agent automation path deliberately runs the agent call outside
+    // every tenant scope, so run()/stream() thread instance.tenantId into
+    // getClient — otherwise a keyed claude-code provider would still fail
+    // with "credential is not available" on that path (#929, keyed case).
+    setTenantSecretMasterKey(Buffer.alloc(32, 7));
+    try {
+      const sealed = sealCredentialField(TENANT_A, 'sk-ant-test');
+      const service = new AgentRunnerService(providerDb(sealed));
+      const resolved = await getClient(service, PROVIDER_ID, TENANT_A);
+      expect(resolved.schema).toBe('claude-code');
+      expect(factoryCalls[0]?.apiKey).toBe('sk-ant-test');
     } finally {
       setTenantSecretMasterKey(null);
     }
@@ -254,6 +278,68 @@ describe('agent-runner — claude-code session continuity with the dispatch path
     const parts: string[] = [];
     for await (const part of service.stream(runContext())) {
       parts.push(part);
+    }
+
+    expect(upserts).toEqual([
+      {
+        instanceId: 'inst-1',
+        sessionKey: `provider:${PROVIDER_ID}:session:5511999999999@s.whatsapp.net`,
+        sessionId: CLAUDE_SESSION_UUID,
+      },
+    ]);
+  });
+
+  test('per_thread: the session key carries the threadId, matching the dispatcher', async () => {
+    const upserts: Array<{ instanceId: string; sessionKey: string; sessionId: unknown }> = [];
+    const service = new AgentRunnerService(sessionDb(null, upserts));
+    stubClient(service, {
+      run: async () =>
+        ({ content: 'pong', runId: 'run-3', sessionId: CLAUDE_SESSION_UUID, status: 'completed' }) as ProviderResponse,
+    } as unknown as IAgentClient);
+
+    await service.run(runContext({ threadId: 'T42' }, 'per_thread'));
+
+    // Without the threadId this collapses to thread:<chatId>:<chatId> and every
+    // thread of the chat shares one Claude session.
+    expect(upserts[0]?.sessionKey).toBe(`provider:${PROVIDER_ID}:session:thread:5511999999999@s.whatsapp.net:T42`);
+  });
+
+  test('a failed session-store write never discards the reply the agent produced', async () => {
+    const failingDb: Record<string, unknown> = {
+      select: () => ({ from: () => ({ where: () => ({ limit: async () => [] }) }) }),
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: async () => {
+            throw new Error('db blip');
+          },
+        }),
+      }),
+    };
+    const service = new AgentRunnerService(failingDb as unknown as Database);
+    stubClient(service, {
+      run: async () =>
+        ({ content: 'pong', runId: 'run-4', sessionId: CLAUDE_SESSION_UUID, status: 'completed' }) as ProviderResponse,
+    } as unknown as IAgentClient);
+
+    // The write is continuity bookkeeping — the reply must survive its failure.
+    const result = await service.run(runContext());
+    expect(result.parts).toEqual(['pong']);
+  });
+
+  test('stream(): a consumer breaking out early still persists the captured session', async () => {
+    const upserts: Array<{ instanceId: string; sessionKey: string; sessionId: unknown }> = [];
+    const service = new AgentRunnerService(sessionDb(null, upserts));
+    stubClient(service, {
+      stream: async function* (): AsyncGenerator<StreamChunk> {
+        yield { event: 'RunStarted', isComplete: false, sessionId: CLAUDE_SESSION_UUID };
+        yield { event: 'RunResponse', content: 'part-1\n\npart-2 begins', isComplete: false };
+        yield { event: 'RunCompleted', isComplete: true };
+      },
+    } as unknown as IAgentClient);
+
+    for await (const part of service.stream(runContext())) {
+      expect(part).toBe('part-1');
+      break; // early exit — the finally block must still persist the session
     }
 
     expect(upserts).toEqual([

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -12,6 +12,8 @@ import {
   type IAgentClient,
   ProviderError,
   type ProviderFile,
+  type ProviderSchema,
+  type SessionStorage,
   type StreamChunk,
   createProviderClient,
   isProviderSchemaSupported,
@@ -21,6 +23,7 @@ import type { AgentReplyFilter, AgentSessionStrategy, ChannelType, Instance } fr
 import type { Database } from '@omni/db';
 import { agentProviders, instances, persons } from '@omni/db';
 import { eq } from 'drizzle-orm';
+import { createSessionStorage } from '../plugins/session-storage';
 import { isSealedCredentialField, openCredentialField } from '../tenancy/sealed-credentials';
 import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 
@@ -315,6 +318,16 @@ async function* processStreamChunks(
 // Agent Runner Service
 // ============================================================================
 
+/**
+ * A provider client plus the schema it was built for. The schema drives
+ * dispatch behavior in run()/stream(): local schemas (claude-code) need
+ * provider-session mapping instead of passing the strategy key through.
+ */
+interface ResolvedProviderClient {
+  client: IAgentClient;
+  schema: ProviderSchema;
+}
+
 export class AgentRunnerService {
   /**
    * Provider clients, keyed `providerId::tenant`.
@@ -327,7 +340,7 @@ export class AgentRunnerService {
    * and its key — would be served to every later tenant. The scope-less legacy
    * path keys on `-`, so it still shares exactly one client per provider.
    */
-  private clientCache: Map<string, IAgentClient> = new Map();
+  private clientCache: Map<string, ResolvedProviderClient> = new Map();
 
   constructor(private db: Database) {}
 
@@ -337,9 +350,9 @@ export class AgentRunnerService {
   }
 
   /**
-   * Get or create an Agno client for a provider
+   * Get or create a provider client for a provider
    */
-  private async getClient(providerId: string): Promise<IAgentClient> {
+  private async getClient(providerId: string): Promise<ResolvedProviderClient> {
     // Check cache
     const cacheKey = this.clientCacheKey(providerId);
     const cached = this.clientCache.get(cacheKey);
@@ -374,27 +387,73 @@ export class AgentRunnerService {
     // fails CLOSED — a null never becomes a bearer token.
     const apiKey = openCredentialField(currentTenantScope()?.tenantId ?? null, provider.apiKey);
 
-    if (!apiKey) {
+    // A sealed credential that cannot be opened in this tenant context is an
+    // error for EVERY schema — the alternative is silently running under the
+    // wrong identity (or the host's ambient key).
+    if (!apiKey && isSealedCredentialField(provider.apiKey)) {
       throw new ProviderError(
-        isSealedCredentialField(provider.apiKey)
-          ? `Provider ${providerId} credential is not available in this tenant context`
-          : `Provider ${providerId} has no API key configured`,
+        `Provider ${providerId} credential is not available in this tenant context`,
         'AUTHENTICATION_FAILED',
         401,
       );
     }
 
+    // claude-code providers run in-process (`local://claude-code`): there is no
+    // HTTP endpoint and legitimately no API key (the SDK falls back to the
+    // host's ANTHROPIC_API_KEY). Build the client from schemaConfig instead of
+    // requiring a bearer credential — this is how `call_agent` automations reach
+    // the same providers that already answer chats via message routing (#929).
+    if (provider.schema === 'claude-code') {
+      const resolved: ResolvedProviderClient = {
+        client: createProviderClient({
+          schema: provider.schema,
+          baseUrl: provider.baseUrl,
+          apiKey: apiKey ?? '',
+          defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
+          schemaConfig: (provider.schemaConfig ?? {}) as Record<string, unknown>,
+        }),
+        schema: provider.schema,
+      };
+      this.clientCache.set(cacheKey, resolved);
+      return resolved;
+    }
+
+    if (!apiKey) {
+      throw new ProviderError(`Provider ${providerId} has no API key configured`, 'AUTHENTICATION_FAILED', 401);
+    }
+
     // Create client
-    const client = createProviderClient({
+    const resolved: ResolvedProviderClient = {
+      client: createProviderClient({
+        schema: provider.schema,
+        baseUrl: provider.baseUrl,
+        apiKey,
+        defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
+      }),
       schema: provider.schema,
-      baseUrl: provider.baseUrl,
-      apiKey,
-      defaultTimeoutMs: (provider.defaultTimeout ?? 600) * 1000,
-    });
+    };
 
     // Cache it
-    this.clientCache.set(cacheKey, client);
-    return client;
+    this.clientCache.set(cacheKey, resolved);
+    return resolved;
+  }
+
+  /**
+   * Session store for a claude-code provider, per run.
+   *
+   * Claude Code resumes by its OWN session UUID, not the strategy-computed
+   * key. The mapping key → UUID lives in the same per-provider store the
+   * message-routing dispatcher uses (`ClaudeCodeAgentProvider` +
+   * `createSessionStorage`), and both paths compute the key with
+   * `computeSessionId` over the same inputs — so a `call_agent` automation
+   * resumes the very session the chat conversation runs in.
+   */
+  private claudeSessionStore(instance: RunInstance, providerId: string): SessionStorage {
+    return createSessionStorage(this.db, providerId, undefined, {
+      // Persisted ownership from the loaded instance row — same trusted
+      // derivation the dispatcher supplies (G5, ADR-0008).
+      resolveTenantId: () => instance.tenantId ?? null,
+    });
   }
 
   /**
@@ -477,7 +536,7 @@ export class AgentRunnerService {
       throw new ProviderError('No agent internal ID configured for instance', 'NOT_FOUND', 400);
     }
 
-    const client = await this.getClient(instance.agentProviderId);
+    const { client, schema } = await this.getClient(instance.agentProviderId);
 
     // Format messages with sender name prefix if enabled
     const prefixEnabled = instance.agentPrefixSenderName ?? true;
@@ -489,6 +548,14 @@ export class AgentRunnerService {
     // Compute session ID based on configured strategy
     const sessionStrategy = instance.agentSessionStrategy ?? 'per_chat';
     const sessionId = computeSessionId(sessionStrategy, senderId, chatId);
+
+    // claude-code: resolve the strategy key to the provider's session UUID (or
+    // start a fresh session when none is stored). Other schemas take the key
+    // as-is, unchanged.
+    const sessionStore = schema === 'claude-code' ? this.claudeSessionStore(instance, instance.agentProviderId) : null;
+    const providerSessionId = sessionStore
+      ? (await sessionStore.getSession(instance.id, sessionId))?.sessionId
+      : sessionId;
 
     log.info('Running agent', {
       instanceId: instance.id,
@@ -506,7 +573,7 @@ export class AgentRunnerService {
       agentId: instance.agentInternalId,
       agentType: (instance.agentType ?? 'agent') as 'agent' | 'team' | 'workflow',
       stream: false,
-      sessionId, // Computed based on session strategy
+      sessionId: providerSessionId,
       userId: personId || senderId, // ← Person UUID (internal identity)
       platform: {
         id: senderId,
@@ -527,9 +594,18 @@ export class AgentRunnerService {
       },
       timeoutMs: (instance.agentTimeout ?? 600) * 1000,
       files,
+      // Parity with the dispatcher's claude-code path: HTTP MCP servers get the
+      // conversation identifier appended to their URL.
+      ...(sessionStore && chatId ? { mcpUrlParams: { chat_id: chatId } } : {}),
     };
 
     const response = await client.run(request);
+
+    // Persist the provider session UUID under the strategy key so the next
+    // call — from either dispatch path — resumes this session.
+    if (sessionStore && response.sessionId) {
+      await sessionStore.upsertSession(instance.id, sessionId, response.sessionId, null);
+    }
 
     // Split response if enabled
     const parts = splitResponse(response.content, instance.enableAutoSplit ?? true);
@@ -612,7 +688,7 @@ export class AgentRunnerService {
       throw new ProviderError('No agent internal ID configured for instance', 'NOT_FOUND', 400);
     }
 
-    const client = await this.getClient(instance.agentProviderId);
+    const { client, schema } = await this.getClient(instance.agentProviderId);
 
     // Format messages with sender name prefix if enabled
     const prefixEnabled = instance.agentPrefixSenderName ?? true;
@@ -625,12 +701,18 @@ export class AgentRunnerService {
     const sessionStrategy = instance.agentSessionStrategy ?? 'per_chat';
     const sessionId = computeSessionId(sessionStrategy, senderId, chatId);
 
+    // claude-code: strategy key → provider session UUID, as in run().
+    const sessionStore = schema === 'claude-code' ? this.claudeSessionStore(instance, instance.agentProviderId) : null;
+    const providerSessionId = sessionStore
+      ? (await sessionStore.getSession(instance.id, sessionId))?.sessionId
+      : sessionId;
+
     const request = {
       message: combinedMessage,
       agentId: instance.agentInternalId,
       agentType: (instance.agentType ?? 'agent') as 'agent' | 'team' | 'workflow',
       stream: true,
-      sessionId, // Computed based on session strategy
+      sessionId: providerSessionId,
       userId: personId || senderId, // ← Person UUID (internal identity)
       platform: {
         id: senderId,
@@ -650,10 +732,30 @@ export class AgentRunnerService {
         participantCount,
       },
       timeoutMs: (instance.agentTimeout ?? 600) * 1000,
+      ...(sessionStore && chatId ? { mcpUrlParams: { chat_id: chatId } } : {}),
     };
 
     // Client routes by agentType internally
-    yield* processStreamChunks(client.stream(request), enableSplit);
+    if (!sessionStore) {
+      yield* processStreamChunks(client.stream(request), enableSplit);
+      return;
+    }
+
+    // Capture the provider session UUID from the chunk stream so it can be
+    // persisted under the strategy key once the stream completes.
+    let providerSession: string | undefined;
+    const source = (async function* (): AsyncGenerator<StreamChunk> {
+      for await (const chunk of client.stream(request)) {
+        if (chunk.sessionId) providerSession = chunk.sessionId;
+        yield chunk;
+      }
+    })();
+
+    yield* processStreamChunks(source, enableSplit);
+
+    if (providerSession) {
+      await sessionStore.upsertSession(instance.id, sessionId, providerSession, null);
+    }
   }
 
   /**

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -51,6 +51,9 @@ export interface AgentRunContext {
   /** Chat ID for session continuity */
   chatId: string;
 
+  /** Thread/topic identifier (e.g. Telegram forum topic) — drives per_thread session keys */
+  threadId?: string;
+
   /** Person UUID (internal identity) — falls back to senderId if unresolved */
   personId?: string;
 
@@ -344,17 +347,26 @@ export class AgentRunnerService {
 
   constructor(private db: Database) {}
 
-  /** The cache key for `providerId` under the tenant scope active right now. */
-  private clientCacheKey(providerId: string): string {
-    return `${providerId}::${currentTenantScope()?.tenantId ?? '-'}`;
-  }
-
   /**
-   * Get or create a provider client for a provider
+   * Get or create a provider client for a provider.
+   *
+   * `openedForTenantId` is the tenant the provider's credential is opened (and
+   * the client cached) under, when the caller threads one — the same
+   * threaded-over-ambient rule the dispatcher's `openclawPoolKey` applies.
+   * run()/stream() thread the instance's persisted `tenantId` because the
+   * `call_agent` automation path deliberately runs the agent call OUTSIDE every
+   * tenant scope (see `plugins/automation-actions.ts`): with only the ambient
+   * scope a sealed `agent_providers.api_key` could never be opened there. A
+   * null/absent value falls back to the ambient scope, so direct callers and
+   * the legacy world behave exactly as before.
    */
-  private async getClient(providerId: string): Promise<ResolvedProviderClient> {
+  private async getClient(providerId: string, openedForTenantId?: string | null): Promise<ResolvedProviderClient> {
+    // Credential open and cache key MUST use the same tenant — the cache stores
+    // a credential (see the clientCache doc above).
+    const tenantId = openedForTenantId ?? currentTenantScope()?.tenantId ?? null;
+
     // Check cache
-    const cacheKey = this.clientCacheKey(providerId);
+    const cacheKey = `${providerId}::${tenantId ?? '-'}`;
     const cached = this.clientCache.get(cacheKey);
     if (cached) return cached;
 
@@ -385,7 +397,7 @@ export class AgentRunnerService {
     // a flag-off/key-absent deployment hands `createProviderClient` exactly the
     // bytes it handed it before (g). Only a sealed value is decided here, and it
     // fails CLOSED — a null never becomes a bearer token.
-    const apiKey = openCredentialField(currentTenantScope()?.tenantId ?? null, provider.apiKey);
+    const apiKey = openCredentialField(tenantId, provider.apiKey);
 
     // A sealed credential that cannot be opened in this tenant context is an
     // error for EVERY schema — the alternative is silently running under the
@@ -444,9 +456,20 @@ export class AgentRunnerService {
    * Claude Code resumes by its OWN session UUID, not the strategy-computed
    * key. The mapping key → UUID lives in the same per-provider store the
    * message-routing dispatcher uses (`ClaudeCodeAgentProvider` +
-   * `createSessionStorage`), and both paths compute the key with
-   * `computeSessionId` over the same inputs — so a `call_agent` automation
-   * resumes the very session the chat conversation runs in.
+   * `createSessionStorage`). This path computes the legacy strategy key
+   * (`computeSessionId(strategy, senderId, chatId, threadId)`) — the same key
+   * the dispatcher's `resolveKhalSessionId` produces for claude-code, EXCEPT
+   * when a message's rawPayload carries an explicit khal session id: that id
+   * never reaches automation payloads, so such sessions keep their
+   * dispatcher-side key and an automation computes the legacy key instead.
+   *
+   * Concurrency: the automation engine consumer is independent of the
+   * dispatcher's per-chat dispatch queue, so an automation (e.g. a
+   * chat.idle_timeout `call_agent`) can resume the same session UUID while a
+   * chat message is mid-dispatch. Both then upsert the same mapping row
+   * (last-write-wins on an identical UUID, so the row converges). If
+   * interleaved resumes prove problematic in practice, reuse the dispatcher's
+   * per-chat serialisation here.
    */
   private claudeSessionStore(instance: RunInstance, providerId: string): SessionStorage {
     return createSessionStorage(this.db, providerId, undefined, {
@@ -454,6 +477,42 @@ export class AgentRunnerService {
       // derivation the dispatcher supplies (G5, ADR-0008).
       resolveTenantId: () => instance.tenantId ?? null,
     });
+  }
+
+  /**
+   * The session id to hand the provider client: claude-code maps the strategy
+   * key through the session store (undefined = start a fresh session); every
+   * other schema takes the key as-is, unchanged.
+   */
+  private async resolveProviderSessionId(
+    sessionStore: SessionStorage | null,
+    instanceId: string,
+    sessionKey: string,
+  ): Promise<string | undefined> {
+    if (!sessionStore) return sessionKey;
+    return (await sessionStore.getSession(instanceId, sessionKey))?.sessionId;
+  }
+
+  /**
+   * Best-effort persist of the claude-code session mapping — never throws.
+   * Continuity bookkeeping only: a failed write must not discard a reply the
+   * agent already produced (the next call just starts a fresh session).
+   */
+  private async persistProviderSession(
+    sessionStore: SessionStorage,
+    instanceId: string,
+    sessionKey: string,
+    providerSessionId: string,
+  ): Promise<void> {
+    try {
+      await sessionStore.upsertSession(instanceId, sessionKey, providerSessionId, null);
+    } catch (error) {
+      log.warn('Failed to persist claude-code session mapping', {
+        instanceId,
+        sessionKey,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**
@@ -516,6 +575,7 @@ export class AgentRunnerService {
     const {
       instance,
       chatId,
+      threadId,
       personId,
       senderId,
       senderName,
@@ -536,7 +596,7 @@ export class AgentRunnerService {
       throw new ProviderError('No agent internal ID configured for instance', 'NOT_FOUND', 400);
     }
 
-    const { client, schema } = await this.getClient(instance.agentProviderId);
+    const { client, schema } = await this.getClient(instance.agentProviderId, instance.tenantId);
 
     // Format messages with sender name prefix if enabled
     const prefixEnabled = instance.agentPrefixSenderName ?? true;
@@ -547,15 +607,10 @@ export class AgentRunnerService {
 
     // Compute session ID based on configured strategy
     const sessionStrategy = instance.agentSessionStrategy ?? 'per_chat';
-    const sessionId = computeSessionId(sessionStrategy, senderId, chatId);
+    const sessionId = computeSessionId(sessionStrategy, senderId, chatId, threadId);
 
-    // claude-code: resolve the strategy key to the provider's session UUID (or
-    // start a fresh session when none is stored). Other schemas take the key
-    // as-is, unchanged.
     const sessionStore = schema === 'claude-code' ? this.claudeSessionStore(instance, instance.agentProviderId) : null;
-    const providerSessionId = sessionStore
-      ? (await sessionStore.getSession(instance.id, sessionId))?.sessionId
-      : sessionId;
+    const providerSessionId = await this.resolveProviderSessionId(sessionStore, instance.id, sessionId);
 
     log.info('Running agent', {
       instanceId: instance.id,
@@ -604,7 +659,7 @@ export class AgentRunnerService {
     // Persist the provider session UUID under the strategy key so the next
     // call — from either dispatch path — resumes this session.
     if (sessionStore && response.sessionId) {
-      await sessionStore.upsertSession(instance.id, sessionId, response.sessionId, null);
+      await this.persistProviderSession(sessionStore, instance.id, sessionId, response.sessionId);
     }
 
     // Split response if enabled
@@ -649,7 +704,7 @@ export class AgentRunnerService {
     }
 
     const sessionStrategy = context.instance.agentSessionStrategy ?? 'per_chat';
-    const sessionId = computeSessionId(sessionStrategy, context.senderId, context.chatId);
+    const sessionId = computeSessionId(sessionStrategy, context.senderId, context.chatId, context.threadId);
 
     return {
       parts,
@@ -669,6 +724,7 @@ export class AgentRunnerService {
     const {
       instance,
       chatId,
+      threadId,
       personId,
       senderId,
       senderName,
@@ -688,7 +744,7 @@ export class AgentRunnerService {
       throw new ProviderError('No agent internal ID configured for instance', 'NOT_FOUND', 400);
     }
 
-    const { client, schema } = await this.getClient(instance.agentProviderId);
+    const { client, schema } = await this.getClient(instance.agentProviderId, instance.tenantId);
 
     // Format messages with sender name prefix if enabled
     const prefixEnabled = instance.agentPrefixSenderName ?? true;
@@ -699,13 +755,11 @@ export class AgentRunnerService {
 
     // Compute session ID based on configured strategy
     const sessionStrategy = instance.agentSessionStrategy ?? 'per_chat';
-    const sessionId = computeSessionId(sessionStrategy, senderId, chatId);
+    const sessionId = computeSessionId(sessionStrategy, senderId, chatId, threadId);
 
     // claude-code: strategy key → provider session UUID, as in run().
     const sessionStore = schema === 'claude-code' ? this.claudeSessionStore(instance, instance.agentProviderId) : null;
-    const providerSessionId = sessionStore
-      ? (await sessionStore.getSession(instance.id, sessionId))?.sessionId
-      : sessionId;
+    const providerSessionId = await this.resolveProviderSessionId(sessionStore, instance.id, sessionId);
 
     const request = {
       message: combinedMessage,
@@ -742,7 +796,10 @@ export class AgentRunnerService {
     }
 
     // Capture the provider session UUID from the chunk stream so it can be
-    // persisted under the strategy key once the stream completes.
+    // persisted under the strategy key once the stream ends. The persist sits
+    // in a finally — mirroring ClaudeCodeAgentProvider.triggerStream — so a
+    // consumer breaking out early (or a throw mid-stream) does not orphan the
+    // session the provider just created.
     let providerSession: string | undefined;
     const source = (async function* (): AsyncGenerator<StreamChunk> {
       for await (const chunk of client.stream(request)) {
@@ -751,10 +808,12 @@ export class AgentRunnerService {
       }
     })();
 
-    yield* processStreamChunks(source, enableSplit);
-
-    if (providerSession) {
-      await sessionStore.upsertSession(instance.id, sessionId, providerSession, null);
+    try {
+      yield* processStreamChunks(source, enableSplit);
+    } finally {
+      if (providerSession) {
+        await this.persistProviderSession(sessionStore, instance.id, sessionId, providerSession);
+      }
     }
   }
 

--- a/packages/core/src/automations/__tests__/actions.test.ts
+++ b/packages/core/src/automations/__tests__/actions.test.ts
@@ -273,3 +273,63 @@ describe('call_agent — promptOverride', () => {
     expect(receivedContext.messages).toEqual(['fallback message']);
   });
 });
+
+describe('extractAgentCallContext — threadId (per_thread session keys)', () => {
+  test('payload.threadId reaches the agent call context', async () => {
+    const callAgent = mock(async (_ctx: AgentCallContext, _cfg: CallAgentActionConfig) => makeAgentResult());
+    const context = makeContext({
+      payload: {
+        instanceId: 'wa-001',
+        from: { id: 'user-1', name: 'Alice' },
+        chatId: 'chat-1',
+        threadId: 'T42',
+        content: 'in a thread',
+      },
+    });
+
+    const result = await executeAction({ type: 'call_agent', config: agentConfig }, context, {
+      eventBus: null,
+      callAgent,
+    });
+
+    expect(result.status).toBe('success');
+    const receivedContext = callAgent.mock.calls[0]![0] as AgentCallContext;
+    expect(receivedContext.threadId).toBe('T42');
+  });
+
+  test('falls back to rawPayload.threadId when the payload has none at top level', async () => {
+    const callAgent = mock(async (_ctx: AgentCallContext, _cfg: CallAgentActionConfig) => makeAgentResult());
+    const context = makeContext({
+      payload: {
+        instanceId: 'wa-001',
+        from: { id: 'user-1', name: 'Alice' },
+        chatId: 'chat-1',
+        rawPayload: { threadId: 'T77' },
+        content: 'in a thread',
+      },
+    });
+
+    const result = await executeAction({ type: 'call_agent', config: agentConfig }, context, {
+      eventBus: null,
+      callAgent,
+    });
+
+    expect(result.status).toBe('success');
+    const receivedContext = callAgent.mock.calls[0]![0] as AgentCallContext;
+    expect(receivedContext.threadId).toBe('T77');
+  });
+
+  test('stays undefined for threadless events', async () => {
+    const callAgent = mock(async (_ctx: AgentCallContext, _cfg: CallAgentActionConfig) => makeAgentResult());
+    const context = makeContext();
+
+    const result = await executeAction({ type: 'call_agent', config: agentConfig }, context, {
+      eventBus: null,
+      callAgent,
+    });
+
+    expect(result.status).toBe('success');
+    const receivedContext = callAgent.mock.calls[0]![0] as AgentCallContext;
+    expect(receivedContext.threadId).toBeUndefined();
+  });
+});

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -50,6 +50,8 @@ export interface AgentCallContext {
   providerId?: string;
   /** Chat ID for session continuity */
   chatId: string;
+  /** Thread/topic identifier (e.g. Telegram forum topic) — drives per_thread session keys */
+  threadId?: string;
   /** Sender ID for user identification */
   senderId: string;
   /** Sender's display name */
@@ -419,6 +421,12 @@ function extractAgentCallContext(
   if (!chatId) return { error: 'chatId not found in payload' };
   if (!senderId) return { error: 'senderId not found in payload' };
 
+  // Thread identifier: message events carry it at payload.threadId; some
+  // channels only stamp it inside rawPayload. Needed so a call_agent on a
+  // per_thread instance resumes the thread's session, not the whole chat's.
+  const rawPayload = (context.payload.rawPayload ?? {}) as Record<string, unknown>;
+  const threadId = (context.payload.threadId as string | undefined) ?? (rawPayload.threadId as string | undefined);
+
   const messagesResult = extractMessages(context, config.promptOverride);
   if ('error' in messagesResult) return messagesResult;
 
@@ -431,6 +439,7 @@ function extractAgentCallContext(
       agentId: agentId || undefined,
       providerId: config.providerId ? substituteTemplate(config.providerId, context) : undefined,
       chatId,
+      threadId,
       senderId,
       senderName,
       messages: messagesResult,


### PR DESCRIPTION
## Summary

Fixes #929 — the `call_agent` automation action could not dispatch to `local://claude-code` providers, failing with `Provider <id> has no API key configured` even though the same provider serves normal message routing fine.

## Changes (all in `AgentRunnerService`, the path `call_agent` lands on)

- **`getClient`**: claude-code providers are now built from `schemaConfig` (`projectPath`) via the factory's existing `claude-code` branch, with the API key optional (the SDK falls back to the host's `ANTHROPIC_API_KEY`). The sealed-credential posture is unchanged and now schema-uniform: a sealed envelope that cannot be opened in the current tenant context fails closed for **every** schema; the "no API key configured" 401 still applies to HTTP schemas.
- **`run()`/`stream()` session continuity**: Claude Code resumes by its own session UUID, not the strategy-computed key. Both methods now map key → UUID through the same per-provider session store the message-routing dispatcher uses (`createSessionStorage`, same `provider:<id>:session:<key>` keys, same `computeSessionId` inputs) — so an automation `call_agent` resumes the very session the chat conversation runs in, and persists the returned UUID for the next turn from either path. HTTP MCP servers also get the same `chat_id` URL param the dispatcher appends.

## Tests

- New `agent-runner-claude-code.test.ts`: keyless claude-code client construction (the #929 regression), plaintext key forwarding, sealed-credential fail-closed, fresh-session start + UUID persistence, stored-session resume, and stream-path session capture.
- Existing agent-runner suites (sealed provider, tenant-keyed client cache, runOrStream) pass unchanged: 484 pass / 0 fail across services + dispatcher + automation-actions suites; `tsc` and biome clean.

## Not addressed (secondary observations in #929)

- `extractAgentCallContext` still requires `chatId`/`senderId` (chatless events — deferred to #925 G4).
- Provider health checks still probe `local://` base URLs over HTTP and permanently report `error` for claude-code providers.