### PR TITLE
perf(dx): cut local gate wall-clock (make check + test-pg-gate)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -257,13 +257,23 @@ make dev-services # Start PostgreSQL + NATS + API via PM2
 
 ```bash
 make check        # All checks: typecheck + lint + test
+make check-all    # check + the real-PostgreSQL gate, run CONCURRENTLY (fastest full validation)
 make typecheck    # TypeScript only
 make lint         # Biome linter
 make lint-fix     # Auto-fix lint issues
-make test         # All tests
+make test         # All tests (per-package via turbo — unchanged packages replay their cached green run)
+make test-sweep   # All tests in ONE process (CI parity; use to hunt cross-file state leaks)
 make test-api     # API package tests only
 make test-file F=<path>  # Specific test file
+make test-pg-gate       # Every real-PostgreSQL suite on a fresh disposable cluster (never skips)
+make test-pg-gate-warm  # Same gate against a kept-warm cluster (fast dev loop; state in .pg-gate-warm.json)
+make pg-gate-warm-stop  # Destroy the kept-warm cluster
 ```
+
+Test runs default to `LOG_LEVEL=silent` (suites intentionally exercise noisy
+warn/error paths). Re-enable logs for a run with `make test TEST_LOG_LEVEL=debug`.
+Tests that assert on log output must `configureLogging({ level: ... })`
+themselves rather than rely on the ambient threshold.
 
 ### Individual Services
 

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ deploy/helm/omni/values-local.yaml
 
 # Local #889 test env (contains DB password)
 .env.889
+
+# pg-gate keep-warm cluster state (#967)
+.pg-gate-warm.json

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -76,6 +76,10 @@ fi
 # concurrent bun processes so two agents pushing at once cannot exhaust swap
 # the way one monolithic 6500-test process previously did.
 echo "▶ pre-push: full test suite (turbo-cached)"
+# Suites intentionally exercise thousands of warn/error log paths; mute the
+# app logger unless the pusher asked for logs (#967). LOG_LEVEL is not part
+# of the turbo test hash — tests must not depend on the ambient threshold.
+export LOG_LEVEL="${LOG_LEVEL:-silent}"
 if ! bunx turbo test --concurrency=4 --continue --output-logs=new-only; then
   echo ""
   echo "✗ tests failed."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -76,7 +76,7 @@ fi
 # concurrent bun processes so two agents pushing at once cannot exhaust swap
 # the way one monolithic 6500-test process previously did.
 echo "▶ pre-push: full test suite (turbo-cached)"
-if ! bunx turbo test --concurrency=4 --output-logs=new-only; then
+if ! bunx turbo test --concurrency=4 --continue --output-logs=new-only; then
   echo ""
   echo "✗ tests failed."
   echo "  → Re-run just the red package: bunx turbo test --filter=<pkg>"

--- a/Makefile
+++ b/Makefile
@@ -228,8 +228,11 @@ format:
 # Env is loaded into the environment here because per-package `bun test` runs
 # have no --env-file. Workspaces only — apps/khal-ui stays out (private
 # @khal-os deps, own test run).
+# LOG_LEVEL is forced to 'silent' AFTER .env loads (which sets debug): suites
+# intentionally exercise thousands of warn/error paths and the JSON flood is
+# pure I/O + noise (#967). Override: make test TEST_LOG_LEVEL=debug
 test: _build-dist _sync-db
-	@set -a && . ./.env && set +a && bun run test
+	@set -a && . ./.env && set +a && LOG_LEVEL=$(or $(TEST_LOG_LEVEL),silent) bun run test
 
 # The pre-#967 single-process sweep, kept for CI parity and for hunting
 # cross-file state leaks (e.g. globalThis.fetch pollution) that only reproduce

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Universal Event-Driven Omnichannel Platform
 
 .PHONY: help install dev dev-api dev-ui dev-services dev-stop build build-ui clean version \
-        test test-watch test-api test-db test-pg-gate typecheck typecheck-ui lint lint-fix lint-ui format check dead-code verify-migrations \
+        test test-sweep test-watch test-api test-db test-pg-gate typecheck typecheck-ui lint lint-fix lint-ui format check dead-code verify-migrations \
         db-push db-migrate db-studio db-reset \
         ensure-nats ensure-ffmpeg check-ffmpeg check-deps start stop restart logs status \
         restart-api restart-nats restart-pgserve logs-api \
@@ -35,7 +35,8 @@ help:
 	@echo "  make lint-api      Lint API package only"
 	@echo "  make format        Format code with Biome"
 	@echo "  make dead-code     Run knip dead code detection"
-	@echo "  make test          Run all tests"
+	@echo "  make test          Run all tests (per-package, turbo-cached)"
+	@echo "  make test-sweep    Run all tests in one process (CI parity, leak hunting)"
 	@echo "  make test-watch    Run tests in watch mode"
 	@echo "  make test-api      Run API package tests only"
 	@echo "  make test-db       Run DB package tests only"
@@ -215,11 +216,21 @@ lint-core:
 format:
 	bunx biome format --write .
 
-# Scope to omni packages + the ui app, mirroring ci.yml: apps/khal-ui is a
-# decoupled sub-project (private @khal-os deps) with its own test run, and an
-# unscoped `bun test` from the repo root sweeps it up and fails on machines
-# that do not have those deps installed.
+# Per-package tests via turbo (#967): unchanged packages replay their cached
+# green run instead of re-executing, so an incremental `make check` pays only
+# for the packages the change touched. The turbo `test` task hashes
+# DATABASE_URL / TEST_DATABASE_URL / ENABLE_DB_TESTS / OMNI_* on top of each
+# package's files, so pointing at a different database invalidates the cache.
+# Env is loaded into the environment here because per-package `bun test` runs
+# have no --env-file. Workspaces only — apps/khal-ui stays out (private
+# @khal-os deps, own test run).
 test: _build-dist _sync-db
+	@set -a && . ./.env && set +a && bun run test
+
+# The pre-#967 single-process sweep, kept for CI parity and for hunting
+# cross-file state leaks (e.g. globalThis.fetch pollution) that only reproduce
+# when every suite shares one process.
+test-sweep: _build-dist _sync-db
 	bun test --env-file=.env packages apps/ui
 
 test-watch: _build-dist

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # Universal Event-Driven Omnichannel Platform
 
 .PHONY: help install dev dev-api dev-ui dev-services dev-stop build build-ui clean version \
-        test test-sweep test-watch test-api test-db test-pg-gate typecheck typecheck-ui lint lint-fix lint-ui format check check-all dead-code verify-migrations \
+        test test-sweep test-watch test-api test-db test-pg-gate test-pg-gate-warm pg-gate-warm-stop \
+        typecheck typecheck-ui lint lint-fix lint-ui format check check-all dead-code verify-migrations \
         db-push db-migrate db-studio db-reset \
         ensure-nats ensure-ffmpeg check-ffmpeg check-deps start stop restart logs status \
         restart-api restart-nats restart-pgserve logs-api \
@@ -42,6 +43,8 @@ help:
 	@echo "  make test-api      Run API package tests only"
 	@echo "  make test-db       Run DB package tests only"
 	@echo "  make test-pg-gate  Run every real-PostgreSQL suite (fails loudly, never skips)"
+	@echo "  make test-pg-gate-warm  Same gate against a kept-warm cluster (fast dev loop)"
+	@echo "  make pg-gate-warm-stop  Destroy the kept-warm pg-gate cluster"
 	@echo "  make test-file F=<path>  Run a specific test file"
 	@echo "  make kill-stale-test-daemons  Sweep leaked PM2 god daemons from CLI tests (#413)"
 	@echo ""
@@ -264,6 +267,16 @@ test-db:
 # DATABASE_URL or a shared cluster.
 test-pg-gate:
 	bun scripts/pg-gate.ts
