### PR TITLE
fix(api): skip MinIO suites when Docker cannot publish ports

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -40,10 +40,19 @@ set -e
 #         Reach for spyOn/local fixtures over mock.module.
 #
 #   • MinIO suites timing out locally
-#       → The harness needs a healthy Docker daemon. Leaked test containers
-#         from OOM-killed runs degrade it; the harness reaps stale ones at
-#         launch, but `docker ps --filter label=com.automagik.omni.test-harness=minio`
-#         shows anything left to clean by hand.
+#       → Two distinct host problems look identical from the outside:
+#         (a) Docker cannot PUBLISH ports (rootless Docker without port
+#             forwarding, IPv4 forwarding disabled, missing default bridge
+#             network, VPN/firewall interference) — `docker info` passes but
+#             `docker run -p` yields an unreachable port (#948). The harness
+#             now probes publishability up front and SKIPS the MinIO suites
+#             with a loud warning instead of hanging; readiness also aborts
+#             early on persistent connection-refused. If you see the skip
+#             warning, fix Docker networking (or force with MINIO_INTEGRATION=1).
+#         (b) Leaked test containers from OOM-killed runs degrade the daemon;
+#             the harness reaps stale ones at launch, but
+#             `docker ps --filter label=com.automagik.omni.test-harness=minio`
+#             shows anything left to clean by hand.
 #
 #   • Force push to main/master
 #       → Refused by design. Main is production; merge through the

--- a/packages/api/src/__tests__/minio-harness-cleanup.test.ts
+++ b/packages/api/src/__tests__/minio-harness-cleanup.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  type DockerPublishProbeDependencies,
   MinioContainerLifecycle,
   STALE_CONTAINER_MIN_AGE_MS,
   type SharedMinioHarnessDependencies,
+  createDockerPublishProbe,
   createSharedMinioHarness,
   reapStaleContainers,
 } from './minio-harness';
@@ -197,6 +199,7 @@ function setup(
     sessionId: 'session-123',
     readinessTimeoutMs: 1_000,
     readyRequestTimeoutMs: 100,
+    connectionRefusedFastFailMs: 250,
     reportCleanupFailure: (message) => cleanupFailures.push(message),
   };
   const harness = createSharedMinioHarness(dependencies);
@@ -404,6 +407,230 @@ describe('shared MinIO harness cleanup', () => {
     expect(observedSignal?.aborted).toBe(true);
     expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-hung-probe']]);
   }, 250);
