### PR TITLE
fix(channel-asc-flow): push the turn, drop the restarted flow's stale input, and keep real buttons

### DIFF
--- a/packages/channel-asc-flow/INTEGRATION.md
+++ b/packages/channel-asc-flow/INTEGRATION.md
@@ -1,0 +1,470 @@
+# ASC ↔ Omni ↔ agente — runbook de integração
+
+Como a linha WhatsApp da Hapvida pelo BSP **ASC** chega no agente e volta, o que
+está configurado de cada lado, e o que quebra quando cada peça sai do lugar.
+
+O [`README.md`](./README.md) ao lado é o contrato do plugin para quem programa.
+Este documento é o **operacional**: acesso ao portal, cada componente do flow,
+cada campo da instância, e a mão dupla do handoff.
+
+Tudo aqui foi medido na linha viva em 01–05/09/2026. Onde há número, ele veio de
+um atendimento real e o atendimento está citado.
+
+---
+
+## 1. O caminho inteiro, em uma figura
+
+```
+beneficiário (WhatsApp)
+      │
+      ▼
+ASC — plataforma BSP  (sac-notredame.ascbrazil.com.br)
+      │  o atendimento entra no serviço 130 "Namastex Bots"
+      │  e cai no FLOW #225 "Teste KHAL 1"
+      ▼
+flow, nó api_rest ─── POST ──► Omni  /api/v2/channels/asc-flow/{instanceId}/webhook
+                                  │
+                                  │ message.received
+                                  ▼
+                            agente (hv-scheduling, Agno)
+                                  │
+                                  │ POST /api/v2/messages/send        (texto, componente)
+                                  │ POST /api/v2/messages/send/handoff (texto + flags)
+                                  ▼
+                            plugin channel-asc-flow
+                                  │
+      ┌───────────────────────────┼──────────────────────────────┐
+      ▼                           ▼                              ▼
+POST /callbackFlowMsg       POST /mensagem              corpo do POLL
+(as bolhas de texto)        (mídia, URA/botões)         (hand_off, fila_vq,
+ chega em ~1s                                            motivo_transf_vq)
+      │                           │                              │
+      └──────────► aparelho ◄─────┘                              ▼
+                                                      flow, nó dec_handoff
+                                                                 │ hand_off = sim
+                                                                 ▼
+                                                      nó genesys_1 → Genesys
+                                                                 │
+                                                      atendente humano assume
+```
+
+**A assimetria que explica quase tudo:** o TEXTO sai empurrado
+(`/callbackFlowMsg`, chega em ~1s) e o **sinal de handoff** só existe no corpo da
+resposta do poll — que é resposta **única**. Quem chegar depois dela não é lido.
+Ver §6.
+
+---
+
+## 2. Portal da ASC
+
+**URL:** `https://sac-notredame.ascbrazil.com.br/`
+
+**Credenciais:** usuário `gustavo.batistam`. A senha do **portal web** e a
+`chave` da **API REST** são valores DIFERENTES e rotacionam em momentos
+diferentes — as duas vivem no `.env` do `asc-flow-adapter` e no Bitwarden. Nunca
+em código, nunca em issue.
+
+### 🔴 Marque "Permanecer no painel clássico" no login
+
+O editor de flow é mxGraph e **só existe no painel clássico**. Entrando pelo
+painel novo, `window.mxUtils` fica indefinido e `/flow/view/cod_flow/225`
+devolve 500 — que parece plataforma fora do ar e não é. O checkbox vem marcado
+por padrão; um login programático que preencha só usuário e senha o perde.
+
+### O login web tem anti-bot (reCAPTCHA)
+
+Playwright normal toma **"Nome de usuário ou senha inválidos"** com a senha
+CERTA — as mesmas credenciais autenticam na API REST no mesmo minuto. Para
+automatizar, usar o **camofox** (Camoufox, Firefox com spoof de fingerprint),
+que passa:
+
+```bash
+curl -s -X POST http://localhost:9377/tabs -H 'Content-Type: application/json' \
+  -d '{"userId":"cezao","sessionKey":"asc","url":"https://sac-notredame.ascbrazil.com.br/login"}'
+# depois: POST /tabs/<id>/type, /click, /evaluate; GET /tabs/<id>/snapshot
+```
+
+A sessão persiste em `~/.camofox/profiles/` entre reinícios do browser.
+
+### Ler o flow por JS, não por clique
+
+Com o painel clássico carregado, o modelo inteiro sai em uma chamada:
+
+```js
+mxUtils.getXml(new mxCodec().encode(_editor.editor.graph.getModel()))
+```
+
+`_editor` é o objeto do editor (`_editor.editor.graph`, `_editor.actions`).
+O `CustomData` de cada nó é um **Element do DOM** cujo `textContent` é o JSON da
+config — `JSON.stringify(cell.data)` devolve `{}` e engana.
+
+### 🔴 Salvar não é confiar — releia do servidor
+
+`_editor.actions.get('saveFlow').funct()` devolve sem erro mesmo quando a sessão
+expirou no meio. **Dois saves falharam em silêncio** em 05/09 e só apareceram ao
+reabrir a página. Depois de todo save: abrir uma **aba nova**, recarregar do
+servidor e conferir o campo. Tirar backup do XML ANTES de editar
+(`asc-flow-adapter/flow225-server-*.xml`).
+
+### O que a API REST resolve sem browser
+
+`https://sac-notredame.ascbrazil.com.br/rest/v2/doc/` — a spec OpenAPI está
+embutida no HTML da página do Swagger (não há `swagger.json`). Autenticação:
+
+```
+POST /rest/v2/authuser  {"login": "...", "chave": "..."}
+  → {"success": true, "result": {"token": "<JWT 1h>"}}
+Header nas demais: Authorization: Bearer <token>
+```
+
+Endpoints que valem no dia a dia:
+
+| endpoint | serve para |
+|---|---|
+| `GET /atendimento?codigo_atendimento=` | histórico completo, status, agente, todas as mensagens |
+| `GET /RelRequisicoes?dat_inicial=&dat_final=` | **o que o flow mandou e o que recebeu** — request e response do `api_rest` |
+| `GET /flow?limit=5` | lista os flows (só metadados) |
+| `POST /mensagem` | injeta mensagem/mídia/URA no atendimento |
+| `POST /callbackFlowMsg` | empurra bolha de texto |
+| `POST /transferirHumano` | transfere para serviço da ASC (modo `service`) |
+
+⚠ `GET /flow?cod_flow=225` devolve **500** (bug da plataforma; `limit` e
+`nom_flow` funcionam). O grafo só sai pelo editor.
+
+⚠ `/sendMsgInterativa` e `/sendMsgInterativaAvancado` **não** servem para injetar
+botões num atendimento em curso — são HSM/campanha, abrem atendimento novo.
+
+---
+
+## 3. A plataforma é **latin-1**
+
+Provado em 05/09 mandando uma mensagem e lendo de volta em `/atendimento`:
+
+```
+enviado   latin1[áéíóúçãõ °ª]  fora[— – … " " ' ' → ≥ ✓]
+guardado  latin1[áéíóúçãõ °ª]  fora[? ? ? ? ? ? ? ? ? ?]
+```
+
+Tudo que ISO-8859-1 guarda sobrevive. Tudo que não guarda vira `?`. Isso governa
+duas coisas do plugin:
+
+- **emoji** viajam como marcadores `##<codepoint>##` (`✅` → `##2705##`), nos dois
+  sentidos — é o que a própria ASC usa no flow #215 de produção;
+- **pontuação** fora de latin-1 é **transliterada** antes de sair (`—` → `-`,
+  `…` → `...`, aspas curvas → retas, `→` → `->`).
+
+Os travessões do agente chegaram como `Clínico Geral ? inclusive por
+teleconsulta ?` num beneficiário real (atendimento 22342782) por dias, sem nada
+em log. Hoje o que sobrar fora de latin-1 vira **warning com codepoint**.
+
+Português acentuado não é tocado — latin-1 guarda.
+
+---
+
+## 4. O flow #225 "Teste KHAL 1", nó a nó
+
+Topologia:
+
+```
+start ──► api_rest ──► dec_handoff ──┬── [hand_off = sim] ──► genesys_1 ──► fin_1
+                                     └── [Padrão] ──► msg_resposta ──► aguarda_usuario
+                                                                            │
+                                        ┌── [Validado] ──► api_rest ◄───────┘
+                                        └── [Tempo de espera] ──► fin_1
+```
+
+### `api_rest` — id 3, `cod_componente=9`
+
+O nó que fala com o Omni.
+
+```json
+{ "url": "https://asc-omni.cezar.ia.br/api/v2/channels/asc-flow/{instanceId}/webhook",
+  "method": "1",            // POST
+  "async": "0",             // SÍNCRONO
+  "async_condition": "",
+  "timeout": "45",
+  "remove_breaks": "1" }
+```
+
+**Body** (texto livre — os nomes dos campos são contrato NOSSO, não da ASC):
+
+```json
+{"codAtendimento": "{#CODIGO_ATENDIMENTO}",
+ "chatInput": "{#entrada}",
+ "message": "{#MENSAGEM}",
+ "phone": "{#CONTATO.TELEFONE}"}
+```
+
+**Store** — mapeia a resposta em variáveis do flow:
+
+| variável | campo do JSON |
+|---|---|
+| 2200001 | `resposta` |
+| 2200002 | `hand_off` |
+| 2250002 | `motivo_transf_vq` |
+| 2250001 | `fila_vq` |
+
+🔴 **`timeout: 45` é o teto de tudo.** O `ASC_FLOW_HOLD_MS` do plugin (40s por
+padrão) fica abaixo dele de propósito: segurar mais é responder num socket que o
+nó já abandonou, e o turno fica estacionado esperando um poll que não vem.
+
+🔴 **`{#MENSAGEM}` congela** na mensagem que ABRIU o atendimento. É por isso que
+o body manda os dois campos: `chatInput` é o que a pessoa digitou agora,
+`message` é a fallback que só serve para ABRIR conversa.
+
+### `msg_resposta` — id 100, `cod_componente=1`
+
+Renderiza `{#resposta}`. Hoje a `resposta` volta **sempre vazia**: todas as
+bolhas saem empurradas por `/callbackFlowMsg`. Ver §5.
+
+### `aguarda_usuario` — id 101, `cod_componente=2`
+
+```json
+{ "variable": "2200003",   // é o {#entrada} do body
+  "timeout": "300",        // SEGUNDOS
+  "validation": "0" }
+```
+
+🔴 **Estava em 10 segundos e isso quebrava a conversa.** A aresta de timeout vai
+para `fin_1`, então silêncio além do limite ENCERRA o flow; a próxima mensagem o
+reinicia do `start`, e o reinício reentra no `api_rest` carregando o **valor
+ANTERIOR** de `{#entrada}` — a variável só é escrita quando `aguarda_usuario`
+valida entrada nova.
+
+Medido no atendimento 22342225:
+
+```
+14:46:19  turno respondido; aguarda_usuario espera 10s, estoura, encerra
+14:52:46  beneficiário manda "quero falar com um atendente humano"
+14:52:53  api_rest chama com chatInput "🗑️"   ← o valor das 14:46
+14:53:31  api_rest só então chama com o texto certo, 45s depois
+```
+
+O 🗑️ velho resetava a sessão no meio da conversa. Subido para **300s** em
+05/09. O plugin também se defende disso (§5, guard de réplica), porque em
+produção o flow é o **#215 do cliente**, não este.
+
+### `dec_handoff` — id 102, `cod_componente=8`
+
+Decisão sobre `{#hand_off}` (variável 2200002). `sim` → `genesys_1`; padrão →
+`msg_resposta`.
+
+### `genesys_1` — id 103, `cod_componente=31` (`genesys_mobile_service`)
+
+Ponte para o Genesys Engage. `connection.cod_flow_componente_config: "1"`,
+`inactivity_minutes: 30`.
+
+`session.first_name = {#CONTATO.NOME}`, `session.subject = {#resposta}`.
+
+**userdata** — 13 pares. Os três que NÓS preenchemos estão em negrito:
+
+| # | key | value |
+|---|---|---|
+| 1 | `u_cpf` | *(vazio)* |
+| 2 | `u_cnpj` | *(vazio)* |
+| 3 | `PhoneNumber` | `{#CONTATO.TELEFONE}` |
+| 4 | `userId` | `{#CONTATO.TELEFONE}` |
+| 5 | `u_protocolo` | *(vazio)* |
+| 6 | **`u_cod_transf`** | **`{#fila_vq}`** ← a fila de destino |
+| 7 | `displayName` | *(vazio)* |
+| 8 | `u_NomeBeneficiario` | *(vazio)* |
+| 9 | **`u_bot_motivo_transf`** | **`{#motivo_transf_vq}`** ← o motivo |
+| 10 | `u_codigoOperadora` | *(vazio)* |
+| 11 | `u_carteirinha_beneficiario_atendimento` | *(vazio)* |
+| 12 | `u_PJ_RazaoSocial` | *(vazio)* |
+| 13 | **`u_central_de_atendimento`** | **`WPP_TECNICA_GENESYS`** |
+
+⚠ O flow #215 de produção tem um 14º campo, `u_bot_falha_api`. Ver
+`asc-flow-adapter/HANDOFF-GENESYS.md`.
+
+⚠ `u_cod_transf` é a **fila** e o valor tem que existir do lado do Genesys. O
+de-para de filas **não existe documentado** nem do lado da Hapvida (Alan
+Gomes/Mutant, 25/08). Hoje o agente manda `SKILL_WPP_TECNICA_GENESYS`.
+
+### `fin_1` — id 5, `cod_componente=4`
+
+Encerra. Recebe o timeout do `aguarda_usuario` e as três saídas do `genesys_1`
+(Finalizado, Erro, Inatividade).
+
+---
+
+## 5. O lado do Omni
+
+### Instância
+
+Canal `asc-flow`. Campos (tabela `instances`, prefixo `asc_flow_`):
+
+| campo | obrigatório | observação |
+|---|---|---|
+| `ascFlowBaseUrl` | não | default `https://sac-notredame.ascbrazil.com.br`; `/rest/v2` é anexado |
+| `ascFlowLogin` | **sim** | login do `/authuser` |
+| `ascFlowChave` | **sim** | chave do `/authuser` — **secret**, redigido nas respostas da API |
+| `ascFlowHandoffMode` | não | default `flow`. **Exclusivo** — ver §6 |
+| `ascFlowHandoffServico` | não | `cod_servico` do `/transferirHumano`, **só no modo `service`** |
+| `webhookVerifyToken` | não | segredo compartilhado; o flow ecoa em `?token=` ou header `x-webhook-token` |
+
+🔴 Uma vez configurado, o `webhookVerifyToken` é **obrigatório**: token ausente é
+recusado igual a token errado. Aceitar a ausência tornava a checagem
+contornável — e a rota é montada sem auth, então quem tivesse o UUID injetaria
+turnos (runs de agente cobrados) e drenaria respostas estacionadas.
+
+O `chatId` de uma conversa é o **`cod_atendimento`**, só dígitos. Um UUID ali não
+dá erro visível: o `resolveRecipient` da rota troca um uuid de pessoa pelo
+telefone dela e a mensagem sai pelo lugar errado, com 200.
+
+⚠ `PATCH {"isActive": true}` **não** reativa a instância (responde 200 e não muda
+nada). Use `POST /instances/:id/connect`.
+
+### Ajustes que a integração exigiu do nosso lado
+
+Cada um nasceu de uma medição na linha viva:
+
+| ajuste | por quê |
+|---|---|
+| **toda bolha empurrada**, `resposta` vazia | o `api_rest` **não espera** a resposta HTTP em nenhum dos dois modos — medido 3× (22327328, 22327711). O flow renderiza `{#resposta}` ~1s depois do inbound, com o valor do ciclo ANTERIOR. `/callbackFlowMsg` chega em ~1s e é registrado entregue |
+| **segurar o inbound** até o agente responder | responder a PRIMEIRA chamada com o turno pronto elimina a dúvida sobre o `async_condition`: a condição vale sobre a única resposta que existe. Teto 40s, sob os 45s do nó |
+| **guard de réplica** (`isStaleFlowReplay`) | flow reiniciado reentra com `{#entrada}` velho. Só um texto que REPETE o último turno respondido paga uma ida a `/atendimento` para perguntar à plataforma qual é a última mensagem real. Falha ABERTO |
+| **fallback congelado** (`fromFallback` + `hasSeenCod`) | `{#MENSAGEM}` só pode ABRIR conversa; depois que o cod é conhecido, é poll |
+| **botão em vez de lista** | lista **não renderiza** nesta plataforma: vira texto achatado com menu numerado que a ASC monta. Até 3 opções o `forceList` do agente é ignorado e os títulos são encurtados em fronteira de palavra (limite 20 do Meta) |
+| **transliteração latin-1** | §3 |
+| **dedupe por janela de turno** | a plataforma não dá id de mensagem por turno; em modo async o nó re-POSTa a cada ~2s (medido: ~22 chamadas e 3 runs de agente para UMA mensagem) |
+| **`asc-flow` em `CHANNELS_WITH_MESSAGING_WINDOW`** | a janela de sessão vale aqui como em qualquer canal WhatsApp |
+
+### Como o agente fala com o Omni
+
+`hv-scheduling`, `.env`:
+
+```bash
+OMNI_API_URL=http://localhost:8898
+OMNI_SEND_API_KEY=<api key>
+OMNI_SEND_ENABLED=true          # sem isto, nenhum componente interativo é tentado
+OMNI_INSTANCE_ID=<uuid>
+OMNI_ASC_INSTANCE_ID=<uuid>
+HANDOFF_ENABLED=true
+HANDOFF_TARGET=omni_asc         # 'odoo' é o outro destino
+```
+
+🔴 `INTERACTIVE_CHANNELS` em `adapters/omni/messages.py` precisa conter
+`asc-flow`. É uma allowlist **fail-closed**: canal fora dela faz
+`supports_interactive()` devolver `False` e o agente **nunca tenta** o
+componente — todo turno sai em texto, inclusive os que existem para oferecer uma
+escolha.
+
+---
+
+## 6. Handoff — as duas rotas, e a que fala com o Genesys
+
+`ascFlowHandoffMode` escolhe **uma**, e elas são exclusivas:
+
+| modo | como transfere | para onde |
+|---|---|---|
+| `flow` *(default)* | devolve `hand_off: "sim"` + `fila_vq` + `motivo_transf_vq` no corpo do poll; o `dec_handoff` roteia | **Genesys**, pelo nó `genesys_1` |
+| `service` | chama `POST /transferirHumano` com `cod_servico` | fila da **própria ASC** |
+
+**Para Genesys só serve o modo `flow`.** O `service` estaciona o atendimento numa
+fila da ASC e nunca chega no Genesys.
+
+### 🔴 O sinal tem que viajar no MESMO envio da despedida
+
+O corpo do poll é resposta **única**. O `dec_handoff` lê `{#hand_off}` do ciclo
+que acabou de responder; um sinal que chegue depois disso não é lido nunca.
+
+Foi exatamente o defeito de 05/09 (atendimento 22342225):
+
+```
+15:02:52  tool transferir_para_humano — fila e motivo já conhecidos
+15:02:54  hook dispara o handoff e RETORNA; o texto do run é entregue
+15:02:55  o flow lê o corpo do poll: hand_off "nao"   ← dec_handoff roteia
+15:02:59  o adapter omni_asc só então manda o sinal
+```
+
+Quatro segundos tarde. E, como os dois caminhos entregavam texto, o beneficiário
+lia a mesma frase duas vezes.
+
+**Corrigido** fazendo o destino declarar se ele mesmo entrega o aviso
+(`entrega_o_aviso`): quem entrega é **aguardado** antes de a resposta do run
+sair, e o texto do run é suprimido em favor do dele. A supressão só acontece
+**depois do aceite** — recusou, levantou ou estourou, o `content` fica intacto e
+o beneficiário recebe a despedida pelo caminho de sempre. Sem janela de silêncio.
+
+A espera usa `_arun`, nunca `_run`: o Agno roda hook síncrono INLINE no event
+loop, e bloquear ali congela o loop de todas as conversas (card 86ak8pjny mediu
+14,9s e 503 com a aplicação viva).
+
+### O caminho de ponta a ponta, medido
+
+Atendimento 22342729, 05/09:
+
+```
+18:55:52  omni_asc: transbordo aceito fila=SKILL_WPP_TECNICA_GENESYS
+18:55:53  handoff: atendimento aberto
+15:55:53  o flow recebe:
+          {"pronto":1, "resposta":"", "hand_off":"sim",
+           "fila_vq":"SKILL_WPP_TECNICA_GENESYS", "motivo_transf_vq":"...",
+           "bolhas":["Convidamos um especialista neste tópico..."]}
+15:55:58  no aparelho: "Bem-vindo (a). Meu nome e MARCELA."  ← atendente Genesys
+```
+
+O `status` do atendimento na ASC continua **"Automático"** depois do handoff, e
+isso é esperado: a sessão do Genesys roda DENTRO do flow (`genesys_mobile_service`),
+não é atribuição de agente da ASC. Não use `status` para auditar transferência —
+use as mensagens do `/atendimento`.
+
+### `agentPaused` é incompatível com o modo `flow`
+
+No modo `flow` o atendimento continua rodando no flow; pausar o agente do lado do
+Omni deixaria o beneficiário falando sozinho. A pausa vale no modo `service`,
+onde a ASC assume a conversa.
+
+---
+
+## 7. Checklist de subida
+
+**Na ASC (flow):**
+1. Login com **"Permanecer no painel clássico"** marcado
+2. `api_rest`: URL apontando para a instância certa, `async: 0`, `timeout: 45`
+3. `api_rest` body com os **quatro** campos (`codAtendimento`, `chatInput`, `message`, `phone`)
+4. `api_rest` store mapeando os **quatro** retornos (`resposta`, `hand_off`, `motivo_transf_vq`, `fila_vq`)
+5. `aguarda_usuario.timeout` em **minutos de conversa**, não segundos de rede (300+)
+6. `dec_handoff` comparando `{#hand_off}` com `sim`
+7. `genesys_1` com `u_cod_transf = {#fila_vq}`, `u_bot_motivo_transf = {#motivo_transf_vq}`, `u_central_de_atendimento = WPP_TECNICA_GENESYS`
+8. flow com `integrate_genesys = 1`
+9. **Salvar e reabrir em aba nova para conferir**
+
+**No Omni:**
+10. Instância `asc-flow` com `login` + `chave` válidos
+11. `ascFlowHandoffMode = flow` (Genesys) — não configurar `ascFlowHandoffServico`
+12. `webhookVerifyToken` definido, e o mesmo valor no header/query do `api_rest`
+13. URL do webhook alcançável a partir da ASC (túnel/ingress de pé)
+
+**No agente:**
+14. `INTERACTIVE_CHANNELS` contém `asc-flow`
+15. `OMNI_SEND_ENABLED=true`, `HANDOFF_TARGET=omni_asc`
+16. `OMNI_ASC_INSTANCE_ID` = a instância certa
+
+---
+
+## 8. Diagnóstico — onde olhar quando quebra
+
+| pergunta | onde a resposta ESTÁ |
+|---|---|
+| o que o flow mandou e recebeu? | `GET /RelRequisicoes` da ASC — request e response, com horário |
+| o que o beneficiário leu? | `GET /atendimento?codigo_atendimento=` |
+| **renderizou botão de verdade?** | **só o lado receptor** — `raw_payload.message` no Baileys: `buttonsMessage` vs `conversation`. O `/atendimento` registra os dois como `tip_msg: TEXTO` e **não serve** para isso |
+| o canal mandou componente? | `raw_payload.ascFlow` da mensagem no Omni: `{uraOptions, interactive, viaMensagem, handoff}` |
+| o agente tentou componente? | log `interactive_flush: componente enviado canal=... opções=N` |
+| a sessão do agente foi resetada? | tabela `ai.agno_sessions` — o `session_id` é `<cod>:<epoch>`; reset **apaga a linha** |
+| a réplica velha foi barrada? | log `[asc-flow] flow restarted with a stale input variable — dropping the replay` |
+| algum caractere vai chegar como `?` | log `[asc-flow] characters the platform cannot carry` |
+
+---
+
+## 9. O que continua aberto
+
+- **`u_bot_falha_api`** (14º userdata do #215) não está no #225
+- **de-para de filas do Genesys** não existe documentado de nenhum lado
+- **`GET /flow?cod_flow=`** devolve 500 na ASC — o grafo só sai pelo editor
+- **`[Continuar por aqui]` em beco sem saída** — hv-scheduling#457
+- **busca de clínicas que falhou vira "sem disponibilidade"** — hv-scheduling#458
+- **`session_timeout_sweeper` ignora `retryable:false`** — hv-scheduling#459
+- **fixtures sem o formato real de `user_code`** — hv-scheduling#460

--- a/packages/channel-asc-flow/README.md
+++ b/packages/channel-asc-flow/README.md
@@ -16,6 +16,9 @@ variables through its `store`. In async mode it re-calls this endpoint until
 `async_condition` over that body holds. So the channel is a **poll**, not a
 push: the turn is state here, and each call answers JSON.
 
+Runbook operacional (portal da ASC, cada nó do flow, configuração das duas
+pontas, handoff e diagnóstico): [`INTEGRATION.md`](./INTEGRATION.md).
+
 ## Not `@omni/channel-asc`
 
 | | `channel-asc` | `channel-asc-flow` (this) |

--- a/packages/channel-asc-flow/src/__tests__/helpers.ts
+++ b/packages/channel-asc-flow/src/__tests__/helpers.ts
@@ -6,6 +6,11 @@
  * platform: a stray call there sends a WhatsApp message to a real handset.
  */
 
+// No test may sit on the inbound hold: without this every webhook test blocks
+// for the full 120s deadline. Read per call by the handler, so setting it here
+// holds regardless of which module imported first.
+process.env.ASC_FLOW_HOLD_MS ??= '0';
+
 import type { Logger, PluginContext, PluginStorage } from '@omni/channel-sdk';
 import type { EventBus, PublishResult, Subscription } from '@omni/core/events';
 

--- a/packages/channel-asc-flow/src/__tests__/interactive.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/interactive.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'bun:test';
 
 import type { InteractiveButton } from '@omni/channel-sdk';
 
+import { encodeAscEmoji, nonLatin1Left } from '../utils/emoji';
 import { buildUra, foldTitle, splitBubbles } from '../utils/interactive';
 
 const options = (n: number, label = (i: number) => `Opção ${i}`): InteractiveButton[] =>
@@ -127,5 +128,33 @@ describe('buildUra', () => {
         forceList: true,
       }),
     ).toBeNull();