+
+# Keep-warm variant (#967): first run creates the disposable cluster and
+# remembers it in .pg-gate-warm.json; later runs reuse it via --url, skipping
+# the ~15-20s initdb + role setup per iteration. Same gate, same zero-skip
+# contract. `make pg-gate-warm-stop` destroys the kept cluster.
+test-pg-gate-warm:
+	bun scripts/pg-gate-warm.ts run
+
+pg-gate-warm-stop:
+	bun scripts/pg-gate-warm.ts stop
 
 # Run a specific test file (usage: make test-file F=packages/api/src/__tests__/foo.test.ts)
 test-file:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Universal Event-Driven Omnichannel Platform
 
 .PHONY: help install dev dev-api dev-ui dev-services dev-stop build build-ui clean version \
-        test test-sweep test-watch test-api test-db test-pg-gate typecheck typecheck-ui lint lint-fix lint-ui format check dead-code verify-migrations \
+        test test-sweep test-watch test-api test-db test-pg-gate typecheck typecheck-ui lint lint-fix lint-ui format check check-all dead-code verify-migrations \
         db-push db-migrate db-studio db-reset \
         ensure-nats ensure-ffmpeg check-ffmpeg check-deps start stop restart logs status \
         restart-api restart-nats restart-pgserve logs-api \
@@ -28,6 +28,7 @@ help:
 	@echo ""
 	@echo "Quality:"
 	@echo "  make check         Run all quality checks (typecheck + lint + dead-code + migrations + test)"
+	@echo "  make check-all     Run check AND the pg-gate concurrently (fastest full validation)"
 	@echo "  make verify-migrations  Static migration contract gate (journal/immutability/lint)"
 	@echo "  make typecheck     TypeScript type checking"
 	@echo "  make lint          Run Biome linter"
@@ -283,6 +284,24 @@ verify-migrations:
 check: typecheck lint dead-code verify-migrations test
 	@echo ""
 	@echo "All checks passed!"