+
+  function connectionRefusedError(code: 'ECONNREFUSED' | 'ConnectionRefused'): Error {
+    const error = new Error('Unable to connect. Is the computer able to access the url?');
+    (error as Error & { code?: string }).code = code;
+    return error;
+  }
+
+  for (const code of ['ECONNREFUSED', 'ConnectionRefused'] as const) {
+    test(`aborts readiness early with a port-publishing diagnosis when every probe is ${code}`, async () => {
+      const fake = setup(['container-unpublished']);
+      fake.dependencies.readyFetch = async () => {
+        throw connectionRefusedError(code);
+      };
+
+      await expect(fake.getSharedMinio()).rejects.toThrow(
+        /refused every connection for 500ms.*Docker likely cannot publish ports/s,
+      );
+
+      // Fast-failed at 500ms of fake time, well inside the 1s readiness
+      // deadline, and the container was still stopped synchronously.
+      expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-unpublished']]);
+    });
+  }
+
+  test('a brief startup connection-refused window does not trip the fast-fail', async () => {
+    const fake = setup(['container-slow-bind']);
+    let attempts = 0;
+    fake.dependencies.readyFetch = async () => {
+      attempts += 1;
+      if (attempts === 1) throw connectionRefusedError('ConnectionRefused');
+      return { ok: true };
+    };
+
+    await expect(fake.getSharedMinio()).resolves.toMatchObject({ endpoint: 'http://127.0.0.1:30000' });
+    expect(attempts).toBe(2);
+  });
+
+  test('once the port has answered, later refusals get the full readiness deadline, not the fast-fail', async () => {
+    const fake = setup(['container-answered-then-died']);
+    let attempts = 0;
+    fake.dependencies.readyFetch = async () => {
+      attempts += 1;
+      if (attempts === 1) return { ok: false };
+      throw connectionRefusedError('ECONNREFUSED');
+    };
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('MinIO did not become ready within 1s');
+    expect(fake.docker.operations('stop')).toEqual([
+      ['docker', 'stop', '--time', '10', 'container-answered-then-died'],
+    ]);
+  });
+
+  test('non-refused readiness failures still burn the full deadline (slow container, not a wiring problem)', async () => {
+    // The default fake readyFetch throws a generic (non-refused) error, so the
+    // pre-existing timeout path must be unchanged by the fast-fail logic.
+    const fake = setup(['container-slow'], { ready: false });
+
+    await expect(fake.getSharedMinio()).rejects.toThrow('MinIO did not become ready within 1s');
+  });
+});
+
+describe('Docker port-publishability probe', () => {
+  const FAKE_BUN = '/fake/bin/bun';
+
+  function probeSetup(
+    options: {
+      /** Number of failed fetch attempts before one succeeds; omit for never-reachable. */
+      reachableAfterAttempts?: number;
+      runFails?: boolean;
+      emptyRunStdout?: boolean;
+    } = {},
+  ): {
+    probe: () => boolean;
+    warns: string[];
+    calls: string[][];
+    operations(operation: string): string[][];
+    fetchAttempts(): number;
+  } {
+    let clock = 0;
+    let attempts = 0;
+    const warns: string[] = [];
+    const calls: string[][] = [];
+    const handleProbeFetch = (): { exitCode: number; stdout: string; stderr: string } => {
+      attempts += 1;
+      const reachable = options.reachableAfterAttempts !== undefined && attempts > options.reachableAfterAttempts;
+      return { exitCode: reachable ? 0 : 1, stdout: '', stderr: '' };
+    };
+    const handleDockerRun = (): { exitCode: number; stdout: string; stderr: string } => {
+      if (options.runFails) return { exitCode: 125, stdout: '', stderr: 'fake docker run failure' };
+      return { exitCode: 0, stdout: options.emptyRunStdout ? '' : 'probe-container\n', stderr: '' };
+    };
+    const dependencies: DockerPublishProbeDependencies = {
+      runSync: (command) => {
+        calls.push([...command]);
+        if (command[0] === FAKE_BUN) return handleProbeFetch();
+        if (command[1] === 'run') return handleDockerRun();
+        if (command[1] === 'rm') return { exitCode: 0, stdout: 'probe-container\n', stderr: '' };
+        throw new Error(`Unexpected fake probe command: ${command.join(' ')}`);
+      },
+      now: () => clock,
+      sleepSync: (ms) => {
+        clock += ms;
+      },
+      random: () => 0.5,
+      execPath: FAKE_BUN,
+      sessionId: 'session-123',
+      probeTimeoutMs: 1_000,
+      probePollIntervalMs: 250,
+      warn: (message) => warns.push(message),
+    };
+    return {
+      probe: createDockerPublishProbe(dependencies),
+      warns,
+      calls,
+      operations: (operation) => calls.filter((command) => command[0] === 'docker' && command[1] === operation),
+      fetchAttempts: () => attempts,
+    };
+  }
+
+  test('a reachable published port passes: labeled bounded probe container, fetch via child bun, then removal', () => {
+    const fake = probeSetup({ reachableAfterAttempts: 0 });
+
+    expect(fake.probe()).toBe(true);
+    expect(fake.warns).toEqual([]);
+
+    // Same labeled, resource-bounded, port-publishing run shape as the real
+    // harness container — the probe must test exactly what the suites need.
+    expect(fake.operations('run')).toEqual([
+      [
+        'docker',
+        'run',
+        '--rm',
+        '-d',
+        '--label',
+        'com.automagik.omni.test-harness=minio',
+        '--label',
+        'com.automagik.omni.test-session=session-123',
+        '--cpus',
+        '1',
+        '--memory',
+        '512m',
+        '--pids-limit',
+        '256',
+        '--tmpfs',
+        '/data:rw,noexec,nosuid,size=256m',
+        '-p',
+        '30000:9000',
+        '-e',
+        'MINIO_ROOT_USER=minioadmin',
+        '-e',
+        'MINIO_ROOT_PASSWORD=minioadmin',
+        'minio/minio',
+        'server',
+        '/data',
+      ],
+    ]);
+    const fetchCommand = fake.calls.find((command) => command[0] === FAKE_BUN);
+    expect(fetchCommand?.[1]).toBe('--eval');
+    expect(fetchCommand?.[2]).toContain('http://127.0.0.1:30000/minio/health/ready');
+    expect(fake.operations('rm')).toEqual([['docker', 'rm', '-f', 'probe-container']]);
+  });
+
+  test('a slow-to-listen but reachable port still passes without a warning', () => {
+    const fake = probeSetup({ reachableAfterAttempts: 2 });
+
+    expect(fake.probe()).toBe(true);
+    expect(fake.warns).toEqual([]);
+    expect(fake.fetchAttempts()).toBe(3);
+    expect(fake.operations('rm')).toEqual([['docker', 'rm', '-f', 'probe-container']]);
+  });
+
+  test('an unreachable published port fails loudly once and never leaks the probe container', () => {
+    const fake = probeSetup();
+
+    expect(fake.probe()).toBe(false);
+
+    // 1s budget / 250ms poll interval => exactly 4 attempts before giving up.
+    expect(fake.fetchAttempts()).toBe(4);
+    expect(fake.warns).toHaveLength(1);
+    expect(fake.warns[0]).toContain('Docker is running but cannot publish container ports');
+    expect(fake.warns[0]).toContain('127.0.0.1:30000');
+    expect(fake.warns[0]).toContain('MINIO_INTEGRATION=1');
+    expect(fake.operations('rm')).toEqual([['docker', 'rm', '-f', 'probe-container']]);
+  });
+
+  test('the verdict and the warning are cached per process: one probe container for all six suites', () => {
+    const fake = probeSetup();
+
+    expect(fake.probe()).toBe(false);
+    expect(fake.probe()).toBe(false);
+    expect(fake.probe()).toBe(false);
+
+    expect(fake.operations('run')).toHaveLength(1);
+    expect(fake.warns).toHaveLength(1);
+  });
+
+  test('a positive verdict is cached too', () => {
+    const fake = probeSetup({ reachableAfterAttempts: 0 });
+
+    expect(fake.probe()).toBe(true);
+    expect(fake.probe()).toBe(true);
+
+    expect(fake.operations('run')).toHaveLength(1);
+  });
+
+  test('a failed docker run fails the probe loudly with the stderr and removes nothing', () => {
+    const fake = probeSetup({ runFails: true });
+
+    expect(fake.probe()).toBe(false);
+    expect(fake.warns).toEqual([
+      'MinIO integration suites SKIPPED: the Docker port-publishability probe could not start a container: fake docker run failure',
+    ]);
+    expect(fake.operations('rm')).toHaveLength(0);
+  });
+
+  test('an empty container ID from docker run fails the probe loudly', () => {
+    const fake = probeSetup({ emptyRunStdout: true });
+
+    expect(fake.probe()).toBe(false);
+    expect(fake.warns).toEqual([
+      'MinIO integration suites SKIPPED: the Docker port-publishability probe got no container ID from docker run',
+    ]);
+    expect(fake.operations('rm')).toHaveLength(0);
+  });
 });
 
 describe('stale MinIO container reaper', () => {

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -50,18 +50,28 @@ function dockerAvailable(): boolean {
 /**
  * Whether the MinIO container-integration suites should actually run.
  *
- * They need a real `minio/minio` container. Locally (pre-push) that is fine, but
- * on a shared/loaded CI runner the container's readiness probe intermittently
+ * They need a real `minio/minio` container, and — critically — a Docker daemon
+ * that can actually PUBLISH a container port to the host. `docker info`
+ * succeeding is a weaker condition: rootless Docker without port forwarding, a
+ * host with IPv4 forwarding disabled, a missing default bridge network, or
+ * Docker Desktop under some VPNs all pass `docker info` while `docker run -p`
+ * silently produces an unreachable port. On such a host every suite would burn
+ * the full 120s readiness deadline (#948), so the gate probes publishability
+ * up front (cached per process) and skips with one loud warning instead.
+ *
+ * On a shared/loaded CI runner the container's readiness probe intermittently
  * blows the 120s deadline (~50% flake observed), which would red the whole
  * Quality Gate for entirely unrelated PRs. So in CI these suites are OPT-IN:
  * set `MINIO_INTEGRATION=1` (e.g. a dedicated integration job) to run them;
- * otherwise they skip deterministically. Docker is still required either way,
- * and local runs (no `CI` env) always run when Docker is present.
+ * otherwise they skip deterministically. `MINIO_INTEGRATION=1` also bypasses
+ * the publishability probe (locally too), as the escape hatch for a
+ * false-negative probe on a badly overloaded machine.
  */
 export function minioIntegrationEnabled(): boolean {
   if (!dockerAvailable()) return false;
   if (process.env.CI === 'true' && process.env.MINIO_INTEGRATION !== '1') return false;
-  return true;
+  if (process.env.MINIO_INTEGRATION === '1') return true;
+  return dockerCanPublishPorts();
 }
 
 function sha256hex(data: string): string {
@@ -126,6 +136,12 @@ export interface SharedMinioHarnessDependencies {
   sessionId: string;
   readinessTimeoutMs: number;
   readyRequestTimeoutMs: number;
+  /**
+   * How long an unbroken run of connection-refused probes (with the port never
+   * having answered at all) is tolerated before readiness aborts with a
+   * port-publishing diagnosis instead of waiting out `readinessTimeoutMs`.
+   */
+  connectionRefusedFastFailMs: number;
   reportCleanupFailure(message: string): void;
 }
 
@@ -153,6 +169,125 @@ const processHooks: ProcessHooks = {
   },
 };
 
+/**
+ * The one `docker run` shape this harness ever uses, shared by the real
+ * container launch and the publishability probe so the two cannot drift:
+ * labeled (so `reapStaleContainers` can sweep leaks), resource-bounded, and
+ * publishing `port` on the host.
+ */
+function minioRunCommand(port: number, sessionId: string): string[] {
+  return [
+    'docker',
+    'run',
+    '--rm',
+    '-d',
+    '--label',
+    'com.automagik.omni.test-harness=minio',
+    '--label',
+    `com.automagik.omni.test-session=${sessionId}`,
+    '--cpus',
+    '1',
+    '--memory',
+    '512m',
+    '--pids-limit',
+    '256',
+    '--tmpfs',
+    '/data:rw,noexec,nosuid,size=256m',
+    '-p',
+    `${port}:9000`,
+    '-e',
+    `MINIO_ROOT_USER=${ACCESS_KEY}`,
+    '-e',
+    `MINIO_ROOT_PASSWORD=${SECRET_KEY}`,
+    'minio/minio',
+    'server',
+    '/data',
+  ];
+}
+
+export interface DockerPublishProbeDependencies {
+  runSync(command: string[]): SyncCommandResult;
+  now(): number;
+  sleepSync(ms: number): void;
+  random(): number;
+  /** Path to the bun executable used for the synchronous child-process fetch. */
+  execPath: string;
+  sessionId: string;
+  probeTimeoutMs: number;
+  probePollIntervalMs: number;
+  warn(message: string): void;
+}
+
+/**
+ * The gate must stay synchronous (it feeds module-top-level `describe.skipIf`
+ * in six suites), but proving a published port is reachable requires an HTTP
+ * request. Bridge the gap by spawning a short-lived bun child that does the
+ * fetch and reports via its exit code. ANY HTTP response — even a 503 while
+ * MinIO is still starting — proves end-to-end port publishing works.
+ */
+function probeFetchCommand(execPath: string, port: number): string[] {
+  const script = `const res = await fetch('http://127.0.0.1:${port}/minio/health/ready', { signal: AbortSignal.timeout(1000) }).catch(() => undefined);\nprocess.exit(res ? 0 : 1);`;
+  return [execPath, '--eval', script];
+}
+
+/**
+ * Verify Docker can publish a container port to the host — the condition the
+ * MinIO suites actually depend on, which `docker info` does not establish
+ * (#948). Starts a throwaway labeled MinIO container with `-p` and polls its
+ * published port until it serves ANY HTTP response or the probe deadline
+ * lapses. Every negative outcome emits exactly one loud warning naming the
+ * real cause, so a green-but-skipped run is never mistaken for full coverage.
+ */
+function probeDockerPortPublishing(dependencies: DockerPublishProbeDependencies): boolean {
+  const port = 20000 + Math.floor(dependencies.random() * 20000);
+  const run = dependencies.runSync(minioRunCommand(port, dependencies.sessionId));
+  if (run.exitCode !== 0) {
+    dependencies.warn(
+      `MinIO integration suites SKIPPED: the Docker port-publishability probe could not start a container: ${
+        run.stderr.trim() || `exit ${run.exitCode}`
+      }`,
+    );
+    return false;
+  }
+  const containerId = run.stdout.trim();
+  if (!containerId) {
+    dependencies.warn(
+      'MinIO integration suites SKIPPED: the Docker port-publishability probe got no container ID from docker run',
+    );
+    return false;
+  }
+  try {
+    const deadline = dependencies.now() + dependencies.probeTimeoutMs;
+    while (dependencies.now() < deadline) {
+      if (dependencies.runSync(probeFetchCommand(dependencies.execPath, port)).exitCode === 0) return true;
+      dependencies.sleepSync(dependencies.probePollIntervalMs);
+    }
+    dependencies.warn(
+      `MinIO integration suites SKIPPED: Docker is running but cannot publish container ports — a probe container published 127.0.0.1:${port} and never accepted an HTTP request within ${
+        dependencies.probeTimeoutMs / 1000
+      }s. Likely causes: rootless Docker without port forwarding, IPv4 forwarding disabled, a missing default bridge network, or VPN/firewall interference. Fix Docker networking, or force the suites with MINIO_INTEGRATION=1.`,
+    );
+    return false;
+  } finally {
+    // Best-effort removal; a SIGKILL-orphaned probe container is still labeled
+    // and swept by reapStaleContainers on a later launch.
+    dependencies.runSync(['docker', 'rm', '-f', containerId]);
+  }
+}
+
+/**
+ * Cache the probe verdict per factory (one throwaway container per process for
+ * the module-level instance), so six suites gating on `minioIntegrationEnabled`
+ * pay for — and warn about — exactly one probe.
+ */
+export function createDockerPublishProbe(dependencies: DockerPublishProbeDependencies): () => boolean {
+  let verdict: boolean | undefined;
+  return () => {
+    verdict ??= probeDockerPortPublishing(dependencies);
+    return verdict;
+  };
+}
+
 async function fetchReadyWithTimeout(
   url: string,
   timeoutMs: number,
@@ -177,11 +312,33 @@ async function fetchReadyWithTimeout(
   }
 }
 
+/**
+ * Whether a readiness-probe failure was an immediate connection refusal —
+ * nothing bound on the host port — as opposed to a slow/hung request (which a
+ * starting container legitimately produces). Bun's fetch surfaces this as
+ * code `ConnectionRefused`; Node-style errors use `ECONNREFUSED`.
+ */
+function isConnectionRefused(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as Error & { code?: unknown }).code;
+  if (code === 'ECONNREFUSED' || code === 'ConnectionRefused') return true;
+  return /ECONNREFUSED|ConnectionRefused|connection refused/i.test(error.message);
+}
+
 async function waitForReady(port: number, dependencies: SharedMinioHarnessDependencies): Promise<void> {
   // Single wait for the shared container. Generous deadline: on a loaded CI
   // runner (Blacksmith 4vcpu, full suite hammering the box) MinIO has been
   // observed to need well over 45s to serve its readiness probe.
-  const deadline = dependencies.now() + dependencies.readinessTimeoutMs;
+  const start = dependencies.now();
+  const deadline = start + dependencies.readinessTimeoutMs;
+  // Once the published port has answered in ANY form (an HTTP response, or a
+  // non-refused failure such as a slow request timing out), the container is
+  // wired up and only slowness remains — the full deadline applies. Until
+  // then, an unbroken run of connection-refused longer than
+  // connectionRefusedFastFailMs means nothing is listening on the host port at
+  // all: Docker cannot publish ports (#948), and waiting out the remaining
+  // deadline would only turn a diagnosis into a stall.
+  let portEverAnswered = false;
   while (dependencies.now() < deadline) {
     try {
       const remainingMs = Math.max(1, deadline - dependencies.now());
@@ -192,8 +349,18 @@ async function waitForReady(port: number, dependencies: SharedMinioHarnessDepend
         dependencies,
       );
       if (res.ok) return;
-    } catch {
-      // not up yet
+      portEverAnswered = true;
+    } catch (error) {
+      if (!isConnectionRefused(error)) {
+        portEverAnswered = true;
+      } else if (!portEverAnswered) {
+        const refusedForMs = dependencies.now() - start;
+        if (refusedForMs >= dependencies.connectionRefusedFastFailMs) {
+          throw new Error(
+            `MinIO readiness aborted early: 127.0.0.1:${port} refused every connection for ${refusedForMs}ms — the published container port is not reachable from the host. Docker likely cannot publish ports (rootless Docker without port forwarding, IPv4 forwarding disabled, a missing default bridge network, or VPN/firewall interference).`,
+          );
+        }
+      }
     }
     await dependencies.sleep(500);
   }
@@ -440,33 +607,7 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
     lifecycle.beginLaunch();
     let proc: SyncCommandResult;
     try {
-      proc = dependencies.runSync([
-        'docker',
-        'run',
-        '--rm',
-        '-d',
-        '--label',
-        'com.automagik.omni.test-harness=minio',
-        '--label',
-        `com.automagik.omni.test-session=${dependencies.sessionId}`,
-        '--cpus',
-        '1',
-        '--memory',
-        '512m',
-        '--pids-limit',
-        '256',
-        '--tmpfs',
-        '/data:rw,noexec,nosuid,size=256m',
-        '-p',
-        `${port}:9000`,
-        '-e',
-        `MINIO_ROOT_USER=${ACCESS_KEY}`,
-        '-e',
-        `MINIO_ROOT_PASSWORD=${SECRET_KEY}`,
-        'minio/minio',
-        'server',
-        '/data',
-      ]);
+      proc = dependencies.runSync(minioRunCommand(port, dependencies.sessionId));
     } catch (error) {
       lifecycle.abortLaunch();
       throw error;
@@ -508,6 +649,20 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
   };
 }
 
+const harnessSessionId = `${process.pid}-${randomUUID()}`;
+
+const dockerCanPublishPorts = createDockerPublishProbe({
+  runSync,
+  now: Date.now,
+  sleepSync: (ms) => Bun.sleepSync(ms),
+  random: Math.random,
+  execPath: process.execPath,
+  sessionId: harnessSessionId,
+  probeTimeoutMs: 10_000,
+  probePollIntervalMs: 250,
+  warn: (message) => console.warn(message),
+});
+
 const sharedMinioHarness = createSharedMinioHarness({
   runSync,
   process: processHooks,
@@ -515,9 +670,10 @@ const sharedMinioHarness = createSharedMinioHarness({
   now: Date.now,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   random: Math.random,
-  sessionId: `${process.pid}-${randomUUID()}`,
+  sessionId: harnessSessionId,
   readinessTimeoutMs: 120_000,
   readyRequestTimeoutMs: 5_000,
+  connectionRefusedFastFailMs: 5_000,
   reportCleanupFailure: (message) => console.error(message),
 });
 


### PR DESCRIPTION
## Summary

Closes #948.

On hosts where Docker passes `docker info` but cannot publish container ports (rootless Docker without port forwarding, IPv4 forwarding disabled, missing default bridge network, VPN/firewall interference), the MinIO container-integration suites burned the full 120s readiness deadline once per consuming suite, making `git push` appear to hang. The only workaround was remembering to prefix `CI=true`.

## What changed

1. **Publishability probe (primary fix).** `minioIntegrationEnabled()` now ends with a per-process-cached, synchronous probe: a throwaway MinIO container using the exact same `docker run` shape as the real harness (shared `minioRunCommand`, so probe and harness cannot drift — labeled, resource-bounded, `-p random:9000`) must serve one HTTP response within 10s, checked via a `bun --eval` child fetch so the gate stays sync for the module-top-level `describe.skipIf` in all six suites. A negative verdict skips the suites with **one loud `console.warn`** naming the real cause and the `MINIO_INTEGRATION=1` override. The probe container is `rm -f`'d in a `finally` and carries the harness label so `reapStaleContainers` sweeps a SIGKILL-orphaned probe. CI ordering is unchanged: the `CI=true` short-circuit runs *before* the probe, so CI never pays for a probe container.
2. **Readiness fast-fail.** `waitForReady` no longer swallows the error class: an unbroken run of connection-refused (Bun's `ConnectionRefused` / Node's `ECONNREFUSED`) longer than 5s with the port never having answered aborts with a port-publishing diagnosis instead of burning the 120s deadline. Timeouts, resets, and non-ok HTTP latch "the port answered" and keep the full generous deadline, so slow-CI behavior is unchanged.
3. **`.husky/pre-push` guidance** now names port publishability alongside the stale-container reaper as a cause of local MinIO stalls.

A wall-clock timeout wrapper around the turbo invocation was considered and deliberately skipped: macOS has no GNU `timeout`, and a portable background-and-kill wrapper risks killing turbo mid-cache-write; the probe + fast-fail remove the hang class at its source.

## Behavior by host

- **Healthy host:** one ~2–3s probe round-trip per test process; suites run exactly as before (verified locally against real Docker).
- **Broken-publishing host:** at most 10s once per process, all six suites skip loudly, no env var needed. If a container still launches somehow, readiness aborts in ~5s with the same diagnosis instead of 120s × 6.

## Tests

11 new tests in `minio-harness-cleanup.test.ts` using the existing injectable fake-deps pattern (38 total, all green): probe pass/slow-listen/unreachable/docker-run-failure/empty-ID paths with exact command and cleanup assertions, per-process caching of verdict + single warning, and fast-fail coverage for both refusal error-code shapes plus the startup-grace and answered-then-refused latch cases.

`make check` green locally (modulo the 4 documented pre-existing environmental worktree failures, re-verified identical on unmodified `dev`); migration contract untouched; biome/knip/typecheck clean; pushed through the full pre-push gate.

## Known pre-existing issue surfaced while testing (not addressed here)

The shared MinIO container leaks on every normal test-process exit — the `process.once('exit')` stop never takes effect in real runs; today only the 30-minute reaper cleans these (512MB reserved each). Reproduced on unmodified `dev`. Worth its own issue.