### PR TITLE
fix(api): invalidate cached agent providers on instance/agent config changes

### DIFF
--- a/packages/api/src/plugins/__tests__/provider-cache-instance-invalidation.test.ts
+++ b/packages/api/src/plugins/__tests__/provider-cache-instance-invalidation.test.ts
@@ -96,6 +96,55 @@ describe('invalidateProviderCacheForInstance', () => {
   });
 });
 
+describe('openclaw eviction — the shared pooled WS client must survive', () => {
+  class MockOpenClawClient {
+    static stopCalls = 0;
+    static instances: MockOpenClawClient[] = [];
+    connected = true;
+    state = 'open';
+    constructor(readonly config: Record<string, unknown>) {
+      MockOpenClawClient.instances.push(this);
+    }
+    start(): void {}
+    stop(): void {
+      MockOpenClawClient.stopCalls++;
+    }
+  }
+
+  function fakeOpenClawProvider(): ResolveProviderParams[0] {
+    return fakeAgnoProvider({
+      id: 'provider-openclaw-1',
+      schema: 'openclaw',
+      schemaConfig: { defaultAgentId: 'test-agent' },
+    });
+  }
+
+  it('evicts the provider wrapper without stopping the pooled client, and the rebuild reuses it', () => {
+    MockOpenClawClient.stopCalls = 0;
+    MockOpenClawClient.instances = [];
+    __test__.OpenClawClientClass = MockOpenClawClient as any;
+    try {
+      const provider = fakeOpenClawProvider();
+      const cached = resolveProvider(provider, fakeInstance('inst-oc-a'), db);
+      expect(cached).not.toBeNull();
+      expect(MockOpenClawClient.instances).toHaveLength(1);
+
+      // The regression this pins: dispose() on an evicted OpenClaw provider
+      // would stop the SHARED pooled client for every sibling instance, and
+      // nothing on the instance-eviction path restarts or replaces it.
+      invalidateProviderCacheForInstance('inst-oc-a');
+      expect(MockOpenClawClient.stopCalls).toBe(0);
+
+      const rebuilt = resolveProvider(provider, fakeInstance('inst-oc-a'), db);
+      expect(rebuilt).not.toBe(cached);
+      expect(MockOpenClawClient.instances).toHaveLength(1);
+      expect(__test__.openclawPoolKeys()).toEqual(['provider-openclaw-1::-']);
+    } finally {
+      __test__.resetOpenClawClientClass();
+    }
+  });
+});
+
 describe('touchesProviderBakedConfig', () => {
   it('fires for every provider-baked column, including explicit nulls', () => {
     expect(touchesProviderBakedConfig({ enableAutoSplit: false })).toBe(true);

--- a/packages/api/src/plugins/__tests__/provider-cache-instance-invalidation.test.ts
+++ b/packages/api/src/plugins/__tests__/provider-cache-instance-invalidation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * omni#906 — instance-level config (enableAutoSplit, agentTimeout, …) is baked
+ * into the cached IAgentProvider at construction, so an instance update must
+ * evict the `${providerId}:${instanceId}` cache entry or the dispatcher keeps
+ * the stale provider until the process restarts.
+ *
+ * These tests pin the eviction primitive itself:
+ *   - resolveProvider caches per (provider, instance) pair
+ *   - invalidateProviderCacheForInstance evicts exactly that instance's
+ *     entries and leaves sibling instances of the same provider cached
+ *   - the guard used by InstanceService.update only fires for fields that are
+ *     actually baked into providers
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { Database } from '@omni/db';
+import { touchesProviderBakedConfig } from '../../services/instances';
+import { __test__, invalidateProviderCacheForInstance, resolveProvider } from '../agent-dispatcher';
+
+type ResolveProviderParams = Parameters<typeof resolveProvider>;
+
+function fakeAgnoProvider(overrides: Record<string, unknown> = {}): ResolveProviderParams[0] {
+  return {
+    id: 'provider-agno-1',
+    name: 'Test Agno',
+    schema: 'agno',
+    baseUrl: 'http://localhost:9999',
+    apiKey: 'test-key',
+    schemaConfig: { agentId: 'test-agent' },
+    defaultStream: false,
+    defaultTimeout: 60,
+    isActive: true,
+    ...overrides,
+  } as unknown as ResolveProviderParams[0];
+}
+
+function fakeInstance(id: string, overrides: Record<string, unknown> = {}): ResolveProviderParams[1] {
+  return {
+    id,
+    name: `Instance ${id}`,
+    channel: 'whatsapp-baileys',
+    agentProviderId: 'provider-agno-1',
+    enableAutoSplit: true,
+    agentPrefixSenderName: true,
+    ...overrides,
+  } as unknown as ResolveProviderParams[1];
+}
+
+const db = {} as Database;
+
+afterEach(() => {
+  __test__.resetProviderCaches();
+});
+
+describe('invalidateProviderCacheForInstance', () => {
+  it('resolveProvider caches per (provider, instance) pair', () => {
+    const provider = fakeAgnoProvider();
+    const first = resolveProvider(provider, fakeInstance('inst-a'), db);
+    const second = resolveProvider(provider, fakeInstance('inst-a'), db);
+
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+  });
+
+  it('evicts only the target instance, keeping siblings of the same provider cached', () => {
+    const provider = fakeAgnoProvider();
+    const cachedA = resolveProvider(provider, fakeInstance('inst-a'), db);
+    const cachedB = resolveProvider(provider, fakeInstance('inst-b'), db);
+
+    invalidateProviderCacheForInstance('inst-a');
+
+    const rebuiltA = resolveProvider(provider, fakeInstance('inst-a', { enableAutoSplit: false }), db);
+    const stillB = resolveProvider(provider, fakeInstance('inst-b'), db);
+
+    expect(rebuiltA).not.toBe(cachedA);
+    expect(stillB).toBe(cachedB);
+  });
+
+  it('is a no-op for an instance with no cached provider', () => {
+    const provider = fakeAgnoProvider();
+    const cached = resolveProvider(provider, fakeInstance('inst-a'), db);
+
+    invalidateProviderCacheForInstance('inst-unknown');
+
+    expect(resolveProvider(provider, fakeInstance('inst-a'), db)).toBe(cached);
+  });
+
+  it('does not match on instance-id suffix collisions (":a" must not evict ":not-a")', () => {
+    const provider = fakeAgnoProvider();
+    const cachedLong = resolveProvider(provider, fakeInstance('inst-a'), db);
+
+    // "a" is a suffix of "inst-a" but the key delimiter must prevent the match
+    invalidateProviderCacheForInstance('a');
+
+    expect(resolveProvider(provider, fakeInstance('inst-a'), db)).toBe(cachedLong);
+  });
+});
+
+describe('touchesProviderBakedConfig', () => {
+  it('fires for every provider-baked column, including explicit nulls', () => {
+    expect(touchesProviderBakedConfig({ enableAutoSplit: false })).toBe(true);
+    expect(touchesProviderBakedConfig({ agentTimeout: 30 })).toBe(true);
+    expect(touchesProviderBakedConfig({ agentPrefixSenderName: false })).toBe(true);
+    expect(touchesProviderBakedConfig({ agentId: null })).toBe(true);
+  });
+
+  it('stays quiet for fields the cached provider never sees', () => {
+    expect(touchesProviderBakedConfig({})).toBe(false);
+    expect(touchesProviderBakedConfig({ profileName: 'renamed' })).toBe(false);
+    expect(touchesProviderBakedConfig({ isActive: false })).toBe(false);
+    // fresh-per-send via getSplitDelayConfig, not baked at construction
+    expect(touchesProviderBakedConfig({ messageSplitDelayFixedMs: 1000 })).toBe(false);
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -4514,6 +4514,41 @@ export function invalidateProviderCache(providerId: string): void {
 }
 
 /**
+ * Invalidate cached IAgentProvider instances for a specific instance.
+ *
+ * Instance-level config (enableAutoSplit, agentType, agentTimeout,
+ * agentPrefixSenderName, the resolved agentId) is baked into the provider at
+ * construction time (see createAgnoProvider and friends), so an instance
+ * update must evict the cached entry or the change stays invisible until a
+ * process restart (omni#906). Cache keys are `${providerId}:${instanceId}`;
+ * matching on the `:instanceId` suffix lets callers invalidate without
+ * knowing which provider the instance resolves to.
+ *
+ * Unlike invalidateProviderCache, this leaves the shared OpenClaw client
+ * pool alone — that pool holds provider-level connection state, which an
+ * instance mutation cannot affect.
+ */
+export function invalidateProviderCacheForInstance(instanceId: string): void {
+  const suffix = `:${instanceId}`;
+  let removed = 0;
+
+  for (const [key, provider] of providerCache.entries()) {
+    if (!key.endsWith(suffix)) continue;
+    providerCache.delete(key);
+    removed++;
+    if (provider.dispose) {
+      provider.dispose().catch((err) => {
+        log.warn('Error disposing provider on instance cache invalidation', { key, error: String(err) });
+      });
+    }
+  }
+
+  if (removed > 0) {
+    log.debug('Provider cache invalidated for instance', { instanceId, removed });
+  }
+}
+
+/**
  * Look up provider from DB and resolve to IAgentProvider.
  * Accepts DispatchInstance which carries the transient agentProviderId stamped by applyAgentFkOverrides.
  */

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -4524,9 +4524,23 @@ export function invalidateProviderCache(providerId: string): void {
  * matching on the `:instanceId` suffix lets callers invalidate without
  * knowing which provider the instance resolves to.
  *
- * Unlike invalidateProviderCache, this leaves the shared OpenClaw client
- * pool alone — that pool holds provider-level connection state, which an
- * instance mutation cannot affect.
+ * Unlike invalidateProviderCache, this never touches the shared OpenClaw
+ * client pool — that pool holds provider-level connection state, which an
+ * instance mutation cannot affect — and accordingly it does NOT dispose
+ * evicted OpenClaw providers: their dispose() stops the pooled client that
+ * every sibling instance of the provider is dispatching through, and nothing
+ * on this path would restart or replace the pool entry. Dropping the wrapper
+ * is the whole eviction there. Every other schema owns its resources (e.g.
+ * the NATS Genie per-provider connection and reply subscription) and must be
+ * disposed, or the rebuilt provider would subscribe alongside the leaked one
+ * and every reply would be delivered twice.
+ *
+ * GRANULARITY CAVEAT: the cache key is route-blind. When agent routes on one
+ * instance target different agents of the SAME provider, they share this one
+ * entry, so eviction guarantees a rebuild from fresh rows but whichever route
+ * dispatches first decides which agent's config gets baked in — a pre-existing
+ * limit of the `${providerId}:${instanceId}` key, not something per-instance
+ * eviction can fix.
  */
 export function invalidateProviderCacheForInstance(instanceId: string): void {
   const suffix = `:${instanceId}`;
@@ -4536,6 +4550,7 @@ export function invalidateProviderCacheForInstance(instanceId: string): void {
     if (!key.endsWith(suffix)) continue;
     providerCache.delete(key);
     removed++;
+    if (provider.schema === 'openclaw') continue;
     if (provider.dispose) {
       provider.dispose().catch((err) => {
         log.warn('Error disposing provider on instance cache invalidation', { key, error: String(err) });

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -12,6 +12,7 @@ import { accessCache } from '../../cache/cache-keys';
 import { DEFAULT_TURN_SCOPES } from '../../constants/scopes';
 import { agentKeyName } from '../../lib/agent-key-name';
 import { filterByInstanceAccess, requireInstanceAccess } from '../../middleware/auth';
+import { invalidateProviderCacheForInstance } from '../../plugins/agent-dispatcher';
 import { getQrCode } from '../../plugins/qr-store';
 import type { Services } from '../../services';
 import { PairingRequestConsumedError, PairingRequestExpiredError } from '../../services/access';
@@ -1522,6 +1523,11 @@ instancesRoutes.post('/:id/restart', instanceAccess, async (c) => {
   if (!plugin) {
     return c.json({ error: { code: 'PLUGIN_NOT_FOUND', message: `No plugin for channel: ${instance.channel}` } }, 400);
   }
+
+  // omni#906: operators expect restart to re-read config, but disconnect/connect
+  // only recycles the channel connection — the dispatcher's cached agent
+  // provider lives independently of the channel lifecycle, so evict it here.
+  invalidateProviderCacheForInstance(id);
 
   try {
     await plugin.disconnect(id);

--- a/packages/api/src/services/__tests__/agents.test.ts
+++ b/packages/api/src/services/__tests__/agents.test.ts
@@ -37,7 +37,10 @@ function createMockDatabase(results: Agent[] = []) {
       $dynamic: () => selectQuery,
     })),
     $dynamic: () => selectQuery,
-    where: mock(() => selectQuery),
+    // where() returns a real Promise carrying the chainable props, so the
+    // builder resolves like Drizzle's whether awaited directly (update()'s
+    // provider-cache eviction lookups) or chained through orderBy/limit.
+    where: mock((): typeof selectQuery => Object.assign(Promise.resolve(results), selectQuery)),
     orderBy: mock(() => selectQuery),
     limit: mock((_n: number) => Promise.resolve(results)),
   };

--- a/packages/api/src/services/agents.ts
+++ b/packages/api/src/services/agents.ts
@@ -5,9 +5,25 @@
 import { NotFoundError } from '@omni/core';
 import type { EventBus } from '@omni/core';
 import type { Database } from '@omni/db';
-import { type Agent, type NewAgent, agents } from '@omni/db';
+import { type Agent, type NewAgent, agentRoutes, agents, instances } from '@omni/db';
 import { and, eq, sql } from 'drizzle-orm';
+import { invalidateProviderCacheForInstance } from '../plugins/agent-dispatcher';
 import { scopedHandle } from '../tenancy/tenant-scope';
+
+/**
+ * Agent columns whose values get baked into cached IAgentProvider instances by
+ * applyAgentFkOverrides + resolveProvider (agentType, the provider FK, and the
+ * provider-internal agent id resolved from metadata/configPath/name). An update
+ * touching any of these must evict the provider's cache entries or dispatch
+ * keeps the stale values until the process restarts (omni#906).
+ */
+const PROVIDER_BAKED_AGENT_COLUMNS = [
+  'name',
+  'agentProviderId',
+  'agentType',
+  'metadata',
+  'configPath',
+] as const satisfies readonly (keyof NewAgent)[];
 
 export interface ListAgentsOptions {
   limit?: number;
@@ -108,6 +124,23 @@ export class AgentService {
 
     if (!updated) {
       throw new NotFoundError('Agent', id);
+    }
+
+    // omni#906: evict cached providers built from the pre-update agent row —
+    // per-instance (not invalidateProviderCache) so the provider's shared
+    // OpenClaw WS clients, whose connection config an agent row can't affect,
+    // stay up.
+    if (PROVIDER_BAKED_AGENT_COLUMNS.some((column) => column in data)) {
+      // Both reference paths: the instance-level agentId FK and per-chat/user
+      // agent routes (mergeRouteOverrides stamps route agents onto the same
+      // `${providerId}:${instanceId}` cache entry).
+      const [direct, routed] = await Promise.all([
+        this.db.select({ id: instances.id }).from(instances).where(eq(instances.agentId, id)),
+        this.db.select({ id: agentRoutes.instanceId }).from(agentRoutes).where(eq(agentRoutes.agentId, id)),
+      ]);
+      for (const instanceId of new Set([...direct, ...routed].map((row) => row.id))) {
+        invalidateProviderCacheForInstance(instanceId);
+      }
     }
 
     return updated;

--- a/packages/api/src/services/agents.ts
+++ b/packages/api/src/services/agents.ts
@@ -8,7 +8,7 @@ import type { Database } from '@omni/db';
 import { type Agent, type NewAgent, agentRoutes, agents, instances } from '@omni/db';
 import { and, eq, sql } from 'drizzle-orm';
 import { invalidateProviderCacheForInstance } from '../plugins/agent-dispatcher';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import { runAfterTenantCommit, scopedHandle } from '../tenancy/tenant-scope';
 
 /**
  * Agent columns whose values get baked into cached IAgentProvider instances by
@@ -133,14 +133,19 @@ export class AgentService {
     if (PROVIDER_BAKED_AGENT_COLUMNS.some((column) => column in data)) {
       // Both reference paths: the instance-level agentId FK and per-chat/user
       // agent routes (mergeRouteOverrides stamps route agents onto the same
-      // `${providerId}:${instanceId}` cache entry).
+      // `${providerId}:${instanceId}` cache entry). The lookup runs in the
+      // transaction; the eviction waits for commit so a concurrent dispatch
+      // can't refill the cache from the pre-commit agent row.
       const [direct, routed] = await Promise.all([
         this.db.select({ id: instances.id }).from(instances).where(eq(instances.agentId, id)),
         this.db.select({ id: agentRoutes.instanceId }).from(agentRoutes).where(eq(agentRoutes.agentId, id)),
       ]);
-      for (const instanceId of new Set([...direct, ...routed].map((row) => row.id))) {
-        invalidateProviderCacheForInstance(instanceId);
-      }
+      const affected = new Set([...direct, ...routed].map((row) => row.id));
+      runAfterTenantCommit(() => {
+        for (const instanceId of affected) {
+          invalidateProviderCacheForInstance(instanceId);
+        }
+      });
     }
 
     return updated;

--- a/packages/api/src/services/instances.ts
+++ b/packages/api/src/services/instances.ts
@@ -44,6 +44,7 @@ import { NotFoundError } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type ChannelType, type Instance, type NewInstance, instances } from '@omni/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
+import { invalidateProviderCacheForInstance } from '../plugins/agent-dispatcher';
 import { forgetInstanceOwner, rememberInstanceOwners } from '../tenancy/instance-owner-registry';
 import { credentialSealingEngages, openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
 import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
@@ -130,6 +131,25 @@ function openInstanceCredentials<T extends { tenantId?: string | null }>(row: T)
 /** Open a batch of loaded rows. Identity when nothing in the batch is sealed. */
 function openInstanceCredentialsAll<T extends { tenantId?: string | null }>(rows: T[]): T[] {
   return rows.map(openInstanceCredentials);
+}
+
+/**
+ * The `instances` columns that get baked into a cached IAgentProvider at
+ * construction time (see resolveProvider / createAgnoProvider and friends in
+ * agent-dispatcher). An update touching any of these must evict the instance's
+ * provider-cache entry or the running dispatcher keeps the stale values until
+ * the process restarts (omni#906).
+ */
+const PROVIDER_BAKED_COLUMNS = [
+  'agentId',
+  'agentTimeout',
+  'enableAutoSplit',
+  'agentPrefixSenderName',
+] as const satisfies readonly (keyof NewInstance)[];
+
+/** Presence check, not value diff: `null` is a meaningful new value here. */
+export function touchesProviderBakedConfig(data: Partial<NewInstance>): boolean {
+  return PROVIDER_BAKED_COLUMNS.some((column) => column in data);
 }
 
 export class InstanceService {
@@ -351,6 +371,15 @@ export class InstanceService {
       throw new NotFoundError('Instance', id);
     }
 
+    // omni#906: these fields are baked into the cached IAgentProvider at
+    // construction, so the dispatcher would keep serving the old values until
+    // a process restart unless the cache entry is evicted here. Guarded by
+    // field presence so unrelated updates (profileName, isActive, presence…)
+    // don't churn providers that hold live NATS/WS subscriptions.
+    if (touchesProviderBakedConfig(data)) {
+      invalidateProviderCacheForInstance(id);
+    }
+
     rememberInstanceOwners([updated]);
     return openInstanceCredentials(updated);
   }
@@ -400,6 +429,10 @@ export class InstanceService {
     // The instance is gone; drop its ownership entry so the registry stays
     // bounded by what actually exists.
     forgetInstanceOwner(id);
+
+    // Dispose the cached agent provider (and its NATS/WS subscriptions) —
+    // nothing can dispatch for this instance anymore (omni#906).
+    invalidateProviderCacheForInstance(id);
 
     if (this.eventBus) {
       await this.eventBus.publish('instance.disconnected', {

--- a/packages/api/src/services/instances.ts
+++ b/packages/api/src/services/instances.ts
@@ -47,7 +47,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { invalidateProviderCacheForInstance } from '../plugins/agent-dispatcher';
 import { forgetInstanceOwner, rememberInstanceOwners } from '../tenancy/instance-owner-registry';
 import { credentialSealingEngages, openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
-import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+import { currentTenantScope, runAfterTenantCommit, scopedHandle } from '../tenancy/tenant-scope';
 
 export interface ListInstancesOptions {
   channel?: ChannelType[];
@@ -375,9 +375,12 @@ export class InstanceService {
     // construction, so the dispatcher would keep serving the old values until
     // a process restart unless the cache entry is evicted here. Guarded by
     // field presence so unrelated updates (profileName, isActive, presence…)
-    // don't churn providers that hold live NATS/WS subscriptions.
+    // don't churn providers that hold live NATS/WS subscriptions. Deferred to
+    // commit: inside the request transaction a concurrent dispatch still reads
+    // the OLD row and would re-cache a stale provider right after an immediate
+    // eviction — and a rollback must not have disposed a live provider.
     if (touchesProviderBakedConfig(data)) {
-      invalidateProviderCacheForInstance(id);
+      runAfterTenantCommit(() => invalidateProviderCacheForInstance(id));
     }
 
     rememberInstanceOwners([updated]);
@@ -431,8 +434,10 @@ export class InstanceService {
     forgetInstanceOwner(id);
 
     // Dispose the cached agent provider (and its NATS/WS subscriptions) —
-    // nothing can dispatch for this instance anymore (omni#906).
-    invalidateProviderCacheForInstance(id);
+    // nothing can dispatch for this instance anymore (omni#906). After commit,
+    // so a concurrent dispatch can't rebuild a provider for a row whose DELETE
+    // is still uncommitted (and a rollback keeps the provider alive).
+    runAfterTenantCommit(() => invalidateProviderCacheForInstance(id));
 
     if (this.eventBus) {
       await this.eventBus.publish('instance.disconnected', {

--- a/packages/api/src/services/routes.ts
+++ b/packages/api/src/services/routes.ts
@@ -7,7 +7,8 @@ import type { CreateAgentRoute, ListAgentRoutesQuery, UpdateAgentRoute } from '@
 import type { Database } from '@omni/db';
 import { type AgentRoute, type NewAgentRoute, agentRoutes } from '@omni/db';
 import { and, desc, eq } from 'drizzle-orm';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import { invalidateProviderCacheForInstance } from '../plugins/agent-dispatcher';
+import { runAfterTenantCommit, scopedHandle } from '../tenancy/tenant-scope';
 import type { RouteResolver } from './route-resolver';
 
 export class RouteService {
@@ -146,8 +147,22 @@ export class RouteService {
     } catch {
       // Ignore cache invalidation errors - the route was created successfully
     }
+    this.evictCachedProvider(instanceId);
 
     return created;
+  }
+
+  /**
+   * omni#906: route overrides (agentId, agentTimeout, enableAutoSplit,
+   * agentPrefixSenderName) get baked into the cached IAgentProvider via
+   * mergeRouteOverrides/applyAgentFkOverrides, onto the same
+   * `${providerId}:${instanceId}` entry the instance itself uses — so every
+   * route mutation must evict it, exactly like an instance update. Deferred to
+   * commit so a concurrent dispatch can't refill the cache from the
+   * pre-commit route row.
+   */
+  private evictCachedProvider(instanceId: string): void {
+    runAfterTenantCommit(() => invalidateProviderCacheForInstance(instanceId));
   }
 
   /**
@@ -173,6 +188,7 @@ export class RouteService {
     } catch {
       // Ignore cache invalidation errors
     }
+    this.evictCachedProvider(route.instanceId);
 
     return updated;
   }
@@ -196,5 +212,6 @@ export class RouteService {
     } catch {
       // Ignore cache invalidation errors
     }
+    this.evictCachedProvider(route.instanceId);
   }
 }

--- a/packages/api/src/tenancy/__tests__/tenant-scope.test.ts
+++ b/packages/api/src/tenancy/__tests__/tenant-scope.test.ts
@@ -10,7 +10,13 @@
 import { describe, expect, test } from 'bun:test';
 import type { Database } from '@omni/db';
 import type { AuthContext } from '../auth-context';
-import { currentTenantScope, requireTenantScope, runInTenantScope, scopedHandle } from '../tenant-scope';
+import {
+  currentTenantScope,
+  requireTenantScope,
+  runAfterTenantCommit,
+  runInTenantScope,
+  scopedHandle,
+} from '../tenant-scope';
 import { TenantContextError } from '../tenant-transaction';
 
 const TENANT_A = '11111111-1111-4111-8111-111111111111';
@@ -161,5 +167,55 @@ describe('tenant scope — fail closed', () => {
       // The outer identity must be intact after the refusal.
       expect(requireTenantScope().tenantId).toBe(TENANT_A);
     });
+  });
+});
+
+describe('runAfterTenantCommit — post-commit side effects (omni#906)', () => {
+  test('with no scope active, the callback runs immediately (ambient pool autocommits)', () => {
+    let ran = false;
+    runAfterTenantCommit(() => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
+  test('inside a scope, the callback waits for commit instead of firing mid-transaction', async () => {
+    const { db } = fakeDb();
+    const order: string[] = [];
+    await runInTenantScope(db, tenantContext(TENANT_A), async () => {
+      runAfterTenantCommit(() => order.push('post-commit'));
+      order.push('in-transaction');
+    });
+    expect(order).toEqual(['in-transaction', 'post-commit']);
+  });
+
+  test('a rollback drops the queued callback — the side effect matches the write', async () => {
+    const { db } = fakeDb();
+    let ran = false;
+    await expect(
+      runInTenantScope(db, tenantContext(TENANT_A), async () => {
+        runAfterTenantCommit(() => {
+          ran = true;
+        });
+        throw new Error('handler failed → transaction rolls back');
+      }),
+    ).rejects.toThrow('rolls back');
+    expect(ran).toBe(false);
+  });
+
+  test('a throwing callback is best-effort: the committed result still reaches the caller', async () => {
+    const { db } = fakeDb();
+    let secondRan = false;
+    const result = await runInTenantScope(db, tenantContext(TENANT_A), async () => {
+      runAfterTenantCommit(() => {
+        throw new Error('cache eviction blew up');
+      });
+      runAfterTenantCommit(() => {
+        secondRan = true;
+      });
+      return 'committed';
+    });
+    expect(result).toBe('committed');
+    expect(secondRan).toBe(true);
   });
 });

--- a/packages/api/src/tenancy/tenant-scope.ts
+++ b/packages/api/src/tenancy/tenant-scope.ts
@@ -61,6 +61,8 @@ export interface TenantScopeState {
   readonly tx: TenantTx;
   /** The one tenant this request may touch. Resolved by the G3 boundary. */
   readonly tenantId: string;
+  /** Callbacks queued by `runAfterTenantCommit`; run after COMMIT, dropped on rollback. */
+  readonly postCommit: Array<() => void>;
 }
 
 /**
@@ -106,7 +108,43 @@ export async function runInTenantScope<T>(db: Database, context: AuthContext, fn
   if (storage.getStore()) {
     throw new Error('tenant-scope: a tenant scope is already active for this request');
   }
-  return withTenantTransaction(db, context, async (tx, tenantId) => storage.run({ tx, tenantId }, fn));
+  const postCommit: Array<() => void> = [];
+  const result = await withTenantTransaction(db, context, async (tx, tenantId) =>
+    storage.run({ tx, tenantId, postCommit }, fn),
+  );
+  // withTenantTransaction resolved → the transaction COMMITTED. A throw above
+  // (rollback) skips this, so queued callbacks never observe a write that
+  // didn't land. Best-effort by design: a callback failure must not turn a
+  // committed request into an error response.
+  for (const cb of postCommit) {
+    try {
+      cb();
+    } catch {
+      // Swallowed — same stance as the services' best-effort cache invalidation.
+    }
+  }
+  return result;
+}
+
+/**
+ * Run `fn` after the active tenant transaction commits — or immediately when no
+ * scope is active, where the ambient pool autocommits per statement and "after
+ * the write" already means "after commit".
+ *
+ * For in-memory side effects of a DB write (cache eviction, invalidation) that
+ * must not fire while the write is still uncommitted: inside the transaction a
+ * concurrent reader on another connection still sees the OLD row, so an
+ * eviction now could be refilled from pre-commit state and the write would land
+ * with the side effect already undone. Queued callbacks are dropped on
+ * rollback, matching the write they belong to.
+ */
+export function runAfterTenantCommit(fn: () => void): void {
+  const scope = storage.getStore();
+  if (scope) {
+    scope.postCommit.push(fn);
+  } else {
+    fn();
+  }
 }
 
 /**

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -1184,6 +1184,24 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
   // as `tenant-boundary`, so retiring it LOWERS the converted count by one. That
   // direction matters: the scanner fix is a correction, not a way to make this
   // group's numbers look better, and it was allowed to cost a point.
+  //
+  // omni#906 later added REAL `instances` and `agent_routes` reads to this
+  // file: `update()`'s provider-cache eviction looks up which instances
+  // reference the updated agent (via the instance FK and agent routes) so
+  // their cached IAgentProviders can be rebuilt from fresh config. Both reads
+  // go through `scopedHandle`, and every `update()` caller is an HTTP route
+  // inside the request context — under a tenant scope the lookup sees only
+  // that tenant's instances, which is exactly the eviction set it may touch.
+  {
+    file: 'packages/api/src/services/agents.ts',
+    table: 'instances',
+    class: 'tenant-boundary',
+  },
+  {
+    file: 'packages/api/src/services/agents.ts',
+    table: 'agent_routes',
+    class: 'tenant-boundary',
+  },
   {
     file: 'packages/api/src/services/auth-bootstrap.ts',
     table: 'tenant_key_lineage',


### PR DESCRIPTION
Fixes #906

## Problem

Instance config that gets baked into the agent provider at construction (`enableAutoSplit`, `agentTimeout`, `agentPrefixSenderName`, the resolved `agentId`/`agentType`) had **no effect until a pod restart**. `resolveProvider()` caches the built `IAgentProvider` keyed by `${providerId}:${instanceId}`, and that cache was only invalidated by provider PATCH/DELETE — never by instance mutations, agent-entity mutations, or `POST /instances/:id/restart`. The API returned 200 and the DB showed the new value, but the dispatcher kept the stale provider.

## Fix

- **`agent-dispatcher.ts`** — new `invalidateProviderCacheForInstance(instanceId)`: evicts `${providerId}:${instanceId}` entries by key suffix and disposes them. Unlike `invalidateProviderCache`, it leaves the provider-level shared OpenClaw WS pool up, since instance mutations can't affect connection-level config.
- **`InstanceService.update()`** — evicts when the patch touches a provider-baked field (`agentId`, `agentTimeout`, `enableAutoSplit`, `agentPrefixSenderName`). Presence-guarded so profile/status churn doesn't drop providers holding live NATS/WS subscriptions. Service-level, so REST PATCH, tRPC, and follow-up config paths are all covered. `delete()` now also disposes the cached provider.
- **`AgentService.update()`** — agent-entity fields baked in via `applyAgentFkOverrides` (`name`, `agentProviderId`, `agentType`, `metadata`, `configPath`) evict cached providers for every instance referencing the agent, through both the instance FK and agent routes.
- **`POST /instances/:id/restart`** — evicts too, so restart re-reads config as operators expect (previously it only recycled the channel connection).
- Registered the two new scoped reads in the tenancy db-access guard as `tenant-boundary` (all callers are HTTP routes).

## Tests

New `provider-cache-instance-invalidation.test.ts` pins: per-(provider, instance) caching, targeted eviction leaving sibling instances cached, no-op on unknown ids, no suffix-collision eviction, and the field-presence guard. Full API suite + pre-push gate green.

## Not addressed (pre-existing, noted in #906 as option 3)

The long-term fix — reading mutable instance config per-dispatch instead of baking it into the cached provider — is untouched; this PR closes every mutation path that can leave the cache stale.