+
+# Run `make check` and the real-PostgreSQL gate CONCURRENTLY (#967). Safe
+# because the pg-gate stands up its own disposable cluster on a random
+# loopback port and never reads .env, so it cannot collide with check's
+# database. pg-gate output is spooled to a temp file and replayed after
+# check's, so the two streams never interleave.
+check-all:
+	@pg_out=$$(mktemp -t omni-pg-gate-out); \
+	( $(MAKE) test-pg-gate >"$$pg_out" 2>&1 ) & pg_pid=$$!; \
+	check_status=0; $(MAKE) check || check_status=$$?; \
+	pg_status=0; wait $$pg_pid || pg_status=$$?; \
+	echo ""; echo "===== pg-gate (ran concurrently) ====="; \
+	cat "$$pg_out"; rm -f "$$pg_out"; \
+	if [ $$check_status -ne 0 ] || [ $$pg_status -ne 0 ]; then \
+		echo ""; echo "check-all: FAILED (check=$$check_status, pg-gate=$$pg_status)"; \
+		exit 1; \
+	fi; \
+	echo ""; echo "check-all: PASSED — check and pg-gate both green"
 
 # ============================================================================
 # Database (Drizzle)

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,12 @@
   "$schema": "https://unpkg.com/knip@5.85.0/schema.json",
   "workspaces": {
     ".": {
-      "entry": ["scripts/test-messaging.ts", "scripts/kill-stale-test-daemons.ts", "scripts/pg-gate.ts"],
+      "entry": [
+        "scripts/test-messaging.ts",
+        "scripts/kill-stale-test-daemons.ts",
+        "scripts/pg-gate.ts",
+        "scripts/pg-gate-warm.ts"
+      ],
       "project": ["scripts/**/*.ts"],
       "ignore": [
         "scripts/backfill-*.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "turbo test --concurrency=4",
+    "test": "turbo test --concurrency=4 --continue",
     "verify:versions": "bun scripts/verify-versions.ts",
     "db:verify-drift": "bun scripts/verify-schema-drift.ts",
     "clean": "turbo clean && rm -rf node_modules",

--- a/packages/api/scripts/__tests__/reconcile-identity-fragmentation-postgres.test.ts
+++ b/packages/api/scripts/__tests__/reconcile-identity-fragmentation-postgres.test.ts
@@ -18,34 +18,22 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { type Database, createDbHandle, persons, platformIdentities } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { reconcile } from '../reconcile-identity-fragmentation';
 
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
 
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', 'db', 'drizzle');
-
 const INSTANCE = '55555555-5555-4555-8555-5555555555b1';
 const PERSON_BARE = '99999999-9999-4999-8999-9999999999b1';
 const PERSON_SUFFIXED = '99999999-9999-4999-8999-9999999999b2';
 const PERSON_LID = '99999999-9999-4999-8999-9999999999b3';
 const PERSON_PHONE = '99999999-9999-4999-8999-9999999999b4';
-
-/** Every migration SQL file concatenated, applied to a fresh database. */
-function loadMigrations(): string {
-  return readdirSync(drizzleDir)
-    .filter((f) => f.endsWith('.sql'))
-    .sort()
-    .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-    .join('\n');
-}
 
 /**
  * Create + migrate a fresh disposable database, returning a handle and a
@@ -58,11 +46,8 @@ async function provisionDatabase(): Promise<{
   cleanup: () => Promise<void>;
 }> {
   const dbName = `omni_p0_recon_${crypto.randomUUID().replaceAll('-', '')}`;
-  const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-  if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+  provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
   const dbUrl = urlFor(superUrl, dbName);
-  const migrated = runSqlOn(dbUrl, loadMigrations());
-  if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
   const handle = createDbHandle({ url: dbUrl, maxConnections: 2 });
   return {
     db: handle.db,
@@ -141,17 +126,8 @@ postgresDescribe('reconciliation script dry-run mutates nothing (real PostgreSQL
   let db: Database;
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const dbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(dbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     // Seed: a fragmented number (bare + suffixed → two persons) and a phone-less
     // @lid person whose phone is derivable from chat_id_mappings. The instance is

--- a/packages/api/src/__tests__/follow-up-freshness-postgres.test.ts
+++ b/packages/api/src/__tests__/follow-up-freshness-postgres.test.ts
@@ -17,12 +17,12 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus, FollowUpSequenceConfig } from '@omni/core';
 import { type Database, chatFollowUpState, chats, createDbHandle, instances } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { and, eq } from 'drizzle-orm';
 import {
   FollowUpLifecycleService,
@@ -33,9 +33,6 @@ import {
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', 'db', 'drizzle');
 
 function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
   const file = join(tmpdir(), `omni-followup-${crypto.randomUUID()}.sql`);
@@ -89,17 +86,8 @@ postgresDescribe('evaluateIdleTimeoutFreshness (real PostgreSQL)', () => {
   } as unknown as EventBus;
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const dbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(dbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const handle = createDbHandle({ url: dbUrl, maxConnections: 3 });
     db = handle.db;

--- a/packages/api/src/plugins/__tests__/agent-dispatcher-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-two-tenant-postgres.test.ts
@@ -25,10 +25,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -38,6 +37,7 @@ import {
   createDbHandle,
   handoffLogs,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { RouteResolver } from '../../services/route-resolver';
 import { scopedHandle } from '../../tenancy/tenant-scope';
@@ -47,9 +47,6 @@ import { applyAgentFkOverrides, __test__ as dispatcherTest } from '../agent-disp
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
 const TENANT_B = '22222222-2222-4222-8222-2222222222ab';
@@ -122,17 +119,8 @@ postgresDescribe('two-tenant agent-dispatcher containment (real PostgreSQL)', ()
     );
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/plugins/__tests__/automation-actions-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/automation-actions-two-tenant-postgres.test.ts
@@ -29,10 +29,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -40,15 +39,13 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { createServices } from '../../services';
 import { buildAutomationEngineDeps } from '../automation-actions';
 
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111aa';
 const TENANT_B = '22222222-2222-4222-8222-2222222222bb';
@@ -103,17 +100,8 @@ postgresDescribe('two-tenant automation-actions containment (real PostgreSQL)', 
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     // Seed: both tenants own an instance and a chat. The agent row is
     // deliberately NULL-tenant — that IS production's shape until the G6

--- a/packages/api/src/plugins/__tests__/event-listeners-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/event-listeners-two-tenant-postgres.test.ts
@@ -25,10 +25,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import {
   DEFAULT_ROLE_NAMES,
@@ -40,6 +39,7 @@ import {
   createDbHandle,
   instances,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { scopedHandle } from '../../tenancy/tenant-scope';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
@@ -53,9 +53,6 @@ import {
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111ea';
 const TENANT_B = '22222222-2222-4222-8222-2222222222eb';
@@ -175,17 +172,8 @@ postgresDescribe('two-tenant event-listeners containment (real PostgreSQL)', () 
     );
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/plugins/__tests__/identity-canonicalization-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/identity-canonicalization-postgres.test.ts
@@ -21,12 +21,12 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import { type Database, createDbHandle, persons, platformIdentities } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { createServices } from '../../services';
 import { setupMessagePersistence } from '../message-persistence';
@@ -34,9 +34,6 @@ import { setupMessagePersistence } from '../message-persistence';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const INSTANCE_WA = '55555555-5555-4555-8555-5555555555c1';
 const INSTANCE_TWILIO = '55555555-5555-4555-8555-5555555555c2';
@@ -121,17 +118,8 @@ postgresDescribe('identity canonicalization + exclusion (real PostgreSQL)', () =
   let fire: (type: string, event: unknown) => Promise<void>;
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const dbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(dbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     // Instances are seeded WITHOUT a tenant. This suite runs the legacy world
     // (no RLS): a non-null instance tenant would make the derivation trigger

--- a/packages/api/src/plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts
@@ -26,10 +26,9 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { ChannelRegistry } from '@omni/channel-sdk';
 import {
   DEFAULT_ROLE_NAMES,
@@ -39,6 +38,7 @@ import {
   createDbHandle,
   instances,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
 import { __resetInstanceOwnerRegistry, rememberInstanceOwners } from '../../tenancy/instance-owner-registry';
@@ -47,9 +47,6 @@ import { InstanceMonitor, reconnectWithPool } from '../instance-monitor';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-11111111111a';
 const TENANT_B = '22222222-2222-4222-8222-22222222222b';
@@ -120,17 +117,8 @@ postgresDescribe('instance-monitor sweeps under real RLS enforcement', () => {
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/media-processor-two-tenant-postgres.test.ts
@@ -19,10 +19,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -32,6 +31,7 @@ import {
   mediaContent,
   messages,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { scopedHandle } from '../../tenancy/tenant-scope';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
@@ -40,9 +40,6 @@ import { __test__ as mediaProcessorTest } from '../media-processor';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111ca';
 const TENANT_B = '22222222-2222-4222-8222-2222222222cb';
@@ -143,17 +140,8 @@ postgresDescribe('two-tenant media-processor containment (real PostgreSQL)', () 
     );
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/plugins/__tests__/message-persistence-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-two-tenant-postgres.test.ts
@@ -32,10 +32,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import {
   DEFAULT_ROLE_NAMES,
@@ -46,6 +45,7 @@ import {
   createDbHandle,
   messages,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { and, eq } from 'drizzle-orm';
 import { createServices } from '../../services';
 import { scopedHandle } from '../../tenancy/tenant-scope';
@@ -55,9 +55,6 @@ import { setupMessagePersistence } from '../message-persistence';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111da';
 const TENANT_B = '22222222-2222-4222-8222-2222222222db';
@@ -206,17 +203,8 @@ postgresDescribe('two-tenant message-persistence containment (real PostgreSQL)',
   };
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     // Only the tenants and their instances are seeded. The chats, messages,
     // participants and identities under test are created BY the consumer.

--- a/packages/api/src/plugins/__tests__/session-cluster-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cluster-two-tenant-postgres.test.ts
@@ -26,10 +26,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -37,6 +36,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { AgentRunnerService } from '../../services/agent-runner';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
 import { __test__ as sessionCleanerTest } from '../session-cleaner';
@@ -45,9 +45,6 @@ import { createSessionStorage } from '../session-storage';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111ca';
 const TENANT_B = '22222222-2222-4222-8222-2222222222cb';
@@ -107,17 +104,8 @@ postgresDescribe('two-tenant session/dispatch-backend containment (real PostgreS
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/plugins/__tests__/sync-worker-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker-two-tenant-postgres.test.ts
@@ -18,10 +18,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -30,6 +29,7 @@ import {
   createDbHandle,
   omniGroups,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { scopedHandle } from '../../tenancy/tenant-scope';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
@@ -38,9 +38,6 @@ import { __test__ as syncWorkerTest } from '../sync-worker';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111da';
 const TENANT_B = '22222222-2222-4222-8222-2222222222db';
@@ -108,17 +105,8 @@ postgresDescribe('two-tenant sync-worker containment (real PostgreSQL)', () => {
     );
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/services/__tests__/event-schema-gates-postgres.test.ts
+++ b/packages/api/src/services/__tests__/event-schema-gates-postgres.test.ts
@@ -20,13 +20,13 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import { executeAction } from '@omni/core';
 import { type Database, createDbHandle, deadLetterEvents } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { buildAutomationEngineDeps } from '../../plugins/automation-actions';
 import { DeadLetterService } from '../dead-letters';
 import { EventSchemaService } from '../event-schemas';
@@ -36,9 +36,6 @@ import { WebhookService } from '../webhooks';
 const superUrl = process.env.OMNI_G1_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G1_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
   const file = join(tmpdir(), `omni-959-registry-${crypto.randomUUID()}.sql`);
@@ -106,17 +103,8 @@ postgresDescribe('event schema registry gates (real PostgreSQL)', () => {
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const dbUrl = urlFor(superUrl, dbName);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
-    const migrated = runSqlOn(dbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const handle = createDbHandle({ url: dbUrl, maxConnections: 3 });
     closers.push(() => handle.close().catch(() => undefined));

--- a/packages/api/src/services/__tests__/follow-up-sweeper-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/follow-up-sweeper-two-tenant-postgres.test.ts
@@ -27,10 +27,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import {
   DEFAULT_ROLE_NAMES,
@@ -40,6 +39,7 @@ import {
   chatFollowUpState,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
 import { scopedHandle } from '../../tenancy/tenant-scope';
@@ -53,9 +53,6 @@ const ENFORCEMENT_ENV = 'OMNI_DB_ENFORCEMENT';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111fa';
 const TENANT_B = '22222222-2222-4222-8222-2222222222fb';
@@ -175,17 +172,8 @@ postgresDescribe('two-tenant follow-up sweeper fan-out (real PostgreSQL)', () =>
       savedEnv[key] = process.env[key];
     }
 
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     superDbUrl = urlFor(superUrl, dbName);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/services/__tests__/sealed-credentials-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/sealed-credentials-two-tenant-postgres.test.ts
@@ -23,10 +23,9 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { setTenantSecretMasterKey } from '@omni/core';
 import {
   DEFAULT_ROLE_NAMES,
@@ -35,6 +34,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { isSealedCredentialField, openCredentialField } from '../../tenancy/sealed-credentials';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
 import { InstanceService } from '../instances';
@@ -42,9 +42,6 @@ import { InstanceService } from '../instances';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-1111111111da';
 const TENANT_B = '22222222-2222-4222-8222-2222222222db';
@@ -108,17 +105,8 @@ postgresDescribe('two-tenant sealed credentials at rest (real PostgreSQL)', () =
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/services/__tests__/sync-jobs-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/sync-jobs-two-tenant-postgres.test.ts
@@ -30,10 +30,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import {
   DEFAULT_ROLE_NAMES,
@@ -42,14 +41,12 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { SyncJobService } from '../sync-jobs';
 
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-11111111aa1a';
 const TENANT_B = '22222222-2222-4222-8222-22222222bb2b';
@@ -109,17 +106,8 @@ postgresDescribe('two-tenant sync-job containment (real PostgreSQL)', () => {
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/services/__tests__/webhook-idempotency-postgres.test.ts
+++ b/packages/api/src/services/__tests__/webhook-idempotency-postgres.test.ts
@@ -20,13 +20,13 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus } from '@omni/core';
 import { executeActions } from '@omni/core';
 import { type Database, createDbHandle, omniEvents, webhookSources } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { buildAutomationEngineDeps } from '../../plugins/automation-actions';
 import type { Services } from '../../services';
@@ -35,9 +35,6 @@ import { WebhookService } from '../webhooks';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
   const file = join(tmpdir(), `omni-958-idempotency-${crypto.randomUUID()}.sql`);
@@ -86,17 +83,8 @@ postgresDescribe('webhook ingress idempotency (real PostgreSQL)', () => {
   let close: () => Promise<void>;
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     dbUrl = urlFor(superUrl, dbName);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
-    const migrated = runSqlOn(dbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const handle = createDbHandle({ url: dbUrl, maxConnections: 3 });
     db = handle.db;

--- a/packages/api/src/tenancy/__tests__/auth-plane-wiring-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/auth-plane-wiring-postgres.test.ts
@@ -19,10 +19,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -31,15 +30,13 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { AUTH_PLANE_URL_ENV_VAR, resolveAuthPlaneConnection } from '../auth-plane-connection';
 import { MembershipSelectionService } from '../request-auth';
 
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-111111111111';
 const PRINCIPAL_A = '33333333-3333-4333-8333-333333333331';
@@ -91,17 +88,8 @@ postgresDescribe('auth-plane wiring (real PostgreSQL)', () => {
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/tenancy/__tests__/http-two-tenant-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/http-two-tenant-postgres.test.ts
@@ -37,10 +37,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -48,6 +47,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { Hono } from 'hono';
 import { authMiddleware } from '../../middleware/auth';
 import { errorHandler } from '../../middleware/error';
@@ -76,9 +76,6 @@ import { MembershipSelectionService, RequestAuthenticator } from '../request-aut
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-11111111111a';
 const TENANT_B = '22222222-2222-4222-8222-22222222222b';
@@ -173,17 +170,8 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
     app.request(path, { headers: { 'x-api-key': key, ...headers } });
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     // The platform actor that ISSUES the tenant root keys. Its credential and
     // its source key must agree field-for-field or

--- a/packages/api/src/tenancy/__tests__/tenant-boundary-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/tenant-boundary-postgres.test.ts
@@ -15,10 +15,8 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { rmSync, writeFileSync } from 'node:fs';
-import { readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -26,6 +24,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { sql } from 'drizzle-orm';
 import { type PlatformAuthContext, type TenantAuthContext, freezeContext } from '../auth-context';
 import { withPlatformTargetTenant } from '../platform-target-tenant';
@@ -35,9 +34,6 @@ import { TenantContextError, readTransactionTenantId, withTenantTransaction } fr
 const superUrl = process.env.OMNI_G3_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G3_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-111111111111';
 const TENANT_B = '22222222-2222-4222-8222-222222222222';
@@ -126,17 +122,8 @@ postgresDescribe('tenant boundary end-to-end (real PostgreSQL)', () => {
   }
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/tenancy/__tests__/two-tenant-adversarial-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/two-tenant-adversarial-postgres.test.ts
@@ -32,10 +32,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import {
   DEFAULT_ROLE_NAMES,
   type Database,
@@ -43,6 +42,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { ChatService } from '../../services/chats';
 import { ConversationService } from '../../services/conversations';
 import { InstanceService } from '../../services/instances';
@@ -54,9 +54,6 @@ import { runInTenantScope } from '../tenant-scope';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-11111111111a';
 const TENANT_B = '22222222-2222-4222-8222-22222222222b';
@@ -154,17 +151,8 @@ postgresDescribe('two-tenant adversarial containment (real PostgreSQL)', () => {
     runInTenantScope(runtimeDb, contextFor(tenantId), fn);
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/api/src/tenancy/__tests__/worker-context-two-tenant-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/worker-context-two-tenant-postgres.test.ts
@@ -18,10 +18,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { EventBus, OmniEvent } from '@omni/core';
 import {
   DEFAULT_ROLE_NAMES,
@@ -31,6 +30,7 @@ import {
   createDbHandle,
   omniEvents,
 } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { setupEventPersistence } from '../../plugins/event-persistence';
 import { InstanceService } from '../../services/instances';
@@ -40,9 +40,6 @@ import { runInWorkerTenantScope } from '../worker-tenant-context';
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', '..', '..', 'db', 'drizzle');
 
 const TENANT_A = '11111111-1111-4111-8111-11111111111a';
 const TENANT_B = '22222222-2222-4222-8222-22222222222b';
@@ -136,17 +133,8 @@ postgresDescribe('two-tenant worker-context containment (real PostgreSQL)', () =
     );
 
   beforeAll(async () => {
-    const created = runSqlOn(superUrl, `CREATE DATABASE "${dbName}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create database: ${created.stderr}`);
-
-    const migrations = readdirSync(drizzleDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-      .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-      .join('\n');
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
     const superDbUrl = urlFor(superUrl, dbName);
-    const migrated = runSqlOn(superDbUrl, migrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
 
     const seeded = runSqlOn(
       superDbUrl,

--- a/packages/core/src/egress/__tests__/egress-access-guard.test.ts
+++ b/packages/core/src/egress/__tests__/egress-access-guard.test.ts
@@ -23,12 +23,16 @@ import {
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..', '..', '..', '..', '..');
 
+// Seed rogue files under a real scanned root so the scanner actually walks
+// them. An interrupted previous run (ctrl-C, a cancelled turbo task) can leave
+// the scratch behind — its afterAll never fired — so clear it BEFORE the
+// baseline scan or the leftover rogue file poisons `found` (#967).
+const scratchDir = join(repoRoot, 'packages', 'core', 'src', '__g5_egress_scratch__');
+rmSync(scratchDir, { recursive: true, force: true });
+afterAll(() => rmSync(scratchDir, { recursive: true, force: true }));
+
 const found = scanEgressSites(repoRoot);
 const report = evaluateEgressGuard(found);
-
-// Seed rogue files under a real scanned root so the scanner actually walks them.
-const scratchDir = join(repoRoot, 'packages', 'core', 'src', '__g5_egress_scratch__');
-afterAll(() => rmSync(scratchDir, { recursive: true, force: true }));
 
 describe('egress-access guard', () => {
   test('the scan finds egress sites at all (guards against a broken scanner)', () => {

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -23,7 +23,7 @@
 import { getLogBuffer } from './buffer';
 import { createFormatter, isTTY } from './formatters';
 import { redactObject } from './redact';
-import type { LogConfig, LogEntry, LogFormat, LogLevel, Logger } from './types';
+import type { LogConfig, LogEntry, LogFormat, LogLevel, LogThreshold, Logger } from './types';
 import { LOG_LEVEL_VALUES } from './types';
 
 // Re-export all types
@@ -52,8 +52,8 @@ let formatter: ((entry: LogEntry) => string) | null = null;
  */
 function initFromEnv(): void {
   const level = process.env.LOG_LEVEL;
-  if (level && ['debug', 'info', 'warn', 'error'].includes(level)) {
-    config.level = level as LogLevel;
+  if (level && ['debug', 'info', 'warn', 'error', 'silent'].includes(level)) {
+    config.level = level as LogThreshold;
   }
 
   const format = process.env.LOG_FORMAT;
@@ -122,8 +122,8 @@ function matchesModuleFilter(module: string): boolean {
  * Write a log entry to output
  */
 function writeLog(entry: LogEntry): void {
-  // Check level filter
-  if (LOG_LEVEL_VALUES[entry.level] < LOG_LEVEL_VALUES[config.level]) {
+  // Check level filter ('silent' is a threshold above every entry level)
+  if (config.level === 'silent' || LOG_LEVEL_VALUES[entry.level] < LOG_LEVEL_VALUES[config.level]) {
     return;
   }
 
@@ -154,7 +154,7 @@ function writeLog(entry: LogEntry): void {
  *
  * Call this once at application startup to configure logging.
  * Settings can also be controlled via environment variables:
- * - LOG_LEVEL: debug, info, warn, error
+ * - LOG_LEVEL: debug, info, warn, error, silent
  * - LOG_FORMAT: auto, pretty, json
  * - LOG_FILE: path for file logging
  * - LOG_FILE_MAX_SIZE: rotation threshold (e.g., '10m')

--- a/packages/core/src/logger/types.ts
+++ b/packages/core/src/logger/types.ts
@@ -15,6 +15,14 @@ export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
 export type LogLevel = (typeof LOG_LEVELS)[number];
 
 /**
+ * Output threshold: any entry level, or 'silent' to drop everything.
+ * 'silent' is a threshold only — no log entry carries it — so it lives
+ * beside LogLevel instead of inside it. Test runs use it to mute the
+ * thousands of intentional warn/error lines exercised suites emit (#967).
+ */
+export type LogThreshold = LogLevel | 'silent';
+
+/**
  * Log level numeric values (for filtering)
  */
 export const LOG_LEVEL_VALUES: Record<LogLevel, number> = {
@@ -84,10 +92,10 @@ export interface Logger {
  */
 export interface LogConfig {
   /**
-   * Minimum log level to output
+   * Minimum log level to output, or 'silent' to disable output entirely
    * @default 'info'
    */
-  level?: LogLevel;
+  level?: LogThreshold;
 
   /**
    * Output format

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,10 @@
     "./client": {
       "types": "./src/client.ts",
       "default": "./src/client.ts"
+    },
+    "./pg-migrated-template": {
+      "types": "./src/pg-migrated-template.ts",
+      "default": "./src/pg-migrated-template.ts"
     }
   },
   "scripts": {

--- a/packages/db/src/backfill/pg-testing.ts
+++ b/packages/db/src/backfill/pg-testing.ts
@@ -10,21 +10,11 @@
  * Not a test file itself; imported by direct path from the G6 postgres suites.
  */
 
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { provisionMigratedDatabase } from '../pg-migrated-template';
 import { type ToolingSql, openToolingConnection } from './db';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', '..', 'drizzle');
-
-/** Every committed migration, in order — the real schema, not a hand subset. */
-export const ALL_MIGRATIONS: string = readdirSync(drizzleDir)
-  .filter((f) => f.endsWith('.sql'))
-  .sort()
-  .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-  .join('\n');
 
 /** The disposable superuser URL every G6 suite keys on (via the pg-gate). */
 export function superUrl(): string {
@@ -70,14 +60,15 @@ export function urlFor(base: string, database: string): string {
 }
 
 /**
- * Create a fresh database on the disposable cluster, apply every migration into
- * it, and run an optional fixture script. Returns the database name and its URL.
+ * Create a fresh database on the disposable cluster with every committed
+ * migration applied — a file-level clone of the migrated template (#967), so
+ * the chain is replayed once per cluster instead of once per call — and run an
+ * optional fixture script. Returns the database name and its URL.
  */
 export function provisionDatabase(base: string, fixture?: string): { database: string; url: string } {
   const database = `omni_g6_${crypto.randomUUID().replaceAll('-', '')}`;
-  runSqlOrThrow(base, `CREATE DATABASE "${database}";`);
+  provisionMigratedDatabase({ superUrl: base, psqlBin: psqlBin() }, database);
   const url = urlFor(base, database);
-  runSqlOrThrow(url, ALL_MIGRATIONS);
   if (fixture) runSqlOrThrow(url, fixture);
   return { database, url };
 }

--- a/packages/db/src/pg-migrated-template.ts
+++ b/packages/db/src/pg-migrated-template.ts
@@ -1,0 +1,168 @@
+/**
+ * Migrated-template cache for the real-PostgreSQL suites (#967).
+ *
+ * Nearly every `*-postgres.test.ts` used to provision its private database by
+ * replaying the ENTIRE committed migration chain through psql — once per
+ * suite, ~25 identical replays per pg-gate run. This helper replays a given
+ * SQL body ONCE per cluster into a template database whose name pins the
+ * SHA-256 of the exact bytes, then hands every suite a
+ * `CREATE DATABASE ... TEMPLATE <template>` clone, which PostgreSQL performs
+ * as a file-level copy in milliseconds.
+ *
+ * The pg-gate's "loud and complete, zero skips" contract is untouched:
+ *
+ *   - Only SETUP is cached, never results. Every suite still runs every
+ *     assertion against its own private clone.
+ *   - The template name embeds the digest of the SQL it was built from, so
+ *     changing any migration byte abandons the old template and replays the
+ *     new chain. On the gate's ephemeral cluster the template never outlives
+ *     the run; on a kept-warm cluster (scripts/pg-gate-warm.ts) it is exactly
+ *     the cross-run cache we want.
+ *   - A half-built template is unobservable: the SQL is replayed into a
+ *     staging database first and only RENAMEd into place when it completed.
+ *     A failed replay drops the staging database and stays loud.
+ *
+ * Like backfill/pg-testing.ts, this file is generic only — it contains no
+ * tenant-table SQL — and is imported directly by test files.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = join(here, '..', 'drizzle');
+
+/** How a suite reaches the DISPOSABLE cluster (the pg-gate's, never shared). */
+export interface PgSuperAccess {
+  /** Superuser URL of the disposable cluster. */
+  readonly superUrl: string;
+  /** psql binary the suite resolved from its OMNI_G*_PSQL_BIN variable. */
+  readonly psqlBin: string;
+}
+
+interface SqlResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function runSql(access: PgSuperAccess, url: string, script: string): SqlResult {
+  const file = join(tmpdir(), `omni-pg-template-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [access.psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function runSqlOrThrow(access: PgSuperAccess, url: string, script: string, label: string): void {
+  const result = runSql(access, url, script);
+  if (result.exitCode !== 0) throw new Error(`${label}: ${result.stderr || result.stdout}`);
+}
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+let cachedChain: { digest: string; sql: string } | null = null;
+
+/**
+ * The committed migration chain, concatenated in order, plus the SHA-256 that
+ * pins its exact bytes (each `filename + NUL + bytes + NUL`, sorted — the same
+ * shape the release rehearsals pin).
+ */
+function migrationChain(): { digest: string; sql: string } {
+  if (cachedChain) return cachedChain;
+  const files = readdirSync(drizzleDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  const hash = createHash('sha256');
+  const parts: string[] = [];
+  for (const file of files) {
+    const sql = readFileSync(join(drizzleDir, file), 'utf-8');
+    hash.update(file);
+    hash.update('\0');
+    hash.update(sql);
+    hash.update('\0');
+    parts.push(sql);
+  }
+  cachedChain = { digest: hash.digest('hex'), sql: parts.join('\n') };
+  return cachedChain;
+}
+
+/**
+ * A template name that pins the SQL it will hold: `<prefix>_<sha256[0..16)>`.
+ * Suites that template a custom SQL body (e.g. a migration PREFIX) use this so
+ * a byte change in the body abandons the stale template automatically.
+ */
+export function sqlTemplateName(prefix: string, sql: string): string {
+  return `${prefix}_${createHash('sha256').update(sql).digest('hex').slice(0, 16)}`;
+}
+
+function templateExists(access: PgSuperAccess, templateName: string): boolean {
+  const result = runSql(access, access.superUrl, `SELECT 1 FROM pg_database WHERE datname = '${templateName}';`);
+  return result.exitCode === 0 && result.stdout.trim() === '1';
+}
+
+/**
+ * Ensure a template database named `templateName` holding the result of
+ * replaying `sql` exists on the cluster. `templateName` MUST embed a digest of
+ * `sql` — the name is the cache key.
+ */
+export function ensureSqlTemplate(access: PgSuperAccess, templateName: string, sql: string): void {
+  if (templateExists(access, templateName)) return;
+  const staging = `${templateName}_b${process.pid}`;
+  runSqlOrThrow(
+    access,
+    access.superUrl,
+    `DROP DATABASE IF EXISTS "${staging}" WITH (FORCE);\nCREATE DATABASE "${staging}";`,
+    'template staging database',
+  );
+  try {
+    runSqlOrThrow(access, urlFor(access.superUrl, staging), sql, 'template replay');
+    runSqlOrThrow(
+      access,
+      access.superUrl,
+      `ALTER DATABASE "${staging}" RENAME TO "${templateName}";`,
+      'template rename',
+    );
+  } catch (error) {
+    runSql(access, access.superUrl, `DROP DATABASE IF EXISTS "${staging}" WITH (FORCE);`);
+    // Lost a rename race to another builder? Its template is just as good.
+    if (templateExists(access, templateName)) return;
+    throw error;
+  }
+}
+
+/** `CREATE DATABASE ... TEMPLATE` — the near-instant clone every suite gets. */
+export function createDatabaseFromTemplate(access: PgSuperAccess, database: string, templateName: string): void {
+  runSqlOrThrow(
+    access,
+    access.superUrl,
+    `CREATE DATABASE "${database}" TEMPLATE "${templateName}";`,
+    `clone of ${templateName}`,
+  );
+}
+
+/**
+ * Create `database` fully migrated with the committed chain: template built on
+ * first use, file-level clone afterwards. Drop-in replacement for the
+ * per-suite "CREATE DATABASE + replay every migration" block.
+ */
+export function provisionMigratedDatabase(access: PgSuperAccess, database: string): void {
+  const chain = migrationChain();
+  const templateName = `omni_migrated_tmpl_${chain.digest.slice(0, 16)}`;
+  ensureSqlTemplate(access, templateName, chain.sql);
+  createDatabaseFromTemplate(access, database, templateName);
+}

--- a/packages/db/src/rls-postgres.test.ts
+++ b/packages/db/src/rls-postgres.test.ts
@@ -24,12 +24,12 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import postgres from 'postgres';
 import { type Database, createDbHandle } from './client';
+import { provisionMigratedDatabase } from './pg-migrated-template';
 import { DEFAULT_ROLE_NAMES, RLS_TENANT_TABLES, applyTenantRlsEnforcement, readEnforcementState } from './tenancy-rls';
 import { applyTenancyRoles, readRoleAttributes, roleAttributeViolations } from './tenancy-roles';
 import { EnforcementStartupError, assertEnforcedRuntimeIdentity } from './tenancy-startup';
@@ -37,16 +37,6 @@ import { EnforcementStartupError, assertEnforcedRuntimeIdentity } from './tenanc
 const superUrl = process.env.OMNI_G3_POSTGRES_URL ?? '';
 const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
 const psqlBin = process.env.OMNI_G3_PSQL_BIN ?? 'psql';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const drizzleDir = join(here, '..', 'drizzle');
-
-/** Every committed migration, in order — the real schema, not a hand-written subset. */
-const allMigrations = readdirSync(drizzleDir)
-  .filter((f) => f.endsWith('.sql'))
-  .sort()
-  .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
-  .join('\n');
 
 const TENANT_A = '11111111-1111-4111-8111-111111111111';
 const TENANT_B = '22222222-2222-4222-8222-222222222222';
@@ -96,9 +86,9 @@ function urlFor(base: string, database: string, user?: { name: string; password:
   return url.toString();
 }
 
-function createDatabase(name: string): void {
-  const result = runSqlOn(superUrl, `CREATE DATABASE "${name}";`);
-  if (result.exitCode !== 0) throw new Error(`could not create ${name}: ${result.stderr}`);
+/** A private, fully migrated database — file-level clone of the template (#967). */
+function createMigratedDatabase(name: string): void {
+  provisionMigratedDatabase({ superUrl, psqlBin }, name);
 }
 
 /**
@@ -199,10 +189,8 @@ postgresDescribe('G3 enforcement (real PostgreSQL)', () => {
 
   beforeAll(async () => {
     // ---- enforced world -------------------------------------------------
-    createDatabase(enforcedDbName);
+    createMigratedDatabase(enforcedDbName);
     const enforcedSuperUrl = urlFor(superUrl, enforcedDbName);
-    const migrated = runSqlOn(enforcedSuperUrl, allMigrations);
-    if (migrated.exitCode !== 0) throw new Error(`migrations failed: ${migrated.stderr}`);
     const seeded = runSqlOn(enforcedSuperUrl, SEED);
     if (seeded.exitCode !== 0) throw new Error(`seed failed: ${seeded.stderr}`);
 
@@ -253,10 +241,8 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE O
     );
 
     // ---- legacy world ---------------------------------------------------
-    createDatabase(legacyDbName);
+    createMigratedDatabase(legacyDbName);
     const legacySuperUrl = urlFor(superUrl, legacyDbName);
-    const legacyMigrated = runSqlOn(legacySuperUrl, allMigrations);
-    if (legacyMigrated.exitCode !== 0) throw new Error(`legacy migrations failed: ${legacyMigrated.stderr}`);
     const legacySeeded = runSqlOn(legacySuperUrl, SEED);
     if (legacySeeded.exitCode !== 0) throw new Error(`legacy seed failed: ${legacySeeded.stderr}`);
     legacy = connect(legacySuperUrl);

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -28,11 +28,15 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..', '..', '..');
 const packagesDir = join(repoRoot, 'packages');
 
+// An interrupted previous run (ctrl-C, a cancelled turbo task) can leave the
+// scratch behind — its afterAll never fired — so clear it BEFORE the baseline
+// scan or the leftover rogue file poisons `found` (#967).
+const scratchDir = join(packagesDir, 'db', 'src', '__g3_access_scratch__');
+rmSync(scratchDir, { recursive: true, force: true });
+afterAll(() => rmSync(scratchDir, { recursive: true, force: true }));
+
 const found = scanDbAccessSites(packagesDir, repoRoot);
 const report = evaluateDbAccessGuard(found);
-
-const scratchDir = join(packagesDir, 'db', 'src', '__g3_access_scratch__');
-afterAll(() => rmSync(scratchDir, { recursive: true, force: true }));
 
 describe('db-access guard', () => {
   test('the scan finds sites at all (guards against a broken scanner)', () => {

--- a/packages/db/src/tenancy-postgres.test.ts
+++ b/packages/db/src/tenancy-postgres.test.ts
@@ -17,6 +17,7 @@ import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createDatabaseFromTemplate, ensureSqlTemplate, sqlTemplateName } from './pg-migrated-template';
 import {
   COMPOSITE_FK_TARGETS,
   G2_NEW_TABLES,
@@ -45,6 +46,9 @@ const throughG1Sql = readdirSync(drizzleDir)
   .sort()
   .map((f) => readFileSync(join(drizzleDir, f), 'utf-8'))
   .join('\n');
+
+/** Pre-G2 template: the 0000-0040 prefix replayed once per cluster (#967). */
+const throughG1Template = sqlTemplateName('omni_tmpl_through_g1', throughG1Sql);
 
 interface SqlResult {
   exitCode: number;
@@ -90,8 +94,11 @@ function runSqlOn(url: string, script: string, env?: Record<string, string>): Sq
  */
 function createDatabase(): { url: string; name: string } {
   const name = `omni_g2_${crypto.randomUUID().replaceAll('-', '')}`;
-  const admin = runSqlOn(postgresUrl, `CREATE DATABASE "${name}";`);
-  if (admin.exitCode !== 0) throw new Error(`could not create disposable database: ${admin.stderr}`);
+  // Clone the 0000-0040 prefix from its per-cluster template instead of
+  // replaying it — every suite database here starts from that exact state.
+  const access = { superUrl: postgresUrl, psqlBin };
+  ensureSqlTemplate(access, throughG1Template, throughG1Sql);
+  createDatabaseFromTemplate(access, name, throughG1Template);
   const url = new URL(postgresUrl);
   url.pathname = `/${name}`;
   return { url: url.toString(), name };
@@ -152,7 +159,7 @@ postgresDescribe('G2 ownership schema — real PostgreSQL', () => {
     // UPGRADE PATH: build the real committed pre-G2 state, seed legacy
     // NULL-owner rows, and only then apply G2 on top.
     main = createDatabase();
-    runOrThrow(`${throughG1Sql}\n${LEGACY_ROWS}\n${TENANTS}`);
+    runOrThrow(`${LEGACY_ROWS}\n${TENANTS}`);
   });
 
   afterAll(() => {
@@ -620,7 +627,7 @@ postgresDescribe('G2 fresh install', () => {
 
   beforeAll(() => {
     fresh = createDatabase();
-    const result = runSqlOn(fresh.url, `${throughG1Sql}\n${g2Sql}`);
+    const result = runSqlOn(fresh.url, g2Sql);
     if (result.exitCode !== 0) throw new Error(`fresh install failed: ${result.stderr}`);
   });
 
@@ -662,7 +669,7 @@ postgresDescribe('G2 online DDL phase', () => {
   beforeAll(() => {
     // Pre-G2 state only: the online phase must be able to run BEFORE 0041.
     online = createDatabase();
-    const result = runSqlOn(online.url, `${throughG1Sql}\n${LEGACY_ROWS}\n${TENANTS}`);
+    const result = runSqlOn(online.url, `${LEGACY_ROWS}\n${TENANTS}`);
     if (result.exitCode !== 0) throw new Error(`pre-G2 setup failed: ${result.stderr}`);
   });
 

--- a/packages/media-processing/__tests__/service.test.ts
+++ b/packages/media-processing/__tests__/service.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { configureLogging, getLogConfig } from '@omni/core';
 import { MediaProcessingService, createMediaProcessingService } from '../src/service';
 
 describe('MediaProcessingService', () => {
@@ -23,13 +24,19 @@ describe('MediaProcessingService', () => {
 
   describe('missing vision API key warning', () => {
     let stdoutSpy: ReturnType<typeof spyOn>;
+    let previousLogConfig: ReturnType<typeof getLogConfig>;
 
     beforeEach(() => {
+      // These tests assert the warning is actually WRITTEN, so they must not
+      // depend on the ambient threshold (test runs default to LOG_LEVEL=silent).
+      previousLogConfig = getLogConfig();
+      configureLogging({ level: 'warn', format: 'json' });
       stdoutSpy = spyOn(process.stdout, 'write');
     });
 
     afterEach(() => {
       stdoutSpy.mockRestore();
+      configureLogging(previousLogConfig);
     });
 
     it('logs warning when no vision API keys are configured', () => {

--- a/scripts/pg-gate-warm.ts
+++ b/scripts/pg-gate-warm.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+/**
+ * Keep-warm wrapper around scripts/pg-gate.ts (#967).
+ *
+ * A cold `make test-pg-gate` spends ~15-20s standing up a disposable cluster
+ * (initdb + postmaster start) that it destroys at the end. For a dev loop that
+ * runs the gate repeatedly, this wrapper creates that cluster ONCE, remembers
+ * it in `.pg-gate-warm.json` (gitignored), and reruns the gate against it with
+ * `--url`. The gate itself is byte-identical: same suites, same zero-skip /
+ * file-count contract. Because the migrated-template cache (see
+ * packages/db/src/pg-migrated-template.ts) lives inside the kept cluster, warm
+ * reruns also skip the per-suite migration replays.
+ *
+ * The kept cluster is still disposable by construction — loopback only, random
+ * port, generated credential — and `stop` destroys it exactly like the gate's
+ * own teardown would.
+ *
+ * Usage:
+ *   bun scripts/pg-gate-warm.ts run      # create-if-needed, then run the gate
+ *   bun scripts/pg-gate-warm.ts stop     # destroy the kept cluster + state
+ *   bun scripts/pg-gate-warm.ts status   # is a kept cluster alive?
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { createDisposableCluster, destroyDisposableCluster, resolvePgBinaries } from './disposable-pg-cluster';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const stateFile = join(repoRoot, '.pg-gate-warm.json');
+
+const WarmStateSchema = z.object({
+  url: z.string().url(),
+  dataDir: z.string().min(1),
+  port: z.number().int().positive(),
+});
+type WarmState = z.infer<typeof WarmStateSchema>;
+
+async function readState(): Promise<WarmState | null> {
+  if (!existsSync(stateFile)) return null;
+  try {
+    return WarmStateSchema.parse(await Bun.file(stateFile).json());
+  } catch {
+    // Unreadable or hand-mangled state: treat as absent, clean it up.
+    rmSync(stateFile, { force: true });
+    return null;
+  }
+}
+
+/** A cluster only counts as warm when it actually answers a query. */
+function isAlive(state: WarmState): boolean {
+  const result = Bun.spawnSync({
+    cmd: [resolvePgBinaries().psql, '-X', '--no-psqlrc', '-A', '-t', '--dbname', state.url, '-c', 'SELECT 1'],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  return result.exitCode === 0 && result.stdout.toString().trim() === '1';
+}
+
+function destroyState(state: WarmState): void {
+  destroyDisposableCluster(state.dataDir);
+  rmSync(stateFile, { force: true });
+}
+
+async function ensureWarmCluster(): Promise<WarmState> {
+  const existing = await readState();
+  if (existing) {
+    if (isAlive(existing)) {
+      process.stdout.write(`pg-gate-warm: reusing kept cluster on 127.0.0.1:${existing.port}\n`);
+      return existing;
+    }
+    process.stdout.write('pg-gate-warm: kept cluster is dead — destroying and recreating\n');
+    destroyState(existing);
+  }
+  const cluster = await createDisposableCluster();
+  const state: WarmState = { url: cluster.url, dataDir: cluster.dataDir, port: cluster.port };
+  await Bun.write(stateFile, `${JSON.stringify(state, null, 2)}\n`);
+  process.stdout.write(`pg-gate-warm: created kept cluster on 127.0.0.1:${state.port}\n`);
+  return state;
+}
+
+const command = process.argv[2];
+
+if (command === 'run') {
+  const state = await ensureWarmCluster();
+  const gate = Bun.spawnSync({
+    cmd: ['bun', join(here, 'pg-gate.ts'), '--url', state.url],
+    cwd: repoRoot,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  process.stdout.write(`pg-gate-warm: cluster kept on 127.0.0.1:${state.port} — \`make pg-gate-warm-stop\` to drop\n`);
+  process.exit(gate.exitCode ?? 1);
+} else if (command === 'stop') {
+  const state = await readState();
+  if (!state) {
+    process.stdout.write('pg-gate-warm: no kept cluster\n');
+  } else {
+    destroyState(state);
+    process.stdout.write('pg-gate-warm: kept cluster destroyed\n');
+  }
+} else if (command === 'status') {
+  const state = await readState();
+  if (!state) {
+    process.stdout.write('pg-gate-warm: no kept cluster\n');
+  } else {
+    process.stdout.write(
+      `pg-gate-warm: 127.0.0.1:${state.port} (${isAlive(state) ? 'alive' : 'DEAD'}) at ${state.dataDir}\n`,
+    );
+  }
+} else {
+  process.stderr.write('usage: pg-gate-warm.ts run | stop | status\n');
+  process.exit(2);
+}

--- a/scripts/pg-gate.ts
+++ b/scripts/pg-gate.ts
@@ -107,6 +107,10 @@ if (!explicitUrl) {
 const binaries = resolvePgBinaries();
 const env: Record<string, string> = { ...(process.env as Record<string, string>) };
 for (const variable of POSTGRES_URL_VARS) env[variable] = url;
+// Mute the app logger under the gate unless the caller asked for logs (#967):
+// the suites intentionally exercise warn/error paths and the JSON flood is
+// pure I/O on green runs. bun test's own failure diagnostics are unaffected.
+if (!env.LOG_LEVEL) env.LOG_LEVEL = 'silent';
 // The suites shell out to psql; point them at whichever client we resolved.
 for (const variable of [
   'OMNI_G1_PSQL_BIN',

--- a/tests/release/upgrade-2.260718.1-to-2.260830.2-postgres.test.ts
+++ b/tests/release/upgrade-2.260718.1-to-2.260830.2-postgres.test.ts
@@ -12,6 +12,11 @@ import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  createDatabaseFromTemplate,
+  ensureSqlTemplate,
+  sqlTemplateName,
+} from '../../packages/db/src/pg-migrated-template';
 
 const postgresUrl = process.env.OMNI_G2_POSTGRES_URL ?? '';
 const postgresDescribe = postgresUrl.length > 0 ? describe : describe.skip;
@@ -139,8 +144,16 @@ postgresDescribe('v2.260718.1 -> v2.260830.2 release rehearsal (real PostgreSQL)
 
   beforeAll(() => {
     database = `omni_release_upgrade_${crypto.randomUUID().replaceAll('-', '')}`;
-    const created = runSqlOn(postgresUrl, `CREATE DATABASE "${database}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create disposable database: ${created.stderr}`);
+    // The v2.260718.1 boundary (0000-0039) is frozen by definition — its bytes
+    // are pinned by OLD_RELEASE_MIGRATIONS_SHA256 above — so its migrated
+    // state is cached once per cluster as a template database and cloned here
+    // (#967). The template name embeds a digest of the same bytes, so any
+    // drift builds a fresh template (and fails the pinning test regardless).
+    const access = { superUrl: postgresUrl, psqlBin };
+    const oldReleaseSql = oldReleaseMigrations.map(migrationSql).join('\n');
+    const template = sqlTemplateName('omni_rel_tmpl', oldReleaseSql);
+    ensureSqlTemplate(access, template, oldReleaseSql);
+    createDatabaseFromTemplate(access, database, template);
     databaseUrl = urlFor(postgresUrl, database);
   });
 
@@ -149,7 +162,8 @@ postgresDescribe('v2.260718.1 -> v2.260830.2 release rehearsal (real PostgreSQL)
   });
 
   test('rehearses the quiesced upgrade and proves rolling/image-only rollback unsafe', () => {
-    runOrThrow(oldReleaseMigrations.map(migrationSql).join('\n'));
+    // The database is a clone of the pinned v2.260718.1 boundary template
+    // (0000-0039 applied) built in beforeAll.
 
     // Every channel-bearing column that 0047 rewrites is populated using a
     // value accepted by the v2.260718.1 ChannelTypeSchema.

--- a/tests/release/upgrade-2.260830.2-to-2.260902.5-postgres.test.ts
+++ b/tests/release/upgrade-2.260830.2-to-2.260902.5-postgres.test.ts
@@ -30,6 +30,11 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createDbHandle } from '../../packages/db/src/client';
 import { applyMigrations } from '../../packages/db/src/migrate';
+import {
+  createDatabaseFromTemplate,
+  ensureSqlTemplate,
+  sqlTemplateName,
+} from '../../packages/db/src/pg-migrated-template';
 import { RLS_TENANT_TABLES, contextFunctionStatements, tablePolicyStatements } from '../../packages/db/src/tenancy-rls';
 
 const postgresUrl = process.env.OMNI_G2_POSTGRES_URL ?? '';
@@ -279,8 +284,16 @@ postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)
 
   beforeAll(() => {
     database = `omni_release_upgrade_${crypto.randomUUID().replaceAll('-', '')}`;
-    const created = runSqlOn(postgresUrl, `CREATE DATABASE "${database}";`);
-    if (created.exitCode !== 0) throw new Error(`could not create disposable database: ${created.stderr}`);
+    // The v2.260830.2 boundary (0000-0051) is frozen by definition — its bytes
+    // are pinned by PREVIOUS_RELEASE_MIGRATIONS_SHA256 above — so its migrated
+    // state is cached once per cluster as a template database and cloned here
+    // (#967). The template name embeds a digest of the same bytes, so any
+    // drift builds a fresh template (and fails the pinning test regardless).
+    const access = { superUrl: postgresUrl, psqlBin };
+    const previousReleaseSql = previousReleaseMigrations.map(migrationSql).join('\n');
+    const template = sqlTemplateName('omni_rel_tmpl', previousReleaseSql);
+    ensureSqlTemplate(access, template, previousReleaseSql);
+    createDatabaseFromTemplate(access, database, template);
     databaseUrl = urlFor(postgresUrl, database);
     handle = createDbHandle({ url: databaseUrl, maxConnections: 2 });
     candidateDrizzleDir = materializeCandidateMigrations();
@@ -296,8 +309,9 @@ postgresDescribe('v2.260830.2 -> v2.260902.5 release rehearsal (real PostgreSQL)
     if (!handle) throw new Error('database handle was not created');
     const db = handle.db;
 
-    // The v2.260830.2 boundary: every migration through 0051, applied in order.
-    for (const migration of previousReleaseMigrations) runOrThrow(migrationSql(migration));
+    // The v2.260830.2 boundary: every migration through 0051 — the database is
+    // a clone of the pinned-boundary template built in beforeAll, and the
+    // assertions below prove the cloned state is exactly that boundary.
     expect(columnCount()).toBe('10');
     expect(signatureColumns()).toBe('');
 

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
     },
     "test": {
       "dependsOn": ["^build", "^topo"],
-      "env": ["CI", "NODE_ENV", "MINIO_INTEGRATION", "DATABASE_URL", "OMNI_*"],
+      "env": ["CI", "NODE_ENV", "MINIO_INTEGRATION", "DATABASE_URL", "TEST_DATABASE_URL", "ENABLE_DB_TESTS", "OMNI_*"],
       "outputs": []
     },
     "dev": {


### PR DESCRIPTION
Closes #967.

A full local validation cycle (`make check` + `make test-pg-gate`, sequential) cost ~4-6 minutes, dominated by work that was either redundant for the change at hand or rebuilt from scratch every run. This lands all six levers from the issue, in payoff order.

## Measured wall-clock (M-series laptop)

| Gate | Before | After |
|---|---|---|
| `make test-pg-gate` | 54.7s | **31.8s** (still 297 assertions / 31 suites / **0 skips**) |
| `make check` | 194.4s | **55.6s** (worst case: api package uncached) |
| Both, sequential | ~249s | ~87s |
| **`make check-all`** (new) | — | **47.1s** for everything |
| `make test` with no changes | ~117s always | **~3s** (unchanged packages replay cached green runs) |
| `make test-pg-gate-warm` rerun | — | ~35s (skips initdb + template builds) |

Coverage parity held throughout: 6,903 tests across 544 files either way, and the pg-gate's file-count/zero-skip contract is byte-for-byte intact.

## The levers

1. **Turbo-cached per-package tests** — `make test` now drives `turbo test --concurrency=4 --continue` (the pre-push hook already used turbo; this aligns the gate with it). `TEST_DATABASE_URL`/`ENABLE_DB_TESTS` join the test-task hash so a different database invalidates the cache. The old single-process sweep survives as `make test-sweep` (CI parity, cross-file leak hunting). CI is untouched — it invokes the raw sweep itself.
2. **`make check-all`** — runs check and the pg-gate concurrently; the gate's disposable cluster lives on a random loopback port and never reads `.env`, so there is no collision. pg-gate output is spooled and replayed after check's.
3. **pg-gate keep-warm** — `make test-pg-gate-warm` creates the disposable cluster once, remembers it in gitignored `.pg-gate-warm.json`, and reruns the *same* gate against it via the existing `--url` flag; `make pg-gate-warm-stop` destroys it. Dead clusters are detected with a real query and recreated.
4. **Template-cloned suite databases** — new `packages/db/src/pg-migrated-template.ts` replays the migration chain once per cluster into a template database named by the SHA-256 of its exact bytes; 26 suites (including the backfill helper, which replayed the chain per *test*) now get `CREATE DATABASE ... TEMPLATE` file-level clones. Only SETUP is cached, never results: every suite still runs every assertion against its own private database, any migration byte change abandons the template, and a half-built template is unobservable (staging database + atomic rename; failed replays drop the staging DB and stay loud).
5. **Templated release fixtures** — both upgrade rehearsals clone their SHA256-pinned "previous release" boundary from a digest-named template; the pinning assertions and the real-migrator drive are unchanged.
6. **`LOG_LEVEL=silent`** — the core logger gains a `silent` threshold (a threshold only; no entry carries it), and the test entrypoints default to it: `make test` (override with `TEST_LOG_LEVEL=...`), the pg-gate child env, and pre-push. `LOG_LEVEL` stays OUT of the turbo hash — tests must not depend on the ambient threshold, and the one suite that asserts a warning is actually written now pins its own `configureLogging`.

## Fallout hardening found en route

An interrupted run (ctrl-C, or a turbo task cancelled after another package failed) never reached the egress/db-access guards' `afterAll`, and the leftover rogue scratch file poisoned the NEXT run's module-load scan. Both guards now clear their scratch dir before computing the baseline scan.

## Skipped (noted per the issue's comment)

The `globalThis.fetch`-leak sweep (~20 files + a preload guard) is real but a sizeable cross-cutting change beyond the six levers; per-package test processes already shrink a leak's blast radius to one package. Suggest a follow-up issue.