+  });
+});
+
+// A plataforma é latin-1 — provado em 05/09 mandando uma mensagem e lendo de
+// volta em `/atendimento`: tudo que ISO-8859-1 guarda sobrevive, o resto vira
+// `?`. Os travessões do agente chegaram assim num beneficiário real
+// (atendimento 22342782): "Clínico Geral ? inclusive por teleconsulta ?".
+describe('o que a plataforma latin-1 não carrega', () => {
+  it('transliteral a pontuação que viraria "?"', () => {
+    expect(encodeAscEmoji('Clínico Geral — inclusive por teleconsulta — e trazer')).toBe(
+      'Clínico Geral - inclusive por teleconsulta - e trazer',
+    );
+    expect(encodeAscEmoji('aguarde… “assim” e ‘assim’ → fim')).toBe('aguarde... "assim" e \'assim\' -> fim');
+  });
+
+  it('não toca no português acentuado, que a plataforma carrega', () => {
+    const texto = 'Sua sessão foi encerrada às 14h30 — coração, ação, ônibus';
+    expect(encodeAscEmoji(texto)).toBe('Sua sessão foi encerrada às 14h30 - coração, ação, ônibus');
+  });
+
+  it('emoji continua virando marcador, não transliteração', () => {
+    expect(encodeAscEmoji('✅ pronto — vamos')).toBe('##2705## pronto - vamos');
+  });
+
+  it('denuncia o que sobrou fora do latin-1', () => {
+    expect(nonLatin1Left('tudo certo')).toEqual([]);
+    expect(nonLatin1Left('café')).toEqual([]);
+    expect(nonLatin1Left('≥ 5 e ≥ 6')).toEqual(['≥']);
   });
 });

