### PR TITLE
ci(images): publish an attested dev image channel on every dev push

### DIFF
--- a/.github/workflows/image-dev.yml
+++ b/.github/workflows/image-dev.yml
@@ -1,14 +1,29 @@
 # =============================================================================
-# Publish the dev image channel from every qualifying push to `dev`.
+# Publish the dev image channel: one image per merged PR to `dev`.
 # =============================================================================
 # The HML instance is kept on the `dev` branch by Argo CD through the private
 # GitOps repository, which pins ghcr.io/<owner>/omni-api by digest. This
-# workflow is the only producer of that channel: on each push to `dev` that
-# changes a protected image build input (the list in
-# scripts/release/verify-promotion-candidate.sh, mirrored in the `paths:`
-# filter below) it builds the linux/amd64 + linux/arm64 OCI index, pushes an
-# immutable `dev-<sha12>` alias plus the floating `dev` alias, and registers
-# GitHub-native provenance for the index digest.
+# workflow is the only producer of that channel and it has no `push:`
+# trigger, so no commit to `dev` ever builds an image by itself. It is built
+# once per merged PR to `dev`: version.yml calls it as a local reusable
+# workflow (`uses: ./.github/workflows/image-dev.yml`) exactly once per dev
+# version cut, passing the version bump commit it just pushed to `dev`, so
+# every dev image corresponds to one dev version cut. Direct commits to `dev`
+# (fixes, merges, chores) never build; the previous dev image stays valid
+# until the next merged PR. A manual dispatch rebuilds the current `dev` head
+# (for example after a registry-side cleanup) or, given `ref`, one exact
+# commit that is already on `dev`.
+#
+# A local call rather than a dispatch: GitHub resolves a dispatched workflow
+# file against the DEFAULT branch, so a workflow that exists only on `dev`
+# cannot be dispatched until the next dev-to-main promotion (that 404 is
+# exactly how the first image-build.yml dispatch failed). A `uses:` call
+# resolves the file from the caller's own checkout, so it works on `dev`
+# before it ever reaches `main`.
+#
+# Each run builds the linux/amd64 + linux/arm64 OCI index from the resolved
+# `dev` commit, pushes an immutable `dev-<sha12>` alias plus the floating
+# `dev` alias, and registers GitHub-native provenance for the index digest.
 #
 # Dev images are NOT release candidates. Nothing here is promotable: the
 # workflow never creates a tag ref, never pushes a `v<version>` alias, never
@@ -17,10 +32,13 @@
 # dispatch-only image-build.yml at an exact `v<version>` tag, and the read-only
 # main promotion (image-publish.yml) verifies only those.
 #
-# Only the newest `dev` head matters, so an in-flight build is cancelled when a
-# newer push arrives. The floating `dev` alias therefore always converges on
-# the newest head that finished; consumers that need an exact identity pin the
-# `dev-<sha12>` alias or, better, the digest printed in the step summary.
+# Only the newest `dev` cut matters, so an in-flight build is cancelled when a
+# newer call or dispatch arrives (one constant concurrency group: a run is
+# started only for a commit on `dev`, and version.yml serializes bumps, so a
+# newer run is always a newer cut). The floating `dev` alias therefore always
+# converges on the newest cut that finished; consumers that need an exact
+# identity pin the `dev-<sha12>` alias or, better, the digest printed in the
+# step summary.
 #
 # Actions are pinned to full commit SHAs (supply-chain hardening: this
 # workflow holds `packages: write`). Bump the SHA and the trailing version
@@ -29,24 +47,23 @@
 name: Publish dev image
 
 on:
-  push:
-    branches: [dev]
-    # Keep in sync with build_inputs in
-    # scripts/release/verify-promotion-candidate.sh (the contract test binds
-    # the two lists). A push that touches none of these leaves the previous
-    # dev image valid, so it is not rebuilt.
-    paths:
-      - deploy/Dockerfile
-      - deploy/Dockerfile.dockerignore
-      - package.json
-      - bun.lock
-      - 'packages/**'
-      - 'apps/**'
-      - .github/workflows/image-dev.yml
-  # Rebuild the current dev head (for example after a registry-side cleanup).
-  # No inputs: the source is always the head of the ref the run is dispatched
-  # on, and the guard below requires that ref to be `dev`.
+  # No `push:` trigger by design: an image is built once per merged PR to
+  # `dev`, when version.yml calls this workflow after the version bump lands,
+  # and never on a regular commit. Both entries take the same single input;
+  # the guard below requires the resolved commit to be on `dev`.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Exact 40-hex commit on dev to build (version.yml passes the bump commit)'
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Exact 40-hex commit on dev to build; empty builds the current dev head'
+        required: false
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -56,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: image-dev-${{ github.ref }}
+      group: image-dev
       cancel-in-progress: true
     permissions:
       contents: read
@@ -66,33 +83,59 @@ jobs:
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
     steps:
