### PR TITLE
ci(release): harden production GitOps publication

### DIFF
--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -65,15 +65,15 @@ jobs:
             runner:   macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -84,13 +84,29 @@ jobs:
       - name: Resolve version
         id: ver
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          [[ "${PACKAGE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::packages/cli/package.json contains an invalid release version"
+            exit 1
+          }
+          if [[ -n "${INPUT_VERSION}" ]]; then
+            [[ "${INPUT_VERSION}" == "${PACKAGE_VERSION}" ]] || {
+              echo "::error::version override does not match packages/cli/package.json"
+              exit 1
+            }
+            VERSION="${PACKAGE_VERSION}"
           elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
+            [[ "${VERSION}" == "${PACKAGE_VERSION}" ]] || {
+              echo "::error::release tag does not match packages/cli/package.json"
+              exit 1
+            }
           else
-            VERSION=$(node -p "require('./packages/cli/package.json').version")
+            VERSION="${PACKAGE_VERSION}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Resolved version: ${VERSION}"
@@ -180,7 +196,7 @@ jobs:
           fi
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: omni-${{ steps.ver.outputs.version }}-${{ matrix.platform }}-tarball
           path: dist/omni-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: GitGuardian/ggshield-action@v1
+      - uses: GitGuardian/ggshield-action@7059aef1ffb7d2374ce27201144f5613beecefe0 # v1
         continue-on-error: true
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
@@ -47,17 +47,61 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: oven-sh/setup-bun@v2
+      - name: Release, immutable pin, and Helm contract gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools="${RUNNER_TEMP}/release-contract-tools"
+          mkdir -p "${tools}/helm" "${tools}/actionlint"
+
+          helm_archive="${tools}/helm/helm-v3.16.4-linux-amd64.tar.gz"
+          curl -fsSLo "${helm_archive}" https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz
+          printf '%s  %s\n' fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179 "${helm_archive}" | sha256sum -c -
+          tar -xzf "${helm_archive}" -C "${tools}/helm"
+
+          actionlint_archive="${tools}/actionlint/actionlint_1.7.7_linux_amd64.tar.gz"
+          curl -fsSLo "${actionlint_archive}" https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+          printf '%s  %s\n' 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757 "${actionlint_archive}" | sha256sum -c -
+          tar -xzf "${actionlint_archive}" -C "${tools}/actionlint" actionlint
+
+          scripts/release/release-workflow-contract.test.sh
+          scripts/release/stable-release-order.test.sh
+          scripts/release/pin-production-image.test.sh
+          scripts/release/verify-oci-release.test.sh
+          scripts/release/verify-release-source.test.sh
+          scripts/release/verify-release-assets.test.sh
+          scripts/release/verify-orchestrator-run.test.sh
+          scripts/release/verify-npm-stable-state.test.sh
+          scripts/release/verify-npm-artifact.test.sh
+          scripts/release/reconcile-npm-stable.test.sh
+          scripts/release/verify-remote-tag.test.sh
+          scripts/release/verify-tag-ruleset.test.sh
+          scripts/release/verify-oci-alias.test.sh
+          scripts/release/classify-image-change.test.sh
+          scripts/release/authorize-release-entry.test.sh
+          scripts/release/verify-version-only-diff.test.sh
+          scripts/release/verify-release-state.test.sh
+          HELM_BIN="${tools}/helm/linux-amd64/helm" scripts/ci/test-helm-image-digest.sh
+          "${tools}/actionlint/actionlint" \
+            .github/workflows/image-publish.yml \
+            .github/workflows/version.yml \
+            .github/workflows/release.yml \
+            .github/workflows/release-publish.yml \
+            .github/workflows/build-tarballs.yml \
+            .github/workflows/sign-attest.yml \
+            .github/workflows/ci.yml
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.2.1
+        uses: rharkor/caching-for-turbo@35a1f2e1570392a7fc1c03552acaf6340f0c5eef # v2.2.1
 
       - name: Cache bun packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -65,7 +109,7 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Cache NATS binary
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: bin/
           key: nats-${{ runner.os }}-${{ hashFiles('scripts/ensure-nats.sh') }}
@@ -172,14 +216,14 @@ jobs:
     # cluster. So this job supplies a postgres SERVER build and lets the gate
     # stand up and tear down its own cluster.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
       - name: Cache bun packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -247,14 +291,14 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
       - name: Cache bun packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -313,17 +357,17 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
       - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@v2.2.1
+        uses: rharkor/caching-for-turbo@35a1f2e1570392a7fc1c03552acaf6340f0c5eef # v2.2.1
 
       - name: Cache bun packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -331,7 +375,7 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Cache NATS binary
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: bin/
           key: nats-${{ runner.os }}-${{ hashFiles('scripts/ensure-nats.sh') }}

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -52,31 +52,180 @@ on:
       - '.github/workflows/image-publish.yml'
   workflow_dispatch:
     inputs:
-      platforms:
-        description: 'Target platforms (comma-separated)'
-        default: 'linux/amd64,linux/arm64'
+      repair_release:
+        description: 'Repair an immutable release ref instead of publishing a branch build'
+        type: boolean
+        default: false
+      expected_version:
+        description: 'Repair only: exact version without the v prefix'
+        required: false
+        type: string
+      expected_sha:
+        description: 'Repair only: exact 40-character release source SHA'
+        required: false
+        type: string
+      expected_existing_digest:
+        description: 'Repair only: exact digest for an idempotent already-published tag'
+        required: false
+        type: string
 
 concurrency:
-  group: image-publish-${{ github.ref }}
-  cancel-in-progress: true
+  # Main publication and immutable repair share one lane so they cannot race
+  # the same v<version> alias or stable release state.
+  group: image-publish-${{ github.ref == 'refs/heads/homolog' && 'homolog' || 'stable' }}
+  # A release identity must finish once started. Branch pushes queue behind the
+  # active run instead of cancelling a build after it may have pushed one tag.
+  cancel-in-progress: false
 
 permissions:
   contents: read
-  packages: write
-  # GitHub-native build provenance for the published images — this is what
-  # makes the documented `gh attestation verify oci://…` command
-  # (deploy/README.md) actually pass. `id-token` signs via OIDC/Sigstore;
-  # `attestations` stores the provenance in the repo's Attestations API.
-  id-token: write
-  attestations: write
 
 jobs:
-  build-push:
+  classify-changes:
     runs-on: ubuntu-latest
+    outputs:
+      build_required: ${{ steps.classify.outputs.build_required }}
+      pin_only: ${{ steps.classify.outputs.pin_only }}
+      infra_only: ${{ steps.classify.outputs.infra_only }}
+      publish_required: ${{ steps.classify.outputs.publish_required }}
+      existing_digest: ${{ steps.classify.outputs.existing_digest }}
+      release_version: ${{ steps.classify.outputs.version }}
+      release_source_sha: ${{ steps.classify.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Keep the exact hardened control code that defined this workflow.
+          # Historical repair sources are checked out separately below and
+          # can never replace the verifier scripts being executed.
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check out immutable historical repair source
+        if: ${{ inputs.repair_release }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.expected_sha }}
+          path: .release-source
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Classify immutable repair or changed paths
+        id: classify
+        env:
+          REPAIR_RELEASE: ${{ inputs.repair_release || false }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          EXPECTED_EXISTING_DIGEST: ${{ inputs.expected_existing_digest }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          classification_out="${RUNNER_TEMP}/classification.out"
+          : > "${classification_out}"
+          emit() { printf '%s\n' "$@" >> "${classification_out}"; }
+          finish() { cat "${classification_out}" >> "$GITHUB_OUTPUT"; }
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${REPAIR_RELEASE}" != "true" ]]; then
+            echo "::error::manual dispatches must set repair_release=true and provide exact immutable expectations"
+            exit 1
+          fi
+          if [[ "${REPAIR_RELEASE}" == "true" ]]; then
+            args=(
+              --ref "refs/tags/v${EXPECTED_VERSION}"
+              --expected-version "${EXPECTED_VERSION}"
+              --expected-sha "${EXPECTED_SHA}"
+              --image "${IMAGE}"
+            )
+            if [[ -n "${EXPECTED_EXISTING_DIGEST}" ]]; then
+              args+=(--expected-existing-digest "${EXPECTED_EXISTING_DIGEST}")
+            fi
+            preflight="${RUNNER_TEMP}/release-preflight.out"
+            (
+              cd "${GITHUB_WORKSPACE}/.release-source"
+              GITHUB_OUTPUT="${preflight}" \
+                "${GITHUB_WORKSPACE}/scripts/release/verify-oci-release.sh" "${args[@]}"
+            )
+            while IFS= read -r line; do emit "${line}"; done < "${preflight}"
+            emit "pin_only=false" "infra_only=false"
+            publish_required=""
+            while IFS='=' read -r key value; do
+              [[ "${key}" == "publish_required" ]] && publish_required="${value}"
+            done < "${preflight}"
+            [[ -n "${publish_required}" ]]
+            if [[ "${publish_required}" == "true" && "${GITHUB_REF}" != "refs/tags/v${EXPECTED_VERSION}" ]]; then
+              echo "::error::a detached historical repair may only reuse an explicitly approved existing digest; rebuilding from main would mis-bind workflow provenance"
+              exit 1
+            fi
+            emit "build_required=${publish_required}"
+            finish
+            exit 0
+          fi
+
+          emit "publish_required=true"
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            range_state=$(scripts/release/classify-image-change.sh \
+              --before "${GITHUB_EVENT_BEFORE}" --after "${GITHUB_SHA}")
+            while IFS= read -r line; do emit "${line}"; done <<<"${range_state}"
+            if grep -qx 'build_required=false' <<<"${range_state}"; then
+              finish
+              exit 0
+            fi
+          else
+            emit "pin_only=false" "infra_only=false"
+          fi
+
+          # Every main application release must arrive with a version that has
+          # not already been published. Otherwise build-push-action would move
+          # the v<version> registry alias before provenance verification.
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            version=$(node -p "require('./packages/cli/package.json').version")
+            version_ref="${IMAGE}:v${version}"
+            if git rev-parse "refs/tags/v${version}^{commit}" >/dev/null 2>&1; then
+              echo "::error::Git tag v${version} already exists; a stable release PR must carry a fresh untagged version"
+              exit 1
+            fi
+            scripts/release/verify-remote-tag.sh \
+              --remote origin --version "${version}" --mode absent
+            inspect_error="${RUNNER_TEMP}/existing-version.err"
+            if docker buildx imagetools inspect "${version_ref}" >/dev/null 2>"${inspect_error}"; then
+              echo "::error::version tag ${version_ref} already published; bump the version in the release PR"
+              exit 1
+            fi
+            error_text=$(<"${inspect_error}")
+            case "${error_text,,}" in
+              *"not found"*|*"manifest unknown"*) ;;
+              *)
+                echo "::error::registry inspection failed without a not-found response"
+                exit 1
+                ;;
+            esac
+          fi
+          emit "build_required=true"
+          finish
+
+  build-push:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.build_required == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      version: ${{ steps.meta.outputs.version }}
+      source_sha: ${{ steps.source.outputs.sha }}
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # A repair that would rebuild is rejected during classification;
+          # builds therefore always use the workflow event source itself.
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Resolve image version
         id: meta
@@ -87,6 +236,25 @@ jobs:
             echo "sha_short=${GITHUB_SHA::12}"
             echo "ref_name=${GITHUB_REF_NAME}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Bind and re-check source identity before registry write
+        id: source
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          REPAIR_RELEASE: ${{ inputs.repair_release || false }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          source_sha=$(git rev-parse "HEAD^{commit}")
+          echo "sha=${source_sha}" >> "$GITHUB_OUTPUT"
+          if [[ "${REPAIR_RELEASE}" == "true" ]]; then
+            [[ "${source_sha}" == "${EXPECTED_SHA}" ]]
+            scripts/release/verify-remote-tag.sh \
+              --remote origin --version "${VERSION}" --mode exact --expected-sha "${EXPECTED_SHA}"
+          elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            scripts/release/verify-remote-tag.sh \
+              --remote origin --version "${VERSION}" --mode absent
+          fi
 
       # LOW-23: arm64 is built under QEMU emulation (slow for the Bun
       # install/build stages). The repo is public, so native
@@ -114,7 +282,7 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile
-          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ steps.meta.outputs.ref_name }}
@@ -125,8 +293,16 @@ jobs:
           provenance: true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+
+      - name: Read back exact published version alias
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          EXPECTED_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          scripts/release/verify-oci-alias.sh \
+            --image "${IMAGE}" --version "${VERSION}" --expected-digest "${EXPECTED_DIGEST}"
 
       # GitHub-native provenance (Attestations API + registry referrer), so
       # `gh attestation verify oci://…` works as deploy/README.md documents.
@@ -144,7 +320,14 @@ jobs:
   # <branch> / <branch>-<sha> tags ride along so every omni promotion has a
   # matching autopg tag (contract C1').
   build-push-autopg:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.build_required == 'true' && inputs.repair_release != true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/autopg
       # autopg release baked into deploy/autopg.Dockerfile. Bump together
@@ -184,7 +367,7 @@ jobs:
         with:
           context: deploy
           file: deploy/autopg.Dockerfile
-          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             AUTOPG_VERSION=${{ env.AUTOPG_VERSION }}
@@ -213,6 +396,8 @@ jobs:
   # KHAL_NPM_TOKEN presence as an output. build-push-ui skips cleanly (keeping
   # the promotion green) until the token is configured, then self-activates.
   check-ui-secret:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.build_required == 'true' && inputs.repair_release != true
     runs-on: ubuntu-latest
     outputs:
       has_token: ${{ steps.probe.outputs.has_token }}
@@ -229,8 +414,13 @@ jobs:
   # adminUi.image.tag "" → v<appVersion> always resolves.
   build-push-ui:
     runs-on: ubuntu-latest
-    needs: check-ui-secret
-    if: needs.check-ui-secret.outputs.has_token == 'true'
+    needs: [classify-changes, check-ui-secret]
+    if: needs.classify-changes.outputs.build_required == 'true' && needs.check-ui-secret.outputs.has_token == 'true'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/omni-admin-ui
     steps:
@@ -277,7 +467,7 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile.admin-ui
-          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64,linux/arm64
           push: true
           secret-files: |
             npmrc=${{ runner.temp }}/khal.npmrc
@@ -300,3 +490,280 @@ jobs:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  # Main is the authorization boundary. Verify the immutable artifact first,
+  # then update exactly one Git-owned deployment-state file. Argo—not CI—is the
+  # only production cluster writer.
+  verify-and-pin:
+    needs: [classify-changes, build-push]
+    if: >-
+      always() &&
+      ((github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        needs.classify-changes.outputs.build_required == 'true' &&
+        needs.build-push.result == 'success') ||
+       (github.event_name == 'workflow_dispatch' &&
+        inputs.repair_release == true &&
+        (needs.build-push.result == 'success' ||
+         (needs.build-push.result == 'skipped' &&
+          needs.classify-changes.outputs.publish_required == 'false'))))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+      attestations: read
+      actions: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+      DIGEST: ${{ needs.build-push.outputs.digest || needs.classify-changes.outputs.existing_digest }}
+      VERSION: ${{ needs.build-push.outputs.version || needs.classify-changes.outputs.release_version }}
+      SOURCE_SHA: ${{ needs.build-push.outputs.source_sha || needs.classify-changes.outputs.release_source_sha }}
+    steps:
+      - name: Require protected release writer credential
+        env:
+          RELEASE_WRITER_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
+        run: |
+          [[ -n "${RELEASE_WRITER_TOKEN}" ]] || {
+            echo "::error::VERSION_BUMP_PAT is required so the production-pin push triggers protected CI"
+            exit 1
+          }
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.VERSION_BUMP_PAT }}
+
+      - name: Log in to GHCR for independent verification
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up Buildx for independent index inspection
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Verify exact digest, platforms, and GitHub provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          docker buildx imagetools inspect "${IMAGE}@${DIGEST}" > "${RUNNER_TEMP}/image-index.txt"
+          python3 - "${RUNNER_TEMP}/image-index.txt" <<'PY'
+          import sys
+          text = open(sys.argv[1], encoding="utf-8").read()
+          required = ("MediaType: application/vnd.oci.image.index.v1+json", "Platform:    linux/amd64", "Platform:    linux/arm64")
+          missing = [item for item in required if item not in text]
+          if missing:
+              raise SystemExit(f"verified OCI index is missing: {missing}")
+          PY
+          gh attestation verify "oci://${IMAGE}@${DIGEST}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${SOURCE_SHA}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/image-publish.yml"
+
+      - name: Install cosign for existing release verification
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Install slsa-verifier for existing release verification
+        uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
+
+      - name: Finalize stable Git tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPAIR_RELEASE: ${{ inputs.repair_release || false }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          source_args=(--source "${SOURCE_SHA}" --main origin/main)
+          [[ "${REPAIR_RELEASE}" != "true" ]] || \
+            source_args+=(--allow-detached-repair --expected-version "${VERSION}")
+          source_state=$(scripts/release/verify-release-source.sh "${source_args[@]}")
+          detached_repair="${source_state#detached_repair=}"
+          [[ "${detached_repair}" == "true" || "${detached_repair}" == "false" ]]
+          tag="v${VERSION}"
+          ref="refs/tags/v${VERSION}"
+          ruleset_ok=false
+          while IFS= read -r ruleset_id; do
+            [[ -n "${ruleset_id}" ]] || continue
+            gh api "repos/${GITHUB_REPOSITORY}/rulesets/${ruleset_id}" > "${RUNNER_TEMP}/tag-ruleset-${ruleset_id}.json"
+            if scripts/release/verify-tag-ruleset.py \
+              --ruleset-json "${RUNNER_TEMP}/tag-ruleset-${ruleset_id}.json" \
+              --tag "${ref}"; then
+              ruleset_ok=true
+              break
+            fi
+          done < <(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --paginate --jq '.[] | select(.target == "tag" and .enforcement == "active") | .id')
+          [[ "${ruleset_ok}" == "true" ]] || {
+            echo "::error::an active v* tag ruleset blocking update and deletion is required before stable finalization"
+            exit 1
+          }
+          if git show-ref --verify --quiet "${ref}"; then
+            existing_sha=$(git rev-parse "${ref}^{commit}")
+            if [[ "${existing_sha}" != "${SOURCE_SHA}" ]]; then
+              echo "::error::${ref} already points to ${existing_sha}, not verified source ${SOURCE_SHA}"
+              exit 1
+            fi
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="${ref}" \
+              -f sha="${SOURCE_SHA}" >/dev/null
+          fi
+          scripts/release/verify-remote-tag.sh \
+            --remote origin --version "${VERSION}" --mode exact --expected-sha "${SOURCE_SHA}"
+          echo "Verified remote tag target before publication"
+
+          release_exists=false
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" >/dev/null 2>&1; then
+            release_exists=true
+          fi
+          if [[ "${release_exists}" == "true" ]]; then
+            release_state=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '[.draft,.prerelease] | @tsv')
+            [[ "${release_state}" == $'false\tfalse' ]] || {
+              echo "::error::existing stable release is not public stable"
+              exit 1
+            }
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" > "${RUNNER_TEMP}/release.json"
+            verify_dir="${RUNNER_TEMP}/existing-release"
+            mkdir -p "${verify_dir}"
+            gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" --dir "${verify_dir}"
+            scripts/release/verify-release-assets.py \
+              --version "${VERSION}" \
+              --release-json "${RUNNER_TEMP}/release.json" \
+              --dist "${verify_dir}"
+            for tarball in "${verify_dir}"/*.tar.gz; do
+              cosign verify-blob \
+                --bundle "${tarball}.bundle" \
+                --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/sign-attest.yml@refs/tags/v${VERSION}$" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                "${tarball}"
+              slsa-verifier verify-artifact "${tarball}" \
+                --provenance-path "${tarball}.intoto.jsonl" \
+                --source-uri "github.com/${GITHUB_REPOSITORY}" \
+                --source-tag "v${VERSION}"
+              gh attestation verify "${tarball}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --source-digest "${SOURCE_SHA}" \
+                --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/sign-attest.yml"
+            done
+            echo "Existing public release assets already match immutable v${VERSION} identity"
+          else
+            [[ "${detached_repair}" == "false" ]] || {
+              echo "::error::a version-only detached repair may reuse a verified public release but cannot execute historical mutable release workflows"
+              exit 1
+            }
+            release_url=$(gh workflow run release.yml \
+              --repo "${GITHUB_REPOSITORY}" \
+              --ref "${tag}" \
+              --field version="${VERSION}" \
+              --field channel=stable \
+              --field expected_sha="${SOURCE_SHA}" \
+              --field expected_digest="${DIGEST}" \
+              --field orchestrator_run_id="${GITHUB_RUN_ID}")
+            release_run_id="${release_url##*/}"
+            [[ "${release_run_id}" =~ ^[0-9]+$ ]] || {
+              echo "::error::could not resolve dispatched release run from: ${release_url}"
+              exit 1
+            }
+            gh run watch "${release_run_id}" --repo "${GITHUB_REPOSITORY}" --exit-status
+          fi
+
+          scripts/release/verify-remote-tag.sh \
+            --remote origin --version "${VERSION}" --mode exact --expected-sha "${SOURCE_SHA}"
+          echo "Verified remote tag target after publication"
+
+          # Always dispatch the hardened npm reconciler—even when version and
+          # latest already look correct—so existing package bytes, registry
+          # signatures, and available provenance attestations are reverified.
+          npm_url=$(gh workflow run version.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            --field stable_publish_only=true \
+            --field expected_version="${VERSION}" \
+            --field expected_sha="${SOURCE_SHA}" \
+            --field expected_digest="${DIGEST}" \
+            --field orchestrator_run_id="${GITHUB_RUN_ID}" \
+            --field orchestrator_control_sha="${GITHUB_SHA}")
+          npm_run_id="${npm_url##*/}"
+          [[ "${npm_run_id}" =~ ^[0-9]+$ ]] || {
+            echo "::error::could not resolve dispatched stable npm run from: ${npm_url}"
+            exit 1
+          }
+          gh run watch "${npm_run_id}" --repo "${GITHUB_REPOSITORY}" --exit-status
+
+      - name: Re-check version alias after release finalization
+        run: |
+          scripts/release/verify-oci-alias.sh \
+            --image "${IMAGE}" --version "${VERSION}" --expected-digest "${DIGEST}"
+
+      - name: Commit production pin with bounded CAS retry
+        id: pin
+        env:
+          REPAIR_RELEASE: ${{ inputs.repair_release || false }}
+        run: |
+          set -euo pipefail
+          git config user.name "release-bot"
+          git config user.email "release-bot@example.com"
+          success=false
+          for attempt in 1 2 3; do
+            echo "Pin attempt ${attempt}/3"
+            git fetch origin main
+            git reset --hard origin/main
+            source_args=(--source "${SOURCE_SHA}" --main origin/main)
+            [[ "${REPAIR_RELEASE}" != "true" ]] || \
+              source_args+=(--allow-detached-repair --expected-version "${VERSION}")
+            source_state=$(scripts/release/verify-release-source.sh "${source_args[@]}")
+            detached_repair="${source_state#detached_repair=}"
+            if [[ "${detached_repair}" == "false" ]]; then
+              current_version=$(node -p "require('./packages/cli/package.json').version")
+              [[ "${current_version}" == "${VERSION}" ]] || {
+                echo "::error::main advanced to version ${current_version}; refusing to overwrite with ${VERSION}"
+                exit 1
+              }
+            else
+              [[ "${detached_repair}" == "true" ]]
+            fi
+            expected_parent=$(git rev-parse HEAD)
+            pin_output="${RUNNER_TEMP}/pin-${attempt}.out"
+            GITHUB_OUTPUT="${pin_output}" scripts/release/pin-production-image.sh \
+              --version "${VERSION}" \
+              --digest "${DIGEST}" \
+              --source-sha "${SOURCE_SHA}" \
+              --expected-parent "${expected_parent}"
+            changed=""
+            while IFS='=' read -r key value; do
+              [[ "${key}" == "changed" ]] && changed="${value}"
+            done < "${pin_output}"
+            if [[ "${changed}" == "false" ]]; then
+              echo "pin_commit=${expected_parent}" >> "$GITHUB_OUTPUT"
+              success=true
+              break
+            fi
+            git add deploy/helm/omni/values-prod-gitops.yaml
+            git commit -m "chore(release): pin omni prod v${VERSION}"
+            if git push origin HEAD:main; then
+              echo "pin_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              success=true
+              break
+            fi
+            echo "main advanced during pin attempt ${attempt}; retrying"
+          done
+          [[ "${success}" == "true" ]] || {
+            echo "::error::production pin CAS failed after three attempts"
+            exit 1
+          }
+
+      - name: Write redacted delivery receipt
+        run: |
+          {
+            echo "### Omni production pin"
+            echo "- source: \`${SOURCE_SHA}\`"
+            echo "- version: \`${VERSION}\`"
+            echo "- OCI digest: \`${DIGEST}\`"
+            echo "- pin commit: \`${{ steps.pin.outputs.pin_commit }}\`"
+            echo "- Argo CD is responsible for reconciliation; this workflow made no cluster call."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -42,6 +42,22 @@ on:
         required: false
         type: boolean
         default: false
+      expected_sha:
+        description: 'Stable only: exact verified release source SHA'
+        required: false
+        type: string
+      expected_digest:
+        description: 'Stable only: exact verified omni-api OCI digest'
+        required: false
+        type: string
+      orchestrator_run_id:
+        description: 'Stable only: exact in-progress image-publish workflow run'
+        required: false
+        type: string
+      orchestrated:
+        description: 'Set only by release.yml reusable orchestration'
+        required: true
+        type: boolean
   # Manual-recovery escape hatch — operators can re-publish from a stranded
   # sign-attest run by passing version + run_id explicitly. draft defaults
   # to true here so a replay never auto-promotes by accident.
@@ -78,6 +94,9 @@ concurrency:
 
 permissions:
   contents: write              # gh release create/upload + push latest.json commit
+  actions: read
+  packages: read
+  attestations: read
 
 jobs:
   publish:
@@ -85,23 +104,87 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Reject unverified stable publish
+        env:
+          ACTOR: ${{ github.actor }}
+          CHANNEL: ${{ inputs.channel || 'stable' }}
+          DRAFT: ${{ inputs.draft }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          EXPECTED_DIGEST: ${{ inputs.expected_digest }}
+          ORCHESTRATOR_RUN_ID: ${{ inputs.orchestrator_run_id }}
+          RECOVERY_RUN_ID: ${{ inputs.run_id }}
+          ORCHESTRATED: ${{ inputs.orchestrated || false }}
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+        run: |
+          set -euo pipefail
+          entry_args=(--channel "${CHANNEL}" --orchestrated "${ORCHESTRATED}")
+          [[ -z "${RECOVERY_RUN_ID}" ]] || entry_args+=(--recovery-run-id "${RECOVERY_RUN_ID}")
+          entry_state=$(scripts/release/authorize-release-entry.py "${entry_args[@]}")
+          entry_mode="${entry_state#mode=}"
+          if [[ "${CHANNEL}" == "stable" ]]; then
+            [[ "${entry_mode}" == "orchestrated" ]]
+            [[ "${ACTOR}" == "github-actions[bot]" ]]
+            [[ "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]
+            [[ "${EXPECTED_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
+            [[ "${ORCHESTRATOR_RUN_ID}" =~ ^[0-9]+$ ]]
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ORCHESTRATOR_RUN_ID}" > "${RUNNER_TEMP}/orchestrator.json"
+            scripts/release/verify-orchestrator-run.py \
+              --run-json "${RUNNER_TEMP}/orchestrator.json" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --source-sha "${EXPECTED_SHA}"
+            gh attestation verify "oci://${IMAGE}@${EXPECTED_DIGEST}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --source-digest "${EXPECTED_SHA}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/image-publish.yml"
+          elif [[ "${entry_mode}" == "recovery" ]]; then
+            [[ "${RECOVERY_RUN_ID}" =~ ^[0-9]+$ ]]
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RECOVERY_RUN_ID}" > "${RUNNER_TEMP}/upstream-run.json"
+            scripts/release/verify-orchestrator-run.py \
+              --run-json "${RUNNER_TEMP}/upstream-run.json" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --source-sha "${GITHUB_SHA}" \
+              --expected-workflow .github/workflows/sign-attest.yml \
+              --required-status completed \
+              --allowed-event workflow_dispatch
+          fi
+
+      - name: Require protected release writer credential
+        env:
+          RELEASE_WRITER_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
+        run: |
+          [[ -n "${RELEASE_WRITER_TOKEN}" ]] || {
+            echo "::error::VERSION_BUMP_PAT is required so release-manifest pushes trigger protected CI"
+            exit 1
+          }
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Resolve upstream sign-attest run-id
         id: src
         shell: bash
+        env:
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          if [[ -n "${{ inputs.run_id }}" ]]; then
-            RUN_ID="${{ inputs.run_id }}"
+          if [[ -n "${INPUT_RUN_ID}" ]]; then
+            RUN_ID="${INPUT_RUN_ID}"
           else
-            RUN_ID="${{ github.run_id }}"
+            RUN_ID="${CURRENT_RUN_ID}"
           fi
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "Upstream sign-attest run-id: ${RUN_ID}"
 
       - name: Download all signed artifacts (sign-attest.yml)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: omni-*-signed
           merge-multiple: true
@@ -132,8 +215,23 @@ jobs:
             exit 1
           fi
           VERSION="${PARSED}"
+          [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::signed artifact version is invalid"
+            exit 1
+          }
           if [[ -n "${INPUT_VERSION:-}" && "${INPUT_VERSION}" != "${VERSION}" ]]; then
             echo "::error::workflow_dispatch input version='${INPUT_VERSION}' does not match upstream artifact version='${VERSION}'"
+            exit 1
+          fi
+          missing=()
+          for platform in linux-x64-glibc linux-x64-musl linux-arm64 darwin-arm64; do
+            for suffix in "" .bundle .intoto.jsonl; do
+              asset="omni-${VERSION}-${platform}.tar.gz${suffix}"
+              [[ -f "${asset}" ]] || missing+=("${asset}")
+            done
+          done
+          if [[ ${#missing[@]} -ne 0 ]]; then
+            echo "::error::signed release inventory is incomplete: ${missing[*]}"
             exit 1
           fi
           CHANNEL="${INPUT_CHANNEL:-}"
@@ -153,6 +251,8 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
           CHANNEL: ${{ steps.meta.outputs.channel }}
           DRAFT_FLAG: ${{ inputs.draft && '--draft' || '' }}
+          REQUESTED_DRAFT: ${{ inputs.draft || false }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -161,30 +261,98 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           fi
 
-          if ! gh release view "v${VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          git fetch origin "+refs/tags/v${VERSION}:refs/tags/v${VERSION}"
+          tag_sha=$(git rev-parse "refs/tags/v${VERSION}^{commit}")
+          if [[ -n "${EXPECTED_SHA}" ]]; then
+            [[ "${tag_sha}" == "${EXPECTED_SHA}" ]] || {
+              echo "::error::remote tag target before publication is ${tag_sha}, expected ${EXPECTED_SHA}"
+              exit 1
+            }
+          else
+            EXPECTED_SHA="${tag_sha}"
+          fi
+
+          upload_assets=true
+          if gh release view "v${VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            read -r IS_DRAFT IS_PRERELEASE < <(
+              gh release view "v${VERSION}" --repo "${{ github.repository }}" \
+                --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | @tsv'
+            )
+            scripts/release/verify-release-state.py \
+              --phase existing --channel "${CHANNEL}" \
+              --draft "${IS_DRAFT}" --prerelease "${IS_PRERELEASE}" \
+              --requested-draft "${REQUESTED_DRAFT}"
+            if [[ "${IS_DRAFT}" != "true" ]]; then
+              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" > "${RUNNER_TEMP}/existing-release.json"
+              scripts/release/verify-release-assets.py \
+                --version "${VERSION}" \
+                --release-json "${RUNNER_TEMP}/existing-release.json" \
+                --dist dist
+              echo "Existing public release assets already match the immutable signed inventory"
+              upload_assets=false
+            fi
+          else
             # shellcheck disable=SC2086 # intentional word-split on optional flags
             gh release create "v${VERSION}" \
               --repo "${{ github.repository }}" \
+              --verify-tag \
               --title "v${VERSION}" \
               --notes "Release v${VERSION} (channel: ${CHANNEL})" \
-              ${DRAFT_FLAG} ${PRERELEASE_FLAG}
+              --draft ${PRERELEASE_FLAG}
           fi
 
-          if [[ -d dist && -n "$(ls -A dist 2>/dev/null)" ]]; then
+          if [[ "${upload_assets}" == "true" && -d dist && -n "$(ls -A dist 2>/dev/null)" ]]; then
             gh release upload "v${VERSION}" \
               --repo "${{ github.repository }}" \
               --clobber \
               dist/*
-          else
+          elif [[ "${upload_assets}" == "true" ]]; then
             echo "::error::dist/ is empty — nothing to upload"
             exit 1
           fi
 
+          # Read back GitHub's authoritative names and SHA-256 digests before
+          # any draft can become public. This also closes an upload/race gap:
+          # a count of 12 alone does not prove that the intended bytes landed.
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+            > "${RUNNER_TEMP}/uploaded-release.json"
+          scripts/release/verify-release-assets.py \
+            --version "${VERSION}" \
+            --release-json "${RUNNER_TEMP}/uploaded-release.json" \
+            --dist dist
+
           ASSET_COUNT=$(gh release view "v${VERSION}" --repo "${{ github.repository }}" --json assets --jq '.assets | length')
           echo "v${VERSION} now lists ${ASSET_COUNT} assets"
-          if [[ "${ASSET_COUNT}" -lt 12 ]]; then
-            echo "::warning::expected 12 assets, found ${ASSET_COUNT}"
+          if [[ "${ASSET_COUNT}" -ne 12 ]]; then
+            echo "::error::expected exactly 12 signed assets, found ${ASSET_COUNT}"
+            exit 1
           fi
+
+          if [[ -z "${DRAFT_FLAG}" ]]; then
+            if [[ "${CHANNEL}" == "stable" ]]; then
+              gh release edit "v${VERSION}" --repo "${{ github.repository }}" \
+                --draft=false --prerelease=false --latest
+            else
+              gh release edit "v${VERSION}" --repo "${{ github.repository }}" \
+                --draft=false --prerelease=true
+            fi
+          fi
+
+          read -r IS_DRAFT IS_PRERELEASE < <(
+            gh release view "v${VERSION}" --repo "${{ github.repository }}" \
+              --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | @tsv'
+          )
+          scripts/release/verify-release-state.py \
+            --phase final --channel "${CHANNEL}" \
+            --draft "${IS_DRAFT}" --prerelease "${IS_PRERELEASE}" \
+            --requested-draft "${REQUESTED_DRAFT}"
+
+          git fetch origin "+refs/tags/v${VERSION}:refs/tags/v${VERSION}"
+          final_tag_sha=$(git rev-parse "refs/tags/v${VERSION}^{commit}")
+          [[ "${final_tag_sha}" == "${EXPECTED_SHA}" ]] || {
+            echo "::error::remote tag target after publication is ${final_tag_sha}, expected ${EXPECTED_SHA}"
+            exit 1
+          }
 
       # ---------------------------------------------------------------------
       # Per-channel manifest pointers — committed to main so install.sh +
@@ -212,6 +380,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
+          git fetch origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}"
           git checkout main
           git pull --ff-only origin main
 
@@ -249,15 +418,18 @@ jobs:
               ;;
           esac
 
-          mkdir -p .well-known
+          MANIFEST_STAGE="${RUNNER_TEMP}/release-manifests"
+          mkdir -p "${MANIFEST_STAGE}"
+          source_epoch=$(git show -s --format=%ct "v${VERSION}^{commit}")
+          released_at=$(date -u -d "@${source_epoch}" +%Y-%m-%dT%H:%M:%SZ)
           for manifest_channel in "${!MANIFEST_FILES[@]}"; do
             FILE="${MANIFEST_FILES[$manifest_channel]}"
-            cat > ".well-known/${FILE}" <<EOF
+            cat > "${MANIFEST_STAGE}/${FILE}" <<EOF
           {
             "schema_version": 1,
             "channel": "${manifest_channel}",
             "version": "${VERSION}",
-            "released_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "released_at": "${released_at}",
             "tarball_base": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}",
             "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
           }
@@ -276,14 +448,25 @@ jobs:
           for f in "${MANIFEST_FILES[@]}"; do
             MANIFEST_PATHS+=(".well-known/${f}")
           done
-          git add "${MANIFEST_PATHS[@]}"
-          if git diff --cached --quiet HEAD -- "${MANIFEST_PATHS[@]}"; then
-            echo "manifests unchanged — nothing to commit"
-            exit 0
-          fi
           MANIFEST_LIST=$(IFS=','; echo "${!MANIFEST_FILES[*]}")
-          git commit -m "chore(release): update manifests (${MANIFEST_LIST}) → v${VERSION}"
-          git push origin main || {
-            echo "::warning::push to main failed (likely branch protection); update ${MANIFEST_PATHS[*]} manually"
-            exit 0
-          }
+          for attempt in 1 2 3; do
+            echo "Manifest CAS attempt ${attempt}/3"
+            git fetch origin main
+            git reset --hard origin/main
+            mkdir -p .well-known
+            for f in "${MANIFEST_FILES[@]}"; do
+              cp "${MANIFEST_STAGE}/${f}" ".well-known/${f}"
+            done
+            git add "${MANIFEST_PATHS[@]}"
+            if git diff --cached --quiet HEAD -- "${MANIFEST_PATHS[@]}"; then
+              echo "manifests already match v${VERSION} — nothing to commit"
+              exit 0
+            fi
+            git commit -m "chore(release): update manifests (${MANIFEST_LIST}) → v${VERSION}"
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "main advanced during manifest attempt ${attempt}; retrying"
+          done
+          echo "::error::release manifest CAS failed after three attempts"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ name: Release
 #   3. publish         — workflow_call into release-publish.yml (GH release + assets)
 #   4. release-notes   — git-cliff changelog appended to the GH release body.
 #
-# npm publishing happens in version.yml inline (branch-derived dist-tag:
-# main → @latest, dev → @next). Single source of truth — no duplicate
-# publish step here. Codex P1 on PR #633 caught the gap when a previous
+# npm publishing happens in version.yml inline (dev/homolog auto-versioning,
+# plus the verified stable-only entry point dispatched by image-publish.yml).
+# Single source of truth — no duplicate publish step here. Codex P1 on PR #633 caught the gap when a previous
 # revision of this file ran an unconditional `npm publish --tag latest`
 # alongside version.yml's @next publish, promoting dev cuts to @latest.
 
@@ -49,6 +49,18 @@ on:
           - stable
           - homolog
           - dev
+      expected_sha:
+        description: 'Stable only: exact verified release source SHA'
+        required: false
+        type: string
+      expected_digest:
+        description: 'Stable only: exact verified omni-api OCI digest'
+        required: false
+        type: string
+      orchestrator_run_id:
+        description: 'Stable only: exact in-progress image-publish workflow run'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -58,10 +70,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  authorize:
+    name: Authorize release channel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Reject unverified stable entry points
+        env:
+          CHANNEL: ${{ inputs.channel || 'stable' }}
+          ACTOR: ${{ github.actor }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          EXPECTED_DIGEST: ${{ inputs.expected_digest }}
+          ORCHESTRATOR_RUN_ID: ${{ inputs.orchestrator_run_id }}
+          INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+        run: |
+          set -euo pipefail
+          if [[ "${CHANNEL}" == "stable" ]]; then
+            [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${ACTOR}" == "github-actions[bot]" ]]
+            [[ "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]
+            [[ "${EXPECTED_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
+            [[ "${ORCHESTRATOR_RUN_ID}" =~ ^[0-9]+$ ]]
+            [[ "${GITHUB_REF}" == "refs/tags/v${INPUT_VERSION}" ]]
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ORCHESTRATOR_RUN_ID}" > "${RUNNER_TEMP}/orchestrator.json"
+            scripts/release/verify-orchestrator-run.py \
+              --run-json "${RUNNER_TEMP}/orchestrator.json" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --source-sha "${EXPECTED_SHA}"
+            gh attestation verify "oci://${IMAGE}@${EXPECTED_DIGEST}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --source-digest "${EXPECTED_SHA}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/image-publish.yml"
+          fi
+
   # ---------------------------------------------------------------------------
   # Signed-tarball pipeline (mirror of genie pattern)
   # ---------------------------------------------------------------------------
   build:
+    needs: authorize
     uses: ./.github/workflows/build-tarballs.yml
     permissions:
       contents: read
@@ -82,24 +137,30 @@ jobs:
     uses: ./.github/workflows/release-publish.yml
     permissions:
       contents: write       # gh release create/upload + push latest.json
-      id-token: write       # reserved for any OIDC-using publish-time verifiers
+      actions: read
+      packages: read
+      attestations: read
     secrets: inherit
     with:
       version: ${{ needs.sign-attest.outputs.version }}
-      # workflow_dispatch supplies the channel (version.yml passes 'dev' for
-      # dev-branch dispatches, 'stable' for main-branch dispatches). Bare
-      # tag pushes fall through to stable. Mirrors genie wish
+      # workflow_dispatch supplies the channel (version.yml passes dev/homolog;
+      # the verified image pipeline passes stable). Bare tag pushes fall
+      # through to stable. Mirrors genie wish
       # release-channel-dev (PR #2419).
       channel: ${{ inputs.channel || 'stable' }}
       draft: false
+      expected_sha: ${{ inputs.expected_sha }}
+      expected_digest: ${{ inputs.expected_digest }}
+      orchestrator_run_id: ${{ inputs.orchestrator_run_id }}
+      orchestrated: true
 
   # ---------------------------------------------------------------------------
   # Release notes (git-cliff) — runs after publish so the GH release exists.
   # Updates the release body with the generated changelog.
   #
-  # NOTE: npm publish is NOT performed by this workflow. version.yml runs
-  # `npm publish --tag <next|latest>` inline using a branch-derived dist-tag
-  # (main → @latest, dev → @next). A duplicate publish step here would race
+  # NOTE: npm publish is NOT performed by this workflow. version.yml owns
+  # `npm publish` for dev/homolog and the verified stable-only dispatch. A
+  # duplicate publish step here would race
   # version.yml's inline path AND, before this drop, the missing channel
   # gate meant dev dispatches were attempting `npm publish --tag latest`
   # against a version version.yml had already pushed as @next — promoting
@@ -114,7 +175,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -135,7 +196,7 @@ jobs:
       - name: Find previous release tag
         id: prev
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.pkg.outputs.tag }}"
           PREV=$(gh release list --limit 50 --json tagName -q '.[].tagName' | grep -v "^${TAG}$" | head -1)
@@ -161,7 +222,7 @@ jobs:
 
       - name: Update release body with changelog
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.pkg.outputs.tag }}"
           if [[ -s /tmp/release-notes.md ]]; then

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -62,6 +62,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -77,21 +78,45 @@ jobs:
       run_id:  ${{ steps.runid.outputs.run_id }}
       hashes:  ${{ steps.hash.outputs.hashes }}
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Authorize manual recovery source run
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+          [[ "${RUN_ID}" =~ ^[0-9]+$ ]]
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" > "${RUNNER_TEMP}/upstream-run.json"
+          scripts/release/verify-orchestrator-run.py \
+            --run-json "${RUNNER_TEMP}/upstream-run.json" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --source-sha "${GITHUB_SHA}" \
+            --expected-workflow .github/workflows/build-tarballs.yml \
+            --required-status completed \
+            --allowed-event workflow_dispatch
+
       - name: Resolve upstream run-id
         id: runid
         shell: bash
+        env:
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          if [[ -n "${{ inputs.run_id }}" ]]; then
-            RUN_ID="${{ inputs.run_id }}"
+          if [[ -n "${INPUT_RUN_ID}" ]]; then
+            RUN_ID="${INPUT_RUN_ID}"
           else
-            RUN_ID="${{ github.run_id }}"
+            RUN_ID="${CURRENT_RUN_ID}"
           fi
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "Upstream run-id: ${RUN_ID}"
 
       - name: Download all tarball artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: omni-*-tarball
           merge-multiple: true
@@ -102,6 +127,8 @@ jobs:
       - name: Resolve version + compute base64 subjects
         id: hash
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           cd dist
@@ -118,8 +145,12 @@ jobs:
             echo "::error::could not parse VERSION from filename '${FIRST}'"
             exit 1
           fi
-          if [[ -n "${{ inputs.version }}" && "${{ inputs.version }}" != "${VERSION}" ]]; then
-            echo "::error::workflow_dispatch input version='${{ inputs.version }}' does not match upstream artifact version='${VERSION}'"
+          [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::upstream artifact version is invalid"
+            exit 1
+          }
+          if [[ -n "${INPUT_VERSION}" && "${INPUT_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::workflow_dispatch input version='${INPUT_VERSION}' does not match upstream artifact version='${VERSION}'"
             exit 1
           fi
           echo "Resolved version: ${VERSION}"
@@ -143,7 +174,7 @@ jobs:
       id-token: write    # OIDC for SLSA provenance signing
       contents: write    # Required by nested `upload-assets` job static check
       actions: read      # read upstream workflow run metadata
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ needs.prepare.outputs.hashes }}
       provenance-name: omni-${{ needs.prepare.outputs.version }}.intoto.jsonl
@@ -173,10 +204,10 @@ jobs:
           - darwin-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download tarball artifact (${{ matrix.platform }})
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}-tarball
           path: dist
@@ -184,7 +215,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download SLSA provenance artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
           path: dist
@@ -206,12 +237,12 @@ jobs:
           ls -la "${DEST}"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.4.1'
 
       - name: Install slsa-verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
+        uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
 
       - name: cosign sign-blob (keyless OIDC, sigstore bundle)
         shell: bash
@@ -239,7 +270,7 @@ jobs:
 
       - name: GitHub-native build-provenance attestation
         id: attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz
 
@@ -340,7 +371,7 @@ jobs:
           rm -f "${MUTATED}"
 
       - name: Upload signed artifact (${{ matrix.platform }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: omni-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}-signed
           path: |

--- a/.github/workflows/signing-identity-pin.yml
+++ b/.github/workflows/signing-identity-pin.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Assert signing-identity pin agrees across all four witnesses
         run: bash scripts/check-fingerprint-pinning.sh

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,27 +1,48 @@
 name: Version
 
 on:
-  # Fire when a PR merges to dev or homolog.
-  # homolog is the canonical image-build branch for controlled HML promotion,
-  # so homolog PR merges must bump the build number on homolog, not on dev.
+  # Fire directly when a PR merges to dev. Homolog has a single canonical
+  # entry point below, after its push CI succeeds, so one merge cannot publish
+  # twice through both pull_request and workflow_run.
   # Prior trigger (workflow_run CI on branch=dev) never fired because CI's
   # `on.push` only lists `[main, homolog]`, never `dev`; merges to dev thus
   # produced no push-event CI run for workflow_run to observe.
   pull_request:
     types: [closed]
-    branches: [dev, homolog]
-  # main-side promotion arrives via CI-on-push (main IS in CI's push
-  # branches). Keep this path so release-to-@latest continues to trigger
-  # automatically when the rolling PR dev→main merges. homolog branch
-  # added 2026-05-12 so promotions to homolog also
-  # auto-fire the version + release pipeline → .well-known/homolog.json
-  # advances. CI's push branches list must include `homolog` for this
-  # workflow_run trigger to fire from there.
+    branches: [dev]
+  # Homolog promotion arrives via CI-on-push. Stable main releases are NOT
+  # versioned here: the release PR must already contain its final version, and
+  # image-publish.yml finalizes the tag/release only after OCI verification.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main, homolog]
+    branches: [homolog]
   workflow_dispatch:
+    inputs:
+      stable_publish_only:
+        description: 'Publish one already verified stable tag to npm without creating a new version'
+        type: boolean
+        default: false
+      expected_version:
+        description: 'Stable-only: exact version without the v prefix'
+        required: false
+        type: string
+      expected_sha:
+        description: 'Stable-only: exact 40-character release source SHA'
+        required: false
+        type: string
+      expected_digest:
+        description: 'Stable-only: exact verified omni-api OCI digest'
+        required: false
+        type: string
+      orchestrator_run_id:
+        description: 'Stable-only: exact in-progress image-publish workflow run'
+        required: false
+        type: string
+      orchestrator_control_sha:
+        description: 'Stable-only: exact control revision executing image-publish'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -40,16 +61,10 @@ permissions:
   actions: write
 
 concurrency:
-  # Serialize per target branch so dev and homolog bumps cannot overwrite each other.
-  # KNOWN GAP (documented, not fixed here): the group key includes event_name,
-  # so a dev→homolog promotion PR can fire this job twice for one merge —
-  # once via pull_request-closed and again via workflow_run (the merge commit
-  # "Merge pull request … /dev" passes the guard below) — in SEPARATE groups
-  # that run concurrently. Worst case is a duplicate bump/publish, not a loop:
-  # the bump commit itself never re-triggers (it fails the startsWith
-  # 'Merge pull request' guard). A real dedupe needs a gate job or step-level
-  # skip plumbing; deferred to keep this workflow's shape stable.
-  group: version-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.base.ref || github.ref_name }}
+  # Serialize every equivalent entry event by target branch. Keeping event_name
+  # out of the key prevents a future trigger expansion from reintroducing
+  # concurrent duplicate publication for one branch.
+  group: version-${{ github.event.workflow_run.head_branch || github.event.pull_request.base.ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -64,15 +79,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: >-
-      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_dispatch' && inputs.stable_publish_only != true) ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == 'dev' &&
        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
-       (github.event.workflow_run.head_branch == 'main' ||
-        github.event.workflow_run.head_branch == 'homolog') &&
+       github.event.workflow_run.head_branch == 'homolog' &&
        !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
        startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
        (contains(github.event.workflow_run.head_commit.message, '/dev') ||
@@ -83,9 +98,8 @@ jobs:
         id: context
         run: |
           # Branch semantics:
-          #   - workflow_run on main → promoted release → @latest, bump carried on dev
           #   - pull_request merged on dev → new dev build → @next, bump dev
-          #   - pull_request/workflow_run on homolog → canonical HML build → @homolog, bump homolog
+          #   - workflow_run on homolog → canonical HML build → @homolog, bump homolog
           #   - workflow_dispatch → defaults to dev/@next
           TRIGGER_BRANCH="dev"
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
@@ -95,12 +109,6 @@ jobs:
           fi
 
           case "${TRIGGER_BRANCH}" in
-            main)
-              echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
-              echo "release_channel=stable" >> "$GITHUB_OUTPUT"
-              echo "checkout_ref=dev" >> "$GITHUB_OUTPUT"
-              echo "push_ref=dev" >> "$GITHUB_OUTPUT"
-              ;;
             homolog)
               echo "npm_tag=homolog" >> "$GITHUB_OUTPUT"
               echo "release_channel=homolog" >> "$GITHUB_OUTPUT"
@@ -117,11 +125,19 @@ jobs:
           echo "trigger_branch=${TRIGGER_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "Triggering branch: ${TRIGGER_BRANCH}"
 
+      - name: Require protected version writer credential
+        env:
+          VERSION_WRITER_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
+        run: |
+          [[ -n "${VERSION_WRITER_TOKEN}" ]] || {
+            echo "::error::VERSION_BUMP_PAT is required so version branch pushes trigger their downstream workflows"
+            exit 1
+          }
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # Bump the canonical target branch. main-triggered runs preserve the
-          # historical behavior of carrying the bump on dev; homolog-triggered
-          # runs bump homolog because HML images are built from homolog.
+          # Bump the canonical dev/homolog target branch. Stable main versions
+          # are fixed in their release PR and never created by this workflow.
           ref: ${{ steps.context.outputs.checkout_ref }}
           fetch-depth: 0
           # Machine-account PAT for the bump push (checkout persists this
@@ -131,9 +147,6 @@ jobs:
           # when the push actor is github-actions[bot], GitHub holds those
           # runs at `action_required`, wedging the PR until a human closes/
           # reopens it. Pushing as a machine account avoids the bot-actor hold.
-          # Fallback: while VERSION_BUMP_PAT is unset/empty this expression
-          # resolves to github.token — exactly the old behavior — so this is
-          # safe to merge before the secret exists.
           # Secret spec: fine-grained PAT on a machine account (e.g.
           # automagik-bot) scoped to automagik-dev/omni, Contents: read+write.
           # NOTE: unlike GITHUB_TOKEN, PAT pushes DO fire on:push workflows.
@@ -143,7 +156,7 @@ jobs:
           # MESSAGE, not the actor, and bump messages fail the startsWith
           # 'Merge pull request' check, so no re-fire loop. The v* TAG push
           # must NOT use the PAT: see "Commit and tag" below.
-          token: ${{ secrets.VERSION_BUMP_PAT || github.token }}
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
@@ -247,14 +260,13 @@ jobs:
       # guard); workflow_dispatch and repository_dispatch are the documented
       # exceptions, so this step kicks the orchestrator from version.yml.
       #
-      # Channel selector: main-branch builds publish to stable (the rolling
-      # PR dev→main promotion path), everything else publishes to dev.
-      # Mirrors genie wish release-channel-dev (PR #2419).
+      # Channel selector is dev/homolog only. Stable is finalized by the
+      # verified main image pipeline.
       - name: Build CLI
         run: bunx turbo run build --filter=@automagik/omni
 
       - name: Setup Node 24 (for npm OIDC publish)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -296,4 +308,100 @@ jobs:
             echo "::error ::release-trigger.dispatch_failed release.yml dispatch failed for ${TAG} — investigate gh CLI auth or workflow availability before re-running manually"
             exit 1
           fi
+
+  publish-stable:
+    name: Publish verified stable npm package
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.stable_publish_only == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+      packages: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Authorize verified stable orchestration
+        env:
+          ACTOR: ${{ github.actor }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          EXPECTED_DIGEST: ${{ inputs.expected_digest }}
+          ORCHESTRATOR_RUN_ID: ${{ inputs.orchestrator_run_id }}
+          ORCHESTRATOR_CONTROL_SHA: ${{ inputs.orchestrator_control_sha }}
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+        run: |
+          set -euo pipefail
+          [[ "${ACTOR}" == "github-actions[bot]" ]]
+          [[ "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${EXPECTED_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${ORCHESTRATOR_RUN_ID}" =~ ^[0-9]+$ ]]
+          [[ "${ORCHESTRATOR_CONTROL_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ORCHESTRATOR_RUN_ID}" > "${RUNNER_TEMP}/orchestrator.json"
+          scripts/release/verify-orchestrator-run.py \
+            --run-json "${RUNNER_TEMP}/orchestrator.json" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --source-sha "${ORCHESTRATOR_CONTROL_SHA}"
+          gh attestation verify "oci://${IMAGE}@${EXPECTED_DIGEST}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${EXPECTED_SHA}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/image-publish.yml"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.expected_sha }}
+          path: .stable-source
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Verify immutable stable identity
+        working-directory: .stable-source
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          [[ "${EXPECTED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(git rev-parse 'HEAD^{commit}')" == "${EXPECTED_SHA}" ]]
+          [[ "$(git rev-parse "refs/tags/v${EXPECTED_VERSION}^{commit}")" == "${EXPECTED_SHA}" ]]
+          [[ "$(node -p "require('./packages/cli/package.json').version")" == "${EXPECTED_VERSION}" ]]
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        working-directory: .stable-source
+        run: bun install --frozen-lockfile
+
+      - name: Build stable CLI
+        working-directory: .stable-source
+        run: bunx turbo run build --filter=@automagik/omni
+
+      - name: Setup Node 24 for npm trusted publishing
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish or verify existing stable npm package
+        working-directory: .stable-source
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          NPM_RECOVERY_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"
+        run: |
+          set -euo pipefail
+          "${GITHUB_WORKSPACE}/scripts/release/reconcile-npm-stable.sh" \
+            --expected "${EXPECTED_VERSION}" \
+            --package-dir "${GITHUB_WORKSPACE}/.stable-source/packages/cli"
 

--- a/deploy/helm/omni/templates/_helpers.tpl
+++ b/deploy/helm/omni/templates/_helpers.tpl
@@ -26,6 +26,23 @@ Fully qualified app name.
 {{- end }}
 
 {{/*
+Immutable omni-api image reference. A non-empty digest wins over tag and must
+be one lowercase sha256 digest; empty preserves the historical tag/appVersion
+rendering byte-for-byte.
+*/}}
+{{- define "omni.image" -}}
+{{- $digest := default "" .Values.image.digest -}}
+{{- if $digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $digest) -}}
+{{- fail "image.digest must be a lowercase sha256 digest (sha256 followed by 64 hexadecimal characters)" -}}
+{{- end -}}
+{{- printf "%s@%s" .Values.image.repository $digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default (printf "v%s" .Chart.AppVersion)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels.
 */}}
 {{- define "omni.labels" -}}

--- a/deploy/helm/omni/templates/deployment.yaml
+++ b/deploy/helm/omni/templates/deployment.yaml
@@ -74,9 +74,9 @@ spec:
       {{- end }}
       containers:
         - name: omni-api
-          # image.tag "" → v<Chart.appVersion>, the tag scheme image-publish.yml
-          # actually pushes (v<packages/cli version>).
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          # image.digest wins for immutable GitOps deploys; otherwise tag ""
+          # preserves the historical v<Chart.appVersion> default.
+          image: {{ include "omni.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deploy/helm/omni/values-prod-gitops.yaml
+++ b/deploy/helm/omni/values-prod-gitops.yaml
@@ -1,0 +1,15 @@
+# Immutable production deployment state consumed by Argo CD.
+#
+# This file intentionally owns only the omni-api artifact identity and its
+# human-readable provenance. Realm shape and AWS coordinates remain in
+# values-prod.yaml, values-prod-alb.yaml, and the central Argo Application.
+# CI may update this file after independently verifying the OCI index; it must
+# never call Helm or kubectl against production.
+image:
+  # Adoption pin: the image already running before Argo takes ownership.
+  # The verified v2.260830.2 pipeline replaces this digest only after adoption.
+  digest: sha256:c4ede7c3a0f8768a1307e5534c00f163b12eb89ba8d882e75a5cafaae16cd414
+
+gitopsRelease:
+  version: "2.260830.1"
+  sourceRevision: "01a1f26f206437d272c23035f1ae989f664aee72"

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -16,6 +16,10 @@ fullnameOverride: ""
 image:
   repository: ghcr.io/automagik-dev/omni-api
   tag: ""
+  # Optional immutable OCI index digest. When set, omni-api renders as
+  # repository@digest and tag/appVersion are ignored. Only lowercase sha256
+  # digests are accepted so GitOps cannot silently deploy a mutable alias.
+  digest: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 

--- a/scripts/ci/test-helm-image-digest.sh
+++ b/scripts/ci/test-helm-image-digest.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART="${ROOT}/deploy/helm/omni"
+HELM_BIN="${HELM_BIN:-helm}"
+PIN_VALUES="${CHART}/values-prod-gitops.yaml"
+VALID_DIGEST="sha256:c4ede7c3a0f8768a1307e5534c00f163b12eb89ba8d882e75a5cafaae16cd414"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+render() {
+  "${HELM_BIN}" template omni "${CHART}" "$@"
+}
+
+assert_count() {
+  local expected="$1" pattern="$2" file="$3" actual
+  actual="$(python3 - "$pattern" "$file" <<'PY'
+import re, sys
+pattern, path = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    print(len(re.findall(pattern, handle.read(), flags=re.MULTILINE)))
+PY
+)"
+  [[ "${actual}" == "${expected}" ]] || fail "expected ${expected} matches for ${pattern}, found ${actual}"
+}
+
+[[ -f "${PIN_VALUES}" ]] || fail "missing ${PIN_VALUES}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+render >"${work}/default.yaml"
+assert_count 1 'image: "ghcr\.io/automagik-dev/omni-api:v2\.260830\.1"' "${work}/default.yaml"
+
+render --set-string "image.digest=${VALID_DIGEST}" >"${work}/digest.yaml"
+assert_count 1 "image: \"ghcr\\.io/automagik-dev/omni-api@${VALID_DIGEST}\"" "${work}/digest.yaml"
+assert_count 0 'image: "ghcr\.io/automagik-dev/omni-api:' "${work}/digest.yaml"
+
+for invalid in \
+  'sha256:ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789' \
+  'sha256:abc123' \
+  'sha512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
+  'c4ede7c3a0f8768a1307e5534c00f163b12eb89ba8d882e75a5cafaae16cd414'; do
+  if render --set-string "image.digest=${invalid}" >"${work}/invalid.yaml" 2>"${work}/invalid.err"; then
+    fail "invalid digest rendered successfully: ${invalid}"
+  fi
+  python3 - "${work}/invalid.err" <<'PY' || fail "invalid digest did not report a useful error"
+import sys
+text = open(sys.argv[1], encoding="utf-8").read().lower()
+raise SystemExit(0 if "sha256" in text and "digest" in text else 1)
+PY
+done
+
+render \
+  -f "${CHART}/values-prod.yaml" \
+  -f "${CHART}/values-prod-alb.yaml" \
+  -f "${PIN_VALUES}" \
+  --set-string ingress.host=omni.khal.ai \
+  --set-string 'ingress.annotations.alb\.ingress\.kubernetes\.io/certificate-arn=arn:aws:acm:sa-east-1:000000000000:certificate/00000000-0000-0000-0000-000000000000' \
+  --set-string 'serviceAccount.annotations.eks\.amazonaws\.com/role-arn=arn:aws:iam::000000000000:role/omni-media' \
+  >"${work}/prod.yaml"
+
+assert_count 1 "image: \"ghcr\\.io/automagik-dev/omni-api@${VALID_DIGEST}\"" "${work}/prod.yaml"
+assert_count 1 '^kind: HorizontalPodAutoscaler$' "${work}/prod.yaml"
+assert_count 1 '^  minReplicas: 2$' "${work}/prod.yaml"
+assert_count 1 '^  maxReplicas: 2$' "${work}/prod.yaml"
+assert_count 1 '^kind: PodDisruptionBudget$' "${work}/prod.yaml"
+assert_count 0 '^kind: (Deployment|StatefulSet)\nmetadata:\n  name: .*admin' "${work}/prod.yaml"
+assert_count 0 '^kind: Deployment\nmetadata:\n  name: .*autopg' "${work}/prod.yaml"
+assert_count 0 '^kind: StatefulSet\nmetadata:\n  name: .*minio' "${work}/prod.yaml"
+assert_count 1 '^                  name: omni-db$' "${work}/prod.yaml"
+assert_count 1 '^              mountPath: /etc/omni/db-tls$' "${work}/prod.yaml"
+assert_count 1 '^    eks\.amazonaws\.com/role-arn: arn:aws:iam::000000000000:role/omni-media$' "${work}/prod.yaml"
+assert_count 0 'OMNI_MEDIA_S3_ACCESS_KEY' "${work}/prod.yaml"
+assert_count 1 '^kind: StatefulSet\nmetadata:\n  name: omni-nats$' "${work}/prod.yaml"
+assert_count 1 '^  volumeClaimTemplates:$' "${work}/prod.yaml"
+assert_count 1 '^        storageClassName: "gp3"$' "${work}/prod.yaml"
+assert_count 1 '^            storage: "8Gi"$' "${work}/prod.yaml"
+
+printf 'PASS: Helm digest and production GitOps render contract\n'

--- a/scripts/release/authorize-release-entry.py
+++ b/scripts/release/authorize-release-entry.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import argparse
+import re
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"release entry authorization failed: {message}")
+
+
+parser = argparse.ArgumentParser(description="Classify reusable orchestration versus direct recovery")
+parser.add_argument("--channel", required=True, choices=("stable", "homolog", "dev"))
+parser.add_argument("--orchestrated", required=True, choices=("true", "false"))
+parser.add_argument("--recovery-run-id", default="")
+args = parser.parse_args()
+
+orchestrated = args.orchestrated == "true"
+if args.channel == "stable" and not orchestrated:
+    fail("direct stable workflow_dispatch is disabled; use verified image orchestration")
+if orchestrated:
+    if args.recovery_run_id:
+        fail("orchestrated publication must use artifacts from its current run")
+    print("mode=orchestrated")
+else:
+    if re.fullmatch(r"[0-9]+", args.recovery_run_id) is None:
+        fail("direct recovery requires an exact numeric sign-attest run ID")
+    print("mode=recovery")

--- a/scripts/release/authorize-release-entry.test.sh
+++ b/scripts/release/authorize-release-entry.test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/authorize-release-entry.py"
+if "${SCRIPT}" --channel stable --orchestrated false --recovery-run-id 123; then
+  echo 'FAIL: direct stable dispatch was accepted' >&2; exit 1
+fi
+[[ "$("${SCRIPT}" --channel stable --orchestrated true)" == 'mode=orchestrated' ]]
+[[ "$("${SCRIPT}" --channel dev --orchestrated true)" == 'mode=orchestrated' ]]
+[[ "$("${SCRIPT}" --channel homolog --orchestrated false --recovery-run-id 123)" == 'mode=recovery' ]]
+if "${SCRIPT}" --channel dev --orchestrated false --recovery-run-id '1; touch /tmp/injected'; then
+  echo 'FAIL: invalid recovery run id was accepted' >&2; exit 1
+fi
+printf 'PASS: reusable versus direct release entry contract\n'

--- a/scripts/release/classify-image-change.sh
+++ b/scripts/release/classify-image-change.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+before=""
+after=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --before) before="${2:-}"; shift 2 ;;
+    --after) after="${2:-}"; shift 2 ;;
+    *) echo "classify image change failed: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+[[ "${before}" =~ ^[0-9a-f]{40}$ ]] || { echo 'classify image change failed: invalid before SHA' >&2; exit 1; }
+[[ -n "${after}" ]] || { echo 'classify image change failed: missing after revision' >&2; exit 1; }
+after_sha=$(git rev-parse "${after}^{commit}")
+zero=0000000000000000000000000000000000000000
+if [[ "${before}" == "${zero}" ]]; then
+  base=$(git hash-object -t tree /dev/null)
+else
+  git cat-file -e "${before}^{commit}" 2>/dev/null || {
+    echo "classify image change failed: before commit is unavailable: ${before}" >&2
+    exit 1
+  }
+  base="${before}"
+fi
+changed_output="$(git diff --name-only "${base}" "${after_sha}")" || {
+  echo "classify image change failed: could not inspect ${base}..${after_sha}" >&2
+  exit 1
+}
+changed=()
+while IFS= read -r path; do
+  [[ -n "${path}" ]] && changed+=("${path}")
+done <<<"${changed_output}"
+if [[ ${#changed[@]} -eq 1 && "${changed[0]}" == "deploy/helm/omni/values-prod-gitops.yaml" ]]; then
+  printf '%s\n' 'pin_only=true' 'infra_only=false' 'build_required=false'
+  exit 0
+fi
+infra_only=true
+if [[ ${#changed[@]} -eq 0 ]]; then
+  infra_only=false
+fi
+for path in "${changed[@]}"; do
+  case "${path}" in
+    .github/workflows/*|scripts/release/*|scripts/ci/*|deploy/helm/*) ;;
+    *) infra_only=false ;;
+  esac
+done
+if [[ "${infra_only}" == "true" ]]; then
+  printf '%s\n' 'pin_only=false' 'infra_only=true' 'build_required=false'
+else
+  printf '%s\n' 'pin_only=false' 'infra_only=false' 'build_required=true'
+fi

--- a/scripts/release/classify-image-change.test.sh
+++ b/scripts/release/classify-image-change.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/classify-image-change.sh"
+work=$(mktemp -d)
+trap 'rm -rf "${work}"' EXIT
+git -C "${work}" init -q
+git -C "${work}" config user.name test
+git -C "${work}" config user.email test@example.com
+mkdir -p "${work}/packages/api" "${work}/scripts/release" "${work}/deploy/helm/omni"
+printf 'base\n' >"${work}/README.md"
+git -C "${work}" add . && git -C "${work}" commit -qm base
+base=$(git -C "${work}" rev-parse HEAD)
+printf 'app\n' >"${work}/packages/api/index.ts"
+git -C "${work}" add . && git -C "${work}" commit -qm app
+printf 'infra\n' >"${work}/scripts/release/contract.sh"
+git -C "${work}" add . && git -C "${work}" commit -qm infra
+out=$(cd "${work}" && "${SCRIPT}" --before "${base}" --after HEAD)
+grep -qx 'build_required=true' <<<"${out}"
+grep -qx 'infra_only=false' <<<"${out}"
+
+git -C "${work}" checkout -q -b infra-only "${base}"
+mkdir -p "${work}/.github/workflows" "${work}/scripts/release"
+printf 'name: x\n' >"${work}/.github/workflows/x.yml"
+printf 'infra\n' >"${work}/scripts/release/x.sh"
+git -C "${work}" add . && git -C "${work}" commit -qm infra1
+printf 'infra2\n' >>"${work}/scripts/release/x.sh"
+git -C "${work}" commit -qam infra2
+out=$(cd "${work}" && "${SCRIPT}" --before "${base}" --after HEAD)
+grep -qx 'build_required=false' <<<"${out}"
+grep -qx 'infra_only=true' <<<"${out}"
+
+git -C "${work}" checkout -q -b pin-only "${base}"
+printf 'image:\n' >"${work}/deploy/helm/omni/values-prod-gitops.yaml"
+git -C "${work}" add . && git -C "${work}" commit -qm pin
+out=$(cd "${work}" && "${SCRIPT}" --before "${base}" --after HEAD)
+grep -qx 'pin_only=true' <<<"${out}"
+
+out=$(cd "${work}" && "${SCRIPT}" --before 0000000000000000000000000000000000000000 --after HEAD)
+grep -qx 'build_required=true' <<<"${out}"
+
+real_git=$(command -v git)
+mkdir -p "${work}/mock-bin"
+cat >"${work}/mock-bin/git" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "diff" ]]; then
+  exit 90
+fi
+exec "${REAL_GIT}" "$@"
+SH
+chmod +x "${work}/mock-bin/git"
+if (cd "${work}" && PATH="${work}/mock-bin:${PATH}" REAL_GIT="${real_git}" \
+  "${SCRIPT}" --before "${base}" --after HEAD >/dev/null 2>&1); then
+  echo 'classification hid a git diff failure' >&2
+  exit 1
+fi
+printf 'PASS: full push-range image classification contract\n'

--- a/scripts/release/pin-production-image.sh
+++ b/scripts/release/pin-production-image.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: pin-production-image.sh --version VERSION --digest sha256:... \
+  --source-sha FULL_SHA --expected-parent FULL_SHA [--file PATH]
+EOF
+  exit 2
+}
+
+fail() {
+  printf 'production pin failed: %s\n' "$*" >&2
+  exit 1
+}
+
+version=""
+digest=""
+source_sha=""
+expected_parent=""
+pin_file="deploy/helm/omni/values-prod-gitops.yaml"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) version="${2:-}"; shift 2 ;;
+    --digest) digest="${2:-}"; shift 2 ;;
+    --source-sha) source_sha="${2:-}"; shift 2 ;;
+    --expected-parent) expected_parent="${2:-}"; shift 2 ;;
+    --file) pin_file="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "${version}" && -n "${digest}" && -n "${source_sha}" && -n "${expected_parent}" ]] || usage
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "version must be numeric dotted form"
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "digest must be lowercase sha256 with 64 hexadecimal characters"
+[[ "${source_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "source SHA must be 40 lowercase hexadecimal characters"
+[[ "${expected_parent}" =~ ^[0-9a-f]{40}$ ]] || fail "expected parent must be 40 lowercase hexadecimal characters"
+[[ -f "${pin_file}" ]] || fail "pin file does not exist: ${pin_file}"
+
+actual_parent="$(git rev-parse HEAD^{commit})"
+[[ "${actual_parent}" == "${expected_parent}" ]] || fail "HEAD ${actual_parent} moved from expected parent ${expected_parent}"
+if ! git diff --quiet -- "${pin_file}" || ! git diff --cached --quiet -- "${pin_file}"; then
+  fail "pin file has uncommitted changes"
+fi
+
+changed="$(PIN_FILE="${pin_file}" PIN_VERSION="${version}" PIN_DIGEST="${digest}" PIN_SOURCE_SHA="${source_sha}" python3 - <<'PY'
+import os, re
+from pathlib import Path
+
+path = Path(os.environ["PIN_FILE"])
+target_version = os.environ["PIN_VERSION"]
+target_digest = os.environ["PIN_DIGEST"]
+target_source = os.environ["PIN_SOURCE_SHA"]
+text = path.read_text(encoding="utf-8")
+
+patterns = {
+    "digest": re.compile(r"^(\s*digest:\s*)(sha256:[0-9a-f]{64})(\s*)$", re.MULTILINE),
+    "version": re.compile(r'^(\s*version:\s*)"([0-9]+\.[0-9]+\.[0-9]+)"(\s*)$', re.MULTILINE),
+    "source": re.compile(r'^(\s*sourceRevision:\s*)"([0-9a-f]{40})"(\s*)$', re.MULTILINE),
+}
+for name, pattern in patterns.items():
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise SystemExit(f"production pin failed: expected exactly one {name} field, found {len(matches)}")
+
+current_digest = patterns["digest"].search(text).group(2)
+current_version = patterns["version"].search(text).group(2)
+current_source = patterns["source"].search(text).group(2)
+
+def numeric(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+if numeric(target_version) < numeric(current_version):
+    raise SystemExit(f"production pin failed: refusing version downgrade {current_version} -> {target_version}")
+if target_version == current_version:
+    if current_digest != target_digest or current_source != target_source:
+        raise SystemExit("production pin failed: version is already bound to a different digest or source revision")
+    print("false")
+    raise SystemExit(0)
+
+text = patterns["digest"].sub(lambda m: f"{m.group(1)}{target_digest}{m.group(3)}", text)
+text = patterns["version"].sub(lambda m: f'{m.group(1)}"{target_version}"{m.group(3)}', text)
+text = patterns["source"].sub(lambda m: f'{m.group(1)}"{target_source}"{m.group(3)}', text)
+path.write_text(text, encoding="utf-8")
+print("true")
+PY
+)"
+
+output="${GITHUB_OUTPUT:-/dev/stdout}"
+{
+  printf 'changed=%s\n' "${changed}"
+  printf 'version=%s\n' "${version}"
+  printf 'digest=%s\n' "${digest}"
+  printf 'source_sha=%s\n' "${source_sha}"
+  printf 'expected_parent=%s\n' "${expected_parent}"
+  printf 'pin_file=%s\n' "${pin_file}"
+} >>"${output}"

--- a/scripts/release/pin-production-image.test.sh
+++ b/scripts/release/pin-production-image.test.sh
@@ -38,6 +38,10 @@ PARENT="$(git -C "${repo}" rev-parse HEAD)"
 
 run_pin() {
   (
+    # GitHub Actions exports this for every step. The fixture asserts the
+    # command's stdout contract, so do not let the runner redirect it to the
+    # workflow output file while this unit test is capturing stdout.
+    unset GITHUB_OUTPUT
     cd "${repo}"
     "${SCRIPT}" \
       --version 2.260830.2 \

--- a/scripts/release/pin-production-image.test.sh
+++ b/scripts/release/pin-production-image.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/pin-production-image.sh"
+OLD_DIGEST="sha256:c4ede7c3a0f8768a1307e5534c00f163b12eb89ba8d882e75a5cafaae16cd414"
+NEW_DIGEST="sha256:dba9b81cead5efacf9303ab75487a762fa100992dc2bb52741524a7a036b2da8"
+OTHER_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+SOURCE_SHA="b8c1bf20cd42b1e30974fc8d67f2b7d0fb620031"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+repo="${work}/repo"
+mkdir -p "${repo}/deploy/helm/omni"
+cat >"${repo}/deploy/helm/omni/values-prod-gitops.yaml" <<EOF
+image:
+  digest: ${OLD_DIGEST}
+
+gitopsRelease:
+  version: "2.260830.1"
+  sourceRevision: "01a1f26f206437d272c23035f1ae989f664aee72"
+EOF
+(
+  cd "${repo}"
+  git init -q
+  git config user.name test
+  git config user.email test@example.com
+  git add .
+  git commit -qm fixture
+)
+PARENT="$(git -C "${repo}" rev-parse HEAD)"
+
+run_pin() {
+  (
+    cd "${repo}"
+    "${SCRIPT}" \
+      --version 2.260830.2 \
+      --digest "${NEW_DIGEST}" \
+      --source-sha "${SOURCE_SHA}" \
+      --expected-parent "${PARENT}" \
+      "$@"
+  )
+}
+
+run_pin >"${work}/changed.out"
+python3 - "${work}/changed.out" "${repo}/deploy/helm/omni/values-prod-gitops.yaml" <<'PY' || fail "upgrade pin did not update exactly"
+import sys
+out = open(sys.argv[1], encoding="utf-8").read()
+text = open(sys.argv[2], encoding="utf-8").read()
+expected = {
+  "changed=true",
+  "version=2.260830.2",
+  "digest=sha256:dba9b81cead5efacf9303ab75487a762fa100992dc2bb52741524a7a036b2da8",
+  "source_sha=b8c1bf20cd42b1e30974fc8d67f2b7d0fb620031",
+}
+if not all(x in out for x in expected): raise SystemExit(1)
+if text.count("digest:") != 1 or text.count("version:") != 1 or text.count("sourceRevision:") != 1: raise SystemExit(1)
+if "2.260830.2" not in text or "dba9b81c" not in text or "b8c1bf20" not in text: raise SystemExit(1)
+PY
+
+git -C "${repo}" add deploy/helm/omni/values-prod-gitops.yaml
+git -C "${repo}" commit -qm pinned
+PARENT="$(git -C "${repo}" rev-parse HEAD)"
+run_pin >"${work}/same.out"
+python3 - "${work}/same.out" <<'PY' || fail "idempotent pin did not no-op"
+import sys
+raise SystemExit(0 if "changed=false" in open(sys.argv[1], encoding="utf-8").read() else 1)
+PY
+[[ -z "$(git -C "${repo}" status --porcelain)" ]] || fail "idempotent pin dirtied the tree"
+
+if (
+  cd "${repo}"
+  "${SCRIPT}" --version 2.260830.1 --digest "${OLD_DIGEST}" --source-sha "${SOURCE_SHA}" --expected-parent "${PARENT}"
+) >"${work}/downgrade.out" 2>"${work}/downgrade.err"; then
+  fail "version downgrade was accepted"
+fi
+
+if (
+  cd "${repo}"
+  "${SCRIPT}" --version 2.260830.2 --digest "${OTHER_DIGEST}" --source-sha "${SOURCE_SHA}" --expected-parent "${PARENT}"
+) >"${work}/rebind.out" 2>"${work}/rebind.err"; then
+  fail "existing version was rebound to a different digest"
+fi
+
+if (
+  cd "${repo}"
+  "${SCRIPT}" --version 2.260830.3 --digest sha256:ABC --source-sha "${SOURCE_SHA}" --expected-parent "${PARENT}"
+) >"${work}/invalid.out" 2>"${work}/invalid.err"; then
+  fail "invalid digest was accepted"
+fi
+
+if (
+  cd "${repo}"
+  "${SCRIPT}" --version 2.260830.3 --digest "${OTHER_DIGEST}" --source-sha "${SOURCE_SHA}" --expected-parent 0000000000000000000000000000000000000000
+) >"${work}/parent.out" 2>"${work}/parent.err"; then
+  fail "wrong expected parent was accepted"
+fi
+
+printf 'PASS: race-safe production digest pin contract\n'

--- a/scripts/release/reconcile-npm-stable.sh
+++ b/scripts/release/reconcile-npm-stable.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  printf 'Usage: reconcile-npm-stable.sh --expected VERSION --package-dir PATH\n' >&2
+  exit 2
+}
+fail() { printf 'npm stable reconciliation failed: %s\n' "$*" >&2; exit 1; }
+
+expected=""
+package_dir=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expected) expected="${2:-}"; shift 2 ;;
+    --package-dir) package_dir="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ "${expected}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && -d "${package_dir}" ]] || usage
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+state_helper="${script_dir}/verify-npm-stable-state.sh"
+artifact_helper="${script_dir}/verify-npm-artifact.py"
+[[ -x "${state_helper}" ]] || fail "state verifier is unavailable"
+[[ -x "${artifact_helper}" ]] || fail "artifact verifier is unavailable"
+
+# Keep the recovery credential out of every package lifecycle process. Only
+# the repair_latest branch reintroduces it as NODE_AUTH_TOKEN for one command.
+recovery_token="${NPM_RECOVERY_TOKEN:-}"
+unset NPM_RECOVERY_TOKEN NODE_AUTH_TOKEN
+pack_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/omni-npm-pack.XXXXXX")"
+audit_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/omni-npm-audit.XXXXXX")"
+pack_output="${pack_dir}/npm-pack.out"
+if ! (cd "${package_dir}" && npm pack --json --silent --pack-destination "${pack_dir}") >"${pack_output}"; then
+  cat "${pack_output}" >&2 || true
+  fail "npm pack failed"
+fi
+pack_name="$(python3 - "${pack_output}" <<'PY'
+import json, pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+found = ""
+for index, char in enumerate(text):
+    if char != "[":
+        continue
+    try:
+        value, end = json.JSONDecoder().raw_decode(text[index:])
+    except json.JSONDecodeError:
+        continue
+    if not text[index + end:].strip() and isinstance(value, list) and len(value) == 1:
+        item = value[0]
+        if isinstance(item, dict) and isinstance(item.get("filename"), str):
+            found = item["filename"]
+if not found:
+    raise SystemExit("could not parse final npm pack JSON")
+print(found)
+PY
+)"
+[[ -n "${pack_name}" && -f "${pack_dir}/${pack_name##*/}" ]] || \
+  fail "npm pack did not produce exactly one expected tarball"
+tarball="${pack_dir}/${pack_name##*/}"
+
+read_published() {
+  local error_file="$1" value=""
+  if ! value="$(npm view "@automagik/omni@${expected}" version 2>"${error_file}")"; then
+    local error_text
+    error_text="$(<"${error_file}")"
+    case "${error_text}" in
+      *E404*|*"404 Not Found"*) value="" ;;
+      *) fail "npm registry lookup failed without a not-found response" ;;
+    esac
+  fi
+  printf '%s\n' "${value}"
+}
+
+error_file="${RUNNER_TEMP:-/tmp}/npm-view-${$}.err"
+dist_file="${RUNNER_TEMP:-/tmp}/npm-dist-${$}.json"
+keys_file="${RUNNER_TEMP:-/tmp}/npm-keys-${$}.json"
+trap 'rm -f "${error_file}" "${dist_file}" "${keys_file}"; rm -rf "${pack_dir}" "${audit_dir}"' EXIT
+published="$(read_published "${error_file}")"
+latest="$(npm view @automagik/omni dist-tags --json | jq -r '.latest // empty')"
+state="$("${state_helper}" --expected "${expected}" --published "${published}" --latest "${latest}")"
+action="${state#npm_action=}"
+
+case "${action}" in
+  none)
+    ;;
+  publish)
+    npm publish "${tarball}" --access public --tag latest
+    ;;
+  repair_latest)
+    [[ -n "${recovery_token}" ]] || \
+      fail "NPM_RECOVERY_TOKEN is required to repair an existing package's latest dist-tag"
+    NODE_AUTH_TOKEN="${recovery_token}" \
+      npm dist-tag add "@automagik/omni@${expected}" latest
+    ;;
+  *) fail "unexpected state action ${action}" ;;
+esac
+
+published_after="$(npm view "@automagik/omni@${expected}" version)"
+latest_after="$(npm view @automagik/omni dist-tags --json | jq -r '.latest // empty')"
+final_state="$("${state_helper}" \
+  --expected "${expected}" --published "${published_after}" --latest "${latest_after}")"
+[[ "${final_state}" == "npm_action=none" ]] || \
+  fail "registry state did not converge after ${action}"
+npm view "@automagik/omni@${expected}" dist --json > "${dist_file}"
+integrity="$(jq -r '.integrity // empty' "${dist_file}")"
+resolved="$(jq -r '.tarball // empty' "${dist_file}")"
+expected_url="https://registry.npmjs.org/@automagik/omni/-/omni-${expected}.tgz"
+[[ -n "${integrity}" && "${resolved}" == "${expected_url}" ]] || \
+  fail "registry metadata is missing an approved npm tarball URL"
+registry_tarball="${pack_dir}/registry-omni-${expected}.tgz"
+curl -fsSLo "${registry_tarball}" "${resolved}"
+curl -fsSLo "${keys_file}" "https://registry.npmjs.org/-/npm/v1/keys"
+"${artifact_helper}" --expected-tarball "${tarball}" \
+  --registry-tarball "${registry_tarball}" --dist-json "${dist_file}" \
+  --keys-json "${keys_file}" --package @automagik/omni --version "${expected}" >/dev/null
+jq -n --arg version "${expected}" \
+  '{name:"omni-signature-audit",version:"0.0.0",private:true,dependencies:{"@automagik/omni":$version}}' \
+  > "${audit_dir}/package.json"
+(
+  cd "${audit_dir}"
+  npm install --ignore-scripts --no-audit --no-fund >/dev/null
+  npm audit signatures --json --include-attestations > "${audit_dir}/audit.json"
+)
+if [[ "${action}" == "publish" ]]; then
+  python3 - "${audit_dir}/audit.json" "${expected}" <<'PY'
+import json, pathlib, sys
+document = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+matches = [
+    item for item in document.get("verified", [])
+    if isinstance(item, dict)
+    and item.get("name") == "@automagik/omni"
+    and item.get("version") == sys.argv[2]
+]
+if len(matches) != 1:
+    raise SystemExit("new npm publication has no verified package attestation")
+provenance = matches[0].get("attestations", {}).get("provenance", {})
+if provenance.get("predicateType") != "https://slsa.dev/provenance/v1":
+    raise SystemExit("new npm publication has no verified SLSA provenance")
+PY
+fi
+printf 'npm_action=%s\n' "${action}"

