### PR TITLE
ci(quality-gate): turbo-cache the PR test run, keep the sweep on pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,12 +205,39 @@ jobs:
       - name: Dead code check (knip)
         run: bunx knip
 
-      - name: Test
-        # Scope to omni packages + the ui app; apps/khal-ui is a decoupled
-        # sub-project (private @khal-os deps) with its own test run.
+      - name: Test (pull requests — per-package via the turbo cache)
+        # Per-package `turbo test` (#967), fed by the "Turbo remote cache" step
+        # above: packages a PR does not touch replay their previously proven
+        # green run (byte-identical inputs — package files, dependency sources
+        # via the synthetic `topo` task, and the declared env vars) instead of
+        # re-executing, so an incremental PR pays only for what it changed.
+        # Coverage is identical to the sweep: every workspace with test files
+        # has a `test` script, and the pre-push hook runs this same command.
+        #
+        # Env: per-package runs have no --env-file, so .env is sourced into the
+        # environment here. NODE_ENV=test is re-exported AFTER sourcing (the
+        # .env template says development), matching the old step's env, and
+        # LOG_LEVEL=silent mutes the thousands of intentional warn/error lines
+        # the suites emit — neither is part of the turbo test hash.
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -a && . ./.env && set +a
+          export NODE_ENV=test LOG_LEVEL=silent
+          bun run test
+
+      - name: Test (pushes — full single-process sweep)
+        # Pushes to dev/main re-prove everything with the pre-#967 sweep: no
+        # cache replay on the integration branch, and the one-process run is
+        # also the only configuration where cross-file state leaks (e.g.
+        # globalThis.fetch pollution, issue #967 comment) reproduce. Scope to
+        # omni packages + the ui app; apps/khal-ui is a decoupled sub-project
+        # (private @khal-os deps) with its own test run.
+        if: ${{ github.event_name != 'pull_request' }}
         run: bun test packages apps/ui --env-file=.env
         env:
           NODE_ENV: test
+          LOG_LEVEL: silent
 
   pg-isolation-gate:
     name: PostgreSQL Isolation Gate (tenancy/RLS)


### PR DESCRIPTION
Follow-up to #967 / #970, bringing the local-gate wins to CI.

## What was left slow in CI

After #970, the pg-isolation-gate job already got the migrated-template savings for free (it runs `make test-pg-gate` verbatim). The remaining uncached multi-minute cost was the Quality Gate's **Test** step: a raw `bun test packages apps/ui` sweep that re-ran all ~6,900 tests on every PR regardless of what changed — while `bun run build` and `bun run typecheck` in the very same job already rode the `caching-for-turbo` remote cache.

## The change (one step, split by event)

- **Pull requests** → `turbo test --concurrency=4 --continue` — the exact command `make test` and the pre-push hook run. With the remote cache, packages a PR does not touch replay their previously proven green run (byte-identical inputs: package files, dependency sources via the synthetic `topo` task, and the declared env vars), so an incremental PR pays only for the packages it changed. Coverage is identical to the sweep: 6,903 tests / 544 files either way.
- **Pushes to dev/main** → the pre-existing single-process sweep, unchanged. The integration branch re-proves everything with zero cache replay, and one shared process remains the only configuration where cross-file state leaks (the `globalThis.fetch` polluter from the #967 comment) reproduce — so merges keep that detection surface.

Both paths set `LOG_LEVEL=silent` (from #970's logger threshold; verified that bun `--env-file` never overrides process env, so the step env wins over the `.env` template's `debug`), which drops the thousands of intentional scope-enforcer/pino warn-error lines from CI logs and leaves failures readable.

**Deliberately untouched:** the remote-media job — its H8 anti-skip guard greps logger output ("Initialized S3 media backend") and must keep logs on.

## Expected effect

First PR run after merge populates the cache (no faster). From then on, a typical single-package PR's test step drops from the full sweep (~2–4 min on the 4-vCPU runner) to roughly the changed package's own suite plus dependents — for most channel/UI PRs, seconds. Semantics trade-off, made explicit: a green PR check may replay cached green runs for untouched packages rather than re-execute them; the push-time sweep on dev re-proves the merged state in full.

Verified locally: `actionlint` clean on all workflows; the release-workflow-contract script only fails locally on Python 3.9 (needs 3.10+, present on the CI image) and fails identically on a clean tree.
