### PR TITLE
ci(dx): turbo-cached pre-push gates, bounded concurrency, MinIO container reaper

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,15 +9,22 @@ set -e
 # failure was already on dev. "It was already broken" is not an exception;
 # the hook stays strict so the repo state monotonically improves.
 #
+# HOW IT STAYS FAST without getting lenient: both gates run through turbo,
+# whose task hashes cover each package's own files, the sources of every
+# internal dependency (via the synthetic `topo` task in turbo.json), and the
+# env vars that gate test behavior (CI, MINIO_INTEGRATION, OMNI_*, ...).
+# A cache hit therefore replays a run of BYTE-IDENTICAL inputs — nothing is
+# skipped, previously-proven work is just not re-proven. Any change to a
+# package re-runs that package's tests plus every dependent's. To force a
+# full uncached run: `bunx turbo test --force`.
+#
+# The SDK dist/ staleness footgun is gone: `test` and `typecheck` depend on
+# `^build`, so turbo rebuilds packages/sdk (content-hashed) whenever its
+# sources change — no manual `cd packages/sdk && bun run build` needed.
+#
 # Common causes + how to fix them:
 #
-#   • Typecheck error in packages/cli referencing SDK types
-#       → SDK dist/ is stale. Run `cd packages/sdk && bun run build`,
-#         then re-push. The hook auto-builds SDK if dist/ is missing
-#         entirely, but a stale dist (older than source) is harder to
-#         detect — always rebuild after touching packages/sdk/src.
-#
-#   • Logger / Buffer / formatter tests failing in full suite but
+#   • Logger / Buffer / formatter tests failing in a package's suite but
 #     passing in isolation
 #       → Some other test file is calling `mock.module('@omni/core', ...)`
 #         with a truncated surface. Bun's mock.module is process-wide,
@@ -31,6 +38,12 @@ set -e
 #       → Bisect: `bun test <suspect_file> packages/core/src/logger`.
 #         If failing only in pairs, the suspect is poisoning shared state.
 #         Reach for spyOn/local fixtures over mock.module.
+#
+#   • MinIO suites timing out locally
+#       → The harness needs a healthy Docker daemon. Leaked test containers
+#         from OOM-killed runs degrade it; the harness reaps stale ones at
+#         launch, but `docker ps --filter label=com.automagik.omni.test-harness=minio`
+#         shows anything left to clean by hand.
 #
 #   • Force push to main/master
 #       → Refused by design. Main is production; merge through the
@@ -50,30 +63,25 @@ while read local_ref local_oid remote_ref remote_oid; do
   fi
 done
 
-# Build SDK dist if missing (CLI typecheck depends on SDK type declarations)
-if [ ! -d packages/sdk/dist ]; then
-  echo "Building SDK (dist/ missing) — re-running typecheck against fresh dist..."
-  cd packages/sdk && bun run build && cd ../..
-fi
-
-echo "▶ pre-push: typecheck"
+echo "▶ pre-push: typecheck (turbo-cached)"
 if ! make typecheck; then
   echo ""
-  echo "✗ typecheck failed."
-  echo "  → If errors reference SDK types, run: cd packages/sdk && bun run build"
-  echo "  → Then re-push. See hook header for full guidance."
+  echo "✗ typecheck failed. See hook header for guidance."
   exit 1
 fi
 
-echo "▶ pre-push: full test suite"
-if ! bun test packages apps/ui; then
+# Full test suite, per-package via turbo. Coverage is identical to the old
+# `bun test packages apps/ui` (every workspace with test files has a `test`
+# script — keep it that way when adding packages). --concurrency=4 bounds
+# concurrent bun processes so two agents pushing at once cannot exhaust swap
+# the way one monolithic 6500-test process previously did.
+echo "▶ pre-push: full test suite (turbo-cached)"
+if ! bunx turbo test --concurrency=4 --output-logs=new-only; then
   echo ""
   echo "✗ tests failed."
-  echo "  → If Logger / Buffer tests fail in the full suite but pass in"
-  echo "    isolation, hunt for a mock.module('@omni/core', ...) call in"
-  echo "    api/cli test files — that's the usual culprit. See hook"
-  echo "    header for full guidance."
-  echo "  → Bisect with: bun test <suspect_file> packages/core/src/logger"
+  echo "  → Re-run just the red package: bunx turbo test --filter=<pkg>"
+  echo "  → Force a full uncached run:   bunx turbo test --force"
+  echo "  → See hook header for mock.module / MinIO guidance."
   exit 1
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -214,8 +214,12 @@ lint-core:
 format:
 	bunx biome format --write .
 