--- a/scripts/release/reconcile-npm-stable.test.sh
+++ b/scripts/release/reconcile-npm-stable.test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/reconcile-npm-stable.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+mkdir -p "${work}/bin" "${work}/package"
+printf '{"version":"2.260830.2"}\n' > "${work}/package/package.json"
+openssl ecparam -name prime256v1 -genkey -noout -out "${work}/private.pem"
+openssl pkey -in "${work}/private.pem" -pubout -outform DER -out "${work}/public.der"
+key_id="$(python3 - "${work}/public.der" <<'PY'
+import base64, hashlib, pathlib, sys
+print('SHA256:' + base64.b64encode(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).digest()).decode())
+PY
+)"
+cat > "${work}/bin/npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${MOCK_STATE_DIR}"
+if [[ "${1:-}" == "pack" ]]; then
+  [[ -z "${NPM_RECOVERY_TOKEN:-}" && -z "${NODE_AUTH_TOKEN:-}" ]] || exit 90
+  destination=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--pack-destination" ]]; then destination="$2"; break; fi
+    shift
+  done
+  [[ -n "${destination}" ]]
+  python3 - "${destination}/omni-2.260830.2.tgz" <<'PY'
+import io, tarfile, sys
+with tarfile.open(sys.argv[1], 'w:gz') as archive:
+    raw = b'expected package bytes\n'
+    info = tarfile.TarInfo('package/index.js')
+    info.size = len(raw)
+    info.mode = 0o644
+    archive.addfile(info, io.BytesIO(raw))
+PY
+  cp "${destination}/omni-2.260830.2.tgz" "${state}/expected.tgz"
+  printf '[{"filename":"omni-2.260830.2.tgz"}]\n'
+  exit 0
+fi
+case "${1:-} ${2:-} ${3:-}" in
+  "view @automagik/omni@2.260830.2 version")
+    [[ -f "${state}/published" ]] || { echo 'E404 404 Not Found' >&2; exit 1; }
+    cat "${state}/published"
+    ;;
+  "view @automagik/omni dist-tags")
+    latest="$(cat "${state}/latest" 2>/dev/null || true)"
+    printf '{"latest":"%s"}\n' "${latest}"
+    ;;
+  "view @automagik/omni@2.260830.2 dist")
+    [[ -f "${state}/published" ]] || exit 93
+    python3 - "${state}/expected.tgz" "${MOCK_WRONG_ARTIFACT:-false}" <<'PY'
+import base64, hashlib, json, os, pathlib, subprocess, sys
+raw = pathlib.Path(sys.argv[1]).read_bytes()
+if sys.argv[2] == 'true': raw += b'wrong'
+integrity = 'sha512-' + base64.b64encode(hashlib.sha512(raw).digest()).decode()
+payload = f'@automagik/omni@2.260830.2:{integrity}'.encode()
+signature = subprocess.run(
+    ['openssl', 'dgst', '-sha256', '-sign', os.environ['MOCK_PRIVATE_KEY']],
+    input=payload, check=True, capture_output=True,
+).stdout
+print(json.dumps({
+    'integrity': integrity,
+    'shasum': hashlib.sha1(raw).hexdigest(),
+    'tarball': 'https://registry.npmjs.org/@automagik/omni/-/omni-2.260830.2.tgz',
+    'signatures': [{'keyid': os.environ['MOCK_KEY_ID'], 'sig': base64.b64encode(signature).decode()}],
+}))
+PY
+    ;;
+  "audit signatures --json")
+    [[ -z "${NPM_RECOVERY_TOKEN:-}" && -z "${NODE_AUTH_TOKEN:-}" ]] || exit 95
+    [[ "${MOCK_AUDIT_FAIL:-false}" != "true" ]] || exit 96
+    if [[ "${MOCK_NO_ATTESTATIONS:-false}" == "true" ]]; then
+      printf '{"verified":[]}\n'
+    else
+      printf '{"verified":[{"name":"@automagik/omni","version":"2.260830.2","attestations":{"provenance":{"predicateType":"https://slsa.dev/provenance/v1"}}}]}\n'
+    fi
+    ;;
+  "install --ignore-scripts --no-audit")
+    [[ -z "${NPM_RECOVERY_TOKEN:-}" && -z "${NODE_AUTH_TOKEN:-}" ]] || exit 97
+    ;;
+  publish*)
+    [[ -z "${NPM_RECOVERY_TOKEN:-}" && -z "${NODE_AUTH_TOKEN:-}" ]] || exit 94
+    printf 'publish\n' >> "${state}/mutations"
+    printf '2.260830.2\n' > "${state}/published"
+    if [[ "${MOCK_NO_CONVERGE:-false}" != "true" ]]; then
+      printf '2.260830.2\n' > "${state}/latest"
+    fi
+    ;;
+  "dist-tag add @automagik/omni@2.260830.2")
+    [[ -n "${NODE_AUTH_TOKEN:-}" ]] || exit 91
+    printf 'repair_latest\n' >> "${state}/mutations"
+    if [[ "${MOCK_NO_CONVERGE:-false}" != "true" ]]; then
+      printf '2.260830.2\n' > "${state}/latest"
+    fi
+    ;;
+  *)
+    printf 'unexpected npm invocation: %s\n' "$*" >&2
+    exit 92
+    ;;
+esac
+SH
+chmod +x "${work}/bin/npm"
+cat > "${work}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "-fsSLo" && -n "${2:-}" ]]
+if [[ "${3:-}" == "https://registry.npmjs.org/-/npm/v1/keys" ]]; then
+  python3 - "${MOCK_PUBLIC_KEY}" "${MOCK_KEY_ID}" "$2" <<'PY'
+import base64, json, pathlib, sys
+public = pathlib.Path(sys.argv[1]).read_bytes()
+pathlib.Path(sys.argv[3]).write_text(json.dumps({'keys': [{
+    'keyid': sys.argv[2], 'keytype': 'ecdsa-sha2-nistp256',
+    'scheme': 'ecdsa-sha2-nistp256', 'key': base64.b64encode(public).decode(),
+}]}))
+PY
+else
+  cp "${MOCK_STATE_DIR}/expected.tgz" "$2"
+fi
+SH
+chmod +x "${work}/bin/curl"
+
+run_case() {
+  local state="$1"
+  shift
+  mkdir -p "${state}"
+  PATH="${work}/bin:${PATH}" MOCK_STATE_DIR="${state}" \
+    MOCK_PRIVATE_KEY="${work}/private.pem" MOCK_PUBLIC_KEY="${work}/public.der" MOCK_KEY_ID="${key_id}" \
+    "${SCRIPT}" --expected 2.260830.2 --package-dir "${work}/package" "$@"
+}
+
+exact="${work}/exact"
+mkdir -p "${exact}"
+printf '2.260830.2\n' > "${exact}/published"
+printf '2.260830.2\n' > "${exact}/latest"
+out="$(run_case "${exact}")"
+grep -q '^npm_action=none$' <<<"${out}" || fail "exact state was not idempotent"
+[[ ! -e "${exact}/mutations" ]] || fail "exact state mutated npm"
+
+missing="${work}/missing"
+out="$(run_case "${missing}")"
+grep -q '^npm_action=publish$' <<<"${out}" || fail "missing package was not published"
+[[ "$(cat "${missing}/latest")" == "2.260830.2" ]] || fail "publish did not converge latest"
+
+repair="${work}/repair"
+mkdir -p "${repair}"
+printf '2.260830.2\n' > "${repair}/published"
+printf '2.260830.1\n' > "${repair}/latest"
+out="$(NPM_RECOVERY_TOKEN=token run_case "${repair}")"
+grep -q '^npm_action=repair_latest$' <<<"${out}" || fail "latest drift was not repaired"
+[[ "$(cat "${repair}/latest")" == "2.260830.2" ]] || fail "latest repair did not converge"
+
+no_token="${work}/no-token"
+mkdir -p "${no_token}"
+printf '2.260830.2\n' > "${no_token}/published"
+printf '2.260830.1\n' > "${no_token}/latest"
+if run_case "${no_token}" >"${work}/no-token.out" 2>"${work}/no-token.err"; then
+  fail "latest repair succeeded without NPM_RECOVERY_TOKEN"
+fi
+
+no_converge="${work}/no-converge"
+if MOCK_NO_CONVERGE=true run_case "${no_converge}" >"${work}/no-converge.out" 2>"${work}/no-converge.err"; then
+  fail "publish succeeded without exact post-mutation readback convergence"
+fi
+
+wrong_artifact="${work}/wrong-artifact"
+mkdir -p "${wrong_artifact}"
+printf '2.260830.2\n' > "${wrong_artifact}/published"
+printf '2.260830.2\n' > "${wrong_artifact}/latest"
+if MOCK_WRONG_ARTIFACT=true run_case "${wrong_artifact}" >"${work}/wrong-artifact.out" 2>"${work}/wrong-artifact.err"; then
+  fail "registry version/tag state accepted wrong package bytes"
+fi
+
+bad_signature="${work}/bad-signature"
+mkdir -p "${bad_signature}"
+printf '2.260830.2\n' > "${bad_signature}/published"
+printf '2.260830.2\n' > "${bad_signature}/latest"
+if MOCK_AUDIT_FAIL=true run_case "${bad_signature}" >"${work}/bad-signature.out" 2>"${work}/bad-signature.err"; then
+  fail "failed npm signature/provenance audit was accepted"
+fi
+
+no_provenance="${work}/no-provenance"
+if MOCK_NO_ATTESTATIONS=true run_case "${no_provenance}" >"${work}/no-provenance.out" 2>"${work}/no-provenance.err"; then
+  fail "new trusted publication without verified SLSA provenance was accepted"
+fi
+
+printf 'PASS: token-isolated npm publish, latest repair, and exact signed artifact readback contract\n'

