### PR TITLE
feat(webhooks): verify source signatures and lock down generic ingress

### DIFF
--- a/packages/api/src/__tests__/webhook-ingress.test.ts
+++ b/packages/api/src/__tests__/webhook-ingress.test.ts
@@ -122,6 +122,26 @@ describe('public webhook ingress', () => {
     expect(res.status).toBe(401);
   });
 
+  test('a signed non-JSON body is rejected with 400, not silently emptied', async () => {
+    const app = buildApp([makeSource()]);
+    const body = 'a=1&b=2';
+
+    const res = await post(app, '/api/v2/webhooks/ingress/github', body, { 'X-Hub-Signature-256': sign(body) });
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe('VALIDATION');
+  });
+
+  test('a signed request missing an expected header is a 400, not a 500', async () => {
+    const app = buildApp([makeSource({ expectedHeaders: { 'X-GitHub-Event': true } })]);
+    const body = JSON.stringify({ action: 'push' });
+
+    const res = await post(app, '/api/v2/webhooks/ingress/github', body, { 'X-Hub-Signature-256': sign(body) });
+
+    expect(res.status).toBe(400);
+  });
+
   test('the authenticated receiver route still requires an API key', async () => {
     const app = buildApp([makeSource()]);
 

--- a/packages/api/src/__tests__/webhook-ingress.test.ts
+++ b/packages/api/src/__tests__/webhook-ingress.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Public generic webhook ingress tests (issue #928).
+ *
+ * POST /api/v2/webhooks/ingress/:source is auth-exempt: authenticity comes
+ * from the per-source signature config, verified over the raw body before
+ * anything is published. These tests pin the surface's contract:
+ *   - a correctly signed request for a configured source is accepted;
+ *   - unknown, unconfigured, and badly signed requests all yield the SAME
+ *     401 shape (no source-name existence oracle);
+ *   - the authenticated /api/v2/webhooks/:source route still demands a key.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import type { Database, WebhookSource } from '@omni/db';
+import { createApp } from '../app';
+
+const SECRET = 'ingress-test-secret';
+
+function makeSource(overrides: Partial<WebhookSource> = {}): WebhookSource {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    tenantId: null,
+    name: 'github',
+    description: null,
+    expectedHeaders: null,
+    signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Hub-Signature-256', prefix: 'sha256=' },
+    signatureSecret: SECRET,
+    enabled: true,
+    lastReceivedAt: null,
+    totalReceived: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal DB stub: source lookups resolve to `sources`, the stats update is a
+ * no-op, and anything else throws so the surface can't quietly grow DB use.
+ */
+function buildApp(sources: WebhookSource[]) {
+  const db = new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (prop === 'select') {
+          return () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve(sources) }) }) });
+        }
+        if (prop === 'update') {
+          return () => ({ set: () => ({ where: () => Promise.resolve([]) }) });
+        }
+        return () => {
+          throw new Error(`db.${String(prop)} must not be touched by ingress tests`);
+        };
+      },
+    },
+  ) as unknown as Database;
+
+  const { app } = createApp(db);
+  return app;
+}
+
+function sign(body: string): string {
+  return `sha256=${createHmac('sha256', SECRET).update(body).digest('hex')}`;
+}
+
+function post(app: ReturnType<typeof buildApp>, path: string, body: string, headers: Record<string, string> = {}) {
+  return app.request(path, { method: 'POST', body, headers });
+}
+
+describe('public webhook ingress', () => {
+  test('accepts a correctly signed request without any API key', async () => {
+    const app = buildApp([makeSource()]);
+    const body = JSON.stringify({ action: 'push' });
+
+    const res = await post(app, '/api/v2/webhooks/ingress/github', body, { 'X-Hub-Signature-256': sign(body) });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { received: boolean; eventType: string };
+    expect(json.received).toBe(true);
+    expect(json.eventType).toBe('custom.webhook.github');
+  });
+
+  test('rejects a bad signature with the uniform 401', async () => {
+    const app = buildApp([makeSource()]);
+    const body = JSON.stringify({ action: 'push' });
+
+    const res = await post(app, '/api/v2/webhooks/ingress/github', body, {
+      'X-Hub-Signature-256': 'sha256=deadbeef',
+    });
+
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: { code: string; message: string } };
+    expect(json.error.message).toBe('Webhook verification failed');
+  });
+
+  test('unknown source yields the same 401 shape, not a 404', async () => {
+    const app = buildApp([]);
+
+    const res = await post(app, '/api/v2/webhooks/ingress/does-not-exist', '{}');
+
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: { message: string } };
+    expect(json.error.message).toBe('Webhook verification failed');
+  });
+
+  test('a source without signature config is unreachable on the public surface', async () => {
+    const app = buildApp([makeSource({ signatureConfig: null, signatureSecret: null })]);
+
+    const res = await post(app, '/api/v2/webhooks/ingress/github', '{}');
+
+    expect(res.status).toBe(401);
+  });
+
+  test('a disabled source is rejected with the same 401 shape', async () => {
+    const app = buildApp([makeSource({ enabled: false })]);
+    const body = '{}';
+
+    const res = await post(app, '/api/v2/webhooks/ingress/github', body, { 'X-Hub-Signature-256': sign(body) });
+
+    expect(res.status).toBe(401);
+  });
+
+  test('the authenticated receiver route still requires an API key', async () => {
+    const app = buildApp([makeSource()]);
+
+    const res = await post(app, '/api/v2/webhooks/github', '{}');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -443,17 +443,26 @@ export function createApp(
   // unconfigured, bad signature) collapse into one 401 shape so the public
   // endpoint is not a source-name existence oracle; the real reason is logged.
   // The authenticated POST /api/v2/webhooks/:source route remains for internal
-  // callers. Must be mounted before protectedApp.
+  // callers. A non-empty body that is not a JSON object is a 400 — silently
+  // publishing an empty payload would fire automations on a hollow event.
+  // Must be mounted before protectedApp.
   app.post('/api/v2/webhooks/ingress/:source', webhookIngressRateLimitMiddleware, async (c) => {
     const sourceName = c.req.param('source');
     const services = c.get('services');
 
     const rawBody = await c.req.text();
-    let payload: Record<string, unknown>;
-    try {
-      payload = rawBody ? JSON.parse(rawBody) : {};
-    } catch {
-      payload = {};
+    let payload: Record<string, unknown> = {};
+    if (rawBody) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawBody);
+      } catch {
+        parsed = undefined;
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return c.json({ error: { code: 'VALIDATION', message: 'Request body must be a JSON object' } }, 400);
+      }
+      payload = parsed as Record<string, unknown>;
     }
 
     const headers: Record<string, string> = {};

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -6,7 +6,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import type { ChannelRegistry } from '@omni/channel-sdk';
 import type { WhatsAppBusinessPlugin } from '@omni/channel-whatsapp-business';
-import { type EventBus, createLogger } from '@omni/core';
+import { type EventBus, NotFoundError, OmniError, createLogger } from '@omni/core';
 import { type Database, type Instance, whatsappFlowKeys } from '@omni/db';
 import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
@@ -76,7 +76,7 @@ import { tenancyMiddleware } from './middleware/tenancy';
 
 import { createContextMiddleware } from './middleware/context';
 import { errorHandler } from './middleware/error';
-import { rateLimitMiddleware } from './middleware/rate-limit';
+import { rateLimitMiddleware, webhookIngressRateLimitMiddleware } from './middleware/rate-limit';
 import { defaultTimeoutMiddleware } from './middleware/timeout';
 import { versionHeadersMiddleware } from './middleware/version-headers';
 import { createWebhookAuthMiddleware } from './middleware/webhook-auth';
@@ -432,6 +432,52 @@ export function createApp(
     }
 
     return plugin.handleWebhook(c.req.raw);
+  });
+
+  // Public generic webhook ingress — auth-exempt, verified EXCLUSIVELY by the
+  // source's signature config (issue #928), following the channel-webhook
+  // precedent (Telegram/Meta/Twilio above). A source is reachable here only
+  // when an admin has configured `signatureConfig` + secret on it; verification
+  // runs over the raw body BEFORE anything is published. Sources are never
+  // auto-created on this surface. All rejections (unknown source, disabled,
+  // unconfigured, bad signature) collapse into one 401 shape so the public
+  // endpoint is not a source-name existence oracle; the real reason is logged.
+  // The authenticated POST /api/v2/webhooks/:source route remains for internal
+  // callers. Must be mounted before protectedApp.
+  app.post('/api/v2/webhooks/ingress/:source', webhookIngressRateLimitMiddleware, async (c) => {
+    const sourceName = c.req.param('source');
+    const services = c.get('services');
+
+    const rawBody = await c.req.text();
+    let payload: Record<string, unknown>;
+    try {
+      payload = rawBody ? JSON.parse(rawBody) : {};
+    } catch {
+      payload = {};
+    }
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(c.req.header())) {
+      headers[key.toLowerCase()] = value ?? '';
+    }
+
+    try {
+      const result = await services.webhooks.receive(sourceName, payload, headers, {
+        autoCreate: false,
+        rawBody,
+        requireSignature: true,
+      });
+      return c.json(result);
+    } catch (error) {
+      const rejected =
+        error instanceof NotFoundError ||
+        (error instanceof OmniError && (error.code === 'UNAUTHORIZED' || error.code === 'FORBIDDEN'));
+      if (rejected) {
+        httpLog.warn('Webhook ingress rejected', { sourceName, reason: (error as Error).message });
+        return c.json({ error: { code: 'UNAUTHORIZED', message: 'Webhook verification failed' } }, 401);
+      }
+      throw error;
+    }
   });
 
   // ── Multitenancy control plane — feature-flagged, OFF by default ────────────

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -42,9 +42,13 @@ const RATE_LIMITS = {
 } as const;
 
 /**
- * Create rate limiting middleware
+ * Create rate limiting middleware.
+ *
+ * `keyPrefix` isolates a limiter's counters from the default bucket so a
+ * surface with its own budget (e.g. the public webhook ingress) doesn't share
+ * windows with the general limiter for the same identifier.
  */