-      # Branch-only by construction: any other ref (a tag, another branch, a
-      # dispatch from the wrong ref) is refused before anything is checked out.
-      - name: Require the dev branch head
-        id: guard
-        run: |
-          set -euo pipefail
-          [[ "${GITHUB_REF}" == "refs/heads/dev" ]] || {
-            echo "::error::dev images are built only from the dev branch head, not ${GITHUB_REF}"
-            exit 1
-          }
-          [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::GITHUB_SHA is not a full commit SHA"
-            exit 1
-          }
-          echo "sha12=${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
-
+      # Always the `dev` branch, never the calling ref: under the version.yml
+      # call on a merged pull_request the caller's github.ref is the PR merge
+      # ref and github.sha its merge commit, neither of which is on `dev`.
+      # Full history so the ancestry guard below can see every dev commit.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.sha }}
+          ref: dev
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Bind the checked-out source to the dev head
+      # Branch-only by construction: the build source is `inputs.ref` when
+      # given (the bump commit from version.yml, or an operator's exact
+      # commit), else the current `dev` head, and it must be a full commit SHA
+      # that is reachable from `origin/dev`. Anything else (a short SHA, a
+      # branch name, a tag, a commit from another branch or a PR merge ref) is
+      # refused before anything is built.
+      - name: Resolve and require a commit on dev
+        id: guard
+        env:
+          REQUESTED_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          dev_head=$(git rev-parse "refs/remotes/origin/dev^{commit}")
+          [[ "${dev_head}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::origin/dev did not resolve to a full commit SHA"
+            exit 1
+          }
+          target="${REQUESTED_REF:-${dev_head}}"
+          [[ "${target}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::ref must be an exact 40-hex commit SHA on dev, not '${REQUESTED_REF}'"
+            exit 1
+          }
+          git cat-file -e "${target}^{commit}" || {
+            echo "::error::${target} is not a commit in this repository"
+            exit 1
+          }
+          git merge-base --is-ancestor "${target}" origin/dev || {
+            echo "::error::dev images are built only from commits on the dev branch; ${target} is not reachable from origin/dev"
+            exit 1
+          }
+          git checkout --detach "${target}"
+          echo "sha=${target}" >> "$GITHUB_OUTPUT"
+          echo "sha12=${target:0:12}" >> "$GITHUB_OUTPUT"
+          echo "Building dev image from ${target} (dev head: ${dev_head})"
+
+      - name: Bind the checked-out source to the resolved dev commit
+        env:
+          TARGET_SHA: ${{ steps.guard.outputs.sha }}
         run: |
           set -euo pipefail
           source_sha=$(git rev-parse "HEAD^{commit}")
-          [[ "${source_sha}" == "${GITHUB_SHA}" ]] || {
-            echo "::error::checked-out source ${source_sha} is not the dev head ${GITHUB_SHA}"
+          [[ "${source_sha}" == "${TARGET_SHA}" ]] || {
+            echo "::error::checked-out source ${source_sha} is not the resolved dev commit ${TARGET_SHA}"
             exit 1
           }
 
@@ -119,7 +162,7 @@ jobs:
           file: deploy/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          # One immutable alias per dev head plus the floating channel alias.
+          # One immutable alias per dev commit plus the floating channel alias.
           # Never a `v<version>` alias: that identity belongs to candidates
           # minted by image-build.yml.
           tags: |
@@ -127,24 +170,30 @@ jobs:
             ${{ env.IMAGE }}:dev
           # BuildKit cache, deliberately unlike image-build.yml. A candidate is
           # built once from its attested source alone, so it refuses the
-          # mutable GHA cache. A dev image is rebuilt on every qualifying push
-          # and is never promotable, while its QEMU arm64 `bun install` stage
-          # dominates a cold build; without a cache every dev push pays that
-          # in full. The scope is written only by this workflow on
-          # refs/heads/dev (GitHub isolates caches per branch, so a PR or
-          # fork run cannot seed it), and `mode=max` exports the intermediate
-          # deps/builder stages that the runtime stage only copies from.
+          # mutable GHA cache. A dev image is rebuilt for every merged PR to
+          # dev and is never promotable, while its QEMU arm64 `bun install`
+          # stage dominates a cold build; without a cache every dev cut pays
+          # that in full. `mode=max` exports the intermediate deps/builder
+          # stages that the runtime stage only copies from. GitHub isolates
+          # the cache per ref (a run reads its own ref's entries plus the base
+          # and default branches', and writes only its own), so a PR or fork
+          # run can never seed an entry a `dev` run reads. Under the
+          # version.yml call the run's ref is the merged PR's `refs/pull/N/
+          # merge`, so that run reads entries written by manual dispatches on
+          # `dev` and its own write is only reusable by that closed PR; a miss
+          # costs a cold build, nothing else. A manual dispatch on `dev`
+          # warms the entry every later call reads.
           cache-from: type=gha,scope=omni-api-dev
           cache-to: type=gha,scope=omni-api-dev,mode=max
           provenance: true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.guard.outputs.sha }}
             org.opencontainers.image.version=dev-${{ steps.guard.outputs.sha12 }}
 
       # The immutable alias must resolve to the index this run produced; the
-      # floating alias must too, because a newer dev push cancels this run
-      # before it can build, so at this point this run is the newest head.
+      # floating alias must too, because a newer call cancels this run before
+      # it can build, so at this point this run is the newest cut.
       - name: Read back the immutable and floating dev aliases
         env:
           SHA12: ${{ steps.guard.outputs.sha12 }}
@@ -169,6 +218,7 @@ jobs:
 
       - name: Write dev image receipt
         env:
+          TARGET_SHA: ${{ steps.guard.outputs.sha }}
           SHA12: ${{ steps.guard.outputs.sha12 }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
@@ -178,7 +228,7 @@ jobs:
             exit 1
           }
           {
-            echo "### Omni dev image \`${GITHUB_SHA}\`"
+            echo "### Omni dev image \`${TARGET_SHA}\`"
             echo "- immutable alias: \`${IMAGE}:dev-${SHA12}\`"
             echo "- floating alias: \`${IMAGE}:dev\`"
             echo "- OCI index digest: \`${DIGEST}\`"

--- a/.github/workflows/image-dev.yml
+++ b/.github/workflows/image-dev.yml
@@ -1,0 +1,191 @@
+# =============================================================================
+# Publish the dev image channel from every qualifying push to `dev`.
+# =============================================================================
+# The HML instance is kept on the `dev` branch by Argo CD through the private
+# GitOps repository, which pins ghcr.io/<owner>/omni-api by digest. This
+# workflow is the only producer of that channel: on each push to `dev` that
+# changes a protected image build input (the list in
+# scripts/release/verify-promotion-candidate.sh, mirrored in the `paths:`
+# filter below) it builds the linux/amd64 + linux/arm64 OCI index, pushes an
+# immutable `dev-<sha12>` alias plus the floating `dev` alias, and registers
+# GitHub-native provenance for the index digest.
+#
+# Dev images are NOT release candidates. Nothing here is promotable: the
+# workflow never creates a tag ref, never pushes a `v<version>` alias, never
+# dispatches release.yml or version.yml, never writes public channel metadata,
+# and runs in no protected environment. Candidates are minted only by the
+# dispatch-only image-build.yml at an exact `v<version>` tag, and the read-only
+# main promotion (image-publish.yml) verifies only those.
+#
+# Only the newest `dev` head matters, so an in-flight build is cancelled when a
+# newer push arrives. The floating `dev` alias therefore always converges on
+# the newest head that finished; consumers that need an exact identity pin the
+# `dev-<sha12>` alias or, better, the digest printed in the step summary.
+#
+# Actions are pinned to full commit SHAs (supply-chain hardening: this
+# workflow holds `packages: write`). Bump the SHA and the trailing version
+# comment together.
+# =============================================================================
+name: Publish dev image
+
+on:
+  push:
+    branches: [dev]
+    # Keep in sync with build_inputs in
+    # scripts/release/verify-promotion-candidate.sh (the contract test binds
+    # the two lists). A push that touches none of these leaves the previous
+    # dev image valid, so it is not rebuilt.
+    paths:
+      - deploy/Dockerfile
+      - deploy/Dockerfile.dockerignore
+      - package.json
+      - bun.lock
+      - 'packages/**'
+      - 'apps/**'
+      - .github/workflows/image-dev.yml
+  # Rebuild the current dev head (for example after a registry-side cleanup).
+  # No inputs: the source is always the head of the ref the run is dispatched
+  # on, and the guard below requires that ref to be `dev`.
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build-push-dev:
+    name: Build, push, and attest the dev image
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: image-dev-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+    steps:
+      # Branch-only by construction: any other ref (a tag, another branch, a
+      # dispatch from the wrong ref) is refused before anything is checked out.
+      - name: Require the dev branch head
+        id: guard
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REF}" == "refs/heads/dev" ]] || {
+            echo "::error::dev images are built only from the dev branch head, not ${GITHUB_REF}"
+            exit 1
+          }
+          [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::GITHUB_SHA is not a full commit SHA"
+            exit 1
+          }
+          echo "sha12=${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Bind the checked-out source to the dev head
+        run: |
+          set -euo pipefail
+          source_sha=$(git rev-parse "HEAD^{commit}")
+          [[ "${source_sha}" == "${GITHUB_SHA}" ]] || {
+            echo "::error::checked-out source ${source_sha} is not the dev head ${GITHUB_SHA}"
+            exit 1
+          }
+
+      # arm64 is built under QEMU emulation, exactly as image-build.yml does;
+      # both target clusters are arm64, so that platform is not optional.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # One immutable alias per dev head plus the floating channel alias.
+          # Never a `v<version>` alias: that identity belongs to candidates
+          # minted by image-build.yml.
+          tags: |
+            ${{ env.IMAGE }}:dev-${{ steps.guard.outputs.sha12 }}
+            ${{ env.IMAGE }}:dev
+          # BuildKit cache, deliberately unlike image-build.yml. A candidate is
+          # built once from its attested source alone, so it refuses the
+          # mutable GHA cache. A dev image is rebuilt on every qualifying push
+          # and is never promotable, while its QEMU arm64 `bun install` stage
+          # dominates a cold build; without a cache every dev push pays that
+          # in full. The scope is written only by this workflow on
+          # refs/heads/dev (GitHub isolates caches per branch, so a PR or
+          # fork run cannot seed it), and `mode=max` exports the intermediate
+          # deps/builder stages that the runtime stage only copies from.
+          cache-from: type=gha,scope=omni-api-dev
+          cache-to: type=gha,scope=omni-api-dev,mode=max
+          provenance: true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=dev-${{ steps.guard.outputs.sha12 }}
+
+      # The immutable alias must resolve to the index this run produced; the
+      # floating alias must too, because a newer dev push cancels this run
+      # before it can build, so at this point this run is the newest head.
+      - name: Read back the immutable and floating dev aliases
+        env:
+          SHA12: ${{ steps.guard.outputs.sha12 }}
+          EXPECTED_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          scripts/release/verify-oci-alias.sh \
+            --image "${IMAGE}" --tag "dev-${SHA12}" --expected-digest "${EXPECTED_DIGEST}"
+          scripts/release/verify-oci-alias.sh \
+            --image "${IMAGE}" --tag dev --expected-digest "${EXPECTED_DIGEST}"
+
+      # GitHub-native provenance (Attestations API + registry referrer), so
+      # `gh attestation verify oci://<image>@<digest> -R <owner>/omni` works
+      # for the GitOps pin. BuildKit's inline `provenance: true` above is NOT
+      # visible to `gh`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Write dev image receipt
+        env:
+          SHA12: ${{ steps.guard.outputs.sha12 }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::build produced no index digest"
+            exit 1
+          }
+          {
+            echo "### Omni dev image \`${GITHUB_SHA}\`"
+            echo "- immutable alias: \`${IMAGE}:dev-${SHA12}\`"
+            echo "- floating alias: \`${IMAGE}:dev\`"
+            echo "- OCI index digest: \`${DIGEST}\`"
+            echo "- GitOps pin form: \`${IMAGE}@${DIGEST}\`"
+            echo "- channel: dev only — not a release candidate, never promotable"
+            echo "- mutation boundary: no tag ref, release, npm, channel metadata, or cluster write"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "DEV_IMAGE_DIGEST=${DIGEST}"
+          echo "DEV_IMAGE_TAG=${IMAGE}:dev-${SHA12}"
+          echo "DEV_IMAGE_FLOATING_TAG=${IMAGE}:dev"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -71,6 +71,10 @@ jobs:
     # /usr/local. (Trade-off: slower job startup vs. publish reliability.)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      # The commit "Commit and tag" pushed to dev; the dev-image job below
+      # builds exactly this commit.
+      bump_sha: ${{ steps.bump.outputs.bump_sha }}
     permissions:
       contents: write
       # OIDC token issuance for npm Trusted Publishing — pairs with the
@@ -178,6 +182,7 @@ jobs:
           bun install
 
       - name: Commit and tag
+        id: bump
         env:
           # The branch and tag pushes deliberately use different credentials.
           GITHUB_TOKEN: ${{ github.token }}
@@ -202,6 +207,12 @@ jobs:
 
           git tag "v${VERSION}"
 
+          # The commit that lands on dev (the fresh bump, or the unchanged
+          # head on a no-op re-run). The dev-image job builds exactly this
+          # commit, so it is emitted only after both pushes below succeed.
+          BUMP_SHA=$(git rev-parse "HEAD^{commit}")
+          [[ "${BUMP_SHA}" =~ ^[0-9a-f]{40}$ ]]
+
           # Split push (was --atomic): the two refs need DIFFERENT credentials.
           # Branch push uses the machine PAT explicitly so the push actor is not
           # github-actions[bot] — see the checkout step for why.
@@ -224,6 +235,8 @@ jobs:
           git -c http.https://github.com/.extraheader= \
             push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "refs/tags/v${VERSION}"
+
+          echo "bump_sha=${BUMP_SHA}" >> "$GITHUB_OUTPUT"
 
       # Dispatch the signed-tarball release pipeline (build → sign-attest →
       # publish) via release.yml's workflow_dispatch entry. GITHUB_TOKEN-
@@ -305,6 +318,43 @@ jobs:
             echo "::error ::release-trigger.dispatch_failed release.yml dispatch failed for ${TAG} — investigate gh CLI auth or workflow availability before re-running manually"
             exit 1
           fi
+
+  # Dev image policy: ONE image per merged PR to dev, never per commit.
+  # image-dev.yml has no push trigger, so a direct commit to dev (a fix, a
+  # merge commit, a chore) never builds an image; the only producer of the
+  # `dev` / `dev-<sha12>` channel is this call, which runs once per dev
+  # version cut after the bump commit and its v<version> tag have been
+  # pushed, and builds exactly that bump commit. A manual dispatch of
+  # image-dev.yml rebuilds the dev head (or a given dev commit) on demand.
+  #
+  # A local reusable-workflow call, not `gh workflow run`: a dispatch resolves
+  # the workflow file against the DEFAULT branch, so image-dev.yml could not
+  # be dispatched until it reached main (the exact 404 the first
+  # image-build.yml dispatch hit). `uses:` resolves it from this run's own
+  # checkout, so it works on dev before any promotion.
+  #
+  # `candidate=true` skips this: a candidate cut mints its own attested image
+  # via image-build.yml at the exact v<version> tag, and a dev image is never
+  # a candidate. On the merged-PR trigger `inputs` is empty, so
+  # `inputs.candidate` is null and `null != true` holds: every merged PR is a
+  # dev cut and builds. (Same expression as the npm publish step above.)
+  #
+  # Runs AFTER auto-version has fully succeeded (tag push, npm publish, and
+  # release dispatch included), so a build failure can never block those; it
+  # surfaces as a failed job, and the operator rebuilds by dispatching
+  # image-dev.yml with `ref=<bump sha>`.
+  dev-image:
+    name: Dev image
+    needs: auto-version
+    if: needs.auto-version.result == 'success' && inputs.candidate != true
+    uses: ./.github/workflows/image-dev.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      ref: ${{ needs.auto-version.outputs.bump_sha }}
 
   publish-stable:
     name: Publish verified stable npm package

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,7 @@ or legacy overlays.
 | Realm | Cluster | Values file | Images | Database | Media | Who operates it |
 |---|---|---|---|---|---|---|
 | **dev / self-host** | Local or self-managed k8s (OrbStack, k3d, kind, …) | [`values-dev.yaml`](helm/omni/values-dev.yaml) | Locally built `omni-api:dev` + `autopg:dev` (`pullPolicy: Never`) or an explicitly selected public version | Bundled **autopg** subchart (Postgres 18, in-cluster) | Bundled **MinIO** (in-cluster S3) | The self-hoster |
-| **HML** (`hml.omni.khal.ai`) | Private arm64 cluster | Private GitOps repo | Follows `dev` via `ghcr.io/automagik-dev/omni-api:dev-<sha12>` (built by `.github/workflows/image-dev.yml`), pinned by digest in the private GitOps repo (`git.namastex.io/khal/deploy`) | Private | Private | The private GitOps repo (Argo CD) |
+| **HML** (`hml.omni.khal.ai`) | Private arm64 cluster | Private GitOps repo | Follows `dev` via `ghcr.io/automagik-dev/omni-api:dev-<sha12>` (built by `.github/workflows/image-dev.yml`: one image per merged PR to `dev`, called by `version.yml` with the version bump commit; direct commits never build; a manual dispatch rebuilds the `dev` head), pinned by digest in the private GitOps repo (`git.namastex.io/khal/deploy`) | Private | Private | The private GitOps repo (Argo CD) |
 | **prod** | Private arm64 cluster | Private GitOps repo | Pinned to the verified candidate digest by the private GitOps repo; the public repo only declares the candidate (`image-publish.yml`, `.well-known/latest.json`) | Private | Private | The private GitOps repo (Argo CD) |
 
 - **One replica per installation** — a WhatsApp credential maps to a single live

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,6 +23,8 @@ or legacy overlays.
 | Realm | Cluster | Values file | Images | Database | Media | Who operates it |
 |---|---|---|---|---|---|---|
 | **dev / self-host** | Local or self-managed k8s (OrbStack, k3d, kind, …) | [`values-dev.yaml`](helm/omni/values-dev.yaml) | Locally built `omni-api:dev` + `autopg:dev` (`pullPolicy: Never`) or an explicitly selected public version | Bundled **autopg** subchart (Postgres 18, in-cluster) | Bundled **MinIO** (in-cluster S3) | The self-hoster |
+| **HML** (`hml.omni.khal.ai`) | Private arm64 cluster | Private GitOps repo | Follows `dev` via `ghcr.io/automagik-dev/omni-api:dev-<sha12>` (built by `.github/workflows/image-dev.yml`), pinned by digest in the private GitOps repo (`git.namastex.io/khal/deploy`) | Private | Private | The private GitOps repo (Argo CD) |
+| **prod** | Private arm64 cluster | Private GitOps repo | Pinned to the verified candidate digest by the private GitOps repo; the public repo only declares the candidate (`image-publish.yml`, `.well-known/latest.json`) | Private | Private | The private GitOps repo (Argo CD) |
 
 - **One replica per installation** — a WhatsApp credential maps to a single live
   Baileys socket; see the "replicas + scaling" notes in

--- a/docs/deployment/public-launch-readiness.md
+++ b/docs/deployment/public-launch-readiness.md
@@ -87,6 +87,28 @@ on a tag ref). The active `v*` tag ruleset must keep its `update` and
 environment is protected, any write collaborator who can dispatch the
 workflow can publish a stable release and move npm `latest`.
 