--- a/scripts/release/release-workflow-contract.test.sh
+++ b/scripts/release/release-workflow-contract.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/image-publish.yml"
+CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+SOURCE_CONTRACT="${ROOT}/scripts/release/verify-release-source.sh"
+REMOTE_TAG_CONTRACT="${ROOT}/scripts/release/verify-remote-tag.sh"
+
+python3 - "${WORKFLOW}" "${CI_WORKFLOW}" "${SOURCE_CONTRACT}" "${REMOTE_TAG_CONTRACT}" <<'PY'
+import re, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+ci = Path(sys.argv[2]).read_text(encoding="utf-8")
+source_contract = Path(sys.argv[3]).read_text(encoding="utf-8")
+remote_tag_contract = Path(sys.argv[4]).read_text(encoding="utf-8")
+errors: list[str] = []
+
+def require(pattern: str, message: str) -> None:
+    if re.search(pattern, text, flags=re.MULTILINE) is None:
+        errors.append(message)
+
+def forbid(pattern: str, message: str) -> None:
+    if re.search(pattern, text, flags=re.MULTILINE | re.IGNORECASE) is not None:
+        errors.append(message)
+
+require(r"^\s+repair_release:\s*$", "workflow_dispatch must expose repair_release")
+require(r"^\s+expected_version:\s*$", "repair must require an expected version")
+require(r"^\s+expected_sha:\s*$", "repair must require an expected source SHA")
+require(r"^\s+expected_existing_digest:\s*$", "repair must accept an idempotent existing digest")
+require(r"manual dispatches must set repair_release=true", "a non-repair manual dispatch can move immutable version tags")
+require(r"^\s+cancel-in-progress:\s+false\s*$", "release/image publication must never cancel in progress")
+require(r"verify-oci-release\.sh", "immutable release preflight is not wired")
+require(r"ref:\s*\$\{\{\s*github\.workflow_sha\s*\}\}[\s\S]{0,500}if:\s*\$\{\{\s*inputs\.repair_release\s*\}\}[\s\S]{0,300}ref:\s*\$\{\{\s*inputs\.expected_sha\s*\}\}[\s\S]{0,200}path:\s*\.release-source", "repair does not keep hardened workflow helpers separate from the historical source checkout")
+require(r"\$\{GITHUB_WORKSPACE\}/scripts/release/verify-oci-release\.sh", "repair preflight can execute a helper from the historical source tree")
+require(r"classify-changes", "pin-only change classifier is missing")
+require(r"build_required", "build jobs are not gated by classified changes")
+require(r"pin_only", "pin-only commits are not explicitly classified")
+require(r"^\s+outputs:\s*$[\s\S]{0,500}^\s+digest:", "image digest is not exported as a job output")
+require(r"^\s+DIGEST:\s+\$\{\{\s*needs\.build-push\.outputs\.digest\s*\|\|\s*needs\.classify-changes\.outputs\.existing_digest\s*\}\}", "verification job does not select the built or explicitly approved digest")
+require(r"needs\.classify-changes\.outputs\.existing_digest", "idempotent repair cannot reuse its explicitly approved existing digest")
+require(r"github\.event_name == 'workflow_dispatch'[\s\S]{0,300}inputs\.repair_release", "repair dispatch cannot recover stable finalization after an earlier release failure")
+require(r"gh attestation verify\s+\"oci://\$\{IMAGE\}@\$\{DIGEST\}\"", "pin path does not verify provenance for the exact digest")
+require(r"--source-digest\s+\"\$\{SOURCE_SHA\}\"", "attestation is not cryptographically bound to the verified source commit")
+require(r"--signer-workflow\s+\"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-publish\.yml\"", "attestation signer workflow is not constrained")
+require(r"pin-production-image\.sh", "verified digest is not written through the narrow pin script")
+require(r"for attempt in 1 2 3", "pin push has no bounded three-attempt CAS retry")
+require(r"git fetch origin main", "pin path does not re-fetch authoritative main")
+if "git diff --name-only" not in source_contract:
+    errors.append("finalization does not inspect drift after the verified source")
+if "non-infrastructure main drift" not in source_contract:
+    errors.append("non-infrastructure main drift is not rejected before finalization")
+if ".well-known/*.json" not in source_contract:
+    errors.append("release-owned channel manifest commits are not allowed through the final pin CAS")
+require(r"VERSION_BUMP_PAT", "pin path does not use the existing narrow release writer")
+forbid(r"VERSION_BUMP_PAT\s*\|\|\s*github\.token", "production pin silently falls back to a non-recursive GITHUB_TOKEN push")
+require(r"Require protected release writer credential", "production pin does not fail closed before a push when VERSION_BUMP_PAT is absent")
+forbid(r"git commit[^\n]*\[skip ci\]", "production pin suppresses protected CI instead of relying on the pin-only classifier")
+require(r"fetch-tags:\s*true", "main classification does not fetch remote release tags before registry publication")
+require(r"verify-remote-tag\.sh", "image publication does not re-check the remote version tag immediately before the registry write")
+if "git ls-remote --exit-code --tags" not in remote_tag_contract:
+    errors.append("remote tag contract does not inspect the authoritative remote independently of the checkout")
+require(r"orchestrator_run_id", "stable release handoff is not bound to the image-publish run id")
+require(r"\.github/workflows/image-publish\.yml", "stable authorization is not constrained to the image-publish workflow")
+require(r"verify-release-source\.sh", "release source topology is not checked by the tested helper")
+require(r"--allow-detached-repair", "the stranded version-only release repair topology is not handled explicitly")
+forbid(r"ref:\s*\$\{\{\s*inputs\.repair_release\s*&&\s*inputs\.expected_sha", "a release job replaces hardened workflow code with the historical repair tree")
+require(r"repos/\$\{GITHUB_REPOSITORY\}/rulesets", "stable finalization does not fail closed when v* tag update/deletion protection is absent")
+require(r"\bupdate\b[\s\S]{0,500}\bdeletion\b|\bdeletion\b[\s\S]{0,500}\bupdate\b", "stable finalization does not require both tag update and deletion rules")
+require(r"verify-tag-ruleset\.py", "tag ruleset validation does not account for exclusions and bypass actors")
+require(r"verify-oci-alias\.sh", "published OCI version alias is not read back against the exact build digest")
+require(r"classify-image-change\.sh", "push classification does not use a tested full-range helper")
+require(r"GITHUB_EVENT_BEFORE", "push classification is not anchored to github.event.before")
+require(r"orchestrator_control_sha", "stable npm handoff does not separate the orchestrator control revision from the release source SHA")
+require(r"cosign verify-blob[\s\S]{0,800}slsa-verifier verify-artifact", "existing release bundles and SLSA provenance are not cryptographically verified")
+if re.search(r"^permissions:\s*$[\s\S]{0,300}^\s+(packages|id-token|attestations):\s+write", text, flags=re.MULTILINE):
+    errors.append("image workflow grants publication credentials globally instead of per build job")
+for action_ref in re.findall(r"^\s*-?\s*uses:\s*([^\s#]+)", ci, flags=re.MULTILINE):
+    if action_ref.startswith("./"):
+        continue
+    if re.fullmatch(r"[^@]+@[0-9a-f]{40}", action_ref) is None:
+        errors.append(f"protected CI uses mutable action reference {action_ref}")
+for gate in (
+    "release-workflow-contract.test.sh",
+    "stable-release-order.test.sh",
+    "pin-production-image.test.sh",
+    "verify-oci-release.test.sh",
+    "verify-release-source.test.sh",
+    "verify-release-assets.test.sh",
+    "verify-orchestrator-run.test.sh",
+    "verify-npm-stable-state.test.sh",
+    "verify-npm-artifact.test.sh",
+    "reconcile-npm-stable.test.sh",
+    "verify-remote-tag.test.sh",
+    "verify-tag-ruleset.test.sh",
+    "verify-oci-alias.test.sh",
+    "classify-image-change.test.sh",
+    "authorize-release-entry.test.sh",
+    "verify-version-only-diff.test.sh",
+    "verify-release-state.test.sh",
+    "test-helm-image-digest.sh",
+    "actionlint",
+):
+    if gate not in ci:
+        errors.append(f"protected CI does not invoke {gate}")
+forbid(r"git\s+push[^\n]*(--force|-f(?:\s|$))", "workflow contains a force push")
+forbid(r"github\.event\.inputs\.platforms", "a repair caller can publish an incomplete platform set")
+forbid(r"\b(?:kubectl|helm\s+(?:upgrade|install)|docker\s+service\s+update)\b", "workflow contains a direct production mutation")
+
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    raise SystemExit(1)
+print("PASS: publish → verify → pin workflow contract")
+PY