-function createRateLimiter(config: RateLimitConfig = RATE_LIMITS.general) {
+function createRateLimiter(config: RateLimitConfig = RATE_LIMITS.general, keyPrefix = 'ratelimit') {
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
     // Use API key ID as identifier, then only trusted infra-provided address data.
     // Do not trust client-supplied IP headers unless explicitly configured.
@@ -56,7 +60,7 @@ function createRateLimiter(config: RateLimitConfig = RATE_LIMITS.general) {
     const normalizedIp = rawIp?.split(',')[0]?.trim() || undefined;
     const identifier = apiKey?.id ? `api:${apiKey.id}` : normalizedIp ? `ip:${normalizedIp}` : 'anon';
 
-    const key = `ratelimit:${identifier}`;
+    const key = `${keyPrefix}:${identifier}`;
     const now = Date.now();
 
     let entry = rateLimitStore.get(key);
@@ -111,3 +115,9 @@ function createRateLimiter(config: RateLimitConfig = RATE_LIMITS.general) {
  * Default rate limiter for general endpoints
  */
 export const rateLimitMiddleware = createRateLimiter(RATE_LIMITS.general);
+
+/**
+ * Rate limiter for the auth-exempt generic webhook ingress (issue #928).
+ * Keyed by IP (no API key on that surface), same budget as channel events.
+ */
+export const webhookIngressRateLimitMiddleware = createRateLimiter(RATE_LIMITS.events, 'ratelimit:webhook-ingress');

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -55,7 +55,14 @@ function createRateLimiter(config: RateLimitConfig = RATE_LIMITS.general, keyPre
     const apiKey = c.get('apiKey');
     const trustedProxyHeader = process.env.TRUSTED_PROXY_HEADER?.toLowerCase();
     const trustedProxyIp = trustedProxyHeader ? c.req.header(trustedProxyHeader) : undefined;
-    const remoteAddr = (c.env as { remoteAddr?: string } | undefined)?.remoteAddr;
+    // Under Bun.serve, Hono's env is the Bun Server, which exposes the peer
+    // address via requestIP() — there is no `remoteAddr` field. Without this,
+    // unauthenticated surfaces (the public webhook ingress) would all share
+    // one 'anon' bucket instead of being limited per IP.
+    const server = c.env as
+      | { remoteAddr?: string; requestIP?: (req: Request) => { address?: string } | null }
+      | undefined;
+    const remoteAddr = server?.remoteAddr ?? server?.requestIP?.(c.req.raw)?.address;
     const rawIp = trustedProxyIp ?? remoteAddr;
     const normalizedIp = rawIp?.split(',')[0]?.trim() || undefined;
     const identifier = apiKey?.id ? `api:${apiKey.id}` : normalizedIp ? `ip:${normalizedIp}` : 'anon';

--- a/packages/api/src/routes/v2/webhooks.ts
+++ b/packages/api/src/routes/v2/webhooks.ts
@@ -4,6 +4,8 @@
 
 import { zValidator } from '@hono/zod-validator';
 import type { CustomEventType } from '@omni/core';
+import type { WebhookSource } from '@omni/db';
+import { webhookSignatureAlgorithms } from '@omni/db';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { ApiKeyService } from '../../services/api-keys';
@@ -15,13 +17,30 @@ const webhooksRoutes = new Hono<{ Variables: AppVariables }>();
 // Webhook Source CRUD
 // ============================================================================
 
+// Signature verification contract for the source (issue #928)
+const signatureConfigSchema = z.object({
+  algorithm: z.enum(webhookSignatureAlgorithms).describe('How to verify: HMAC over the raw body, or token match'),
+  header: z.string().min(1).max(200).describe('Header carrying the signature/token (e.g. X-Hub-Signature-256)'),
+  prefix: z.string().max(50).optional().describe('Prefix before the hex digest (e.g. "sha256=")'),
+});
+
 // Create webhook source schema
 const createWebhookSourceSchema = z.object({
   name: z.string().min(1).max(100).describe('Unique source name (e.g., github, stripe, agno)'),
   description: z.string().optional().describe('Description of the webhook source'),
   expectedHeaders: z.record(z.string(), z.boolean()).optional().describe('Headers to validate'),
+  signatureConfig: signatureConfigSchema.nullable().optional().describe('Signature verification config'),
+  signatureSecret: z.string().min(8).max(512).nullable().optional().describe('Shared secret (write-only)'),
   enabled: z.boolean().default(true).describe('Whether source is enabled'),
 });
+
+/** The secret is write-only: strip it from every response shape. */
+function sanitizeSource(source: WebhookSource): Omit<WebhookSource, 'signatureSecret'> & {
+  hasSignatureSecret: boolean;
+} {
+  const { signatureSecret, ...rest } = source;
+  return { ...rest, hasSignatureSecret: Boolean(signatureSecret) };
+}
 
 // Update webhook source schema
 const updateWebhookSourceSchema = createWebhookSourceSchema.partial();
@@ -40,7 +59,7 @@ webhooksRoutes.get('/webhook-sources', zValidator('query', listQuerySchema), asy
 
   const sources = await services.webhooks.list({ enabled });
 
-  return c.json({ items: sources });
+  return c.json({ items: sources.map(sanitizeSource) });
 });
 
 /**
@@ -52,7 +71,7 @@ webhooksRoutes.get('/webhook-sources/:id', async (c) => {
 
   const source = await services.webhooks.getById(id);
 
-  return c.json({ data: source });
+  return c.json({ data: sanitizeSource(source) });
 });
 
 /**
@@ -64,7 +83,7 @@ webhooksRoutes.post('/webhook-sources', zValidator('json', createWebhookSourceSc
 
   const source = await services.webhooks.create(data);
 
-  return c.json({ data: source }, 201);
+  return c.json({ data: sanitizeSource(source) }, 201);
 });
 
 /**
@@ -77,7 +96,7 @@ webhooksRoutes.patch('/webhook-sources/:id', zValidator('json', updateWebhookSou
 
   const source = await services.webhooks.update(id, data);
 
-  return c.json({ data: source });
+  return c.json({ data: sanitizeSource(source) });
 });
 
 /**
@@ -101,15 +120,20 @@ webhooksRoutes.delete('/webhook-sources/:id', async (c) => {
  *
  * The payload is passed through to the event system as-is.
  * Creates `custom.webhook.{source}` event.
+ *
+ * Sources are created administratively (POST /webhook-sources); a request for
+ * an unknown source is a 404 unless OMNI_WEBHOOK_AUTOCREATE=true opts the
+ * deployment into the old auto-create behavior (dev convenience, issue #928).
  */
 webhooksRoutes.post('/webhooks/:source', async (c) => {
   const sourceName = c.req.param('source');
   const services = c.get('services');
 
-  // Get the raw JSON body
+  // Keep the raw bytes: HMAC signature verification must run over them
+  const rawBody = await c.req.text();
   let payload: Record<string, unknown>;
   try {
-    payload = await c.req.json();
+    payload = rawBody ? JSON.parse(rawBody) : {};
   } catch {
     payload = {}; // Empty payload is fine for some webhooks
   }
@@ -122,7 +146,8 @@ webhooksRoutes.post('/webhooks/:source', async (c) => {
 
   // Receive and process the webhook
   const result = await services.webhooks.receive(sourceName, payload, headers, {
-    autoCreate: true, // Auto-create source if it doesn't exist
+    autoCreate: process.env.OMNI_WEBHOOK_AUTOCREATE === 'true',
+    rawBody,
   });
 
   return c.json(result);

--- a/packages/api/src/routes/v2/webhooks.ts
+++ b/packages/api/src/routes/v2/webhooks.ts
@@ -18,11 +18,16 @@ const webhooksRoutes = new Hono<{ Variables: AppVariables }>();
 // ============================================================================
 
 // Signature verification contract for the source (issue #928)
-const signatureConfigSchema = z.object({
-  algorithm: z.enum(webhookSignatureAlgorithms).describe('How to verify: HMAC over the raw body, or token match'),
-  header: z.string().min(1).max(200).describe('Header carrying the signature/token (e.g. X-Hub-Signature-256)'),
-  prefix: z.string().max(50).optional().describe('Prefix before the hex digest (e.g. "sha256=")'),
-});
+const signatureConfigSchema = z
+  .object({
+    algorithm: z.enum(webhookSignatureAlgorithms).describe('How to verify: HMAC over the raw body, or token match'),
+    header: z.string().min(1).max(200).describe('Header carrying the signature/token (e.g. X-Hub-Signature-256)'),
+    prefix: z.string().max(50).optional().describe('Prefix before the hex digest (HMAC algorithms only)'),
+  })
+  .refine((config) => config.algorithm !== 'token-match' || config.prefix === undefined, {
+    message: "prefix is not applicable to algorithm 'token-match'",
+    path: ['prefix'],
+  });
 
 // Create webhook source schema
 const createWebhookSourceSchema = z.object({

--- a/packages/api/src/schemas/openapi/webhooks.ts
+++ b/packages/api/src/schemas/openapi/webhooks.ts
@@ -6,12 +6,26 @@ import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import { z } from '../../lib/zod-openapi';
 import { ErrorSchema, SuccessSchema } from './common';
 
+// Signature verification contract (issue #928). The secret itself is
+// write-only — it never appears in any response schema.
+export const WebhookSignatureConfigSchema = z.object({
+  algorithm: z.enum(['hmac-sha256', 'hmac-sha1', 'token-match']).openapi({
+    description: 'How to verify: HMAC over the raw request body, or direct token match',
+  }),
+  header: z.string().openapi({ description: 'Header carrying the signature/token (e.g. X-Hub-Signature-256)' }),
+  prefix: z.string().optional().openapi({ description: 'Prefix before the hex digest (e.g. "sha256=")' }),
+});
+
 // Webhook source schema
 export const WebhookSourceSchema = z.object({
   id: z.string().uuid().openapi({ description: 'Source UUID' }),
   name: z.string().openapi({ description: 'Source name' }),
   description: z.string().nullable().openapi({ description: 'Description' }),
   expectedHeaders: z.record(z.string(), z.boolean()).nullable().openapi({ description: 'Expected headers' }),
+  signatureConfig: WebhookSignatureConfigSchema.nullable().openapi({ description: 'Signature verification config' }),
+  hasSignatureSecret: z
+    .boolean()
+    .openapi({ description: 'Whether a signature secret is stored (secret is write-only)' }),
   enabled: z.boolean().openapi({ description: 'Whether enabled' }),
   createdAt: z.string().datetime().openapi({ description: 'Creation timestamp' }),
   updatedAt: z.string().datetime().openapi({ description: 'Last update timestamp' }),
@@ -22,6 +36,12 @@ export const CreateWebhookSourceSchema = z.object({
   name: z.string().min(1).max(100).openapi({ description: 'Unique source name' }),
   description: z.string().optional().openapi({ description: 'Description' }),
   expectedHeaders: z.record(z.string(), z.boolean()).optional().openapi({ description: 'Headers to validate' }),
+  signatureConfig: WebhookSignatureConfigSchema.nullable().optional().openapi({
+    description: 'Signature verification config; required for the source to be reachable on the public ingress',
+  }),
+  signatureSecret: z.string().min(8).max(512).nullable().optional().openapi({
+    description: 'Shared secret used by signatureConfig (write-only, never returned)',
+  }),
   enabled: z.boolean().default(true).openapi({ description: 'Whether enabled' }),
 });
 
@@ -146,6 +166,30 @@ export function registerWebhookSchemas(registry: OpenAPIRegistry): void {
         description: 'Webhook received',
         content: { 'application/json': { schema: WebhookReceiveResponseSchema } },
       },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/webhooks/ingress/{source}',
+    operationId: 'receiveWebhookIngress',
+    tags: ['Webhooks'],
+    summary: 'Public webhook ingress',
+    description:
+      'Auth-exempt receiver for third-party webhook senders. Requires the source to have a signature ' +
+      'configuration; the request is verified against it (HMAC over the raw body, or token match) before any ' +
+      'event is published. Unknown, disabled, unconfigured, or badly signed requests all return the same 401.',
+    security: [],
+    request: {
+      params: z.object({ source: z.string().openapi({ description: 'Source name' }) }),
+      body: { content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    },
+    responses: {
+      200: {
+        description: 'Webhook received',
+        content: { 'application/json': { schema: WebhookReceiveResponseSchema } },
+      },
+      401: { description: 'Verification failed', content: { 'application/json': { schema: ErrorSchema } } },
     },
   });
 

--- a/packages/api/src/schemas/openapi/webhooks.ts
+++ b/packages/api/src/schemas/openapi/webhooks.ts
@@ -13,7 +13,9 @@ export const WebhookSignatureConfigSchema = z.object({
     description: 'How to verify: HMAC over the raw request body, or direct token match',
   }),
   header: z.string().openapi({ description: 'Header carrying the signature/token (e.g. X-Hub-Signature-256)' }),
-  prefix: z.string().optional().openapi({ description: 'Prefix before the hex digest (e.g. "sha256=")' }),
+  prefix: z.string().optional().openapi({
+    description: 'Prefix before the hex digest (e.g. "sha256="). HMAC algorithms only — rejected with token-match',
+  }),
 });
 
 // Webhook source schema

--- a/packages/api/src/services/__tests__/webhooks.test.ts
+++ b/packages/api/src/services/__tests__/webhooks.test.ts
@@ -617,6 +617,12 @@ describe('WebhookService', () => {
       ).rejects.toThrow('signatureSecret is required');
     });
 
+    test('create() rejects a secret without a signatureConfig', async () => {
+      await expect(service.create({ name: 'github', signatureSecret: 'orphan-secret' })).rejects.toThrow(
+        'signatureSecret cannot be set without a signatureConfig',
+      );
+    });
+
     test('update() clearing the config also clears the stored secret', async () => {
       const source = createMockSource({ id: 'test-123', signatureSecret: 'stored' });
       mockDb = createMockDatabase([source]);
@@ -625,6 +631,36 @@ describe('WebhookService', () => {
       await service.update('test-123', { signatureConfig: null });
 
       expect(mockDb._calls.update[0]).toMatchObject({ signatureConfig: null, signatureSecret: null });
+    });
+
+    test('update() rejects nulling the secret while the config stays set', async () => {
+      const source = createMockSource({
+        id: 'test-123',
+        signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Hub-Signature-256' },
+        signatureSecret: 'stored',
+      });
+      mockDb = createMockDatabase([source]);
+      service = new WebhookService(mockDb, mockEventBus);
+
+      await expect(service.update('test-123', { signatureSecret: null })).rejects.toThrow(
+        'signatureSecret is required when signatureConfig is set',
+      );
+      expect(mockDb._calls.update).toHaveLength(0);
+    });
+
+    test('update() rejects a new secret alongside clearing the config', async () => {
+      const source = createMockSource({
+        id: 'test-123',
+        signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Hub-Signature-256' },
+        signatureSecret: 'stored',
+      });
+      mockDb = createMockDatabase([source]);
+      service = new WebhookService(mockDb, mockEventBus);
+
+      await expect(service.update('test-123', { signatureConfig: null, signatureSecret: 'fresh-one' })).rejects.toThrow(
+        'signatureSecret cannot be set without a signatureConfig',
+      );
+      expect(mockDb._calls.update).toHaveLength(0);
     });
   });
 

--- a/packages/api/src/services/__tests__/webhooks.test.ts
+++ b/packages/api/src/services/__tests__/webhooks.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
 import type { CustomEventType, EventBus } from '@omni/core';
 import type { Database, NewWebhookSource, WebhookSource } from '@omni/db';
 import { WebhookService } from '../webhooks';
@@ -17,6 +18,8 @@ function createMockSource(overrides: Partial<WebhookSource> = {}): WebhookSource
     name: 'test-webhook',
     description: 'Test webhook source',
     expectedHeaders: null,
+    signatureConfig: null,
+    signatureSecret: null,
     enabled: true,
     lastReceivedAt: null,
     totalReceived: 0,
@@ -76,6 +79,8 @@ function createMockDatabase(initialSources: WebhookSource[] = []) {
           name: data.name,
           description: data.description ?? null,
           expectedHeaders: data.expectedHeaders ?? null,
+          signatureConfig: data.signatureConfig ?? null,
+          signatureSecret: data.signatureSecret ?? null,
           enabled: data.enabled ?? true,
           lastReceivedAt: null,
           totalReceived: 0,
@@ -472,6 +477,19 @@ describe('WebhookService', () => {
       await expect(service.receive('non-existent', {}, {}, { autoCreate: false })).rejects.toThrow('WebhookSource');
     });
 
+    test('does not auto-create sources by default (issue #928)', async () => {
+      mockDb.select = mock(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([]),
+          }),
+        }),
+      })) as unknown as typeof mockDb.select;
+
+      await expect(service.receive('never-seen', {}, {})).rejects.toThrow('WebhookSource');
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
     test('updates source stats on successful receive', async () => {
       const source = createMockSource({ id: 'test-123', name: 'agno', enabled: true, totalReceived: 5 });
 
@@ -487,6 +505,126 @@ describe('WebhookService', () => {
 
       // Verify update was called to increment stats
       expect(mockDb.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('receive() signature verification', () => {
+    const secret = 'super-secret-value';
+
+    function mockSourceLookup(source: WebhookSource) {
+      mockDb.select = mock(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([source]),
+          }),
+        }),
+      })) as unknown as typeof mockDb.select;
+    }
+
+    function hmacSource(overrides: Partial<WebhookSource> = {}): WebhookSource {
+      return createMockSource({
+        name: 'github',
+        signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Hub-Signature-256', prefix: 'sha256=' },
+        signatureSecret: secret,
+        ...overrides,
+      });
+    }
+
+    test('accepts a valid hmac-sha256 signature over the raw body', async () => {
+      mockSourceLookup(hmacSource());
+      const rawBody = JSON.stringify({ action: 'push' });
+      const signature = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+
+      const result = await service.receive(
+        'github',
+        { action: 'push' },
+        { 'x-hub-signature-256': signature },
+        { rawBody },
+      );
+
+      expect(result.received).toBe(true);
+      expect(mockEventBus._publishedEvents).toHaveLength(1);
+    });
+
+    test('rejects an invalid hmac signature and publishes nothing', async () => {
+      mockSourceLookup(hmacSource());
+      const rawBody = JSON.stringify({ action: 'push' });
+
+      await expect(
+        service.receive('github', { action: 'push' }, { 'x-hub-signature-256': 'sha256=deadbeef' }, { rawBody }),
+      ).rejects.toThrow('Invalid webhook signature');
+      expect(mockEventBus._publishedEvents).toHaveLength(0);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    test('rejects when the signature header is absent, whatever other headers say', async () => {
+      mockSourceLookup(hmacSource());
+
+      await expect(service.receive('github', {}, { 'x-anything': 'value' }, { rawBody: '{}' })).rejects.toThrow(
+        'Missing signature header: X-Hub-Signature-256',
+      );
+    });
+
+    test('rejects hmac verification without the raw body', async () => {
+      mockSourceLookup(hmacSource());
+      const signature = `sha256=${createHmac('sha256', secret).update('{}').digest('hex')}`;
+
+      await expect(service.receive('github', {}, { 'x-hub-signature-256': signature })).rejects.toThrow(
+        'raw request body',
+      );
+    });
+
+    test('token-match compares the header value against the secret', async () => {
+      const source = createMockSource({
+        name: 'telegram-like',
+        signatureConfig: { algorithm: 'token-match', header: 'X-Secret-Token' },
+        signatureSecret: secret,
+      });
+      mockSourceLookup(source);
+
+      const ok = await service.receive('telegram-like', {}, { 'x-secret-token': secret });
+      expect(ok.received).toBe(true);
+
+      await expect(service.receive('telegram-like', {}, { 'x-secret-token': 'wrong' })).rejects.toThrow(
+        'Invalid webhook signature',
+      );
+    });
+
+    test('requireSignature rejects sources without a signature config', async () => {
+      mockSourceLookup(createMockSource({ name: 'plain' }));
+
+      await expect(service.receive('plain', {}, {}, { requireSignature: true })).rejects.toThrow(
+        'no signature configuration',
+      );
+    });
+
+    test('rejects when config exists but no secret is stored', async () => {
+      mockSourceLookup(hmacSource({ signatureSecret: null }));
+
+      await expect(
+        service.receive('github', {}, { 'x-hub-signature-256': 'sha256=abc' }, { rawBody: '{}' }),
+      ).rejects.toThrow('verification unavailable');
+    });
+  });
+
+  describe('signature secret invariants', () => {
+    test('create() rejects a signatureConfig without a secret', async () => {
+      await expect(
+        service.create({
+          name: 'github',
+          signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Hub-Signature-256' },
+        }),
+      ).rejects.toThrow('signatureSecret is required');
+    });
+
+    test('update() clearing the config also clears the stored secret', async () => {
+      const source = createMockSource({ id: 'test-123', signatureSecret: 'stored' });
+      mockDb = createMockDatabase([source]);
+      service = new WebhookService(mockDb, mockEventBus);
+
+      await service.update('test-123', { signatureConfig: null });
+
+      expect(mockDb._calls.update[0]).toMatchObject({ signatureConfig: null, signatureSecret: null });
     });
   });
 

--- a/packages/api/src/services/webhooks.ts
+++ b/packages/api/src/services/webhooks.ts
@@ -101,6 +101,9 @@ export class WebhookService {
     if (data.signatureConfig && !data.signatureSecret) {
       throw new ValidationError('signatureSecret is required when signatureConfig is set');
     }
+    if (data.signatureSecret && !data.signatureConfig) {
+      throw new ValidationError('signatureSecret cannot be set without a signatureConfig');
+    }
 
     const values = data.signatureSecret
       ? { ...data, signatureSecret: sealCredentialField(this.tenantId, data.signatureSecret) }
@@ -120,22 +123,28 @@ export class WebhookService {
   async update(id: string, data: Partial<NewWebhookSource>): Promise<WebhookSource> {
     const patch: Partial<NewWebhookSource> = { ...data };
 
-    if (data.signatureSecret != null) {
+    if (typeof data.signatureSecret === 'string') {
       patch.signatureSecret = sealCredentialField(this.tenantId, data.signatureSecret);
-    } else if (data.signatureConfig === null && data.signatureSecret === undefined) {
-      // Clearing the config would orphan the stored secret — clear it too.
-      patch.signatureSecret = null;
     }
 
-    if (data.signatureConfig) {
-      if (data.signatureSecret === null) {
+    // Invariant across every partial-update combination: a signature config
+    // always has a secret, and a secret never outlives its config. `undefined`
+    // means "untouched" and inherits the stored value; `null` is an explicit
+    // clear.
+    if (data.signatureConfig !== undefined || data.signatureSecret !== undefined) {
+      const existing = await this.getById(id);
+      const nextConfig = data.signatureConfig === undefined ? existing.signatureConfig : data.signatureConfig;
+      const nextSecret = data.signatureSecret === undefined ? existing.signatureSecret : patch.signatureSecret;
+
+      if (nextConfig && !nextSecret) {
         throw new ValidationError('signatureSecret is required when signatureConfig is set');
       }
-      if (data.signatureSecret === undefined) {
-        const existing = await this.getById(id);
-        if (!existing.signatureSecret) {
-          throw new ValidationError('signatureSecret is required when signatureConfig is set');
+      if (!nextConfig) {
+        if (typeof data.signatureSecret === 'string') {
+          throw new ValidationError('signatureSecret cannot be set without a signatureConfig');
         }
+        // Clearing the config would orphan the stored secret — clear it too.
+        patch.signatureSecret = null;
       }
     }
 
@@ -221,7 +230,7 @@ export class WebhookService {
     if (source.expectedHeaders) {
       for (const headerName of Object.keys(source.expectedHeaders)) {
         if (!headers[headerName.toLowerCase()]) {
-          throw new Error(`Missing required header: ${headerName}`);
+          throw new ValidationError(`Missing required header: ${headerName}`);
         }
       }
     }

--- a/packages/api/src/services/webhooks.ts
+++ b/packages/api/src/services/webhooks.ts
@@ -2,19 +2,39 @@
  * Webhook service - manages webhook sources and receives webhooks
  */
 
-import { NotFoundError } from '@omni/core';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { ERROR_CODES, NotFoundError, OmniError, ValidationError, createLogger } from '@omni/core';
 import type { CustomEventType, EventBus } from '@omni/core';
 import { generateId } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type NewWebhookSource, type WebhookSource, webhookSources } from '@omni/db';
 import { eq, sql } from 'drizzle-orm';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import { openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
+import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
+
+const log = createLogger('api:webhooks');
 
 export interface WebhookReceiveResult {
   received: boolean;
   eventId: string;
   source: string;
   eventType: string;
+}
+
+export interface WebhookReceiveOptions {
+  /** Create the source on first receive. Administrative creation is the norm; this is a dev convenience. */
+  autoCreate?: boolean;
+  /** Raw request body bytes as received — HMAC verification must run over these, not a re-serialization. */
+  rawBody?: string;
+  /** Reject sources without a signature config (the auth-exempt public ingress sets this). */
+  requireSignature?: boolean;
+}
+
+/** Constant-time string comparison; a length mismatch short-circuits, which leaks only the length. */
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
 }
 
 export class WebhookService {
@@ -28,6 +48,11 @@ export class WebhookService {
    */
   private get db(): Database {
     return scopedHandle(this.pool);
+  }
+
+  /** Tenant of the active request scope; seals/opens the signature secret (providers.ts precedent). */
+  private get tenantId(): string | null {
+    return currentTenantScope()?.tenantId ?? null;
   }
 
   constructor(
@@ -73,7 +98,14 @@ export class WebhookService {
    * Create a new webhook source
    */
   async create(data: NewWebhookSource): Promise<WebhookSource> {
-    const [created] = await this.db.insert(webhookSources).values(data).returning();
+    if (data.signatureConfig && !data.signatureSecret) {
+      throw new ValidationError('signatureSecret is required when signatureConfig is set');
+    }
+
+    const values = data.signatureSecret
+      ? { ...data, signatureSecret: sealCredentialField(this.tenantId, data.signatureSecret) }
+      : data;
+    const [created] = await this.db.insert(webhookSources).values(values).returning();
 
     if (!created) {
       throw new Error('Failed to create webhook source');
@@ -86,9 +118,30 @@ export class WebhookService {
    * Update a webhook source
    */
   async update(id: string, data: Partial<NewWebhookSource>): Promise<WebhookSource> {
+    const patch: Partial<NewWebhookSource> = { ...data };
+
+    if (data.signatureSecret != null) {
+      patch.signatureSecret = sealCredentialField(this.tenantId, data.signatureSecret);
+    } else if (data.signatureConfig === null && data.signatureSecret === undefined) {
+      // Clearing the config would orphan the stored secret — clear it too.
+      patch.signatureSecret = null;
+    }
+
+    if (data.signatureConfig) {
+      if (data.signatureSecret === null) {
+        throw new ValidationError('signatureSecret is required when signatureConfig is set');
+      }
+      if (data.signatureSecret === undefined) {
+        const existing = await this.getById(id);
+        if (!existing.signatureSecret) {
+          throw new ValidationError('signatureSecret is required when signatureConfig is set');
+        }
+      }
+    }
+
     const [updated] = await this.db
       .update(webhookSources)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...patch, updatedAt: new Date() })
       .where(eq(webhookSources.id, id))
       .returning();
 
@@ -111,16 +164,21 @@ export class WebhookService {
   }
 
   /**
-   * Receive a webhook and publish as event
-   * If source doesn't exist and autoCreate is true, creates it
+   * Receive a webhook and publish as event.
+   *
+   * Sources are created by administrative act; `autoCreate` (default OFF,
+   * issue #928) is a dev-environment convenience only. When the source
+   * carries a `signatureConfig`, the request is verified against it BEFORE
+   * anything is published or counted — verification failure means nothing
+   * enters the journal.
    */
   async receive(
     sourceName: string,
     payload: Record<string, unknown>,
     headers: Record<string, string>,
-    options: { autoCreate?: boolean } = {},
+    options: WebhookReceiveOptions = {},
   ): Promise<WebhookReceiveResult> {
-    const { autoCreate = true } = options;
+    const { autoCreate = false, rawBody, requireSignature = false } = options;
 
     // Get or create source
     let source = await this.getByName(sourceName);
@@ -137,10 +195,29 @@ export class WebhookService {
     }
 
     if (!source.enabled) {
-      throw new Error(`Webhook source '${sourceName}' is disabled`);
+      throw new OmniError({
+        code: ERROR_CODES.FORBIDDEN,
+        message: `Webhook source '${sourceName}' is disabled`,
+        context: { sourceName },
+      });
     }
 
-    // Validate expected headers if configured
+    // The public ingress carries no API key: a source is reachable there only
+    // once an admin has configured its signature contract.
+    if (requireSignature && !source.signatureConfig) {
+      throw new OmniError({
+        code: ERROR_CODES.UNAUTHORIZED,
+        message: `Webhook source '${sourceName}' has no signature configuration`,
+        context: { sourceName },
+      });
+    }
+
+    if (source.signatureConfig) {
+      this.verifySignature(source, rawBody, headers);
+    }
+
+    // Validate expected headers if configured (presence only — the signature
+    // check above is the authenticity gate)
     if (source.expectedHeaders) {
       for (const headerName of Object.keys(source.expectedHeaders)) {
         if (!headers[headerName.toLowerCase()]) {
@@ -184,6 +261,46 @@ export class WebhookService {
       source: sourceName,
       eventType,
     };
+  }
+
+  /**
+   * Verify a request against the source's signature config. Throws
+   * UNAUTHORIZED (→ 401) on any failure; callers reach the publish path only
+   * when this returns.
+   */
+  private verifySignature(source: WebhookSource, rawBody: string | undefined, headers: Record<string, string>): void {
+    const config = source.signatureConfig;
+    if (!config) return;
+
+    const sourceName = source.name;
+    const unauthorized = (message: string) =>
+      new OmniError({ code: ERROR_CODES.UNAUTHORIZED, message, context: { sourceName } });
+
+    const provided = headers[config.header.toLowerCase()];
+    if (!provided) {
+      throw unauthorized(`Missing signature header: ${config.header}`);
+    }
+
+    const secret = openCredentialField(source.tenantId ?? this.tenantId, source.signatureSecret);
+    if (!secret) {
+      log.warn('Webhook source has a signature config but no usable secret', { sourceName });
+      throw unauthorized('Webhook signature verification unavailable for this source');
+    }
+
+    let expected: string;
+    if (config.algorithm === 'token-match') {
+      expected = secret;
+    } else {
+      if (rawBody === undefined) {
+        throw unauthorized('Webhook signature verification requires the raw request body');
+      }
+      const hmac = createHmac(config.algorithm === 'hmac-sha256' ? 'sha256' : 'sha1', secret);
+      expected = `${config.prefix ?? ''}${hmac.update(rawBody).digest('hex')}`;
+    }
+
+    if (!timingSafeEqualStrings(provided, expected)) {
+      throw unauthorized('Invalid webhook signature');
+    }
   }
 
   /**

--- a/packages/api/src/tenancy/route-ownership.ts
+++ b/packages/api/src/tenancy/route-ownership.ts
@@ -276,6 +276,19 @@ const PUBLIC_PRIVACY_CONTRACTS: readonly RouteOwnershipDeclaration[] = [
       'fixed 200 acks with no row data.',
   },
   {
+    route: 'POST /api/v2/webhooks/ingress/:source',
+    class: 'public-by-contract',
+    justification:
+      'Generic webhook ingress (issue #928). Auth-exempt because third-party senders (GitHub/Stripe-class) hold ' +
+      'no omni credential; authenticity is the per-source signature contract (HMAC over the raw body or token ' +
+      'match) verified against the server-held, per-tenant-sealed secret BEFORE anything is published. A source ' +
+      'is reachable here only after an administrative act configured its signature_config — sources are never ' +
+      'auto-created on this surface. All rejections (unknown source, disabled, unconfigured, bad signature) ' +
+      'collapse into a single 401 shape so the endpoint is not a source-name existence oracle, and the surface ' +
+      'is IP-rate-limited. The tenant, when one applies, comes from the server-side webhook_sources row, never ' +
+      'from a request claim. Responses carry only the generated event id and echo of the source name.',
+  },
+  {
     route: 'GET /api/v2/channels/whatsapp-business/webhook',
     class: 'public-by-contract',
     justification:

--- a/packages/api/src/tenancy/route-ownership.ts
+++ b/packages/api/src/tenancy/route-ownership.ts
@@ -286,7 +286,10 @@ const PUBLIC_PRIVACY_CONTRACTS: readonly RouteOwnershipDeclaration[] = [
       'auto-created on this surface. All rejections (unknown source, disabled, unconfigured, bad signature) ' +
       'collapse into a single 401 shape so the endpoint is not a source-name existence oracle, and the surface ' +
       'is IP-rate-limited. The tenant, when one applies, comes from the server-side webhook_sources row, never ' +
-      'from a request claim. Responses carry only the generated event id and echo of the source name.',
+      'from a request claim. Responses carry only the generated event id and echo of the source name. ' +
+      'ACCEPTED LIMITATION: the signature covers the body only — no timestamp tolerance or delivery-id dedupe — ' +
+      'so a captured signed request can be replayed within the rate limit; consumers of custom.webhook.* events ' +
+      'must treat deliveries as at-least-once, exactly as they already must for provider-side webhook retries.',
   },
   {
     route: 'GET /api/v2/channels/whatsapp-business/webhook',

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -32,6 +32,9 @@ function buildSignatureConfig(options: {
   if (!algorithm) {
     output.error(`Invalid --signature-algorithm; expected one of: ${SIGNATURE_ALGORITHMS.join(', ')}`);
   }
+  if (algorithm === 'token-match' && signaturePrefix) {
+    output.error('--signature-prefix is not applicable to token-match (the header carries the secret verbatim)');
+  }
   return { algorithm, header: signatureHeader, prefix: signaturePrefix };
 }
 
@@ -133,11 +136,16 @@ export function createWebhooksCommand(): Command {
             signatureSecret: options.signatureSecret,
           });
 
-          output.success(`Webhook source created: ${source.id}`, {
+          const details: Record<string, unknown> = {
             id: source.id,
             name: source.name,
-            url: `POST /api/v2/webhooks/${source.id}`,
-          });
+            // Both receivers key on the source NAME, not the id
+            url: `POST /api/v2/webhooks/${source.name}`,
+          };
+          if (signatureConfig) {
+            details.publicUrl = `POST /api/v2/webhooks/ingress/${source.name}`;
+          }
+          output.success(`Webhook source created: ${source.id}`, details);
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error';
           output.error(`Failed to create webhook source: ${message}`);

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -9,10 +9,31 @@
  * omni webhooks trigger --type <event-type> --payload <json> [--instance <id>]
  */
 
+import type { WebhookSignatureConfigBody } from '@omni/sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
 import { resolveWebhookId } from '../resolve.js';
+
+const SIGNATURE_ALGORITHMS = ['hmac-sha256', 'hmac-sha1', 'token-match'] as const;
+
+/** Assemble a signatureConfig from the --signature-* flags, or undefined when none given. */
+function buildSignatureConfig(options: {
+  signatureAlgorithm?: string;
+  signatureHeader?: string;
+  signaturePrefix?: string;
+}): WebhookSignatureConfigBody | undefined {
+  const { signatureAlgorithm, signatureHeader, signaturePrefix } = options;
+  if (!signatureAlgorithm && !signatureHeader && !signaturePrefix) return undefined;
+  if (!signatureAlgorithm || !signatureHeader) {
+    output.error('--signature-algorithm and --signature-header must be provided together');
+  }
+  const algorithm = SIGNATURE_ALGORITHMS.find((a) => a === signatureAlgorithm);
+  if (!algorithm) {
+    output.error(`Invalid --signature-algorithm; expected one of: ${SIGNATURE_ALGORITHMS.join(', ')}`);
+  }
+  return { algorithm, header: signatureHeader, prefix: signaturePrefix };
+}
 
 export function createWebhooksCommand(): Command {
   const webhooks = new Command('webhooks').description('Manage webhook sources');
@@ -74,36 +95,55 @@ export function createWebhooksCommand(): Command {
     .option('--description <desc>', 'Description')
     .option('--disabled', 'Create in disabled state')
     .option('--headers <json>', 'Expected headers as JSON (e.g., \'{"X-Secret": true}\')')
-    .action(async (options: { name: string; description?: string; disabled?: boolean; headers?: string }) => {
-      const client = getClient();
+    .option('--signature-algorithm <alg>', 'Signature verification: hmac-sha256, hmac-sha1, or token-match')
+    .option('--signature-header <name>', 'Header carrying the signature/token (e.g., X-Hub-Signature-256)')
+    .option('--signature-prefix <prefix>', "Prefix before the hex digest (e.g., 'sha256=')")
+    .option('--signature-secret <secret>', 'Shared secret for signature verification (write-only)')
+    .action(
+      async (options: {
+        name: string;
+        description?: string;
+        disabled?: boolean;
+        headers?: string;
+        signatureAlgorithm?: string;
+        signatureHeader?: string;
+        signaturePrefix?: string;
+        signatureSecret?: string;
+      }) => {
+        const client = getClient();
 
-      try {
-        let expectedHeaders: Record<string, boolean> | undefined;
-        if (options.headers) {
-          try {
-            expectedHeaders = JSON.parse(options.headers);
-          } catch {
-            output.error('Invalid JSON for --headers');
+        try {
+          let expectedHeaders: Record<string, boolean> | undefined;
+          if (options.headers) {
+            try {
+              expectedHeaders = JSON.parse(options.headers);
+            } catch {
+              output.error('Invalid JSON for --headers');
+            }
           }
+
+          const signatureConfig = buildSignatureConfig(options);
+
+          const source = await client.webhooks.createSource({
+            name: options.name,
+            description: options.description,
+            enabled: !options.disabled,
+            expectedHeaders,
+            signatureConfig,
+            signatureSecret: options.signatureSecret,
+          });
+
+          output.success(`Webhook source created: ${source.id}`, {
+            id: source.id,
+            name: source.name,
+            url: `POST /api/v2/webhooks/${source.id}`,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          output.error(`Failed to create webhook source: ${message}`);
         }
-
-        const source = await client.webhooks.createSource({
-          name: options.name,
-          description: options.description,
-          enabled: !options.disabled,
-          expectedHeaders,
-        });
-
-        output.success(`Webhook source created: ${source.id}`, {
-          id: source.id,
-          name: source.name,
-          url: `POST /api/v2/webhooks/${source.id}`,
-        });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        output.error(`Failed to create webhook source: ${message}`);
-      }
-    });
+      },
+    );
 
   // omni webhooks update <id>
   webhooks
@@ -113,17 +153,48 @@ export function createWebhooksCommand(): Command {
     .option('--description <desc>', 'New description')
     .option('--enable', 'Enable the webhook')
     .option('--disable', 'Disable the webhook')
+    .option('--signature-algorithm <alg>', 'Signature verification: hmac-sha256, hmac-sha1, or token-match')
+    .option('--signature-header <name>', 'Header carrying the signature/token (e.g., X-Hub-Signature-256)')
+    .option('--signature-prefix <prefix>', "Prefix before the hex digest (e.g., 'sha256=')")
+    .option('--signature-secret <secret>', 'Shared secret for signature verification (write-only)')
+    .option('--clear-signature', 'Remove the signature config and stored secret')
     .action(
-      async (id: string, options: { name?: string; description?: string; enable?: boolean; disable?: boolean }) => {
+      async (
+        id: string,
+        options: {
+          name?: string;
+          description?: string;
+          enable?: boolean;
+          disable?: boolean;
+          signatureAlgorithm?: string;
+          signatureHeader?: string;
+          signaturePrefix?: string;
+          signatureSecret?: string;
+          clearSignature?: boolean;
+        },
+      ) => {
         const resolvedId = await resolveWebhookId(id);
         const client = getClient();
 
         try {
-          const updates: { name?: string; description?: string; enabled?: boolean } = {};
+          const updates: {
+            name?: string;
+            description?: string;
+            enabled?: boolean;
+            signatureConfig?: WebhookSignatureConfigBody | null;
+            signatureSecret?: string;
+          } = {};
           if (options.name) updates.name = options.name;
           if (options.description) updates.description = options.description;
           if (options.enable) updates.enabled = true;
           if (options.disable) updates.enabled = false;
+          if (options.clearSignature) {
+            updates.signatureConfig = null;
+          } else {
+            const signatureConfig = buildSignatureConfig(options);
+            if (signatureConfig) updates.signatureConfig = signatureConfig;
+            if (options.signatureSecret) updates.signatureSecret = options.signatureSecret;
+          }
 
           const source = await client.webhooks.updateSource(resolvedId, updates);
           output.success(`Webhook source updated: ${source.id}`, {

--- a/packages/db/drizzle/0052_webhook_source_signature.sql
+++ b/packages/db/drizzle/0052_webhook_source_signature.sql
@@ -1,0 +1,26 @@
+-- Webhook source signature verification (#928).
+--
+-- The generic webhook ingress (POST /api/v2/webhooks/:source) validated
+-- expected headers by PRESENCE only — any value passed. These columns let a
+-- source carry a real verification contract, checked before anything is
+-- published to the bus:
+--
+--   signature_config  jsonb  { algorithm: 'hmac-sha256'|'hmac-sha1'|'token-match',
+--                              header: string, prefix?: string }
+--   signature_secret  text   the shared secret; sealed per-tenant via
+--                            sealCredentialField like other credential columns,
+--                            never returned by the API.
+--
+-- A source with signature_config set is verifiable by the auth-exempt public
+-- ingress route (POST /api/v2/webhooks/ingress/:source); a source without one
+-- stays reachable only through the authenticated route.
+--
+-- Hand-written following the 0044-0051 precedent (snapshot drift keeps
+-- drizzle-kit generate interactive). Additive + idempotent.
+
+-- NOTE: no explicit BEGIN/COMMIT — the boot migrator executes this file on a
+-- pooled postgres-js connection, which rejects raw transaction control
+-- (UNSAFE_TRANSACTION).
+
+ALTER TABLE "webhook_sources" ADD COLUMN IF NOT EXISTS "signature_config" jsonb;
+ALTER TABLE "webhook_sources" ADD COLUMN IF NOT EXISTS "signature_secret" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1785100000000,
       "tag": "0051_message_pin_star",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1785200000000,
+      "tag": "0052_webhook_source_signature",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2634,6 +2634,30 @@ export type NewEventPayload = Omit<typeof eventPayloads.$inferInsert, 'tenantId'
 // WEBHOOK SOURCES (Events Ext)
 // ============================================================================
 
+/** Signature verification algorithms supported by the generic webhook ingress. */
+export const webhookSignatureAlgorithms = ['hmac-sha256', 'hmac-sha1', 'token-match'] as const;
+export type WebhookSignatureAlgorithm = (typeof webhookSignatureAlgorithms)[number];
+
+/**
+ * Per-source request verification for the generic webhook ingress.
+ *
+ * `hmac-sha256`/`hmac-sha1`: the header carries an HMAC of the raw request
+ * body computed with the source's secret (GitHub's X-Hub-Signature-256
+ * pattern; `prefix` covers the `sha256=` style the digest is wrapped in).
+ * `token-match`: the header carries the secret itself (Telegram's
+ * X-Telegram-Bot-Api-Secret-Token pattern).
+ *
+ * The secret lives in the sibling `signature_secret` column, not here, so it
+ * can be sealed per-tenant like other credential fields.
+ */
+export interface WebhookSignatureConfig {
+  algorithm: WebhookSignatureAlgorithm;
+  /** Header carrying the signature or token (e.g. 'X-Hub-Signature-256'). */
+  header: string;
+  /** Prefix the provider prepends to the hex digest (e.g. 'sha256='). */
+  prefix?: string;
+}
+
 /**
  * Webhook source configurations.
  * External systems can trigger events in Omni via webhooks.
@@ -2649,6 +2673,11 @@ export const webhookSources = pgTable(
 
     // Optional validation
     expectedHeaders: jsonb('expected_headers').$type<Record<string, boolean>>(), // { 'X-GitHub-Event': true }
+
+    // Signature verification (issue #928). Config holds algorithm/header;
+    // the secret is a separate column so it can be sealed per-tenant.
+    signatureConfig: jsonb('signature_config').$type<WebhookSignatureConfig>(),
+    signatureSecret: text('signature_secret'),
 
     // State
     enabled: boolean('enabled').notNull().default(true),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -710,12 +710,27 @@ export interface ListWebhookSourcesParams {
 }
 
 /**
+ * Signature verification contract for a webhook source (issue #928)
+ */
+export interface WebhookSignatureConfigBody {
+  algorithm: 'hmac-sha256' | 'hmac-sha1' | 'token-match';
+  /** Header carrying the signature/token (e.g. 'X-Hub-Signature-256') */
+  header: string;
+  /** Prefix before the hex digest (e.g. 'sha256=') */
+  prefix?: string;
+}
+
+/**
  * Body for creating a webhook source
  */
 export interface CreateWebhookSourceBody {
   name: string;
   description?: string;
   expectedHeaders?: Record<string, boolean>;
+  /** Required for the source to be reachable on the public ingress route */
+  signatureConfig?: WebhookSignatureConfigBody | null;
+  /** Shared secret used by signatureConfig (write-only, never returned) */
+  signatureSecret?: string | null;
   enabled?: boolean;
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -96,6 +96,7 @@ export type {
   // Webhook types
   WebhookSource,
   ListWebhookSourcesParams,
+  WebhookSignatureConfigBody,
   CreateWebhookSourceBody,
   TriggerEventBody,
   // Payload types


### PR DESCRIPTION
## Summary

Implements the #928 hardening for the generic webhook receiver (`POST /api/v2/webhooks/:source`). Closes #928.

### 1. Per-source signature verification
- `webhook_sources` gains `signature_config` (`hmac-sha256` / `hmac-sha1` / `token-match` + header name + optional digest prefix like `sha256=`) and `signature_secret`, sealed per-tenant via `sealCredentialField` like other credential columns (migration `0052`, hand-written per the 0044–0051 precedent, additive + idempotent).
- `WebhookService.receive` verifies the signature **over the raw request body** with a timing-safe compare **before** the stats update and publish — a failed verification is a typed 401 and nothing enters the journal.
- The secret is write-only: CRUD responses return `hasSignatureSecret` instead of the value.

### 2. autoCreate off by default
- `receive()` now defaults `autoCreate: false`; sources are created by administrative act (API/CLI). `OMNI_WEBHOOK_AUTOCREATE=true` restores the old behavior for dev environments. **Behavioral change:** an authenticated POST to an unknown source is now 404 instead of silently materializing it.

### 3. Dedicated auth-exempt ingress route
- `POST /api/v2/webhooks/ingress/:source`, mounted before `protectedApp` following the channel-webhook precedent (Telegram/Meta/Twilio). Reachable **only** for sources with a signature config; never auto-creates; registered in the route-ownership gate as public-by-contract.
- All rejections (unknown source, disabled, unconfigured, bad signature) collapse into one 401 shape so the endpoint is not a source-name existence oracle; the real reason is logged server-side.
- The authenticated `/webhooks/:source` route remains for internal use (and now also verifies signatures when configured).

### 4. Rate limiting
- The public ingress gets its own IP-keyed limiter (events budget, isolated key prefix).

### Tooling
- SDK: `WebhookSignatureConfigBody` + new fields on `CreateWebhookSourceBody`.
- CLI: `omni webhooks create/update --signature-algorithm --signature-header --signature-prefix --signature-secret`, plus `--clear-signature` on update.
- OpenAPI: source schemas updated, ingress path registered with `security: []`.

> Note: generated SDKs (`packages/sdk*/generated`) were **not** regenerated — `make sdk-generate` needs a running API. Follow-up on next spec regen.

## Testing
- `bun test` full suite via pre-push gate: 5831 pass / 0 fail.
- New app-level tests (`webhook-ingress.test.ts`): signed request accepted with no API key; bad signature / unknown source / unconfigured source / disabled source all return the uniform 401; authenticated route still 401s without a key.
- New service tests: HMAC valid/invalid, token-match, missing header, missing raw body, missing secret, autoCreate-off default, secret invariants on create/update.
- `make typecheck` and `make lint` green.