+## Dev image channel
+
+`.github/workflows/image-dev.yml` ("Publish dev image") is the only producer
+of the dev image channel. Every push to `dev` that changes a protected image
+build input (the same list as `scripts/release/verify-promotion-candidate.sh`,
+plus the workflow file itself; a `workflow_dispatch` rebuilds the current
+`dev` head) builds the `linux/amd64` + `linux/arm64` OCI index, pushes the
+immutable `ghcr.io/automagik-dev/omni-api:dev-<sha12>` alias and the floating
+`:dev` alias, and registers GitHub-native provenance for the index digest
+(`DEV_IMAGE_DIGEST=` in the run log and step summary). It uses only
+`github.token` with `contents: read, packages: write, id-token: write,
+attestations: write`, runs in no environment, and never creates a tag ref, a
+`v<version>` alias, a release, an npm publication, or public channel metadata.
+
+`dev` and `dev-<sha12>` are never promotable: candidates are minted only by
+`image-build.yml` at an exact `v<version>` tag, `image-publish.yml` verifies
+only those, and `verify-promotion-candidate.sh` is unaffected by this channel
+(a dev image is not a candidate and has no version tag to bind). The HML
+instance tracks the channel through the private GitOps repository
+(`git.namastex.io/khal/deploy`), which pins the `dev-<sha12>` alias by digest;
+the `dev` → `main` promotion never carries a dev image.
+
 ## Public repository ownership
 
 The generic Helm `image.digest` renderer remains available, but the public