+# Scope to omni packages + the ui app, mirroring ci.yml: apps/khal-ui is a
+# decoupled sub-project (private @khal-os deps) with its own test run, and an
+# unscoped `bun test` from the repo root sweeps it up and fails on machines
+# that do not have those deps installed.
 test: _build-dist _sync-db
-	bun test --env-file=.env
+	bun test --env-file=.env packages apps/ui
 
 test-watch: _build-dist
 	bun test --env-file=.env --watch

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/"
   },

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
-    "typecheck": "turbo typecheck",
+    "typecheck": "turbo typecheck --concurrency=4",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "turbo test",
+    "test": "turbo test --concurrency=4",
     "verify:versions": "bun scripts/verify-versions.ts",
     "db:verify-drift": "bun scripts/verify-schema-drift.ts",
     "clean": "turbo clean && rm -rf node_modules",

--- a/packages/api/src/__tests__/minio-harness-cleanup.test.ts
+++ b/packages/api/src/__tests__/minio-harness-cleanup.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
   MinioContainerLifecycle,
+  STALE_CONTAINER_MIN_AGE_MS,
   type SharedMinioHarnessDependencies,
   createSharedMinioHarness,
+  reapStaleContainers,
 } from './minio-harness';
 
 type HarnessSignal = 'SIGINT' | 'SIGTERM' | 'SIGHUP';
@@ -43,6 +45,12 @@ class FakeProcessHooks {
   }
 }
 
