### PR TITLE
feat(gupshup): per-instance handoff routing defaults and customerFields template

### DIFF
--- a/apps/khal-ui/package/src/pages/instances/config-schemas.ts
+++ b/apps/khal-ui/package/src/pages/instances/config-schemas.ts
@@ -42,6 +42,37 @@ const replyFilterSchema = z
   })
   .optional();
 
+/**
+ * Mirrors `gupshupHandoffOptionsSchema` in the API (packages/api/src/routes/v2/
+ * instances.ts) minus the cross-field refinement on `customerFields` entries —
+ * the API still enforces "exactly one of value/from"; the form only needs the
+ * shape to render editable fields.
+ */
+const gupshupHandoffOptionsSchema = z
+  .object({
+    defaultFields: z.record(z.string()).optional().describe('Handoff fields used when the agent sends none'),
+    fieldsByPhonePrefix: z
+      .array(
+        z.object({
+          prefixes: z.array(z.string()).describe('Digit-only phone prefixes (country and area code)'),
+          fields: z.record(z.string()).describe('Fields for numbers matching one of the prefixes'),
+        }),
+      )
+      .optional()
+      .describe('First matching rule overrides the defaults'),
+    customerFields: z
+      .array(
+        z.object({
+          apiKey: z.string().describe('Customer field key in the Custom Integration'),
+          value: z.string().optional().describe('Literal value'),
+          from: z.string().optional().describe('Handoff field to copy the value from'),
+        }),
+      )
+      .optional()
+      .describe('customerFields template sent with every HANDOFF'),
+  })
+  .optional();
+
 const sections: ConfigSection[] = [
   {
     id: 'identity',
@@ -224,6 +255,15 @@ const sections: ConfigSection[] = [
       webhookVerifyToken: z.string().optional().describe('Webhook verify token'),
     }),
     keys: ['gupshupCallbackUrl', 'gupshupAuthToken', 'gupshupEventId', 'webhookVerifyToken'],
+  },
+  {
+    id: 'handoff-gupshup',
+    title: 'Gupshup handoff',
+    description:
+      'Routing defaults and customer fields applied to HANDOFF messages. Explicit fields from the agent always win.',
+    channels: ['gupshup'],
+    schema: z.object({ gupshupHandoffOptions: gupshupHandoffOptionsSchema }),
+    keys: ['gupshupHandoffOptions'],
   },
   {
     id: 'creds-twilio',

--- a/packages/api/src/plugins/instance-monitor.ts
+++ b/packages/api/src/plugins/instance-monitor.ts
@@ -38,7 +38,7 @@
  */
 
 import type { ChannelPlugin, ChannelRegistry } from '@omni/channel-sdk';
-import type { Database } from '@omni/db';
+import type { Database, GupshupHandoffOptions } from '@omni/db';
 import { instances } from '@omni/db';
 import { eq } from 'drizzle-orm';
 
@@ -181,6 +181,7 @@ function buildInstanceConnectOptions(instance: {
   gupshupCallbackUrl?: string | null;
   gupshupAuthToken?: string | null;
   gupshupEventId?: string | null;
+  gupshupHandoffOptions?: GupshupHandoffOptions | null;
   webhookVerifyToken?: string | null;
   twilioAccountSid?: string | null;
   twilioAuthToken?: string | null;
@@ -256,6 +257,7 @@ function applyGupshupOptions(
     gupshupCallbackUrl?: string | null;
     gupshupAuthToken?: string | null;
     gupshupEventId?: string | null;
+    gupshupHandoffOptions?: GupshupHandoffOptions | null;
     gupshupApiKey?: string | null;
     gupshupAppName?: string | null;
     gupshupSourcePhone?: string | null;
@@ -265,6 +267,7 @@ function applyGupshupOptions(
   if (instance.gupshupCallbackUrl) options.gupshupCallbackUrl = instance.gupshupCallbackUrl;
   if (instance.gupshupAuthToken) options.gupshupAuthToken = instance.gupshupAuthToken;
   if (instance.gupshupEventId) options.gupshupEventId = instance.gupshupEventId;
+  if (instance.gupshupHandoffOptions) options.gupshupHandoffOptions = instance.gupshupHandoffOptions;
   if (instance.gupshupApiKey) options.gupshupApiKey = instance.gupshupApiKey;
   if (instance.gupshupAppName) options.gupshupAppName = instance.gupshupAppName;
   if (instance.gupshupSourcePhone) options.gupshupSourcePhone = instance.gupshupSourcePhone;
@@ -316,6 +319,7 @@ async function connectInstance(
     gupshupCallbackUrl?: string | null;
     gupshupAuthToken?: string | null;
     gupshupEventId?: string | null;
+    gupshupHandoffOptions?: GupshupHandoffOptions | null;
     webhookVerifyToken?: string | null;
     twilioAccountSid?: string | null;
     twilioAuthToken?: string | null;
@@ -763,6 +767,7 @@ export class InstanceMonitor {
     gupshupCallbackUrl?: string | null;
     gupshupAuthToken?: string | null;
     gupshupEventId?: string | null;
+    gupshupHandoffOptions?: GupshupHandoffOptions | null;
     webhookVerifyToken?: string | null;
     twilioAccountSid?: string | null;
     twilioAuthToken?: string | null;

--- a/packages/api/src/routes/v2/__tests__/instances-gupshup-handoff-options.test.ts
+++ b/packages/api/src/routes/v2/__tests__/instances-gupshup-handoff-options.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Gupshup per-instance handoff options round-trip through the API.
+ *
+ * The channel plugin validates `gupshupHandoffOptions` in `connect()` and
+ * applies it to every HANDOFF it emits. That only helps if the column reaches
+ * the plugin on every path an instance can be (re)connected from: create,
+ * PATCH and the generic connect route.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppVariables } from '../../../types';
+import { instancesRoutes } from '../instances';
+
+const INSTANCE_ID = '44444444-4444-4444-8444-444444444444';
+
+const HANDOFF_OPTIONS = {
+  defaultFields: { queue: 'DEFAULT' },
+  fieldsByPhonePrefix: [{ prefixes: ['5511'], fields: { queue: 'SOUTHEAST' } }],
+  customerFields: [
+    { apiKey: 'Queue', from: 'queue' },
+    { apiKey: 'Source', value: 'assistant' },
+  ],
+};
+
+interface Captured {
+  connectOptions?: Record<string, unknown>;
+  created?: Record<string, unknown>;
+  updated?: Record<string, unknown>;
+}
+
+/** Mount the routes over a fake instance service + gupshup plugin. */
+function mount(captured: Captured, instanceOverrides: Record<string, unknown> = {}) {
+  const app = new Hono<{ Variables: AppVariables }>();
+
+  const instance = {
+    id: INSTANCE_ID,
+    name: 'gs-handoff',
+    channel: 'gupshup',
+    gupshupCallbackUrl: 'https://callbacks.example.com/abc',
+    gupshupAuthToken: 'persisted-token',
+    gupshupEventId: 'nx_omni_agent_reply',
+    gupshupHandoffOptions: HANDOFF_OPTIONS,
+    ...instanceOverrides,
+  };
+
+  app.use('*', async (c, next) => {
+    c.set('services', {
+      instances: {
+        getById: mock(async () => instance),
+        create: mock(async (data: Record<string, unknown>) => {
+          captured.created = data;
+          return { ...instance, ...data };
+        }),
+        update: mock(async (_id: string, data: Record<string, unknown>) => {
+          captured.updated = data;
+          return { ...instance, ...data };
+        }),
+        updateStatus: mock(async () => instance),
+      },
+    } as never);
+
+    c.set('channelRegistry', {
+      get: () => ({
+        id: 'gupshup',
+        capabilities: {},
+        connect: mock(async (_id: string, config: Record<string, unknown>) => {
+          captured.connectOptions = config.options as Record<string, unknown>;
+        }),
+        disconnect: mock(async () => {}),
+        getStatus: mock(async () => ({ state: 'connected' })),
+      }),
+    } as never);
+
+    c.set('apiKey', {
+      id: 'test',
+      name: 'test',
+      scopes: ['*'],
+      instanceIds: null,
+      expiresAt: null,
+    } as never);
+
+    await next();
+  });
+
+  app.route('/', instancesRoutes);
+  return app;
+}
+
+const json = (method: string, body?: unknown): RequestInit => ({
+  method,
+  headers: { 'Content-Type': 'application/json' },
+  ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+});
+
+describe('POST /instances — gupshupHandoffOptions', () => {
+  test('is persisted and handed to the plugin on the initial connect', async () => {
+    const captured: Captured = {};
+    const app = mount(captured);
+
+    const res = await app.request(
+      '/',
+      json('POST', {
+        name: 'gs-handoff',
+        channel: 'gupshup',
+        gupshupCallbackUrl: 'https://callbacks.example.com/abc',
+        gupshupAuthToken: 'persisted-token',
+        gupshupHandoffOptions: HANDOFF_OPTIONS,
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(captured.created?.gupshupHandoffOptions).toEqual(HANDOFF_OPTIONS);
+    expect(captured.connectOptions?.gupshupHandoffOptions).toEqual(HANDOFF_OPTIONS);
+  });
+
+  test('rejects a malformed template before anything is written', async () => {
+    const captured: Captured = {};
+    const app = mount(captured);
+
+    const bad = [
+      // exactly one of value/from per customerFields entry
+      { customerFields: [{ apiKey: 'Queue', value: 'a', from: 'b' }] },
+      { customerFields: [{ apiKey: 'Queue' }] },
+      // prefixes are digits only
+      { fieldsByPhonePrefix: [{ prefixes: ['+55'], fields: { queue: 'x' } }] },
+      // strict object: a typo must not be silently dropped
+      { defaultField: { queue: 'x' } },
+    ];
+    for (const gupshupHandoffOptions of bad) {
+      const res = await app.request(
+        '/',
+        json('POST', { name: 'gs-handoff', channel: 'gupshup', gupshupHandoffOptions }),
+      );
+      expect(res.status).toBe(400);
+    }
+    expect(captured.created).toBeUndefined();
+    expect(captured.connectOptions).toBeUndefined();
+  });
+});
+
+describe('PATCH /instances/:id — gupshupHandoffOptions', () => {
+  test('is forwarded to the update untouched', async () => {
+    const captured: Captured = {};
+    const app = mount(captured, { gupshupHandoffOptions: null });
+
+    const res = await app.request(`/${INSTANCE_ID}`, json('PATCH', { gupshupHandoffOptions: HANDOFF_OPTIONS }));
+
+    expect(res.status).toBe(200);
+    expect(captured.updated?.gupshupHandoffOptions).toEqual(HANDOFF_OPTIONS);
+  });
+
+  test('null clears it', async () => {
+    const captured: Captured = {};
+    const app = mount(captured);
+
+    const res = await app.request(`/${INSTANCE_ID}`, json('PATCH', { gupshupHandoffOptions: null }));
+
+    expect(res.status).toBe(200);
+    expect(captured.updated).toHaveProperty('gupshupHandoffOptions', null);
+  });
+});
+
+describe('POST /instances/:id/connect — persisted options reach the plugin', () => {
+  test('hydrates gupshupHandoffOptions from the row next to the credentials', async () => {
+    const captured: Captured = {};
+    const app = mount(captured);
+
+    const res = await app.request(`/${INSTANCE_ID}/connect`, json('POST', {}));
+
+    expect(res.status).toBe(200);
+    expect(captured.connectOptions?.gupshupCallbackUrl).toBe('https://callbacks.example.com/abc');
+    expect(captured.connectOptions?.gupshupAuthToken).toBe('persisted-token');
+    expect(captured.connectOptions?.gupshupHandoffOptions).toEqual(HANDOFF_OPTIONS);
+  });
+
+  test('omits the key entirely when the row has none', async () => {
+    const captured: Captured = {};
+    const app = mount(captured, { gupshupHandoffOptions: null });
+
+    await app.request(`/${INSTANCE_ID}/connect`, json('POST', {}));
+
+    expect(captured.connectOptions).not.toHaveProperty('gupshupHandoffOptions');
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/instances-gupshup-handoff-options.test.ts
+++ b/packages/api/src/routes/v2/__tests__/instances-gupshup-handoff-options.test.ts
@@ -4,7 +4,10 @@
  * The channel plugin validates `gupshupHandoffOptions` in `connect()` and
  * applies it to every HANDOFF it emits. That only helps if the column reaches
  * the plugin on every path an instance can be (re)connected from: create,
- * PATCH and the generic connect route.
+ * PATCH, the generic connect route and restart. Restart had no gupshup branch
+ * at all before this — it re-connected without the persisted callback URL and
+ * auth token, so the plugin refused and the instance stayed down (same class
+ * of bug as the whatsapp-business fix, #894).
  */
 
 import { describe, expect, mock, test } from 'bun:test';
@@ -181,5 +184,21 @@ describe('POST /instances/:id/connect — persisted options reach the plugin', (
     await app.request(`/${INSTANCE_ID}/connect`, json('POST', {}));
 
     expect(captured.connectOptions).not.toHaveProperty('gupshupHandoffOptions');
+  });
+});
+
+describe('POST /instances/:id/restart — re-reads the persisted Gupshup config', () => {
+  test('threads credentials and handoff options into the reconnect', async () => {
+    const captured: Captured = {};
+    const app = mount(captured);
+
+    const res = await app.request(`/${INSTANCE_ID}/restart`, json('POST'));
+
+    expect(res.status).toBe(200);
+    // Without these the plugin throws "gupshupCallbackUrl is required" and the
+    // handler answers 500 RESTART_FAILED with the instance left disconnected.
+    expect(captured.connectOptions?.gupshupCallbackUrl).toBe('https://callbacks.example.com/abc');
+    expect(captured.connectOptions?.gupshupAuthToken).toBe('persisted-token');
+    expect(captured.connectOptions?.gupshupHandoffOptions).toEqual(HANDOFF_OPTIONS);
   });
 });

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -15,6 +15,7 @@ import { applyWhatsAppBusinessConnectionOptions } from '../../lib/whatsapp-busin
 import { filterByInstanceAccess, requireInstanceAccess } from '../../middleware/auth';
 import { invalidateProviderCacheForInstance } from '../../plugins/agent-dispatcher';
 import { getQrCode } from '../../plugins/qr-store';
+import { GupshupHandoffOptionsSchema } from '../../schemas/openapi/instances';
 import type { Services } from '../../services';
 import { PairingRequestConsumedError, PairingRequestExpiredError } from '../../services/access';
 import { AgentReplayService } from '../../services/agent-replay';
@@ -42,43 +43,6 @@ const listQuerySchema = z.object({
 });
 
 // Reply filter schema
-/**
- * Gupshup HANDOFF options. Mirrors the validator the channel plugin applies on
- * connect (packages/channel-gupshup/src/handoff-options.ts) so a bad shape is
- * rejected here with a 400 instead of failing the instance later. Keep the two
- * in step.
- */
-const gupshupHandoffFieldValue = z.string().max(2048);
-const gupshupHandoffFieldKey = z.string().min(1).max(128);
-const gupshupHandoffOptionsSchema = z
-  .object({
-    defaultFields: z.record(gupshupHandoffFieldKey, gupshupHandoffFieldValue).optional(),
-    fieldsByPhonePrefix: z
-      .array(
-        z.object({
-          prefixes: z.array(z.string().min(1).max(15).regex(/^\d+$/)).min(1).max(256),
-          fields: z.record(gupshupHandoffFieldKey, gupshupHandoffFieldValue),
-        }),
-      )
-      .max(64)
-      .optional(),
-    customerFields: z
-      .array(
-        z
-          .object({
-            apiKey: gupshupHandoffFieldKey,
-            value: gupshupHandoffFieldValue.optional(),
-            from: gupshupHandoffFieldKey.optional(),
-          })
-          .refine((entry) => (entry.value === undefined) !== (entry.from === undefined), {
-            message: 'each customerFields entry needs exactly one of `value` or `from`',
-          }),
-      )
-      .max(64)
-      .optional(),
-  })
-  .strict();
-
 const agentReplyFilterSchema = z.object({
   mode: z.enum(['all', 'filtered']).describe('Reply mode: all = reply to everything, filtered = check conditions'),
   conditions: z
@@ -211,8 +175,8 @@ const createInstanceSchema = z.object({
   gupshupCallbackUrl: z.string().optional().nullable().describe('Gupshup Custom Integration callback URL'),
   gupshupAuthToken: z.string().optional().nullable().describe('Gupshup Custom Integration auth token'),
   gupshupEventId: z.string().optional().nullable().describe('Gupshup event ID (default: nx_omni_agent_reply)'),
-  gupshupHandoffOptions: gupshupHandoffOptionsSchema
-    .optional()
+  // One definition with the OpenAPI document (schemas/openapi/instances.ts).
+  gupshupHandoffOptions: GupshupHandoffOptionsSchema.optional()
     .nullable()
     .describe('Gupshup HANDOFF routing defaults and customerFields template'),
   webhookVerifyToken: z.string().optional().nullable().describe('Gupshup webhook verify token'),
@@ -338,7 +302,7 @@ const updateInstanceSchema = createInstanceSchema.partial().extend({
   gupshupCallbackUrl: z.string().nullable().optional(),
   gupshupAuthToken: z.string().nullable().optional(),
   gupshupEventId: z.string().nullable().optional(),
-  gupshupHandoffOptions: gupshupHandoffOptionsSchema.nullable().optional(),
+  gupshupHandoffOptions: GupshupHandoffOptionsSchema.nullable().optional(),
   webhookVerifyToken: z.string().nullable().optional(),
   twilioAccountSid: z.string().nullable().optional(),
   twilioAuthToken: z.string().nullable().optional(),

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -1632,6 +1632,12 @@ instancesRoutes.post('/:id/restart', instanceAccess, async (c) => {
     if (instance.channel === 'hermes') {
       applyHermesConnectionOptions(restartOptions, instance);
     }
+    if (instance.channel === 'gupshup') {
+      // Same failure mode as #894: the plugin's connect() requires the persisted
+      // callback URL and auth token (and validates the handoff options there),
+      // so a restart without this branch left the instance disconnected.
+      applyGupshupConnectionOptions(restartOptions, instance);
+    }
     if (instance.channel === 'whatsapp-business') {
       // Persisted Meta credentials — without them plugin.connect() throws
       // "metaAccessToken is required" and the restart bricks the instance (#894).

--- a/packages/api/src/routes/v2/instances.ts
+++ b/packages/api/src/routes/v2/instances.ts
@@ -5,7 +5,7 @@
 import { zValidator } from '@hono/zod-validator';
 import type { ChannelPlugin, ChannelRegistry, GroupParticipantUpdateResult } from '@omni/channel-sdk';
 import { AccessModeSchema, ChannelTypeSchema, NotFoundError, createLogger } from '@omni/core';
-import type { SyncJobType } from '@omni/db';
+import type { GupshupHandoffOptions, SyncJobType } from '@omni/db';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { accessCache } from '../../cache/cache-keys';
@@ -42,6 +42,43 @@ const listQuerySchema = z.object({
 });
 
 // Reply filter schema
+/**
+ * Gupshup HANDOFF options. Mirrors the validator the channel plugin applies on
+ * connect (packages/channel-gupshup/src/handoff-options.ts) so a bad shape is
+ * rejected here with a 400 instead of failing the instance later. Keep the two
+ * in step.
+ */
+const gupshupHandoffFieldValue = z.string().max(2048);
+const gupshupHandoffFieldKey = z.string().min(1).max(128);
+const gupshupHandoffOptionsSchema = z
+  .object({
+    defaultFields: z.record(gupshupHandoffFieldKey, gupshupHandoffFieldValue).optional(),
+    fieldsByPhonePrefix: z
+      .array(
+        z.object({
+          prefixes: z.array(z.string().min(1).max(15).regex(/^\d+$/)).min(1).max(256),
+          fields: z.record(gupshupHandoffFieldKey, gupshupHandoffFieldValue),
+        }),
+      )
+      .max(64)
+      .optional(),
+    customerFields: z
+      .array(
+        z
+          .object({
+            apiKey: gupshupHandoffFieldKey,
+            value: gupshupHandoffFieldValue.optional(),
+            from: gupshupHandoffFieldKey.optional(),
+          })
+          .refine((entry) => (entry.value === undefined) !== (entry.from === undefined), {
+            message: 'each customerFields entry needs exactly one of `value` or `from`',
+          }),
+      )
+      .max(64)
+      .optional(),
+  })
+  .strict();
+
 const agentReplyFilterSchema = z.object({
   mode: z.enum(['all', 'filtered']).describe('Reply mode: all = reply to everything, filtered = check conditions'),
   conditions: z
@@ -174,6 +211,10 @@ const createInstanceSchema = z.object({
   gupshupCallbackUrl: z.string().optional().nullable().describe('Gupshup Custom Integration callback URL'),
   gupshupAuthToken: z.string().optional().nullable().describe('Gupshup Custom Integration auth token'),
   gupshupEventId: z.string().optional().nullable().describe('Gupshup event ID (default: nx_omni_agent_reply)'),
+  gupshupHandoffOptions: gupshupHandoffOptionsSchema
+    .optional()
+    .nullable()
+    .describe('Gupshup HANDOFF routing defaults and customerFields template'),
   webhookVerifyToken: z.string().optional().nullable().describe('Gupshup webhook verify token'),
   twilioAccountSid: z.string().optional().nullable().describe('Twilio Account SID'),
   twilioAuthToken: z.string().optional().nullable().describe('Twilio Auth Token'),
@@ -297,6 +338,7 @@ const updateInstanceSchema = createInstanceSchema.partial().extend({
   gupshupCallbackUrl: z.string().nullable().optional(),
   gupshupAuthToken: z.string().nullable().optional(),
   gupshupEventId: z.string().nullable().optional(),
+  gupshupHandoffOptions: gupshupHandoffOptionsSchema.nullable().optional(),
   webhookVerifyToken: z.string().nullable().optional(),
   twilioAccountSid: z.string().nullable().optional(),
   twilioAuthToken: z.string().nullable().optional(),
@@ -533,6 +575,7 @@ type InstanceConnectionOptionsInput = {
   gupshupCallbackUrl?: string | null;
   gupshupAuthToken?: string | null;
   gupshupEventId?: string | null;
+  gupshupHandoffOptions?: GupshupHandoffOptions | null;
   webhookVerifyToken?: string | null;
   twilioAccountSid?: string | null;
   twilioAuthToken?: string | null;
@@ -574,10 +617,17 @@ function applySlackConnectionOptions(options: Record<string, unknown>, input: In
   if (input.slackSigningSecret) options.signingSecret = input.slackSigningSecret;
 }
 
-function applyGupshupConnectionOptions(options: Record<string, unknown>, input: InstanceConnectionOptionsInput): void {
+function applyGupshupConnectionOptions(
+  options: Record<string, unknown>,
+  input: Pick<
+    InstanceConnectionOptionsInput,
+    'gupshupCallbackUrl' | 'gupshupAuthToken' | 'gupshupEventId' | 'gupshupHandoffOptions' | 'webhookVerifyToken'
+  >,
+): void {
   if (input.gupshupCallbackUrl) options.gupshupCallbackUrl = input.gupshupCallbackUrl;
   if (input.gupshupAuthToken) options.gupshupAuthToken = input.gupshupAuthToken;
   if (input.gupshupEventId) options.gupshupEventId = input.gupshupEventId;
+  if (input.gupshupHandoffOptions) options.gupshupHandoffOptions = input.gupshupHandoffOptions;
   if (input.webhookVerifyToken) options.webhookVerifyToken = input.webhookVerifyToken;
 }
 
@@ -861,6 +911,7 @@ instancesRoutes.post('/', zValidator('json', createInstanceSchema), async (c) =>
     gupshupCallbackUrl: instance.gupshupCallbackUrl,
     gupshupAuthToken: instance.gupshupAuthToken,
     gupshupEventId: instance.gupshupEventId,
+    gupshupHandoffOptions: instance.gupshupHandoffOptions,
     webhookVerifyToken: instance.webhookVerifyToken,
     twilioAccountSid: instance.twilioAccountSid,
     twilioAuthToken: instance.twilioAuthToken,
@@ -1349,6 +1400,7 @@ function buildConnectConnectionOptions(
     gupshupCallbackUrl: instance.gupshupCallbackUrl,
     gupshupAuthToken: instance.gupshupAuthToken,
     gupshupEventId: instance.gupshupEventId,
+    gupshupHandoffOptions: instance.gupshupHandoffOptions,
     webhookVerifyToken: instance.webhookVerifyToken,
     twilioAccountSid: body.twilioAccountSid ?? instance.twilioAccountSid,
     twilioAuthToken: body.twilioAuthToken ?? body.token ?? instance.twilioAuthToken,

--- a/packages/api/src/schemas/openapi/instances.ts
+++ b/packages/api/src/schemas/openapi/instances.ts
@@ -32,6 +32,73 @@ export const InstanceSchema = z.object({
 });
 
 /**
+ * Gupshup HANDOFF options (instances.gupshup_handoff_options). This is the ONE
+ * Zod definition: the route validator (`routes/v2/instances.ts`) imports it for
+ * POST and PATCH, so the published OpenAPI document and the runtime validation
+ * cannot drift. It mirrors the validator the channel plugin applies on connect
+ * (packages/channel-gupshup/src/handoff-options.ts) so a bad shape is rejected
+ * here with a 400 instead of failing the instance later. Keep the two in step.
+ */
+const gupshupHandoffFieldValue = z.string().max(2048);
+const gupshupHandoffFieldKey = z.string().min(1).max(128);
+const gupshupHandoffFields = z.record(gupshupHandoffFieldKey, gupshupHandoffFieldValue);
+export const GupshupHandoffOptionsSchema = z
+  .object({
+    defaultFields: gupshupHandoffFields.optional().openapi({
+      description:
+        'Routing fields merged under whatever the emitter sent; explicit handoff fields always win, so system-initiated handoffs (dispatch error, silence watchdog) still land in a queue',
+      example: { queue: 'SALES' },
+    }),
+    fieldsByPhonePrefix: z
+      .array(
+        z.object({
+          prefixes: z
+            .array(z.string().min(1).max(15).regex(/^\d+$/))
+            .min(1)
+            .max(256)
+            .openapi({
+              description: 'Digit-only phone prefixes (country code first, no +)',
+              example: ['5511', '5521'],
+            }),
+          fields: gupshupHandoffFields.openapi({
+            description: 'Routing fields applied when the customer phone starts with one of the prefixes',
+            example: { queue: 'SALES-SOUTHEAST' },
+          }),
+        }),
+      )
+      .max(64)
+      .optional()
+      .openapi({ description: 'Prefix rules layered over defaultFields; the first matching rule wins' }),
+    customerFields: z
+      .array(
+        z
+          .object({
+            apiKey: gupshupHandoffFieldKey.openapi({ description: 'customerFields apiKey your Gupshup Journey reads' }),
+            value: gupshupHandoffFieldValue
+              .optional()
+              .openapi({ description: 'Literal value to send; mutually exclusive with `from`' }),
+            from: gupshupHandoffFieldKey.optional().openapi({
+              description: 'Resolved handoff field to copy the value from; mutually exclusive with `value`',
+            }),
+          })
+          .refine((entry) => (entry.value === undefined) !== (entry.from === undefined), {
+            message: 'each customerFields entry needs exactly one of `value` or `from`',
+          }),
+      )
+      .max(64)
+      .optional()
+      .openapi({
+        description:
+          'Ordered template for the Custom Integration customerFields array. Entries whose source resolves empty are dropped; the array is only sent when non-empty',
+        example: [
+          { apiKey: 'Queue', from: 'queue' },
+          { apiKey: 'Handled By', value: 'assistant' },
+        ],
+      }),
+  })
+  .strict();
+
+/**
  * Create instance request schema
  */
 export const CreateInstanceSchema = z.object({
@@ -46,6 +113,20 @@ export const CreateInstanceSchema = z.object({
   agentStreamMode: z.boolean().default(false).openapi({ description: 'Enable streaming responses' }),
   isDefault: z.boolean().default(false).openapi({ description: 'Set as default instance for channel' }),
   token: z.string().optional().openapi({ description: 'Bot token for Discord instances' }),
+  gupshupHandoffOptions: GupshupHandoffOptionsSchema.nullable()
+    .optional()
+    .openapi({
+      description:
+        'Gupshup HANDOFF routing defaults and customerFields template (gupshup instances only). Read by the plugin at connect: restart the instance after changing it. null clears it',
+      example: {
+        defaultFields: { queue: 'SALES' },
+        fieldsByPhonePrefix: [{ prefixes: ['5511', '5521'], fields: { queue: 'SALES-SOUTHEAST' } }],
+        customerFields: [
+          { apiKey: 'Queue', from: 'queue' },
+          { apiKey: 'Handled By', value: 'assistant' },
+        ],
+      },
+    }),
 });
 
 /**

--- a/packages/channel-gupshup/RUNBOOK.md
+++ b/packages/channel-gupshup/RUNBOOK.md
@@ -87,5 +87,14 @@ error, it never surfaces as a broken handoff later.
   Entries whose source resolves empty are dropped. The `apiKey` set is whatever your Journey
   reads; the channel does not assume any.
 
-Set it with `omni instances update <id> --gupshup-handoff-options '<json>'` or through
-`PATCH /api/v2/instances/:id`. Instances without the column set behave exactly as before.
+Set it at creation with `omni instances create ... --gupshup-handoff-options '<json>'`, later
+with `omni instances update <id> --gupshup-handoff-options '<json>'` (`'null'` clears it), or
+through `POST /api/v2/instances` / `PATCH /api/v2/instances/:id` (`"gupshupHandoffOptions": null`
+clears it) and the dashboard's instance Config tab. Instances without the column set behave
+exactly as before.
+
+A `PATCH` or Config-tab save only persists the row. The plugin reads the options once, at
+connect, so a running instance keeps the template it connected with until it is restarted:
+`omni instances restart <id>` or `POST /api/v2/instances/:id/restart`. The API rejects a bad
+shape with a 400 before it is stored; anything that still reaches the plugin fails that
+connect/restart with the offending path, and the instance stays down until it is corrected.

--- a/packages/channel-gupshup/RUNBOOK.md
+++ b/packages/channel-gupshup/RUNBOOK.md
@@ -58,3 +58,34 @@ Handled enum:
 A healthy instance shows almost all traffic under `processed` +
 `dropped_known_non_message`. Any sustained volume under `dropped_unknown_fail_open`
 or `dropped_unrecognized_shape` is an incident.
+
+## Handoff options
+
+Per-instance, stored in `instances.gupshup_handoff_options` (jsonb) and validated
+on connect — a malformed object fails the connect with the offending path in the
+error, it never surfaces as a broken handoff later.
+
+```json
+{
+  "defaultFields": { "queue": "SALES" },
+  "fieldsByPhonePrefix": [
+    { "prefixes": ["5511", "5521"], "fields": { "queue": "SALES-SOUTHEAST" } }
+  ],
+  "customerFields": [
+    { "apiKey": "Queue", "from": "queue" },
+    { "apiKey": "Handled By", "value": "assistant" },
+    { "apiKey": "Full Name", "from": "name" }
+  ]
+}
+```
+
+- `defaultFields` / `fieldsByPhonePrefix` — routing fields merged **under** whatever the
+  emitter sent. Explicit fields always win; an empty or `"undefined"`/`"null"` value from the
+  emitter counts as not sent. This is what keeps a system-initiated handoff (agent dispatch
+  error, silence watchdog) inside a queue: those paths never carry `handoff_fields`.
+- `customerFields` — ordered template for the Custom Integration `customerFields` array.
+  Entries whose source resolves empty are dropped. The `apiKey` set is whatever your Journey
+  reads; the channel does not assume any.
+
+Set it with `omni instances update <id> --gupshup-handoff-options '<json>'` or through
+`PATCH /api/v2/instances/:id`. Instances without the column set behave exactly as before.

--- a/packages/channel-gupshup/src/__tests__/client.test.ts
+++ b/packages/channel-gupshup/src/__tests__/client.test.ts
@@ -157,3 +157,53 @@ describe('GupshupClient — validateCredentials', () => {
     fetchSpy.mockRestore();
   });
 });
+
+describe('GupshupClient — send HANDOFF customerFields', () => {
+  function postedBody(fetchSpy: ReturnType<typeof spyOn>): Record<string, unknown> {
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    return JSON.parse(String(init?.body)) as Record<string, unknown>;
+  }
+
+  it('omits customerFields from the wire when not provided', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeOkResponse({ status: 'ok' }));
+    const client = makeClient();
+
+    await client.send('5511999990000', { type: 'HANDOFF', text: 'hi', handoff_fields: { queue: 'X' } });
+
+    const body = postedBody(fetchSpy);
+    expect(body).not.toHaveProperty('customerFields');
+    expect(body.handoff_fields).toEqual({ queue: 'X' });
+    fetchSpy.mockRestore();
+  });
+
+  it('posts customerFields verbatim, in order, when provided', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeOkResponse({ status: 'ok' }));
+    const client = makeClient();
+
+    await client.send('5511999990000', {
+      type: 'HANDOFF',
+      text: 'hi',
+      handoff_fields: { queue: 'X' },
+      customer_fields: [
+        { apiKey: 'Queue', value: 'X' },
+        { apiKey: 'Source', value: 'assistant' },
+      ],
+    });
+
+    expect(postedBody(fetchSpy).customerFields).toEqual([
+      { apiKey: 'Queue', value: 'X' },
+      { apiKey: 'Source', value: 'assistant' },
+    ]);
+    fetchSpy.mockRestore();
+  });
+
+  it('omits customerFields when the array is empty', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeOkResponse({ status: 'ok' }));
+    const client = makeClient();
+
+    await client.send('5511999990000', { type: 'HANDOFF', text: 'hi', customer_fields: [] });
+
+    expect(postedBody(fetchSpy)).not.toHaveProperty('customerFields');
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/channel-gupshup/src/__tests__/handoff-options.test.ts
+++ b/packages/channel-gupshup/src/__tests__/handoff-options.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Gupshup handoff options — unit tests
+ *
+ * Covers the three pure helpers: schema parsing, routing-default resolution
+ * and the customerFields template. The wire shape is asserted in
+ * client.test.ts; the plugin integration in plugin.test.ts.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { buildCustomerFields, parseHandoffOptions, resolveHandoffFields } from '../handoff-options';
+
+const options = parseHandoffOptions({
+  defaultFields: { queue: 'DEFAULT' },
+  fieldsByPhonePrefix: [
+    { prefixes: ['5511', '5521'], fields: { queue: 'SOUTHEAST' } },
+    { prefixes: ['55'], fields: { queue: 'BRAZIL' } },
+  ],
+  customerFields: [
+    { apiKey: 'Queue', from: 'queue' },
+    { apiKey: 'Source', value: 'assistant' },
+    { apiKey: 'Full Name', from: 'name' },
+  ],
+});
+
+describe('parseHandoffOptions', () => {
+  it('returns undefined when nothing is configured', () => {
+    expect(parseHandoffOptions(undefined)).toBeUndefined();
+    expect(parseHandoffOptions(null)).toBeUndefined();
+  });
+
+  it('accepts an empty object', () => {
+    expect(parseHandoffOptions({})).toEqual({});
+  });
+
+  it('rejects unknown keys', () => {
+    expect(() => parseHandoffOptions({ defaultFields: {}, typo: true })).toThrow();
+  });
+
+  it('rejects a customerFields entry with neither value nor from', () => {
+    expect(() => parseHandoffOptions({ customerFields: [{ apiKey: 'X' }] })).toThrow(/exactly one/);
+  });
+
+  it('rejects a customerFields entry with both value and from', () => {
+    expect(() => parseHandoffOptions({ customerFields: [{ apiKey: 'X', value: 'a', from: 'b' }] })).toThrow(
+      /exactly one/,
+    );
+  });
+
+  it('rejects non-digit prefixes', () => {
+    expect(() => parseHandoffOptions({ fieldsByPhonePrefix: [{ prefixes: ['+55'], fields: { queue: 'x' } }] })).toThrow(
+      /digits only/,
+    );
+  });
+
+  it('rejects a rule with no prefixes', () => {
+    expect(() => parseHandoffOptions({ fieldsByPhonePrefix: [{ prefixes: [], fields: { queue: 'x' } }] })).toThrow();
+  });
+});
+
+describe('resolveHandoffFields', () => {
+  it('returns explicit fields untouched when no options are configured', () => {
+    const explicit = { queue: 'FROM_AGENT' };
+    expect(resolveHandoffFields('5511999990000', explicit, undefined)).toBe(explicit);
+    expect(resolveHandoffFields('5511999990000', undefined, undefined)).toBeUndefined();
+  });
+
+  it('fills defaults when the emitter sent nothing', () => {
+    expect(resolveHandoffFields('4915112345678', undefined, options)).toEqual({ queue: 'DEFAULT' });
+  });
+
+  it('applies the first matching prefix rule over the defaults', () => {
+    expect(resolveHandoffFields('5511999990000', undefined, options)).toEqual({ queue: 'SOUTHEAST' });
+    expect(resolveHandoffFields('5585999990000', undefined, options)).toEqual({ queue: 'BRAZIL' });
+  });
+
+  it('strips formatting before matching prefixes', () => {
+    expect(resolveHandoffFields('+55 (21) 99999-0000', undefined, options)).toEqual({ queue: 'SOUTHEAST' });
+  });
+
+  it('never overrides a field the emitter provided', () => {
+    expect(resolveHandoffFields('5511999990000', { queue: 'FROM_AGENT' }, options)).toEqual({
+      queue: 'FROM_AGENT',
+    });
+  });
+
+  it('treats an empty or sentinel value from the emitter as not sent', () => {
+    expect(resolveHandoffFields('5511999990000', { queue: '' }, options)).toEqual({ queue: 'SOUTHEAST' });
+    expect(resolveHandoffFields('5511999990000', { queue: 'undefined' }, options)).toEqual({ queue: 'SOUTHEAST' });
+    expect(resolveHandoffFields('5511999990000', { queue: 'null' }, options)).toEqual({ queue: 'SOUTHEAST' });
+  });
+
+  it('keeps unrelated explicit fields alongside the defaults', () => {
+    expect(resolveHandoffFields('5511999990000', { name: 'Ana' }, options)).toEqual({
+      name: 'Ana',
+      queue: 'SOUTHEAST',
+    });
+  });
+
+  it('returns explicit fields as-is when options carry no routing defaults', () => {
+    const onlyTemplate = parseHandoffOptions({ customerFields: [{ apiKey: 'A', value: 'b' }] });
+    const explicit = { name: 'Ana' };
+    expect(resolveHandoffFields('5511999990000', explicit, onlyTemplate)).toBe(explicit);
+  });
+});
+
+describe('buildCustomerFields', () => {
+  it('returns undefined without a template', () => {
+    expect(buildCustomerFields({ queue: 'X' }, undefined)).toBeUndefined();
+    expect(buildCustomerFields({ queue: 'X' }, [])).toBeUndefined();
+  });
+
+  it('renders literals and references in template order', () => {
+    expect(buildCustomerFields({ queue: 'SOUTHEAST', name: 'Ana' }, options?.customerFields)).toEqual([
+      { apiKey: 'Queue', value: 'SOUTHEAST' },
+      { apiKey: 'Source', value: 'assistant' },
+      { apiKey: 'Full Name', value: 'Ana' },
+    ]);
+  });
+
+  it('skips entries whose reference is missing or empty', () => {
+    expect(buildCustomerFields({ queue: 'SOUTHEAST' }, options?.customerFields)).toEqual([
+      { apiKey: 'Queue', value: 'SOUTHEAST' },
+      { apiKey: 'Source', value: 'assistant' },
+    ]);
+  });
+
+  it('drops sentinel strings instead of forwarding them', () => {
+    const rendered = buildCustomerFields({ queue: 'SOUTHEAST', name: 'undefined' }, options?.customerFields);
+    expect(rendered?.map((f) => f.apiKey)).toEqual(['Queue', 'Source']);
+  });
+
+  it('returns undefined when every entry resolves empty', () => {
+    const template = parseHandoffOptions({ customerFields: [{ apiKey: 'Name', from: 'name' }] })?.customerFields;
+    expect(buildCustomerFields({}, template)).toBeUndefined();
+    expect(buildCustomerFields(undefined, template)).toBeUndefined();
+  });
+
+  it('coerces non-string references to their string form', () => {
+    const template = parseHandoffOptions({ customerFields: [{ apiKey: 'Score', from: 'score' }] })?.customerFields;
+    expect(buildCustomerFields({ score: 42 }, template)).toEqual([{ apiKey: 'Score', value: '42' }]);
+  });
+});

--- a/packages/channel-gupshup/src/__tests__/plugin.test.ts
+++ b/packages/channel-gupshup/src/__tests__/plugin.test.ts
@@ -138,3 +138,116 @@ describe('GupshupPlugin — outbound provider aliases', () => {
     fetchSpy.mockRestore();
   });
 });
+
+describe('GupshupPlugin — handoff options', () => {
+  const handoffOptions = {
+    defaultFields: { queue: 'DEFAULT' },
+    fieldsByPhonePrefix: [{ prefixes: ['5511'], fields: { queue: 'SOUTHEAST' } }],
+    customerFields: [
+      { apiKey: 'Queue', from: 'queue' },
+      { apiKey: 'Source', value: 'assistant' },
+    ],
+  };
+
+  async function connectedPlugin(options: unknown): Promise<GupshupPlugin> {
+    const plugin = new GupshupPlugin();
+    await plugin.initialize({
+      eventBus: { publish: mock(async () => undefined) } as unknown as EventBus,
+      logger: makeLogger(),
+      storage: {} as never,
+      config: {} as never,
+      db: {} as never,
+    });
+    await plugin.connect('inst-1', {
+      instanceId: 'inst-1',
+      credentials: {
+        gupshupCallbackUrl: 'https://callbacks.gupshup.io/custom/abc123',
+        gupshupAuthToken: 'Bearer test-auth-token',
+      },
+      options: { gupshupHandoffOptions: options },
+    });
+    return plugin;
+  }
+
+  function captureBodies(): { bodies: Record<string, unknown>[]; restore: () => void } {
+    const bodies: Record<string, unknown>[] = [];
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (_url: unknown, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return makeOkResponse({ status: 'ok' });
+    }) as unknown as typeof fetch);
+    return { bodies, restore: () => fetchSpy.mockRestore() };
+  }
+
+  it('routes a fieldless handoff with the instance defaults and renders customerFields', async () => {
+    const { bodies, restore } = captureBodies();
+    try {
+      const plugin = await connectedPlugin(handoffOptions);
+      const result = await plugin.sendMessage('inst-1', {
+        to: '+55 11 98888-0000',
+        content: { type: 'text', text: 'Transferring you now' },
+        metadata: { isHandoff: true, motivoHandoff: 'agent_dispatch_error' },
+      });
+
+      expect(result.success).toBe(true);
+      const handoff = bodies.find((b) => b.msg_type === 'HANDOFF');
+      expect(handoff?.handoff_fields).toEqual({ queue: 'SOUTHEAST' });
+      expect(handoff?.customerFields).toEqual([
+        { apiKey: 'Queue', value: 'SOUTHEAST' },
+        { apiKey: 'Source', value: 'assistant' },
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('never overrides fields the emitter provided', async () => {
+    const { bodies, restore } = captureBodies();
+    try {
+      const plugin = await connectedPlugin(handoffOptions);
+      await plugin.sendMessage('inst-1', {
+        to: '+55 11 98888-0000',
+        content: { type: 'text', text: 'Transferring you now' },
+        metadata: { isHandoff: true, handoffFields: { queue: 'FROM_AGENT', name: 'Ana' } },
+      });
+
+      const handoff = bodies.find((b) => b.msg_type === 'HANDOFF');
+      expect(handoff?.handoff_fields).toEqual({ queue: 'FROM_AGENT', name: 'Ana' });
+      expect(handoff?.customerFields).toEqual([
+        { apiKey: 'Queue', value: 'FROM_AGENT' },
+        { apiKey: 'Source', value: 'assistant' },
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves the wire untouched for instances without options', async () => {
+    const { bodies, restore } = captureBodies();
+    try {
+      const plugin = await connectedPlugin(undefined);
+      await plugin.sendMessage('inst-1', {
+        to: '+55 11 98888-0000',
+        content: { type: 'text', text: 'Transferring you now' },
+        metadata: { isHandoff: true },
+      });
+
+      const handoff = bodies.find((b) => b.msg_type === 'HANDOFF');
+      expect(handoff).not.toHaveProperty('handoff_fields');
+      expect(handoff).not.toHaveProperty('customerFields');
+    } finally {
+      restore();
+    }
+  });
+
+  it('rejects malformed options at connect, before any network call', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(makeOkResponse({ status: 'ok' }));
+    try {
+      await expect(connectedPlugin({ customerFields: [{ apiKey: 'Missing source' }] })).rejects.toThrow(
+        /gupshupHandoffOptions is invalid/,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/packages/channel-gupshup/src/__tests__/senders.test.ts
+++ b/packages/channel-gupshup/src/__tests__/senders.test.ts
@@ -117,6 +117,25 @@ describe('sendHandoff', () => {
     });
   });
 
+  it('forwards customerFields only when provided', async () => {
+    const client = makeClient();
+    const spy = spyOn(client, 'send').mockResolvedValue({ status: 'ok' });
+
+    await sendHandoff(client, '5511111111111', 'Transferring', undefined, undefined, { queue: 'X' });
+    expect(spy.mock.calls[0]?.[1]).not.toHaveProperty('customer_fields');
+
+    await sendHandoff(client, '5511111111111', 'Transferring', undefined, undefined, { queue: 'X' }, [
+      { apiKey: 'Queue', value: 'X' },
+    ]);
+    expect(spy.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        type: 'HANDOFF',
+        handoff_fields: { queue: 'X' },
+        customer_fields: [{ apiKey: 'Queue', value: 'X' }],
+      }),
+    );
+  });
+
   it('includes dados_lead and motivo_handoff when provided', async () => {
     const client = makeClient();
     const spy = spyOn(client, 'send').mockResolvedValueOnce({ status: 'ok' });

--- a/packages/channel-gupshup/src/client.ts
+++ b/packages/channel-gupshup/src/client.ts
@@ -37,6 +37,7 @@ export class GupshupClient {
     if (msg.dados_lead) payload.dados_lead = msg.dados_lead;
     if (msg.motivo_handoff) payload.motivo_handoff = msg.motivo_handoff;
     if (msg.handoff_fields) payload.handoff_fields = msg.handoff_fields;
+    if (msg.customer_fields && msg.customer_fields.length > 0) payload.customerFields = msg.customer_fields;
 
     // POST to callback URL
     const res = await fetch(this.callbackUrl, {

--- a/packages/channel-gupshup/src/handoff-options.ts
+++ b/packages/channel-gupshup/src/handoff-options.ts
@@ -1,0 +1,157 @@
+/**
+ * Per-instance handoff options for the Gupshup Custom Integration.
+ *
+ * Two gaps this closes, both seen on real deployments:
+ *
+ * 1. System-initiated handoffs reach the channel with no `handoff_fields`.
+ *    The agent-dispatch error path, a silence watchdog, any emitter that is
+ *    not the agent itself — none of them know the operator's queue layout.
+ *    On the Gupshup side the Journey routes on exactly those fields, so a
+ *    handoff without them lands outside every queue and nobody picks it up.
+ *    `defaultFields` and `fieldsByPhonePrefix` let the operator declare
+ *    routing defaults on the instance. They are applied UNDER whatever the
+ *    emitter sent: an explicit field always wins.
+ *
+ * 2. The Custom Integration accepts a `customerFields` array of
+ *    `{ apiKey, value }` that the Journey writes onto the contact record.
+ *    Which keys a given Journey expects is per account, so this is a template
+ *    the operator owns rather than something the channel can hardcode.
+ *
+ * Both are validated with Zod when the instance connects. Bad config fails the
+ * connect, not the first handoff at 3 a.m.
+ */
+
+import { z } from 'zod';
+
+const fieldValue = z.string().max(2048);
+const fieldKey = z.string().min(1).max(128);
+const fieldMap = z.record(fieldKey, fieldValue);
+
+export const gupshupHandoffOptionsSchema = z
+  .object({
+    /** Fields merged under every HANDOFF that lacks them. */
+    defaultFields: fieldMap.optional(),
+
+    /**
+     * Ordered prefix rules, matched against the destination phone with all
+     * non-digits stripped. The first rule with a matching prefix wins and its
+     * fields override `defaultFields`. Country codes, area codes and number
+     * ranges are all just prefixes here.
+     */
+    fieldsByPhonePrefix: z
+      .array(
+        z.object({
+          prefixes: z.array(z.string().min(1).max(15).regex(/^\d+$/, 'prefixes must be digits only')).min(1).max(256),
+          fields: fieldMap,
+        }),
+      )
+      .max(64)
+      .optional(),
+
+    /**
+     * Ordered template for the Custom Integration `customerFields` array.
+     * Each entry is either a literal (`value`) or a reference to a key of the
+     * resolved handoff fields (`from`). Entries whose source resolves to an
+     * empty value are skipped, so a missing optional field never produces a
+     * blank customer field on the contact.
+     */
+    customerFields: z
+      .array(
+        z
+          .object({
+            apiKey: fieldKey,
+            value: fieldValue.optional(),
+            from: fieldKey.optional(),
+          })
+          .refine((entry) => (entry.value === undefined) !== (entry.from === undefined), {
+            message: 'each customerFields entry needs exactly one of `value` or `from`',
+          }),
+      )
+      .max(64)
+      .optional(),
+  })
+  .strict();
+
+export type GupshupHandoffOptions = z.infer<typeof gupshupHandoffOptionsSchema>;
+
+export interface GupshupCustomerField {
+  apiKey: string;
+  value: string;
+}
+
+/**
+ * Values that must never reach the Journey as a field value. LLM-driven
+ * emitters occasionally serialise an absent value as the literal string.
+ */
+const EMPTY_SENTINELS = new Set(['', 'undefined', 'null']);
+
+function cleanValue(value: unknown): string {
+  const text = String(value ?? '').trim();
+  return EMPTY_SENTINELS.has(text.toLowerCase()) ? '' : text;
+}
+
+/**
+ * Validate raw instance options. Returns `undefined` when nothing is
+ * configured; throws a `ZodError` when the shape is wrong so the caller can
+ * surface a precise message at connect time.
+ */
+export function parseHandoffOptions(raw: unknown): GupshupHandoffOptions | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  return gupshupHandoffOptionsSchema.parse(raw);
+}
+
+/**
+ * Merge routing defaults under the fields an emitter provided.
+ *
+ * Precedence, lowest to highest: `defaultFields` → matching
+ * `fieldsByPhonePrefix` rule → explicit fields from the emitter. A key the
+ * emitter sent as empty (or as an empty sentinel) counts as "not sent" and is
+ * filled from the defaults — a blank routing key is exactly the failure this
+ * exists to prevent.
+ *
+ * Returns the explicit fields untouched when no options are configured, so
+ * instances without options behave byte-for-byte as before.
+ */
+export function resolveHandoffFields(
+  phone: string,
+  explicit: Record<string, unknown> | undefined,
+  options: GupshupHandoffOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (!options) return explicit;
+
+  const defaults: Record<string, string> = { ...(options.defaultFields ?? {}) };
+  const digits = String(phone ?? '').replace(/\D/g, '');
+  if (digits && options.fieldsByPhonePrefix) {
+    const rule = options.fieldsByPhonePrefix.find((r) => r.prefixes.some((p) => digits.startsWith(p)));
+    if (rule) Object.assign(defaults, rule.fields);
+  }
+  if (Object.keys(defaults).length === 0) return explicit;
+
+  const out: Record<string, unknown> = { ...(explicit ?? {}) };
+  for (const [key, value] of Object.entries(defaults)) {
+    if (cleanValue(out[key]) === '') out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Render the `customerFields` template against the resolved handoff fields.
+ * Template order is preserved; entries that resolve to an empty value are
+ * dropped. Returns `undefined` when there is nothing to send, so the wire
+ * payload stays unchanged for instances without a template.
+ */
+export function buildCustomerFields(
+  handoffFields: Record<string, unknown> | undefined,
+  template: GupshupHandoffOptions['customerFields'],
+): GupshupCustomerField[] | undefined {
+  if (!template || template.length === 0) return undefined;
+
+  const out: GupshupCustomerField[] = [];
+  for (const entry of template) {
+    const value =
+      entry.value !== undefined ? cleanValue(entry.value) : cleanValue(handoffFields?.[entry.from as string]);
+    if (value === '') continue;
+    out.push({ apiKey: entry.apiKey, value });
+  }
+  return out.length > 0 ? out : undefined;
+}

--- a/packages/channel-gupshup/src/plugin.ts
+++ b/packages/channel-gupshup/src/plugin.ts
@@ -19,9 +19,16 @@ import type {
 import type { Logger } from '@omni/core';
 import type { ChannelType } from '@omni/core/types';
 
+import { ZodError } from 'zod';
 import { GUPSHUP_CAPABILITIES } from './capabilities';
 import { GupshupClient } from './client';
 import { handleGupshupWebhook } from './handlers/webhooks';
+import {
+  type GupshupHandoffOptions,
+  buildCustomerFields,
+  parseHandoffOptions,
+  resolveHandoffFields,
+} from './handoff-options';
 import { sendCloseContact } from './senders/close-contact';
 import { sendHandoff } from './senders/handoff';
 import { sendLocation } from './senders/location';
@@ -36,6 +43,7 @@ async function dispatchContent(
   client: GupshupClient,
   dest: string,
   message: OutgoingMessage,
+  handoffOptions?: GupshupHandoffOptions,
 ): Promise<GupshupSendResponse> {
   const { content } = message;
   const meta = message.metadata as Record<string, unknown> | undefined;
@@ -44,8 +52,13 @@ async function dispatchContent(
   if (meta?.isHandoff === true) {
     const dadosLead = meta.dadosLead as string | undefined;
     const motivoHandoff = meta.motivoHandoff as string | undefined;
-    const handoffFields = meta.handoffFields as Record<string, unknown> | undefined;
-    return sendHandoff(client, dest, content.text ?? '', dadosLead, motivoHandoff, handoffFields);
+    // Routing defaults sit UNDER whatever the emitter sent. A system-initiated
+    // handoff (dispatch error, watchdog) arrives with no fields at all; without
+    // this it would reach the Journey unroutable.
+    const explicitFields = meta.handoffFields as Record<string, unknown> | undefined;
+    const handoffFields = resolveHandoffFields(dest, explicitFields, handoffOptions);
+    const customerFields = buildCustomerFields(handoffFields, handoffOptions?.customerFields);
+    return sendHandoff(client, dest, content.text ?? '', dadosLead, motivoHandoff, handoffFields, customerFields);
   }
 
   if (meta?.isCloseContact === true) {
@@ -144,6 +157,19 @@ export class GupshupPlugin extends BaseChannelPlugin {
     const eventId = ((creds.gupshupEventId ?? opts.gupshupEventId) as string | undefined) ?? 'nx_omni_agent_reply';
     const webhookVerifyToken = (creds.webhookVerifyToken ?? opts.webhookVerifyToken) as string | undefined;
 
+    // Validate before touching the network: a malformed template should fail
+    // the connect with a precise message, not the first handoff.
+    let handoffOptions: GupshupHandoffOptions | undefined;
+    try {
+      handoffOptions = parseHandoffOptions(creds.gupshupHandoffOptions ?? opts.gupshupHandoffOptions);
+    } catch (err) {
+      const detail =
+        err instanceof ZodError
+          ? err.issues.map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`).join('; ')
+          : String(err);
+      throw new GupshupError(GupshupErrorCode.BAD_REQUEST, `gupshupHandoffOptions is invalid — ${detail}`);
+    }
+
     if (!callbackUrl) throw new GupshupError(GupshupErrorCode.AUTH_FAILED, 'gupshupCallbackUrl is required');
     if (!authToken) throw new GupshupError(GupshupErrorCode.AUTH_FAILED, 'gupshupAuthToken is required');
 
@@ -165,6 +191,7 @@ export class GupshupPlugin extends BaseChannelPlugin {
       gupshupAuthToken: authToken,
       gupshupEventId: eventId,
       webhookVerifyToken,
+      handoffOptions,
     };
     const dedupeCache = createInboundDedupeCache();
 
@@ -221,7 +248,7 @@ export class GupshupPlugin extends BaseChannelPlugin {
     if (correlationId) this.captureT10(correlationId);
 
     try {
-      const response = await dispatchContent(client, dest, message);
+      const response = await dispatchContent(client, dest, message, state.config.handoffOptions);
       const providerAliases = extractGupshupProviderAliases(response);
       // Preserve existing externalId semantics: use Gupshup's canonical
       // messageId when present, otherwise keep Omni's UUID fallback. Other

--- a/packages/channel-gupshup/src/senders/handoff.ts
+++ b/packages/channel-gupshup/src/senders/handoff.ts
@@ -3,6 +3,7 @@
  */
 
 import type { GupshupClient } from '../client';
+import type { GupshupCustomerField } from '../handoff-options';
 import type { GupshupSendResponse } from '../types';
 
 export async function sendHandoff(
@@ -12,6 +13,7 @@ export async function sendHandoff(
   dadosLead?: string,
   motivoHandoff?: string,
   handoffFields?: Record<string, unknown>,
+  customerFields?: GupshupCustomerField[],
 ): Promise<GupshupSendResponse> {
   return client.send(to, {
     type: 'HANDOFF',
@@ -19,5 +21,6 @@ export async function sendHandoff(
     dados_lead: dadosLead,
     motivo_handoff: motivoHandoff,
     handoff_fields: handoffFields,
+    ...(customerFields ? { customer_fields: customerFields } : {}),
   });
 }

--- a/packages/channel-gupshup/src/types.ts
+++ b/packages/channel-gupshup/src/types.ts
@@ -5,12 +5,16 @@
  * Outbound: Custom Integration callback URL
  */
 
+import type { GupshupCustomerField, GupshupHandoffOptions } from './handoff-options';
+
 // Instance config
 export interface GupshupConfig {
   gupshupCallbackUrl: string; // required — Custom Integration callback URL
   gupshupAuthToken: string; // required — Custom Integration auth token
   gupshupEventId?: string; // optional, default: "nx_omni_agent_reply"
   webhookVerifyToken?: string; // optional — skip token check if not set
+  /** Validated HANDOFF routing defaults + customerFields template (see handoff-options.ts). */
+  handoffOptions?: GupshupHandoffOptions;
 }
 
 // Outbound message shape (internal)
@@ -27,6 +31,8 @@ export interface GupshupOutboundMessage {
   dados_lead?: string;
   motivo_handoff?: string;
   handoff_fields?: Record<string, unknown>;
+  /** Custom Integration contact fields, rendered from the instance template — HANDOFF only. */
+  customer_fields?: GupshupCustomerField[];
   // Close-contact fields — present only on type === 'CLOSING' (the wire
   // literal Gupshup's Journey routes on; the Omni-side concept is "close
   // contact" but the partner contract uses 'CLOSING').

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -454,6 +454,53 @@ describe('CLI Integration Tests', () => {
       expect(status.instanceId).toBe(testInstanceId);
     });
 
+    test('instances update --gupshup-handoff-options forwards the parsed JSON object', async () => {
+      if (!testInstanceId) return;
+
+      const handoffOptions = {
+        defaultFields: { queue: 'SALES' },
+        fieldsByPhonePrefix: [{ prefixes: ['5511', '5521'], fields: { queue: 'SALES-SOUTHEAST' } }],
+        customerFields: [
+          { apiKey: 'Queue', from: 'queue' },
+          { apiKey: 'Handled By', value: 'assistant' },
+        ],
+      };
+      const result = await runCli(
+        ['instances', 'update', testInstanceId, '--gupshup-handoff-options', JSON.stringify(handoffOptions)],
+        { OMNI_FORMAT: 'json' },
+      );
+
+      assertSuccess(result, 'instances update --gupshup-handoff-options');
+      // The body the CLI built carries the object, not the raw string...
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.data.gupshupHandoffOptions).toEqual(handoffOptions);
+
+      // ...and that is what reached the API's PATCH /instances/:id.
+      const stored = await fetch(`${MOCK_URL}/api/v2/instances/${testInstanceId}`, {
+        headers: { 'x-api-key': MOCK_API_KEY },
+      });
+      const instance = (await stored.json()) as { data: { gupshupHandoffOptions?: unknown } };
+      expect(instance.data.gupshupHandoffOptions).toEqual(handoffOptions);
+    });
+
+    test('instances update --gupshup-handoff-options null clears the field', async () => {
+      if (!testInstanceId) return;
+
+      const result = await runCli(['instances', 'update', testInstanceId, '--gupshup-handoff-options', 'null'], {
+        OMNI_FORMAT: 'json',
+      });
+
+      assertSuccess(result, 'instances update --gupshup-handoff-options null');
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.data).toHaveProperty('gupshupHandoffOptions', null);
+
+      const stored = await fetch(`${MOCK_URL}/api/v2/instances/${testInstanceId}`, {
+        headers: { 'x-api-key': MOCK_API_KEY },
+      });
+      const instance = (await stored.json()) as { data: { gupshupHandoffOptions?: unknown } };
+      expect(instance.data).toHaveProperty('gupshupHandoffOptions', null);
+    });
+
     test('instances delete removes instance', async () => {
       if (!testInstanceId) {
         return;

--- a/packages/cli/src/__tests__/mock-api.ts
+++ b/packages/cli/src/__tests__/mock-api.ts
@@ -219,6 +219,7 @@ let dynamicInstances: Array<{
   channel: string;
   isActive: boolean;
   profileName: string | null;
+  gupshupHandoffOptions?: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
 }> = [];
@@ -299,6 +300,20 @@ function handleGetInstance(path: string): Response {
   const id = match?.[1] ?? '';
   const found = getAllInstances().find((i) => i.id === id);
   if (!found) return json({ error: { code: 'NOT_FOUND', message: 'Instance not found' } }, 404);
+  return json({ data: found });
+}
+
+async function handleUpdateInstance(req: Request, path: string): Promise<Response> {
+  const match = path.match(/^\/api\/v2\/instances\/([^/]+)$/);
+  const id = match?.[1] ?? '';
+  const found = dynamicInstances.find((i) => i.id === id);
+  if (!found) return json({ error: { code: 'NOT_FOUND', message: 'Instance not found' } }, 404);
+  const body = (await req.json()) as Record<string, unknown>;
+  if (body.name !== undefined) found.name = body.name as string;
+  if (body.gupshupHandoffOptions !== undefined) {
+    found.gupshupHandoffOptions = body.gupshupHandoffOptions as Record<string, unknown> | null;
+  }
+  found.updatedAt = new Date().toISOString();
   return json({ data: found });
 }
 
@@ -580,6 +595,11 @@ const patternRoutes: Array<{
     handler: (_req, path) => handleInstanceStatus(path),
   },
   { method: 'GET', pattern: /^\/api\/v2\/instances\/[^/]+$/, handler: (_req, path) => handleGetInstance(path) },
+  {
+    method: 'PATCH',
+    pattern: /^\/api\/v2\/instances\/[^/]+$/,
+    handler: (req, path) => handleUpdateInstance(req, path),
+  },
   { method: 'DELETE', pattern: /^\/api\/v2\/instances\/[^/]+$/, handler: (_req, path) => handleDeleteInstance(path) },
   // Provider routes
   {

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -1055,6 +1055,11 @@ export function createInstancesCommand(): Command {
     .option('--twilio-webhook-url <url>', 'Public Twilio webhook URL for signature validation (use "null" to clear)')
     .option('--twilio-validate-signature', 'Validate X-Twilio-Signature on webhooks')
     .option('--no-twilio-validate-signature', 'Disable X-Twilio-Signature validation')
+    // Gupshup
+    .option(
+      '--gupshup-handoff-options <json>',
+      'Gupshup HANDOFF routing defaults and customerFields template (JSON object, use "null" to clear). The plugin reads it at connect: restart the instance for the change to take effect',
+    )
     // Trigger events
     .option('--trigger-events <events>', 'Trigger events (comma-separated, use "null" to clear)')
     // WhatsApp profile name (separate endpoint)

--- a/packages/cli/src/commands/instances.ts
+++ b/packages/cli/src/commands/instances.ts
@@ -135,6 +135,9 @@ function applyMiscFields(body: Record<string, unknown>, opts: Record<string, unk
   setVal(body, 'gupshupCallbackUrl', opts.gupshupCallbackUrl);
   setVal(body, 'gupshupAuthToken', opts.gupshupAuthToken);
   setVal(body, 'gupshupEventId', opts.gupshupEventId);
+  if (typeof opts.gupshupHandoffOptions === 'string' && opts.gupshupHandoffOptions.length > 0) {
+    body.gupshupHandoffOptions = JSON.parse(opts.gupshupHandoffOptions);
+  }
   setVal(body, 'webhookVerifyToken', opts.gupshupWebhookVerifyToken);
   setVal(body, 'twilioAccountSid', opts.twilioAccountSid);
   setVal(body, 'twilioAuthToken', opts.twilioAuthToken);
@@ -386,6 +389,10 @@ export function createInstancesCommand(): Command {
     .option('--gupshup-callback-url <url>', 'Gupshup Custom Integration callback URL')
     .option('--gupshup-auth-token <token>', 'Gupshup Custom Integration auth token')
     .option('--gupshup-event-id <id>', 'Gupshup event ID (default: nx_omni_agent_reply)')
+    .option(
+      '--gupshup-handoff-options <json>',
+      'Gupshup HANDOFF routing defaults and customerFields template (JSON object)',
+    )
     .option('--gupshup-webhook-verify-token <token>', 'Gupshup webhook verify token')
     // Twilio WhatsApp
     .option('--twilio-account-sid <sid>', 'Twilio Account SID')

--- a/packages/db/drizzle/0053_gupshup_handoff_options.sql
+++ b/packages/db/drizzle/0053_gupshup_handoff_options.sql
@@ -1,0 +1,23 @@
+-- Gupshup per-instance handoff options.
+--
+-- One jsonb column holding routing defaults and the Custom Integration
+-- `customerFields` template for HANDOFF messages:
+--
+--   gupshup_handoff_options  jsonb  { defaultFields?:        Record<string,string>,
+--                                     fieldsByPhonePrefix?:  Array<{ prefixes: string[],
+--                                                                     fields: Record<string,string> }>,
+--                                     customerFields?:       Array<{ apiKey: string,
+--                                                                     value?: string, from?: string }> }
+--
+-- Shape is validated by the channel plugin on connect
+-- (packages/channel-gupshup/src/handoff-options.ts). Not a credential: the
+-- column is returned by the instances API like gupshup_event_id.
+--
+-- Hand-written following the 0044-0052 precedent (snapshot drift keeps
+-- drizzle-kit generate interactive). Additive + idempotent.
+
+-- NOTE: no explicit BEGIN/COMMIT — the boot migrator executes this file on a
+-- pooled postgres-js connection, which rejects raw transaction control
+-- (UNSAFE_TRANSACTION).
+
+ALTER TABLE "instances" ADD COLUMN IF NOT EXISTS "gupshup_handoff_options" jsonb;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1785200000000,
       "tag": "0052_webhook_source_signature",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1785300000000,
+      "tag": "0053_gupshup_handoff_options",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -94,6 +94,20 @@ export interface AgentReplyFilter {
 }
 
 /**
+ * Per-instance Gupshup HANDOFF options: routing defaults applied under the
+ * emitter's fields, and the Custom Integration `customerFields` template.
+ * Validated by the channel plugin on connect (packages/channel-gupshup/src/handoff-options.ts).
+ */
+export interface GupshupHandoffOptions {
+  /** Fields merged under every HANDOFF that lacks them. */
+  defaultFields?: Record<string, string>;
+  /** First rule whose prefix matches the destination phone (digits only) overrides `defaultFields`. */
+  fieldsByPhonePrefix?: Array<{ prefixes: string[]; fields: Record<string, string> }>;
+  /** Ordered template; each entry is a literal (`value`) or a reference to a handoff field (`from`). */
+  customerFields?: Array<{ apiKey: string; value?: string; from?: string }>;
+}
+
+/**
  * Session strategy for agent memory
  * - per_user: Same session across all chats for this user (user continuity)
  * - per_chat: All users in a chat share the session (group memory)
@@ -741,6 +755,8 @@ export const instances = pgTable(
     gupshupAuthToken: text('gupshup_auth_token'),
     gupshupEventId: varchar('gupshup_event_id', { length: 255 }),
     webhookVerifyToken: text('webhook_verify_token'),
+    /** HANDOFF routing defaults + customerFields template. Not a credential. */
+    gupshupHandoffOptions: jsonb('gupshup_handoff_options').$type<GupshupHandoffOptions>(),
 
     // ---- Twilio WhatsApp Configuration ----
     twilioAccountSid: varchar('twilio_account_sid', { length: 34 }),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -303,6 +303,7 @@ export interface CreateInstanceBody {
   twilioStatusCallbackUrl?: string;
   twilioWebhookUrl?: string;
   twilioValidateSignature?: boolean;
+  gupshupHandoffOptions?: components['schemas']['CreateInstanceRequest']['gupshupHandoffOptions'];
 }
 
 /**

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2861,6 +2861,87 @@ export interface components {
             isDefault: boolean;
             /** @description Bot token for Discord instances */
             token?: string;
+            /**
+             * @description Gupshup HANDOFF routing defaults and customerFields template (gupshup instances only). Read by the plugin at connect: restart the instance after changing it. null clears it
+             * @example {
+             *       "defaultFields": {
+             *         "queue": "SALES"
+             *       },
+             *       "fieldsByPhonePrefix": [
+             *         {
+             *           "prefixes": [
+             *             "5511",
+             *             "5521"
+             *           ],
+             *           "fields": {
+             *             "queue": "SALES-SOUTHEAST"
+             *           }
+             *         }
+             *       ],
+             *       "customerFields": [
+             *         {
+             *           "apiKey": "Queue",
+             *           "from": "queue"
+             *         },
+             *         {
+             *           "apiKey": "Handled By",
+             *           "value": "assistant"
+             *         }
+             *       ]
+             *     }
+             */
+            gupshupHandoffOptions?: {
+                /**
+                 * @description Routing fields merged under whatever the emitter sent; explicit handoff fields always win, so system-initiated handoffs (dispatch error, silence watchdog) still land in a queue
+                 * @example {
+                 *       "queue": "SALES"
+                 *     }
+                 */
+                defaultFields?: {
+                    [key: string]: string;
+                };
+                /** @description Prefix rules layered over defaultFields; the first matching rule wins */
+                fieldsByPhonePrefix?: {
+                    /**
+                     * @description Digit-only phone prefixes (country code first, no +)
+                     * @example [
+                     *       "5511",
+                     *       "5521"
+                     *     ]
+                     */
+                    prefixes: string[];
+                    /**
+                     * @description Routing fields applied when the customer phone starts with one of the prefixes
+                     * @example {
+                     *       "queue": "SALES-SOUTHEAST"
+                     *     }
+                     */
+                    fields: {
+                        [key: string]: string;
+                    };
+                }[];
+                /**
+                 * @description Ordered template for the Custom Integration customerFields array. Entries whose source resolves empty are dropped; the array is only sent when non-empty
+                 * @example [
+                 *       {
+                 *         "apiKey": "Queue",
+                 *         "from": "queue"
+                 *       },
+                 *       {
+                 *         "apiKey": "Handled By",
+                 *         "value": "assistant"
+                 *       }
+                 *     ]
+                 */
+                customerFields?: {
+                    /** @description customerFields apiKey your Gupshup Journey reads */
+                    apiKey: string;
+                    /** @description Literal value to send; mutually exclusive with `from` */
+                    value?: string;
+                    /** @description Resolved handoff field to copy the value from; mutually exclusive with `value` */
+                    from?: string;
+                }[];
+            } | null;
         };
         InstanceStatus: {
             /**
@@ -6560,6 +6641,87 @@ export interface operations {
                     isDefault?: boolean;
                     /** @description Bot token for Discord instances */
                     token?: string;
+                    /**
+                     * @description Gupshup HANDOFF routing defaults and customerFields template (gupshup instances only). Read by the plugin at connect: restart the instance after changing it. null clears it
+                     * @example {
+                     *       "defaultFields": {
+                     *         "queue": "SALES"
+                     *       },
+                     *       "fieldsByPhonePrefix": [
+                     *         {
+                     *           "prefixes": [
+                     *             "5511",
+                     *             "5521"
+                     *           ],
+                     *           "fields": {
+                     *             "queue": "SALES-SOUTHEAST"
+                     *           }
+                     *         }
+                     *       ],
+                     *       "customerFields": [
+                     *         {
+                     *           "apiKey": "Queue",
+                     *           "from": "queue"
+                     *         },
+                     *         {
+                     *           "apiKey": "Handled By",
+                     *           "value": "assistant"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+                    gupshupHandoffOptions?: {
+                        /**
+                         * @description Routing fields merged under whatever the emitter sent; explicit handoff fields always win, so system-initiated handoffs (dispatch error, silence watchdog) still land in a queue
+                         * @example {
+                         *       "queue": "SALES"
+                         *     }
+                         */
+                        defaultFields?: {
+                            [key: string]: string;
+                        };
+                        /** @description Prefix rules layered over defaultFields; the first matching rule wins */
+                        fieldsByPhonePrefix?: {
+                            /**
+                             * @description Digit-only phone prefixes (country code first, no +)
+                             * @example [
+                             *       "5511",
+                             *       "5521"
+                             *     ]
+                             */
+                            prefixes: string[];
+                            /**
+                             * @description Routing fields applied when the customer phone starts with one of the prefixes
+                             * @example {
+                             *       "queue": "SALES-SOUTHEAST"
+                             *     }
+                             */
+                            fields: {
+                                [key: string]: string;
+                            };
+                        }[];
+                        /**
+                         * @description Ordered template for the Custom Integration customerFields array. Entries whose source resolves empty are dropped; the array is only sent when non-empty
+                         * @example [
+                         *       {
+                         *         "apiKey": "Queue",
+                         *         "from": "queue"
+                         *       },
+                         *       {
+                         *         "apiKey": "Handled By",
+                         *         "value": "assistant"
+                         *       }
+                         *     ]
+                         */
+                        customerFields?: {
+                            /** @description customerFields apiKey your Gupshup Journey reads */
+                            apiKey: string;
+                            /** @description Literal value to send; mutually exclusive with `from` */
+                            value?: string;
+                            /** @description Resolved handoff field to copy the value from; mutually exclusive with `value` */
+                            from?: string;
+                        }[];
+                    } | null;
                 };
             };
         };
@@ -6872,6 +7034,87 @@ export interface operations {
                     isDefault?: boolean;
                     /** @description Bot token for Discord instances */
                     token?: string;
+                    /**
+                     * @description Gupshup HANDOFF routing defaults and customerFields template (gupshup instances only). Read by the plugin at connect: restart the instance after changing it. null clears it
+                     * @example {
+                     *       "defaultFields": {
+                     *         "queue": "SALES"
+                     *       },
+                     *       "fieldsByPhonePrefix": [
+                     *         {
+                     *           "prefixes": [
+                     *             "5511",
+                     *             "5521"
+                     *           ],
+                     *           "fields": {
+                     *             "queue": "SALES-SOUTHEAST"
+                     *           }
+                     *         }
+                     *       ],
+                     *       "customerFields": [
+                     *         {
+                     *           "apiKey": "Queue",
+                     *           "from": "queue"
+                     *         },
+                     *         {
+                     *           "apiKey": "Handled By",
+                     *           "value": "assistant"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+                    gupshupHandoffOptions?: {
+                        /**
+                         * @description Routing fields merged under whatever the emitter sent; explicit handoff fields always win, so system-initiated handoffs (dispatch error, silence watchdog) still land in a queue
+                         * @example {
+                         *       "queue": "SALES"
+                         *     }
+                         */
+                        defaultFields?: {
+                            [key: string]: string;
+                        };
+                        /** @description Prefix rules layered over defaultFields; the first matching rule wins */
+                        fieldsByPhonePrefix?: {
+                            /**
+                             * @description Digit-only phone prefixes (country code first, no +)
+                             * @example [
+                             *       "5511",
+                             *       "5521"
+                             *     ]
+                             */
+                            prefixes: string[];
+                            /**
+                             * @description Routing fields applied when the customer phone starts with one of the prefixes
+                             * @example {
+                             *       "queue": "SALES-SOUTHEAST"
+                             *     }
+                             */
+                            fields: {
+                                [key: string]: string;
+                            };
+                        }[];
+                        /**
+                         * @description Ordered template for the Custom Integration customerFields array. Entries whose source resolves empty are dropped; the array is only sent when non-empty
+                         * @example [
+                         *       {
+                         *         "apiKey": "Queue",
+                         *         "from": "queue"
+                         *       },
+                         *       {
+                         *         "apiKey": "Handled By",
+                         *         "value": "assistant"
+                         *       }
+                         *     ]
+                         */
+                        customerFields?: {
+                            /** @description customerFields apiKey your Gupshup Journey reads */
+                            apiKey: string;
+                            /** @description Literal value to send; mutually exclusive with `from` */
+                            value?: string;
+                            /** @description Resolved handoff field to copy the value from; mutually exclusive with `value` */
+                            from?: string;
+                        }[];
+                    } | null;
                 };
             };
         };

--- a/tests/release/upgrade-2.260830.2-to-2.260902.5-postgres.test.ts
+++ b/tests/release/upgrade-2.260830.2-to-2.260902.5-postgres.test.ts
@@ -12,11 +12,19 @@
  * (`applyMigrations` from packages/db/src/migrate.ts) so that the journal
  * guard, the advisory lock, and the count check are exercised rather than
  * simulated.
+ *
+ * The migrator is pointed at a candidate folder materialised from the live
+ * `packages/db/drizzle`: exactly the files the 2.260902.5 image ships
+ * (0000-0052) and a journal truncated to idx 0-52. Both the drizzle migrator
+ * and the count guard read `meta/_journal.json` from the folder they are
+ * given, so migrations added to the live folder after this hop (0053+) belong
+ * to later rehearsals and never leak into this one. The digest and pinning
+ * helpers still read the live folder: the bytes must not drift.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -53,12 +61,16 @@ interface JournalEntry {
   readonly tag: string;
 }
 
-const journalEntries = (JSON.parse(readFileSync(journalPath, 'utf-8')) as { entries: JournalEntry[] }).entries;
+const journal = JSON.parse(readFileSync(journalPath, 'utf-8')) as { entries: JournalEntry[] } & Record<string, unknown>;
+const journalEntries = journal.entries;
 
 const migrationFiles = readdirSync(drizzleDir)
   .filter((file) => file.endsWith('.sql'))
   .sort();
 const previousReleaseMigrations = migrationFiles.filter((file) => file <= PREVIOUS_RELEASE_LAST_MIGRATION);
+// What the 2.260902.5 image ships: 0000-0052 and the matching journal prefix.
+const candidateMigrations = migrationFiles.filter((file) => file <= TARGET_MIGRATION);
+const candidateJournalEntries = journalEntries.filter((entry) => entry.idx <= TARGET_JOURNAL_IDX);
 
 function migrationSql(file: string): string {
   return readFileSync(join(drizzleDir, file), 'utf-8');
@@ -84,6 +96,24 @@ function journalEntry(idx: number): JournalEntry {
   const entry = journalEntries.find((candidate) => candidate.idx === idx);
   if (!entry) throw new Error(`journal has no entry with idx ${idx}`);
   return entry;
+}
+
+/**
+ * The migrations folder exactly as the 2.260902.5 image ships it: the `.sql`
+ * files through 0052 (byte-identical copies of the live files) and a journal
+ * with the real top-level shape but only entries idx 0-52. drizzle reads
+ * `meta/_journal.json` and then `<tag>.sql` for every entry from this folder,
+ * and `applyMigrations` counts the same journal for its guard.
+ */
+function materializeCandidateMigrations(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'omni-release-candidate-'));
+  mkdirSync(join(dir, 'meta'));
+  for (const file of candidateMigrations) copyFileSync(join(drizzleDir, file), join(dir, file));
+  writeFileSync(
+    join(dir, 'meta', '_journal.json'),
+    JSON.stringify({ ...journal, entries: candidateJournalEntries }, null, 2),
+  );
+  return dir;
 }
 
 interface SqlResult {
@@ -120,8 +150,11 @@ function urlFor(base: string, database: string): string {
 describe('release migration artifacts', () => {
   test('the source and target boundaries stay byte-for-byte pinned', () => {
     expect(previousReleaseMigrations).toHaveLength(PREVIOUS_RELEASE_MIGRATION_COUNT);
-    const targetReleaseMigrations = migrationFiles.filter((file) => file > PREVIOUS_RELEASE_LAST_MIGRATION);
+    const targetReleaseMigrations = migrationFiles.filter(
+      (file) => file > PREVIOUS_RELEASE_LAST_MIGRATION && file <= TARGET_MIGRATION,
+    );
     expect(targetReleaseMigrations).toEqual([...TARGET_MIGRATIONS]);
+    expect(candidateMigrations).toEqual([...previousReleaseMigrations, ...TARGET_MIGRATIONS]);
     expect(migrationDigest(previousReleaseMigrations)).toBe(PREVIOUS_RELEASE_MIGRATIONS_SHA256);
     expect(
       migrationDigest(previousReleaseMigrations.filter((file) => file > '0039_instances_message_supersede_mode.sql')),
@@ -133,10 +166,13 @@ describe('release migration artifacts', () => {
     // packages/db/src/migrate.ts documents the failure mode: drizzle silently
     // skips a migration whose journal `when` is not later than the last applied
     // row's created_at, and the count guard only catches it after the fact.
-    expect(journalEntries).toHaveLength(PREVIOUS_RELEASE_MIGRATION_COUNT + TARGET_MIGRATIONS.length);
-    journalEntries.forEach((entry, position) => {
+    // Only the prefix the candidate ships is under test; later entries (0053+)
+    // belong to later hops and are excluded from the materialised folder.
+    expect(candidateJournalEntries).toHaveLength(PREVIOUS_RELEASE_MIGRATION_COUNT + TARGET_MIGRATIONS.length);
+    expect(journalEntries.slice(0, candidateJournalEntries.length)).toEqual(candidateJournalEntries);
+    candidateJournalEntries.forEach((entry, position) => {
       expect(entry.idx).toBe(position);
-      expect(migrationFiles[position]).toBe(`${entry.tag}.sql`);
+      expect(candidateMigrations[position]).toBe(`${entry.tag}.sql`);
       if (position > 0) expect(entry.when).toBeGreaterThan(journalEntry(position - 1).when);
     });
     const previous = journalEntry(TARGET_JOURNAL_IDX - 1);
@@ -144,7 +180,7 @@ describe('release migration artifacts', () => {
     expect(`${previous.tag}.sql`).toBe(PREVIOUS_RELEASE_LAST_MIGRATION);
     expect(`${target.tag}.sql`).toBe(TARGET_MIGRATION);
     expect(target.when).toBeGreaterThan(previous.when);
-    expect(journalEntries.at(-1)).toEqual(target);
+    expect(candidateJournalEntries.at(-1)).toEqual(target);
   });
 
   test('0052 is additive, idempotent, transaction-free, and touches no policy or data', () => {
@@ -176,6 +212,7 @@ describe('release migration artifacts', () => {
 postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)', () => {
   let database = '';
   let databaseUrl = '';
+  let candidateDrizzleDir = '';
   let handle: ReturnType<typeof createDbHandle> | null = null;
 
   function runSql(script: string): SqlResult {
@@ -246,11 +283,13 @@ postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)
     if (created.exitCode !== 0) throw new Error(`could not create disposable database: ${created.stderr}`);
     databaseUrl = urlFor(postgresUrl, database);
     handle = createDbHandle({ url: databaseUrl, maxConnections: 2 });
+    candidateDrizzleDir = materializeCandidateMigrations();
   });
 
   afterAll(async () => {
     if (handle) await handle.close();
     if (database) runSqlOn(postgresUrl, `DROP DATABASE IF EXISTS "${database}" WITH (FORCE);`);
+    if (candidateDrizzleDir) rmSync(candidateDrizzleDir, { recursive: true, force: true });
   });
 
   test('applies 0052 once through the journaled migrator and proves image-only rollback safe', async () => {
@@ -324,8 +363,9 @@ postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)
       `);
     expect(appliedMigrationCount()).toBe(String(PREVIOUS_RELEASE_MIGRATION_COUNT));
 
-    // The real boot path: advisory lock, drizzle migrator, count guard.
-    await applyMigrations(db, drizzleDir);
+    // The real boot path: advisory lock, drizzle migrator, count guard — fed
+    // the candidate folder so only the 0052 hop is on the table.
+    await applyMigrations(db, candidateDrizzleDir);
 
     const target = journalEntry(TARGET_JOURNAL_IDX);
     expect(appliedMigrationCount()).toBe(String(PREVIOUS_RELEASE_MIGRATION_COUNT + 1));
@@ -351,7 +391,7 @@ postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)
 
     // Re-running the migrator is a no-op, and — unlike 0045 — the raw file is
     // also safe to replay by hand because every statement is IF NOT EXISTS.
-    await applyMigrations(db, drizzleDir);
+    await applyMigrations(db, candidateDrizzleDir);
     expect(appliedMigrationCount()).toBe(String(PREVIOUS_RELEASE_MIGRATION_COUNT + 1));
     const rawReplay = runSql(migrationSql(TARGET_MIGRATION));
     expect(rawReplay.exitCode).toBe(0);
@@ -407,7 +447,7 @@ postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)
     expect(catalogFingerprint()).toBe(fingerprintBefore);
 
     // ...and the re-upgrade after that manual reverse is the ordinary hop.
-    await applyMigrations(db, drizzleDir);
+    await applyMigrations(db, candidateDrizzleDir);
     expect(columnCount()).toBe('12');
     expect(appliedMigrationCount()).toBe(String(PREVIOUS_RELEASE_MIGRATION_COUNT + 1));
     expect(signatureColumns()).toBe('signature_config:jsonb/YES/none,signature_secret:text/YES/none');


### PR DESCRIPTION
## Why

Two things the Gupshup channel could not express without patching the plugin at deploy time:

1. **HANDOFF with no `handoff_fields`.** The agent is not the only thing that emits a handoff — the agent-dispatch error path, a silence watchdog, an operator script — and none of them know the Journey's queue layout. The handoff reaches Gupshup with no routing fields, lands outside every queue, and nothing on our side notices.
2. **Journey contact fields.** The Custom Integration accepts a `customerFields: [{ apiKey, value }]` array on HANDOFF that the Journey writes onto the contact record. Which keys an account expects is per-account, so the channel cannot hardcode it.

## What

One nullable jsonb column, `instances.gupshup_handoff_options`, validated with Zod when the instance connects:

```json
{
  "defaultFields": { "queue": "DEFAULT" },
  "fieldsByPhonePrefix": [
    { "prefixes": ["5511", "5521"], "fields": { "queue": "SOUTHEAST" } }
  ],
  "customerFields": [
    { "apiKey": "Queue", "from": "queue" },
    { "apiKey": "Source", "value": "assistant" }
  ]
}
```

- `defaultFields` / `fieldsByPhonePrefix` sit **under** whatever the emitter sent — an explicit field always wins; an empty or `"undefined"`/`"null"` string counts as not sent. Prefixes match the destination with non-digits stripped; first rule wins.
- `customerFields` is an ordered template: each entry is a literal (`value`) or a reference to a resolved handoff field (`from`). Entries that resolve empty are skipped.
- Instances without options produce byte-for-byte the previous payload — `customerFields` only goes on the wire when the template rendered something, and `handoff_fields` passes through untouched.
- A bad shape fails `connect()` with the Zod path (`gupshupHandoffOptions is invalid — customerFields.0: …`) instead of the first handoff at 3 a.m.

Surfaces: `POST`/`PATCH /api/v2/instances` (schema mirrored there, so a malformed template is a 400 before anything is written), connect / restart / instance-monitor reconnect hydrate it from the row, `omni instances create --gupshup-handoff-options '<json>'`, a **Gupshup handoff** group in the instance Config tab, and a RUNBOOK section.

## Restart fix (second commit)

While threading the option through the reconnect paths I found `POST /instances/:id/restart` had no gupshup branch at all: it disconnected and then called `connect()` without the persisted callback URL and auth token, so the plugin refused and the instance stayed down — same class as #894 for whatsapp-business. Fixed with the existing `applyGupshupConnectionOptions` helper (narrowed to the fields it reads so a DB row satisfies it); the last case in the new route spec covers it.

## Migration

`0053_gupshup_handoff_options.sql` — hand-written `ADD COLUMN IF NOT EXISTS`, no transaction wrapper, journal entry appended; same shape as 0052. Nullable, no backfill, no index.

## Tests

- `channel-gupshup`: schema parsing (strict keys, exactly one of `value`/`from`, digit-only prefixes), precedence and prefix resolution, template rendering, wire shape via a `fetch` spy, and plugin integration (`connect()` rejects bad config; defaults fill a bare handoff; no options → previous payload).
- `api`: create / PATCH / connect / restart round-trip of the option over a fake instance service, alongside the existing instance route and monitor specs.
- `typecheck` clean on channel-gupshup, db, api and cli; biome clean on every touched file. The Config tab change is schema-only; I checked it with the SchemaForm introspection walker (record / array-of-object nodes) rather than the full UI build.

Heads-up: `bunx biome check .` is currently red on `dev` because of the four `brain/.obsidian/*.json` files that came in with #945 (missing trailing newline) — unrelated to this change, and the pre-commit hook trips on the same thing. Happy to fold a one-line fix in here if you'd rather not do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mLsKk6CPtZY5giDJS7fB9