--- a/docs/deployment/public-launch-readiness.md
+++ b/docs/deployment/public-launch-readiness.md
@@ -90,16 +90,29 @@ workflow can publish a stable release and move npm `latest`.
 ## Dev image channel
 
 `.github/workflows/image-dev.yml` ("Publish dev image") is the only producer
-of the dev image channel. Every push to `dev` that changes a protected image
-build input (the same list as `scripts/release/verify-promotion-candidate.sh`,
-plus the workflow file itself; a `workflow_dispatch` rebuilds the current
-`dev` head) builds the `linux/amd64` + `linux/arm64` OCI index, pushes the
-immutable `ghcr.io/automagik-dev/omni-api:dev-<sha12>` alias and the floating
-`:dev` alias, and registers GitHub-native provenance for the index digest
-(`DEV_IMAGE_DIGEST=` in the run log and step summary). It uses only
-`github.token` with `contents: read, packages: write, id-token: write,
-attestations: write`, runs in no environment, and never creates a tag ref, a
-`v<version>` alias, a release, an npm publication, or public channel metadata.
+of the dev image channel, and it builds exactly one image per merged PR to
+`dev`. It has no `push:` trigger: `version.yml` calls it as a local reusable
+workflow (`uses: ./.github/workflows/image-dev.yml`) once per dev version cut,
+after the version bump commit and its `v<version>` tag have landed on `dev`,
+passing that bump commit as the `ref` input. Direct commits to `dev` (fixes,
+merge commits, chores) never build an image; the previous dev image stays
+valid until the next merged PR. A manual dispatch rebuilds the current `dev`
+head on demand (`gh workflow run image-dev.yml --ref dev`, or with
+`-f ref=<sha>` for one exact commit already on `dev`; a dispatch only resolves
+once the workflow file is on the default branch, which is why `version.yml`
+calls it instead of dispatching it), and a candidate cut (`version.yml` with
+`candidate=true`) skips the call because `image-build.yml` mints that image at
+its tag. Whatever the entry, the workflow checks out the `dev` branch itself
+and refuses any `ref` that is not a full commit SHA reachable from `dev`.
+
+Each run builds the `linux/amd64` + `linux/arm64` OCI index from the resolved
+`dev` commit, pushes the immutable `ghcr.io/automagik-dev/omni-api:dev-<sha12>`
+alias and the floating `:dev` alias, and registers GitHub-native provenance
+for the index digest (`DEV_IMAGE_DIGEST=` in the run log and step summary). It
+uses only `github.token` with `contents: read, packages: write, id-token:
+write, attestations: write`, runs in no environment, and never creates a tag
+ref, a `v<version>` alias, a release, an npm publication, or public channel
+metadata.
 
 `dev` and `dev-<sha12>` are never promotable: candidates are minted only by
 `image-build.yml` at an exact `v<version>` tag, `image-publish.yml` verifies

--- a/scripts/release/release-workflow-contract.test.sh
+++ b/scripts/release/release-workflow-contract.test.sh
@@ -238,6 +238,91 @@ else:
         require(workflows[other], r"verify-orchestrator-run\.py[\s\S]{0,300}--expected-workflow \.github/workflows/image-build\.yml\s*\\\n\s+--allowed-event workflow_dispatch", f"{other} does not require an in-progress dispatch-only image-build orchestrator run")
     forbid(all_workflows, r"--signer-workflow\s+\"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-publish\.yml\"", "a workflow still treats the read-only promotion verifier as the OCI signer")
 
