### PR TITLE
fix(channel-asc-flow): answer one turn per agent reply, not per dispatched part

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher-response-parts.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-response-parts.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `sendResponseParts` — the one funnel every agent reply leaves through.
+ *
+ * One reply becomes N sends: the provider splits it on blank lines
+ * (`agno-provider.ts`, `enableAutoSplit`) and each part goes out on its own.
+ * Every channel but one wants exactly that. asc-flow's transport carries a
+ * SINGLE answer per polled turn, so it has to know where a reply ENDS — its
+ * first part used to answer the poll, the flow collected it and closed the
+ * turn, and parts 2..N were refused as undeliverable (atendimento 22325225).
+ *
+ * `partIndex`/`partCount` is that signal, and it must count the sends that
+ * really happen — a part the sanitizer empties never reaches the plugin.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+const sends: Array<{ text: string; metadata: Record<string, unknown> }> = [];
+
+// Mock the plugin loader — same pattern as agent-dispatch-error-message.test.ts.
+// Without it the module init crashes loading the parent agent-dispatcher.ts.
+mock.module('../loader', () => ({
+  getPlugin: mock(async () => ({
+    async sendMessage(_instanceId: string, message: { content: { text: string }; metadata: Record<string, unknown> }) {
+      sends.push({ text: message.content.text, metadata: message.metadata });
+      return { success: true, timestamp: Date.now() };
+    },
+  })),
+}));
+
+import { __test__ } from '../agent-dispatcher';
+
+const NO_DELAY = { mode: 'disabled', fixedMs: 0, minMs: 0, maxMs: 0 } as const;
+
+const send = (parts: string[]) => {
+  sends.length = 0;
+  return __test__.sendResponseParts('asc-flow' as never, 'inst-1', '42', parts, NO_DELAY);
+};
+
+describe('sendResponseParts stamps where each send sits in the reply', () => {
+  it('numbers every part of one reply', async () => {
+    await send(['primeiro', 'segundo', 'terceiro']);
+
+    expect(sends.map((s) => s.text)).toEqual(['primeiro', 'segundo', 'terceiro']);
+    expect(sends.map((s) => [s.metadata.partIndex, s.metadata.partCount])).toEqual([
+      [0, 3],
+      [1, 3],
+      [2, 3],
+    ]);
+  });
+
+  it('marks a single-part reply as its own last part', async () => {
+    await send(['so uma']);
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.metadata).toMatchObject({ partIndex: 0, partCount: 1 });
+  });
+
+  it('counts the sends that happen, not the parts that came in', async () => {
+    // A part that is nothing but an internal routing header never reaches the
+    // plugin. Counting it would leave asc-flow holding the reply for a last
+    // part that never arrives.
+    await send(['primeiro', '[channel:asc-flow instance:inst-1 chat:42]', 'ultimo']);
+
+    expect(sends.map((s) => s.text)).toEqual(['primeiro', 'ultimo']);
+    expect(sends.map((s) => s.metadata.partCount)).toEqual([2, 2]);
+    expect(sends.at(-1)?.metadata.partIndex).toBe(1);
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -555,6 +555,7 @@ async function sendTextMessage(
   correlationId?: string,
   senderAgentId?: string,
   systemNotice?: boolean,
+  part?: { index: number; count: number },
 ): Promise<void> {
   const plugin = await getPlugin(channel);
   if (!plugin) throw new Error(`Channel plugin not found: ${channel}`);
@@ -567,7 +568,13 @@ async function sendTextMessage(
     to: chatId,
     content: { type: 'text', text: sanitized },
     replyTo,
-    metadata: { messageFormatMode, correlationId, senderAgentId, systemNotice },
+    metadata: {
+      messageFormatMode,
+      correlationId,
+      senderAgentId,
+      systemNotice,
+      ...(part ? { partIndex: part.index, partCount: part.count } : {}),
+    },
   });
 }
 
@@ -1568,10 +1575,16 @@ async function sendResponseParts(
   senderAgentId?: string,
 ): Promise<void> {
   const messageLimit = getMessageLimit(channel);
-  const allChunks: string[] = [];
+  const chunked: string[] = [];
   for (const part of parts) {
-    allChunks.push(...chunkText(part, messageLimit));
+    chunked.push(...chunkText(part, messageLimit));
   }
+
+  // Sanitize BEFORE numbering. `sendTextMessage` drops a chunk that is nothing
+  // but internal metadata, and `partIndex`/`partCount` must count the sends
+  // that really happen — a channel that answers its turn on the LAST part
+  // (asc-flow) would otherwise wait for a part that never arrives.
+  const allChunks = chunked.map((chunk) => sanitizeOutboundText(chunk)).filter(Boolean);
 
   // Slack needs thread_ts on every message to stay in thread.
   // WhatsApp/Discord senders only quote the first chunk internally,
@@ -1589,6 +1602,11 @@ async function sendResponseParts(
       chunkReplyTo,
       correlationId,
       senderAgentId,
+      undefined,
+      // ONE agent reply, many sends. Every channel but one wants exactly that;
+      // asc-flow needs to know where the reply ENDS, because its transport
+      // carries a single answer per polled turn.
+      { index, count: allChunks.length },
     );
     const isLastChunk = index === allChunks.length - 1;
     if (!isLastChunk) {
@@ -6587,6 +6605,8 @@ export const setupAgentResponder = setupAgentDispatcher;
 /** @internal Exported for unit testing only — do not use in production code. */
 export const __test__ = {
   buildContextMessages,
+  /** The one funnel every agent reply leaves through — pins the part stamping. */
+  sendResponseParts,
   awaitMediaProcessing,
   // #914 cancel plumbing — exposed so tests can stage in-flight runs and
   // assert the thread-scoped lookup + requestedAt guard.

--- a/packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts
@@ -142,6 +142,77 @@ describe('a parked handoff survives the agent finishing its turn', () => {
   });
 });
 
+describe('one agent reply is one turn, however many sends it arrives in', () => {
+  // The provider splits a reply on blank lines and the dispatcher sends each
+  // part separately. The FIRST part used to answer the poll, the flow collected
+  // it and closed the turn, and parts 2..N were refused as undeliverable — one
+  // paragraph of three reached the beneficiary, and whatever the agent sent
+  // after the text was lost. Measured on atendimento 22325225.
+  const part = (text: string, index: number, count: number, content: Record<string, unknown> = {}) =>
+    plugin.sendMessage(instanceId, {
+      to: '42',
+      content: { type: 'text', text, ...content } as never,
+      metadata: { partIndex: index, partCount: count },
+    });
+
+  it('answers once, with every part a bubble and the URA on the last', async () => {
+    await boot();
+    await openTurn(plugin);
+
+    expect((await part('primeiro', 0, 3)).success).toBe(true);
+    // A poll landing between parts finds the turn still unanswered — that is
+    // what stops the flow from advancing on the first paragraph alone.
+    expect(poll(TURN_TEXT)).toBeNull();
+
+    await part('segundo', 1, 3);
+    await part('Escolha:', 2, 3, { buttons: [{ text: 'Manha' }, { text: 'Tarde' }] });
+
+    expect(poll(TURN_TEXT)).toMatchObject({
+      pronto: 1,
+      bolhas: ['primeiro', 'segundo', 'Escolha:'],
+      ura_opcoes: { '1': 'Manha', '2': 'Tarde' },
+      forcar_botoes: true,
+    });
+
+    // The leading bubbles really left; the last one rode `/mensagem` with the
+    // URA, which is why `resposta` comes back empty.
+    expect(calls.filter((c) => c.path === '/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual([
+      'primeiro',
+      'segundo',
+    ]);
+    expect(calls.filter((c) => c.path === '/mensagem')).toHaveLength(1);
+  });
+
+  it('records the reply once, not one message per part', async () => {
+    await boot();
+    await openTurn(plugin);
+
+    await part('primeiro', 0, 3);
+    await part('segundo', 1, 3);
+    await part('terceiro', 2, 3);
+
+    const sent = eventBus.published.filter((e) => e.type.includes('sent'));
+    expect(sent).toHaveLength(1);
+    expect(eventBus.published.some((e) => e.type.includes('failed'))).toBe(false);
+    expect((sent[0]?.payload as { content: { text: string } }).content.text).toBe('primeiro\n\nsegundo\n\nterceiro');
+  });
+
+  it('still refuses a part that arrives after the turn was collected', async () => {
+    await boot();
+    await openTurn(plugin);
+    await part('primeiro', 0, 2);
+    await part('segundo', 1, 2);
+    expect(poll(TURN_TEXT)).toMatchObject({ pronto: 1 });
+
+    // Nothing is polling any more: a straggler must say it reached nobody
+    // rather than be held for a last part that will never come.
+    const late = await part('esqueci de dizer', 0, 2);
+
+    expect(late.success).toBe(false);
+    expect(late.error).toContain('no ASC flow turn is polling');
+  });
+});
+
 describe('an undeliverable send is reported as one', () => {
   // A text turn reaches the handset ONLY by being collected from the poll body.
   // Parking one with nobody polling — a follow-up sweep, or a `to` that

--- a/packages/channel-asc-flow/src/plugin.ts
+++ b/packages/channel-asc-flow/src/plugin.ts
@@ -31,15 +31,15 @@
  * Always HTTP 200. The flow is configured with `async = 1` and
  * `async_condition = {#BODY.pronto} = 1`.
  *
- * Turn boundary. One `sendMessage` is one flow turn. A turn's paragraphs
- * (blank-line separated) become separate bubbles, which is how the scheduling
- * agent writes and what the adapter proved against the ASC emulator. The
- * bubbles before the last one are PUSHED through `callbackFlowMsg` (with typing
- * between them, for rhythm); the LAST one rides back in `resposta`, which is
- * the single slot the flow's `message` node renders.
- * ponytail: if an agent ever emits two `sendMessage` calls for one user turn,
- * the flow advances twice. Upgrade path is a per-`cod` turn buffer flushed on
- * an end-of-turn signal — not built until a dispatcher actually does that.
+ * Turn boundary. One agent REPLY is one flow turn — not one `sendMessage`. A
+ * turn's paragraphs (blank-line separated) become separate bubbles, which is
+ * how the scheduling agent writes and what the adapter proved against the ASC
+ * emulator. The bubbles before the last one are PUSHED through
+ * `callbackFlowMsg` (with typing between them, for rhythm); the LAST one rides
+ * back in `resposta`, which is the single slot the flow's `message` node
+ * renders. The dispatcher does split one reply across several `sendMessage`
+ * calls, so the parts before the last are HELD on the turn window and the last
+ * one answers with all of them — see `collectTurnParts`.
  *
  * Handoff. Detected from `metadata.isHandoff` (the Gupshup precedent), not by
  * sniffing the agent's prose: the adapter only regex-matched the invitation
@@ -115,6 +115,11 @@ interface AscFlowTurnState {
    * sends.
    */
   correlationId?: string;
+  /**
+   * The parts of one agent reply that arrived before its last one. They ride
+   * the window so they share its TTL and its identity — see `collectTurnParts`.
+   */
+  parts?: string[];
   /** Set by `sendMessage`; the next poll takes it and the turn is over. */
   ready?: AscFlowTurnReady;
 }
@@ -196,6 +201,50 @@ function resolveOutboundText(message: OutgoingMessage): string {
   // confirmation). Encoding is the mirror of the inbound decode and runs even
   // in passthrough: it is transport, not formatting.
   return encodeAscEmoji(formatted);
+}
+
+/**
+ * The message that answers the turn — or `null` while its earlier parts are
+ * still being held.
+ *
+ * One agent reply reaches a channel as MANY `sendMessage` calls: the provider
+ * splits it on blank lines (`agno-provider.ts`, `enableAutoSplit`) and the
+ * dispatcher sends each part on its own. Every other channel just shows N
+ * messages. Here the FIRST part answered the poll, the flow's next poll
+ * collected it and closed the turn, and parts 2..N found nothing polling and
+ * were refused as undeliverable — the beneficiary read one paragraph of three
+ * and lost whatever the agent sent after the text. Measured on atendimento
+ * 22325225: "Agno agent responded parts:3", then two undeliverable warnings.
+ *
+ * So the turn is the whole reply, not its first part. The dispatcher stamps
+ * `partIndex`/`partCount`; the parts before the last are held and the last one
+ * answers with all of them joined by a blank line — which `splitBubbles` turns
+ * back into the same bubbles, with the URA on the last one.
+ *
+ * Holding is only ever done on a turn that is really being polled, and the
+ * held parts live ON that window, so they inherit its TTL and its identity: a
+ * window that closes mid-reply takes its held parts with it rather than
+ * leaking them or answering the next turn. A part that arrives with no window
+ * falls through to the usual undeliverable refusal, unchanged.
+ */
+function collectTurnParts(message: OutgoingMessage, turn: AscFlowTurnState | undefined): OutgoingMessage | null {
+  const meta = message.metadata ?? {};
+  const partCount = Number(meta.partCount ?? 1);
+  const partIndex = Number(meta.partIndex ?? 0);
+  // Nothing to collect: no turn to hold on to, a send that stands alone, or a
+  // hint that is not a hint (NaN fails both comparisons). Rich content never
+  // takes this path — it leaves through `/mensagem` and needs no poll.
+  if (!turn || message.content.type !== 'text' || !(partCount > 1) || !(partIndex >= 0)) return message;
+
+  const part = message.content.text ?? '';
+  if (partIndex < partCount - 1) {
+    turn.parts = [...(turn.parts ?? []), part];
+    return null;
+  }
+
+  const text = [...(turn.parts ?? []), part].join('\n\n');
+  turn.parts = undefined;
+  return { ...message, content: { ...message.content, text } };
 }
 
 /** The list presentation hints `buildUra` accepts, when the caller set any. */
@@ -379,9 +428,8 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       return { success: false, error: 'ASC Flow instance not connected', retryable: false, timestamp: Date.now() };
     }
 
-    const { content, to } = message;
+    const { to } = message;
     const meta = message.metadata ?? {};
-    const text = resolveOutboundText(message);
 
     const correlationId = meta.correlationId as string | undefined;
     if (correlationId) this.captureT10(correlationId);
@@ -402,7 +450,17 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       const answering = state.inFlight.get(to.trim());
       const polling = answering !== undefined && answering.text !== '';
 
-      const { rich, bubbles } = await this.prepareTurn(message, text);
+      // One agent reply, many sends. Hold every part but the last so ONE turn
+      // answers with all of them — see `collectTurnParts`. A held part reached
+      // nobody yet and produced no message, hence no id: the dispatcher does
+      // not read this result, and nothing else stamps the hint.
+      const turnMessage = collectTurnParts(message, polling ? answering : undefined);
+      if (!turnMessage) return { success: true, timestamp: Date.now() };
+
+      const content = turnMessage.content;
+      const text = resolveOutboundText(turnMessage);
+
+      const { rich, bubbles } = await this.prepareTurn(turnMessage, text);
 
       // The URA rides on the LAST bubble — the options attach to the last thing
       // the beneficiary read, and that bubble is the one that goes back in
@@ -421,7 +479,14 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       // being collected from the poll body.
       if (!rich && !ura && !polling) return this.refuseUndeliverable(instanceId, to, content.type);
 
-      const { delivered } = await this.deliver(state, cod, { text, bubbles, lastBubble, rich, ura, message });
+      const { delivered } = await this.deliver(state, cod, {
+        text,
+        bubbles,
+        lastBubble,
+        rich,
+        ura,
+        message: turnMessage,
+      });
 
       // The farewell only needs pushing when `/mensagem` did not already put it
       // on the handset (`delivered`); in flow mode it rides `resposta` as usual.
@@ -450,7 +515,7 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       // The platform returns no per-message id, so Omni's UUID stays canonical.
       const messageId = crypto.randomUUID();
 
-      await this.emitTurnSent(instanceId, message, messageId, {
+      await this.emitTurnSent(instanceId, turnMessage, messageId, {
         cod,
         bubbles: bubbles.length,
         ura,

--- a/packages/channel-sdk/src/types/messaging.ts
+++ b/packages/channel-sdk/src/types/messaging.ts
@@ -115,6 +115,20 @@ export interface MessageMetadata {
    */
   systemNotice?: boolean;
 
+  /**
+   * Position of this send inside ONE agent reply, when the caller split that
+   * reply into several messages (the agent dispatcher does: the provider
+   * splits on blank lines, then each part is sent separately).
+   * `partIndex` is 0-based; the last part is `partCount - 1`.
+   *
+   * Most channels ignore this — N messages is exactly what they want. It
+   * exists for a channel whose transport carries ONE answer per turn
+   * (asc-flow answers a poll), which holds the earlier parts and answers once
+   * on the last. Absent means "a send that stands alone".
+   */
+  partIndex?: number;
+  partCount?: number;
+
   /** Additional plugin-specific metadata */
   [key: string]: unknown;
 }


### PR DESCRIPTION
## The bug

On ASC only the **first paragraph** of every multi-paragraph agent reply reaches the
beneficiary, and anything the agent sends after the text is lost.

Root cause is a contract mismatch between two layers that were each right on their own:

1. `packages/core/src/providers/agno-provider.ts:86` — `enableAutoSplit !== false` splits the
   agent's reply on `\n\n` into N parts.
2. `packages/api/src/plugins/agent-dispatcher.ts` `sendResponseParts` sends each part as its
   own `plugin.sendMessage`.
3. `packages/channel-asc-flow/src/plugin.ts` answers a **poll**, so one `sendMessage` was one
   flow turn. The first part called `resolveTurn`, the flow's next poll (~2s) collected it via
   `takeReadyTurn` and cleared the window, and parts 2..N hit `refuseUndeliverable`.

The plugin's own header even named this as a known ceiling:

> `ponytail: if an agent ever emits two sendMessage calls for one user turn, the flow advances
> twice. Upgrade path is a per-cod turn buffer flushed on an end-of-turn signal — not built
> until a dispatcher actually does that.`

It does. Evidence from omni-api (instance `6c53c4cb-…`, chat `22325225`):
`Agno agent responded parts:3` → two `Message failed … undeliverable` warnings ~1s later →
`agent_dispatch_queue_finished`.

## The fix — option (b), the end-of-turn signal

No per-part hint existed, so the dispatcher now stamps one, and asc-flow alone uses it.

**`sendResponseParts` stamps `metadata.partIndex` / `partCount`** on every send of one reply.
It is neutral information every other channel ignores — no channel branch in the dispatcher.
It also sanitizes **before** numbering, because a chunk that is nothing but an internal
routing header never reaches the plugin and would leave the reply waiting on a last part that
never arrives.

**asc-flow holds every part but the last** (`collectTurnParts`) and answers the turn once with
all of them joined by a blank line. `splitBubbles` turns that straight back into the same
bubbles, `pushLeadingBubbles` pushes all but the last through `/callbackFlowMsg`, and the URA
still rides the last bubble. The poll body's shape is unchanged.

Held parts live **on the turn window itself**, so they inherit its TTL, its sweep and its
identity: a window that closes mid-reply takes its held parts with it rather than leaking them
or answering the next turn. Holding only ever happens on a turn that is genuinely being
polled.

`dispatchId` was skipped — the window's object identity already correlates a reply to its turn,
and `resolveTurn` compares it. Add it if a second dispatch ever needs to interleave on one cod.

## Kept

- the undeliverable refusal for a genuinely late send — a part that arrives with no window
  falls straight through to it (pinned by a test);
- the URA-on-last-bubble rule;
- handoff behaviour, including the parked-`hand_off:'sim'` guard;
- the poll contract `{pronto, resposta, bolhas, hand_off, fila_vq, motivo_transf_vq, ura_opcoes}`.

## Tests

`packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts` — new block
*"one agent reply is one turn, however many sends it arrives in"*:

- 3-part dispatch → **one** resolved turn, `bolhas: ['primeiro','segundo','Escolha:']`, URA on
  the last, leading bubbles really pushed through `/callbackFlowMsg`, and a poll landing
  *between* parts still gets `null`;
- 3-part dispatch → **one** `message.sent` carrying the joined text, zero `message.failed`;
- a straggler after the turn was collected → still refused with
  `no ASC flow turn is polling…`.

Both new-behaviour tests were confirmed to FAIL against the old code path
(`resposta: "primeiro"`, `bolhas: ["primeiro"]` / 3 sent events).

`packages/api/src/plugins/__tests__/agent-dispatcher-response-parts.test.ts` — pins the other
half: every part numbered, a single-part reply is its own last part, and the count follows the
sends that really happen (also confirmed to fail without the pre-sanitize).

## Validation

- `bun test` @omni/channel-asc-flow → **131 pass / 0 fail**
- `bun test` @omni/channel-sdk → **421 pass / 0 fail**
- `bun test` dispatcher suites (5 files incl. the new one) → **119 pass / 0 fail**
- `bun run typecheck` in @omni/api, @omni/channel-sdk, @omni/channel-asc-flow → clean
- `bun run lint` (biome, 1723 files) → clean
- pre-push gate (`make typecheck` + `bun test packages apps/ui`) → green

No manual version bump — `version.yml` bumps on merge to `dev`.
