### PR TITLE
feat(events): glob type filters, custom-row identity + omni events wait

### DIFF
--- a/packages/api/src/__tests__/events-custom-journal-postgres.test.ts
+++ b/packages/api/src/__tests__/events-custom-journal-postgres.test.ts
@@ -1,9 +1,13 @@
 /**
  * Custom-event journal row fidelity, over real PostgreSQL (#966).
  *
- * The `custom.>` subscriber (#957) truncated eventType to a stale 50-char cap
- * (the column is 255 since #958), silently breaking exact-match `--type`
- * filters for longer `custom.webhook.{source}.{event}` types.
+ * The `custom.>` subscriber (#957) journals every custom event, but the row
+ * it wrote was lossy in ways that broke the CLI event surface:
+ *  - eventType was truncated to a stale 50-char cap (the column is 255 since
+ *    #958), silently breaking exact-match `--type` filters for longer
+ *    `custom.webhook.{source}.{event}` types;
+ *  - chatUuid/personId were never populated, so `--chat-id`/`--person-id`
+ *    could never match a custom event.
  *
  * These suites drive the REAL subscriber handler (a mock bus captures it —
  * events-trace.test.ts precedent) against a migrated disposable database.
@@ -15,7 +19,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 import type { EventBus } from '@omni/core';
-import { type Database, type EventType, createDbHandle } from '@omni/db';
+import { type Database, type EventType, chats, createDbHandle, instances, persons } from '@omni/db';
 import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { setupEventPersistence } from '../plugins/event-persistence';
 import { EventService } from '../services/events';
@@ -60,6 +64,10 @@ postgresDescribe('custom event journal fidelity (#966, real PostgreSQL)', () => 
   let closeDb: () => Promise<void>;
   let handler: CustomEventHandler;
   let service: EventService;
+  let instanceId: string;
+  let personId: string;
+  let chatUuid: string;
+  const chatExternalId = 'wait-966@s.whatsapp.net';
 
   beforeAll(async () => {
     provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
@@ -69,6 +77,32 @@ postgresDescribe('custom event journal fidelity (#966, real PostgreSQL)', () => 
 
     handler = await captureCustomHandler(db);
     service = new EventService(db);
+
+    const [instance] = await db
+      .insert(instances)
+      .values({ name: 'events-966', channel: 'whatsapp-baileys' as const })
+      .returning();
+    if (!instance) throw new Error('instance insert returned nothing');
+    instanceId = instance.id;
+
+    const [person] = await db.insert(persons).values({ displayName: 'Wait 966' }).returning();
+    if (!person) throw new Error('person insert returned nothing');
+    personId = person.id;
+
+    const [chat] = await db
+      .insert(chats)
+      .values({
+        instanceId,
+        externalId: chatExternalId,
+        chatType: 'dm',
+        channel: 'whatsapp-baileys',
+        name: 'Wait 966 DM',
+        visibility: 'visible',
+        lastMessageAt: new Date(),
+      })
+      .returning();
+    if (!chat) throw new Error('chat insert returned nothing');
+    chatUuid = chat.id;
   });
 
   afterAll(async () => {
@@ -112,6 +146,39 @@ postgresDescribe('custom event journal fidelity (#966, real PostgreSQL)', () => 
       expect(row.eventType).toBe(overlongType.slice(0, 255) as EventType);
       // The untruncated type is preserved in the metadata jsonb for forensics.
       expect((row.metadata as { fullEventType?: string })?.fullEventType).toBe(overlongType);
+    });
+  });
+
+  describe('chatUuid/personId population', () => {
+    test('metadata.personId maps onto the row when the person exists', async () => {
+      const { row } = await journal('custom.identity-966.meta_person', {}, { personId });
+      expect(row.personId).toBe(personId);
+    });
+
+    test('payload.personId maps when metadata carries none', async () => {
+      const { row } = await journal('custom.identity-966.payload_person', { personId });
+      expect(row.personId).toBe(personId);
+    });
+
+    test('a personId claim with no persons row is dropped, not fatal (FK safety)', async () => {
+      const { row } = await journal('custom.identity-966.bogus_person', { personId: randomUUID() });
+      expect(row.personId).toBeNull(); // the row itself still persisted
+    });
+
+    test('payload.chatId + metadata.instanceId resolve to the chats.id UUID', async () => {
+      const { row } = await journal('custom.identity-966.chat_jid', { chatId: chatExternalId }, { instanceId });
+      expect(row.chatUuid).toBe(chatUuid);
+      expect(row.chatId).toBe(chatExternalId);
+    });
+
+    test('payload.chatUuid maps directly when it names an existing chat', async () => {
+      const { row } = await journal('custom.identity-966.chat_uuid', { chatUuid });
+      expect(row.chatUuid).toBe(chatUuid);
+    });
+
+    test('a chatUuid claim with no chats row is dropped, not fatal (FK safety)', async () => {
+      const { row } = await journal('custom.identity-966.bogus_chat', { chatUuid: randomUUID() });
+      expect(row.chatUuid).toBeNull();
     });
   });
 });

--- a/packages/api/src/__tests__/events-custom-journal-postgres.test.ts
+++ b/packages/api/src/__tests__/events-custom-journal-postgres.test.ts
@@ -1,5 +1,6 @@
 /**
- * Custom-event journal row fidelity, over real PostgreSQL (#966).
+ * Custom-event journal row fidelity + type-glob list filtering, over real
+ * PostgreSQL (#966).
  *
  * The `custom.>` subscriber (#957) journals every custom event, but the row
  * it wrote was lossy in ways that broke the CLI event surface:
@@ -8,6 +9,8 @@
  *    `custom.webhook.{source}.{event}` types;
  *  - chatUuid/personId were never populated, so `--chat-id`/`--person-id`
  *    could never match a custom event.
+ * And `--type 'custom.*'` matched nothing anywhere: EventService.list used
+ * strict inArray equality only.
  *
  * These suites drive the REAL subscriber handler (a mock bus captures it —
  * events-trace.test.ts precedent) against a migrated disposable database.
@@ -179,6 +182,47 @@ postgresDescribe('custom event journal fidelity (#966, real PostgreSQL)', () => 
     test('a chatUuid claim with no chats row is dropped, not fatal (FK safety)', async () => {
       const { row } = await journal('custom.identity-966.bogus_chat', { chatUuid: randomUUID() });
       expect(row.chatUuid).toBeNull();
+    });
+  });
+
+  describe('trailing-* glob type filtering', () => {
+    let alphaId: string;
+    let betaId: string;
+    let outsiderId: string;
+
+    beforeAll(async () => {
+      ({ id: alphaId } = await journal('custom.globtest-966.alpha', {}));
+      ({ id: betaId } = await journal('custom.globtest-966.beta', {}));
+      ({ id: outsiderId } = await journal('custom.other-966.gamma', {}));
+    });
+
+    test('`custom.globtest-966.*` matches the prefix and nothing else', async () => {
+      const listed = await service.list({ eventType: ['custom.globtest-966.*' as EventType], limit: 50 });
+      const ids = listed.items.map((e) => e.id);
+      expect(ids).toContain(alphaId);
+      expect(ids).toContain(betaId);
+      expect(ids).not.toContain(outsiderId);
+    });
+
+    test('a mixed exact + glob list ORs the two', async () => {
+      const listed = await service.list({
+        eventType: ['custom.other-966.gamma' as EventType, 'custom.globtest-966.*' as EventType],
+        limit: 50,
+      });
+      const ids = listed.items.map((e) => e.id);
+      expect(ids).toEqual(expect.arrayContaining([alphaId, betaId, outsiderId]));
+    });
+
+    test('LIKE wildcards in the prefix are escaped, not interpreted', async () => {
+      // `custom.glob_est-966.*` must NOT match custom.globtest-966.* rows —
+      // `_` is a literal underscore in the glob contract, not any-one-char.
+      const listed = await service.list({ eventType: ['custom.glob_est-966.*' as EventType], limit: 50 });
+      expect(listed.items.map((e) => e.id)).not.toContain(alphaId);
+    });
+
+    test('an exact type filter still requires the full type', async () => {
+      const listed = await service.list({ eventType: ['custom.globtest-966' as EventType], limit: 50 });
+      expect(listed.items).toHaveLength(0);
     });
   });
 });

--- a/packages/api/src/__tests__/events-custom-journal-postgres.test.ts
+++ b/packages/api/src/__tests__/events-custom-journal-postgres.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Custom-event journal row fidelity, over real PostgreSQL (#966).
+ *
+ * The `custom.>` subscriber (#957) truncated eventType to a stale 50-char cap
+ * (the column is 255 since #958), silently breaking exact-match `--type`
+ * filters for longer `custom.webhook.{source}.{event}` types.
+ *
+ * These suites drive the REAL subscriber handler (a mock bus captures it —
+ * events-trace.test.ts precedent) against a migrated disposable database.
+ *
+ * Set `OMNI_G3_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import type { EventBus } from '@omni/core';
+import { type Database, type EventType, createDbHandle } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { setupEventPersistence } from '../plugins/event-persistence';
+import { EventService } from '../services/events';
+
+const superUrl = process.env.OMNI_G3_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G3_PSQL_BIN ?? 'psql';
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+type CustomEventHandler = (event: {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  timestamp: number;
+  metadata: Record<string, unknown>;
+}) => Promise<void>;
+
+/** Capture the real `custom.>` subscriber handler via a mock bus. */
+async function captureCustomHandler(db: Database): Promise<CustomEventHandler> {
+  const subscriptions = new Map<string, CustomEventHandler>();
+  const mockBus = {
+    subscribe: async () => {},
+    subscribePattern: async (pattern: string, handler: CustomEventHandler) => {
+      subscriptions.set(pattern, handler);
+    },
+  } as unknown as EventBus;
+
+  await setupEventPersistence(mockBus, db);
+  const handler = subscriptions.get('custom.>');
+  if (!handler) throw new Error('custom.> subscriber was not registered');
+  return handler;
+}
+
+postgresDescribe('custom event journal fidelity (#966, real PostgreSQL)', () => {
+  const dbName = `omni_events_journal_${randomUUID().replaceAll('-', '')}`;
+  let db: Database;
+  let closeDb: () => Promise<void>;
+  let handler: CustomEventHandler;
+  let service: EventService;
+
+  beforeAll(async () => {
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
+    const handle = createDbHandle({ url: urlFor(superUrl, dbName), maxConnections: 3 });
+    db = handle.db;
+    closeDb = () => handle.close().catch(() => undefined);
+
+    handler = await captureCustomHandler(db);
+    service = new EventService(db);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  /** Journal one custom event through the real handler and read the row back. */
+  async function journal(
+    type: string,
+    payload: Record<string, unknown>,
+    metadata: Record<string, unknown> = {},
+  ): Promise<{ id: string; row: Awaited<ReturnType<EventService['getById']>> }> {
+    const id = randomUUID();
+    await handler({
+      id,
+      type,
+      payload,
+      timestamp: Date.now(),
+      metadata: { correlationId: randomUUID(), ...metadata },
+    });
+    return { id, row: await service.getById(id) };
+  }
+
+  describe('eventType truncation regression', () => {
+    test('a type longer than the old 50-char cap round-trips exactly and stays filterable', async () => {
+      const longType = `custom.webhook.truncation-966.push_review_comment_thread_resolved.${randomUUID().slice(0, 4)}`;
+      expect(longType.length).toBeGreaterThan(50);
+      expect(longType.length).toBeLessThanOrEqual(255);
+
+      const { id, row } = await journal(longType, { probe: 'truncation-966' }, { source: 'webhook' });
+      expect(row.eventType).toBe(longType as EventType);
+
+      // Exact-match type filter finds it (the inArray path the API list uses).
+      const listed = await service.list({ eventType: [longType as EventType], limit: 10 });
+      expect(listed.items.map((e) => e.id)).toContain(id);
+    });
+
+    test('a type longer than the column caps at 255 instead of failing the insert', async () => {
+      const overlongType = `custom.overlong-966.${'x'.repeat(300)}`;
+      const { row } = await journal(overlongType, {});
+      expect(row.eventType).toBe(overlongType.slice(0, 255) as EventType);
+      // The untruncated type is preserved in the metadata jsonb for forensics.
+      expect((row.metadata as { fullEventType?: string })?.fullEventType).toBe(overlongType);
+    });
+  });
+});

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -22,7 +22,7 @@
 import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
 import { JOURNEY_STAGES, createLogger, getJourneyTracker, isValidUuid } from '@omni/core';
 import type { Database, NewOmniEvent } from '@omni/db';
-import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents } from '@omni/db';
+import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents, persons } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
 import { scopedHandle } from '../tenancy/tenant-scope';
 import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