--- a/scripts/release/stable-release-order.test.sh
+++ b/scripts/release/stable-release-order.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+python3 - "${ROOT}/.github/workflows/version.yml" "${ROOT}/.github/workflows/image-publish.yml" "${ROOT}/.github/workflows/release.yml" "${ROOT}/.github/workflows/release-publish.yml" "${ROOT}/.github/workflows/build-tarballs.yml" "${ROOT}/.github/workflows/sign-attest.yml" "${ROOT}/scripts/release/verify-release-source.sh" "${ROOT}/.github/workflows/signing-identity-pin.yml" <<'PY'
+import re, sys
+from pathlib import Path
+version = Path(sys.argv[1]).read_text(encoding="utf-8")
+image = Path(sys.argv[2]).read_text(encoding="utf-8")
+release = Path(sys.argv[3]).read_text(encoding="utf-8")
+release_publish = Path(sys.argv[4]).read_text(encoding="utf-8")
+build_tarballs = Path(sys.argv[5]).read_text(encoding="utf-8")
+sign_attest = Path(sys.argv[6]).read_text(encoding="utf-8")
+source_contract = Path(sys.argv[7]).read_text(encoding="utf-8")
+signing_identity_pin = Path(sys.argv[8]).read_text(encoding="utf-8")
+errors=[]
+
+def require(text, pattern, message):
+    if re.search(pattern, text, flags=re.MULTILINE | re.DOTALL) is None: errors.append(message)
+
+def forbid(text, pattern, message):
+    if re.search(pattern, text, flags=re.MULTILINE | re.DOTALL) is not None: errors.append(message)
+
+def forbid_inputs_in_run(text, workflow_name):
+    lines = text.splitlines()
+    run_indent = None
+    for line in lines:
+        match = re.match(r"^(\s*)run:\s*\|\s*$", line)
+        if match:
+            run_indent = len(match.group(1))
+            continue
+        if run_indent is None:
+            continue
+        if line.strip() and len(line) - len(line.lstrip()) <= run_indent:
+            run_indent = None
+            continue
+        if "${{ inputs." in line:
+            errors.append(f"{workflow_name} interpolates an input directly inside a shell run block")
+            run_indent = None
+
+forbid(version, r"workflow_run:[\s\S]{0,250}branches:\s*\[[^\]]*main", "version workflow still fires a post-main bump")
+require(version, r"pull_request:\s*\n\s*types:\s*\[closed\]\s*\n\s*branches:\s*\[dev\]", "homolog versioning must have one canonical workflow_run entry point")
+forbid(version, r"group:[^\n]*github\.event_name", "equivalent version events can run in separate concurrency groups")
+forbid(version, r"main\)\s*[\s\S]{0,250}checkout_ref=dev", "stable main path still creates a release from dev")
+require(image, r"infra_only", "release-infrastructure-only merges are not classified away from image publication")
+require(image, r"version tag .*already exists|already published", "main does not fail closed when its version tag already exists")
+require(image, r"Finalize stable Git tag and release", "stable release is not finalized by the verified image pipeline")
+require(image, r"gh attestation verify[\s\S]{0,5000}refs/tags/v\$\{VERSION\}", "stable tag can be created before exact OCI provenance verification")
+require(image, r"gh workflow run release\.yml[\s\S]{0,300}channel=stable|--field channel=stable", "verified main artifact does not dispatch the stable release channel")
+require(image, r"gh run watch[\s\S]{0,1500}gh workflow run version\.yml[\s\S]{0,500}stable_publish_only=true", "stable npm publication is not sequenced after successful release finalization")
+require(source_contract, r"git merge-base --is-ancestor", "stable source is not required to be reachable from main")
+require(version, r"stable_publish_only:", "version workflow has no trusted-publisher stable-only entry point")
+require(version, r"Publish verified stable npm package", "stable npm package is not published by the trusted version workflow")
+require(image, r"gh workflow run version\.yml[\s\S]{0,300}--ref main", "stable npm recovery dispatches the historical tag workflow instead of hardened main")
+forbid(image, r"npm_action[^\n]*none[\s\S]{0,800}gh workflow run version\.yml", "an apparently exact npm tag bypasses package byte/signature verification")
+require(version, r"Publish verified stable npm package[\s\S]{0,2500}ref:\s*\$\{\{\s*github\.workflow_sha\s*\}\}[\s\S]{0,2500}ref:\s*\$\{\{\s*inputs\.expected_sha\s*\}\}[\s\S]{0,200}path:\s*\.stable-source", "stable npm publication does not separate hardened control code from the immutable source checkout")
+require(version, r"Authorize verified stable orchestration[\s\S]{0,2500}actions/runs/\$\{ORCHESTRATOR_RUN_ID\}", "stable npm authorization is not bound to the exact image-publish run")
+require(version, r"reconcile-npm-stable\.sh", "stable npm publication does not use the behavior-tested publish/repair/readback reconciler")
+require(version, r"NPM_RECOVERY_TOKEN:[^\n]*secrets\.NPM_TOKEN", "latest dist-tag recovery is not protected by the repository npm credential")
+require(image, r"orchestrator_control_sha=\"\$\{GITHUB_SHA\}\"", "stable npm repair does not pass the exact current control revision separately")
+require(version, r"--source-sha\s+\"\$\{ORCHESTRATOR_CONTROL_SHA\}\"[\s\S]{0,300}--source-digest\s+\"\$\{EXPECTED_SHA\}\"", "stable npm authorization conflates orchestrator control SHA with release source SHA")
+require(release, r"Authorize release channel", "release workflow has no stable-channel authorization gate")
+require(release, r"actions/runs/\$\{ORCHESTRATOR_RUN_ID\}", "stable release authorization does not inspect the exact image-publish run")
+require(release, r"--source-digest\s+\"\$\{EXPECTED_SHA\}\"[\s\S]{0,300}--signer-workflow", "stable release authorization does not independently bind OCI provenance to source and signer")
+require(release_publish, r"authorize-release-entry\.py", "direct release-publish dispatch can reach the stable channel")
+require(release_publish, r"--draft=false --prerelease=false --latest", "idempotent recovery does not force an existing stable release to public stable state")
+require(release_publish, r"gh release create[\s\S]{0,300}--verify-tag", "release publication can create an unverified tag implicitly")
+require(release_publish, r"gh release create[\s\S]{0,300}--verify-tag[\s\S]{0,200}--draft", "a new release is exposed before its signed asset inventory is complete")
+require(release_publish, r"isDraft,isPrerelease", "release publication does not verify its final public/prerelease state")
+require(release_publish, r"verify-release-state\.py[\s\S]{0,200}--phase existing", "existing public release channel classification is mutable")
+require(release_publish, r"ASSET_COUNT.*-ne 12", "release publication does not fail closed on an incomplete signed asset set")
+require(release_publish, r"ASSET_COUNT[\s\S]{0,1000}--draft=false --prerelease=false --latest", "stable release is promoted before signed assets are verified")
+state_check = release_publish.find("--json isDraft,isPrerelease")
+asset_upload = release_publish.find("gh release upload")
+if state_check < 0 or asset_upload < 0 or state_check > asset_upload:
+    errors.append("existing release state is not validated before any asset upload")
+promotion = release_publish.find("--draft=false", asset_upload)
+uploaded_asset_verify = release_publish.find("verify-release-assets.py", asset_upload)
+if promotion < 0 or uploaded_asset_verify < 0 or uploaded_asset_verify > promotion:
+    errors.append("newly uploaded release assets are not read back by name and digest before public promotion")
+require(release_publish, r"public release assets already match|verify existing public release assets", "public release recovery does not verify immutable asset identity")
+require(release_publish, r"remote tag.*before publication|tag target before publication", "release publication does not read back the remote tag before mutation")
+require(release_publish, r"remote tag.*after publication|tag target after publication", "release publication does not read back the remote tag after mutation")
+require(build_tarballs, r"version override does not match packages/cli/package\.json", "manual tarball recovery can relabel a different source version")
+require(build_tarballs, r"PACKAGE_VERSION.*=~.*\^\[0-9\]", "tarball builder does not constrain source package versions before shell reuse")
+require(sign_attest, r"VERSION.*=~.*\^\[0-9\]", "signing workflow does not constrain artifact versions before shell reuse")
+require(release_publish, r"VERSION.*=~.*\^\[0-9\]", "release workflow does not constrain artifact versions before shell reuse")
+require(sign_attest, r"Authorize manual recovery source run[\s\S]{0,1200}expected-workflow \.github/workflows/build-tarballs\.yml", "manual signing recovery is not bound to an exact successful build workflow run")
+require(release_publish, r"expected-workflow \.github/workflows/sign-attest\.yml", "manual release recovery is not bound to an exact successful signing workflow run")
+require(release_publish, r"authorize-release-entry\.py", "release publication does not behaviorally distinguish reusable orchestration from direct recovery")
+require(release_publish, r"workflow_call:[\s\S]{0,1000}orchestrated:", "release publication has no workflow_call-only orchestration marker")
+require(release, r"orchestrated:\s*true", "release orchestrator does not identify its reusable publish call")
+forbid_inputs_in_run(build_tarballs, "build-tarballs.yml")
+forbid_inputs_in_run(sign_attest, "sign-attest.yml")
+forbid_inputs_in_run(release_publish, "release-publish.yml")
+forbid_inputs_in_run(release, "release.yml")
+forbid(release_publish, r"warning::expected 12", "incomplete signed release assets are only a warning")
+require(release_publish, r"for attempt in 1 2 3", "release manifest push has no bounded CAS retry")
+require(release_publish, r"VERSION_BUMP_PAT", "release manifest CAS does not use the protected-branch writer credential")
+for workflow_name, workflow in (("image-publish.yml", image), ("release-publish.yml", release_publish), ("version.yml", version)):
+    forbid(workflow, r"VERSION_BUMP_PAT\s*\|\|\s*github\.token", f"{workflow_name} silently falls back to a non-recursive GITHUB_TOKEN branch push")
+require(release_publish, r"Require protected release writer credential", "release manifest write does not fail closed when VERSION_BUMP_PAT is absent")
+require(version, r"Require protected version writer credential", "version branch write does not fail closed when VERSION_BUMP_PAT is absent")
+require(release_publish, r"git show -s --format=%ct \"v\$\{VERSION\}\^\{commit\}\"", "release manifest timestamp is not deterministic from the immutable tag")
+forbid(release_publish, r"git push origin main\s*\|\|", "release manifest push failure is swallowed as success")
+forbid(release, r"GH_TOKEN:\s*\$\{\{\s*secrets\.RELEASE_PLEASE_TOKEN\s*\|\|\s*secrets\.GITHUB_TOKEN\s*\}\}", "release notes still prefer the stale broad token")
+require(release, r"GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}", "release notes do not use the job-scoped GitHub token")
+forbid(release, r"\n  publish:[\s\S]{0,500}\n      id-token:\s*write", "release publish job grants an unused OIDC token")
+
+for workflow_name, workflow in (
+    ("version.yml", version),
+    ("image-publish.yml", image),
+    ("release.yml", release),
+    ("release-publish.yml", release_publish),
+    ("build-tarballs.yml", build_tarballs),
+    ("sign-attest.yml", sign_attest),
+    ("signing-identity-pin.yml", signing_identity_pin),
+):
+    for match in re.finditer(r"^\s*-?\s*uses:\s*([^\s#]+)", workflow, flags=re.MULTILINE):
+        ref = match.group(1)
+        if ref.startswith("./"):
+            continue
+        if re.fullmatch(r"[^@]+@[0-9a-f]{40}", ref) is None:
+            errors.append(f"{workflow_name} contains mutable action or reusable-workflow ref {ref}")
+
+if errors:
+    for error in errors: print(f"FAIL: {error}", file=sys.stderr)
+    raise SystemExit(1)
+print("PASS: stable release ordering contract")
+PY