+# image-dev.yml is the dev image channel: it builds and attests the dev head
+# on every push to dev that changes a protected build input, pushes only the
+# `dev-<sha12>` and floating `dev` aliases, and is never a candidate path. It
+# must not be able to create a tag, a `v<version>` alias, a release, an npm
+# publication, or public channel metadata, and it runs in no environment.
+image_dev = workflows.get("image-dev.yml")
+if image_dev is None:
+    errors.append("dev image channel workflow image-dev.yml is missing")
+else:
+    dev_trigger_match = re.search(
+        r"^on:\n  push:\n    branches: \[dev\]\n(?:    #[^\n]*\n)*    paths:\n(?P<paths>(?:      - [^\n]+\n)+)(?:  #[^\n]*\n)*  workflow_dispatch:\n(?P<dispatch>(?:    [^\n]*\n)*)",
+        image_dev,
+        flags=re.MULTILINE,
+    )
+    if dev_trigger_match is None:
+        errors.append("dev image channel is not triggered by push to dev with a paths filter plus a bare workflow_dispatch")
+    else:
+        dev_paths = {
+            line.strip()[2:].strip().strip("'\"")
+            for line in dev_trigger_match.group("paths").splitlines()
+        }
+        candidate_inputs_match = re.search(r"build_inputs=\((?P<inputs>[^)]*)\)", (root / "scripts/release/verify-promotion-candidate.sh").read_text(encoding="utf-8"))
+        if candidate_inputs_match is None:
+            errors.append("candidate verifier build_inputs list could not be read for the dev image path filter")
+        else:
+            for build_input in candidate_inputs_match.group("inputs").split():
+                expected_path = f"{build_input}/**" if (root / build_input).is_dir() else build_input
+                if expected_path not in dev_paths:
+                    errors.append(f"dev image channel does not rebuild when protected build input {expected_path} changes")
+        if ".github/workflows/image-dev.yml" not in dev_paths:
+            errors.append("dev image channel does not rebuild when its own workflow changes")
+        if dev_trigger_match.group("dispatch").strip():
+            errors.append("dev image channel workflow_dispatch takes inputs; it must rebuild only the current dev head")
+    forbid(image_dev, r"^    tags:", "dev image channel can run on a tag push")
+    forbid(image_dev, r"^  push:\n(?:    [^\n]*\n)*    branches: \[[^\]]*\bmain\b", "dev image channel can run on a push to main")
+    forbid(image_dev, r"pull_request", "dev image channel can run on a pull request event")
+    forbid(image_dev, r"refs/tags", "dev image channel names a tag ref")
+    forbid(image_dev, r"\bv\$\{", "dev image channel can push or name a v<version> alias")
+    require(image_dev, r"^permissions:\s*\{\s*\}\s*$", "dev image channel does not clear top-level token permissions")
+    require(image_dev, r"^    concurrency:\n      group: image-dev-\$\{\{ github\.ref \}\}\n      cancel-in-progress: true", "dev image channel does not cancel superseded builds per ref")
+    require(image_dev, r"timeout-minutes:\s*[0-9]+", "dev image channel has no finite job timeout")
+    require(image_dev, r"\[\[ \"\$\{GITHUB_REF\}\" == \"refs/heads/dev\" \]\]", "dev image channel is not bound to the dev branch head")
+    require(image_dev, r"echo \"sha12=\$\{GITHUB_SHA:0:12\}\" >> \"\$GITHUB_OUTPUT\"", "dev image channel does not derive the immutable alias from the dev head SHA")
+    require(image_dev, r"actions/checkout@[0-9a-f]{40}[^\n]*\n\s+with:\n\s+ref: \$\{\{ github\.sha \}\}\n\s+persist-credentials: false", "dev image channel does not check out the exact dev head without persisted credentials")
+    require(image_dev, r"docker/build-push-action@[0-9a-f]{40}", "dev image channel does not build with the pinned build-push action")
+    require(image_dev, r"platforms:\s*linux/amd64,linux/arm64", "dev image channel does not build both supported platforms")
+    require(image_dev, r"^\s+push: true\n(?:\s+#[^\n]*\n)*\s+tags: \|\n\s+\$\{\{ env\.IMAGE \}\}:dev-\$\{\{ steps\.guard\.outputs\.sha12 \}\}\n\s+\$\{\{ env\.IMAGE \}\}:dev\n", "dev image channel does not push exactly the dev-<sha12> and floating dev aliases")
+    require(image_dev, r"org\.opencontainers\.image\.revision=\$\{\{ github\.sha \}\}\n\s+org\.opencontainers\.image\.version=dev-\$\{\{ steps\.guard\.outputs\.sha12 \}\}", "dev image channel does not label the image with the dev head identity")
+    require(image_dev, r"verify-oci-alias\.sh \\\n\s+--image \"\$\{IMAGE\}\" --tag \"dev-\$\{SHA12\}\" --expected-digest \"\$\{EXPECTED_DIGEST\}\"", "dev image channel does not read back the immutable dev alias digest")
+    require(image_dev, r"verify-oci-alias\.sh \\\n\s+--image \"\$\{IMAGE\}\" --tag dev --expected-digest \"\$\{EXPECTED_DIGEST\}\"", "dev image channel does not read back the floating dev alias digest")
+    require(image_dev, r"actions/attest-build-provenance@[0-9a-f]{40}[\s\S]{0,300}push-to-registry:\s*true", "dev image channel does not register GitHub provenance in the registry")
+    require(image_dev, r"echo \"DEV_IMAGE_DIGEST=\$\{DIGEST\}\"", "dev image channel does not print the digest the GitOps pin consumes")
+    for pattern, message in (
+        (r"\bgh\s+workflow\s+run\b", "dev image channel dispatches a publisher"),
+        (r"\bgh\s+release\b", "dev image channel touches a GitHub release"),
+        (r"\bnpm\s+(?:publish|dist-tag)\b", "dev image channel can publish or move an npm alias"),
+        (r"\bgit\s+(?:push|tag)\b", "dev image channel can move or create a Git ref"),
+        (r"\bgh\s+api\b[^\n]*(?:--method|-X)\s+(?:POST|PATCH|PUT|DELETE)", "dev image channel performs a mutating API call"),
+        (r"secrets\.", "dev image channel reads a repository secret instead of github.token"),
+        (r"secrets:\s*inherit", "dev image channel inherits repository secrets"),
+        (r"^\s+environment:", "dev image channel runs in a protected environment; dev is not gated"),
+        (r"contents:\s*write", "dev image channel grants a Git-writing token"),
+        (r"actions:\s*write", "dev image channel grants a dispatching token"),
+        (r"\.well-known", "dev image channel touches public channel metadata"),
+        (r"imagetools\s+create", "dev image channel can retag an OCI manifest"),
+        (r"persist-credentials:\s*true", "dev image channel persists checkout credentials"),
+        (r"\b(?:kubectl|helm\s+(?:upgrade|install)|docker\s+service\s+update|aws\s+)", "dev image channel can mutate infrastructure"),
+        (r"^\s+(?:[A-Z_]+=\S+\s+)?scripts/release/verify-(?:promotion-candidate|oci-release)\.sh\b", "dev image channel runs a promotion candidate verifier"),
+    ):
+        forbid(image_dev, pattern, message)
+    expected_image_dev_permissions = {
+        "build-push-dev": {"contents": "read", "packages": "write", "id-token": "write", "attestations": "write"},
+    }
+    image_dev_permissions = effective_job_permissions(image_dev)
+    if set(image_dev_permissions) != set(expected_image_dev_permissions):
+        errors.append(f"dev image channel job set changed: {sorted(image_dev_permissions)}")
+    for job_name, expected in expected_image_dev_permissions.items():
+        actual = image_dev_permissions.get(job_name)
+        if actual != expected:
+            errors.append(f"dev image channel job {job_name} permissions are {actual}, expected exactly {expected}")
+    # Only the candidate minter may sign OCI provenance that the stable
+    # publishers accept; nothing may name image-dev.yml as a signer.
+    forbid(all_workflows, r"--signer-workflow\s+\"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-dev\.yml\"", "a workflow treats the dev image channel as the candidate OCI signer")
+
+
 # Tarball provenance is GitHub-native and produced in-repo. The repository
 # requires every action to be pinned to a full-length commit SHA; the SLSA
 # generator reusable workflow references its own helper actions by tag, so it

--- a/scripts/release/release-workflow-contract.test.sh
+++ b/scripts/release/release-workflow-contract.test.sh
@@ -238,54 +238,70 @@ else:
         require(workflows[other], r"verify-orchestrator-run\.py[\s\S]{0,300}--expected-workflow \.github/workflows/image-build\.yml\s*\\\n\s+--allowed-event workflow_dispatch", f"{other} does not require an in-progress dispatch-only image-build orchestrator run")
     forbid(all_workflows, r"--signer-workflow\s+\"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-publish\.yml\"", "a workflow still treats the read-only promotion verifier as the OCI signer")
 
-# image-dev.yml is the dev image channel: it builds and attests the dev head
-# on every push to dev that changes a protected build input, pushes only the
-# `dev-<sha12>` and floating `dev` aliases, and is never a candidate path. It
-# must not be able to create a tag, a `v<version>` alias, a release, an npm
-# publication, or public channel metadata, and it runs in no environment.
+# image-dev.yml is the dev image channel: one image per merged PR to dev. It
+# has no push trigger (no paths filter, no branches filter), so a direct
+# commit to dev never builds. It is a local reusable workflow: version.yml
+# calls it once per dev version cut with the bump commit it pushed to dev,
+# and a manual dispatch rebuilds the dev head or one exact dev commit. Both
+# entries take exactly one `ref` input, and the guard requires the resolved
+# commit to be a full SHA reachable from origin/dev. It builds and attests
+# that commit, pushes only the `dev-<sha12>` and floating `dev` aliases, and
+# is never a candidate path. It must not be able to create a tag, a
+# `v<version>` alias, a release, an npm publication, or public channel
+# metadata, and it runs in no environment.
 image_dev = workflows.get("image-dev.yml")
 if image_dev is None:
     errors.append("dev image channel workflow image-dev.yml is missing")
 else:
     dev_trigger_match = re.search(
-        r"^on:\n  push:\n    branches: \[dev\]\n(?:    #[^\n]*\n)*    paths:\n(?P<paths>(?:      - [^\n]+\n)+)(?:  #[^\n]*\n)*  workflow_dispatch:\n(?P<dispatch>(?:    [^\n]*\n)*)",
+        r"^on:\n(?:  #[^\n]*\n)*"
+        r"  workflow_call:\n    inputs:\n(?P<call>(?:      [^\n]*\n)*)"
+        r"(?:  #[^\n]*\n)*"
+        r"  workflow_dispatch:\n    inputs:\n(?P<dispatch>(?:      [^\n]*\n)*)"
+        r"\n*permissions:",
         image_dev,
         flags=re.MULTILINE,
     )
     if dev_trigger_match is None:
