### PR TITLE
feat(slack): migrate to Agent messaging experience (agent_view + Agent Sessions API)

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -22,7 +22,9 @@ February 2027**; new Slack apps can only use `agent_view`, and the switch from
 - Omni subscribes to `agent_session_stopped`. Subscribing is what makes Slack
   show the **native stop button** while a session is `processing`; when a user
   presses it, Omni aborts the in-flight provider run (no more paying for a
-  long `claude-code` run nobody wants) and clears the session status.
+  long `claude-code` run nobody wants), clears the session status, and — per
+  Slack's halt-and-keep stop semantics — **keeps** whatever partial reply was
+  already streamed instead of deleting it.
 
 > **Important:** status and the stop button are **thread-scoped**. A
 > channel-level mention that has not opened a thread has no status surface;
@@ -71,10 +73,14 @@ app by hand instead, make sure it has:
 The full bot scope list lives in `REQUIRED_BOT_SCOPES`
 (`packages/channel-slack/src/manifest.ts`); the event list in `BOT_EVENTS`.
 
-> Existing apps still on `assistant_view`: switching the manifest to
-> `agent_view` renames `assistant_description` → `agent_description`, cannot
-> be reverted, and users may need a hard refresh of Slack to see the new
-> experience.
+> **Existing apps still on `assistant_view`:** applying a manifest containing
+> `agent_view` migrates the app permanently — Slack does not allow reverting
+> to `assistant_view` — and users may need a hard refresh of Slack to see the
+> new experience. If you are regenerating a manifest for such an app and are
+> not ready to migrate, pass `agentView: false` to `buildSlackManifest()` to
+> omit the block. (Manifests produced by this generator never contained
+> `assistant_view`, so regenerating one of its own manifests does not migrate
+> anything.)
 
 ### 2. Create the Omni instance
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1,0 +1,124 @@
+# Slack Channel
+
+> Slack bot integration via Bolt.js (Socket Mode or HTTP), with the Agent
+> messaging experience (`agent_view` + Agent Sessions API), native streaming,
+> reactions, pins, slash commands, and an optional user-token mode.
+
+## Agent messaging experience (#914)
+
+Slack apps built as AI agents declare `agent_view` in their manifest. The
+older `assistant_view` experience is **deprecated and will be removed in
+February 2027**; new Slack apps can only use `agent_view`, and the switch from
+`assistant_view` to `agent_view` is **one-way per app**. Omni targets
+`agent_view`:
+
+- `buildSlackManifest()` emits `features.agent_view` (with `agent_description`
+  and optional `suggested_prompts`) — see below for generating a manifest.
+- Working status uses `agents.sessions.setStatus` (`processing` while the
+  agent runs, `active` when it finishes). Workspaces where the Agent Sessions
+  API is not yet available fall back automatically to the deprecated
+  `assistant.threads.setStatus`, which keeps working through Slack's
+  compatibility bridge until February 2027.
+- Omni subscribes to `agent_session_stopped`. Subscribing is what makes Slack
+  show the **native stop button** while a session is `processing`; when a user
+  presses it, Omni aborts the in-flight provider run (no more paying for a
+  long `claude-code` run nobody wants) and clears the session status.
+
+> **Important:** status and the stop button are **thread-scoped**. A
+> channel-level mention that has not opened a thread has no status surface;
+> Omni logs a `no_active_thread` debug line when it skips status for this
+> reason.
+
+## Prerequisites
+
+1. A Slack workspace where you can install apps.
+2. A **Slack app** created at <https://api.slack.com/apps> — use
+   **"From an app manifest"** with the manifest generated below.
+3. For Socket Mode (default): an **app-level token** (`xapp-...`) with
+   `connections:write`.
+4. A **bot token** (`xoxb-...`) issued on install.
+
+## Setup
+
+### 1. Generate the app manifest
+
+`buildSlackManifest()` (exported from `@omni/channel-slack`) produces a
+manifest with every scope and event subscription the plugin needs, including
+the Agent messaging experience:
+
+```typescript
+import { buildSlackManifest } from '@omni/channel-slack';
+
+const manifest = buildSlackManifest({
+  appName: 'My Omni Bot',
+  description: 'Omni-powered agent',
+  agentDescription: 'Answers questions and runs long tasks in threads', // ≤300 chars
+  suggestedPrompts: [{ title: 'Status', message: 'What are you working on?' }],
+});
+console.log(JSON.stringify(manifest, null, 2));
+```
+
+Paste the JSON into **Create app → From an app manifest**. If you maintain an
+app by hand instead, make sure it has:
+
+| Manifest piece | Value | Why |
+|---|---|---|
+| `features.agent_view.agent_description` | your agent's description | Enables the Agent messaging experience; `assistant_view` is deprecated |
+| `settings.event_subscriptions.bot_events` | includes `agent_session_stopped` | Slack only shows the native stop button if the app subscribes to this |
+| `oauth_config.scopes.bot` | includes `chat:write` | Required by `agents.sessions.setStatus` / message sending |
+| `settings.socket_mode_enabled` | `true` (Socket Mode) | Default transport; HTTP receiver also supported |
+
+The full bot scope list lives in `REQUIRED_BOT_SCOPES`
+(`packages/channel-slack/src/manifest.ts`); the event list in `BOT_EVENTS`.
+
+> Existing apps still on `assistant_view`: switching the manifest to
+> `agent_view` renames `assistant_description` → `agent_description`, cannot
+> be reverted, and users may need a hard refresh of Slack to see the new
+> experience.
+
+### 2. Create the Omni instance
+
+Provide the tokens as instance credentials:
+
+```jsonc
+{
+  "channel": "slack",
+  "config": {
+    "botToken": "xoxb-...",
+    "appToken": "xapp-...", // Socket Mode
+    "mode": "socket"         // or "http" + signingSecret
+  }
+}
+```
+
+See `SlackConfig` (`packages/channel-slack/src/types.ts`) for every option:
+DM policy, channel allow/blocklists, stream mode, reply-to mode, slash
+commands, and user-token mode (`authMode: 'user'`, #889).
+
+### 3. Verify
+
+Mention the bot inside a thread (or DM it) while an agent provider is
+configured. You should see:
+
+- the session status ("working") while the provider runs,
+- a native stop button (press it — the provider run aborts and the status
+  clears),
+- the streamed reply rendered word-by-word (native `chat.startStream` when the
+  workspace supports it).
+
+## Status & stop internals
+
+| Concern | Where |
+|---|---|
+| Status calls (`agents.sessions.setStatus` + legacy fallback) | `packages/channel-slack/src/handlers/typing.ts` |
+| Thread resolution for status (`activeThreads`) | `packages/channel-slack/src/plugin.ts` (`sendPresenceStatus`) |
+| `agent_session_stopped` handling | `packages/channel-slack/src/handlers/agent-sessions.ts` |
+| Run abort propagation (`agent.run.cancel_requested`) | `packages/api/src/plugins/agent-dispatcher.ts` (`cancelActiveAgentRun`) |
+| Manifest generation | `packages/channel-slack/src/manifest.ts` |
+
+## References
+
+- [Agent messaging experience migration guide](https://docs.slack.dev/ai/migrating-to-agent-messaging/)
+- [`agents.sessions.setStatus`](https://docs.slack.dev/reference/methods/agents.sessions.setStatus/)
+- [`agent_session_stopped` event](https://docs.slack.dev/reference/events/agent_session_stopped/)
+- [App manifest reference (`agent_view`)](https://docs.slack.dev/reference/app-manifest)

--- a/packages/api/src/__tests__/messages-presence.test.ts
+++ b/packages/api/src/__tests__/messages-presence.test.ts
@@ -242,7 +242,7 @@ describeWithDb('POST /messages/send/presence', () => {
         options?: { threadId?: string; status?: string; loadingMessages?: string[] },
       ) => ({
         delivered: true,
-        method: 'assistant.threads.setStatus',
+        method: 'agents.sessions.setStatus',
         threadId: options?.threadId,
         status: options?.status ?? 'is typing...',
         loadingMessages: options?.loadingMessages,
@@ -271,7 +271,7 @@ describeWithDb('POST /messages/send/presence', () => {
     };
     expect(body.success).toBe(true);
     expect(body.data.delivered).toBe(true);
-    expect(body.data.method).toBe('assistant.threads.setStatus');
+    expect(body.data.method).toBe('agents.sessions.setStatus');
     expect(body.data.threadId).toBe('1234567890.001');
     expect(body.data.status).toBe('analisando contexto...');
     expect(body.data.loadingMessages).toEqual(['Lendo contexto...', 'Chamando ferramentas...']);

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -411,6 +411,80 @@ describe('agent-dispatcher', () => {
       await expect(cancelActiveAgentRun('inst-none', 'chat-none', 'user_stop')).resolves.toBe(false);
     });
 
+    it('cancelActiveAgentRun aborts only the targeted thread (#914)', async () => {
+      const { activeRunAborts, runAbortKey } = __test__;
+      const runA = { controller: new AbortController(), startedAt: Date.now() - 5_000 };
+      const runB = { controller: new AbortController(), startedAt: Date.now() - 5_000 };
+      activeRunAborts.set(runAbortKey('inst-1', 'C1', 'thread-A'), runA);
+      activeRunAborts.set(runAbortKey('inst-1', 'C1', 'thread-B'), runB);
+
+      try {
+        await expect(cancelActiveAgentRun('inst-1', 'C1', 'user_stop', { threadId: 'thread-A' })).resolves.toBe(true);
+        expect(runA.controller.signal.aborted).toBe(true);
+        expect(runB.controller.signal.aborted).toBe(false);
+      } finally {
+        activeRunAborts.clear();
+      }
+    });
+
+    it('cancelActiveAgentRun falls back to the threadless run for the same chat (#914)', async () => {
+      const { activeRunAborts, runAbortKey } = __test__;
+      // Top-level mention / DM: the run registered without a threadId, but
+      // Slack's stop event carries the thread_ts of the reply thread.
+      const run = { controller: new AbortController(), startedAt: Date.now() - 5_000 };
+      activeRunAborts.set(runAbortKey('inst-1', 'C1'), run);
+
+      try {
+        await expect(cancelActiveAgentRun('inst-1', 'C1', 'user_stop', { threadId: '1234.5678' })).resolves.toBe(true);
+        expect(run.controller.signal.aborted).toBe(true);
+      } finally {
+        activeRunAborts.clear();
+      }
+    });
+
+    it('cancelActiveAgentRun ignores a run that started after the stop press (#914)', async () => {
+      const { activeRunAborts, runAbortKey } = __test__;
+      const stopPressedAt = Date.now() - 10_000;
+      const newerRun = { controller: new AbortController(), startedAt: Date.now() };
+      activeRunAborts.set(runAbortKey('inst-1', 'C1', 'thread-A'), newerRun);
+
+      try {
+        await expect(
+          cancelActiveAgentRun('inst-1', 'C1', 'user_stop', { threadId: 'thread-A', requestedAt: stopPressedAt }),
+        ).resolves.toBe(false);
+        expect(newerRun.controller.signal.aborted).toBe(false);
+      } finally {
+        activeRunAborts.clear();
+      }
+    });
+
+    it('cancelActiveAgentRun prefers sender.cancel (halt-and-keep) over abort (#914)', async () => {
+      const { activeRunAborts, runAbortKey } = __test__;
+      const cancelMock = mock(async () => {});
+      const abortMock = mock(async () => {});
+      const run = {
+        controller: new AbortController(),
+        startedAt: Date.now() - 5_000,
+        sender: {
+          onThinkingDelta: mock(async () => {}),
+          onContentDelta: mock(async () => {}),
+          onFinal: mock(async () => {}),
+          onError: mock(async () => {}),
+          abort: abortMock,
+          cancel: cancelMock,
+        },
+      };
+      activeRunAborts.set(runAbortKey('inst-1', 'C1', 'thread-A'), run);
+
+      try {
+        await expect(cancelActiveAgentRun('inst-1', 'C1', 'user_stop', { threadId: 'thread-A' })).resolves.toBe(true);
+        expect(cancelMock).toHaveBeenCalledTimes(1);
+        expect(abortMock).not.toHaveBeenCalled();
+      } finally {
+        activeRunAborts.clear();
+      }
+    });
+
     it('returns a cleanup function that can be called without error', async () => {
       const eventBus = createMockEventBus();
       const services = createMockServices();

--- a/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher.test.ts
@@ -35,6 +35,7 @@ import { instances } from '@omni/db';
 import {
   type DispatcherCleanup,
   __test__,
+  cancelActiveAgentRun,
   isFirstPartyInstanceSender,
   resolveQuotedMessage,
   setupAgentDispatcher,
@@ -382,7 +383,7 @@ describe('agent-dispatcher', () => {
   // setupAgentDispatcher — subscribes to correct NATS subjects
   // ======================================================================
   describe('setupAgentDispatcher', () => {
-    it('subscribes to message.received, reaction.received, reaction.removed, presence.typing, and media.processed', async () => {
+    it('subscribes to message.received, reaction.received, reaction.removed, presence.typing, media.processed, and agent.run.cancel_requested', async () => {
       const eventBus = createMockEventBus();
       const services = createMockServices();
 
@@ -392,7 +393,7 @@ describe('agent-dispatcher', () => {
         mockDb,
       );
 
-      expect(eventBus.subscribe).toHaveBeenCalledTimes(5);
+      expect(eventBus.subscribe).toHaveBeenCalledTimes(6);
 
       // Verify event types subscribed
       const subscribedTypes = eventBus.subscribe.mock.calls.map((call: unknown[]) => call[0]);
@@ -401,8 +402,13 @@ describe('agent-dispatcher', () => {
       expect(subscribedTypes).toContain('reaction.removed');
       expect(subscribedTypes).toContain('presence.typing');
       expect(subscribedTypes).toContain('media.processed');
+      expect(subscribedTypes).toContain('agent.run.cancel_requested');
 
       cleanup();
+    });
+
+    it('cancelActiveAgentRun resolves false when nothing is in flight (#914)', async () => {
+      await expect(cancelActiveAgentRun('inst-none', 'chat-none', 'user_stop')).resolves.toBe(false);
     });
 
     it('returns a cleanup function that can be called without error', async () => {

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -33,6 +33,7 @@ import type { StreamSender } from '@omni/channel-sdk';
 import {
   A2AAgentProvider,
   AgUiAgentProvider,
+  type AgentRunCancelRequestedPayload,
   type AgentTrigger,
   type AgentTriggerType,
   AgnoAgentProvider,
@@ -2039,6 +2040,46 @@ async function fetchChatMetadata(
 // ─── Per-chatId stream guard ──────────────────────────────
 const activeStreams = new Map<string, StreamSender>();
 
+// ─── Per-chatId run cancellation (#914) ───────────────────
+// Populated while a provider run is in flight; `agent.run.cancel_requested`
+// (e.g. Slack's native stop button) aborts the controller. Streaming providers
+// honor the signal end-to-end (claude-code aborts the SDK run); accumulate-mode
+// runs that ignore it have their reply discarded on completion instead.
+const activeRunAborts = new Map<string, AbortController>();
+
+/**
+ * Abort the in-flight agent run and stream for a chat, if any.
+ * Exported for tests.
+ */
+export async function cancelActiveAgentRun(instanceId: string, chatId: string, reason: string): Promise<boolean> {
+  const key = `${instanceId}:${chatId}`;
+  const controller = activeRunAborts.get(key);
+  const sender = activeStreams.get(key);
+
+  if (!controller && !sender) {
+    log.info('Agent run cancel requested but nothing in flight', { instanceId, chatId, reason });
+    return false;
+  }
+
+  log.info('Cancelling in-flight agent run', {
+    instanceId,
+    chatId,
+    reason,
+    hasAbortController: !!controller,
+    hasActiveStream: !!sender,
+  });
+
+  controller?.abort();
+  if (sender) {
+    try {
+      await sender.abort();
+    } catch (err) {
+      log.warn('Stream sender abort failed during run cancellation', { instanceId, chatId, error: String(err) });
+    }
+  }
+  return true;
+}
+
 /** Route a single StreamDelta to the appropriate StreamSender method. */
 async function routeStreamDelta(sender: StreamSender, delta: StreamDelta): Promise<void> {
   switch (delta.phase) {
@@ -2431,6 +2472,12 @@ async function dispatchViaStreamingProvider(
   const streamKey = `${instance.id}:${chatId}`;
   activeStreams.set(streamKey, sender);
 
+  // Cancellable run (#914): agent.run.cancel_requested aborts this controller,
+  // which providers propagate into the underlying SDK run.
+  const cancelController = new AbortController();
+  activeRunAborts.set(streamKey, cancelController);
+  trigger.abortSignal = cancelController.signal;
+
   const streamDispatchStart = Date.now();
   try {
     const generator = resolved.provider.triggerStream(trigger);
@@ -2452,8 +2499,17 @@ async function dispatchViaStreamingProvider(
       });
     }
 
-    return streamResult;
+    // A cancelled run counts as handled even when the stream ended in an
+    // error delta — falling back would re-run the turn the user stopped.
+    return cancelController.signal.aborted ? true : streamResult;
   } catch (err) {
+    // A user-requested cancellation surfaces as an abort error from the
+    // provider — that's a handled outcome (#914), never a fallback: falling
+    // back to the accumulate path would re-run the turn the user just stopped.
+    if (cancelController.signal.aborted) {
+      log.info('Streaming dispatch cancelled by user', { instanceId: instance.id, chatId, traceId });
+      return true;
+    }
     log.error('Streaming dispatch failed, falling back', {
       instanceId: instance.id,
       chatId,
@@ -2468,6 +2524,7 @@ async function dispatchViaStreamingProvider(
     return false;
   } finally {
     activeStreams.delete(streamKey);
+    activeRunAborts.delete(streamKey);
   }
 }
 
@@ -2799,6 +2856,63 @@ async function dispatchViaTurnBasedProvider(
 }
 
 /**
+ * Why an accumulate-mode reply is withheld instead of sent.
+ * Precedence mirrors the original inline checks: a handoff announcement
+ * always wins over discard reasons.
+ */
+function resolveReplySuppression(flags: {
+  handoffTriggered: boolean;
+  errorHandoffDone: boolean;
+  supersededByNewerInbound: boolean;
+  runCancelled: boolean;
+}): 'handoff_triggered' | 'error_handoff' | 'superseded_by_newer_inbound' | 'run_cancelled_by_user' | null {
+  if (flags.handoffTriggered) return 'handoff_triggered';
+  if (flags.errorHandoffDone) return 'error_handoff';
+  if (flags.supersededByNewerInbound) return 'superseded_by_newer_inbound';
+  if (flags.runCancelled) return 'run_cancelled_by_user';
+  return null;
+}
+
+/**
+ * Run provider.trigger() with cancellation registered in activeRunAborts (#914).
+ *
+ * Returns null when the run was cancelled AND the provider surfaced the abort
+ * as a throw — the turn is over, nothing to send. Otherwise returns the result
+ * plus whether a cancel arrived mid-run (callers discard the reply then).
+ */
+async function triggerProviderWithCancellation(
+  provider: IAgentProvider,
+  trigger: AgentTrigger,
+  spanAttributes: Parameters<typeof withLifecycleSpan>[1],
+  instanceId: string,
+  chatId: string,
+  traceId: string,
+): Promise<{ result: Awaited<ReturnType<IAgentProvider['trigger']>>; cancelled: boolean } | null> {
+  const cancelController = new AbortController();
+  const runKey = `${instanceId}:${chatId}`;
+  activeRunAborts.set(runKey, cancelController);
+
+  try {
+    const result = await withLifecycleSpan('omni.dispatch_to_agno', spanAttributes, () =>
+      provider.trigger({
+        ...trigger,
+        abortSignal: cancelController.signal,
+        traceContext: activeProviderTraceContext() ?? trigger.traceContext,
+      }),
+    );
+    return { result, cancelled: cancelController.signal.aborted };
+  } catch (err) {
+    if (cancelController.signal.aborted) {
+      log.info('Agent run cancelled by user during dispatch', { instanceId, chatId, traceId });
+      return null;
+    }
+    throw err;
+  } finally {
+    activeRunAborts.delete(runKey);
+  }
+}
+
+/**
  * Try IAgentProvider dispatch first, return true if handled.
  * Falls back to legacy agentRunner.run() if provider not resolved.
  */
@@ -2943,15 +3057,23 @@ async function dispatchViaProvider(
       // ── Standard (round-trip / fire-and-forget) dispatch ──
       const correlationId = messages[0]?.metadata.correlationId;
       const dispatchStart = Date.now();
-      const result = await withLifecycleSpan(
-        'omni.dispatch_to_agno',
+
+      // Cancellable run (#914): providers that honor abortSignal stop mid-run;
+      // for the rest, the cancelled flag discards the reply after completion.
+      const triggerOutcome = await triggerProviderWithCancellation(
+        provider,
+        trigger,
         buildLifecycleSpanAttributes({
           ...lifecycleBase,
           stage: 'dispatch_to_agno',
           extra: { trigger_type: triggerType, provider_id: provider.id, provider_schema: provider.schema },
         }),
-        () => provider.trigger({ ...trigger, traceContext: activeProviderTraceContext() ?? trigger.traceContext }),
+        instance.id,
+        chatId,
+        traceId,
       );
+      if (!triggerOutcome) return true;
+      const { result, cancelled: runCancelled } = triggerOutcome;
       const dispatchDurationMs = Date.now() - dispatchStart;
 
       // Sentry metrics: agent dispatch count and latency
@@ -2992,7 +3114,14 @@ async function dispatchViaProvider(
         messages[0]?.metadata.trustedTenantId,
       );
 
-      if (result && result.parts.length > 0 && !handoffTriggered && !errorHandoffDone && !supersededByNewerInbound) {
+      const suppressReason = resolveReplySuppression({
+        handoffTriggered,
+        errorHandoffDone,
+        supersededByNewerInbound,
+        runCancelled,
+      });
+
+      if (result && result.parts.length > 0 && !suppressReason) {
         const selfChat = isSelfChat(chatId, instance.ownerIdentifier);
         const rawParts = selfChat ? result.parts.map((p) => `${BOT_PREFIX}${p}`) : result.parts;
         // Apply before_message_write hooks to each response part before sending
@@ -3032,13 +3161,9 @@ async function dispatchViaProvider(
 
         // T10: Agent chaining — forward response to chained instance if configured
         await forwardToChainedInstance(instance, parts, correlationId, messages);
-      } else if (handoffTriggered) {
-        log.info('Agent response suppressed — handoff triggered during run', {
-          instanceId: instance.id,
-          chatId,
-        });
-      } else if (supersededByNewerInbound) {
-        log.info('Agent response discarded — superseded by newer inbound', {
+      } else if (suppressReason) {
+        log.info('Agent response suppressed', {
+          reason: suppressReason,
           instanceId: instance.id,
           chatId,
           parts: result?.parts.length ?? 0,
@@ -6098,7 +6223,35 @@ export async function setupAgentDispatcher(
       },
     );
 
-    log.info('Agent dispatcher initialized (message + reaction + reaction-removed + media triggers)');
+    // ========================================
+    // Subscribe to agent.run.cancel_requested (#914)
+    // ========================================
+    await eventBus.subscribe(
+      'agent.run.cancel_requested',
+      async (event) => {
+        // Idempotency guard (#411): a replayed cancel must not abort a NEW
+        // run that started for the same chat after the original one ended.
+        await withIdempotency(db, event.id, 'agent-dispatcher-cancel', async () => {
+          const payload = event.payload as AgentRunCancelRequestedPayload;
+          try {
+            await cancelActiveAgentRun(payload.instanceId, payload.chatId, payload.reason);
+          } catch (error) {
+            log.error('Error cancelling agent run', {
+              instanceId: payload.instanceId,
+              chatId: payload.chatId,
+              error: String(error),
+            });
+          }
+        });
+      },
+      {
+        durable: 'agent-dispatcher-cancel',
+        queue: 'agent-dispatcher-cancel',
+        startFrom: 'new',
+      },
+    );
+
+    log.info('Agent dispatcher initialized (message + reaction + reaction-removed + media + cancel triggers)');
   } catch (error) {
     log.error('Failed to set up agent dispatcher', { error: String(error) });
     clearInterval(mediaCleanupInterval);

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -2040,41 +2040,93 @@ async function fetchChatMetadata(
 // ─── Per-chatId stream guard ──────────────────────────────
 const activeStreams = new Map<string, StreamSender>();
 
-// ─── Per-chatId run cancellation (#914) ───────────────────
+// ─── Per-run cancellation (#914) ──────────────────────────
 // Populated while a provider run is in flight; `agent.run.cancel_requested`
 // (e.g. Slack's native stop button) aborts the controller. Streaming providers
 // honor the signal end-to-end (claude-code aborts the SDK run); accumulate-mode
 // runs that ignore it have their reply discarded on completion instead.
-const activeRunAborts = new Map<string, AbortController>();
+
+interface ActiveRunEntry {
+  controller: AbortController;
+  /** Unix ms when the run registered — compared against a cancel's requestedAt */
+  startedAt: number;
+  /** Stream sender owned by this run (streaming dispatch only) */
+  sender?: StreamSender;
+}
+
+// Keyed by runAbortKey — thread-scoped, because two threads in one Slack
+// channel are two concurrent runs (the second goes down the accumulate path
+// past the per-chat streaming guard). A chat-scoped key would let a stop in
+// thread A abort thread B, and each run's cleanup would delete the other's.
+const activeRunAborts = new Map<string, ActiveRunEntry>();
+
+function runAbortKey(instanceId: string, chatId: string, threadId?: string): string {
+  return `${instanceId}:${chatId}:${threadId ?? ''}`;
+}
 
 /**
- * Abort the in-flight agent run and stream for a chat, if any.
+ * Abort the in-flight agent run (and its stream sender) for a chat/thread.
+ *
+ * Looks up the exact thread key first, then the threadless key — Slack's stop
+ * event always carries a thread_ts, but a run triggered by a top-level
+ * mention or DM registered without one. When `requestedAt` is provided, runs
+ * that STARTED after the stop press are left alone, so a late-delivered or
+ * redelivered cancel cannot kill the user's next turn.
+ *
  * Exported for tests.
  */
-export async function cancelActiveAgentRun(instanceId: string, chatId: string, reason: string): Promise<boolean> {
-  const key = `${instanceId}:${chatId}`;
-  const controller = activeRunAborts.get(key);
-  const sender = activeStreams.get(key);
+export async function cancelActiveAgentRun(
+  instanceId: string,
+  chatId: string,
+  reason: string,
+  opts?: { threadId?: string; requestedAt?: number },
+): Promise<boolean> {
+  let entry = activeRunAborts.get(runAbortKey(instanceId, chatId, opts?.threadId));
+  if (!entry && opts?.threadId) {
+    entry = activeRunAborts.get(runAbortKey(instanceId, chatId));
+  }
 
-  if (!controller && !sender) {
-    log.info('Agent run cancel requested but nothing in flight', { instanceId, chatId, reason });
+  if (!entry) {
+    log.info('Agent run cancel requested but nothing in flight', {
+      instanceId,
+      chatId,
+      threadId: opts?.threadId,
+      reason,
+    });
+    return false;
+  }
+
+  // startedAt is this server's clock, requestedAt the platform's; a legit
+  // stop press trails the run start by seconds-to-minutes, so ordinary NTP
+  // skew cannot flip this comparison.
+  if (opts?.requestedAt !== undefined && entry.startedAt > opts.requestedAt) {
+    log.info('Agent run cancel ignored — run started after the stop request', {
+      instanceId,
+      chatId,
+      threadId: opts?.threadId,
+      startedAt: entry.startedAt,
+      requestedAt: opts.requestedAt,
+      reason,
+    });
     return false;
   }
 
   log.info('Cancelling in-flight agent run', {
     instanceId,
     chatId,
+    threadId: opts?.threadId,
     reason,
-    hasAbortController: !!controller,
-    hasActiveStream: !!sender,
+    hasActiveStream: !!entry.sender,
   });
 
-  controller?.abort();
-  if (sender) {
+  entry.controller.abort();
+  if (entry.sender) {
     try {
-      await sender.abort();
+      // cancel() halts and KEEPS the partial output (Slack's stop semantics);
+      // abort() is only a fallback for senders without it.
+      await (entry.sender.cancel ? entry.sender.cancel() : entry.sender.abort());
     } catch (err) {
-      log.warn('Stream sender abort failed during run cancellation', { instanceId, chatId, error: String(err) });
+      log.warn('Stream sender cancel failed during run cancellation', { instanceId, chatId, error: String(err) });
     }
   }
   return true;
@@ -2473,9 +2525,11 @@ async function dispatchViaStreamingProvider(
   activeStreams.set(streamKey, sender);
 
   // Cancellable run (#914): agent.run.cancel_requested aborts this controller,
-  // which providers propagate into the underlying SDK run.
+  // which providers propagate into the underlying SDK run. The sender rides
+  // along so cancellation can halt-and-keep the partial stream output.
   const cancelController = new AbortController();
-  activeRunAborts.set(streamKey, cancelController);
+  const runKey = runAbortKey(instance.id, chatId, rawThreadId);
+  activeRunAborts.set(runKey, { controller: cancelController, startedAt: Date.now(), sender });
   trigger.abortSignal = cancelController.signal;
 
   const streamDispatchStart = Date.now();
@@ -2524,7 +2578,7 @@ async function dispatchViaStreamingProvider(
     return false;
   } finally {
     activeStreams.delete(streamKey);
-    activeRunAborts.delete(streamKey);
+    activeRunAborts.delete(runKey);
   }
 }
 
@@ -2889,8 +2943,8 @@ async function triggerProviderWithCancellation(
   traceId: string,
 ): Promise<{ result: Awaited<ReturnType<IAgentProvider['trigger']>>; cancelled: boolean } | null> {
   const cancelController = new AbortController();
-  const runKey = `${instanceId}:${chatId}`;
-  activeRunAborts.set(runKey, cancelController);
+  const runKey = runAbortKey(instanceId, chatId, trigger.source.threadId);
+  activeRunAborts.set(runKey, { controller: cancelController, startedAt: Date.now() });
 
   try {
     const result = await withLifecycleSpan('omni.dispatch_to_agno', spanAttributes, () =>
@@ -6229,24 +6283,29 @@ export async function setupAgentDispatcher(
     await eventBus.subscribe(
       'agent.run.cancel_requested',
       async (event) => {
-        // Idempotency guard (#411): a replayed cancel must not abort a NEW
-        // run that started for the same chat after the original one ended.
-        await withIdempotency(db, event.id, 'agent-dispatcher-cancel', async () => {
-          const payload = event.payload as AgentRunCancelRequestedPayload;
-          try {
-            await cancelActiveAgentRun(payload.instanceId, payload.chatId, payload.reason);
-          } catch (error) {
-            log.error('Error cancelling agent run', {
-              instanceId: payload.instanceId,
-              chatId: payload.chatId,
-              error: String(error),
-            });
-          }
-        });
+        const payload = event.payload as AgentRunCancelRequestedPayload;
+        try {
+          await cancelActiveAgentRun(payload.instanceId, payload.chatId, payload.reason, {
+            threadId: payload.threadId,
+            requestedAt: payload.requestedAt,
+          });
+        } catch (error) {
+          log.error('Error cancelling agent run', {
+            instanceId: payload.instanceId,
+            chatId: payload.chatId,
+            error: String(error),
+          });
+        }
       },
       {
-        durable: 'agent-dispatcher-cancel',
-        queue: 'agent-dispatcher-cancel',
+        // Broadcast, not queue-grouped: the abort registry is per-process, so
+        // EVERY replica must see the cancel and no-op when it isn't running
+        // the turn — a deliver_group would route ~1/replicaCount of stop
+        // presses to the wrong pod. No durable and no withIdempotency either:
+        // both would elect a single winner and defeat the fan-out. Each
+        // process gets an ephemeral consumer starting at 'new' (no replay on
+        // restart), and the requestedAt guard in cancelActiveAgentRun keeps a
+        // redelivered cancel from aborting a newer run.
         startFrom: 'new',
       },
     );
@@ -6336,6 +6395,10 @@ export const setupAgentResponder = setupAgentDispatcher;
 export const __test__ = {
   buildContextMessages,
   awaitMediaProcessing,
+  // #914 cancel plumbing — exposed so tests can stage in-flight runs and
+  // assert the thread-scoped lookup + requestedAt guard.
+  activeRunAborts,
+  runAbortKey,
   // Read helpers converted in the G5 read-path leg — exported so the
   // worker-scope probes can assert their threading contract directly.
   resolveQuotedMessage,

--- a/packages/api/src/routes/v2/messages.ts
+++ b/packages/api/src/routes/v2/messages.ts
@@ -2427,7 +2427,8 @@ function hasPresenceStatusSender(plugin: unknown): plugin is PresenceStatusSende
  * Shows typing/recording indicator in a chat. Auto-pauses after duration.
  * - WhatsApp: supports typing, recording, paused
  * - Discord: supports typing only (recording/paused treated as typing)
- * - Slack: supports AI Assistant thread status via assistant.threads.setStatus
+ * - Slack: supports agent thread status via agents.sessions.setStatus (legacy
+ *   assistant.threads.setStatus fallback, #914)
  */
 messagesRoutes.post('/send/presence', zValidator('json', sendPresenceSchema), async (c) => {
   const { instanceId, to, type, duration, threadId, status, loadingMessages } = c.req.valid('json');

--- a/packages/channel-sdk/src/types/plugin.ts
+++ b/packages/channel-sdk/src/types/plugin.ts
@@ -227,8 +227,9 @@ export interface ChannelPlugin {
    *
    * A richer sibling of sendTyping for channels whose "someone is working on
    * this" signal is not a plain typing bubble. Slack's is thread-scoped
-   * (`assistant.threads.setStatus`) and carries a status string — which is why
-   * Slack reports `canSendTyping: false` while still implementing this.
+   * (`agents.sessions.setStatus`, with the deprecated
+   * `assistant.threads.setStatus` as fallback, #914) — which is why Slack
+   * reports `canSendTyping: false` while still implementing this.
    *
    * Returns a report rather than void: not-delivered is a normal outcome
    * (Slack has no thread context to attach to, say), and the caller needs to

--- a/packages/channel-sdk/src/types/streaming.ts
+++ b/packages/channel-sdk/src/types/streaming.ts
@@ -31,4 +31,13 @@ export interface StreamSender {
 
   /** Abort mid-stream — clean up any sent messages */
   abort(): Promise<void>;
+
+  /**
+   * User-requested stop (#914): halt the stream but KEEP what was already
+   * shown, finalizing the partial output. Distinct from abort(), whose
+   * delete-the-placeholder semantics exist for the error-fallback path where
+   * another message will replace it. Callers should fall back to abort()
+   * when a sender does not implement this.
+   */
+  cancel?(): Promise<void>;
 }

--- a/packages/channel-slack/src/__tests__/connection.test.ts
+++ b/packages/channel-slack/src/__tests__/connection.test.ts
@@ -157,6 +157,30 @@ describe('App Manifest', () => {
     expect(manifest.features.slash_commands).toHaveLength(1);
     expect(manifest.features.slash_commands?.[0]?.command).toBe('/omni');
   });
+
+  it('enables the Agent messaging experience (#914)', () => {
+    const manifest = buildSlackManifest();
+
+    // agent_view (not the deprecated assistant_view) with a description
+    expect(manifest.features.agent_view).toBeDefined();
+    expect(manifest.features.agent_view?.agent_description.length).toBeGreaterThan(0);
+    expect(manifest.features.agent_view?.agent_description.length).toBeLessThanOrEqual(300);
+
+    // Subscribing to agent_session_stopped is what makes Slack show the
+    // native stop button while a session is processing.
+    expect(manifest.settings.event_subscriptions.bot_events).toContain('agent_session_stopped');
+  });
+
+  it('carries custom agent description and suggested prompts', () => {
+    const manifest = buildSlackManifest({
+      agentDescription: 'Reviews code in Slack threads',
+      suggestedPrompts: [{ title: 'Review PR', message: 'Review the open PR' }],
+    });
+    expect(manifest.features.agent_view?.agent_description).toBe('Reviews code in Slack threads');
+    expect(manifest.features.agent_view?.suggested_prompts).toEqual([
+      { title: 'Review PR', message: 'Review the open PR' },
+    ]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/channel-slack/src/capabilities.ts
+++ b/packages/channel-slack/src/capabilities.ts
@@ -30,9 +30,10 @@ export const SLACK_CAPABILITIES: ChannelCapabilities = {
   canSendText: true,
   canSendMedia: true,
   canSendReaction: true,
-  // Slack typing is thread-only via assistant.threads.setStatus — not a general
-  // typing indicator. The plugin implements sendTyping() for thread contexts but
-  // the capability is false because it cannot show typing in channels/DMs directly.
+  // Slack typing is thread-only via agents.sessions.setStatus (legacy
+  // assistant.threads.setStatus fallback) — not a general typing indicator.
+  // The plugin implements sendTyping() for thread contexts but the capability
+  // is false because it cannot show typing in channels/DMs directly.
   canSendTyping: false,
 
   // Receipts

--- a/packages/channel-slack/src/handlers/agent-sessions.test.ts
+++ b/packages/channel-slack/src/handlers/agent-sessions.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the agent_session_stopped handler (#914)
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import type { Logger } from '@omni/channel-sdk';
+import type { App } from '@slack/bolt';
+import { type AgentSessionStoppedArgs, setupAgentSessionHandlers } from './agent-sessions';
+
+function makeLogger(): Logger {
+  return {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    child: mock(() => makeLogger()),
+  } as unknown as Logger;
+}
+
+/** Minimal Bolt app double that records event registrations. */
+function makeApp() {
+  const listeners = new Map<string, (args: { event: unknown }) => Promise<void>>();
+  const app = {
+    event: mock((name: string, listener: (args: { event: unknown }) => Promise<void>) => {
+      listeners.set(name, listener);
+    }),
+  };
+  return { app: app as unknown as App, listeners };
+}
+
+describe('setupAgentSessionHandlers', () => {
+  it('registers a listener for agent_session_stopped', () => {
+    const { app, listeners } = makeApp();
+    setupAgentSessionHandlers(app, 'inst-1', { onSessionStopped: mock(async () => {}) }, makeLogger());
+
+    expect(listeners.has('agent_session_stopped')).toBe(true);
+  });
+
+  it('maps the Slack payload into the callback args', async () => {
+    const { app, listeners } = makeApp();
+    const stops: Array<{ instanceId: string; args: AgentSessionStoppedArgs }> = [];
+    setupAgentSessionHandlers(
+      app,
+      'inst-1',
+      {
+        onSessionStopped: async (instanceId, args) => {
+          stops.push({ instanceId, args });
+        },
+      },
+      makeLogger(),
+    );
+
+    await listeners.get('agent_session_stopped')?.({
+      event: {
+        type: 'agent_session_stopped',
+        channel: 'C0123ABC456',
+        thread_ts: '1782234671.392669',
+        user: 'U123ABC456',
+        streaming_message_ts: ['1782234987.693923'],
+        event_ts: '1783536983.783769',
+      },
+    });
+
+    expect(stops).toEqual([
+      {
+        instanceId: 'inst-1',
+        args: {
+          channelId: 'C0123ABC456',
+          threadTs: '1782234671.392669',
+          userId: 'U123ABC456',
+          streamingMessageTs: ['1782234987.693923'],
+        },
+      },
+    ]);
+  });
+
+  it('ignores events without a channel', async () => {
+    const { app, listeners } = makeApp();
+    const onSessionStopped = mock(async () => {});
+    setupAgentSessionHandlers(app, 'inst-1', { onSessionStopped }, makeLogger());
+
+    await listeners.get('agent_session_stopped')?.({ event: { type: 'agent_session_stopped' } });
+
+    expect(onSessionStopped).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a missing streaming_message_ts array', async () => {
+    const { app, listeners } = makeApp();
+    const stops: AgentSessionStoppedArgs[] = [];
+    setupAgentSessionHandlers(
+      app,
+      'inst-1',
+      {
+        onSessionStopped: async (_instanceId, args) => {
+          stops.push(args);
+        },
+      },
+      makeLogger(),
+    );
+
+    await listeners.get('agent_session_stopped')?.({
+      event: { type: 'agent_session_stopped', channel: 'C0123ABC456', user: 'U123ABC456' },
+    });
+
+    expect(stops[0]?.streamingMessageTs).toEqual([]);
+    expect(stops[0]?.threadTs).toBeUndefined();
+  });
+});

--- a/packages/channel-slack/src/handlers/agent-sessions.test.ts
+++ b/packages/channel-slack/src/handlers/agent-sessions.test.ts
@@ -69,6 +69,7 @@ describe('setupAgentSessionHandlers', () => {
           threadTs: '1782234671.392669',
           userId: 'U123ABC456',
           streamingMessageTs: ['1782234987.693923'],
+          eventTs: '1783536983.783769',
         },
       },
     ]);

--- a/packages/channel-slack/src/handlers/agent-sessions.ts
+++ b/packages/channel-slack/src/handlers/agent-sessions.ts
@@ -1,0 +1,57 @@
+/**
+ * Agent session event handlers for Slack (Agent messaging experience, #914)
+ *
+ * Handles `agent_session_stopped` — fired when a user presses Slack's native
+ * stop button while a session is in `processing`. Slack only shows that button
+ * when the app subscribes to this event, and expects the app to stop its
+ * in-progress work and transition the session out of `processing`.
+ *
+ * @see https://docs.slack.dev/reference/events/agent_session_stopped/
+ */
+
+import type { Logger } from '@omni/channel-sdk';
+import type { App } from '@slack/bolt';
+
+export interface AgentSessionStoppedArgs {
+  /** Channel the session lives in */
+  channelId: string;
+  /** Thread timestamp of the stopped session, when threaded */
+  threadTs?: string;
+  /** User who pressed stop */
+  userId?: string;
+  /** Timestamps of streaming messages Slack halted (empty if none) */
+  streamingMessageTs: string[];
+}
+
+export interface AgentSessionHandlerCallbacks {
+  onSessionStopped: (instanceId: string, args: AgentSessionStoppedArgs) => Promise<void>;
+}
+
+/** Bolt's typed `event()` doesn't know `agent_session_stopped` yet (Bolt 4.x). */
+type UntypedEventRegistrar = (eventName: string, listener: (args: { event: unknown }) => Promise<void>) => void;
+
+/**
+ * Set up agent session handlers on a Bolt.js app
+ */
+export function setupAgentSessionHandlers(
+  app: App,
+  instanceId: string,
+  callbacks: AgentSessionHandlerCallbacks,
+  logger: Logger,
+): void {
+  (app.event as unknown as UntypedEventRegistrar)('agent_session_stopped', async ({ event }) => {
+    const evt = event as Record<string, unknown>;
+    const channelId = evt.channel as string | undefined;
+    if (!channelId) return;
+
+    const threadTs = evt.thread_ts as string | undefined;
+    const userId = evt.user as string | undefined;
+    const streamingMessageTs = Array.isArray(evt.streaming_message_ts) ? (evt.streaming_message_ts as string[]) : [];
+
+    logger.info('Agent session stopped by user', { instanceId, channelId, threadTs, userId });
+
+    await callbacks.onSessionStopped(instanceId, { channelId, threadTs, userId, streamingMessageTs });
+  });
+
+  logger.info('Agent session handlers registered', { instanceId });
+}

--- a/packages/channel-slack/src/handlers/agent-sessions.ts
+++ b/packages/channel-slack/src/handlers/agent-sessions.ts
@@ -21,6 +21,8 @@ export interface AgentSessionStoppedArgs {
   userId?: string;
   /** Timestamps of streaming messages Slack halted (empty if none) */
   streamingMessageTs: string[];
+  /** Slack timestamp of the stop press ("seconds.micro"), for run-scoping */
+  eventTs?: string;
 }
 
 export interface AgentSessionHandlerCallbacks {
@@ -46,11 +48,12 @@ export function setupAgentSessionHandlers(
 
     const threadTs = evt.thread_ts as string | undefined;
     const userId = evt.user as string | undefined;
+    const eventTs = evt.event_ts as string | undefined;
     const streamingMessageTs = Array.isArray(evt.streaming_message_ts) ? (evt.streaming_message_ts as string[]) : [];
 
-    logger.info('Agent session stopped by user', { instanceId, channelId, threadTs, userId });
+    logger.info('Agent session stopped by user', { instanceId, channelId, threadTs, userId, streamingMessageTs });
 
-    await callbacks.onSessionStopped(instanceId, { channelId, threadTs, userId, streamingMessageTs });
+    await callbacks.onSessionStopped(instanceId, { channelId, threadTs, userId, streamingMessageTs, eventTs });
   });
 
   logger.info('Agent session handlers registered', { instanceId });

--- a/packages/channel-slack/src/handlers/typing.test.ts
+++ b/packages/channel-slack/src/handlers/typing.test.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for Slack typing indicator (assistant.threads.setStatus)
+ * Tests for Slack thread status (agents.sessions.setStatus with
+ * assistant.threads.setStatus fallback, #914)
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -20,7 +21,36 @@ function makeLogger(): Logger {
   } as unknown as Logger;
 }
 
-function makeClientWithAssistant() {
+/** Slack platform error as the WebClient throws it. */
+function slackError(code: string): Error & { data: { error: string } } {
+  return Object.assign(new Error(`An API error occurred: ${code}`), { data: { error: code } });
+}
+
+/** Client whose apiCall supports the Agent Sessions API. */
+function makeAgentApiClient() {
+  const apiCalls: Array<{ method: string; args: Record<string, unknown> }> = [];
+  const client = {
+    apiCall: mock(async (method: string, args: Record<string, unknown>) => {
+      apiCalls.push({ method, args });
+    }),
+  };
+  return { client, apiCalls };
+}
+
+/** Client where agents.sessions.setStatus fails; other methods succeed. */
+function makeAgentApiFailingClient(code: string) {
+  const apiCalls: Array<{ method: string; args: Record<string, unknown> }> = [];
+  const client = {
+    apiCall: mock(async (method: string, args: Record<string, unknown>) => {
+      apiCalls.push({ method, args });
+      if (method === 'agents.sessions.setStatus') throw slackError(code);
+    }),
+  };
+  return { client, apiCalls };
+}
+
+/** Legacy client: typed assistant.threads.setStatus, no generic apiCall. */
+function makeLegacyAssistantClient() {
   const setStatusCalls: Array<{ channel_id: string; thread_ts: string; status: string; loading_messages?: string[] }> =
     [];
   const client = {
@@ -37,17 +67,7 @@ function makeClientWithAssistant() {
   return { client, setStatusCalls };
 }
 
-function makeClientWithApiCall() {
-  const apiCalls: Array<{ method: string; args: Record<string, unknown> }> = [];
-  const client = {
-    apiCall: mock(async (method: string, args: Record<string, unknown>) => {
-      apiCalls.push({ method, args });
-    }),
-  };
-  return { client, apiCalls };
-}
-
-function makeClientWithoutAssistant() {
+function makeBareClient() {
   return { client: {} };
 }
 
@@ -56,8 +76,8 @@ function makeClientWithoutAssistant() {
 // ─────────────────────────────────────────────────────────────
 
 describe('setSlackThreadStatus', () => {
-  it('no-ops when threadTs is absent', async () => {
-    const { client, setStatusCalls } = makeClientWithAssistant();
+  it('no-ops when threadTs is absent, but logs the bail (#914)', async () => {
+    const { client, apiCalls } = makeAgentApiClient();
     const logger = makeLogger();
 
     const result = await setSlackThreadStatus({
@@ -68,12 +88,114 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
-    expect(result).toBe(false);
-    expect(setStatusCalls.length).toBe(0);
+    expect(result.delivered).toBe(false);
+    expect(apiCalls.length).toBe(0);
+
+    const debugCalls = (logger.debug as ReturnType<typeof mock>).mock.calls;
+    expect(debugCalls.length).toBeGreaterThan(0);
+    expect(debugCalls[0]?.[1]).toMatchObject({ reason: 'no_thread_ts' });
   });
 
-  it('calls assistant.threads.setStatus when available', async () => {
-    const { client, setStatusCalls } = makeClientWithAssistant();
+  it('prefers agents.sessions.setStatus, mapping a non-empty status to processing', async () => {
+    const { client, apiCalls } = makeAgentApiClient();
+    const logger = makeLogger();
+
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+
+    expect(result).toEqual({ delivered: true, method: 'agents.sessions.setStatus' });
+    expect(apiCalls).toEqual([
+      {
+        method: 'agents.sessions.setStatus',
+        args: { channel_id: 'C12345', thread_ts: '1234567890.001', status: 'processing' },
+      },
+    ]);
+  });
+
+  it('maps an empty status (clear) to session status active', async () => {
+    const { client, apiCalls } = makeAgentApiClient();
+    const logger = makeLogger();
+
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: '',
+      logger,
+    });
+
+    expect(result).toEqual({ delivered: true, method: 'agents.sessions.setStatus' });
+    expect(apiCalls[0]?.args.status).toBe('active');
+  });
+
+  it('falls back to assistant.threads.setStatus when the Agent Sessions API is unavailable', async () => {
+    const { client, apiCalls } = makeAgentApiFailingClient('unknown_method');
+    const logger = makeLogger();
+
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      loadingMessages: ['Checking context...'],
+      logger,
+    });
+
+    expect(result).toEqual({ delivered: true, method: 'assistant.threads.setStatus' });
+    expect(apiCalls.length).toBe(2);
+    expect(apiCalls[1]).toEqual({
+      method: 'assistant.threads.setStatus',
+      args: {
+        channel_id: 'C12345',
+        thread_ts: '1234567890.001',
+        status: 'is typing...',
+        loading_messages: ['Checking context...'],
+      },
+    });
+
+    // The unavailability is memoized per client: the next call skips the
+    // Agent Sessions attempt entirely.
+    const second = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+    expect(second.method).toBe('assistant.threads.setStatus');
+    expect(apiCalls.length).toBe(3);
+    expect(apiCalls[2]?.method).toBe('assistant.threads.setStatus');
+  });
+
+  it('does not fall back on transient agents.sessions.setStatus errors', async () => {
+    const { client, apiCalls } = makeAgentApiFailingClient('channel_not_found');
+    const logger = makeLogger();
+
+    const result = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+
+    expect(result).toEqual({ delivered: false, method: 'agents.sessions.setStatus' });
+    expect(apiCalls.length).toBe(1);
+
+    // Failure is logged without leaking the raw status string
+    const warnCalls = (logger.warn as ReturnType<typeof mock>).mock.calls;
+    expect(warnCalls.length).toBeGreaterThan(0);
+    expect(warnCalls[0]?.[1]).toMatchObject({ clearing: false, statusLength: 'is typing...'.length });
+    expect(warnCalls[0]?.[1]).not.toHaveProperty('status');
+  });
+
+  it('uses typed assistant.threads.setStatus when there is no generic apiCall', async () => {
+    const { client, setStatusCalls } = makeLegacyAssistantClient();
     const logger = makeLogger();
 
     const result = await setSlackThreadStatus({
@@ -85,8 +207,7 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
-    expect(result).toBe(true);
-    expect(setStatusCalls.length).toBe(1);
+    expect(result).toEqual({ delivered: true, method: 'assistant.threads.setStatus' });
     expect(setStatusCalls[0]).toEqual({
       channel_id: 'C12345',
       thread_ts: '1234567890.001',
@@ -95,30 +216,8 @@ describe('setSlackThreadStatus', () => {
     });
   });
 
-  it('falls back to apiCall when assistant.threads.setStatus is absent', async () => {
-    const { client, apiCalls } = makeClientWithApiCall();
-    const logger = makeLogger();
-
-    const result = await setSlackThreadStatus({
-      client: client as never,
-      channelId: 'C12345',
-      threadTs: '1234567890.001',
-      status: 'is typing...',
-      logger,
-    });
-
-    expect(result).toBe(true);
-    expect(apiCalls.length).toBe(1);
-    expect(apiCalls[0]?.method).toBe('assistant.threads.setStatus');
-    expect(apiCalls[0]?.args).toEqual({
-      channel_id: 'C12345',
-      thread_ts: '1234567890.001',
-      status: 'is typing...',
-    });
-  });
-
   it('does not throw when neither method is available', async () => {
-    const { client } = makeClientWithoutAssistant();
+    const { client } = makeBareClient();
     const logger = makeLogger();
 
     const result = await setSlackThreadStatus({
@@ -129,11 +228,11 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
-    expect(result).toBe(false);
+    expect(result.delivered).toBe(false);
   });
 
-  it('does not throw when API call fails', async () => {
-    const { client } = makeClientWithAssistant();
+  it('does not throw when the legacy API call fails, and keeps the status out of logs', async () => {
+    const { client } = makeLegacyAssistantClient();
     client.assistant.threads.setStatus = mock(async () => {
       throw new Error('not_allowed_token_type');
     });
@@ -147,29 +246,12 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
-    expect(result).toBe(false);
+    expect(result.delivered).toBe(false);
 
-    // Should have logged the failure
     const warnCalls = (logger.warn as ReturnType<typeof mock>).mock.calls;
     expect(warnCalls.length).toBeGreaterThan(0);
     expect(warnCalls[0]?.[1]).toMatchObject({ clearing: false, statusLength: 'is typing...'.length });
     expect(warnCalls[0]?.[1]).not.toHaveProperty('status');
-  });
-
-  it('can clear typing status with empty string', async () => {
-    const { client, setStatusCalls } = makeClientWithAssistant();
-    const logger = makeLogger();
-
-    const result = await setSlackThreadStatus({
-      client: client as never,
-      channelId: 'C12345',
-      threadTs: '1234567890.001',
-      status: '',
-      logger,
-    });
-
-    expect(result).toBe(true);
-    expect(setStatusCalls[0]?.status).toBe('');
   });
 });
 
@@ -178,8 +260,8 @@ describe('setSlackThreadStatus', () => {
 // ─────────────────────────────────────────────────────────────
 
 describe('setTypingStatus', () => {
-  it('sets "is typing..." status', async () => {
-    const { client, setStatusCalls } = makeClientWithAssistant();
+  it('sets processing status', async () => {
+    const { client, apiCalls } = makeAgentApiClient();
     const logger = makeLogger();
 
     const result = await setTypingStatus({
@@ -189,12 +271,12 @@ describe('setTypingStatus', () => {
       logger,
     });
 
-    expect(result).toBe(true);
-    expect(setStatusCalls[0]?.status).toBe('is typing...');
+    expect(result.delivered).toBe(true);
+    expect(apiCalls[0]?.args.status).toBe('processing');
   });
 
   it('no-ops when no threadTs', async () => {
-    const { client, setStatusCalls } = makeClientWithAssistant();
+    const { client, apiCalls } = makeAgentApiClient();
     const logger = makeLogger();
 
     const result = await setTypingStatus({
@@ -203,14 +285,14 @@ describe('setTypingStatus', () => {
       logger,
     });
 
-    expect(result).toBe(false);
-    expect(setStatusCalls.length).toBe(0);
+    expect(result.delivered).toBe(false);
+    expect(apiCalls.length).toBe(0);
   });
 });
 
 describe('clearTypingStatus', () => {
-  it('clears status with empty string', async () => {
-    const { client, setStatusCalls } = makeClientWithAssistant();
+  it('clears status back to active', async () => {
+    const { client, apiCalls } = makeAgentApiClient();
     const logger = makeLogger();
 
     const result = await clearTypingStatus({
@@ -220,7 +302,7 @@ describe('clearTypingStatus', () => {
       logger,
     });
 
-    expect(result).toBe(true);
-    expect(setStatusCalls[0]?.status).toBe('');
+    expect(result.delivered).toBe(true);
+    expect(apiCalls[0]?.args.status).toBe('active');
   });
 });

--- a/packages/channel-slack/src/handlers/typing.test.ts
+++ b/packages/channel-slack/src/handlers/typing.test.ts
@@ -172,7 +172,7 @@ describe('setSlackThreadStatus', () => {
     expect(apiCalls[2]?.method).toBe('assistant.threads.setStatus');
   });
 
-  it('does not fall back on transient agents.sessions.setStatus errors', async () => {
+  it('falls through to legacy on transient errors without writing the client off', async () => {
     const { client, apiCalls } = makeAgentApiFailingClient('channel_not_found');
     const logger = makeLogger();
 
@@ -184,14 +184,55 @@ describe('setSlackThreadStatus', () => {
       logger,
     });
 
-    expect(result).toEqual({ delivered: false, method: 'agents.sessions.setStatus' });
-    expect(apiCalls.length).toBe(1);
+    // The legacy bridge still gets its chance on ANY new-API failure —
+    // a status that worked pre-migration must keep working.
+    expect(result).toEqual({ delivered: true, method: 'assistant.threads.setStatus' });
+    expect(apiCalls.map((c) => c.method)).toEqual(['agents.sessions.setStatus', 'assistant.threads.setStatus']);
+
+    // Transient errors do NOT memoize: the next call attempts the new API again.
+    await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+    expect(apiCalls[2]?.method).toBe('agents.sessions.setStatus');
 
     // Failure is logged without leaking the raw status string
     const warnCalls = (logger.warn as ReturnType<typeof mock>).mock.calls;
     expect(warnCalls.length).toBeGreaterThan(0);
     expect(warnCalls[0]?.[1]).toMatchObject({ clearing: false, statusLength: 'is typing...'.length });
     expect(warnCalls[0]?.[1]).not.toHaveProperty('status');
+  });
+
+  it('memoizes onto the legacy path for auth-shaped errors (wrong token type / missing scope)', async () => {
+    const { client, apiCalls } = makeAgentApiFailingClient('not_allowed_token_type');
+    const logger = makeLogger();
+
+    const first = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+    expect(first).toEqual({ delivered: true, method: 'assistant.threads.setStatus' });
+
+    const second = await setSlackThreadStatus({
+      client: client as never,
+      channelId: 'C12345',
+      threadTs: '1234567890.001',
+      status: 'is typing...',
+      logger,
+    });
+    expect(second.method).toBe('assistant.threads.setStatus');
+    // Second call skips the doomed new-API attempt entirely
+    expect(apiCalls.map((c) => c.method)).toEqual([
+      'agents.sessions.setStatus',
+      'assistant.threads.setStatus',
+      'assistant.threads.setStatus',
+    ]);
   });
 
   it('uses typed assistant.threads.setStatus when there is no generic apiCall', async () => {

--- a/packages/channel-slack/src/handlers/typing.ts
+++ b/packages/channel-slack/src/handlers/typing.ts
@@ -1,15 +1,21 @@
 /**
- * Slack thread typing indicator helper
+ * Slack thread status helper — Agent Sessions API with legacy fallback
  *
- * Uses assistant.threads.setStatus to show/clear typing status in Slack threads.
+ * Prefers `agents.sessions.setStatus` (the Agent messaging experience, #914):
+ * a non-empty status maps to session status `processing`, an empty status to
+ * `active`, per Slack's migration guide. Workspaces/apps where the Agent
+ * Sessions API is unavailable fall back to the deprecated
+ * `assistant.threads.setStatus` (works through Slack's compatibility bridge
+ * until `assistant_view` is retired in February 2027).
+ *
  * Requires a Slack thread timestamp; for top-level channel messages, use the
  * source message timestamp as the thread timestamp.
  *
- * Requires Slack Web API scope `chat:write`. The legacy `assistant:write` scope
- * is also accepted by Slack during their transition period.
- * Failures are swallowed gracefully — typing never blocks message processing.
+ * Requires Slack Web API scope `chat:write`.
+ * Failures are swallowed gracefully — status never blocks message processing.
  *
- * @see https://docs.slack.dev/reference/methods/assistant.threads.setStatus/
+ * @see https://docs.slack.dev/reference/methods/agents.sessions.setStatus/
+ * @see https://docs.slack.dev/ai/migrating-to-agent-messaging/
  */
 
 import type { Logger } from '@omni/channel-sdk';
@@ -18,10 +24,47 @@ import type { WebClient } from '@slack/web-api';
 const TYPING_STATUS = 'is typing...';
 const CLEAR_STATUS = '';
 
+/** Which Slack API actually handled a status call. */
+export type SlackStatusMethod = 'agents.sessions.setStatus' | 'assistant.threads.setStatus';
+
+export interface SlackStatusResult {
+  delivered: boolean;
+  /** Set when a Slack API call was attempted; absent on the no-thread bail. */
+  method?: SlackStatusMethod;
+}
+
 /**
- * Set or clear the Slack thread typing status.
+ * Error codes that mean the Agent Sessions API is not available for this
+ * app/workspace (not yet rolled out, feature disabled, or method unknown to
+ * the workspace). Any of these flips the client to the legacy fallback.
+ */
+const AGENT_API_UNAVAILABLE_ERRORS = new Set(['unknown_method', 'feature_disabled', 'method_deprecated']);
+
+/**
+ * Clients where `agents.sessions.setStatus` has failed with an
+ * availability error — skip straight to the legacy API for these.
+ */
+const agentApiUnavailable = new WeakSet<object>();
+
+/** Extract the Slack platform error code (e.g. 'unknown_method') if present. */
+function slackErrorCode(err: unknown): string | undefined {
+  return (err as { data?: { error?: string } } | undefined)?.data?.error;
+}
+
+type LegacyStatusClient = {
+  assistant?: {
+    threads?: {
+      setStatus?: (args: Record<string, unknown>) => Promise<unknown>;
+    };
+  };
+  apiCall?: (method: string, args: Record<string, unknown>) => Promise<unknown>;
+};
+
+/**
+ * Set or clear the Slack thread status.
  *
- * No-op when `threadTs` is absent (channel-level messages have no typing API).
+ * No-op when `threadTs` is absent (Slack sessions/status are thread-scoped;
+ * there is no status surface for bare channel-level messages).
  */
 export async function setSlackThreadStatus(params: {
   client: WebClient;
@@ -31,12 +74,58 @@ export async function setSlackThreadStatus(params: {
   loadingMessages?: string[];
   logger: Logger;
   instanceId?: string;
-}): Promise<boolean> {
+}): Promise<SlackStatusResult> {
   const { client, channelId, threadTs, status, loadingMessages, logger, instanceId } = params;
 
-  // Thread-only guard
-  if (!threadTs) return false;
+  // Thread-only guard — logged so a silent no-status situation is diagnosable (#914)
+  if (!threadTs) {
+    logger.debug('setSlackThreadStatus: skipped, no thread timestamp', {
+      instanceId,
+      channelId,
+      reason: 'no_thread_ts',
+      clearing: status.length === 0,
+    });
+    return { delivered: false };
+  }
 
+  const clearing = status.length === 0;
+  const logContext = {
+    instanceId,
+    channelId,
+    threadTs,
+    clearing,
+    statusLength: status.length,
+    loadingMessageCount: loadingMessages?.length ?? 0,
+  };
+
+  // ── Agent Sessions API (preferred) ──
+  if (typeof client.apiCall === 'function' && !agentApiUnavailable.has(client)) {
+    try {
+      await client.apiCall('agents.sessions.setStatus', {
+        channel_id: channelId,
+        thread_ts: threadTs,
+        // The new API takes a lifecycle enum, not a freeform string:
+        // non-empty legacy status → 'processing', clear → 'active'.
+        status: clearing ? 'active' : 'processing',
+      });
+      return { delivered: true, method: 'agents.sessions.setStatus' };
+    } catch (err) {
+      const code = slackErrorCode(err);
+      if (code && AGENT_API_UNAVAILABLE_ERRORS.has(code)) {
+        agentApiUnavailable.add(client);
+        logger.info('agents.sessions.setStatus unavailable, falling back to assistant.threads.setStatus', {
+          instanceId,
+          channelId,
+          error: code,
+        });
+      } else {
+        logger.warn('agents.sessions.setStatus failed', { ...logContext, error: String(err) });
+        return { delivered: false, method: 'agents.sessions.setStatus' };
+      }
+    }
+  }
+
+  // ── Legacy fallback (assistant_view compatibility bridge, gone Feb 2027) ──
   const payload = {
     channel_id: channelId,
     thread_ts: threadTs,
@@ -45,37 +134,22 @@ export async function setSlackThreadStatus(params: {
   };
 
   try {
-    const clientAny = client as unknown as {
-      assistant?: {
-        threads?: {
-          setStatus?: (args: typeof payload) => Promise<unknown>;
-        };
-      };
-      apiCall?: (method: string, args: typeof payload) => Promise<unknown>;
-    };
+    const legacyClient = client as unknown as LegacyStatusClient;
 
-    if (typeof clientAny.assistant?.threads?.setStatus === 'function') {
-      await clientAny.assistant.threads.setStatus(payload);
-      return true;
+    if (typeof legacyClient.assistant?.threads?.setStatus === 'function') {
+      await legacyClient.assistant.threads.setStatus(payload);
+      return { delivered: true, method: 'assistant.threads.setStatus' };
     }
 
-    if (typeof clientAny.apiCall === 'function') {
-      await clientAny.apiCall('assistant.threads.setStatus', payload);
-      return true;
+    if (typeof legacyClient.apiCall === 'function') {
+      await legacyClient.apiCall('assistant.threads.setStatus', payload);
+      return { delivered: true, method: 'assistant.threads.setStatus' };
     }
   } catch (err) {
-    logger.warn('setSlackThreadStatus: failed', {
-      instanceId,
-      channelId,
-      threadTs,
-      clearing: status.length === 0,
-      statusLength: status.length,
-      loadingMessageCount: loadingMessages?.length ?? 0,
-      error: String(err),
-    });
+    logger.warn('setSlackThreadStatus: failed', { ...logContext, error: String(err) });
   }
 
-  return false;
+  return { delivered: false, method: 'assistant.threads.setStatus' };
 }
 
 /**
@@ -87,7 +161,7 @@ export async function setTypingStatus(params: {
   threadTs?: string;
   logger: Logger;
   instanceId?: string;
-}): Promise<boolean> {
+}): Promise<SlackStatusResult> {
   return setSlackThreadStatus({ ...params, status: TYPING_STATUS });
 }
 
@@ -100,6 +174,6 @@ export async function clearTypingStatus(params: {
   threadTs?: string;
   logger: Logger;
   instanceId?: string;
-}): Promise<boolean> {
+}): Promise<SlackStatusResult> {
   return setSlackThreadStatus({ ...params, status: CLEAR_STATUS });
 }

--- a/packages/channel-slack/src/handlers/typing.ts
+++ b/packages/channel-slack/src/handlers/typing.ts
@@ -34,11 +34,22 @@ export interface SlackStatusResult {
 }
 
 /**
- * Error codes that mean the Agent Sessions API is not available for this
- * app/workspace (not yet rolled out, feature disabled, or method unknown to
- * the workspace). Any of these flips the client to the legacy fallback.
+ * Error codes after which retrying `agents.sessions.setStatus` with this
+ * client can never succeed — the API isn't rolled out / enabled
+ * (`unknown_method`, `feature_disabled`, `method_deprecated`), the app lacks
+ * the grant (`missing_scope`), or the token is the wrong kind
+ * (`not_allowed_token_type`: the method requires a granular bot token, which
+ * an `authMode: 'user'` acting client is not). These memoize the client onto
+ * the legacy path. Every OTHER error still falls through to the legacy API
+ * for that call — it just doesn't write the client off.
  */
-const AGENT_API_UNAVAILABLE_ERRORS = new Set(['unknown_method', 'feature_disabled', 'method_deprecated']);
+const AGENT_API_UNAVAILABLE_ERRORS = new Set([
+  'unknown_method',
+  'feature_disabled',
+  'method_deprecated',
+  'missing_scope',
+  'not_allowed_token_type',
+]);
 
 /**
  * Clients where `agents.sessions.setStatus` has failed with an
@@ -110,6 +121,9 @@ export async function setSlackThreadStatus(params: {
       });
       return { delivered: true, method: 'agents.sessions.setStatus' };
     } catch (err) {
+      // Any failure falls through to the legacy bridge below — a status that
+      // worked before this migration must keep working (#914 review). Only
+      // errors that can never succeed again memoize the client off this path.
       const code = slackErrorCode(err);
       if (code && AGENT_API_UNAVAILABLE_ERRORS.has(code)) {
         agentApiUnavailable.add(client);
@@ -119,8 +133,10 @@ export async function setSlackThreadStatus(params: {
           error: code,
         });
       } else {
-        logger.warn('agents.sessions.setStatus failed', { ...logContext, error: String(err) });
-        return { delivered: false, method: 'agents.sessions.setStatus' };
+        logger.warn('agents.sessions.setStatus failed, trying legacy fallback', {
+          ...logContext,
+          error: String(err),
+        });
       }
     }
   }

--- a/packages/channel-slack/src/index.ts
+++ b/packages/channel-slack/src/index.ts
@@ -38,6 +38,7 @@ export { setupMessageHandlers, extractMessageMeta } from './handlers/messages';
 export { setupReactionHandlers } from './handlers/reactions';
 export { setupInteractionHandlers } from './handlers/interactions';
 export { setupCommandHandlers } from './handlers/commands';
+export { setupAgentSessionHandlers } from './handlers/agent-sessions';
 
 // Senders
 export { sendTextMessage, editSlackMessage, deleteSlackMessage, readMessages } from './senders/text';

--- a/packages/channel-slack/src/manifest.ts
+++ b/packages/channel-slack/src/manifest.ts
@@ -107,6 +107,21 @@ const USER_EVENTS = [
 ] as const;
 
 /**
+ * Trim to Slack's agent_description cap at a word boundary instead of
+ * mid-word; falls back to a hard cut (without splitting a surrogate pair)
+ * for space-less text.
+ */
+function truncateAtWordBoundary(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const cut = text.slice(0, max + 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  if (lastSpace > 0) return cut.slice(0, lastSpace).trimEnd();
+  const hard = text.slice(0, max);
+  const tailCode = hard.charCodeAt(hard.length - 1);
+  return tailCode >= 0xd800 && tailCode <= 0xdbff ? hard.slice(0, -1) : hard;
+}
+
+/**
  * Build a Slack App Manifest for the Omni bot
  */
 export function buildSlackManifest(options?: {
@@ -117,6 +132,15 @@ export function buildSlackManifest(options?: {
   slashCommands?: SlackSlashCommand[];
   /** Request user-token scopes and user-scoped events too (authMode 'user'). */
   includeUserScopes?: boolean;
+  /**
+   * Emit `features.agent_view` (the Agent messaging experience). Default true
+   * — new Slack apps can only use `agent_view`, and this generator never
+   * emitted the deprecated `assistant_view`. Set false ONLY when regenerating
+   * a manifest for an existing app that still uses `assistant_view` and must
+   * stay on it: applying an `agent_view` manifest to such an app migrates it
+   * permanently (Slack does not allow reverting to `assistant_view`).
+   */
+  agentView?: boolean;
   /**
    * Description shown in the Agent messaging experience (max 300 chars).
    * Defaults to `description`.
@@ -132,6 +156,7 @@ export function buildSlackManifest(options?: {
     backgroundColor = '#4A154B',
     slashCommands = [],
     includeUserScopes = false,
+    agentView = true,
     agentDescription,
     suggestedPrompts,
   } = options ?? {};
@@ -150,10 +175,14 @@ export function buildSlackManifest(options?: {
       // Agent messaging experience (#914). `assistant_view` is deprecated
       // (removed February 2027) and new Slack apps can only use `agent_view`.
       // Slack caps agent_description at 300 chars.
-      agent_view: {
-        agent_description: (agentDescription ?? description).slice(0, 300),
-        ...(suggestedPrompts?.length ? { suggested_prompts: suggestedPrompts } : {}),
-      },
+      ...(agentView
+        ? {
+            agent_view: {
+              agent_description: truncateAtWordBoundary(agentDescription ?? description, 300),
+              ...(suggestedPrompts?.length ? { suggested_prompts: suggestedPrompts } : {}),
+            },
+          }
+        : {}),
       slash_commands:
         slashCommands.length > 0
           ? slashCommands.map((cmd) => ({

--- a/packages/channel-slack/src/manifest.ts
+++ b/packages/channel-slack/src/manifest.ts
@@ -50,6 +50,10 @@ export const BOT_EVENTS = [
   'member_joined_channel',
   'member_left_channel',
   'channel_rename',
+  // Agent messaging experience (#914): fires when the user presses the native
+  // stop button; subscribing is also what makes Slack SHOW that button while a
+  // session is in `processing`.
+  'agent_session_stopped',
 ] as const;
 
 /**
@@ -113,6 +117,13 @@ export function buildSlackManifest(options?: {
   slashCommands?: SlackSlashCommand[];
   /** Request user-token scopes and user-scoped events too (authMode 'user'). */
   includeUserScopes?: boolean;
+  /**
+   * Description shown in the Agent messaging experience (max 300 chars).
+   * Defaults to `description`.
+   */
+  agentDescription?: string;
+  /** Suggested prompts shown at the top of the agent's Messages tab. */
+  suggestedPrompts?: Array<{ title: string; message: string }>;
 }): SlackManifest {
   const {
     appName = 'Omni Bot',
@@ -121,6 +132,8 @@ export function buildSlackManifest(options?: {
     backgroundColor = '#4A154B',
     slashCommands = [],
     includeUserScopes = false,
+    agentDescription,
+    suggestedPrompts,
   } = options ?? {};
 
   return {
@@ -133,6 +146,13 @@ export function buildSlackManifest(options?: {
       bot_user: {
         display_name: displayName,
         always_online: true,
+      },
+      // Agent messaging experience (#914). `assistant_view` is deprecated
+      // (removed February 2027) and new Slack apps can only use `agent_view`.
+      // Slack caps agent_description at 300 chars.
+      agent_view: {
+        agent_description: (agentDescription ?? description).slice(0, 300),
+        ...(suggestedPrompts?.length ? { suggested_prompts: suggestedPrompts } : {}),
       },
       slash_commands:
         slashCommands.length > 0

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -34,13 +34,14 @@ import { SLACK_CAPABILITIES } from './capabilities';
 import { resolveStreamMode, resolveStreamThrottle } from './config/stream-mode';
 import type { BoltConnection } from './connection/bolt-client';
 import { checkBoltHealth, createBoltApp, destroyBoltConnection, startBoltConnection } from './connection/bolt-client';
+import { setupAgentSessionHandlers } from './handlers/agent-sessions';
 import type { CommandPayload } from './handlers/commands';
 import { setupCommandHandlers } from './handlers/commands';
 import { downloadSlackFile, extractFileInfo, getContentTypeFromMime } from './handlers/files';
 import { setupInteractionHandlers } from './handlers/interactions';
 import { type SlackDebouncedArgs, setupMessageHandlers } from './handlers/messages';
 import { setupReactionHandlers } from './handlers/reactions';
-import { clearTypingStatus, setSlackThreadStatus } from './handlers/typing';
+import { type SlackStatusMethod, clearTypingStatus, setSlackThreadStatus } from './handlers/typing';
 import { uploadFile, uploadFileFromUrl } from './senders/media';
 import { createNativeStreamSender } from './senders/native-stream';
 import { createSlackStreamSender } from './senders/stream';
@@ -61,7 +62,8 @@ type SlackPresenceType = 'typing' | 'recording' | 'paused';
 
 type SlackPresenceStatusResult = {
   delivered: boolean;
-  method: 'assistant.threads.setStatus';
+  /** Which Slack API handled the call; absent when no call was attempted. */
+  method?: SlackStatusMethod;
   threadId?: string;
   status?: string;
   loadingMessages?: string[];
@@ -508,28 +510,29 @@ export class SlackPlugin extends BaseChannelPlugin {
   }
 
   /**
-   * Send typing indicator via assistant.threads.setStatus.
+   * Send typing indicator via the Agent Sessions status API.
    *
-   * **Thread-only / no-op for channels and DMs.** Slack's typing API is only
-   * available inside assistant threads (via `assistant.threads.setStatus`).
-   * There is no general "user is typing" indicator for channels or DMs —
-   * hence `canSendTyping: false` in capabilities. This method exists for the
-   * thread context but silently no-ops when no active thread is tracked.
+   * **Thread-only / no-op for channels and DMs.** Slack's status surface is
+   * session/thread-scoped (`agents.sessions.setStatus`, legacy
+   * `assistant.threads.setStatus` as fallback). There is no general "user is
+   * typing" indicator for channels or DMs — hence `canSendTyping: false` in
+   * capabilities. This method exists for the thread context and no-ops (with
+   * a debug log, #914) when no active thread is tracked.
    *
-   * Slack clears status when the assistant replies, when status is set to an
-   * empty string, or after Slack's own timeout. Omni can also clear earlier
-   * when callers pass an explicit duration.
+   * Slack clears status when the agent replies, when status is cleared, or
+   * after Slack's own timeout. Omni can also clear earlier when callers pass
+   * an explicit duration.
    */
   async sendTyping(instanceId: string, chatId: string, duration?: number): Promise<void> {
     await this.sendPresenceStatus(instanceId, chatId, duration === 0 ? 'paused' : 'typing', duration);
   }
 
   /**
-   * Send Slack's official AI Assistant thread status.
+   * Send Slack's official agent session status.
    *
    * This is intentionally separate from `canSendTyping`: Slack does not expose
-   * generic channel typing for bots, but `assistant.threads.setStatus` is the
-   * official status surface for AI assistant threads.
+   * generic channel typing for bots, but the Agent Sessions status API is the
+   * official status surface for AI agent threads.
    */
   async sendPresenceStatus(
     instanceId: string,
@@ -538,24 +541,34 @@ export class SlackPlugin extends BaseChannelPlugin {
     duration?: number,
     options?: { threadId?: string; status?: string; loadingMessages?: string[] },
   ): Promise<SlackPresenceStatusResult> {
-    const method = 'assistant.threads.setStatus' as const;
     const connection = this.connections.get(instanceId);
-    if (!connection) return { delivered: false, method, reason: 'not_connected' };
+    if (!connection) return { delivered: false, reason: 'not_connected' };
 
     const threadTs = options?.threadId ?? this.activeThreads.get(`${instanceId}:${chatId}`);
-    if (!threadTs) return { delivered: false, method, reason: 'no_active_thread' };
+    if (!threadTs) {
+      // Slack status is thread-scoped; a channel-level mention has no thread
+      // to attach to. Logged so the missing status is diagnosable (#914).
+      this.logger.debug('Slack presence status skipped', {
+        instanceId,
+        chatId,
+        type,
+        reason: 'no_active_thread',
+      });
+      return { delivered: false, reason: 'no_active_thread' };
+    }
 
     const shouldClear = type === 'paused';
     const status = shouldClear ? '' : (options?.status ?? (type === 'recording' ? 'is recording...' : 'is typing...'));
     const timerKey = this.presenceStatusTimerKey(instanceId, chatId, threadTs);
 
-    const delivered =
+    const statusResult =
       status === ''
         ? await clearTypingStatus({
             client: connection.actingClient,
             channelId: chatId,
             threadTs,
             logger: this.logger,
+            instanceId,
           })
         : await setSlackThreadStatus({
             client: connection.actingClient,
@@ -564,7 +577,9 @@ export class SlackPlugin extends BaseChannelPlugin {
             status,
             loadingMessages: options?.loadingMessages,
             logger: this.logger,
+            instanceId,
           });
+    const { delivered, method } = statusResult;
 
     if (delivered) {
       this.clearPresenceStatusTimer(timerKey);
@@ -1155,6 +1170,51 @@ export class SlackPlugin extends BaseChannelPlugin {
   }
 
   /**
+   * Handle Slack's native stop button (`agent_session_stopped`, #914).
+   *
+   * Publishes `agent.run.cancel_requested` so the agent dispatcher aborts the
+   * in-flight provider run, then transitions the session out of `processing`
+   * (Slack's contract for this event) by clearing the thread status.
+   */
+  private async handleAgentSessionStopped(
+    instanceId: string,
+    connection: BoltConnection,
+    args: { channelId: string; threadTs?: string; userId?: string },
+  ): Promise<void> {
+    try {
+      await this.eventBus.publish(
+        'agent.run.cancel_requested',
+        {
+          instanceId,
+          chatId: args.channelId,
+          threadId: args.threadTs,
+          requestedBy: args.userId,
+          reason: 'user_stop',
+        },
+        {
+          instanceId,
+          channelType: this.id,
+          source: `channel:${this.id}`,
+        },
+      );
+    } catch (err) {
+      this.logger.error('Failed to publish agent.run.cancel_requested', {
+        instanceId,
+        chatId: args.channelId,
+        error: String(err),
+      });
+    }
+
+    await clearTypingStatus({
+      client: connection.actingClient,
+      channelId: args.channelId,
+      threadTs: args.threadTs ?? this.activeThreads.get(`${instanceId}:${args.channelId}`),
+      logger: this.logger,
+      instanceId,
+    });
+  }
+
+  /**
    * Track the last active thread for a (instanceId, channelId) pair.
    * Used by sendTyping to call assistant.threads.setStatus on the right thread.
    *
@@ -1413,6 +1473,18 @@ export class SlackPlugin extends BaseChannelPlugin {
       {
         onReaction: async (instId, messageId, chatId, userId, emoji, action) => {
           await this.handleReactionReceived(instId, messageId, chatId, userId, emoji, action);
+        },
+      },
+      this.logger,
+    );
+
+    // Agent session handlers — native stop button (#914)
+    setupAgentSessionHandlers(
+      connection.app,
+      instanceId,
+      {
+        onSessionStopped: async (instId, args) => {
+          await this.handleAgentSessionStopped(instId, connection, args);
         },
       },
       this.logger,

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -506,6 +506,11 @@ export class SlackPlugin extends BaseChannelPlugin {
         await base.abort();
         cleanup();
       },
+      async cancel() {
+        // User-requested stop (#914): keep the partial output
+        await (base.cancel ? base.cancel() : base.abort());
+        cleanup();
+      },
     };
   }
 
@@ -541,8 +546,14 @@ export class SlackPlugin extends BaseChannelPlugin {
     duration?: number,
     options?: { threadId?: string; status?: string; loadingMessages?: string[] },
   ): Promise<SlackPresenceStatusResult> {
+    // Nominal method on the bail paths below: no call is attempted, but
+    // callers key off `method` to distinguish Slack's session-status surface
+    // from a plain typing indicator, so it must not fall back to some other
+    // channel's default (#914 review).
+    const nominalMethod: SlackStatusMethod = 'agents.sessions.setStatus';
+
     const connection = this.connections.get(instanceId);
-    if (!connection) return { delivered: false, reason: 'not_connected' };
+    if (!connection) return { delivered: false, method: nominalMethod, reason: 'not_connected' };
 
     const threadTs = options?.threadId ?? this.activeThreads.get(`${instanceId}:${chatId}`);
     if (!threadTs) {
@@ -554,7 +565,7 @@ export class SlackPlugin extends BaseChannelPlugin {
         type,
         reason: 'no_active_thread',
       });
-      return { delivered: false, reason: 'no_active_thread' };
+      return { delivered: false, method: nominalMethod, reason: 'no_active_thread' };
     }
 
     const shouldClear = type === 'paused';
@@ -580,6 +591,15 @@ export class SlackPlugin extends BaseChannelPlugin {
             instanceId,
           });
     const { delivered, method } = statusResult;
+
+    // Echo only what was actually applied (#914 review): the Agent Sessions
+    // API takes a lifecycle enum and accepts no loading messages, so the
+    // caller's freeform status/loading copy is only in effect when the legacy
+    // API delivered it. Failed calls echo the attempted values for diagnostics.
+    const usedLegacy = method === 'assistant.threads.setStatus';
+    const sessionStatus = shouldClear ? 'active' : 'processing';
+    const appliedStatus = !delivered || usedLegacy ? status : sessionStatus;
+    const appliedLoadingMessages = !delivered || usedLegacy ? options?.loadingMessages : undefined;
 
     if (delivered) {
       this.clearPresenceStatusTimer(timerKey);
@@ -608,13 +628,19 @@ export class SlackPlugin extends BaseChannelPlugin {
     }
 
     return delivered
-      ? { delivered: true, method, threadId: threadTs, status, loadingMessages: options?.loadingMessages }
-      : {
-          delivered: false,
+      ? {
+          delivered: true,
           method,
           threadId: threadTs,
-          status,
-          loadingMessages: options?.loadingMessages,
+          status: appliedStatus,
+          loadingMessages: appliedLoadingMessages,
+        }
+      : {
+          delivered: false,
+          method: method ?? nominalMethod,
+          threadId: threadTs,
+          status: appliedStatus,
+          loadingMessages: appliedLoadingMessages,
           reason: 'slack_status_failed',
         };
   }
@@ -1179,8 +1205,14 @@ export class SlackPlugin extends BaseChannelPlugin {
   private async handleAgentSessionStopped(
     instanceId: string,
     connection: BoltConnection,
-    args: { channelId: string; threadTs?: string; userId?: string },
+    args: { channelId: string; threadTs?: string; userId?: string; streamingMessageTs?: string[]; eventTs?: string },
   ): Promise<void> {
+    // Slack event_ts is "seconds.micro"; the dispatcher compares this against
+    // each run's start time so a late-delivered stop cannot abort a run that
+    // began after the user pressed the button.
+    const parsedEventTs = args.eventTs ? Number.parseFloat(args.eventTs) : Number.NaN;
+    const requestedAt = Number.isFinite(parsedEventTs) ? Math.round(parsedEventTs * 1000) : Date.now();
+
     try {
       await this.eventBus.publish(
         'agent.run.cancel_requested',
@@ -1189,6 +1221,7 @@ export class SlackPlugin extends BaseChannelPlugin {
           chatId: args.channelId,
           threadId: args.threadTs,
           requestedBy: args.userId,
+          requestedAt,
           reason: 'user_stop',
         },
         {

--- a/packages/channel-slack/src/senders/native-stream.ts
+++ b/packages/channel-slack/src/senders/native-stream.ts
@@ -146,6 +146,11 @@ export function createNativeStreamSender(options: NativeStreamSenderOptions): St
     async onContentDelta(delta: StreamDelta & { phase: 'content' }) {
       if (fallback) return fallback.onContentDelta(delta);
 
+      // A stopped stream stays stopped: a provider that ignored the abort
+      // signal keeps yielding, and appending after chat.stopStream only
+      // produces an API error per delta (#914).
+      if (stopped) return;
+
       const content = delta.content;
       if (!content) return;
 
@@ -176,6 +181,14 @@ export function createNativeStreamSender(options: NativeStreamSenderOptions): St
 
     async abort() {
       if (fallback) return fallback.abort();
+
+      await stopStream();
+    },
+
+    async cancel() {
+      // Native streaming already halts-and-keeps: chat.stopStream leaves the
+      // streamed content in place. Only the fallback needs distinct handling.
+      if (fallback) return fallback.cancel ? fallback.cancel() : fallback.abort();
 
       await stopStream();
     },

--- a/packages/channel-slack/src/senders/stream-cancel.test.ts
+++ b/packages/channel-slack/src/senders/stream-cancel.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for stream sender stop semantics (#914)
+ *
+ * cancel() = user pressed Slack's native stop button: halt and KEEP the
+ * partial output. abort() = error-path cleanup: delete the placeholder so the
+ * fallback reply can replace it. Post-stop deltas must be no-ops either way.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import type { Logger } from '@omni/channel-sdk';
+import type { StreamDelta } from '@omni/core';
+import { createSlackStreamSender } from './stream';
+
+function makeLogger(): Logger {
+  return {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    child: mock(() => makeLogger()),
+  } as unknown as Logger;
+}
+
+function makeClient() {
+  const postMessage = mock(async () => ({ ts: '111.222' }));
+  const update = mock(async () => ({}));
+  const del = mock(async () => ({}));
+  const client = { chat: { postMessage, update, delete: del } };
+  return { client, postMessage, update, del };
+}
+
+function makeSender(client: unknown, streamMode: 'replace' | 'status_final' | 'off') {
+  return createSlackStreamSender({
+    client: client as never,
+    channelId: 'C12345',
+    threadTs: '1234567890.001',
+    streamMode,
+    throttleMs: 0,
+    logger: makeLogger(),
+  });
+}
+
+const contentDelta = (content: string) => ({ phase: 'content', content }) as StreamDelta & { phase: 'content' };
+const thinkingDelta = (thinking: string) => ({ phase: 'thinking', thinking }) as StreamDelta & { phase: 'thinking' };
+const finalDelta = (content: string) => ({ phase: 'final', content }) as StreamDelta & { phase: 'final' };
+
+describe('replace-mode cancel', () => {
+  it('keeps the partial content: finalizes the draft instead of deleting it', async () => {
+    const { client, postMessage, update, del } = makeClient();
+    const sender = makeSender(client, 'replace');
+
+    await sender.onContentDelta(contentDelta('partial answer so'));
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    await sender.cancel?.();
+
+    expect(del).not.toHaveBeenCalled();
+    // Draft finalized with the last streamed content
+    expect(update).toHaveBeenCalledTimes(1);
+    expect((update.mock.calls[0] as unknown[])[0]).toMatchObject({ ts: '111.222', text: 'partial answer so' });
+  });
+
+  it('cleans up like abort when only a thinking placeholder was shown', async () => {
+    const { client, update, del } = makeClient();
+    const sender = makeSender(client, 'replace');
+
+    await sender.onThinkingDelta(thinkingDelta('pondering'));
+    await sender.cancel?.();
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('drops deltas and finals arriving after cancel', async () => {
+    const { client, postMessage, update } = makeClient();
+    const sender = makeSender(client, 'replace');
+
+    await sender.onContentDelta(contentDelta('partial'));
+    await sender.cancel?.();
+    const updatesAfterCancel = update.mock.calls.length;
+
+    // A provider that ignored the abort keeps yielding
+    await sender.onContentDelta(contentDelta('partial plus more'));
+    await sender.onFinal(finalDelta('full answer'));
+
+    expect(update.mock.calls.length).toBe(updatesAfterCancel);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('abort still deletes the draft, and later deltas cannot resurrect it', async () => {
+    const { client, postMessage, update, del } = makeClient();
+    const sender = makeSender(client, 'replace');
+
+    await sender.onContentDelta(contentDelta('partial'));
+    await sender.abort();
+    expect(del).toHaveBeenCalledTimes(1);
+
+    await sender.onContentDelta(contentDelta('more'));
+    await sender.onFinal(finalDelta('full'));
+
+    // No new message posted, no update against the deleted ts
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('does not post a fresh message when a delta arrives after abort with no draft', async () => {
+    const { client, postMessage } = makeClient();
+    const sender = makeSender(client, 'replace');
+
+    await sender.abort();
+    await sender.onContentDelta(contentDelta('late content'));
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('status_final-mode cancel', () => {
+  it('reveals the partial answer the thinking placeholder was hiding', async () => {
+    const { client, postMessage, update, del } = makeClient();
+    const sender = makeSender(client, 'status_final');
+
+    await sender.onContentDelta(contentDelta('hidden partial'));
+    expect(postMessage).toHaveBeenCalledTimes(1); // the "_Thinking..._" draft
+
+    await sender.cancel?.();
+
+    expect(del).not.toHaveBeenCalled();
+    expect((update.mock.calls[0] as unknown[])[0]).toMatchObject({ ts: '111.222', text: 'hidden partial' });
+  });
+
+  it('deletes the thinking placeholder when no content arrived', async () => {
+    const { client, del } = makeClient();
+    const sender = makeSender(client, 'status_final');
+
+    await sender.onThinkingDelta(thinkingDelta('pondering'));
+    await sender.cancel?.();
+
+    expect(del).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/channel-slack/src/senders/stream.ts
+++ b/packages/channel-slack/src/senders/stream.ts
@@ -56,6 +56,8 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
   let pendingContent: string | undefined;
   /** Throttle timer handle */
   let throttleTimer: ReturnType<typeof setTimeout> | undefined;
+  /** Cumulative content received so far — what cancel() keeps (#914) */
+  let lastContent = '';
 
   function formatText(text: string): string {
     return formatMode === 'passthrough' ? text : markdownToMrkdwn(text);
@@ -132,6 +134,9 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
    * (or becomes the initial message), overflow chunks are posted as new messages.
    */
   async function finalize(text: string): Promise<void> {
+    // A cancelled/aborted stream must not resurrect: late onFinal/onError
+    // deltas from a provider that ignored the abort are dropped here.
+    if (finalized) return;
     finalized = true;
     if (throttleTimer) {
       clearTimeout(throttleTimer);
@@ -164,6 +169,35 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
     }
   }
 
+  /**
+   * Shared abort cleanup: delete the draft (a fallback message will replace
+   * it) and stop accepting deltas.
+   */
+  async function deleteDraft(): Promise<void> {
+    if (draftTs && !finalized) {
+      try {
+        await client.chat.delete({ channel: channelId, ts: draftTs });
+      } catch {
+        // Best effort cleanup
+      }
+    }
+    finalized = true;
+  }
+
+  /**
+   * User-requested stop (#914): keep what was already streamed. Finalizes the
+   * draft with the partial content when any exists; when only a thinking
+   * placeholder (or nothing) was shown, cleans up like abort().
+   */
+  async function cancelKeepingPartial(): Promise<void> {
+    if (finalized) return;
+    if (lastContent.trim()) {
+      await finalize(lastContent);
+      return;
+    }
+    await deleteDraft();
+  }
+
   // Different behavior based on stream mode
   if (streamMode === 'off') {
     // Off mode: collect everything, send once on final
@@ -175,14 +209,20 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
         // No-op: wait for final
       },
       async onFinal(delta: StreamDelta & { phase: 'final' }) {
-        await sendInitial(delta.content);
+        if (finalized) return;
         finalized = true;
+        await sendInitial(delta.content);
       },
       async onError(delta: StreamDelta & { phase: 'error' }) {
-        await sendInitial(`Error: ${delta.error}`);
+        if (finalized) return;
         finalized = true;
+        await sendInitial(`Error: ${delta.error}`);
       },
       async abort() {
+        finalized = true;
+      },
+      async cancel() {
+        // Nothing was shown yet in off mode — nothing to keep
         finalized = true;
       },
     };
@@ -192,11 +232,14 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
     // Status-final mode: show "thinking..." then replace with final
     return {
       async onThinkingDelta(_delta: StreamDelta & { phase: 'thinking' }) {
+        if (finalized) return;
         if (!draftTs) {
           await sendInitial('_Thinking..._');
         }
       },
-      async onContentDelta(_delta: StreamDelta & { phase: 'content' }) {
+      async onContentDelta(delta: StreamDelta & { phase: 'content' }) {
+        if (finalized) return;
+        lastContent = delta.content;
         if (!draftTs) {
           await sendInitial('_Thinking..._');
         }
@@ -208,14 +251,13 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
         await finalize(`Error: ${delta.error}`);
       },
       async abort() {
-        if (draftTs && !finalized) {
-          try {
-            await client.chat.delete({ channel: channelId, ts: draftTs });
-          } catch {
-            // Best effort cleanup
-          }
-        }
-        finalized = true;
+        await deleteDraft();
+      },
+      async cancel() {
+        // The draft only ever showed "_Thinking..._"; on stop, reveal the
+        // partial answer the provider had produced (halt-and-keep), or clean
+        // up the placeholder when there is none.
+        await cancelKeepingPartial();
       },
     };
   }
@@ -223,6 +265,7 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
   // Replace mode (default): send initial → edit progressively → finalize
   return {
     async onThinkingDelta(delta: StreamDelta & { phase: 'thinking' }) {
+      if (finalized) return;
       const text = `_${delta.thinking}_`;
       if (!draftTs) {
         await sendInitial(text);
@@ -231,7 +274,9 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
       }
     },
     async onContentDelta(delta: StreamDelta & { phase: 'content' }) {
+      if (finalized) return;
       const text = delta.content;
+      lastContent = text;
       if (!draftTs) {
         await sendInitial(text);
       } else {
@@ -245,14 +290,10 @@ export function createSlackStreamSender(options: StreamSenderOptions): StreamSen
       await finalize(`Error: ${delta.error}`);
     },
     async abort() {
-      if (draftTs && !finalized) {
-        try {
-          await client.chat.delete({ channel: channelId, ts: draftTs });
-        } catch {
-          // Best effort cleanup
-        }
-      }
-      finalized = true;
+      await deleteDraft();
+    },
+    async cancel() {
+      await cancelKeepingPartial();
     },
   };
 }

--- a/packages/channel-slack/src/types.ts
+++ b/packages/channel-slack/src/types.ts
@@ -321,6 +321,17 @@ export interface SlackManifest {
       display_name: string;
       always_online: boolean;
     };
+    /**
+     * Agent messaging experience (#914). Replaces the deprecated
+     * `assistant_view` (gone February 2027); the switch is one-way per app.
+     */
+    agent_view?: {
+      agent_description: string;
+      suggested_prompts?: Array<{
+        title: string;
+        message: string;
+      }>;
+    };
     slash_commands?: Array<{
       command: string;
       description: string;

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -66,6 +66,8 @@ export const CORE_EVENT_TYPES = [
   'batch-job.failed',
   // Agent state machine (ephemeral — NATS KV)
   'agent.state.changed',
+  // In-flight run cancellation (e.g. Slack's native stop button, #914)
+  'agent.run.cancel_requested',
   // Agent task lifecycle (persistent — omni-m7m)
   'agent.task.created',
   'agent.task.updated',
@@ -676,6 +678,28 @@ export interface AgentStateChangedPayload {
 }
 
 /**
+ * Request to cancel an in-flight agent run for a chat (#914).
+ *
+ * Published by channel plugins when the platform surfaces a native stop
+ * affordance (e.g. Slack's `agent_session_stopped`). The agent dispatcher
+ * aborts the matching run via the trigger's `abortSignal` and the active
+ * stream sender; runs already past the provider boundary have their reply
+ * discarded instead.
+ */
+export interface AgentRunCancelRequestedPayload {
+  /** Instance the run belongs to */
+  instanceId: string;
+  /** Chat whose in-flight run should be cancelled */
+  chatId: string;
+  /** Platform thread the stop originated from, when threaded */
+  threadId?: string;
+  /** Platform user who requested the stop */
+  requestedBy?: string;
+  /** What triggered the cancellation */
+  reason: 'user_stop';
+}
+
+/**
  * Agent task event payloads (omni-m7m)
  */
 export interface AgentTaskCreatedPayload {
@@ -1039,6 +1063,7 @@ export interface EventPayloadMap {
   'batch-job.cancelled': BatchJobCancelledPayload;
   'batch-job.failed': BatchJobFailedPayload;
   'agent.state.changed': AgentStateChangedPayload;
+  'agent.run.cancel_requested': AgentRunCancelRequestedPayload;
   'agent.task.created': AgentTaskCreatedPayload;
   'agent.task.updated': AgentTaskUpdatedPayload;
   'agent.task.completed': AgentTaskCompletedPayload;

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -695,6 +695,12 @@ export interface AgentRunCancelRequestedPayload {
   threadId?: string;
   /** Platform user who requested the stop */
   requestedBy?: string;
+  /**
+   * Unix ms when the user pressed stop (platform event time). Consumers only
+   * abort runs that STARTED at or before this instant, so a late-delivered
+   * cancel cannot kill a newer run under the same chat key.
+   */
+  requestedAt?: number;
   /** What triggered the cancellation */
   reason: 'user_stop';
 }


### PR DESCRIPTION
Closes #914.

Slack deprecated `assistant_view` (removal: February 2027) in favor of the Agent messaging experience. This PR migrates the Slack channel and fixes the related silent-status bug.

## What changed

**1. Agent Sessions API** (`packages/channel-slack/src/handlers/typing.ts`)
- Status calls now prefer `agents.sessions.setStatus` — non-empty status → `processing`, clear → `active`, per Slack's migration guide.
- Per-client fallback to the deprecated `assistant.threads.setStatus` when the Agent Sessions API is unavailable (`unknown_method` / `feature_disabled`), memoized so un-migrated workspaces don't pay a doubled API call per status.
- `assistant.threads.setTitle` → `agents.sessions.rename` was checked: the repo never called setTitle, so there is nothing to migrate there.

**2. Native stop button → provider abort**
- New handler subscribes `agent_session_stopped` (`handlers/agent-sessions.ts`). Subscribing is also what makes Slack *show* the stop button while a session is `processing`.
- On stop, the plugin publishes a new core event `agent.run.cancel_requested` and clears the session status (Slack's contract for the event).
- The agent dispatcher registers a per-run `AbortController` (keyed `instanceId:chatId`, next to `activeStreams`) and feeds `trigger.abortSignal` — already honored end-to-end by the claude-code streaming provider. A cancelled streaming run never falls back to the accumulate path (that would re-run the turn the user just stopped). Accumulate-mode runs that ignore the signal have their reply discarded on completion instead.
- No more 18-minute / ~US$4.50 claude-code runs continuing after the user pressed stop — at least for streaming dispatch; turn-based (fire-and-forget) providers are out of scope here.

**3. Silent status bail is now logged** — both `setSlackThreadStatus` (`no_thread_ts`) and `sendPresenceStatus` (`no_active_thread`) emit a debug line, so a channel-level mention that produces no status is diagnosable without reading the bundle.

**4. Manifest + docs**
- `buildSlackManifest()` emits `features.agent_view` (`agent_description`, optional `suggested_prompts`) and subscribes `agent_session_stopped`.
- New setup guide: `docs/channels/slack.md` (manifest generation, agent_view caveats, stop/status internals).

## Notes for reviewers
- `PresenceStatusResult.method` now reports whichever API actually handled the call; the presence route echoes it (`agents.sessions.setStatus` in the common case).
- `@slack/web-api` 7.15.2 has no typed `agents.*` namespace yet, hence `client.apiCall`.
- The `agent_view` manifest switch is one-way per Slack app; existing apps that apply the new manifest cannot revert to `assistant_view`.

## Testing
- `make typecheck` + `make lint` clean.
- channel-slack: 252 tests pass (new: agent-sessions handler, Agent-Sessions-first status + fallback memoization, manifest agent_view).
- api: dispatcher subscription test updated for the new cancel subscription; full suite green except the pre-existing MinIO-harness timeout (`media-processor-remote.test.ts`, infra-dependent) — unrelated to this change.
- DB-backed presence tests skip locally by design; CI runs them.