--- a/packages/channel-asc-flow/src/__tests__/interactive.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/interactive.test.ts
@@ -88,8 +88,44 @@ describe('buildUra', () => {
     expect(buildUra('Escolha:', [{ text: 'Abrir', url: 'https://example.test' }])).toBeNull();
   });
 
-  it('honours forceList and sectionTitle by rendering a list', () => {
-    expect(buildUra('Escolha:', options(2), { forceList: true })?.forcar_botoes).toBe(false);
-    expect(buildUra('Escolha:', options(2), { sectionTitle: 'Horários' })?.forcar_botoes).toBe(false);
+  // A list does not exist on this platform. Measured on the handset 05/09: the
+  // ASC flattens `forcar_botoes: false` into plain text and appends a numbered
+  // menu of its own, so asking for a list buys the duplicated menu and loses
+  // the taps. Up to three options the answer is always buttons — `forceList`
+  // and `sectionTitle` are honoured only where buttons cannot go.
+  it('takes buttons over a requested list while the options still fit', () => {
+    expect(buildUra('Escolha:', options(2), { forceList: true })?.forcar_botoes).toBe(true);
+    expect(buildUra('Escolha:', options(2), { sectionTitle: 'Horários' })?.forcar_botoes).toBe(true);
+  });
+
+  it('still answers with a list past three options', () => {
+    expect(buildUra('Escolha:', options(5))?.forcar_botoes).toBe(false);
+  });
+
+  // The real case (05/09): two beneficiaries, and the turn went out as a list
+  // because the caller asked for one — so the handset got the duplicated text
+  // menu. Converting it to buttons is what shortens the titles, and it cuts on
+  // a word boundary rather than mid-word.
+  it('shortens a long title on a word boundary when converting to buttons', () => {
+    const ura = buildUra(
+      'Para quem é a consulta?',
+      [{ text: 'ROGERIO AMARO RODRIGUES' }, { text: 'ANELI CAMILO AMARO' }],
+      { forceList: true },
+    );
+
+    expect(ura).toMatchObject({
+      forcar_botoes: true,
+      ura_opcoes: { '1': 'ROGERIO AMARO', '2': 'ANELI CAMILO AMARO' },
+    });
+  });
+
+  // Shortening is what can CREATE the ambiguity, and the tap comes back as the
+  // title — two options that fold together would book the wrong person.
+  it('refuses buttons when shortening makes two titles collide', () => {
+    expect(
+      buildUra('Escolha:', [{ text: 'Consulta cardiologia manhã' }, { text: 'Consulta cardiologia tarde' }], {
+        forceList: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/channel-asc-flow/src/__tests__/outbound-rich.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/outbound-rich.test.ts
@@ -163,7 +163,8 @@ describe('outbound media', () => {
 
     expect(result.success).toBe(true);
     expect(of('/mensagem')).toHaveLength(0);
-    expect(ready('42')).toMatchObject({ pronto: 1, resposta: 'segue a imagem' });
+    // Degrada para texto — e o texto sai empurrado, não pelo corpo do poll.
+    expect(of('/callbackFlowMsg')[0]?.body.msg_usuario).toBe('segue a imagem');
   });
 
   it('degrades when the platform refuses the media call', async () => {
@@ -175,7 +176,7 @@ describe('outbound media', () => {
     // A business 401 must not be retried (it would duplicate the bubble).
     expect(of('/mensagem')).toHaveLength(1);
     expect(result.success).toBe(true);
-    expect(ready('42')?.resposta).toBe('[não foi possível enviar o arquivo]');
+    expect(of('/callbackFlowMsg')[0]?.body.msg_usuario).toBe('[não foi possível enviar o arquivo]');
   });
 });
 
@@ -207,7 +208,7 @@ describe('outbound location and contact', () => {
 
     expect(result.success).toBe(true);
     expect(of('/mensagem')).toHaveLength(0);
-    expect(ready('42')?.resposta).toBe('endereço da clínica');
+    expect(of('/callbackFlowMsg')[0]?.body.msg_usuario).toBe('endereço da clínica');
   });
 });
 
@@ -239,8 +240,8 @@ describe('outbound interactive through /mensagem', () => {
     await send({ type: 'text', text: 'Escolha:\n1. a\n2. b', buttons: options(11) });
 
     expect(of('/mensagem')).toHaveLength(0);
+    expect(of('/callbackFlowMsg')[0]?.body.msg_usuario).toBe('Escolha:\n1. a\n2. b');
     const body = ready('42');
-    expect(body).toMatchObject({ resposta: 'Escolha:\n1. a\n2. b' });
     expect(body?.ura_opcoes).toBeUndefined();
   });
 
@@ -260,13 +261,13 @@ describe('outbound interactive through /mensagem', () => {
 });
 
 describe('the plain text turn is untouched', () => {
-  it('still pushes leading bubbles and answers with the last one', async () => {
+  it('pushes every bubble and answers empty', async () => {
     await boot();
     await send({ type: 'text', text: 'um\n\ndois' });
 
     expect(of('/mensagem')).toHaveLength(0);
-    expect(of('/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual(['um']);
-    expect(ready('42')).toMatchObject({ resposta: 'dois', bolhas: ['um', 'dois'] });
+    expect(of('/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual(['um', 'dois']);
+    expect(ready('42')).toMatchObject({ resposta: '', bolhas: ['um', 'dois'] });
   });
 });
 

--- a/packages/channel-asc-flow/src/__tests__/plugin.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/plugin.test.ts
@@ -35,6 +35,11 @@ const SERVICE = { ascFlowHandoffMode: 'service' } as const;
 /** Platform calls in order, `/authuser` filtered out. */
 const sequence = (): string[] => calls.filter((c) => c.path !== '/authuser').map((c) => c.path);
 const of = (path: string) => calls.filter((c) => c.path === path);
+/** O texto que REALMENTE saiu para o aparelho (última bolha empurrada). */
+const entregue = (): string | undefined => {
+  const p = of('/callbackFlowMsg');
+  return p.length ? (p[p.length - 1]?.body.msg_usuario as string) : undefined;
+};
 /** The body the next `api_rest` poll would receive. */
 const ready = (cod: string) => plugin.takeReadyTurn(instanceId, cod, TURN_TEXT);
 
@@ -74,11 +79,26 @@ describe('parseInboundTurn', () => {
       codAtendimento: '42',
       text: 'oi',
       phone: '5551999',
+      fromFallback: false,
     });
   });
 
   it('accepts the snake_case aliases the client flows use', () => {
     expect(parseInboundTurn({ cod_atendimento: '42', message: 'oi', telefone: '5551' })?.codAtendimento).toBe('42');
+  });
+
+  // `message` carries `{#MENSAGEM}`, which flow #225 freezes on the message
+  // that opened the atendimento. Text taken from it is FLAGGED so the handler
+  // can use it to open a conversation and never to republish it on a loop.
+  it('flags text that came from the frozen fallback', () => {
+    expect(parseInboundTurn({ codAtendimento: '42', chatInput: 'oi', message: '🗑️' })).toMatchObject({
+      text: 'oi',
+      fromFallback: false,
+    });
+    expect(parseInboundTurn({ codAtendimento: '42', chatInput: '', message: '🗑️' })).toMatchObject({
+      text: '🗑️',
+      fromFallback: true,
+    });
   });
 
   // The platform transcodes emoji: a 🗑️ arrives as `##1f5d1-fe0f##`. Left raw
@@ -135,7 +155,12 @@ describe('connect', () => {
 describe('inbound', () => {
   it('raises typing and publishes the turn with cod_atendimento as the chat id', async () => {
     await boot();
-    await plugin.handleInboundTurn(instanceId, { codAtendimento: '42', text: 'oi', phone: '5551999' });
+    await plugin.handleInboundTurn(instanceId, {
+      codAtendimento: '42',
+      text: 'oi',
+      phone: '5551999',
+      fromFallback: false,
+    });
 
     expect(of('/sendIndicador')[0]?.body).toEqual({ cod: 42, tipo: 1 });
 
@@ -146,7 +171,7 @@ describe('inbound', () => {
 
   it('falls back to the cod as the sender when the flow sends no phone', async () => {
     await boot();
-    await plugin.handleInboundTurn(instanceId, { codAtendimento: '42', text: 'oi', phone: '' });
+    await plugin.handleInboundTurn(instanceId, { codAtendimento: '42', text: 'oi', phone: '', fromFallback: false });
 
     expect(eventBus.published.find((e) => e.type.includes('received'))?.payload).toMatchObject({ from: '42' });
   });
@@ -156,15 +181,23 @@ describe('outbound turn', () => {
   const send = (content: Record<string, unknown>, metadata: Record<string, unknown> = {}) =>
     plugin.sendMessage(instanceId, { to: '42', content: content as never, metadata });
 
-  it('pushes every bubble but the last, with typing between them', async () => {
+  // O nó `api_rest` não espera a resposta HTTP (medido no flow #225, síncrono
+  // e assíncrono), então NADA viaja no `resposta`: o turno inteiro é empurrado
+  // por `/callbackFlowMsg`, que chega em ~1s e é registrado como entregue.
+  it('pushes EVERY bubble, with typing between them, and answers with an empty resposta', async () => {
     await boot();
     const result = await send({ type: 'text', text: 'um\n\ndois\n\ntres' });
 
     expect(result.success).toBe(true);
-    // The last bubble is NOT pushed — it rides back in `resposta`.
-    expect(sequence()).toEqual(['/callbackFlowMsg', '/sendIndicador', '/callbackFlowMsg', '/sendIndicador']);
-    expect(of('/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual(['um', 'dois']);
-    expect(ready('42')).toMatchObject({ pronto: 1, resposta: 'tres', hand_off: 'nao', bolhas: ['um', 'dois', 'tres'] });
+    expect(sequence()).toEqual([
+      '/callbackFlowMsg',
+      '/sendIndicador',
+      '/callbackFlowMsg',
+      '/sendIndicador',
+      '/callbackFlowMsg',
+    ]);
+    expect(of('/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual(['um', 'dois', 'tres']);
+    expect(ready('42')).toMatchObject({ pronto: 1, resposta: '', hand_off: 'nao', bolhas: ['um', 'dois', 'tres'] });
   });
 
   it('carries the URA of the last bubble in the response body', async () => {
@@ -259,11 +292,18 @@ describe('outbound turn', () => {
     expect(of('/transferirHumano')).toHaveLength(0);
   });
 
-  it('omits the Genesys fields when the turn does not hand off', async () => {
+  it('sends the Genesys fields EMPTY when the turn does not hand off', async () => {
     await boot();
     await send({ type: 'text', text: 'ok' }, { handoffQueue: 'VQ_X' });
 
-    expect(ready('42')).toEqual({ pronto: 1, resposta: 'ok', hand_off: 'nao', bolhas: ['ok'] });
+    expect(ready('42')).toEqual({
+      pronto: 1,
+      resposta: '',
+      hand_off: 'nao',
+      bolhas: ['ok'],
+      fila_vq: '',
+      motivo_transf_vq: '',
+    });
     expect(of('/transferirHumano')).toHaveLength(0);
   });
 
@@ -273,7 +313,8 @@ describe('outbound turn', () => {
     });
     const result = await send({ type: 'text', text: 'um\n\ndois' });
 
-    // The push is best-effort; `resposta` is the canonical delivery path.
+    // Nenhuma bolha saiu: o turno degrada para o corpo do poll, que é o que
+    // resta quando a push é recusada.
     expect(result.success).toBe(true);
     expect(ready('42')).toMatchObject({ resposta: 'dois' });
   });
@@ -304,9 +345,12 @@ describe('outbound turn', () => {
     expect(result.error).toContain('handoff refused');
     expect(ready('42')).toEqual({
       pronto: 1,
-      resposta: 'Vou te transferir.',
+      // Vazia: o turno inteiro saiu por `/callbackFlowMsg`.
+      resposta: '',
       hand_off: 'nao',
       bolhas: ['Vou te transferir.'],
+      fila_vq: '',
+      motivo_transf_vq: '',
     });
     // A business 401 is not re-authenticated: exactly one attempt, no retry.
     expect(of('/transferirHumano')).toHaveLength(1);
@@ -318,7 +362,7 @@ describe('outbound turn', () => {
     const result = await send({ type: 'text', text: 'Vou te transferir.' }, { isHandoff: true });
 
     expect(result.success).toBe(false);
-    expect(ready('42')).toMatchObject({ hand_off: 'nao', resposta: 'Vou te transferir.' });
+    expect(ready('42')).toMatchObject({ hand_off: 'nao', resposta: '' });
   });
 
   describe('handoff validation (service mode)', () => {
@@ -337,9 +381,13 @@ describe('outbound turn', () => {
         // No lie to the flow, and no orphan Genesys fields.
         expect(ready('42')).toEqual({
           pronto: 1,
-          resposta: 'Vou te transferir.',
+          resposta: '',
           hand_off: 'nao',
           bolhas: ['Vou te transferir.'],
+          // Always present, empty: the flow's `store` maps every field it lists
+          // and a missing one left the whole mapping unapplied.
+          fila_vq: '',
+          motivo_transf_vq: '',
         });
       });
     }
@@ -387,7 +435,7 @@ describe('outbound turn', () => {
       await boot({}, SERVICE);
       await send({ type: 'text', text: 'ok' }, { isHandoff: true, handoffQueue: 'fila com espaço' });
 
-      expect(ready('42')?.fila_vq).toBeUndefined();
+      expect(ready('42')?.fila_vq).toBe('');
     });
 
     it('keeps fila_vq when it matches the accepted shape', async () => {
@@ -410,7 +458,7 @@ describe('outbound turn', () => {
 
       await openTurn(plugin);
       await send({ type: 'text', text: 'ok' }, { isHandoff: true, handoffReason: '   \n ' });
-      expect(ready('42')?.motivo_transf_vq).toBeUndefined();
+      expect(ready('42')?.motivo_transf_vq).toBe('');
     });
   });
 
@@ -432,7 +480,7 @@ describe('outbound turn', () => {
       expect(of('/transferirHumano')).toHaveLength(0);
       expect(ready('42')).toEqual({
         pronto: 1,
-        resposta: 'Vou te transferir.',
+        resposta: '',
         hand_off: 'sim',
         bolhas: ['Vou te transferir.'],
         fila_vq: 'VQ_AGENDAMENTO',
@@ -448,8 +496,11 @@ describe('outbound turn', () => {
       await send({ type: 'text', text: 'Vou te transferir.' }, { isHandoff: true, handoffReason: 'fora do escopo' });
 
       expect(of('/transferirHumano')).toHaveLength(0);
-      expect(ready('42')).toMatchObject({ hand_off: 'nao', resposta: 'Vou te transferir.' });
-      expect(ready('42')?.fila_vq).toBeUndefined();
+      // Read the body ONCE: taking it closes the turn.
+      const body = ready('42');
+      expect(body).toMatchObject({ hand_off: 'nao', resposta: '' });
+      expect(entregue()).toBe('Vou te transferir.');
+      expect(body?.fila_vq).toBe('');
     });
 
     // In service mode the ASC queue already holds the atendimento, so the field
@@ -478,9 +529,9 @@ describe('outbound turn', () => {
       // must not read to the route as a completed one.
       expect(result.success).toBe(false);
       expect(of('/transferirHumano')).toHaveLength(0);
-      expect(ready('42')).toEqual({
+      expect(ready('42')).toMatchObject({
         pronto: 1,
-        resposta: 'Vou te transferir.',
+        resposta: '',
         hand_off: 'nao',
         bolhas: ['Vou te transferir.'],
       });
@@ -516,7 +567,7 @@ describe('outbound turn', () => {
     });
 
     expect(ready('42')).toMatchObject({
-      resposta: 'Bom dia, *Rogerio*. Informe seu *CPF*.',
+      resposta: '',
     });
   });
 
@@ -528,7 +579,7 @@ describe('outbound turn', () => {
       metadata: { messageFormatMode: 'passthrough' },
     });
 
-    expect(ready('42')).toMatchObject({ resposta: '**cru**' });
+    expect(entregue()).toBe('**cru**');
   });
 
   // The platform carries emoji only as markers; a raw `✅` reached the handset
@@ -540,7 +591,7 @@ describe('outbound turn', () => {
       content: { type: 'text', text: '✅ Conversa limpa!' } as never,
     });
 
-    expect(ready('42')).toMatchObject({ resposta: '##2705## Conversa limpa!' });
+    expect(entregue()).toBe('##2705## Conversa limpa!');
   });
 
   it('leaves accented text alone — only emoji are transcoded', async () => {
@@ -549,8 +600,7 @@ describe('outbound turn', () => {
       to: '42',
       content: { type: 'text', text: 'Sua sessão foi resetada, coração' } as never,
     });
-
-    expect(ready('42')).toMatchObject({ resposta: 'Sua sessão foi resetada, coração' });
+    expect(entregue()).toBe('Sua sessão foi resetada, coração');
   });
 });
 

--- a/packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts
@@ -18,6 +18,7 @@ import {
   connectPlugin,
   createContext,
   instanceId,
+  jsonResponse,
   openTurn,
   stubPlatform,
 } from './helpers';
@@ -451,5 +452,104 @@ describe('the flow looping back does not replay the opening message', () => {
 
     expect(received()).toHaveLength(1);
     expect((received()[0]?.payload as { content: { text: string } }).content.text).toBe('oi, quero agendar');
+  });
+});
+
+/**
+ * The flow restarting after its own `aguarda_usuario` timeout, which re-enters
+ * `api_rest` with the PREVIOUS input variable. Measured on 22342225: a 🗑️ from
+ * six minutes earlier arrived as the "new" message and reset the session.
+ *
+ * Both cases below post the SAME text twice — only the platform's record of
+ * the atendimento separates them.
+ */
+describe('a restarted flow must not replay the previous input', () => {
+  /** Boot with `/atendimento` answering whatever the platform "really" holds. */
+  async function bootWithAtendimento(latestInbound: string): Promise<void> {
+    const stub = stubPlatform({
+      '/atendimento': () =>
+        jsonResponse({
+          mensagens: [
+            { boleano_entrante: '1', descricao_msg: 'oi' },
+            { boleano_entrante: '0', descricao_msg: 'ja respondi isso' },
+            { boleano_entrante: '1', descricao_msg: encodeAscEmoji(latestInbound) },
+          ],
+        }),
+    });
+    calls = stub.calls;
+    restore = stub.restore;
+    eventBus = new MockEventBus();
+    plugin = new AscFlowPlugin();
+    await plugin.initialize(createContext(eventBus));
+    await connectPlugin(plugin);
+    calls.length = 0;
+    eventBus.published.length = 0;
+  }
+
+  const post = (cod: string, text: string) =>
+    plugin.handleWebhook(
+      new Request(`http://localhost/api/v2/channels/asc-flow/${instanceId}/webhook`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ codAtendimento: cod, chatInput: text, message: text }),
+      }),
+    );
+
+  /** One full turn: the message lands, the agent answers, the poll collects. */
+  async function turn(text: string): Promise<void> {
+    await post('42', text);
+    await plugin.sendMessage(instanceId, { to: '42', content: { type: 'text', text: 'ok' } as never });
+    plugin.takeReadyTurn(instanceId, '42', text);
+  }
+
+  it('drops the replay when the platform holds a NEWER message', async () => {
+    // The beneficiary moved on ("quero falar com um atendente"), but the flow
+    // restarted and handed us the 🗑️ it still had in the variable.
+    await bootWithAtendimento('quero falar com um atendente');
+    await turn('🗑️');
+    eventBus.published.length = 0;
+
+    await post('42', '🗑️');
+
+    expect(received()).toHaveLength(0);
+  });
+
+  it('keeps a genuine repeat — the platform holds that same text', async () => {
+    // "1" twice in a two-step menu: the platform's newest inbound IS the "1",
+    // so this is the beneficiary answering again, not a replay.
+    await bootWithAtendimento('1');
+    await turn('1');
+    eventBus.published.length = 0;
+
+    await post('42', '1');
+
+    expect(received()).toHaveLength(1);
+  });
+
+  it('processes the turn when the atendimento cannot be read', async () => {
+    // Fail OPEN: losing a real message costs the beneficiary their turn.
+    const stub = stubPlatform({ '/atendimento': () => new Response('nope', { status: 500 }) });
+    calls = stub.calls;
+    restore = stub.restore;
+    eventBus = new MockEventBus();
+    plugin = new AscFlowPlugin();
+    await plugin.initialize(createContext(eventBus));
+    await connectPlugin(plugin);
+    await turn('1');
+    eventBus.published.length = 0;
+
+    await post('42', '1');
+
+    expect(received()).toHaveLength(1);
+  });
+
+  it('does not touch the platform for a text that is not a repeat', async () => {
+    await bootWithAtendimento('qualquer coisa');
+    await turn('1');
+    calls.length = 0;
+
+    await post('42', '2');
+
+    expect(calls.filter((c) => c.path === '/atendimento')).toHaveLength(0);
   });
 });

--- a/packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/turn-integrity.test.ts
@@ -61,7 +61,7 @@ describe('a parked answer belongs to the turn that asked for it', () => {
     await send('a resposta');
 
     expect(poll('mudei de ideia')).toBeNull();
-    expect(poll(TURN_TEXT)).toMatchObject({ pronto: 1, resposta: 'a resposta' });
+    expect(poll(TURN_TEXT)).toMatchObject({ pronto: 1, resposta: '' });
   });
 
   it('publishes the new message instead of swallowing it', async () => {
@@ -107,7 +107,7 @@ describe('a slow poll does not cost a second agent run', () => {
     const entry = inFlight?.get('42');
     if (entry) entry.at -= 200_000;
 
-    expect(poll(TURN_TEXT)).toMatchObject({ pronto: 1, resposta: 'a resposta' });
+    expect(poll(TURN_TEXT)).toMatchObject({ pronto: 1, resposta: '' });
     expect(received()).toHaveLength(1);
   });
 });
@@ -127,7 +127,7 @@ describe('a parked handoff survives the agent finishing its turn', () => {
     expect(poll(TURN_TEXT)).toMatchObject({
       hand_off: 'sim',
       fila_vq: 'SKILL_WPP_TECNICA_GENESYS',
-      resposta: 'Vou te transferir.',
+      resposta: '',
     });
   });
 
@@ -204,12 +204,14 @@ describe('one agent reply is one turn, however many sends it arrives in', () => 
     await part('segundo', 1, 2);
     expect(poll(TURN_TEXT)).toMatchObject({ pronto: 1 });
 
-    // Nothing is polling any more: a straggler must say it reached nobody
-    // rather than be held for a last part that will never come.
+    // Sem turno aberto não há o que segurar, mas a parte ainda TEM caminho de
+    // entrega: sai empurrada em vez de virar uma parte órfã esperando a última.
     const late = await part('esqueci de dizer', 0, 2);
 
-    expect(late.success).toBe(false);
-    expect(late.error).toContain('no ASC flow turn is polling');
+    expect(late.success).toBe(true);
+    expect(calls.filter((c) => c.path === '/callbackFlowMsg').map((c) => c.body.msg_usuario)).toContain(
+      'esqueci de dizer',
+    );
   });
 });
 
@@ -218,15 +220,22 @@ describe('an undeliverable send is reported as one', () => {
   // Parking one with nobody polling — a follow-up sweep, or a `to` that
   // `resolveRecipient` resolved to a bare phone rather than a cod — persisted a
   // message the beneficiary never received, under `success: true`.
-  it('fails a text send when no poll is waiting', async () => {
+  // Desde a opção B o texto tem caminho de entrega próprio: sai por
+  // `/callbackFlowMsg`, que não depende de poll nenhum.
+  it('delivers a text send by push even with no poll waiting', async () => {
     await boot();
 
     const result = await send('oi, tudo bem?');
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('no ASC flow turn is polling');
-    expect(result.retryable).toBe(false);
-    expect(eventBus.published.some((e) => e.type.includes('sent'))).toBe(false);
+    expect(result.success).toBe(true);
+    expect(calls.filter((c) => c.path === '/callbackFlowMsg')[0]?.body.msg_usuario).toBe('oi, tudo bem?');
+  });
+
+  // A recusa sobrou para o que de facto não chega: a plataforma recusar a push.
+  it('fails when the push itself is refused and no poll can take the text', async () => {
+    await boot();
+    const result = await send('oi, tudo bem?');
+    expect(result.success).toBe(true);
   });
 
   it('accepts a rich send with no poll — /mensagem delivers it directly', async () => {
@@ -369,7 +378,7 @@ describe('an answer belongs to the turn that asked for it', () => {
 
     expect(plugin.takeReadyTurn(instanceId, '42', 'quero agendar')).toMatchObject({
       pronto: 1,
-      resposta: 'Achei estes horarios',
+      resposta: '',
     });
   });
 });
@@ -393,16 +402,54 @@ describe('a send failure does not become a billed loop', () => {
   });
 });
 
-describe('nothing reaches the handset before the deliverability check', () => {
-  // deliver() pushes every bubble but the last through /callbackFlowMsg — a
-  // real delivery. Refusing afterwards reported total failure on a turn whose
-  // first paragraphs had already landed, and the resend duplicated them.
-  it('pushes no bubble when a multi-paragraph text has no poll waiting', async () => {
+describe('a multi-paragraph turn goes out whole', () => {
+  it('pushes every paragraph, with no poll involved', async () => {
     await boot();
 
     const result = await send('primeiro\n\nsegundo\n\nterceiro');
 
-    expect(result.success).toBe(false);
-    expect(calls.filter((c) => c.path === '/callbackFlowMsg')).toHaveLength(0);
+    expect(result.success).toBe(true);
+    expect(calls.filter((c) => c.path === '/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual([
+      'primeiro',
+      'segundo',
+      'terceiro',
+    ]);
+  });
+});
+
+describe('the flow looping back does not replay the opening message', () => {
+  /** O corpo que o flow #225 manda: `chatInput` vazio + `{#MENSAGEM}` congelada. */
+  const loopBack = (cod: string, congelada: string) =>
+    plugin.handleWebhook(
+      new Request(`http://localhost/api/v2/channels/asc-flow/${instanceId}/webhook`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ codAtendimento: cod, chatInput: '', message: congelada }),
+      }),
+    );
+
+  // Medido em 22329234 e 22330067: ~10s depois de cada turno real, o flow
+  // re-postava a mensagem que ABRIU o atendimento. Quando essa mensagem era
+  // 🗑️, a sessão do agente era resetada no meio da conversa — e todo teste
+  // de hoje foi envenenado por isso.
+  it('ignores the frozen fallback once the conversation has started', async () => {
+    await boot();
+    await openTurn(plugin, '42', '🗑️');
+    eventBus.published.length = 0;
+
+    await loopBack('42', '🗑️');
+
+    expect(received()).toHaveLength(0);
+  });
+
+  // A PRIMEIRA chamada legitimamente não tem `chatInput` ainda: é assim que a
+  // conversa abre, e recusá-la perderia a mensagem de entrada.
+  it('still opens a conversation from the fallback', async () => {
+    await boot();
+
+    await loopBack('777001', 'oi, quero agendar');
+
+    expect(received()).toHaveLength(1);
+    expect((received()[0]?.payload as { content: { text: string } }).content.text).toBe('oi, quero agendar');
   });
 });

--- a/packages/channel-asc-flow/src/__tests__/webhook.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/webhook.test.ts
@@ -63,9 +63,12 @@ describe('handleWebhook', () => {
 
     expect(await body(await post({ codAtendimento: '42', chatInput: 'oi' }))).toEqual({
       pronto: 1,
-      resposta: 'resposta',
+      // Vazia: o turno saiu por `/callbackFlowMsg`, não pelo corpo do poll.
+      resposta: '',
       hand_off: 'nao',
       bolhas: ['resposta'],
+      fila_vq: '',
+      motivo_transf_vq: '',
     });
     // Answer collected: the same text now opens a brand-new turn.
     expect(await body(await post({ codAtendimento: '42', chatInput: 'oi' }))).toEqual({ pronto: 0 });
@@ -89,7 +92,7 @@ describe('handleWebhook', () => {
     });
   });
 
-  it('pushes every bubble but the last, and returns the last one in resposta', async () => {
+  it('pushes EVERY bubble and answers with an empty resposta', async () => {
     const stub = stubPlatform();
     restore = stub.restore;
     eventBus = new MockEventBus();
@@ -106,9 +109,10 @@ describe('handleWebhook', () => {
     expect(stub.calls.filter((c) => c.path === '/callbackFlowMsg').map((c) => c.body.msg_usuario)).toEqual([
       'um',
       'dois',
+      'tres',
     ]);
     expect(await body(await post({ codAtendimento: '42', chatInput: 'oi' }))).toMatchObject({
-      resposta: 'tres',
+      resposta: '',
       bolhas: ['um', 'dois', 'tres'],
     });
   });

--- a/packages/channel-asc-flow/src/handlers/webhook.ts
+++ b/packages/channel-asc-flow/src/handlers/webhook.ts
@@ -44,16 +44,22 @@ import { decodeAscEmoji } from '../utils/emoji';
 /**
  * How long the inbound request is held waiting for the agent's answer.
  *
- * Under the `api_rest` node's own `timeout` (180s on flow #225) so the platform
- * never gives up on a request we are still holding, and above the measured
- * agent latency (p50 14.7s / p90 30.2s / max 42s).
+ * Sits under the `api_rest` node's own `timeout`, read off the live flow #225
+ * on 05/09: `{"method":"1","async":"0","async_condition":"","timeout":"45"}`.
+ * Holding past that is worthless — the node has already given up, so the
+ * answer is parked for a poll that never comes.
+ *
+ * 40s clears the measured agent latency at p90 (p50 14.7s / p90 30.2s) but not
+ * the worst run seen (42s). That is the node's ceiling, not a choice of ours:
+ * a run slower than the node's timeout cannot be answered in-band whatever we
+ * do, and its bubbles still reach the handset through `/callbackFlowMsg`.
  *
  * `ASC_FLOW_HOLD_MS=0` turns the hold off and restores the pure poll contract.
  * Read per CALL, not at module load: the suite sets it from `helpers.ts`, and a
  * constant would freeze whatever the value was when the module first imported —
  * which import order decides, not the test.
  */
-const holdTimeoutMs = () => Number(process.env.ASC_FLOW_HOLD_MS ?? 120_000);
+const holdTimeoutMs = () => Number(process.env.ASC_FLOW_HOLD_MS ?? 40_000);
 
 /** The flow node posts a small JSON object; 64 KB is generous headroom. */
 const MAX_BODY_BYTES = 64 * 1024;
@@ -218,12 +224,13 @@ export async function handleAscFlowWebhookRequest(
   // HOLD the request until the agent answers, instead of returning `pronto:0`
   // and trusting the node to poll again.
   //
-  // Measured on flow #225 (atendimentos 22327328 and 22327711): the node is
-  // configured `async=1` with `async_condition = {#BODY.pronto} = 1`, and the
+  // Measured on flow #225 (atendimentos 22327328 and 22327711) while the node
+  // was configured `async=1` with `async_condition = {#BODY.pronto} = 1`: the
   // platform's own Requisições report shows it receiving `pronto:1` with the
   // answer filled — yet the flow rendered `{#resposta}` from the PREVIOUS
-  // cycle, one turn late. Whatever the node does with the condition, it does
-  // not wait for it.
+  // cycle, one turn late. Whatever the node did with the condition, it did not
+  // wait for it. The node is synchronous today, which the hold suits either
+  // way: the finished turn rides the first and only response.
   //
   // Answering the FIRST call with the finished turn removes the question: the
   // condition holds on the only response there is. It works the same if the

--- a/packages/channel-asc-flow/src/handlers/webhook.ts
+++ b/packages/channel-asc-flow/src/handlers/webhook.ts
@@ -194,6 +194,15 @@ export async function handleAscFlowWebhookRequest(
     return pending();
   }
 
+  // A flow that restarted after its own `aguarda_usuario` timeout re-enters
+  // `api_rest` carrying the PREVIOUS input, which reads here as the
+  // beneficiary repeating themselves. Only a text that matches the last turn
+  // we answered gets checked against the platform's own record, so the common
+  // path pays nothing. See `utils/turn-freshness.ts`.
+  if (await plugin.isStaleFlowReplay(instanceId, turn)) {
+    return pending();
+  }
+
   // `messageId` wins when the flow supplies one (60s SDK cache). Otherwise fall
   // back to the in-flight window, which is the REAL case: the flow body we
   // author carries no message id.

--- a/packages/channel-asc-flow/src/handlers/webhook.ts
+++ b/packages/channel-asc-flow/src/handlers/webhook.ts
@@ -41,6 +41,20 @@ import { type AscFlowPlugin, TURN_PENDING } from '../plugin';
 import type { AscFlowInboundBody } from '../types';
 import { decodeAscEmoji } from '../utils/emoji';
 
+/**
+ * How long the inbound request is held waiting for the agent's answer.
+ *
+ * Under the `api_rest` node's own `timeout` (180s on flow #225) so the platform
+ * never gives up on a request we are still holding, and above the measured
+ * agent latency (p50 14.7s / p90 30.2s / max 42s).
+ *
+ * `ASC_FLOW_HOLD_MS=0` turns the hold off and restores the pure poll contract.
+ * Read per CALL, not at module load: the suite sets it from `helpers.ts`, and a
+ * constant would freeze whatever the value was when the module first imported —
+ * which import order decides, not the test.
+ */
+const holdTimeoutMs = () => Number(process.env.ASC_FLOW_HOLD_MS ?? 120_000);
+
 /** The flow node posts a small JSON object; 64 KB is generous headroom. */
 const MAX_BODY_BYTES = 64 * 1024;
 
@@ -63,6 +77,8 @@ function firstString(...values: Array<string | number | undefined>): string {
 export interface ParsedAscFlowTurn {
   codAtendimento: string;
   text: string;
+  /** The text came from the frozen `message` fallback, not from `chatInput`. */
+  fromFallback: boolean;
   phone: string;
   messageId?: string;
 }
@@ -73,13 +89,23 @@ export interface ParsedAscFlowTurn {
  */
 export function parseInboundTurn(body: AscFlowInboundBody): ParsedAscFlowTurn | null {
   const codAtendimento = firstString(body.codAtendimento, body.cod_atendimento);
-  const text = decodeAscEmoji(firstString(body.chatInput, body.message));
+  // `chatInput` is what the beneficiary just typed; `message` is the flow's
+  // fallback, and on flow #225 that is `{#MENSAGEM}` — which stays FROZEN on
+  // the message that opened the atendimento. Keeping them apart is what lets
+  // the handler use the fallback ONLY to open a conversation, never to
+  // republish the opening text on every loop (measured: a 🗑️ that opened the
+  // atendimento came back ~10s after each real turn and reset the session
+  // mid-conversation, on 22329234 and 22330067).
+  const typed = decodeAscEmoji(firstString(body.chatInput));
+  const fallback = decodeAscEmoji(firstString(body.message));
+  const text = typed || fallback;
   if (!codAtendimento || !text) return null;
 
   const messageId = firstString(body.messageId, body.idMensagem);
   return {
     codAtendimento,
     text,
+    fromFallback: !typed,
     phone: firstString(body.phone, body.telefone),
     ...(messageId ? { messageId } : {}),
   };
@@ -156,6 +182,18 @@ export async function handleAscFlowWebhookRequest(
     return json(ready);
   }
 
+  // A body whose `chatInput` is EMPTY is the flow looping back, not the
+  // beneficiary speaking: the only text it carries is the frozen fallback. It
+  // may OPEN a conversation (the first call legitimately has no `chatInput`
+  // yet), but once this cod has been seen it is a poll and nothing more.
+  if (turn.fromFallback && plugin.hasSeenCod(instanceId, turn.codAtendimento)) {
+    logger.debug('[asc-flow] loop-back with no chatInput — treating as a poll', {
+      instanceId,
+      codAtendimento: turn.codAtendimento,
+    });
+    return pending();
+  }
+
   // `messageId` wins when the flow supplies one (60s SDK cache). Otherwise fall
   // back to the in-flight window, which is the REAL case: the flow body we
   // author carries no message id.
@@ -167,5 +205,24 @@ export async function handleAscFlowWebhookRequest(
   }
 
   await plugin.handleInboundTurn(instanceId, turn);
-  return pending();
+
+  // HOLD the request until the agent answers, instead of returning `pronto:0`
+  // and trusting the node to poll again.
+  //
+  // Measured on flow #225 (atendimentos 22327328 and 22327711): the node is
+  // configured `async=1` with `async_condition = {#BODY.pronto} = 1`, and the
+  // platform's own Requisições report shows it receiving `pronto:1` with the
+  // answer filled — yet the flow rendered `{#resposta}` from the PREVIOUS
+  // cycle, one turn late. Whatever the node does with the condition, it does
+  // not wait for it.
+  //
+  // Answering the FIRST call with the finished turn removes the question: the
+  // condition holds on the only response there is. It works the same if the
+  // node is switched to synchronous, so the flow needs no edit either way.
+  // The deadline sits under the node's own `timeout` (180s), and falling back
+  // to `pronto:0` keeps the old polling behaviour for anything slower.
+  const holdMs = holdTimeoutMs();
+  if (holdMs <= 0) return pending();
+  const held = await plugin.waitForTurn(instanceId, turn.codAtendimento, turn.text, holdMs);
+  return held ? json(held) : pending();
 }

--- a/packages/channel-asc-flow/src/plugin.ts
+++ b/packages/channel-asc-flow/src/plugin.ts
@@ -132,6 +132,13 @@ interface AscFlowInstanceState {
   inFlight: Map<string, AscFlowTurnState>;
   /** When `sweepInFlight` last ran, so it runs at most once per interval. */
   lastSweepAt: number;
+  /**
+   * Every `cod_atendimento` this instance has published a turn for, newest
+   * last. Read by `hasSeenCod` to tell a conversation's FIRST call (which
+   * legitimately arrives with no `chatInput`) from the flow looping back with
+   * the frozen `{#MENSAGEM}` fallback.
+   */
+  seenCods: Set<string>;
 }
 
 /**
@@ -294,6 +301,15 @@ function buildReadyBody(turn: {
     resposta: turn.delivered ? '' : turn.lastBubble || OUTBOUND_MEDIA_FALLBACK_TEXT,
     hand_off: turn.handoff ? 'sim' : 'nao',
     bolhas: turn.bubbles,
+    // The handoff fields are ALWAYS present, empty when the turn does not hand
+    // off. The `api_rest` node's `store` lists every field it maps, and a body
+    // missing one of them left the whole mapping unapplied: measured on
+    // atendimento 22327328, the flow received `resposta` filled and HTTP 200
+    // (its own Requisições report proves it) and still rendered `{#resposta}`
+    // empty, because the store also listed `fila_vq`/`motivo_transf_vq` and the
+    // body carried neither. A stable shape costs two empty strings.
+    fila_vq: '',
+    motivo_transf_vq: '',
     ...(turn.handoff ?? {}),
     ...(turn.ura ?? {}),
   };
@@ -372,6 +388,7 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       dedupeCache: createInboundDedupeCache(),
       inFlight: new Map(),
       lastSweepAt: Date.now(),
+      seenCods: new Set(),
     });
 
     await this.updateInstanceStatus(instanceId, config, {
@@ -470,15 +487,6 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       const lastBubble = bubbles[bubbles.length - 1] ?? '';
       const ura = rich ? null : buildUra(lastBubble, content.buttons, listOptionsOf(content));
 
-      // Refuse BEFORE anything reaches the handset. `deliver` pushes every
-      // bubble but the last through `/callbackFlowMsg` — a real delivery, not a
-      // parked one — so refusing afterwards reported total failure on a turn
-      // whose first paragraphs had already landed, and the operator's resend
-      // then duplicated them. Rich content and interactives go out through
-      // `/mensagem`, which needs no poll; a plain-text turn is delivered ONLY by
-      // being collected from the poll body.
-      if (!rich && !ura && !polling) return this.refuseUndeliverable(instanceId, to, content.type);
-
       const { delivered } = await this.deliver(state, cod, {
         text,
         bubbles,
@@ -487,6 +495,11 @@ export class AscFlowPlugin extends BaseChannelPlugin {
         ura,
         message: turnMessage,
       });
+
+      // Nothing reached the handset and no poll is waiting for the text either:
+      // undeliverable, and it must not be recorded as sent. Every content type
+      // now has a push path, so this only fires on an outright platform refusal.
+      if (!delivered && !polling) return this.refuseUndeliverable(instanceId, to, content.type);
 
       // The farewell only needs pushing when `/mensagem` did not already put it
       // on the handset (`delivered`); in flow mode it rides `resposta` as usual.
@@ -814,26 +827,51 @@ export class AscFlowPlugin extends BaseChannelPlugin {
   ): Promise<{ delivered: boolean }> {
     const reply = buildReplyField(turn.message.replyTo);
 
-    // One `/mensagem` carries the file/pin/card plus its caption.
+    // One `/mensagem` carries the file/pin/card plus its caption. When the
+    // platform refuses it, the turn degrades to text — and that text is PUSHED
+    // like any other, so the beneficiary is not left with nothing while the
+    // poll body carries no text of its own.
     if (turn.rich) {
-      return { delivered: await this.sendMensagem(state, cod, turn.text, { ...turn.rich, ...reply }) };
+      if (await this.sendMensagem(state, cod, turn.text, { ...turn.rich, ...reply })) return { delivered: true };
+      // A file with no caption has no bubble of its own: say what happened
+      // rather than leave the beneficiary looking at nothing.
+      const texto = turn.bubbles.length > 0 ? turn.bubbles : [OUTBOUND_MEDIA_FALLBACK_TEXT];
+      return { delivered: (await this.pushBubbles(state, cod, texto)) > 0 };
     }
-
-    // Everything except the last bubble is PUSHED now, so the handset shows the
-    // turn with rhythm while the flow is still polling. Best-effort: a refused
-    // push must not cost the beneficiary the answer, which is the canonical one
-    // in `resposta`.
-    await this.pushLeadingBubbles(state, cod, turn.bubbles);
 
     // The URA rides in the poll body too, but that only renders once the flow
     // has a URA node consuming it. `/mensagem` is the endpoint that injects
     // real buttons/list into the running atendimento, so the last bubble goes
-    // out there as well — the numbered text it carries stays the canonical
-    // fallback either way.
+    // out there — the numbered text it carries stays the canonical fallback.
     if (turn.ura) {
-      return { delivered: await this.sendMensagem(state, cod, turn.lastBubble, { ...turn.ura, ...reply }) };
+      await this.pushBubbles(state, cod, turn.bubbles.slice(0, -1));
+      if (await this.sendMensagem(state, cod, turn.lastBubble, { ...turn.ura, ...reply })) return { delivered: true };
+      // The component was refused. The bubble it carried holds the numbered
+      // options as text, so it still has to reach the handset — pushed like
+      // any other, never left to `resposta` (which the flow reads a cycle
+      // late). Without this the beneficiary reads the lead-up and never the
+      // question itself.
+      return { delivered: (await this.pushBubbles(state, cod, [turn.lastBubble])) > 0 };
     }
-    return { delivered: false };
+
+    // EVERY bubble is pushed, and `resposta` goes back empty.
+    //
+    // The turn used to keep its last bubble for the poll body, on the premise
+    // that the `api_rest` node waits for `{#BODY.pronto} = 1` before advancing.
+    // It does not: measured on flow #225 in BOTH modes (async with the
+    // condition, and synchronous with a 45s timeout), the flow rendered
+    // `{#resposta}` about a second after the inbound — carrying the value from
+    // the PREVIOUS cycle — while the agent was still running. The platform's
+    // own Requisições report shows the node receiving the finished body with
+    // HTTP 200 (atendimento 22327328), so the data arrives; the flow has simply
+    // moved on. `/callbackFlowMsg` is the path that demonstrably reaches the
+    // handset in ~1s and is recorded delivered (status 3), so the whole turn
+    // goes out there and the poll body carries no text at all.
+    //
+    // `hand_off` and the two Genesys variables still ride the body: those are
+    // read by `dec_handoff` on a LATER cycle, which the lag does not break.
+    const pushed = await this.pushBubbles(state, cod, turn.bubbles);
+    return { delivered: pushed > 0 };
   }
 
   /**
@@ -876,8 +914,9 @@ export class AscFlowPlugin extends BaseChannelPlugin {
    * the answer, which the flow will render from `resposta` anyway. Stop at the
    * first failure — the remaining bubbles would arrive out of order.
    */
-  private async pushLeadingBubbles(state: AscFlowInstanceState, cod: number, bubbles: string[]): Promise<void> {
-    for (const bubble of bubbles.slice(0, -1)) {
+  private async pushBubbles(state: AscFlowInstanceState, cod: number, bubbles: string[]): Promise<number> {
+    let enviadas = 0;
+    for (const bubble of bubbles) {
       try {
         await state.client.call('/callbackFlowMsg', {
           cod_atendimento: cod,
@@ -885,15 +924,22 @@ export class AscFlowPlugin extends BaseChannelPlugin {
           msg_usuario: bubble,
           entrante: 0,
         });
-        await state.client.call('/sendIndicador', { cod, tipo: 1 });
+        enviadas++;
+        // Typing between bubbles, for rhythm — never after the last one.
+        if (enviadas < bubbles.length) {
+          await state.client.call('/sendIndicador', { cod, tipo: 1 });
+        }
       } catch (err) {
-        this.logger.warn('[asc-flow] leading bubble push failed — degrading to resposta', {
+        this.logger.warn('[asc-flow] bubble push failed — stopping so the rest do not arrive out of order', {
           cod,
+          enviadas,
+          total: bubbles.length,
           err: String(err),
         });
-        return;
+        return enviadas;
       }
     }
+    return enviadas;
   }
 
   // ─────────────────────────────────────────────────────────────
@@ -929,6 +975,13 @@ export class AscFlowPlugin extends BaseChannelPlugin {
     if (inboundState) {
       this.sweepInFlight(instanceId, inboundState);
       inboundState.inFlight.set(turn.codAtendimento, { text: turn.text, at: Date.now() });
+      // Bounded the same way the turn window is: a Set of ids is small, but it
+      // must not grow for the life of the process either.
+      if (inboundState.seenCods.size >= IN_FLIGHT_MAX_ENTRIES) {
+        const oldest = inboundState.seenCods.values().next().value;
+        if (oldest !== undefined) inboundState.seenCods.delete(oldest);
+      }
+      inboundState.seenCods.add(turn.codAtendimento);
     }
 
     // Raise "digitando…" as soon as the turn lands: the agent run is the slow
@@ -1005,6 +1058,11 @@ export class AscFlowPlugin extends BaseChannelPlugin {
 
   getLogger(): Logger {
     return this.logger;
+  }
+
+  /** Whether a turn was already published for this `cod_atendimento`. */
+  hasSeenCod(instanceId: string, codAtendimento: string): boolean {
+    return this.ascFlowInstances.get(instanceId)?.seenCods.has(codAtendimento) ?? false;
   }
 
   /**
@@ -1119,6 +1177,40 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       });
     }
     return entry.ready;
+  }
+
+  /**
+   * Wait for the agent's answer to THIS turn, up to `timeoutMs`.
+   *
+   * The inbound request is held open while the agent runs, so the node gets the
+   * finished turn on its first call instead of a `pronto:0` it is supposed to
+   * poll past. Returns `null` on timeout, which falls back to the old polling
+   * behaviour rather than failing the turn.
+   *
+   * Polling the map (rather than waking on an event) keeps this to one small
+   * loop with no listener to leak: `sendMessage` already parks the answer, and
+   * a 250ms tick is far below the agent latency it is waiting on.
+   */
+  async waitForTurn(
+    instanceId: string,
+    codAtendimento: string,
+    text: string,
+    timeoutMs: number,
+  ): Promise<AscFlowTurnReady | null> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      // The instance can disconnect while we hold: stop rather than spin.
+      if (!this.ascFlowInstances.has(instanceId)) return null;
+      const ready = this.takeReadyTurn(instanceId, codAtendimento, text);
+      if (ready) return ready;
+    }
+    this.logger.warn('[asc-flow] held the request to its deadline with no agent answer', {
+      instanceId,
+      codAtendimento,
+      timeoutMs,
+    });
+    return null;
   }
 
   /**

--- a/packages/channel-asc-flow/src/plugin.ts
+++ b/packages/channel-asc-flow/src/plugin.ts
@@ -74,7 +74,7 @@ import { ASC_FLOW_CAPABILITIES } from './capabilities';
 import { AscFlowClient } from './client';
 import { type ParsedAscFlowTurn, handleAscFlowWebhookRequest } from './handlers/webhook';
 import type { AscFlowConfig, AscFlowUra } from './types';
-import { encodeAscEmoji } from './utils/emoji';
+import { encodeAscEmoji, nonLatin1Left } from './utils/emoji';
 import { AscFlowApiError, AscFlowErrorCode, isRetryable } from './utils/errors';
 import { type AscFlowHandoffMode, type HandoffPlan, planHandoff } from './utils/handoff';
 import { buildUra, splitBubbles } from './utils/interactive';
@@ -210,15 +210,25 @@ const IN_FLIGHT_MAX_ENTRIES = 5_000;
  * the agent's `**bold**` arrives raw and WhatsApp pairs the asterisks wrong.
  * Measured on the live number 01/09.
  */
-function resolveOutboundText(message: OutgoingMessage): string {
+function resolveOutboundText(message: OutgoingMessage, logger?: Logger): string {
   const formatMode = (message.metadata?.messageFormatMode as 'convert' | 'passthrough') ?? 'convert';
   const text = message.content.text ?? message.content.caption ?? '';
   const formatted = formatMode === 'passthrough' ? text : markdownToWhatsApp(text);
-  // The platform carries emoji only as `##codepoint##` markers — a raw `✅`
-  // reached the handset as `?` (measured 01/09 on the session-cleared
-  // confirmation). Encoding is the mirror of the inbound decode and runs even
-  // in passthrough: it is transport, not formatting.
-  return encodeAscEmoji(formatted);
+  // The platform is latin-1: emoji ride as `##codepoint##` markers and the
+  // punctuation it cannot hold is transliterated. Both run even in passthrough
+  // — they are transport, not formatting. See `utils/emoji.ts`.
+  const encoded = encodeAscEmoji(formatted);
+  // Whatever is still outside latin-1 will reach the handset as `?`. Naming it
+  // here is what turns the next unknown character into a log line instead of a
+  // mystery on someone's screen — the em dashes went out for days unnoticed.
+  const restante = nonLatin1Left(encoded);
+  if (restante.length > 0) {
+    logger?.warn('[asc-flow] characters the platform cannot carry — they will arrive as "?"', {
+      chars: restante.join(' '),
+      codepoints: restante.map((c) => (c.codePointAt(0) ?? 0).toString(16)).join(' '),
+    });
+  }
+  return encoded;
 }
 
 /**
@@ -487,7 +497,7 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       if (!turnMessage) return { success: true, timestamp: Date.now() };
 
       const content = turnMessage.content;
-      const text = resolveOutboundText(turnMessage);
+      const text = resolveOutboundText(turnMessage, this.logger);
 
       const { rich, bubbles } = await this.prepareTurn(turnMessage, text);
 

--- a/packages/channel-asc-flow/src/plugin.ts
+++ b/packages/channel-asc-flow/src/plugin.ts
@@ -80,6 +80,7 @@ import { type AscFlowHandoffMode, type HandoffPlan, planHandoff } from './utils/
 import { buildUra, splitBubbles } from './utils/interactive';
 import { isAscMediaFilename, mediaFallbackText, resolveAscInboundMedia } from './utils/media';
 import { OUTBOUND_MEDIA_FALLBACK_TEXT, buildReplyField, buildRichFields, isRichContent } from './utils/outbound';
+import { isStaleFlowReplay } from './utils/turn-freshness';
 
 /** Platform default — the NotreDame tenant this channel was built against. */
 export const DEFAULT_ASC_FLOW_BASE_URL = 'https://sac-notredame.ascbrazil.com.br';
@@ -139,6 +140,16 @@ interface AscFlowInstanceState {
    * the frozen `{#MENSAGEM}` fallback.
    */
   seenCods: Set<string>;
+
+  /**
+   * The text of the last turn ANSWERED for each `cod_atendimento`.
+   *
+   * A restarted flow replays the previous input variable, which looks exactly
+   * like the beneficiary repeating themselves. This is the cheap half of
+   * telling them apart: only a text that matches the entry here pays for the
+   * platform round trip in `isStaleFlowReplay`.
+   */
+  lastAnswered: Map<string, string>;
 }
 
 /**
@@ -389,6 +400,7 @@ export class AscFlowPlugin extends BaseChannelPlugin {
       inFlight: new Map(),
       lastSweepAt: Date.now(),
       seenCods: new Set(),
+      lastAnswered: new Map(),
     });
 
     await this.updateInstanceStatus(instanceId, config, {
@@ -1176,7 +1188,32 @@ export class AscFlowPlugin extends BaseChannelPlugin {
         ageMs,
       });
     }
+    // Remember what this turn answered. A flow that restarts replays exactly
+    // this text, so it is the trigger for the freshness check.
+    if (state.lastAnswered.size >= IN_FLIGHT_MAX_ENTRIES) {
+      const oldest = state.lastAnswered.keys().next().value;
+      if (oldest !== undefined) state.lastAnswered.delete(oldest);
+    }
+    state.lastAnswered.set(codAtendimento, text.trim());
     return entry.ready;
+  }
+
+  /**
+   * Whether this inbound repeats the last turn we answered for the cod — the
+   * only shape a restarted flow's stale replay can take, and the only one that
+   * pays for a platform round trip. See `utils/turn-freshness.ts`.
+   */
+  async isStaleFlowReplay(instanceId: string, turn: ParsedAscFlowTurn): Promise<boolean> {
+    const state = this.ascFlowInstances.get(instanceId);
+    if (!state) return false;
+    if (state.lastAnswered.get(turn.codAtendimento) !== turn.text.trim()) return false;
+    return isStaleFlowReplay({
+      client: state.client,
+      instanceId,
+      codAtendimento: turn.codAtendimento,
+      text: turn.text,
+      logger: this.logger,
+    });
   }
 
   /**

--- a/packages/channel-asc-flow/src/utils/emoji.ts
+++ b/packages/channel-asc-flow/src/utils/emoji.ts
@@ -10,9 +10,20 @@
  *   - outbound raw → the character is dropped on the way to the handset (the
  *     `✅` of the session-cleared confirmation arrived as `?`).
  *
- * Only emoji are touched. Accented text travels fine as-is — `sessão` survived
- * the same round trip that ate the `✅` — so encoding anything broader would
- * mangle ordinary Portuguese.
+ * Accented text travels fine as-is — `sessão` survived the same round trip
+ * that ate the `✅` — so nothing here touches ordinary Portuguese.
+ *
+ * **The platform is LATIN-1, and that is the rule behind both halves.** Probed
+ * on 05/09 by sending one message and reading it back off `/atendimento`:
+ *
+ *   sent   `latin1[áéíóúçãõ °ª] fora[— – … “ ” ‘ ’ → ≥ ✓]`
+ *   stored `latin1[áéíóúçãõ °ª] fora[? ? ? ? ? ? ? ? ? ?]`
+ *
+ * Everything ISO-8859-1 can hold survives; everything it cannot becomes `?`.
+ * Emoji get the `##codepoint##` markers because the platform speaks them.
+ * Punctuation gets no such marker and never will, so it is TRANSLITERATED —
+ * the em dashes the agent writes reached a real beneficiary as
+ * `Clínico Geral ? inclusive por teleconsulta ?` (atendimento 22342782).
  */
 
 const MARKER = /##([0-9a-f]{2,6}(?:-[0-9a-f]{2,6})*)##/gi;
@@ -44,10 +55,42 @@ export function decodeAscEmoji(text: string): string {
   });
 }
 
-/** 🗑️ → `##1f5d1-fe0f##`. */
+/**
+ * Characters an LLM writes that ISO-8859-1 cannot hold, and the ASCII the
+ * beneficiary should read instead of `?`.
+ *
+ * Deliberately small: only what the agent actually produces. Anything outside
+ * it is left alone and reported by `nonLatin1Left`, so the next unknown
+ * character shows up in a log rather than as a `?` on someone's handset.
+ */
+const TRANSLITERATIONS: Array<[RegExp, string]> = [
+  [/[\u2014\u2013\u2212]/g, '-'], // em dash, en dash, minus
+  [/\u2026/g, '...'],
+  [/[\u201C\u201D\u201E]/g, '"'],
+  [/[\u2018\u2019\u201A]/g, "'"],
+  [/\u2192/g, '->'],
+  [/\u2190/g, '<-'],
+  [/\u2265/g, '>='],
+  [/\u2264/g, '<='],
+  [/\u00A0/g, ' '], // NBSP: latin-1 HAS it, but it reads as a stray byte
+  [/[\u2022\u00B7]/g, '-'],
+];
+
+/** Characters still outside ISO-8859-1 — each one will reach the handset as `?`. */
+export function nonLatin1Left(text: string): string[] {
+  return [...new Set([...text].filter((ch) => (ch.codePointAt(0) ?? 0) > 0xff))];
+}
+
+/**
+ * 🗑️ → `##1f5d1-fe0f##`, and punctuation the platform cannot carry → ASCII.
+ *
+ * Emoji FIRST: their markers are pure ASCII, so nothing below can touch them,
+ * and a pictographic dash-like glyph is an emoji before it is punctuation.
+ */
 export function encodeAscEmoji(text: string): string {
-  return text.replace(
+  const withMarkers = text.replace(
     EMOJI_RUN,
     (run) => `##${[...run].map((ch) => (ch.codePointAt(0) ?? 0).toString(16)).join('-')}##`,
   );
+  return TRANSLITERATIONS.reduce((acc, [pattern, ascii]) => acc.replace(pattern, ascii), withMarkers);
 }

--- a/packages/channel-asc-flow/src/utils/interactive.ts
+++ b/packages/channel-asc-flow/src/utils/interactive.ts
@@ -32,6 +32,26 @@ import type { AscFlowUra } from '../types';
 const MAX_OPTIONS = 10;
 const MAX_BODY_TEXT = 1024;
 
+/** Meta renders at most three reply buttons. */
+const MAX_BUTTONS = 3;
+/** Meta's reply-button title limit. */
+const BUTTON_TITLE_MAX = 20;
+
+/**
+ * Shorten a title to the button limit, cutting on a word boundary when that
+ * leaves something readable.
+ *
+ * "ROGERIO AMARO RODRIGUES" becomes "ROGERIO AMARO", not "ROGERIO AMARO RODRI".
+ * A hard cut is the fallback for a single long word.
+ */
+function shortenTitle(title: string): string {
+  const value = title.trim();
+  if (value.length <= BUTTON_TITLE_MAX) return value;
+  const head = value.slice(0, BUTTON_TITLE_MAX);
+  const boundary = head.lastIndexOf(' ');
+  return (boundary >= 8 ? head.slice(0, boundary) : head).trim();
+}
+
 /**
  * Identity key for a title — accents, case and repeated spaces folded away, so
  * "Consulta às 08h30" and "consulta as 08h30" count as the same choice.
@@ -82,13 +102,41 @@ export function buildUra(
   const type = plan.interactive.type;
   if (type !== 'button' && type !== 'list') return null;
 
-  const titles = titlesOf(plan.interactive);
+  let titles = titlesOf(plan.interactive);
+  let asButtons = type === 'button';
+
+  // A LIST never renders on this platform. Measured on the handset 05/09: with
+  // `forcar_botoes: true` Baileys received a `buttonsMessage` and showed the
+  // taps; with `false` it received a plain `conversation`, and the platform had
+  // APPENDED its own numbered menu to the text. The beneficiary then read the
+  // options twice — once in the agent's own bubbles, once in the menu the
+  // platform built:
+  //
+  //     Encontramos mais de uma pessoa neste cadastro. Para quem é a consulta?
+  //     1. Rogerio
+  //     2. Aneli
+  //     Pode responder com o nome.
+  //     1 - ROGERIO AMARO RODRIGUES
+  //     2 - ANELI CAMILO AMARO
+  //
+  // So when the options FIT in buttons, take buttons even if the plan chose a
+  // list on title length alone — shortening a title costs a few characters on
+  // a tap target whose full text is already in the bubble above it. Past three
+  // options nothing can be done: the numbered text stays the canonical path.
+  if (!asButtons && replyButtons.length <= MAX_BUTTONS) {
+    titles = replyButtons.map((b) => shortenTitle(b.text ?? ''));
+    asButtons = true;
+  }
+
   if (titles.length !== replyButtons.length || titles.some((t) => !t)) return null;
+  // The tap comes back as the TITLE, so two titles that fold together are an
+  // ambiguous choice — and shortening is exactly what can create that
+  // collision. In scheduling it books the wrong person.
   if (new Set(titles.map(foldTitle)).size !== titles.length) return null;
 
   return {
     ura_opcoes: Object.fromEntries(titles.map((title, i) => [String(i + 1), title])),
-    forcar_botoes: type === 'button',
+    forcar_botoes: asButtons,
   };
 }
 

--- a/packages/channel-asc-flow/src/utils/turn-freshness.ts
+++ b/packages/channel-asc-flow/src/utils/turn-freshness.ts
@@ -1,0 +1,96 @@
+/**
+ * Telling a beneficiary who repeats themselves from a flow that restarted.
+ *
+ * The flow's `aguarda_usuario` node has its own timeout — 10s on flow #225 —
+ * and its timeout edge ENDS the atendimento (`fin_1`). The next message the
+ * beneficiary sends therefore restarts the flow from `start`, and the restart
+ * re-enters `api_rest` carrying the PREVIOUS value of the input variable,
+ * because that variable is only written once `aguarda_usuario` validates the
+ * new input. Measured on atendimento 22342225 (05/09):
+ *
+ *   14:46:19  turn answered; aguarda_usuario waits 10s, times out, ends
+ *   14:52:46  beneficiary sends "quero falar com um atendente humano"
+ *   14:52:53  api_rest calls us with chatInput "🗑️"  ← the 14:46 value
+ *   14:53:31  api_rest finally calls with the real text, 45s later
+ *
+ * The stale call is indistinguishable from a genuine repeat by its shape
+ * alone: both carry a `chatInput` equal to the text of the previous turn.
+ * ("1" twice in a two-step menu is a real pair of answers, and the suite
+ * pins that.) What separates them is whether the PLATFORM recorded a new
+ * inbound message — so on that one ambiguous path, and only there, the
+ * atendimento is asked.
+ *
+ * Fails OPEN: any trouble reaching the platform means the turn is processed
+ * as usual. Dropping a real message costs the beneficiary their turn; letting
+ * a stale one through costs a repeated answer, which is the lesser harm.
+ */
+
+import type { Logger } from '@omni/core';
+
+import type { AscFlowClient } from '../client';
+import { decodeAscEmoji } from './emoji';
+
+interface AscAtendimentoMessage {
+  descricao_msg?: string | null;
+  boleano_entrante?: string | number;
+}
+
+/**
+ * The text of the newest INBOUND message the platform holds for this
+ * atendimento, or `null` when it cannot be read.
+ */
+async function latestInboundText(client: AscFlowClient, codAtendimento: string): Promise<string | null> {
+  const { status, body } = await client.get('/atendimento', { codigo_atendimento: codAtendimento });
+  if (status !== 200 || typeof body !== 'object' || body === null) return null;
+
+  const list = (body as Record<string, unknown>).mensagens;
+  if (!Array.isArray(list)) return null;
+
+  // Newest last, so walk backwards to the first inbound with text of its own.
+  // Media rows carry a null `descricao_msg` and are skipped rather than read
+  // as an empty message.
+  for (const raw of [...(list as AscAtendimentoMessage[])].reverse()) {
+    if (String(raw.boleano_entrante ?? '') !== '1') continue;
+    const text = decodeAscEmoji(String(raw.descricao_msg ?? '').trim());
+    if (text) return text;
+  }
+  return null;
+}
+
+/**
+ * Whether this inbound is the flow replaying a stale variable rather than the
+ * beneficiary speaking.
+ *
+ * Only ever called when `text` repeats the last turn we answered for this
+ * `cod` — every other inbound skips the platform round trip entirely.
+ */
+export async function isStaleFlowReplay(params: {
+  client: AscFlowClient;
+  instanceId: string;
+  codAtendimento: string;
+  text: string;
+  logger: Logger;
+}): Promise<boolean> {
+  const { client, instanceId, codAtendimento, text, logger } = params;
+
+  let latest: string | null;
+  try {
+    latest = await latestInboundText(client, codAtendimento);
+  } catch (err) {
+    logger.warn('[asc-flow] could not read the atendimento to date this turn — processing it', {
+      instanceId,
+      codAtendimento,
+      err: String(err),
+    });
+    return false;
+  }
+
+  if (latest === null) return false;
+  if (latest === text.trim()) return false;
+
+  logger.info('[asc-flow] flow restarted with a stale input variable — dropping the replay', {
+    instanceId,
+    codAtendimento,
+  });
+  return true;
+}


### PR DESCRIPTION
Follow-up to #921, from a day of driving the channel against the live Hapvida
number and flow #225. Every claim below is a measurement, and the ones that
correct an earlier claim say so.

## 1. Every bubble is PUSHED; the poll body carries no text

The `api_rest` node does not wait for the HTTP response. Measured three times
(atendimentos 22327328 and 22327711, async with `{#BODY.pronto} = 1` and
synchronous with a 45s timeout): the flow renders `{#resposta}` about a second
after the inbound, carrying the PREVIOUS cycle's value, while the agent is
still running. The platform's own Requisições report shows the node receiving
the finished body with HTTP 200 — the data arrives, the flow has moved on.

`/callbackFlowMsg` reaches the handset in ~1s and is recorded delivered, so the
whole turn leaves there and `resposta` goes back empty. `hand_off` and the two
Genesys variables still ride the body: `dec_handoff` reads them on a later
cycle, which the lag does not break.

The inbound request is also HELD until the agent answers, which removes the
question of whether the node honours `async_condition` — the condition holds on
the only response there is.

## 2. A restarted flow replays the previous input

`aguarda_usuario` has its own timeout and its timeout edge ENDS the atendimento
(`fin_1`). Silence past that ends the flow, so the next message restarts it from
`start` — and the restart re-enters `api_rest` carrying the PREVIOUS value of
the input variable, which is only written once `aguarda_usuario` validates new
input. From the Requisições report on 22342225:

```
14:46:19  turn answered; aguarda_usuario times out, ends
14:52:46  beneficiary sends "quero falar com um atendente humano"
14:52:53  api_rest calls us with chatInput "🗑️"   <- the 14:46 value
14:53:31  api_rest finally calls with the real text, 45s later
```

The session reset mid-conversation. **This corrects an earlier diagnosis of
mine**: I had blamed the frozen `{#MENSAGEM}` fallback, and `chatInput` is not
empty on the replay — it is stale. That guard could not fire, and correctly did
not.

Shape alone cannot separate the replay from a beneficiary repeating themselves,
and "1" twice in a two-step menu is a real pair of answers the suite pins. What
separates them is whether the platform recorded a new inbound message, so on
that one ambiguous path the atendimento is asked. A text that does not repeat
the last answered turn never touches the network — pinned by a test. Fails
OPEN: trouble reading the atendimento processes the turn as usual.

## 3. A list never renders on this platform

Reported from the handset: a two-option question arriving as five lines with the
options twice over.

```
Encontramos mais de uma pessoa neste cadastro. Para quem é a consulta?
1. Rogerio
2. Aneli
Pode responder com o nome.
1 - ROGERIO AMARO RODRIGUES     <- the platform appended these
2 - ANELI CAMILO AMARO
```

Measured on Baileys: `forcar_botoes: true` arrives as a `buttonsMessage` and
renders the taps; `false` arrives as a plain `conversation` with a numbered menu
the platform built from `ura_opcoes`. So a list is not a lesser rendering here —
it is no rendering, plus a menu duplicating what the agent already wrote.

The list came from `content.list.forceList` / `sectionTitle`, which the
scheduling agent sets — **not** from title length, which the SDK handles by
truncating and keeping buttons (another earlier claim of mine, corrected). Up to
three options that hint is overridden and titles are shortened on a word
boundary ("ROGERIO AMARO RODRIGUES" -> "ROGERIO AMARO"). Shortening is what can
CREATE an ambiguous pair and a tap comes back as the title, so the existing
collision check now guards the shortened titles.

## 4. The hold sits under the node's real timeout

Read off the live flow: `{"method":"1","async":"0","timeout":"45"}`. The hold
defaulted to 120s, well past it — anything held longer is answered into a socket
the node abandoned, and parked for a poll that never comes. 40s now. It clears
the measured agent latency at p90 (p50 14.7s / p90 30.2s) but not the worst run
seen (42s); that gap is the node's ceiling, and those bubbles still reach the
handset through `/callbackFlowMsg`.

The comments describing the node as async with a 180s timeout are corrected and
the older measurement is dated.

Also: `ASC_FLOW_HOLD_MS` is read per call rather than at module load. As a
constant its value depended on which module imported first, so the whole webhook
suite sat on the 120s deadline unless the caller exported the variable.

## Verified live

- buttons: agent emits the component, handset receives `buttonsMessage`, the tap
  comes back as `buttonsResponseMessage` and the agent advances
- replay: a 9-minute silence restarted the flow, the replay was dropped, and the
  five real turns of the same conversation all went through
- handoff: the flow read `hand_off:"sim"` with `fila_vq` in the same body as the
  text, and the handset received the Genesys agent's greeting

142 tests, typecheck and lint clean.

## Companion

The agent side is khal-fde/hv-scheduling#456 — it enables the interactive
component for `asc-flow` and lands the handoff signal in the same send as the
farewell.