-        errors.append("dev image channel is not triggered by push to dev with a paths filter plus a bare workflow_dispatch")
+        errors.append("dev image channel is not triggered by exactly workflow_call plus workflow_dispatch, each with inputs (one image per merged PR, called by version.yml)")
     else:
-        dev_paths = {
-            line.strip()[2:].strip().strip("'\"")
-            for line in dev_trigger_match.group("paths").splitlines()
-        }
-        candidate_inputs_match = re.search(r"build_inputs=\((?P<inputs>[^)]*)\)", (root / "scripts/release/verify-promotion-candidate.sh").read_text(encoding="utf-8"))
-        if candidate_inputs_match is None:
-            errors.append("candidate verifier build_inputs list could not be read for the dev image path filter")
-        else:
-            for build_input in candidate_inputs_match.group("inputs").split():
-                expected_path = f"{build_input}/**" if (root / build_input).is_dir() else build_input
-                if expected_path not in dev_paths:
-                    errors.append(f"dev image channel does not rebuild when protected build input {expected_path} changes")
-        if ".github/workflows/image-dev.yml" not in dev_paths:
-            errors.append("dev image channel does not rebuild when its own workflow changes")
-        if dev_trigger_match.group("dispatch").strip():
-            errors.append("dev image channel workflow_dispatch takes inputs; it must rebuild only the current dev head")
+        for entry, body, required in (("workflow_call", dev_trigger_match.group("call"), "true"), ("workflow_dispatch", dev_trigger_match.group("dispatch"), "false")):
+            input_names = re.findall(r"^      ([A-Za-z0-9_-]+):\s*$", body, flags=re.MULTILINE)
+            if input_names != ["ref"]:
+                errors.append(f"dev image channel {entry} inputs are {input_names}; exactly one `ref` input is allowed")
+            require(body, rf"^      ref:\n(?:        #[^\n]*\n)*        description:[^\n]*\n        required: {required}\n        type: string\n", f"dev image channel {entry} `ref` input is not a {'required' if required == 'true' else 'optional'} string")
+        require(dev_trigger_match.group("dispatch"), r"^        default: ''\n", "dev image channel workflow_dispatch `ref` does not default to empty (the current dev head)")
+    forbid(image_dev, r"^  push:", "dev image channel can run on a push; images are built once per merged PR via the version.yml call, never per commit")
+    forbid(image_dev, r"^\s+paths(?:-ignore)?:", "dev image channel carries a paths filter, which only makes sense for a push trigger it must not have")
+    forbid(image_dev, r"^\s+branches(?:-ignore)?:", "dev image channel carries a branches filter, which only makes sense for a push trigger it must not have")
+    forbid(image_dev, r"^  (?:schedule|repository_dispatch|workflow_run|merge_group|create|release|pull_request(?:_target)?):", "dev image channel has a trigger other than workflow_call and workflow_dispatch")
     forbid(image_dev, r"^    tags:", "dev image channel can run on a tag push")
-    forbid(image_dev, r"^  push:\n(?:    [^\n]*\n)*    branches: \[[^\]]*\bmain\b", "dev image channel can run on a push to main")
-    forbid(image_dev, r"pull_request", "dev image channel can run on a pull request event")
     forbid(image_dev, r"refs/tags", "dev image channel names a tag ref")
     forbid(image_dev, r"\bv\$\{", "dev image channel can push or name a v<version> alias")
     require(image_dev, r"^permissions:\s*\{\s*\}\s*$", "dev image channel does not clear top-level token permissions")
-    require(image_dev, r"^    concurrency:\n      group: image-dev-\$\{\{ github\.ref \}\}\n      cancel-in-progress: true", "dev image channel does not cancel superseded builds per ref")
+    require(image_dev, r"^    concurrency:\n      group: image-dev\n      cancel-in-progress: true", "dev image channel does not cancel superseded builds under one constant group (only the newest dev cut matters)")
     require(image_dev, r"timeout-minutes:\s*[0-9]+", "dev image channel has no finite job timeout")
-    require(image_dev, r"\[\[ \"\$\{GITHUB_REF\}\" == \"refs/heads/dev\" \]\]", "dev image channel is not bound to the dev branch head")
-    require(image_dev, r"echo \"sha12=\$\{GITHUB_SHA:0:12\}\" >> \"\$GITHUB_OUTPUT\"", "dev image channel does not derive the immutable alias from the dev head SHA")
-    require(image_dev, r"actions/checkout@[0-9a-f]{40}[^\n]*\n\s+with:\n\s+ref: \$\{\{ github\.sha \}\}\n\s+persist-credentials: false", "dev image channel does not check out the exact dev head without persisted credentials")
+    # The source is always the dev branch, never the calling ref: under the
+    # version.yml call on a merged pull_request the caller's ref is the PR
+    # merge ref. Full history so the ancestry guard sees every dev commit.
+    require(image_dev, r"actions/checkout@[0-9a-f]{40}[^\n]*\n\s+with:\n\s+ref: dev\n\s+fetch-depth: 0\n\s+persist-credentials: false", "dev image channel does not check out the dev branch with full history and without persisted credentials")
+    forbid(image_dev, r"^\s+ref: \$\{\{ (?:github\.(?:ref|sha|head_ref)|inputs\.ref) \}\}", "dev image channel checks out the calling ref or the unverified input instead of the dev branch")
+    require(image_dev, r"- name: Resolve and require a commit on dev\n\s+id: guard\n\s+env:\n\s+REQUESTED_REF: \$\{\{ inputs\.ref \}\}\n", "dev image channel guard does not read the `ref` input through env")
+    require(image_dev, r"dev_head=\$\(git rev-parse \"refs/remotes/origin/dev\^\{commit\}\"\)", "dev image channel guard does not resolve the dev head from origin/dev")
+    require(image_dev, r"target=\"\$\{REQUESTED_REF:-\$\{dev_head\}\}\"", "dev image channel guard does not default an empty `ref` to the dev head")
+    require(image_dev, r"\[\[ \"\$\{target\}\" =~ \^\[0-9a-f\]\{40\}\$ \]\] \|\| \{", "dev image channel guard does not require a full 40-hex commit SHA")
+    require(image_dev, r"git merge-base --is-ancestor \"\$\{target\}\" origin/dev \|\| \{", "dev image channel guard does not require the commit to be on the dev branch")
+    require(image_dev, r"git checkout --detach \"\$\{target\}\"", "dev image channel guard does not check out the resolved dev commit")
+    require(image_dev, r"echo \"sha=\$\{target\}\" >> \"\$GITHUB_OUTPUT\"\n\s+echo \"sha12=\$\{target:0:12\}\" >> \"\$GITHUB_OUTPUT\"", "dev image channel does not derive the immutable alias from the resolved dev commit SHA")
+    require(image_dev, r"- name: Bind the checked-out source to the resolved dev commit\n\s+env:\n\s+TARGET_SHA: \$\{\{ steps\.guard\.outputs\.sha \}\}\n[\s\S]{0,200}\[\[ \"\$\{source_sha\}\" == \"\$\{TARGET_SHA\}\" \]\] \|\| \{", "dev image channel does not bind the checked-out tree to the resolved dev commit")
+    # Non-comment lines only: the workflow's comments explain why the
+    # calling ref is the wrong identity, and may name it.
+    image_dev_code = "\n".join(line for line in image_dev.splitlines() if not line.lstrip().startswith("#"))
+    forbid(image_dev_code, r"GITHUB_SHA|github\.sha|GITHUB_REF\b|github\.ref\b", "dev image channel derives identity from the calling ref or SHA, which is the PR merge ref under the version.yml call")
     require(image_dev, r"docker/build-push-action@[0-9a-f]{40}", "dev image channel does not build with the pinned build-push action")
     require(image_dev, r"platforms:\s*linux/amd64,linux/arm64", "dev image channel does not build both supported platforms")
     require(image_dev, r"^\s+push: true\n(?:\s+#[^\n]*\n)*\s+tags: \|\n\s+\$\{\{ env\.IMAGE \}\}:dev-\$\{\{ steps\.guard\.outputs\.sha12 \}\}\n\s+\$\{\{ env\.IMAGE \}\}:dev\n", "dev image channel does not push exactly the dev-<sha12> and floating dev aliases")