--- a/scripts/release/verify-npm-artifact.py
+++ b/scripts/release/verify-npm-artifact.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import tarfile
+import tempfile
+from typing import NoReturn
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"npm artifact verification failed: {message}")
+
+
+def package_files(path: pathlib.Path) -> dict[str, tuple[int, bytes]]:
+    result: dict[str, tuple[int, bytes]] = {}
+    try:
+        archive = tarfile.open(path, mode="r:gz")
+    except (OSError, tarfile.TarError) as exc:
+        fail(f"invalid npm tarball {path}: {exc}")
+    with archive:
+        for member in archive.getmembers():
+            pure = pathlib.PurePosixPath(member.name)
+            if pure.is_absolute() or ".." in pure.parts or not pure.parts or pure.parts[0] != "package":
+                fail(f"unsafe npm tar member {member.name}")
+            if member.isdir():
+                continue
+            if not member.isfile():
+                fail(f"unsupported npm tar member type for {member.name}")
+            handle = archive.extractfile(member)
+            if handle is None:
+                fail(f"could not read npm tar member {member.name}")
+            relative = str(pathlib.PurePosixPath(*pure.parts[1:]))
+            if not relative or relative in result:
+                fail(f"duplicate or empty npm package member {member.name}")
+            data = handle.read()
+            if relative in {"dist/index.js", "dist/server/index.js"}:
+                # Bun embeds the ephemeral checkout prefix in bundled CommonJS
+                # __filename/__dirname constants. Normalize only that prefix;
+                # every path after node_modules/.bun and every other byte must
+                # remain exact.
+                data = re.sub(
+                    rb'(?<=")/[^"\r\n]*/node_modules/\.bun/',
+                    b"<BUILD_ROOT>/node_modules/.bun/",
+                    data,
+                )
+            result[relative] = (member.mode & 0o777, data)
+    if not result:
+        fail("npm tarball has no package files")
+    return result
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--expected-tarball", required=True)
+parser.add_argument("--registry-tarball", required=True)
+parser.add_argument("--dist-json", required=True)
+parser.add_argument("--keys-json", required=True)
+parser.add_argument("--package", required=True)
+parser.add_argument("--version", required=True)
+args = parser.parse_args()
+expected_tarball = pathlib.Path(args.expected_tarball)
+registry_tarball = pathlib.Path(args.registry_tarball)
+dist_path = pathlib.Path(args.dist_json)
+keys_path = pathlib.Path(args.keys_json)
+if (
+    not expected_tarball.is_file()
+    or not registry_tarball.is_file()
+    or not dist_path.is_file()
+    or not keys_path.is_file()
+):
+    fail("expected tarball, registry tarball, dist JSON, or registry keys JSON is missing")
+if re.fullmatch(r"@[a-z0-9._-]+/[a-z0-9._-]+", args.package) is None:
+    fail("package name is invalid")
+if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.version) is None:
+    fail("package version is invalid")
+try:
+    dist = json.loads(dist_path.read_text(encoding="utf-8"))
+    keys_document = json.loads(keys_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    fail(f"invalid registry metadata JSON: {exc}")
+if not isinstance(dist, dict):
+    fail("registry dist metadata is not an object")
+if not isinstance(keys_document, dict) or not isinstance(keys_document.get("keys"), list):
+    fail("registry signing keys metadata is malformed")
+registry_data = registry_tarball.read_bytes()
+expected_integrity = "sha512-" + base64.b64encode(hashlib.sha512(registry_data).digest()).decode()
+expected_shasum = hashlib.sha1(registry_data).hexdigest()
+if dist.get("integrity") != expected_integrity:
+    fail("downloaded registry artifact does not match registry integrity")
+if dist.get("shasum") != expected_shasum:
+    fail("downloaded registry artifact does not match registry shasum")
+signatures = dist.get("signatures")
+if not isinstance(signatures, list) or not signatures:
+    fail("registry metadata has no package signature")
+for signature in signatures:
+    if not isinstance(signature, dict):
+        fail("registry package signature is malformed")
+    if re.fullmatch(r"SHA256:[A-Za-z0-9+/=]+", str(signature.get("keyid", ""))) is None:
+        fail("registry package signature key ID is malformed")
+    if not isinstance(signature.get("sig"), str) or not signature["sig"]:
+        fail("registry package signature value is missing")
+keys = {
+    key.get("keyid"): key
+    for key in keys_document["keys"]
+    if isinstance(key, dict) and isinstance(key.get("keyid"), str)
+}
+payload = f"{args.package}@{args.version}:{expected_integrity}".encode()
+signature_verified = False
+for signature in signatures:
+    key = keys.get(signature["keyid"])
+    if not isinstance(key, dict):
+        continue
+    if key.get("keytype") != "ecdsa-sha2-nistp256" or key.get("scheme") != "ecdsa-sha2-nistp256":
+        continue
+    try:
+        public_der = base64.b64decode(str(key.get("key", "")), validate=True)
+        signature_der = base64.b64decode(signature["sig"], validate=True)
+    except ValueError:
+        continue
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = pathlib.Path(temp_dir)
+        (temp / "key.der").write_bytes(public_der)
+        (temp / "signature.der").write_bytes(signature_der)
+        convert = subprocess.run(
+            ("openssl", "pkey", "-pubin", "-inform", "DER", "-in", str(temp / "key.der"), "-out", str(temp / "key.pem")),
+            check=False,
+            capture_output=True,
+        )
+        if convert.returncode != 0:
+            continue
+        verify = subprocess.run(
+            ("openssl", "dgst", "-sha256", "-verify", str(temp / "key.pem"), "-signature", str(temp / "signature.der")),
+            input=payload,
+            check=False,
+            capture_output=True,
+        )
+        if verify.returncode == 0:
+            signature_verified = True
+            break
+if not signature_verified:
+    fail("registry package signature did not verify against an authoritative npm key")
+if package_files(expected_tarball) != package_files(registry_tarball):
+    fail("registry package contents differ from the exact locally built source package")
+print("npm_artifact_verified=true")

--- a/scripts/release/verify-npm-artifact.test.sh
+++ b/scripts/release/verify-npm-artifact.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-npm-artifact.py"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+python3 - "${work}" <<'PY'
+import io, pathlib, tarfile, sys
+root = pathlib.Path(sys.argv[1])
+for name, mtime in [('expected.tgz', 1), ('registry.tgz', 2)]:
+    with tarfile.open(root / name, 'w:gz') as archive:
+        prefix = b'/tmp/build' if name == 'expected.tgz' else b'/home/runner/work/omni/omni'
+        raw = b'var __filename = "' + prefix + b'/node_modules/.bun/pkg/node_modules/pkg/index.js";\n'
+        info = tarfile.TarInfo('package/dist/index.js')
+        info.size = len(raw)
+        info.mode = 0o644
+        info.mtime = mtime
+        archive.addfile(info, io.BytesIO(raw))
+PY
+openssl ecparam -name prime256v1 -genkey -noout -out "${work}/private.pem"
+openssl pkey -in "${work}/private.pem" -pubout -outform DER -out "${work}/public.der"
+python3 - "${work}/registry.tgz" "${work}/dist.json" "${work}/keys.json" \
+  "${work}/private.pem" "${work}/public.der" <<'PY'
+import base64, hashlib, json, pathlib, subprocess, sys
+raw = pathlib.Path(sys.argv[1]).read_bytes()
+integrity = 'sha512-' + base64.b64encode(hashlib.sha512(raw).digest()).decode()
+public = pathlib.Path(sys.argv[5]).read_bytes()
+keyid = 'SHA256:' + base64.b64encode(hashlib.sha256(public).digest()).decode()
+payload = f'@automagik/omni@2.260830.2:{integrity}'.encode()
+signature = subprocess.run(
+    ['openssl', 'dgst', '-sha256', '-sign', sys.argv[4]],
+    input=payload, check=True, capture_output=True,
+).stdout
+pathlib.Path(sys.argv[2]).write_text(json.dumps({
+    'integrity': integrity,
+    'shasum': hashlib.sha1(raw).hexdigest(),
+    'tarball': 'https://registry.npmjs.org/@automagik/omni/-/omni-2.260830.2.tgz',
+    'signatures': [{'keyid': keyid, 'sig': base64.b64encode(signature).decode()}],
+}))
+pathlib.Path(sys.argv[3]).write_text(json.dumps({'keys': [{
+    'keyid': keyid, 'keytype': 'ecdsa-sha2-nistp256',
+    'scheme': 'ecdsa-sha2-nistp256', 'key': base64.b64encode(public).decode(),
+}]}))
+PY
+"${SCRIPT}" --expected-tarball "${work}/expected.tgz" \
+  --registry-tarball "${work}/registry.tgz" --dist-json "${work}/dist.json" \
+  --keys-json "${work}/keys.json" --package @automagik/omni --version 2.260830.2 \
+  | grep -qx 'npm_artifact_verified=true' || fail "exact signed artifact was rejected"
+python3 - "${work}/expected.tgz" <<'PY'
+import io, tarfile, sys
+with tarfile.open(sys.argv[1], 'w:gz') as archive:
+    raw = b'wrong package file\n'
+    info = tarfile.TarInfo('package/dist/index.js')
+    info.size = len(raw)
+    archive.addfile(info, io.BytesIO(raw))
+PY
+if "${SCRIPT}" --expected-tarball "${work}/expected.tgz" \
+  --registry-tarball "${work}/registry.tgz" --dist-json "${work}/dist.json" \
+  --keys-json "${work}/keys.json" --package @automagik/omni --version 2.260830.2 >/dev/null 2>&1; then
+  fail "wrong package bytes were accepted"
+fi
+python3 - "${work}/dist.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+data = json.loads(p.read_text())
+data['signatures'] = []
+p.write_text(json.dumps(data))
+PY
+if "${SCRIPT}" --expected-tarball "${work}/registry.tgz" \
+  --registry-tarball "${work}/registry.tgz" --dist-json "${work}/dist.json" \
+  --keys-json "${work}/keys.json" --package @automagik/omni --version 2.260830.2 >/dev/null 2>&1; then
+  fail "unsigned registry metadata was accepted"
+fi
+printf 'PASS: exact signed npm artifact identity contract\n'

--- a/scripts/release/verify-npm-stable-state.sh
+++ b/scripts/release/verify-npm-stable-state.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+usage() {
+  printf 'Usage: verify-npm-stable-state.sh --expected VERSION --published VERSION_OR_EMPTY --latest VERSION_OR_EMPTY\n' >&2
+  exit 2
+}
+fail() { printf 'npm stable state verification failed: %s\n' "$*" >&2; exit 1; }
+expected=""
+published=""
+latest=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expected) expected="${2:-}"; shift 2 ;;
+    --published) published="${2:-}"; shift 2 ;;
+    --latest) latest="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ "${expected}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || usage
+if [[ -z "${published}" ]]; then
+  printf 'npm_action=publish\n'
+  exit 0
+fi
+[[ "${published}" == "${expected}" ]] || fail "registry returned ${published}, expected ${expected}"
+if [[ "${latest}" != "${expected}" ]]; then
+  printf 'npm_action=repair_latest\n'
+  exit 0
+fi
+printf 'npm_action=none\n'