+interface FakePsRow {
+  id: string;
+  session: string;
+  createdAt: string;
+}
+
 class FakeDocker {
   readonly calls: string[][] = [];
   readonly events: string[];
@@ -50,15 +58,28 @@ class FakeDocker {
   private readonly containerIds: string[];
   private readonly stopFailures: Map<string, number>;
   private readonly stopThrows: Map<string, number>;
+  private readonly psRows: FakePsRow[];
+  private readonly psFails: boolean;
+  private readonly rmFailures: Map<string, number>;
 
   constructor(
     containerIds: string[],
-    options: { stopFailures?: Record<string, number>; stopThrows?: Record<string, number>; events?: string[] } = {},
+    options: {
+      stopFailures?: Record<string, number>;
+      stopThrows?: Record<string, number>;
+      events?: string[];
+      psRows?: FakePsRow[];
+      psFails?: boolean;
+      rmFailures?: Record<string, number>;
+    } = {},
   ) {
     this.containerIds = [...containerIds];
     this.stopFailures = new Map(Object.entries(options.stopFailures ?? {}));
     this.stopThrows = new Map(Object.entries(options.stopThrows ?? {}));
     this.events = options.events ?? [];
+    this.psRows = options.psRows ?? [];
+    this.psFails = options.psFails ?? false;
+    this.rmFailures = new Map(Object.entries(options.rmFailures ?? {}));
   }
 
   runSync = (command: string[]): { exitCode: number; stdout: string; stderr: string } => {
@@ -66,31 +87,62 @@ class FakeDocker {
     this.beforeCommand?.(command);
     const operation = command[1];
     if (operation === 'pull') return { exitCode: 0, stdout: '', stderr: '' };
-    if (operation === 'run') {
-      const containerId = this.containerIds.shift();
-      return containerId
-        ? { exitCode: 0, stdout: `${containerId}\n`, stderr: '' }
-        : { exitCode: 1, stdout: '', stderr: 'no fake container ID available' };
-    }
-    if (operation === 'inspect') return { exitCode: 0, stdout: 'running exit=0\n', stderr: '' };
+    if (operation === 'run') return this.handleRun();
+    if (operation === 'inspect') return this.handleInspect(command);
+    if (operation === 'ps') return this.handlePs();
+    if (operation === 'rm') return this.handleRm(command.at(-1)!);
     if (operation === 'logs') return { exitCode: 0, stdout: 'fake MinIO log\n', stderr: '' };
-    if (operation === 'stop') {
-      const containerId = command.at(-1)!;
-      this.events.push(`stop:${containerId}`);
-      const throwsRemaining = this.stopThrows.get(containerId) ?? 0;
-      if (throwsRemaining > 0) {
-        this.stopThrows.set(containerId, throwsRemaining - 1);
-        throw new Error('thrown fake stop failure');
-      }
-      const failuresRemaining = this.stopFailures.get(containerId) ?? 0;
-      if (failuresRemaining > 0) {
-        this.stopFailures.set(containerId, failuresRemaining - 1);
-        return { exitCode: 1, stdout: '', stderr: 'temporary fake stop failure' };
-      }
-      return { exitCode: 0, stdout: `${containerId}\n`, stderr: '' };
-    }
+    if (operation === 'stop') return this.handleStop(command.at(-1)!);
     throw new Error(`Unexpected fake Docker command: ${command.join(' ')}`);
   };
+
+  private handleRun(): { exitCode: number; stdout: string; stderr: string } {
+    const containerId = this.containerIds.shift();
+    return containerId
+      ? { exitCode: 0, stdout: `${containerId}\n`, stderr: '' }
+      : { exitCode: 1, stdout: '', stderr: 'no fake container ID available' };
+  }
+
+  private handleInspect(command: string[]): { exitCode: number; stdout: string; stderr: string } {
+    const format = command[3] ?? '';
+    if (!format.includes('.Created')) return { exitCode: 0, stdout: 'running exit=0\n', stderr: '' };
+    const containerId = command.at(-1)!;
+    const row = this.psRows.find((candidate) => candidate.id === containerId);
+    return row
+      ? { exitCode: 0, stdout: `${row.createdAt}\n`, stderr: '' }
+      : { exitCode: 1, stdout: '', stderr: 'no such container' };
+  }
+
+  private handlePs(): { exitCode: number; stdout: string; stderr: string } {
+    if (this.psFails) return { exitCode: 1, stdout: '', stderr: 'fake docker ps failure' };
+    const rows = this.psRows.map((row) => `${row.id}\t${row.session}`).join('\n');
+    return { exitCode: 0, stdout: rows ? `${rows}\n` : '', stderr: '' };
+  }
+
+  private handleRm(containerId: string): { exitCode: number; stdout: string; stderr: string } {
+    this.events.push(`rm:${containerId}`);
+    const failuresRemaining = this.rmFailures.get(containerId) ?? 0;
+    if (failuresRemaining > 0) {
+      this.rmFailures.set(containerId, failuresRemaining - 1);
+      return { exitCode: 1, stdout: '', stderr: 'fake rm failure' };
+    }
+    return { exitCode: 0, stdout: `${containerId}\n`, stderr: '' };
+  }
+
+  private handleStop(containerId: string): { exitCode: number; stdout: string; stderr: string } {
+    this.events.push(`stop:${containerId}`);
+    const throwsRemaining = this.stopThrows.get(containerId) ?? 0;
+    if (throwsRemaining > 0) {
+      this.stopThrows.set(containerId, throwsRemaining - 1);
+      throw new Error('thrown fake stop failure');
+    }
+    const failuresRemaining = this.stopFailures.get(containerId) ?? 0;
+    if (failuresRemaining > 0) {
+      this.stopFailures.set(containerId, failuresRemaining - 1);
+      return { exitCode: 1, stdout: '', stderr: 'temporary fake stop failure' };
+    }
+    return { exitCode: 0, stdout: `${containerId}\n`, stderr: '' };
+  }
 
   operations(operation: string): string[][] {
     return this.calls.filter((command) => command[1] === operation);
@@ -103,6 +155,10 @@ function setup(
     ready?: boolean;
     stopFailures?: Record<string, number>;
     stopThrows?: Record<string, number>;
+    psRows?: FakePsRow[];
+    psFails?: boolean;
+    rmFailures?: Record<string, number>;
+    initialClockMs?: number;
   } = {},
 ): {
   docker: FakeDocker;
@@ -113,13 +169,16 @@ function setup(
   setReady(ready: boolean): void;
   getSharedMinio: ReturnType<typeof createSharedMinioHarness>['getSharedMinio'];
 } {
-  let clock = 0;
+  let clock = options.initialClockMs ?? 0;
   let ready = options.ready ?? true;
   const events: string[] = [];
   const docker = new FakeDocker(containerIds, {
     stopFailures: options.stopFailures,
     stopThrows: options.stopThrows,
     events,
+    psRows: options.psRows,
+    psFails: options.psFails,
+    rmFailures: options.rmFailures,
   });
   const fakeProcess = new FakeProcessHooks(events);
   const cleanupFailures: string[] = [];
@@ -193,7 +252,13 @@ describe('shared MinIO harness cleanup', () => {
     fake.process.emit('exit');
 
     expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-normal']]);
-    expect(fake.docker.calls.some((command) => command.includes('prune') || command[1] === 'ps')).toBe(false);
+    // Cleanup must stay surgical: no prunes ever, and any container listing is
+    // scoped to this harness's own label (the stale-container reaper).
+    expect(fake.docker.calls.some((command) => command.includes('prune'))).toBe(false);
+    for (const ps of fake.docker.operations('ps')) {
+      expect(ps).toContain('label=com.automagik.omni.test-harness=minio');
+    }
+    expect(fake.docker.operations('rm')).toHaveLength(0);
   });
 
   test('registers handlers before launch and closes a SIGTERM race around the blocking run command', async () => {
@@ -287,7 +352,11 @@ describe('shared MinIO harness cleanup', () => {
       'Failed to stop tracked MinIO test container container-first: temporary fake stop failure',
       'Failed to stop tracked MinIO test container container-first: temporary fake stop failure',
     ]);
-    expect(fake.docker.calls.some((command) => command.includes('prune') || command[1] === 'ps')).toBe(false);
+    expect(fake.docker.calls.some((command) => command.includes('prune'))).toBe(false);
+    for (const ps of fake.docker.operations('ps')) {
+      expect(ps).toContain('label=com.automagik.omni.test-harness=minio');
+    }
+    expect(fake.docker.operations('rm')).toHaveLength(0);
   });
 
   test('attempts every tracked ID and preserves native 143 when one SIGTERM stop throws', () => {
@@ -335,4 +404,84 @@ describe('shared MinIO harness cleanup', () => {
     expect(observedSignal?.aborted).toBe(true);
     expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-hung-probe']]);
   }, 250);
+});
+
+describe('stale MinIO container reaper', () => {
+  const EPOCH = '1970-01-01T00:00:00.000Z'; // Date.parse => 0 against the fake clock
+  const THIRTY_MIN = '1970-01-01T00:30:00.000Z';
+  const STALE_CLOCK = STALE_CONTAINER_MIN_AGE_MS + 60_000; // 31 minutes
+
+  test('launch force-removes an abandoned foreign-session container and leaves fresh or own-session ones', async () => {
+    const fake = setup(['container-normal'], {
+      initialClockMs: STALE_CLOCK,
+      psRows: [
+        { id: 'leaked-old', session: 'session-dead', createdAt: EPOCH },
+        { id: 'fresh-foreign', session: 'session-live', createdAt: THIRTY_MIN },
+        { id: 'own-live', session: 'session-123', createdAt: EPOCH },
+      ],
+    });
+
+    await fake.getSharedMinio();
+
+    expect(fake.docker.operations('rm')).toEqual([['docker', 'rm', '-f', 'leaked-old']]);
+    // Only the reap candidates from OTHER sessions are even inspected.
+    const inspectedIds = fake.docker
+      .operations('inspect')
+      .filter((command) => command[3]?.includes('.Created'))
+      .map((command) => command.at(-1));
+    expect(inspectedIds).toEqual(['leaked-old', 'fresh-foreign']);
+    expect(fake.cleanupFailures).toEqual([]);
+  });
+
+  test('a failed listing reaps nothing and never blocks the launch', async () => {
+    const fake = setup(['container-normal'], { psFails: true, initialClockMs: STALE_CLOCK });
+
+    await expect(fake.getSharedMinio()).resolves.toMatchObject({ accessKey: 'minioadmin' });
+
+    expect(fake.docker.operations('rm')).toHaveLength(0);
+  });
+
+  test('a failed removal is reported and never blocks the launch', async () => {
+    const fake = setup(['container-normal'], {
+      initialClockMs: STALE_CLOCK,
+      psRows: [{ id: 'leaked-stubborn', session: 'session-dead', createdAt: EPOCH }],
+      rmFailures: { 'leaked-stubborn': 1 },
+    });
+
+    await expect(fake.getSharedMinio()).resolves.toMatchObject({ accessKey: 'minioadmin' });
+
+    expect(fake.cleanupFailures).toEqual([
+      'Failed to reap stale MinIO test container leaked-stubborn: fake rm failure',
+    ]);
+  });
+
+  test('an unparseable creation time is left alone', () => {
+    const fake = setup([], {
+      initialClockMs: STALE_CLOCK,
+      psRows: [{ id: 'weird-timestamp', session: 'session-dead', createdAt: 'not-a-date' }],
+    });
+
+    reapStaleContainers(fake.dependencies);
+
+    expect(fake.docker.operations('rm')).toHaveLength(0);
+  });
+
+  test('a container that disappears between listing and inspection is skipped', () => {
+    const fake = setup([], { initialClockMs: STALE_CLOCK });
+    // Listed but not inspectable: FakeDocker answers ps from psRows, so fake a
+    // vanished container by making ps report an id inspect will not find.
+    const vanishing = new FakeDocker([], {
+      psRows: [{ id: 'vanished', session: 'session-dead', createdAt: EPOCH }],
+    });
+    const psOnly = vanishing.runSync;
+    fake.dependencies.runSync = (command) => {
+      if (command[1] === 'ps') return psOnly(command);
+      if (command[1] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'no such container' };
+      return fake.docker.runSync(command);
+    };
+
+    reapStaleContainers(fake.dependencies);
+
+    expect(fake.docker.operations('rm')).toHaveLength(0);
+  });
 });

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -348,6 +348,71 @@ export class MinioContainerLifecycle {
   }
 }
 
+/**
+ * How old a labeled container must be before another session may reap it.
+ * A live suite run holds its container for a few minutes at most (readiness
+ * budget is 120s, the suites themselves finish well inside pre-push), so half
+ * an hour of age means the owning process is long gone — while a concurrent
+ * agent's freshly started container is never touched.
+ */
+export const STALE_CONTAINER_MIN_AGE_MS = 30 * 60 * 1000;
+
+/**
+ * Reap MinIO test containers leaked by PREVIOUS test processes.
+ *
+ * The exit/signal teardown in MinioContainerLifecycle cannot run when the test
+ * process dies to SIGKILL — which is exactly what the OOM killer delivers (the
+ * observed exit-144 incidents when two agents ran the full suite at once).
+ * Each leaked container keeps 512MB reserved and slowly degrades the Docker
+ * daemon until the readiness probe itself starts flaking. So the moment a new
+ * container is about to launch is also the moment to sweep: any RUNNING
+ * container carrying our harness label, from a different session, older than
+ * STALE_CONTAINER_MIN_AGE_MS is unambiguously abandoned and force-removed.
+ * Entirely best-effort — a reap failure is reported and never blocks the
+ * launch.
+ */
+export function reapStaleContainers(dependencies: SharedMinioHarnessDependencies): void {
+  const list = dependencies.runSync([
+    'docker',
+    'ps',
+    '--filter',
+    'label=com.automagik.omni.test-harness=minio',
+    '--format',
+    '{{.ID}}\t{{.Label "com.automagik.omni.test-session"}}',
+  ]);
+  if (list.exitCode !== 0) return;
+
+  for (const line of list.stdout.split('\n')) {
+    const [containerId, session] = line.trim().split('\t');
+    if (!containerId || session === dependencies.sessionId) continue;
+
+    // RFC3339 from inspect (docker ps only offers a locale-shaped CreatedAt).
+    const created = dependencies.runSync(['docker', 'inspect', '-f', '{{.Created}}', containerId]);
+    if (created.exitCode !== 0) continue; // gone already — nothing to reap
+    const createdAtMs = Date.parse(created.stdout.trim());
+    if (Number.isNaN(createdAtMs)) continue; // unparseable — leave it alone
+    if (dependencies.now() - createdAtMs < STALE_CONTAINER_MIN_AGE_MS) continue;
+
+    const removed = dependencies.runSync(['docker', 'rm', '-f', containerId]);
+    if (removed.exitCode !== 0) {
+      dependencies.reportCleanupFailure(
+        `Failed to reap stale MinIO test container ${containerId}: ${removed.stderr.trim() || `exit ${removed.exitCode}`}`,
+      );
+    }
+  }
+}
+
+/** reapStaleContainers with every failure funneled to reportCleanupFailure. */
+function reapStaleContainersGuarded(dependencies: SharedMinioHarnessDependencies): void {
+  try {
+    reapStaleContainers(dependencies);
+  } catch (error) {
+    dependencies.reportCleanupFailure(
+      `Stale-container reap failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 export function createSharedMinioHarness(dependencies: SharedMinioHarnessDependencies): {
   getSharedMinio(): Promise<SharedMinio>;
 } {
@@ -358,6 +423,10 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
     // Register signal/exit cleanup before any blocking Docker operation and
     // fail closed if an earlier container has not been successfully stopped.
     lifecycle.prepareForLaunch();
+
+    // Best-effort sweep of containers leaked by SIGKILLed previous runs —
+    // never allowed to fail or delay this launch.
+    reapStaleContainersGuarded(dependencies);
 
     // Pre-pull explicitly so a cold image cache (fresh CI runner) cannot eat
     // into the readiness budget or fail the run with an opaque timeout.

--- a/packages/channel-sdk/turbo.json
+++ b/packages/channel-sdk/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    }
+  }
+}

--- a/packages/media-processing/turbo.json
+++ b/packages/media-processing/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -12,8 +12,12 @@
     "lint": {
       "outputs": []
     },
+    "topo": {
+      "dependsOn": ["^topo"]
+    },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^topo"],
+      "env": ["CI", "NODE_ENV", "MINIO_INTEGRATION", "DATABASE_URL", "OMNI_*"],
       "outputs": []
     },
     "dev": {


### PR DESCRIPTION
## Summary

Makes the local git hooks fast without weakening what they prove, and fixes the two reliability problems found along the way (leaked MinIO containers, unscoped `make test`).

- **`ci(turbo)`** — give the `test` task an accurate fingerprint: a synthetic `topo` task threads internal-dependency sources into every test hash (most packages have no build script, so `^build` alone missed them), gating env vars (`CI`, `NODE_ENV`, `MINIO_INTEGRATION`, `DATABASE_URL`, `OMNI_*`) are declared and hashed, the two `tsc`-under-`noEmit` "builds" stop claiming `dist/**` outputs, and `apps/ui` gets the `test` script it was missing.
- **`ci(hooks)`** — pre-push runs typecheck + tests through turbo. A cache hit replays a byte-identical previously-green run; `--force` escapes. `--concurrency=4` bounds peak memory (turbo's default 10 concurrent `tsc` at ~790MB each is what exhausted swap when two agents pushed at once). The stale-SDK-dist footgun is gone: `^build` is content-hashed, so a stale dist rebuilds, not just a missing one.
- **`test(api)`** — the MinIO harness reaps harness-labeled containers from dead sessions (>30 min old) before each launch. SIGKILL (OOM) skips the teardown; this machine had accumulated 43 leaked containers that degraded Docker enough to flake the readiness/TTL tests and inflate the api suite from ~40s to ~107s. Cleanup stays surgical: label-scoped listing only, never prune, never unlabeled or fresh/own-session containers.
- **`fix(make)`** — `make test` scopes to `packages apps/ui` like ci.yml; unscoped it swept the decoupled `apps/khal-ui` sub-project and failed on machines without its private `@khal-os` deps.

## Timings (same machine, same commands)

| Gate | Before | After |
|---|---|---|
| pre-push, nothing changed | ~4 min (full typecheck + full 6800-test suite, every push) | **~0.6s** (FULL TURBO) |
| pre-push, leaf package changed | same ~2–4 min | **~19s** (that package + dependents) |
| pre-push, fully invalidated (`--force`) | — | 13.7s typecheck + 40.8s tests |
| full suite wall (cold cache, healthy Docker) | 102s monolithic | 40.8s per-package @ concurrency 4 |

## Verification

- Coverage parity proven: **6186 pass / 631 skip / 0 fail** in both monolithic and per-package modes (+5 new reaper tests).
- Fingerprints verified by hash: touching `packages/core` invalidates `@omni/api#test`; a leaf change invalidates only that leaf; setting `MINIO_INTEGRATION` changes the hash.
- CI's Quality Gate keeps its uncached monolithic `bun test packages apps/ui` as the run of record — the pre-push cache is never in the enforcement path of the merge gate.
- `make check` green end-to-end.