-    require(image_dev, r"org\.opencontainers\.image\.revision=\$\{\{ github\.sha \}\}\n\s+org\.opencontainers\.image\.version=dev-\$\{\{ steps\.guard\.outputs\.sha12 \}\}", "dev image channel does not label the image with the dev head identity")
+    require(image_dev, r"org\.opencontainers\.image\.revision=\$\{\{ steps\.guard\.outputs\.sha \}\}\n\s+org\.opencontainers\.image\.version=dev-\$\{\{ steps\.guard\.outputs\.sha12 \}\}", "dev image channel does not label the image with the resolved dev commit identity")
     require(image_dev, r"verify-oci-alias\.sh \\\n\s+--image \"\$\{IMAGE\}\" --tag \"dev-\$\{SHA12\}\" --expected-digest \"\$\{EXPECTED_DIGEST\}\"", "dev image channel does not read back the immutable dev alias digest")
     require(image_dev, r"verify-oci-alias\.sh \\\n\s+--image \"\$\{IMAGE\}\" --tag dev --expected-digest \"\$\{EXPECTED_DIGEST\}\"", "dev image channel does not read back the floating dev alias digest")
     require(image_dev, r"actions/attest-build-provenance@[0-9a-f]{40}[\s\S]{0,300}push-to-registry:\s*true", "dev image channel does not register GitHub provenance in the registry")
@@ -485,6 +501,74 @@ require(
     r"if \[\[ \"\$\{CANDIDATE\}\" == \"true\" \]\]; then\n\s+echo \"[^\n]*image-build\.yml[^\n]*\"\n\s+exit 0\n\s+fi\n[\s\S]{0,200}gh workflow run release\.yml",
     "the version workflow dispatches the dev prerelease even for a candidate cut",
 )
+
+# Dev image policy: exactly one image per merged PR to dev. The bump job emits
+# the commit it pushed to dev, and a dedicated `dev-image` job calls the
+# LOCAL reusable image-dev.yml with exactly that commit, after auto-version
+# has fully succeeded (tag push, npm publish, release dispatch), so the build
+# can block none of them. A candidate cut skips it because image-build.yml
+# mints that image at its own tag. Never `gh workflow run`: a dispatch
+# resolves the workflow file against the default branch, where image-dev.yml
+# does not exist until the next promotion.
+require(
+    version_workflow,
+    r"- name: Commit and tag\n        id: bump\n",
+    "the version bump step has no `bump` id to expose the pushed commit",
+)
+require(
+    version_workflow,
+    r"BUMP_SHA=\$\(git rev-parse \"HEAD\^\{commit\}\"\)\n\s+\[\[ \"\$\{BUMP_SHA\}\" =~ \^\[0-9a-f\]\{40\}\$ \]\]\n[\s\S]{0,2400}"
+    r"\"refs/tags/v\$\{VERSION\}\"\n\n\s+echo \"bump_sha=\$\{BUMP_SHA\}\" >> \"\$GITHUB_OUTPUT\"\n",
+    "the version bump step does not emit the pushed dev commit as bump_sha after both pushes",
+)
+require(
+    version_workflow,
+    r"^  auto-version:\n(?:    [^\n]*\n|\n)*?    outputs:\n(?:      #[^\n]*\n)*      bump_sha: \$\{\{ steps\.bump\.outputs\.bump_sha \}\}\n",
+    "the auto-version job does not expose bump_sha as a job output",
+)
+dev_image_job_match = re.search(
+    r"^  dev-image:\n(?P<body>(?:    [^\n]*\n)*)",
+    version_workflow,
+    flags=re.MULTILINE,
+)
+if dev_image_job_match is None:
+    errors.append("the version workflow has no dev-image job, so no dev image is built per merged PR")
+else:
+    dev_image_job = dev_image_job_match.group("body")
+    require(dev_image_job, r"^    needs: auto-version\n", "the dev-image job does not depend on auto-version")
+    # `inputs` is empty on the merged pull_request trigger, so
+    # `inputs.candidate != true` holds there (null != true) and every merged
+    # PR builds; only an explicit candidate=true dispatch skips.
+    require(dev_image_job, r"^    if: needs\.auto-version\.result == 'success' && inputs\.candidate != true\n", "the dev-image job is not gated on a successful bump and a non-candidate cut")
+    require(dev_image_job, r"^    uses: \./\.github/workflows/image-dev\.yml\n", "the dev-image job does not call the local reusable image-dev.yml")
+    require(dev_image_job, r"^    with:\n      ref: \$\{\{ needs\.auto-version\.outputs\.bump_sha \}\}\n", "the dev-image job does not build exactly the pushed bump commit")
+    if re.findall(r"^      [A-Za-z0-9_-]+:", dev_image_job[dev_image_job.find("    with:"):], flags=re.MULTILINE) != ["      ref:"]:
+        errors.append("the dev-image job passes inputs other than ref to image-dev.yml")
+    forbid(dev_image_job, r"secrets:", "the dev-image job passes secrets to image-dev.yml, which needs only github.token")
+    forbid(dev_image_job, r"^    (?:runs-on|steps):", "the dev-image job runs its own steps instead of only calling image-dev.yml")
+    expected_dev_image_permissions = {"contents": "read", "packages": "write", "id-token": "write", "attestations": "write"}
+    actual_dev_image_permissions = permissions_at(dev_image_job.splitlines(), 4)
+    if actual_dev_image_permissions != expected_dev_image_permissions:
+        errors.append(f"the dev-image job permissions are {actual_dev_image_permissions}, expected exactly {expected_dev_image_permissions}")
+require(
+    version_workflow,
+    r"^  auto-version:\n[\s\S]*- name: Commit and tag\n[\s\S]*- name: Publish to npm via OIDC[\s\S]*- name: Dispatch release pipeline for the new tag\n[\s\S]*^  dev-image:\n[\s\S]*^  publish-stable:",
+    "the dev-image job is not declared after the dev bump job's tag push, npm publish, and release dispatch",
+)
+forbid(version_workflow, r"- name: Dispatch dev image build", "the version workflow still dispatches image-dev.yml instead of calling it")
+# No workflow may dispatch image-dev.yml (it only resolves on the default
+# branch), and no workflow other than version.yml may call it: not the
+# read-only promotion, not the candidate minter, not the release pipeline,
+# not the signer, not CI.
+for other_name in ("image-publish.yml", "image-build.yml", "release.yml", "release-publish.yml", "sign-attest.yml", "ci.yml"):
+    if other_name not in workflows:
+        errors.append(f"{other_name} is missing, so the dev image call boundary cannot be checked")
+for other_name, other in workflows.items():
+    forbid(other, r"gh\s+workflow\s+run\s+(?:\S*/)?image-dev\.yml", f"{other_name} dispatches the dev image build; a dispatch resolves against the default branch, and only version.yml may call image-dev.yml, once per merged PR to dev")
+    forbid(other, r"workflows/image-dev\.yml/dispatches", f"{other_name} dispatches the dev image build through the API; only version.yml may call image-dev.yml, once per merged PR to dev")
+    if other_name == "version.yml":
+        continue
+    forbid(other, r"^\s+uses:\s*\./\.github/workflows/image-dev\.yml", f"{other_name} calls the dev image build; only version.yml may, once per merged PR to dev")
 
 require(release, r"authorize:[\s\S]{0,200}timeout-minutes:\s*[0-9]+", "release authorization has no finite timeout")
 require(release, r"bare tag pushes do not release", "release workflow still misstates bare-tag authorization")