--- a/scripts/release/verify-npm-stable-state.test.sh
+++ b/scripts/release/verify-npm-stable-state.test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-npm-stable-state.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+
+out=$("${SCRIPT}" --expected 2.260830.2 --published 2.260830.2 --latest 2.260830.2)
+grep -q '^npm_action=none$' <<<"${out}" || fail "exact latest state was not idempotent"
+out=$("${SCRIPT}" --expected 2.260830.2 --published '' --latest 2.260830.1)
+grep -q '^npm_action=publish$' <<<"${out}" || fail "missing package did not require publication"
+out=$("${SCRIPT}" --expected 2.260830.2 --published 2.260830.2 --latest 2.260830.1)
+grep -q '^npm_action=repair_latest$' <<<"${out}" || fail "existing package under a non-latest dist-tag did not request repair"
+if "${SCRIPT}" --expected 2.260830.2 --published 2.260830.1 --latest 2.260830.1; then
+  fail "registry returned the wrong requested package version"
+fi
+printf 'PASS: stable npm version and latest dist-tag contract\n'

--- a/scripts/release/verify-oci-alias.sh
+++ b/scripts/release/verify-oci-alias.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=""
+version=""
+expected_digest=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image) image="${2:-}"; shift 2 ;;
+    --version) version="${2:-}"; shift 2 ;;
+    --expected-digest) expected_digest="${2:-}"; shift 2 ;;
+    *) echo "OCI alias verification failed: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+[[ "${image}" =~ ^[a-z0-9.-]+(/[a-z0-9._-]+)+$ ]] || { echo 'OCI alias verification failed: invalid image' >&2; exit 1; }
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'OCI alias verification failed: invalid version' >&2; exit 1; }
+[[ "${expected_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'OCI alias verification failed: invalid expected digest' >&2; exit 1; }
+actual_digest=$(docker buildx imagetools inspect "${image}:v${version}" --format '{{.Manifest.Digest}}')
+actual_digest="${actual_digest//$'\r'/}"
+[[ "${actual_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'OCI alias verification failed: registry returned a malformed digest' >&2; exit 1; }
+[[ "${actual_digest}" == "${expected_digest}" ]] || {
+  echo "OCI alias verification failed: ${image}:v${version} resolves to ${actual_digest}, expected ${expected_digest}" >&2
+  exit 1
+}
+printf 'oci_alias_verified=true\n'

--- a/scripts/release/verify-oci-alias.test.sh
+++ b/scripts/release/verify-oci-alias.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-oci-alias.sh"
+work=$(mktemp -d)
+trap 'rm -rf "${work}"' EXIT
+cat >"${work}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == *'imagetools inspect'* ]]
+printf '%s\n' "${MOCK_DIGEST}"
+SH
+chmod +x "${work}/docker"
+expected=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" "${SCRIPT}" --image ghcr.io/example/omni-api --version 1.2.3 --expected-digest "${expected}"
+if PATH="${work}:${PATH}" MOCK_DIGEST=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+  "${SCRIPT}" --image ghcr.io/example/omni-api --version 1.2.3 --expected-digest "${expected}"; then
+  echo 'FAIL: mismatched OCI alias was accepted' >&2; exit 1
+fi
+if PATH="${work}:${PATH}" MOCK_DIGEST=garbage \
+  "${SCRIPT}" --image ghcr.io/example/omni-api --version 1.2.3 --expected-digest "${expected}"; then
+  echo 'FAIL: malformed OCI alias digest was accepted' >&2; exit 1
+fi
+printf 'PASS: OCI version alias read-back contract\n'

--- a/scripts/release/verify-oci-release.sh
+++ b/scripts/release/verify-oci-release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: verify-oci-release.sh --ref refs/tags/vVERSION --expected-version VERSION \
+  --expected-sha FULL_SHA --image REGISTRY/IMAGE [--expected-existing-digest sha256:...]
+EOF
+  exit 2
+}
+
+fail() {
+  printf 'release preflight failed: %s\n' "$*" >&2
+  exit 1
+}
+
+release_ref=""
+expected_version=""
+expected_sha=""
+image=""
+expected_existing_digest=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref) release_ref="${2:-}"; shift 2 ;;
+    --expected-version) expected_version="${2:-}"; shift 2 ;;
+    --expected-sha) expected_sha="${2:-}"; shift 2 ;;
+    --image) image="${2:-}"; shift 2 ;;
+    --expected-existing-digest) expected_existing_digest="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "${release_ref}" && -n "${expected_version}" && -n "${expected_sha}" && -n "${image}" ]] || usage
+[[ "${expected_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "expected version is not a numeric dotted version"
+[[ "${expected_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "expected SHA must be 40 lowercase hexadecimal characters"
+[[ "${release_ref}" == "refs/tags/v${expected_version}" ]] || fail "release ref must be refs/tags/v${expected_version}"
+if [[ -n "${expected_existing_digest}" && ! "${expected_existing_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  fail "expected existing digest is invalid"
+fi
+
+head_sha="$(git rev-parse HEAD^{commit})"
+[[ "${head_sha}" == "${expected_sha}" ]] || fail "HEAD ${head_sha} does not match expected source ${expected_sha}"
+tag_sha="$(git rev-parse "${release_ref}^{commit}" 2>/dev/null)" || fail "release tag does not exist"
+[[ "${tag_sha}" == "${expected_sha}" ]] || fail "release tag resolves to ${tag_sha}, not ${expected_sha}"
+
+package_version="$(node -p "require('./packages/cli/package.json').version")"
+[[ "${package_version}" == "${expected_version}" ]] || fail "package version ${package_version} does not match ${expected_version}"
+chart_version="$(python3 - <<'PY'
+import re
+text = open('deploy/helm/omni/Chart.yaml', encoding='utf-8').read()
+match = re.search(r'^appVersion:\s*["\x27]?([^"\x27\s]+)["\x27]?\s*$', text, flags=re.MULTILINE)
+if not match:
+    raise SystemExit('Chart.yaml appVersion not found')
+print(match.group(1))
+PY
+)"
+[[ "${chart_version}" == "${expected_version}" ]] || fail "chart appVersion ${chart_version} does not match ${expected_version}"
+
+version_ref="${image}:v${expected_version}"
+inspect_error="$(mktemp)"
+trap 'rm -f "${inspect_error}"' EXIT
+if inspect_output="$(docker buildx imagetools inspect "${version_ref}" 2>"${inspect_error}")"; then
+  existing_digest=""
+  while IFS= read -r line; do
+    case "${line}" in
+      Digest:*)
+        existing_digest="${line#Digest:}"
+        existing_digest="${existing_digest#${existing_digest%%[![:space:]]*}}"
+        break
+        ;;
+    esac
+  done <<<"${inspect_output}"
+  [[ "${existing_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "existing version tag has no valid OCI index digest"
+  [[ -n "${expected_existing_digest}" ]] || fail "${version_ref} already exists; supply its exact digest to make the repair idempotent"
+  [[ "${existing_digest}" == "${expected_existing_digest}" ]] || fail "${version_ref} resolves to ${existing_digest}, not approved ${expected_existing_digest}"
+  publish_required=false
+else
+  error_text="$(<"${inspect_error}")"
+  case "${error_text,,}" in
+    *"not found"*|*"manifest unknown"*) publish_required=true ;;
+    *) fail "registry inspection failed without a not-found response" ;;
+  esac
+  existing_digest=""
+fi
+
+output="${GITHUB_OUTPUT:-/dev/stdout}"
+{
+  printf 'release_ref=%s\n' "${release_ref}"
+  printf 'version=%s\n' "${expected_version}"
+  printf 'source_sha=%s\n' "${expected_sha}"
+  printf 'version_ref=%s\n' "${version_ref}"
+  printf 'publish_required=%s\n' "${publish_required}"
+  printf 'existing_digest=%s\n' "${existing_digest}"
+} >>"${output}"

--- a/scripts/release/verify-oci-release.test.sh
+++ b/scripts/release/verify-oci-release.test.sh
@@ -53,6 +53,10 @@ chmod +x "${work}/bin/docker"
 
 run_verify() {
   (
+    # The script writes step outputs when GitHub Actions exports GITHUB_OUTPUT.
+    # This fixture intentionally captures stdout, so isolate that contract from
+    # the runner-provided environment.
+    unset GITHUB_OUTPUT
     cd "${repo}"
     PATH="${work}/bin:${PATH}" "${SCRIPT}" \
       --ref "refs/tags/v${VERSION}" \

--- a/scripts/release/verify-oci-release.test.sh
+++ b/scripts/release/verify-oci-release.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-oci-release.sh"
+VERSION="2.260830.2"
+DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OTHER_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+repo="${work}/repo"
+mkdir -p "${repo}/packages/cli" "${repo}/deploy/helm/omni" "${work}/bin"
+printf '{"version":"%s"}\n' "${VERSION}" >"${repo}/packages/cli/package.json"
+printf 'apiVersion: v2\nname: omni\nversion: 0.1.0\nappVersion: "%s"\n' "${VERSION}" >"${repo}/deploy/helm/omni/Chart.yaml"
+(
+  cd "${repo}"
+  git init -q
+  git config user.name test
+  git config user.email test@example.com
+  git add .
+  git commit -qm "fixture"
+  git tag "v${VERSION}"
+)
+SHA="$(git -C "${repo}" rev-parse HEAD)"
+[[ ! -e "${repo}/scripts/release/verify-oci-release.sh" ]] || \
+  fail "historical-source fixture unexpectedly contains hardened control helpers"
+
+cat >"${work}/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${MOCK_REGISTRY_MODE:-absent}" in
+  absent)
+    printf 'manifest unknown: not found\n' >&2
+    exit 1
+    ;;
+  existing)
+    printf 'Name: ghcr.io/automagik-dev/omni-api:v2.260830.2\nMediaType: application/vnd.oci.image.index.v1+json\nDigest: %s\n' "${MOCK_REGISTRY_DIGEST}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${work}/bin/docker"
+
+run_verify() {
+  (
+    cd "${repo}"
+    PATH="${work}/bin:${PATH}" "${SCRIPT}" \
+      --ref "refs/tags/v${VERSION}" \
+      --expected-version "${VERSION}" \
+      --expected-sha "${SHA}" \
+      --image ghcr.io/automagik-dev/omni-api \
+      "$@"
+  )
+}
+
+MOCK_REGISTRY_MODE=absent run_verify >"${work}/absent.out"
+python3 - "${work}/absent.out" <<'PY' || fail "missing image did not request publication"
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+raise SystemExit(0 if "publish_required=true" in text and "source_sha=" in text else 1)
+PY
+
+MOCK_REGISTRY_MODE=existing MOCK_REGISTRY_DIGEST="${DIGEST}" \
+  run_verify --expected-existing-digest "${DIGEST}" >"${work}/same.out"
+python3 - "${work}/same.out" <<'PY' || fail "matching existing digest was not idempotent"
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+raise SystemExit(0 if "publish_required=false" in text else 1)
+PY
+
+if MOCK_REGISTRY_MODE=existing MOCK_REGISTRY_DIGEST="${OTHER_DIGEST}" \
+  run_verify --expected-existing-digest "${DIGEST}" >"${work}/mismatch.out" 2>"${work}/mismatch.err"; then
+  fail "mismatched existing digest was accepted"
+fi
+
+if MOCK_REGISTRY_MODE=existing MOCK_REGISTRY_DIGEST="${DIGEST}" \
+  run_verify >"${work}/unapproved.out" 2>"${work}/unapproved.err"; then
+  fail "existing digest without an explicit expectation was accepted"
+fi
+
+if (
+  cd "${repo}"
+  PATH="${work}/bin:${PATH}" MOCK_REGISTRY_MODE=absent "${SCRIPT}" \
+    --ref "refs/tags/v9.9.9" \
+    --expected-version "${VERSION}" \
+    --expected-sha "${SHA}" \
+    --image ghcr.io/automagik-dev/omni-api
+) >"${work}/wrong-ref.out" 2>"${work}/wrong-ref.err"; then
+  fail "wrong release ref was accepted"
+fi
+
+printf '{"version":"9.9.9"}\n' >"${repo}/packages/cli/package.json"
+if MOCK_REGISTRY_MODE=absent run_verify >"${work}/wrong-version.out" 2>"${work}/wrong-version.err"; then
+  fail "package version drift was accepted"
+fi
+
+printf 'PASS: immutable OCI release preflight contract\n'

--- a/scripts/release/verify-orchestrator-run.py
+++ b/scripts/release/verify-orchestrator-run.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import re
+from typing import NoReturn
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"orchestrator verification failed: {message}")
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--run-json", required=True)
+parser.add_argument("--repository", required=True)
+parser.add_argument("--source-sha", required=True)
+parser.add_argument("--expected-workflow", default=".github/workflows/image-publish.yml")
+parser.add_argument("--required-status", choices=("in_progress", "completed"), default="in_progress")
+parser.add_argument("--allowed-event", action="append", choices=("push", "workflow_dispatch"))
+args = parser.parse_args()
+
+if re.fullmatch(r"[0-9a-f]{40}", args.source_sha) is None:
+    fail("source SHA is invalid")
+try:
+    run = json.loads(pathlib.Path(args.run_json).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    fail(f"invalid run JSON: {exc}")
+if not isinstance(run, dict):
+    fail("run JSON is not an object")
+repository = run.get("repository")
+if not isinstance(repository, dict) or repository.get("full_name") != args.repository:
+    fail("workflow run repository does not match")
+if run.get("path") != args.expected_workflow:
+    fail(f"caller is not {args.expected_workflow}")
+if run.get("head_sha") != args.source_sha:
+    fail("caller head SHA does not match")
+if run.get("status") != args.required_status:
+    fail(f"caller run is not {args.required_status}")
+if args.required_status == "completed" and run.get("conclusion") != "success":
+    fail("completed caller run did not succeed")
+allowed_events = set(args.allowed_event or ("push", "workflow_dispatch"))
+if run.get("event") not in allowed_events:
+    fail("caller event is not an approved image publication event")
+print("orchestrator_run_verified=true")

--- a/scripts/release/verify-orchestrator-run.test.sh
+++ b/scripts/release/verify-orchestrator-run.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-orchestrator-run.py"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+cat >"${work}/valid.json" <<JSON
+{"repository":{"full_name":"automagik-dev/omni"},"path":".github/workflows/image-publish.yml","head_sha":"${SHA}","status":"in_progress","event":"workflow_dispatch"}
+JSON
+"${SCRIPT}" --run-json "${work}/valid.json" --repository automagik-dev/omni --source-sha "${SHA}"
+
+python3 - "${work}/valid.json" "${work}/wrong-workflow.json" <<'PY'
+import json, sys
+data=json.load(open(sys.argv[1])); data["path"]=".github/workflows/evil.yml"; json.dump(data,open(sys.argv[2],"w"))
+PY
+if "${SCRIPT}" --run-json "${work}/wrong-workflow.json" --repository automagik-dev/omni --source-sha "${SHA}"; then
+  fail "generic bot workflow substitution was accepted"
+fi
+
+python3 - "${work}/valid.json" "${work}/completed.json" <<'PY'
+import json, sys
+data=json.load(open(sys.argv[1])); data["status"]="completed"; json.dump(data,open(sys.argv[2],"w"))
+PY
+if "${SCRIPT}" --run-json "${work}/completed.json" --repository automagik-dev/omni --source-sha "${SHA}"; then
+  fail "replay of a completed orchestrator run was accepted"
+fi
+
+cat >"${work}/completed-build.json" <<JSON
+{"repository":{"full_name":"automagik-dev/omni"},"path":".github/workflows/build-tarballs.yml","head_sha":"${SHA}","status":"completed","conclusion":"success","event":"workflow_dispatch"}
+JSON
+"${SCRIPT}" --run-json "${work}/completed-build.json" --repository automagik-dev/omni --source-sha "${SHA}" \
+  --expected-workflow .github/workflows/build-tarballs.yml --required-status completed
+python3 - "${work}/completed-build.json" "${work}/failed-build.json" <<'PY'
+import json, sys
+data=json.load(open(sys.argv[1])); data["conclusion"]="failure"; json.dump(data,open(sys.argv[2],"w"))
+PY
+if "${SCRIPT}" --run-json "${work}/failed-build.json" --repository automagik-dev/omni --source-sha "${SHA}" \
+  --expected-workflow .github/workflows/build-tarballs.yml --required-status completed; then
+  fail "failed recovery source run was accepted"
+fi
+
+printf 'PASS: exact in-progress image orchestrator run contract\n'

--- a/scripts/release/verify-release-assets.py
+++ b/scripts/release/verify-release-assets.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+from typing import NoReturn
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"release asset verification failed: {message}")
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--version", required=True)
+parser.add_argument("--release-json", required=True)
+parser.add_argument("--dist", required=True)
+args = parser.parse_args()
+
+if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.version) is None:
+    fail("version is not a numeric dotted version")
+release_path = pathlib.Path(args.release_json)
+dist = pathlib.Path(args.dist)
+if not release_path.is_file() or not dist.is_dir():
+    fail("release JSON or dist directory is missing")
+release: object
+try:
+    release = json.loads(release_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    fail(f"invalid release JSON: {exc}")
+if not isinstance(release, dict) or not isinstance(release.get("assets"), list):
+    fail("release JSON has no asset array")
+
+expected = {
+    f"omni-{args.version}-{platform}.tar.gz{suffix}"
+    for platform in ("linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64")
+    for suffix in ("", ".bundle", ".intoto.jsonl")
+}
+assets = release["assets"]
+names = [asset.get("name") for asset in assets if isinstance(asset, dict)]
+if len(assets) != 12 or len(names) != 12 or set(names) != expected:
+    fail("public release inventory does not match the exact signed 12-asset contract")
+for asset in assets:
+    name = asset["name"]
+    remote_digest = asset.get("digest") or ""
+    path = dist / name
+    if not path.is_file():
+        fail(f"local signed asset is missing: {name}")
+    local_digest = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    if re.fullmatch(r"sha256:[0-9a-f]{64}", remote_digest) is None:
+        fail(f"public asset has no immutable sha256 digest: {name}")
+    if remote_digest != local_digest:
+        fail(f"public asset digest mismatch: {name}")
+
+print("release_assets_verified=true")

--- a/scripts/release/verify-release-assets.test.sh
+++ b/scripts/release/verify-release-assets.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-release-assets.py"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+mkdir -p "${work}/dist"
+VERSION=2.260830.2
+for platform in linux-x64-glibc linux-x64-musl linux-arm64 darwin-arm64; do
+  for suffix in "" .bundle .intoto.jsonl; do
+    name="omni-${VERSION}-${platform}.tar.gz${suffix}"
+    printf '%s\n' "${name}" > "${work}/dist/${name}"
+  done
+done
+python3 - "${work}/dist" "${work}/release.json" <<'PY'
+import hashlib, json, pathlib, sys
+dist = pathlib.Path(sys.argv[1])
+assets = []
+for path in sorted(dist.iterdir()):
+    assets.append({"name": path.name, "digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()})
+json.dump({"draft": False, "prerelease": False, "assets": assets}, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+
+"${SCRIPT}" --version "${VERSION}" --release-json "${work}/release.json" --dist "${work}/dist"
+
+python3 - "${work}/release.json" "${work}/bad.json" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+data["assets"][0]["digest"] = "sha256:" + "0" * 64
+json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if "${SCRIPT}" --version "${VERSION}" --release-json "${work}/bad.json" --dist "${work}/dist"; then
+  fail "mismatched public asset digest was accepted"
+fi
+
+python3 - "${work}/release.json" "${work}/missing.json" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+data["assets"].pop()
+json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if "${SCRIPT}" --version "${VERSION}" --release-json "${work}/missing.json" --dist "${work}/dist"; then
+  fail "incomplete public asset inventory was accepted"
+fi
+
+printf 'PASS: immutable public GitHub release asset contract\n'

--- a/scripts/release/verify-release-source.sh
+++ b/scripts/release/verify-release-source.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  printf 'Usage: verify-release-source.sh --source FULL_SHA --main MAIN_REF [--allow-detached-repair --expected-version VERSION]\n' >&2
+  exit 2
+}
+
+fail() {
+  printf 'release source verification failed: %s\n' "$*" >&2
+  exit 1
+}
+
+source_sha=""
+main_ref=""
+allow_detached=false
+expected_version=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source) source_sha="${2:-}"; shift 2 ;;
+    --main) main_ref="${2:-}"; shift 2 ;;
+    --allow-detached-repair) allow_detached=true; shift ;;
+    --expected-version) expected_version="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ "${source_sha}" =~ ^[0-9a-f]{40}$ && -n "${main_ref}" ]] || usage
+git cat-file -e "${source_sha}^{commit}" 2>/dev/null || fail "source commit does not exist"
+git cat-file -e "${main_ref}^{commit}" 2>/dev/null || fail "main ref does not resolve to a commit"
+
+changed_paths() {
+  local from="$1" to="$2" output
+  output="$(git diff --name-only "${from}" "${to}")" || \
+    fail "could not inspect source drift from ${from} to ${to}"
+  printf '%s\n' "${output}"
+}
+
+if git merge-base --is-ancestor "${source_sha}" "${main_ref}"; then
+  drift="$(changed_paths "${source_sha}" "${main_ref}")"
+  while IFS= read -r path; do
+    [[ -n "${path}" ]] || continue
+    case "${path}" in
+      .github/workflows/*|scripts/release/*|scripts/ci/*|deploy/helm/*|.well-known/*.json) ;;
+      *) fail "reachable source has non-infrastructure main drift at ${path}" ;;
+    esac
+  done <<<"${drift}"
+  printf 'detached_repair=false\n'
+  exit 0
+fi
+
+[[ "${allow_detached}" == "true" ]] || fail "source is not reachable from main"
+[[ "${expected_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+  fail "detached repair requires an exact expected version"
+parent="$(git rev-parse "${source_sha}^")"
+git merge-base --is-ancestor "${parent}" "${main_ref}" || fail "detached source parent is not reachable from main"
+self_verifier="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verify-version-only-diff.py"
+"${self_verifier}" --parent "${parent}" --source "${source_sha}" \
+  --expected-version "${expected_version}" >/dev/null
+self_drift="$(changed_paths "${parent}" "${source_sha}")"
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  case "${path}" in
+    package.json|bun.lock|packages/*/package.json|apps/*/package.json|deploy/helm/omni/Chart.yaml|.claude-plugin/marketplace.json|plugins/omni/.claude-plugin/plugin.json) ;;
+    *) fail "detached source commit itself changes non-version path ${path}" ;;
+  esac
+done <<<"${self_drift}"
+main_drift="$(changed_paths "${source_sha}" "${main_ref}")"
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  case "${path}" in
+    package.json|bun.lock|packages/*/package.json|apps/*/package.json|deploy/helm/omni/Chart.yaml|.claude-plugin/marketplace.json|plugins/omni/.claude-plugin/plugin.json|.github/workflows/*|scripts/release/*|scripts/ci/*|deploy/helm/*|.well-known/*.json) ;;
+    *) fail "version-only detached repair differs from main at non-version path ${path}" ;;
+  esac
+done <<<"${main_drift}"
+printf 'detached_repair=true\n'

--- a/scripts/release/verify-release-source.test.sh
+++ b/scripts/release/verify-release-source.test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-release-source.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+repo="${work}/repo"
+mkdir -p "${repo}/packages/cli" "${repo}/deploy/helm/omni"
+(
+  cd "${repo}"
+  git init -q
+  git config user.name test
+  git config user.email test@example.com
+  printf '{"version":"2.260830.1"}\n' > package.json
+  printf '{"version":"2.260830.1"}\n' > packages/cli/package.json
+  printf 'appVersion: "2.260830.1"\n' > deploy/helm/omni/Chart.yaml
+  git add .
+  git commit -qm base
+)
+BASE="$(git -C "${repo}" rev-parse HEAD)"
+
+(
+  cd "${repo}"
+  git switch -qc main
+  mkdir -p scripts/release
+  printf '# hardened release infrastructure\n' > scripts/release/pin.sh
+  git add .
+  git commit -qm infra
+)
+MAIN="$(git -C "${repo}" rev-parse HEAD)"
+
+(
+  cd "${repo}"
+  git switch -q --detach "${BASE}"
+  printf '{"version":"2.260830.2"}\n' > package.json
+  printf '{"version":"2.260830.2"}\n' > packages/cli/package.json
+  printf 'appVersion: "2.260830.2"\n' > deploy/helm/omni/Chart.yaml
+  git add .
+  git commit -qm version-only
+)
+DETACHED="$(git -C "${repo}" rev-parse HEAD)"
+
+mkdir -p "${work}/bin"
+REAL_GIT="$(command -v git)"
+cat > "${work}/bin/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "diff" && "${2:-}" == "--name-only" &&
+      "${3:-}" == "${MOCK_FAIL_FROM:-}" && "${4:-}" == "${MOCK_FAIL_TO:-}" ]]; then
+  exit 77
+fi
+exec "${REAL_GIT}" "$@"
+SH
+chmod +x "${work}/bin/git"
+
+expect_diff_failure() {
+  local from="$1" to="$2" source="$3"
+  shift 3
+  if (
+    cd "${repo}"
+    PATH="${work}/bin:${PATH}" REAL_GIT="${REAL_GIT}" \
+      MOCK_FAIL_FROM="${from}" MOCK_FAIL_TO="${to}" \
+      "${SCRIPT}" --source "${source}" --main "${MAIN}" "$@"
+  ) >"${work}/git-diff-failure.out" 2>"${work}/git-diff-failure.err"; then
+    fail "git diff failure for ${from}..${to} was accepted"
+  fi
+}
+
+expect_diff_failure "${BASE}" "${MAIN}" "${BASE}"
+expect_diff_failure "${BASE}" "${DETACHED}" "${DETACHED}" --allow-detached-repair --expected-version 2.260830.2
+expect_diff_failure "${DETACHED}" "${MAIN}" "${DETACHED}" --allow-detached-repair --expected-version 2.260830.2
+
+(
+  cd "${repo}"
+  "${SCRIPT}" --source "${DETACHED}" --main "${MAIN}" --allow-detached-repair --expected-version 2.260830.2
+) >"${work}/detached.out"
+grep -q '^detached_repair=true$' "${work}/detached.out" || fail "version-only detached repair was not accepted"
+
+(
+  cd "${repo}"
+  git switch -q --detach "${BASE}"
+  printf 'unexpected\n' > packages/cli/runtime.ts
+  git add .
+  git commit -qm unsafe-detached
+)
+UNSAFE="$(git -C "${repo}" rev-parse HEAD)"
+if (
+  cd "${repo}"
+  "${SCRIPT}" --source "${UNSAFE}" --main "${MAIN}" --allow-detached-repair --expected-version 2.260830.2
+) >"${work}/unsafe.out" 2>"${work}/unsafe.err"; then
+  fail "detached repair with product-code drift was accepted"
+fi
+
+if (
+  cd "${repo}"
+  "${SCRIPT}" --source "${DETACHED}" --main "${MAIN}"
+) >"${work}/disabled.out" 2>"${work}/disabled.err"; then
+  fail "detached repair was accepted without explicit authorization"
+fi
+
+printf 'PASS: reachable and version-only detached release source contract\n'

--- a/scripts/release/verify-release-state.py
+++ b/scripts/release/verify-release-state.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import argparse
+from typing import NoReturn
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"release state verification failed: {message}")
+
+
+def boolean(value: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    fail(f"invalid boolean {value}")
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--phase", choices=("existing", "final"), required=True)
+parser.add_argument("--channel", choices=("stable", "dev", "homolog"), required=True)
+parser.add_argument("--draft", required=True)
+parser.add_argument("--prerelease", required=True)
+parser.add_argument("--requested-draft", default="false")
+args = parser.parse_args()
+draft = boolean(args.draft)
+prerelease = boolean(args.prerelease)
+requested_draft = boolean(args.requested_draft)
+expected_prerelease = args.channel != "stable"
+
+if args.phase == "existing":
+    if not draft:
+        if requested_draft:
+            fail("an existing public release cannot become a draft")
+        if prerelease != expected_prerelease:
+            fail("existing public release channel classification is immutable")
+else:
+    if requested_draft:
+        if not draft:
+            fail("final release is public but a draft was requested")
+    elif draft or prerelease != expected_prerelease:
+        fail("final public release state does not match the requested channel")
+print("release_state_verified=true")

--- a/scripts/release/verify-release-state.test.sh
+++ b/scripts/release/verify-release-state.test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-release-state.py"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+accept() { "${SCRIPT}" "$@" >/dev/null || fail "valid release state rejected: $*"; }
+reject() { if "${SCRIPT}" "$@" >/dev/null 2>&1; then fail "invalid release state accepted: $*"; fi; }
+accept --phase existing --channel stable --draft false --prerelease false
+accept --phase existing --channel homolog --draft false --prerelease true
+accept --phase existing --channel dev --draft true --prerelease false --requested-draft true
+reject --phase existing --channel dev --draft false --prerelease false
+reject --phase existing --channel stable --draft false --prerelease true
+reject --phase existing --channel stable --draft false --prerelease false --requested-draft true
+accept --phase final --channel stable --draft false --prerelease false
+accept --phase final --channel homolog --draft false --prerelease true
+accept --phase final --channel dev --draft true --prerelease false --requested-draft true
+reject --phase final --channel dev --draft false --prerelease false
+reject --phase final --channel stable --draft false --prerelease true
+printf 'PASS: immutable public release channel and final state contract\n'

--- a/scripts/release/verify-remote-tag.sh
+++ b/scripts/release/verify-remote-tag.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+usage() {
+  printf 'Usage: verify-remote-tag.sh --remote REMOTE --version VERSION --mode absent|exact [--expected-sha FULL_SHA]\n' >&2
+  exit 2
+}
+fail() { printf 'remote tag verification failed: %s\n' "$*" >&2; exit 1; }
+remote=""
+version=""
+mode=""
+expected_sha=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote) remote="${2:-}"; shift 2 ;;
+    --version) version="${2:-}"; shift 2 ;;
+    --mode) mode="${2:-}"; shift 2 ;;
+    --expected-sha) expected_sha="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ -n "${remote}" && "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || usage
+[[ "${mode}" == "absent" || "${mode}" == "exact" ]] || usage
+if [[ "${mode}" == "exact" && ! "${expected_sha}" =~ ^[0-9a-f]{40}$ ]]; then usage; fi
+set +e
+result=$(git ls-remote --exit-code --tags "${remote}" "refs/tags/v${version}" 2>/dev/null)
+status=$?
+set -e
+if [[ ${status} -ne 0 && ${status} -ne 2 ]]; then
+  fail "remote lookup failed"
+fi
+remote_sha=""
+if [[ ${status} -eq 0 ]]; then
+  remote_sha=$(awk 'NR == 1 {print $1}' <<<"${result}")
+  [[ "${remote_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "remote tag returned an invalid object id"
+fi
+if [[ "${mode}" == "absent" ]]; then
+  [[ -z "${remote_sha}" ]] || fail "refs/tags/v${version} already exists at ${remote_sha}"
+  printf 'remote_tag_absent=true\n'
+else
+  [[ "${remote_sha}" == "${expected_sha}" ]] || fail "refs/tags/v${version} resolves to ${remote_sha:-<absent>}, expected ${expected_sha}"
+  printf 'remote_tag_sha=%s\n' "${remote_sha}"
+fi

--- a/scripts/release/verify-remote-tag.test.sh
+++ b/scripts/release/verify-remote-tag.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-remote-tag.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+[[ -x "${SCRIPT}" ]] || fail "missing executable ${SCRIPT}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+git init -q --bare "${work}/remote.git"
+git init -q "${work}/source"
+(
+  cd "${work}/source"
+  git config user.name test
+  git config user.email test@example.com
+  printf 'fixture\n' > file
+  git add file
+  git commit -qm fixture
+  git branch -M main
+  git remote add origin "file://${work}/remote.git"
+  git push -q origin main
+  git tag v2.260830.2
+  git push -q origin refs/tags/v2.260830.2
+)
+SHA="$(git -C "${work}/source" rev-parse HEAD)"
+git --git-dir="${work}/remote.git" symbolic-ref HEAD refs/heads/main
+git clone -q --depth=1 --no-tags "file://${work}/remote.git" "${work}/shallow"
+(
+  cd "${work}/shallow"
+  ! git show-ref --verify --quiet refs/tags/v2.260830.2 || fail "fixture unexpectedly fetched tags"
+  "${SCRIPT}" --remote origin --version 2.260830.2 --mode exact --expected-sha "${SHA}"
+  "${SCRIPT}" --remote origin --version 2.260830.3 --mode absent
+  if "${SCRIPT}" --remote origin --version 2.260830.2 --mode absent; then
+    fail "remote tag hidden by shallow no-tags clone was accepted as absent"
+  fi
+  if "${SCRIPT}" --remote origin --version 2.260830.2 --mode exact --expected-sha 0000000000000000000000000000000000000000; then
+    fail "remote tag move was accepted"
+  fi
+)
+printf 'PASS: shallow-clone-independent remote release tag contract\n'

--- a/scripts/release/verify-tag-ruleset.py
+++ b/scripts/release/verify-tag-ruleset.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import argparse
+import fnmatch
+import json
+from pathlib import Path
+from typing import Any, Never
+
+
+def fail(message: str) -> Never:
+    raise SystemExit(f"tag ruleset verification failed: {message}")
+
+
+parser = argparse.ArgumentParser(description="Verify that one active ruleset effectively protects an exact release tag")
+parser.add_argument("--ruleset-json", required=True)
+parser.add_argument("--tag", required=True)
+args = parser.parse_args()
+
+if not args.tag.startswith("refs/tags/v"):
+    fail("candidate is not a v* tag ref")
+decoded: Any = None
+try:
+    decoded = json.loads(Path(args.ruleset_json).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    fail(f"ruleset JSON is unreadable: {exc}")
+if not isinstance(decoded, dict):
+    fail("ruleset JSON is not an object")
+ruleset: dict[str, Any] = decoded
+if ruleset.get("target") != "tag" or ruleset.get("enforcement") != "active":
+    fail("ruleset is not active for tags")
+if ruleset.get("bypass_actors"):
+    fail("ruleset has bypass actors")
+ref_name = (ruleset.get("conditions") or {}).get("ref_name") or {}
+includes = ref_name.get("include") or []
+excludes = ref_name.get("exclude") or []
+
+def matches(pattern: object) -> bool:
+    if not isinstance(pattern, str):
+        return False
+    if pattern == "~ALL":
+        return True
+    if pattern.startswith("~"):
+        return False
+    return fnmatch.fnmatchcase(args.tag, pattern)
+
+if not any(matches(pattern) for pattern in includes):
+    fail("candidate tag is not included")
+if any(matches(pattern) for pattern in excludes):
+    fail("candidate tag is explicitly excluded")
+rule_types = {rule.get("type") for rule in ruleset.get("rules") or [] if isinstance(rule, dict)}
+missing = {"update", "deletion"} - rule_types
+if missing:
+    fail(f"ruleset is missing protections: {sorted(missing)}")
+print("ruleset_protects_tag=true")

--- a/scripts/release/verify-tag-ruleset.test.sh
+++ b/scripts/release/verify-tag-ruleset.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-tag-ruleset.py"
+work=$(mktemp -d)
+trap 'rm -rf "${work}"' EXIT
+cat >"${work}/valid.json" <<'JSON'
+{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":["refs/tags/dev*"]}},"bypass_actors":[],"rules":[{"type":"update"},{"type":"deletion"}]}
+JSON
+"${SCRIPT}" --ruleset-json "${work}/valid.json" --tag refs/tags/v2.260830.2
+python3 - "${work}/valid.json" "${work}/excluded.json" <<'PY'
+import json,sys
+x=json.load(open(sys.argv[1])); x["conditions"]["ref_name"]["exclude"]=["refs/tags/v*"]; json.dump(x,open(sys.argv[2],"w"))
+PY
+if "${SCRIPT}" --ruleset-json "${work}/excluded.json" --tag refs/tags/v2.260830.2; then
+  echo 'FAIL: excluded tag was accepted' >&2; exit 1
+fi
+python3 - "${work}/valid.json" "${work}/bypass.json" <<'PY'
+import json,sys
+x=json.load(open(sys.argv[1])); x["bypass_actors"]=[{"actor_id":1,"actor_type":"Integration","bypass_mode":"always"}]; json.dump(x,open(sys.argv[2],"w"))
+PY
+if "${SCRIPT}" --ruleset-json "${work}/bypass.json" --tag refs/tags/v2.260830.2; then
+  echo 'FAIL: bypass actor was accepted' >&2; exit 1
+fi
+python3 - "${work}/valid.json" "${work}/missing.json" <<'PY'
+import json,sys
+x=json.load(open(sys.argv[1])); x["rules"]=[{"type":"update"}]; json.dump(x,open(sys.argv[2],"w"))
+PY
+if "${SCRIPT}" --ruleset-json "${work}/missing.json" --tag refs/tags/v2.260830.2; then
+  echo 'FAIL: ruleset missing deletion protection was accepted' >&2; exit 1
+fi
+printf 'PASS: effective immutable tag ruleset contract\n'

--- a/scripts/release/verify-version-only-diff.py
+++ b/scripts/release/verify-version-only-diff.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import subprocess
+from typing import NoReturn
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"version-only diff verification failed: {message}")
+
+
+def git_bytes(*args: str) -> bytes:
+    result = subprocess.run(("git", *args), check=False, capture_output=True)
+    if result.returncode != 0:
+        fail(f"git {' '.join(args)} failed")
+    return result.stdout
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--parent", required=True)
+parser.add_argument("--source", required=True)
+parser.add_argument("--expected-version", required=True)
+args = parser.parse_args()
+if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.expected_version) is None:
+    fail("expected version is invalid")
+
+expected_paths = {
+    "package.json",
+    "bun.lock",
+    "apps/ui/package.json",
+    "deploy/helm/omni/Chart.yaml",
+    ".claude-plugin/marketplace.json",
+    "plugins/omni/.claude-plugin/plugin.json",
+    *{
+        f"packages/{name}/package.json"
+        for name in (
+            "api", "channel-a2a", "channel-discord", "channel-gupshup",
+            "channel-hermes", "channel-internal", "channel-sdk", "channel-slack",
+            "channel-telegram", "channel-twilio-whatsapp", "channel-whatsapp",
+            "channel-whatsapp-business", "cli", "core", "db", "media-processing",
+            "plugin-openclaw", "sdk", "voice-client",
+        )
+    },
+}
+
+try:
+    parent_package = json.loads(git_bytes("show", f"{args.parent}:package.json"))
+    source_package = json.loads(git_bytes("show", f"{args.source}:package.json"))
+except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    fail(f"root package metadata is invalid: {exc}")
+old_version = parent_package.get("version")
+new_version = source_package.get("version")
+if not isinstance(old_version, str) or re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", old_version) is None:
+    fail("parent version is invalid")
+if new_version != args.expected_version or old_version == new_version:
+    fail("source version does not match the expected version transition")
+
+status_lines = git_bytes("diff", "--name-status", "--no-renames", args.parent, args.source).decode().splitlines()
+changed_paths: set[str] = set()
+for line in status_lines:
+    parts = line.split("\t")
+    if len(parts) != 2 or parts[0] != "M":
+        fail(f"version transition contains a non-modification entry: {line}")
+    changed_paths.add(parts[1])
+extra = sorted(changed_paths - expected_paths)
+required = {"package.json", "packages/cli/package.json"}
+missing_required = sorted(required - changed_paths)
+if extra or missing_required:
+    fail(f"version path inventory mismatch; missing_required={missing_required}, extra={extra}")
+
+old = old_version.encode()
+new = new_version.encode()
+for path in sorted(changed_paths):
+    before = git_bytes("show", f"{args.parent}:{path}")
+    after = git_bytes("show", f"{args.source}:{path}")
+    if new not in after:
+        fail(f"expected version is absent from {path}")
+    if after.replace(new, old) != before:
+        fail(f"{path} changes content other than exact version substitutions")
+
+print("version_only_diff_verified=true")

--- a/scripts/release/verify-version-only-diff.test.sh
+++ b/scripts/release/verify-version-only-diff.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/release/verify-version-only-diff.py"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+repo="${work}/repo"
+git init -q "${repo}"
+git -C "${repo}" config user.name test
+git -C "${repo}" config user.email test@example.com
+paths=(
+  package.json bun.lock apps/ui/package.json deploy/helm/omni/Chart.yaml
+  .claude-plugin/marketplace.json plugins/omni/.claude-plugin/plugin.json
+)
+for name in api channel-a2a channel-discord channel-gupshup channel-hermes channel-internal channel-sdk channel-slack channel-telegram channel-twilio-whatsapp channel-whatsapp channel-whatsapp-business cli core db media-processing plugin-openclaw sdk voice-client; do
+  paths+=("packages/${name}/package.json")
+done
+for path in "${paths[@]}"; do
+  mkdir -p "${repo}/$(dirname "${path}")"
+  printf '{"version":"2.260830.1"}\n' > "${repo}/${path}"
+done
+git -C "${repo}" add .
+git -C "${repo}" commit -qm parent
+parent="$(git -C "${repo}" rev-parse HEAD)"
+python3 - "${repo}" "${paths[@]}" <<'PY'
+import pathlib, sys
+root = pathlib.Path(sys.argv[1])
+for name in sys.argv[2:]:
+    path = root / name
+    path.write_text(path.read_text().replace('2.260830.1', '2.260830.2'))
+PY
+git -C "${repo}" commit -qam clean-version-bump
+clean="$(git -C "${repo}" rev-parse HEAD)"
+(
+  cd "${repo}"
+  "${SCRIPT}" --parent "${parent}" --source "${clean}" --expected-version 2.260830.2
+) | grep -qx 'version_only_diff_verified=true' || fail "exact version-only bump was rejected"
+
+git -C "${repo}" checkout -q -b malicious "${parent}"
+python3 - "${repo}" "${paths[@]}" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+for name in sys.argv[2:]:
+    path = root / name
+    path.write_text(path.read_text().replace('2.260830.1', '2.260830.2'))
+cli = root / 'packages/cli/package.json'
+data = json.loads(cli.read_text())
+data['scripts'] = {'prepack': 'steal-secret'}
+cli.write_text(json.dumps(data) + '\n')
+PY
+git -C "${repo}" add .
+git -C "${repo}" commit -qm malicious-version-bump
+malicious="$(git -C "${repo}" rev-parse HEAD)"
+if (cd "${repo}" && "${SCRIPT}" --parent "${parent}" --source "${malicious}" --expected-version 2.260830.2 >/dev/null 2>&1); then
+  fail "version-only validation accepted a package lifecycle-script injection"
+fi
+printf 'PASS: semantic version-only detached source contract\n'


### PR DESCRIPTION
## Summary

- add immutable `repository@sha256` Helm rendering and a narrow production GitOps pin file
- make `main` releases artifact-first: publish and verify the exact amd64/arm64 OCI index plus GitHub provenance before stable tag/release/npm finalization
- sequence run-bound signed GitHub release and npm Trusted Publishing before a bounded compare-and-swap pin commit
- add exact, idempotent repair inputs for partially completed immutable releases
- make signed release publication fail closed: verified tag, exact 12-asset inventory, draft-until-verified promotion, final state checks, and deterministic bounded-CAS channel manifests
- suppress image rebuilds for pin-only and release-infrastructure-only commits while still running protected CI; CI never writes to the production cluster
- repair release-note authentication to use the job-scoped GitHub token
- pin every third-party action/reusable workflow in the privileged tarball/signing chain to a full commit SHA
- enforce release, pin, Helm, detached-repair, public-asset, caller-run, npm-dist-tag, remote-tag, and actionlint contracts in the required Quality Gate
- classify the complete GitHub push range (including new-branch zero-SHA events), not only the final commit
- fail closed when Git cannot enumerate either image-classification or release-source drift
- execute repair control code from the exact hardened workflow revision while checking out an immutable historical source separately
- validate detached repairs semantically: every changed byte must be an exact version substitution in an approved version file

## Safety properties

- version tags are fail-closed and never intentionally rebound
- repair requires exact tag, version, 40-character source SHA, and approved existing digest when applicable
- stable entry points require `github-actions[bot]` plus the exact in-progress `image-publish.yml` run, source SHA, OCI digest, and independently verified provenance
- stable finalization fails closed unless an active repository ruleset effectively covers the exact candidate `v*` tag, has no matching exclusion or bypass actor, and prevents update and deletion
- the published OCI `v<version>` alias is read back against the exact build digest immediately after push and again after release finalization; production remains pinned by digest
- direct recovery and reusable orchestration are behaviorally distinguished without relying on inherited `github.event_name`; untrusted workflow inputs enter shell only through validated environment variables
- every branch-writing release path requires `VERSION_BUMP_PAT` and fails before mutation if absent, so protected push CI cannot be silently suppressed by `GITHUB_TOKEN` anti-recursion
- stable npm state is reconciled behaviorally: publish missing versions, repair a drifted `latest` with the protected npm credential, and read back exact version/dist-tag state after mutation
- npm publication removes the recovery token before any lifecycle process; every path repacks the immutable source, compares package contents with the registry tarball, verifies npm integrity/SHA-1 and the registry ECDSA signature against live npm keys, then runs `npm audit signatures --include-attestations`; new publications additionally require their own verified SLSA provenance entry
- orchestrator control SHA and historical release-source SHA are passed and verified as separate identities
- homolog version publication has one canonical post-CI entry point; equivalent version events share a branch-scoped concurrency group to prevent duplicate bumps and publication
- release-adjacent third-party actions, including the signing-identity trust gate, are pinned to immutable commit SHAs and checked by the release contract
- uploaded GitHub Release assets are read back by exact name and SHA-256 digest before draft promotion
- existing release tarballs, Cosign bundles, SLSA provenance, and GitHub attestations are all cryptographically reverified; public stable/prerelease classification is immutable
- all actions in protected CI are commit-pinned, and image publication credentials are granted only to the three publishing jobs
- existing public release assets are never clobbered: all 12 names and SHA-256 digests must match before an idempotent recovery continues
- source drift after the verified release is limited to release/Helm infrastructure paths; the historical `.2` repair additionally proves its detached commit is version-only and based on main ancestry
- production pin updates reject downgrades, same-version rebinding, dirty state, stale parents, and non-fast-forward races
- post-release Git writes are limited to deterministic channel manifests and the narrow production pin; both use bounded non-force CAS retries
- Argo CD remains the sole production cluster writer

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` (22/22 Turbo tasks)
- `bun run build` (5/5 Turbo tasks)
- `bun scripts/verify-versions.ts` (24/24 synchronized)
- `bunx knip`
- `actionlint` 1.7.7 and 1.7.12 on the complete six-workflow privileged release chain plus CI
- `bash -n` on all added shell contracts
- release workflow contract tests: publish→verify→pin, stable ordering, repair preflight, CAS pin, detached source topology, public asset identity, exact orchestrator run, npm latest state, shallow-clone-independent remote tags, effective tag rulesets, OCI alias identity, reusable/direct entry semantics, and multi-commit/new-branch push classification
- behavioral npm reconciliation tests cover idempotence, first publish, `latest` repair, missing recovery credentials, and non-convergent readback
- adversarial tests reject lifecycle-script injection in a supposed version-only commit, npm recovery-token inheritance, wrong package contents, invalid registry signatures, failed provenance audits, and stable↔prerelease demotion
- live historical-source probe ran current hardened control code against `b8c1bf20…`, which does not contain the helpers, and resolved the approved OCI digest idempotently
- live npm replay rebuilt `2.260830.2`, normalized only Bun's ephemeral absolute build-root constants, matched all 279 registry package files, verified registry integrity/signatures, and completed `npm audit signatures --include-attestations` with `npm_action=none`
- live release replay verified all four tarballs against their exact Cosign bundles, SLSA provenance at source `b8c1bf20…`, and GitHub-native attestations
- Helm digest + production overlay render contract with Helm 3.16.4
- real GHCR preflight against `v2.260830.2` resolved the approved digest as idempotent (`publish_required=false`)
- live attestation verification bound the exact OCI digest to source `b8c1bf20…` and signer workflow `image-publish.yml`
- live `v2.260830.2` release verified with exactly 12 assets whose downloaded bytes match GitHub SHA-256 digests; all four tarballs pass source/signer-bound attestations

## Rollout / rollback

This PR itself is release-infrastructure-only, so the changed classifier skips image publication. The checked-in production pin remains the already-running adoption digest/version. No Kubernetes, Helm, Argo, RDS, or NATS mutation is performed by this PR.

Before invoking stable finalization, repository administration must add the active `v*` tag update/deletion ruleset required by the workflow. Until then, release/pin finalization intentionally stops before mutation.

Rollback is a normal revert of this PR before Argo adoption. After adoption, rollback is a forward Git pin to a previously verified digest; no mutable tag or direct cluster write is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production deployments can now use immutable container image digests, with validation to prevent invalid references.
  - Release workflows support verified stable releases, recovery publishing, and safe image-pin updates.
  - Release artifacts and package publications are now checked for version, integrity, provenance, and completeness.

- **Bug Fixes**
  - Improved release handling prevents duplicate versions, mismatched artifacts, incorrect tags, and inconsistent publication states.
  - Added safer retry behavior for updating release metadata and production deployment pins.

- **Tests**
  - Expanded automated coverage for Helm rendering, release authorization, artifact verification, image publishing, and package reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->