@@ -74,6 +74,33 @@ async function resolveChatUuid(
       .from(chats)
       .where(and(eq(chats.instanceId, instanceId), eq(chats.externalId, chatId)))
       .limit(1);
+    return chat?.id ?? null;
+  } catch {
+    return null; // best-effort — never fail event persistence because of this
+  }
+}
+
+/**
+ * Best-effort person resolution for custom journal rows (#966): accept a
+ * personId claim only when it is a valid UUID AND the persons row exists —
+ * person_id carries an FK, and a bogus claim must not fail the whole insert.
+ * Never throws.
+ */
+async function resolvePersonId(db: Database, candidate: unknown): Promise<string | null> {
+  if (typeof candidate !== 'string' || !isValidUuid(candidate)) return null;
+  try {
+    const [person] = await db.select({ id: persons.id }).from(persons).where(eq(persons.id, candidate)).limit(1);
+    return person?.id ?? null;
+  } catch {
+    return null; // best-effort — never fail event persistence because of this
+  }
+}
+
+/** Same FK-safe contract for a direct chats.id claim (payload.chatUuid). */
+async function resolveChatUuidById(db: Database, candidate: unknown): Promise<string | null> {
+  if (typeof candidate !== 'string' || !isValidUuid(candidate)) return null;
+  try {
+    const [chat] = await db.select({ id: chats.id }).from(chats).where(eq(chats.id, candidate)).limit(1);
     return chat?.id ?? null;
   } catch {
     return null; // best-effort — never fail event persistence because of this
@@ -433,7 +460,9 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
     // fact here) and the eventType is truncated to the column's 255 chars
     // (#966 — a stale 50-char cap silently broke exact-match type filters
     // for longer custom.webhook.{source}.{event} types after #958 widened
-    // the column).
+    // the column). chatUuid and personId are mapped best-effort from the
+    // envelope metadata / payload (see the inline comment) so the CLI's
+    // --chat-id / --person-id filters can match custom events too.
     await eventBus.subscribePattern(
       'custom.>',
       async (event) => {
@@ -441,15 +470,36 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         try {
           await runConsumerInTenantContext(db, event, async () => {
             const sdb = scopedHandle(db);
+            const payload =
+              typeof event.payload === 'object' && event.payload !== null
+                ? (event.payload as Record<string, unknown>)
+                : {};
+            const instanceId = metadata.instanceId && isValidUuid(metadata.instanceId) ? metadata.instanceId : null;
+            const payloadChatId = typeof payload.chatId === 'string' ? payload.chatId : undefined;
+
+            // #966: best-effort identity mapping so --chat-id/--person-id
+            // filters can match custom events. personId: metadata.personId
+            // (publisher claim) first, then payload.personId — either must
+            // reference an existing persons row (FK safety). chatUuid:
+            // payload.chatUuid (a chats.id UUID) first, then payload.chatId
+            // (a platform JID) resolved against the instance like the
+            // message subscribers do.
+            const personId =
+              (await resolvePersonId(sdb, metadata.personId)) ?? (await resolvePersonId(sdb, payload.personId));
+            const chatUuid =
+              (await resolveChatUuidById(sdb, payload.chatUuid)) ??
+              (await resolveChatUuid(sdb, instanceId ?? undefined, payloadChatId));
+
             const newEvent: NewOmniEvent = {
               ...eventIdInsert(event.id),
               channel: 'internal',
-              instanceId: metadata.instanceId && isValidUuid(metadata.instanceId) ? metadata.instanceId : null,
+              instanceId,
+              personId,
               eventType: event.type.slice(0, 255) as NewOmniEvent['eventType'],
               direction: 'internal',
               status: 'completed',
               receivedAt: new Date(event.timestamp),
-              rawPayload: deepSanitize(event.payload as Record<string, unknown>),
+              rawPayload: deepSanitize(payload),
               metadata: {
                 correlationId: metadata.correlationId,
                 source: metadata.source,
@@ -457,6 +507,8 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               },
               causationId: metadata.causationId ?? null,
               conversationId: null,
+              chatId: payloadChatId,
+              chatUuid,
             };
             await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
           });

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -430,7 +430,10 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
     // retention. Each custom event gets a minimal row: identity, causality
     // (causation_id column + correlationId in the metadata jsonb), and the
     // payload for debugging. channel is 'internal' (there is no channel-side
-    // fact here) and the eventType is truncated to the column's 50 chars.
+    // fact here) and the eventType is truncated to the column's 255 chars
+    // (#966 — a stale 50-char cap silently broke exact-match type filters
+    // for longer custom.webhook.{source}.{event} types after #958 widened
+    // the column).
     await eventBus.subscribePattern(
       'custom.>',
       async (event) => {
@@ -442,7 +445,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               ...eventIdInsert(event.id),
               channel: 'internal',
               instanceId: metadata.instanceId && isValidUuid(metadata.instanceId) ? metadata.instanceId : null,
-              eventType: event.type.slice(0, 50) as NewOmniEvent['eventType'],
+              eventType: event.type.slice(0, 255) as NewOmniEvent['eventType'],
               direction: 'internal',
               status: 'completed',
               receivedAt: new Date(event.timestamp),

--- a/packages/api/src/services/events.ts
+++ b/packages/api/src/services/events.ts
@@ -5,8 +5,13 @@
 import { NotFoundError } from '@omni/core';
 import type { Database } from '@omni/db';
 import { type ChannelType, type ContentType, type EventType, type OmniEvent, omniEvents } from '@omni/db';
-import { and, desc, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, like, lte, or, sql } from 'drizzle-orm';
 import { scopedHandle } from '../tenancy/tenant-scope';
+
+/** Escape LIKE wildcards so a glob prefix matches literally (backslash is postgres's default escape char). */
+function escapeLikePattern(value: string): string {
+  return value.replace(/([\\%_])/g, '\\$1');
+}
 
 export interface ListEventsOptions {
   channel?: ChannelType[];
@@ -115,7 +120,18 @@ export class EventService {
     }
 
     if (eventType?.length) {
-      conditions.push(inArray(omniEvents.eventType, eventType));
+      // #966: a trailing-* entry is a prefix glob (`custom.*` matches every
+      // custom event); everything else stays exact-match. A mixed list ORs
+      // the two together. The CLI-side sieve (matchesEventTypeFilter in
+      // packages/cli) implements the same contract — keep them in sync.
+      const exact = eventType.filter((t) => !t.endsWith('*'));
+      const prefixes = eventType.filter((t) => t.endsWith('*')).map((t) => t.slice(0, -1));
+      const typeClauses = [
+        ...(exact.length ? [inArray(omniEvents.eventType, exact)] : []),
+        ...prefixes.map((p) => like(omniEvents.eventType, `${escapeLikePattern(p)}%`)),
+      ];
+      const combined = typeClauses.length === 1 ? typeClauses[0] : or(...typeClauses);
+      if (combined) conditions.push(combined);
     }
 
     if (contentType?.length) {

--- a/packages/cli/src/__tests__/events-stream.test.ts
+++ b/packages/cli/src/__tests__/events-stream.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, expect, test } from 'bun:test';
 import type { Event } from '@omni/sdk';
-import { formatEventLine, isErrorEvent, isNoisyEvent, passesStreamFilters } from '../commands/events';
+import {
+  formatEventLine,
+  isErrorEvent,
+  isNoisyEvent,
+  matchesEventTypeFilter,
+  passesStreamFilters,
+} from '../commands/events';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -45,10 +51,18 @@ describe('events stream filters', () => {
     expect(passesStreamFilters(ev, { instanceId: '00000000-0000-0000-0000-000000000222' })).toBe(false);
   });
 
-  test('type filter is exact match', () => {
+  test('type filter is exact match without a glob', () => {
     const ev = makeEvent({ eventType: 'message.sent' });
     expect(passesStreamFilters(ev, { type: 'message.sent' })).toBe(true);
     expect(passesStreamFilters(ev, { type: 'message.received' })).toBe(false);
+  });
+
+  test('type filter with a trailing * is a prefix glob (#966)', () => {
+    const ev = makeEvent({ eventType: 'custom.github.push' });
+    expect(passesStreamFilters(ev, { type: 'custom.*' })).toBe(true);
+    expect(passesStreamFilters(ev, { type: 'custom.github.*' })).toBe(true);
+    expect(passesStreamFilters(ev, { type: 'custom.gitlab.*' })).toBe(false);
+    expect(passesStreamFilters(ev, { type: 'custom.github.push' })).toBe(true);
   });
 
   test('chat-id filter matches chatUuid', () => {
@@ -73,6 +87,23 @@ describe('events stream filters', () => {
     const ev = makeEvent({ eventType: 'message.sent', chatUuid: 'chat-1' });
     expect(passesStreamFilters(ev, { type: 'message.sent', chatId: 'chat-1' })).toBe(true);
     expect(passesStreamFilters(ev, { type: 'message.sent', chatId: 'chat-OTHER' })).toBe(false);
+  });
+});
+
+describe('matchesEventTypeFilter (#966)', () => {
+  test('exact match without a trailing *', () => {
+    expect(matchesEventTypeFilter('custom.github.push', 'custom.github.push')).toBe(true);
+    expect(matchesEventTypeFilter('custom.github.push', 'custom.github')).toBe(false);
+  });
+
+  test('trailing * matches the prefix', () => {
+    expect(matchesEventTypeFilter('custom.github.push', 'custom.*')).toBe(true);
+    expect(matchesEventTypeFilter('message.received', 'custom.*')).toBe(false);
+    expect(matchesEventTypeFilter('custom.github.push', 'custom.github.*')).toBe(true);
+  });
+
+  test('a bare * matches everything', () => {
+    expect(matchesEventTypeFilter('message.received', '*')).toBe(true);
   });
 });
 

--- a/packages/cli/src/__tests__/events-wait.test.ts
+++ b/packages/cli/src/__tests__/events-wait.test.ts
@@ -1,0 +1,184 @@
+/**
+ * `omni events wait` — one-shot blocking subscription (#966).
+ *
+ * Covers the whole contract at the function level (the command action is a
+ * thin option-parsing shell around `waitForEvent`):
+ *  - `--filter k=v` entries become automation trigger conditions and are
+ *    evaluated by the SAME matcher automations use (`evaluateConditions`);
+ *  - the poll loop resolves with the FIRST matching event;
+ *  - the deadline resolves null (→ exit non-zero, empty stdout).
+ *
+ * The integration tests talk to a real in-process Bun.serve speaking the
+ * GET /events contract, so they pin the native fetch for each test — same
+ * hermetic pattern (and rationale) as events-schema.test.ts: another suite's
+ * leaked `globalThis.fetch` stub must not swallow these requests (#967).
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { type Event, createOmniClient } from '@omni/sdk';
+import { matchesWaitEvent, parseWaitFilters, waitForEvent } from '../commands/events';
+
+let priorFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  priorFetch = globalThis.fetch;
+  globalThis.fetch = Bun.fetch as unknown as typeof globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = priorFetch;
+});
+
+type WaitRow = Event & { rawPayload?: Record<string, unknown> | null };
+
+function makeRow(overrides: Partial<WaitRow> = {}): WaitRow {
+  return {
+    id: crypto.randomUUID(),
+    eventType: 'custom.deploy.finished',
+    contentType: null,
+    instanceId: '00000000-0000-0000-0000-0000000000aa',
+    personId: null,
+    direction: 'inbound',
+    textContent: null,
+    transcription: null,
+    imageDescription: null,
+    chatUuid: null,
+    agentId: null,
+    conversationId: null,
+    receivedAt: '2026-09-06T10:00:00.000Z',
+    processedAt: null,
+    rawPayload: { status: 'ok' },
+    ...overrides,
+  };
+}
+
+describe('parseWaitFilters', () => {
+  test('k=v becomes an eq condition; values parse as JSON when valid', () => {
+    expect(parseWaitFilters(['count=5'])).toEqual([{ field: 'count', operator: 'eq', value: 5 }]);
+    expect(parseWaitFilters(['ok=true'])).toEqual([{ field: 'ok', operator: 'eq', value: true }]);
+    expect(parseWaitFilters(['id="5"'])).toEqual([{ field: 'id', operator: 'eq', value: '5' }]);
+  });
+
+  test('non-JSON values fall back to the raw string', () => {
+    expect(parseWaitFilters(['status=open'])).toEqual([{ field: 'status', operator: 'eq', value: 'open' }]);
+  });
+
+  test('dot paths stay on the field; = inside the value survives', () => {
+    expect(parseWaitFilters(['user.id=42', 'note=a=b'])).toEqual([
+      { field: 'user.id', operator: 'eq', value: 42 },
+      { field: 'note', operator: 'eq', value: 'a=b' },
+    ]);
+  });
+});
+
+describe('matchesWaitEvent', () => {
+  test('payload conditions run through the automation matcher (nested paths)', () => {
+    const row = makeRow({ rawPayload: { user: { id: 42 }, status: 'open' } });
+    expect(matchesWaitEvent(row, { all: true }, parseWaitFilters(['user.id=42']))).toBe(true);
+    expect(matchesWaitEvent(row, { all: true }, parseWaitFilters(['user.id=43']))).toBe(false);
+    expect(matchesWaitEvent(row, { all: true }, parseWaitFilters(['status=open', 'user.id=42']))).toBe(true);
+    expect(matchesWaitEvent(row, { all: true }, parseWaitFilters(['status=closed', 'user.id=42']))).toBe(false);
+  });
+
+  test('a row without rawPayload only matches an empty condition set', () => {
+    const row = makeRow({ rawPayload: null });
+    expect(matchesWaitEvent(row, { all: true }, [])).toBe(true);
+    expect(matchesWaitEvent(row, { all: true }, parseWaitFilters(['status=ok']))).toBe(false);
+  });
+
+  test('envelope filters apply too, including type globs', () => {
+    const row = makeRow({ eventType: 'custom.deploy.finished' });
+    expect(matchesWaitEvent(row, { type: 'custom.*', all: true }, [])).toBe(true);
+    expect(matchesWaitEvent(row, { type: 'custom.build.*', all: true }, [])).toBe(false);
+    expect(matchesWaitEvent(row, { type: 'custom.deploy.finished', all: true }, [])).toBe(true);
+  });
+});
+
+describe('waitForEvent against an in-process API', () => {
+  // Mutable batches: each GET /events shifts the next canned response.
+  let batches: WaitRow[][] = [];
+  let requests = 0;
+
+  const server = Bun.serve({
+    port: 0,
+    fetch: (req) => {
+      const url = new URL(req.url);
+      if (req.method === 'GET' && url.pathname.endsWith('/events')) {
+        requests++;
+        const items = batches.length > 1 ? batches.shift() : batches[0];
+        return Response.json({ items: items ?? [], meta: { hasMore: false } });
+      }
+      return Response.json({ error: { code: 'NOT_FOUND', message: 'unknown route' } }, { status: 404 });
+    },
+  });
+
+  const client = createOmniClient({ baseUrl: `http://127.0.0.1:${server.port}`, apiKey: 'test-key' });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  beforeEach(() => {
+    batches = [];
+    requests = 0;
+  });
+
+  test('resolves with the first event matching envelope filters + payload conditions', async () => {
+    const miss = makeRow({ rawPayload: { status: 'failed' }, receivedAt: '2026-09-06T10:00:00.000Z' });
+    const hit = makeRow({ rawPayload: { status: 'ok' }, receivedAt: '2026-09-06T10:00:01.000Z' });
+    batches = [[hit, miss]]; // out of order on purpose — the loop sorts ascending
+
+    const found = await waitForEvent(client, {
+      filters: { type: 'custom.deploy.*', all: true },
+      conditions: parseWaitFilters(['status=ok']),
+      sinceIso: '2026-09-06T00:00:00.000Z',
+      pollMs: 250,
+      timeoutMs: 5000,
+    });
+
+    expect(found?.id).toBe(hit.id);
+    expect(found?.rawPayload).toEqual({ status: 'ok' });
+  });
+
+  test('keeps polling until a matching event appears', async () => {
+    const hit = makeRow();
+    batches = [[], [], [hit]];
+
+    const found = await waitForEvent(client, {
+      filters: { all: true },
+      conditions: [],
+      sinceIso: '2026-09-06T00:00:00.000Z',
+      pollMs: 50,
+      timeoutMs: 5000,
+    });
+
+    expect(found?.id).toBe(hit.id);
+    expect(requests).toBeGreaterThanOrEqual(3);
+  });
+
+  test('resolves null once the deadline passes with nothing matching', async () => {
+    batches = [[]];
+
+    const found = await waitForEvent(client, {
+      filters: { all: true },
+      conditions: [],
+      sinceIso: '2026-09-06T00:00:00.000Z',
+      pollMs: 50,
+      timeoutMs: 200,
+    });
+
+    expect(found).toBeNull();
+  });
+
+  test('a non-matching event never resolves the wait, even before the deadline', async () => {
+    batches = [[makeRow({ rawPayload: { status: 'failed' } })]];
+
+    const found = await waitForEvent(client, {
+      filters: { all: true },
+      conditions: parseWaitFilters(['status=ok']),
+      sinceIso: '2026-09-06T00:00:00.000Z',
+      pollMs: 50,
+      timeoutMs: 200,
+    });
+
+    expect(found).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -10,8 +10,10 @@
 
 import type { EventEmitter } from 'node:events';
 import { readFileSync } from 'node:fs';
+import { type AutomationCondition, evaluateConditions } from '@omni/core';
 import type { Event, OmniClient } from '@omni/sdk';
 import { Command } from 'commander';
+import { z } from 'zod';
 import { getClient } from '../client.js';
 import { getOutputFormat, loadConfig } from '../config.js';
 import * as output from '../output.js';
@@ -622,6 +624,106 @@ async function streamEvents(client: OmniClient, options: StreamOptions): Promise
   }
 }
 
+// ============================================================================
+// WAIT (issue #966)
+// ============================================================================
+
+/**
+ * The journal row as the API actually returns it: the generated SDK `Event`
+ * type is a projection, but GET /events returns full omni_events rows —
+ * including rawPayload, which is where the `custom.>` journal subscriber puts
+ * the published payload. `wait --filter` matches against those top-level
+ * payload fields.
+ */
+type WaitEventRow = Event & { rawPayload?: Record<string, unknown> | null };
+
+/** `--filter` entries must look like key=value (dot paths allowed on the key). */
+const WaitFilterEntrySchema = z
+  .string()
+  .regex(/^[^=\s]+=/, 'each --filter must look like key=value (dot paths allowed, e.g. --filter user.id=42)');
+
+/** Validated `omni events wait` inputs (Zod on external input, repo contract). */
+const WaitOptionsSchema = z.object({
+  timeout: z.coerce.number().positive().max(86400).optional(),
+  pollMs: z.coerce.number().int().min(250).max(60000).default(2000),
+  filter: z.array(WaitFilterEntrySchema).default([]),
+});
+
+/**
+ * Turn `--filter k=v` entries into automation trigger conditions — the SAME
+ * matcher automations use (`evaluateConditions`, @omni/core), per the issue's
+ * contract. Values parse as JSON when valid (`count=5` → number 5,
+ * `ok=true` → boolean) and fall back to the raw string (`status=open`).
+ */
+export function parseWaitFilters(entries: string[]): AutomationCondition[] {
+  return entries.map((entry) => {
+    const idx = entry.indexOf('=');
+    const raw = entry.slice(idx + 1);
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      value = raw;
+    }
+    return { field: entry.slice(0, idx), operator: 'eq', value };
+  });
+}
+
+interface WaitParams {
+  filters: StreamFilterOptions;
+  conditions: AutomationCondition[];
+  sinceIso: string;
+  pollMs: number;
+  /** Absent = wait forever (until the process is interrupted). */
+  timeoutMs?: number;
+}
+
+/** True when the row passes the envelope filters AND the payload conditions. */
+export function matchesWaitEvent(
+  event: WaitEventRow,
+  filters: StreamFilterOptions,
+  conditions: AutomationCondition[],
+): boolean {
+  if (!passesStreamFilters(event, filters)) return false;
+  return evaluateConditions(conditions, event.rawPayload ?? {});
+}
+
+/**
+ * One-shot blocking subscription (#966): poll the same list endpoint
+ * `omni events stream` uses (`fetchStreamBatch`) and resolve with the FIRST
+ * matching event, or null once the deadline passes. DB polling is the
+ * accepted transport (the issue's non-goal keeps SSE/WS out of scope).
+ */
+export async function waitForEvent(client: OmniClient, params: WaitParams): Promise<WaitEventRow | null> {
+  const deadline = params.timeoutMs === undefined ? undefined : Date.now() + params.timeoutMs;
+  const state: StreamState = { sinceIso: params.sinceIso, seen: new Set<string>() };
+
+  for (;;) {
+    const items = await fetchStreamBatch(
+      client,
+      params.filters,
+      params.filters.channel,
+      params.filters.type,
+      state.sinceIso,
+    );
+    const ascending = [...items].sort((a, b) => a.receivedAt.localeCompare(b.receivedAt));
+    for (const ev of ascending) {
+      if (state.seen.has(ev.id)) continue;
+      state.seen.add(ev.id);
+      if (ev.receivedAt > state.sinceIso) state.sinceIso = ev.receivedAt;
+      if (matchesWaitEvent(ev, params.filters, params.conditions)) return ev;
+    }
+    // Same dedupe-set bound as processStreamBatch — an open-ended wait must
+    // not grow memory with every observed-but-unmatched event.
+    if (state.seen.size > 5000 && items.length > 0) {
+      state.seen = new Set(items.map((ev) => ev.id));
+    }
+    const remaining = deadline === undefined ? params.pollMs : deadline - Date.now();
+    if (remaining <= 0) return null;
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(params.pollMs, remaining)));
+  }
+}
+
 export function createEventsCommand(): Command {
   const events = new Command('events').description('Query events');
 
@@ -718,6 +820,81 @@ export function createEventsCommand(): Command {
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error';
           output.error(`Failed to stream events: ${message}`);
+        }
+      },
+    );
+
+  // omni events wait (issue #966) — one-shot blocking subscription
+  events
+    .command('wait')
+    .description('Block until the first matching event, print it as JSON, exit 0. Exits non-zero on --timeout.')
+    .option('--instance <id>', 'Filter by instance ID')
+    .option('--channel <type>', 'Filter by channel type')
+    .option('--type <type>', 'Filter by event type (trailing * = prefix glob, e.g. custom.*)')
+    .option('--chat-id <id>', 'Filter by chat ID')
+    .option('--person-id <id>', 'Filter by person ID')
+    .option(
+      '--filter <k=v>',
+      'Payload condition, repeatable (dot paths + JSON values, e.g. --filter user.id=42 --filter status=open)',
+      (value: string, previous: string[]) => [...previous, value],
+      [] as string[],
+    )
+    .option('--timeout <seconds>', 'Give up after N seconds: exit non-zero, nothing on stdout')
+    .option('--since <time>', 'Start cursor (e.g., 5min, ISO timestamp; default: now)')
+    .option('--poll-ms <n>', 'Polling interval in milliseconds', (v) => Number.parseInt(v, 10), 2000)
+    .action(
+      async (options: {
+        instance?: string;
+        channel?: string;
+        type?: string;
+        chatId?: string;
+        personId?: string;
+        filter: string[];
+        timeout?: string;
+        since?: string;
+        pollMs?: number;
+      }) => {
+        const client = getClient();
+        try {
+          const parsed = WaitOptionsSchema.parse({
+            timeout: options.timeout,
+            pollMs: options.pollMs,
+            filter: options.filter,
+          });
+          const instanceId = options.instance ? await resolveInstanceId(options.instance) : undefined;
+          const chatId = options.chatId ? await resolveChatId(options.chatId) : undefined;
+
+          const event = await waitForEvent(client, {
+            // all: true — an explicit wait must also see "noisy" types
+            // (message.delivered/read etc.) the stream hides by default.
+            filters: {
+              instanceId,
+              channel: options.channel,
+              type: options.type,
+              chatId,
+              personId: options.personId,
+              all: true,
+            },
+            conditions: parseWaitFilters(parsed.filter),
+            sinceIso: options.since ? parseSinceTime(options.since) : new Date().toISOString(),
+            pollMs: parsed.pollMs,
+            timeoutMs: parsed.timeout === undefined ? undefined : parsed.timeout * 1000,
+          });
+
+          if (event) {
+            output.raw(JSON.stringify(event));
+            await output.flushStdout();
+            return;
+          }
+          output.error(`Timed out after ${parsed.timeout}s waiting for a matching event`);
+        } catch (err) {
+          const message =
+            err instanceof z.ZodError
+              ? err.issues.map((i) => i.message).join('; ')
+              : err instanceof Error
+                ? err.message
+                : 'Unknown error';
+          output.error(`Failed to wait for event: ${message}`);
         }
       },
     );

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -452,6 +452,16 @@ export function isNoisyEvent(eventType: string): boolean {
   return NOISY_EVENT_TYPES.has(eventType);
 }
 
+/**
+ * Match an event type against a `--type` filter value (#966). A trailing `*`
+ * makes the filter a prefix glob (`custom.*` matches every custom event);
+ * anything else is an exact match. Same contract as the API-side list filter
+ * (EventService.list) — keep the two in sync.
+ */
+export function matchesEventTypeFilter(eventType: string, filter: string): boolean {
+  return filter.endsWith('*') ? eventType.startsWith(filter.slice(0, -1)) : eventType === filter;
+}
+
 /** Filter predicate matrix for `omni events stream`. Exported for unit tests. */
 export interface StreamFilterOptions {
   instanceId?: string;
@@ -471,7 +481,7 @@ export interface StreamFilterOptions {
  */
 export function passesStreamFilters(event: Event, options: StreamFilterOptions): boolean {
   if (options.instanceId && event.instanceId !== options.instanceId) return false;
-  if (options.type && event.eventType !== options.type) return false;
+  if (options.type && !matchesEventTypeFilter(event.eventType, options.type)) return false;
   if (options.chatId && event.chatUuid !== options.chatId) return false;
   if (options.personId && event.personId !== options.personId) return false;
   if (options.errorsOnly && !isErrorEvent(event.eventType)) return false;
@@ -624,7 +634,7 @@ export function createEventsCommand(): Command {
     .description('List events')
     .option('--instance <id>', 'Filter by instance ID')
     .option('--channel <type>', 'Filter by channel type')
-    .option('--type <type>', 'Filter by event type')
+    .option('--type <type>', 'Filter by event type (trailing * = prefix glob, e.g. custom.*)')
     .option('--chat-id <id>', 'Filter by chat ID')
     .option('--since <time>', 'Events since (e.g., 24h, 7d, or ISO timestamp)')
     .option('--until <time>', 'Events until (ISO timestamp)')
@@ -681,7 +691,7 @@ export function createEventsCommand(): Command {
     .description('Stream events in real-time (tail -f style). Ctrl+C to stop.')
     .option('--instance <id>', 'Filter by instance ID')
     .option('--channel <type>', 'Filter by channel type')
-    .option('--type <type>', 'Filter by event type')
+    .option('--type <type>', 'Filter by event type (trailing * = prefix glob, e.g. custom.*)')
     .option('--chat-id <id>', 'Filter by chat ID')
     .option('--person-id <id>', 'Filter by person ID')
     .option('--since <time>', 'Start cursor (e.g., 5min, 24h, 7d, or ISO timestamp)')

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -948,6 +948,15 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     class: 'tenant-boundary',
   },
   {
+    // Same scoping as the sibling `chats` entry above: the #966 best-effort
+    // personId existence check for custom journal rows (FK safety before
+    // stamping person_id) issues on `scopedHandle` inside the consumer's
+    // worker tenant scope. Consumer-only callers.
+    file: 'packages/api/src/plugins/event-persistence.ts',
+    table: 'persons',
+    class: 'tenant-boundary',
+  },
+  {
     file: 'packages/api/src/plugins/instance-monitor.ts',
     table: 'instances',
     class: 'tenant-boundary',


### PR DESCRIPTION
Closes #966

Completes the #966 scope that remained after the #957 round landed custom-event journaling. Four changes, one commit each, plus a tenancy-guard registration:

## Fixes

- **255-char event types in the journal** — the `custom.>` subscriber still stamped `eventType: event.type.slice(0, 50)` although `omni_events.event_type` is `varchar(255)` since #958. Longer `custom.webhook.{source}.{event}` types were silently truncated, breaking exact-match `--type` filters. The stamp now slices to 255 (the column width); types beyond that keep the full value in `metadata.fullEventType`.
- **chatUuid/personId on custom journal rows** — custom rows set neither, so `--chat-id`/`--person-id` could never match a custom event. Best-effort, FK-safe mapping (a bogus claim is dropped, never fails the insert):
  - `personId`: `metadata.personId`, then `payload.personId` — either must name an existing `persons` row;
  - `chatUuid`: `payload.chatUuid` (an existing `chats.id`), then `payload.chatId` (platform JID) resolved against `metadata.instanceId` like the message subscribers;
  - `chatId` column stamped verbatim from `payload.chatId`.
  The new `persons` access site is registered with the db-access guard as `tenant-boundary` (it issues on `scopedHandle` inside the consumer worker tenant scope, like its siblings).

## Features

- **Trailing-`*` glob type filtering** — `--type 'custom.*'` previously matched nothing (API `inArray` strict equality, CLI `===` sieve). A type filter entry ending in `*` is now a prefix glob on both layers: `EventService.list` emits an escaped `LIKE 'prefix%'` (ORed with exact entries in a mixed list), and the CLI sieve uses `matchesEventTypeFilter` with the identical contract, so `events list`/`stream --type 'custom.*'` work end to end.
- **`omni events wait`** — one-shot blocking subscription for CLI agents. Reuses the stream's DB-polling loop (`fetchStreamBatch`, default `--poll-ms 2000`; no SSE/WS, per the issue's non-goals). First matching event → full journal row as JSON on stdout, exit 0; `--timeout <s>` elapsed → exit non-zero with empty stdout. Filters: `--type` (with glob), `--chat-id`, `--person-id`, `--instance`, `--channel`, `--since`, and repeatable `--filter k=v` payload conditions evaluated by `evaluateConditions` from `@omni/core` — the same matcher automation trigger conditions use (values parse as JSON when valid, else raw string). Options are Zod-validated.

## Tests

- New pg-gate suite `packages/api/src/__tests__/events-custom-journal-postgres.test.ts` (`*-postgres.test.ts` naming so the gate actually runs it): drives the real `custom.>` handler against a migrated disposable database — truncation round-trip + filterability, the 255 cap, all chatUuid/personId mapping paths incl. FK-safety, and API glob semantics (prefix, mixed exact+glob, `LIKE` wildcard escaping, exact still exact).
- CLI: glob unit tests in `events-stream.test.ts`; `events-wait.test.ts` covers filter parsing, matcher semantics, and `waitForEvent` against an in-process `Bun.serve` API (first-match, multi-poll, timeout, non-matching event), pinning native fetch per the events-schema hermetic precedent (#967).

`make check` and `make test-pg-gate` (309 assertions across 32 suites, 0 skipped) both green. No schema/migration changes.