--- a/scripts/release/verify-oci-alias.sh
+++ b/scripts/release/verify-oci-alias.sh
@@ -2,23 +2,36 @@
 set -euo pipefail
 image=""
 version=""
+tag=""
 expected_digest=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --image) image="${2:-}"; shift 2 ;;
     --version) version="${2:-}"; shift 2 ;;
+    --tag) tag="${2:-}"; shift 2 ;;
     --expected-digest) expected_digest="${2:-}"; shift 2 ;;
     *) echo "OCI alias verification failed: unknown argument $1" >&2; exit 2 ;;
   esac
 done
 [[ "${image}" =~ ^[a-z0-9.-]+(/[a-z0-9._-]+)+$ ]] || { echo 'OCI alias verification failed: invalid image' >&2; exit 1; }
-[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'OCI alias verification failed: invalid version' >&2; exit 1; }
+[[ -n "${version}" && -n "${tag}" ]] && { echo 'OCI alias verification failed: --version and --tag are mutually exclusive' >&2; exit 2; }
+if [[ -n "${tag}" ]]; then
+  # A non-candidate alias (the dev channel's `dev` / `dev-<sha12>`). Candidate
+  # aliases are always named through --version so the `v<version>` identity
+  # cannot be spelled two ways.
+  [[ "${tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || { echo 'OCI alias verification failed: invalid tag' >&2; exit 1; }
+  [[ "${tag}" =~ ^v[0-9] ]] && { echo 'OCI alias verification failed: candidate aliases are verified with --version, not --tag' >&2; exit 1; }
+  alias="${image}:${tag}"
+else
+  [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo 'OCI alias verification failed: invalid version' >&2; exit 1; }
+  alias="${image}:v${version}"
+fi
 [[ "${expected_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'OCI alias verification failed: invalid expected digest' >&2; exit 1; }
-actual_digest=$(docker buildx imagetools inspect "${image}:v${version}" --format '{{.Manifest.Digest}}')
+actual_digest=$(docker buildx imagetools inspect "${alias}" --format '{{.Manifest.Digest}}')
 actual_digest="${actual_digest//$'\r'/}"
 [[ "${actual_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'OCI alias verification failed: registry returned a malformed digest' >&2; exit 1; }
 [[ "${actual_digest}" == "${expected_digest}" ]] || {
-  echo "OCI alias verification failed: ${image}:v${version} resolves to ${actual_digest}, expected ${expected_digest}" >&2
+  echo "OCI alias verification failed: ${alias} resolves to ${actual_digest}, expected ${expected_digest}" >&2
   exit 1
 }
 printf 'oci_alias_verified=true\n'

--- a/scripts/release/verify-oci-alias.test.sh
+++ b/scripts/release/verify-oci-alias.test.sh
@@ -8,17 +8,49 @@ cat >"${work}/docker" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 [[ "$*" == *'imagetools inspect'* ]]
+# The caller may pin the exact alias the verifier must inspect.
+[[ -z "${MOCK_EXPECT_REF:-}" || "$*" == *" ${MOCK_EXPECT_REF} "* ]]
 printf '%s\n' "${MOCK_DIGEST}"
 SH
 chmod +x "${work}/docker"
 expected=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" "${SCRIPT}" --image ghcr.io/example/omni-api --version 1.2.3 --expected-digest "${expected}"
-if PATH="${work}:${PATH}" MOCK_DIGEST=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
-  "${SCRIPT}" --image ghcr.io/example/omni-api --version 1.2.3 --expected-digest "${expected}"; then
+other=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+image=ghcr.io/example/omni-api
+
+PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" MOCK_EXPECT_REF="${image}:v1.2.3" \
+  "${SCRIPT}" --image "${image}" --version 1.2.3 --expected-digest "${expected}"
+if PATH="${work}:${PATH}" MOCK_DIGEST="${other}" \
+  "${SCRIPT}" --image "${image}" --version 1.2.3 --expected-digest "${expected}"; then
   echo 'FAIL: mismatched OCI alias was accepted' >&2; exit 1
 fi
 if PATH="${work}:${PATH}" MOCK_DIGEST=garbage \
-  "${SCRIPT}" --image ghcr.io/example/omni-api --version 1.2.3 --expected-digest "${expected}"; then
+  "${SCRIPT}" --image "${image}" --version 1.2.3 --expected-digest "${expected}"; then
   echo 'FAIL: malformed OCI alias digest was accepted' >&2; exit 1
 fi
-printf 'PASS: OCI version alias read-back contract\n'
+
+# Dev channel aliases are named verbatim through --tag and inspected as such.
+PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" MOCK_EXPECT_REF="${image}:dev-0123456789ab" \
+  "${SCRIPT}" --image "${image}" --tag dev-0123456789ab --expected-digest "${expected}"
+PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" MOCK_EXPECT_REF="${image}:dev" \
+  "${SCRIPT}" --image "${image}" --tag dev --expected-digest "${expected}"
+if PATH="${work}:${PATH}" MOCK_DIGEST="${other}" \
+  "${SCRIPT}" --image "${image}" --tag dev-0123456789ab --expected-digest "${expected}"; then
+  echo 'FAIL: mismatched dev OCI alias was accepted' >&2; exit 1
+fi
+if PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" \
+  "${SCRIPT}" --image "${image}" --tag v1.2.3 --expected-digest "${expected}"; then
+  echo 'FAIL: a candidate alias was accepted through --tag' >&2; exit 1
+fi
+if PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" \
+  "${SCRIPT}" --image "${image}" --tag 'dev/../latest' --expected-digest "${expected}"; then
+  echo 'FAIL: malformed tag was accepted' >&2; exit 1
+fi
+if PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" \
+  "${SCRIPT}" --image "${image}" --version 1.2.3 --tag dev --expected-digest "${expected}"; then
+  echo 'FAIL: --version and --tag were accepted together' >&2; exit 1
+fi
+if PATH="${work}:${PATH}" MOCK_DIGEST="${expected}" \
+  "${SCRIPT}" --image "${image}" --expected-digest "${expected}"; then
+  echo 'FAIL: an alias-less invocation was accepted' >&2; exit 1
+fi
+printf 'PASS: OCI version and dev alias read-back contract\n'


### PR DESCRIPTION
## Why

Argo CD (argo.namastex.io) will keep the HML instance on the `dev` branch. It needs one image per dev version cut that it can pin by digest from the private GitOps repo. The public repo currently builds images only for candidate tags.

## What

- `.github/workflows/image-dev.yml`: reusable (`workflow_call` with `ref`) plus manual `workflow_dispatch`. Builds `ghcr.io/automagik-dev/omni-api` for amd64+arm64 from a commit that must be on `dev`, pushes `dev-<sha12>` and floating `dev`, attests provenance. Job-local `packages/id-token/attestations: write`, no environment, no tags, no dispatches, no secrets beyond `github.token`. No push trigger: direct commits to `dev` never build.
- `.github/workflows/version.yml`: after a merged PR bumps `dev`, a `dev-image` job calls `image-dev.yml` with the bump commit. Skipped for `candidate=true` cuts (those mint via `image-build.yml`). A local call resolves from the calling ref, so it works before the file reaches `main`.
- `scripts/release/verify-oci-alias.sh --tag` to read back a dev alias (`--version` unchanged, `v*` refused under `--tag`).
- Contract tests: full `image-dev.yml` and `version.yml` blocks (triggers, on-dev ancestry guard, exact permissions, only version.yml may call it, no dispatch path); 19 born-red mutations across the two rounds.
- Docs: dev image channel section; HML/prod rows in the deploy README pointing at the private GitOps repo.

## Merge order

Merge #940 (dev → main) first: merging any PR into `dev` creates a version bump, which changes a protected build input and would invalidate candidate v2.260902.5. This PR itself touches no build input.

## Not in scope

The Argo AppProject/Applications and the digest pin lanes live in `git.namastex.io/khal/deploy` (PR #282 there). No AWS or cluster access is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)