### PR TITLE
fix(helm): set TRUSTED_PROXY_HEADER in proxied realms

### DIFF
--- a/deploy/helm/omni/values-dev.yaml
+++ b/deploy/helm/omni/values-dev.yaml
@@ -18,6 +18,15 @@ autoscaling:
 config:
   LOG_LEVEL: "debug"
   NODE_ENV: "development"
+  # Every realm below terminates client TLS at a reverse proxy (nginx-ingress
+  # here; the ALB delta layered after this file swaps the controller but keeps
+  # the same shape), so the socket peer the API sees is the proxy, not the
+  # caller. Without this the auth-exempt webhook ingress buckets every caller
+  # under one shared key. resolveClientIp() reads the RIGHTMOST hop — the one
+  # this realm's own proxy appends — so a client-forged prefix cannot pick its
+  # own bucket. Set ONLY where a trusted proxy really fronts the pod: with the
+  # pod directly reachable, the whole header is caller-controlled.
+  TRUSTED_PROXY_HEADER: "X-Forwarded-For"
 
 ingress:
   enabled: true

--- a/deploy/helm/omni/values-homolog.yaml
+++ b/deploy/helm/omni/values-homolog.yaml
@@ -39,6 +39,15 @@ autoscaling:
 config:
   LOG_LEVEL: "info"
   NODE_ENV: "production"
+  # Every realm below terminates client TLS at a reverse proxy (nginx-ingress
+  # here; the ALB delta layered after this file swaps the controller but keeps
+  # the same shape), so the socket peer the API sees is the proxy, not the
+  # caller. Without this the auth-exempt webhook ingress buckets every caller
+  # under one shared key. resolveClientIp() reads the RIGHTMOST hop — the one
+  # this realm's own proxy appends — so a client-forged prefix cannot pick its
+  # own bucket. Set ONLY where a trusted proxy really fronts the pod: with the
+  # pod directly reachable, the whole header is caller-controlled.
+  TRUSTED_PROXY_HEADER: "X-Forwarded-For"
 
 ingress:
   enabled: true

--- a/deploy/helm/omni/values-prod.yaml
+++ b/deploy/helm/omni/values-prod.yaml
@@ -81,6 +81,15 @@ podDisruptionBudget:
 config:
   LOG_LEVEL: "info"
   NODE_ENV: "production"
+  # Every realm below terminates client TLS at a reverse proxy (nginx-ingress
+  # here; the ALB delta layered after this file swaps the controller but keeps
+  # the same shape), so the socket peer the API sees is the proxy, not the
+  # caller. Without this the auth-exempt webhook ingress buckets every caller
+  # under one shared key. resolveClientIp() reads the RIGHTMOST hop — the one
+  # this realm's own proxy appends — so a client-forged prefix cannot pick its
+  # own bucket. Set ONLY where a trusted proxy really fronts the pod: with the
+  # pod directly reachable, the whole header is caller-controlled.
+  TRUSTED_PROXY_HEADER: "X-Forwarded-For"
 
 ingress:
   enabled: true

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -85,6 +85,11 @@ config:
   API_PORT: "8882"
   NODE_ENV: "production"
   LOG_LEVEL: "info"
+  # TRUSTED_PROXY_HEADER is deliberately NOT set here. This base ships
+  # ingress.enabled=false, so the pod may be reached directly and every
+  # forwarding header would be caller-controlled — trusting one would let any
+  # client choose its own rate-limit bucket. Realm overlays that do front the
+  # pod with a proxy (values-dev / values-prod / values-homolog) set it.
 
 # Free-form extra non-secret env (key: value) merged into the ConfigMap.
 extraConfig: {}


### PR DESCRIPTION
Closes the deployment half of #928.

## Problema

O fix de rate limit por IP entrou em código (`resolveClientIp` lê o hop mais à direita — o escrito pelo proxy confiável — e valida como literal de IP), mas `TRUSTED_PROXY_HEADER` **nunca foi configurado em nenhum values file**.

Com a variável não definida o header é ignorado por completo e o código cai no peer do socket. Atrás do nginx-ingress ou do ALB, esse peer é o **próprio proxy** — então todo mundo que chega na ingress de webhook (que é auth-exempt) continuava caindo num único balde `ip:<proxy>`. Um cliente barulhento a 100 req/min esgota a janela de todos os providers.

## Mudança

`TRUSTED_PROXY_HEADER: "X-Forwarded-For"` nos três overlays de realm que de fato têm proxy na frente do pod: `values-dev`, `values-prod` e `values-homolog`.

Os dois deltas ALB (`values-prod-alb`, `values-hml-alb`) são layered **depois** de prod/homolog e herdam `config:`, então uma chave por realm cobre tanto o flavour nginx quanto o ALB. Verificado com `helm template` nas duas combinações.

**Deliberadamente não setado** no `values.yaml` base, que traz `ingress.enabled=false`: com o pod alcançável diretamente, o header inteiro é controlado pelo chamador e confiar nele deixaria qualquer um escolher o próprio balde. Documentado inline para a ausência ler como decisão, não esquecimento.

`X-Forwarded-For` é correto para os dois controllers justamente porque o leitor pega o hop mais à direita: nginx-ingress e ALB cada um **acrescenta** o peer que observou, então um prefixo forjado pelo cliente não influencia a chave.

## Verificação

```
prod + prod-alb        -> TRUSTED_PROXY_HEADER no ConfigMap  ✓
homolog + hml-alb      -> TRUSTED_PROXY_HEADER no ConfigMap  ✓
base (sem ingress)     -> ausente (0 ocorrências)            ✓
```

`bun test packages/api/src/middleware/__tests__/rate-limit.test.ts` → 9 pass / 0 fail. Suite completa passou no pre-push. Sem mudança de código — apenas configuração de deploy.