### PR TITLE
fix(media-processing): stop accepting chat replies as audio transcriptions

### DIFF
--- a/packages/api/src/plugins/media-processor.ts
+++ b/packages/api/src/plugins/media-processor.ts
@@ -749,7 +749,7 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
     services.settings.getSecret('gemini.api_key', 'GEMINI_API_KEY'),
     services.settings.getString('media.default_language', 'DEFAULT_LANGUAGE', 'pt'),
     services.settings.getString('stt.provider', 'STT_PROVIDER', 'openai'),
-    services.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-audio-mini'),
+    services.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-4o-transcribe'),
     services.settings.getString('stt.gemini.model', 'GEMINI_STT_MODEL', GEMINI_AUDIO_MODEL),
     services.settings.getString('prompt.audio_transcription'),
     services.settings.getString('prompt.image_description'),
@@ -763,7 +763,7 @@ export async function setupMediaProcessor(eventBus: EventBus, db: Database, serv
     geminiApiKey,
     defaultLanguage,
     audioProvider: audioProvider ?? 'openai',
-    audioModel: audioModel ?? 'gpt-audio-mini',
+    audioModel: audioModel ?? 'gpt-4o-transcribe',
     geminiAudioModel: geminiAudioModel ?? GEMINI_AUDIO_MODEL,
     audioPrompt: audioPrompt ?? undefined,
   });

--- a/packages/api/src/providers/openai/stt.test.ts
+++ b/packages/api/src/providers/openai/stt.test.ts
@@ -9,7 +9,30 @@ describe('OpenAiSttProvider', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('uses audio-chat input_audio for the quality gpt-audio-mini lane', async () => {
+  it('defaults to the transcriptions endpoint with gpt-4o-transcribe', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ text: 'transcrição real' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAiSttProvider({
+      getSecret: async () => 'test-key',
+      getString: async (_key, _env, defaultValue) => defaultValue,
+    });
+
+    const result = await provider.transcribe(Buffer.from('fake-audio'), 'audio/mpeg', { language: 'pt-BR' });
+
+    expect(result.text).toBe('transcrição real');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toContain('/audio/transcriptions');
+    expect((calls[0]?.init?.body as FormData).get('model')).toBe('gpt-4o-transcribe');
+  });
+
+  it('uses audio-chat input_audio when a gpt-audio model is requested', async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init });
@@ -26,6 +49,7 @@ describe('OpenAiSttProvider', () => {
 
     const result = await provider.transcribe(Buffer.from('fake-audio'), 'audio/mpeg', {
       language: 'pt-BR',
+      model: 'gpt-audio-mini',
       context: 'KHAL WhatsApp voice note',
       glossary: ['Gupshup', 'HV clear'],
     });
@@ -47,6 +71,76 @@ describe('OpenAiSttProvider', () => {
       type: 'input_audio',
       input_audio: { data: Buffer.from('fake-audio').toString('base64'), format: 'mp3' },
     });
+  });
+
+  it('falls back to the transcriptions endpoint when the chat lane returns a conversational reply (issue #942)', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      if (String(url).includes('/chat/completions')) {
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content:
+                    'Claro, por favor me diga o que você gostaria que fosse transcrito. Se tiver um áudio, descreva o conteúdo.',
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify({ text: 'transcrição de verdade' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAiSttProvider({
+      getSecret: async () => 'test-key',
+      getString: async () => 'gpt-audio-mini',
+    });
+
+    const result = await provider.transcribe(Buffer.from('fake-audio'), 'audio/mpeg', { language: 'pt-BR' });
+
+    expect(result.text).toBe('transcrição de verdade');
+    expect(calls.map((call) => String(call.url))).toEqual([
+      'https://api.openai.com/v1/chat/completions',
+      'https://api.openai.com/v1/audio/transcriptions',
+    ]);
+    expect((calls[1]?.init?.body as FormData).get('model')).toBe('gpt-4o-transcribe');
+  });
+
+  it('falls back to the transcriptions endpoint when the chat lane returns empty text', async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      calls.push(String(url));
+      if (String(url).includes('/chat/completions')) {
+        return new Response(JSON.stringify({ choices: [{ message: { content: '   ' } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ text: 'olá mundo' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAiSttProvider({
+      getSecret: async () => 'test-key',
+      getString: async () => 'gpt-audio-mini',
+    });
+
+    const result = await provider.transcribe(Buffer.from('fake-audio'), 'audio/mpeg', { language: 'pt-BR' });
+
+    expect(result.text).toBe('olá mundo');
+    expect(calls).toEqual([
+      'https://api.openai.com/v1/chat/completions',
+      'https://api.openai.com/v1/audio/transcriptions',
+    ]);
   });
 
   it('routes timestamp requests to the transcriptions endpoint even when audio-chat is configured', async () => {

--- a/packages/api/src/providers/openai/stt.ts
+++ b/packages/api/src/providers/openai/stt.ts
@@ -1,8 +1,11 @@
 /**
  * OpenAI STT provider.
  *
- * Quality lane: gpt-audio-mini via chat input_audio.
- * Stable fallback: gpt-4o-transcribe via /audio/transcriptions.
+ * Primary: gpt-4o-transcribe via /audio/transcriptions (purpose-built STT that
+ * fails loudly on bad audio). Opt-in chat lane: gpt-audio-* via chat
+ * input_audio, whose output is validated and which falls back to the
+ * transcriptions endpoint — chat models reply conversationally instead of
+ * failing when the audio is unusable (issue #942).
  */
 
 import { execFile } from 'node:child_process';
@@ -11,11 +14,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { createLogger } from '@omni/core';
+import { detectInvalidTranscription } from '@omni/media-processing';
 import type { ISttProvider, SttOptions, SttResult, SttSegment } from '../types';
 
 const log = createLogger('provider:openai:stt');
 
-const DEFAULT_AUDIO_CHAT_MODEL = 'gpt-audio-mini';
 const DEFAULT_TRANSCRIBE_MODEL = 'gpt-4o-transcribe';
 const CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
 const TRANSCRIPTIONS_URL = 'https://api.openai.com/v1/audio/transcriptions';
@@ -51,12 +54,23 @@ export class OpenAiSttProvider implements ISttProvider {
     const configuredModel = await this.settings.getString(
       'stt.openai.model',
       'OPENAI_STT_MODEL',
-      DEFAULT_AUDIO_CHAT_MODEL,
+      DEFAULT_TRANSCRIBE_MODEL,
     );
-    const model = options?.model ?? configuredModel ?? DEFAULT_AUDIO_CHAT_MODEL;
+    const model = options?.model ?? configuredModel ?? DEFAULT_TRANSCRIBE_MODEL;
 
     if (model.startsWith('gpt-audio') && !options?.timestamps) {
-      return this.transcribeWithAudioChat(apiKey, model, audio, mimeType, options, started);
+      try {
+        return await this.transcribeWithAudioChat(apiKey, model, audio, mimeType, options, started);
+      } catch (error) {
+        // The chat lane has no chain behind it; retry on the real STT endpoint
+        // instead of surfacing (or worse, masking) the chat-lane failure.
+        log.warn('OpenAI audio chat STT failed; falling back to transcriptions endpoint', {
+          model,
+          fallbackModel: DEFAULT_TRANSCRIBE_MODEL,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return this.transcribeWithTranscriptions(apiKey, DEFAULT_TRANSCRIBE_MODEL, audio, mimeType, options, started);
+      }
     }
 
     return this.transcribeWithTranscriptions(
@@ -120,8 +134,15 @@ export class OpenAiSttProvider implements ISttProvider {
     }
 
     const data = (await response.json()) as OpenAiChatResponse;
+    const text = extractAssistantText(data);
+    // Chat models reply conversationally instead of failing on unusable audio;
+    // throw so transcribe() retries on the real transcriptions endpoint.
+    const rejection = detectInvalidTranscription(text);
+    if (rejection) {
+      throw new Error(`OpenAI audio chat STT produced no usable transcript: ${rejection}`);
+    }
     return {
-      text: extractAssistantText(data),
+      text,
       detectedLanguage: options?.language,
       processingMs: Date.now() - started,
     };

--- a/packages/api/src/services/batch-jobs.ts
+++ b/packages/api/src/services/batch-jobs.ts
@@ -237,7 +237,7 @@ export class BatchJobService {
         this.settings.getSecret('gemini.api_key', 'GEMINI_API_KEY'),
         this.settings.getString('media.default_language', 'DEFAULT_LANGUAGE', 'pt'),
         this.settings.getString('stt.provider', 'STT_PROVIDER', 'openai'),
-        this.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-audio-mini'),
+        this.settings.getString('stt.openai.model', 'OPENAI_STT_MODEL', 'gpt-4o-transcribe'),
         this.settings.getString('stt.gemini.model', 'GEMINI_STT_MODEL', GEMINI_AUDIO_MODEL),
         this.settings.getString('prompt.audio_transcription'),
       ]);
@@ -247,7 +247,7 @@ export class BatchJobService {
         geminiApiKey: geminiApiKey ?? undefined,
         defaultLanguage: defaultLanguage ?? 'pt',
         audioProvider: audioProvider ?? 'openai',
-        audioModel: audioModel ?? 'gpt-audio-mini',
+        audioModel: audioModel ?? 'gpt-4o-transcribe',
         geminiAudioModel: geminiAudioModel ?? GEMINI_AUDIO_MODEL,
         audioPrompt: audioPrompt ?? undefined,
       };

--- a/packages/api/src/services/settings.ts
+++ b/packages/api/src/services/settings.ts
@@ -235,8 +235,9 @@ const DEFAULT_SETTINGS: Array<{
     category: 'providers',
     valueType: 'string',
     isSecret: false,
-    description: 'Default OpenAI STT model. Quality candidate: gpt-audio-mini; stable fallback: gpt-4o-transcribe.',
-    defaultValue: 'gpt-audio-mini',
+    description:
+      'Default OpenAI STT model. Primary: gpt-4o-transcribe (dedicated STT); gpt-audio-* models use the chat lane, whose output is validated with a transcriptions-endpoint fallback.',
+    defaultValue: 'gpt-4o-transcribe',
   },
   {
     key: 'stt.gemini.model',

--- a/packages/media-processing/__tests__/processors.test.ts
+++ b/packages/media-processing/__tests__/processors.test.ts
@@ -7,6 +7,7 @@ import { readFileSync } from 'node:fs';
 import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { resetAllCircuitBreakers } from '../src/circuit-breaker';
 import { AudioProcessor, DocumentProcessor, ImageProcessor, VideoProcessor } from '../src/processors';
 import type { ProcessorConfig } from '../src/types';
 
@@ -24,6 +25,7 @@ const originalPath = process.env.PATH;
 afterEach(() => {
   globalThis.fetch = originalFetch;
   process.env.PATH = originalPath;
+  resetAllCircuitBreakers();
 });
 
 describe('processors', () => {
@@ -63,16 +65,13 @@ describe('processors', () => {
       });
     });
 
-    it('falls back from OpenAI audio-chat to OpenAI transcriptions before Gemini/Groq', async () => {
+    it('tries the transcriptions endpoint first and never sends the chat model to it', async () => {
       const audioPath = join(tmpdir(), `omni-audio-processor-${Date.now()}.mp3`);
       await writeFile(audioPath, Buffer.from('fake-audio'));
       const calls: Array<{ url: string; init?: RequestInit }> = [];
       globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
         calls.push({ url: String(url), init });
-        if (String(url).includes('/chat/completions')) {
-          return new Response('audio chat unavailable', { status: 400 });
-        }
-        return new Response(JSON.stringify({ text: 'fallback transcript' }), {
+        return new Response(JSON.stringify({ text: 'real transcript' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
@@ -91,13 +90,175 @@ describe('processors', () => {
         const result = await processorWithOpenAi.process(audioPath, 'audio/mpeg', { language: 'pt-BR' });
 
         expect(result.success).toBe(true);
-        expect(result.content).toBe('fallback transcript');
+        expect(result.content).toBe('real transcript');
         expect(result.provider).toBe('openai');
         expect(result.model).toBe('gpt-4o-transcribe');
+        expect(calls.map((call) => call.url)).toEqual(['https://api.openai.com/v1/audio/transcriptions']);
+        // audioModel gpt-audio-mini is chat-only and would 400 here; the
+        // transcriptions attempt must use the dedicated STT model instead.
+        expect((calls[0]?.init?.body as FormData).get('model')).toBe('gpt-4o-transcribe');
+      } finally {
+        await rm(audioPath, { force: true });
+      }
+    });
+
+    it('falls back from OpenAI transcriptions to the audio-chat lane before Gemini/Groq', async () => {
+      const audioPath = join(tmpdir(), `omni-audio-chat-fallback-${Date.now()}.mp3`);
+      await writeFile(audioPath, Buffer.from('fake-audio'));
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        calls.push({ url: String(url), init });
+        if (String(url).includes('/audio/transcriptions')) {
+          return new Response('transcriptions unavailable', { status: 400 });
+        }
+        return new Response(JSON.stringify({ choices: [{ message: { content: 'transcrição do áudio-chat' } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+
+      try {
+        const processorWithOpenAi = new AudioProcessor({
+          ...mockConfig,
+          openaiApiKey: 'test-openai-key',
+          audioProvider: 'openai',
+          audioModel: 'gpt-audio-mini',
+        });
+
+        const result = await processorWithOpenAi.process(audioPath, 'audio/mpeg', { language: 'pt-BR' });
+
+        expect(result.success).toBe(true);
+        expect(result.content).toBe('transcrição do áudio-chat');
+        expect(result.model).toBe('gpt-audio-mini');
         expect(calls.map((call) => call.url)).toEqual([
-          'https://api.openai.com/v1/chat/completions',
           'https://api.openai.com/v1/audio/transcriptions',
+          'https://api.openai.com/v1/chat/completions',
         ]);
+      } finally {
+        await rm(audioPath, { force: true });
+      }
+    });
+
+    it('rejects a conversational chat reply and continues down the fallback chain (issue #942)', async () => {
+      const audioPath = join(tmpdir(), `omni-audio-meta-${Date.now()}.mp3`);
+      await writeFile(audioPath, Buffer.from('fake-audio'));
+      const calls: Array<{ url: string }> = [];
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        calls.push({ url: String(url) });
+        if (String(url).includes('/audio/transcriptions')) {
+          return new Response('transcriptions unavailable', { status: 400 });
+        }
+        if (String(url).includes('/chat/completions')) {
+          return new Response(
+            JSON.stringify({
+              choices: [
+                {
+                  message: {
+                    content:
+                      'Claro, por favor me diga o que você gostaria que fosse transcrito. Se tiver um áudio ou uma fala específica, descreva o conteúdo.',
+                  },
+                },
+              ],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: 'transcrição real' }] } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+
+      try {
+        const processorWithOpenAi = new AudioProcessor({
+          ...mockConfig,
+          openaiApiKey: 'test-openai-key',
+          geminiApiKey: 'test-gemini-key',
+          audioProvider: 'openai',
+          audioModel: 'gpt-audio-mini',
+        });
+
+        const result = await processorWithOpenAi.process(audioPath, 'audio/mpeg', { language: 'pt-BR' });
+
+        // A 200 chat reply that is conversation, not a transcript, must not
+        // stop the chain — the Gemini fallback should produce the result.
+        expect(result.success).toBe(true);
+        expect(result.provider).toBe('gemini');
+        expect(result.content).toBe('transcrição real');
+        expect(calls.map((call) => call.url.includes('/chat/completions'))).toEqual([false, true, false]);
+      } finally {
+        await rm(audioPath, { force: true });
+      }
+    });
+
+    it('treats an empty transcription result as a failure, not a chain-stopping success', async () => {
+      const audioPath = join(tmpdir(), `omni-audio-empty-${Date.now()}.mp3`);
+      await writeFile(audioPath, Buffer.from('fake-audio'));
+      const calls: Array<{ url: string }> = [];
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        calls.push({ url: String(url) });
+        if (String(url).includes('/audio/transcriptions')) {
+          return new Response(JSON.stringify({ text: '   ' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ choices: [{ message: { content: 'transcrição do fallback' } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+
+      try {
+        const processorWithOpenAi = new AudioProcessor({
+          ...mockConfig,
+          openaiApiKey: 'test-openai-key',
+          audioProvider: 'openai',
+        });
+
+        const result = await processorWithOpenAi.process(audioPath, 'audio/mpeg', { language: 'pt-BR' });
+
+        expect(result.success).toBe(true);
+        expect(result.content).toBe('transcrição do fallback');
+        expect(result.model).toBe('gpt-audio-mini');
+        expect(calls.map((call) => call.url)).toEqual([
+          'https://api.openai.com/v1/audio/transcriptions',
+          'https://api.openai.com/v1/chat/completions',
+        ]);
+      } finally {
+        await rm(audioPath, { force: true });
+      }
+    });
+
+    it('falls back from Gemini to OpenAI transcriptions, not the chat lane', async () => {
+      const audioPath = join(tmpdir(), `omni-audio-gemini-fallback-${Date.now()}.mp3`);
+      await writeFile(audioPath, Buffer.from('fake-audio'));
+      const calls: Array<{ url: string }> = [];
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        calls.push({ url: String(url) });
+        if (String(url).includes('generativelanguage.googleapis.com')) {
+          return new Response('gemini unavailable', { status: 400 });
+        }
+        return new Response(JSON.stringify({ text: 'openai fallback transcript' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+
+      try {
+        const processorWithGemini = new AudioProcessor({
+          ...mockConfig,
+          openaiApiKey: 'test-openai-key',
+          geminiApiKey: 'test-gemini-key',
+          audioProvider: 'gemini',
+        });
+
+        const result = await processorWithGemini.process(audioPath, 'audio/mpeg', { language: 'pt-BR' });
+
+        expect(result.success).toBe(true);
+        expect(result.provider).toBe('openai');
+        expect(result.model).toBe('gpt-4o-transcribe');
+        expect(calls[1]?.url).toBe('https://api.openai.com/v1/audio/transcriptions');
       } finally {
         await rm(audioPath, { force: true });
       }

--- a/packages/media-processing/__tests__/transcription-guard.test.ts
+++ b/packages/media-processing/__tests__/transcription-guard.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the transcription output guard (issue #942).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { detectInvalidTranscription } from '../src/transcription-guard';
+
+describe('detectInvalidTranscription', () => {
+  it('rejects empty and whitespace-only output', () => {
+    expect(detectInvalidTranscription('')).toContain('empty');
+    expect(detectInvalidTranscription('   \n\t ')).toContain('empty');
+  });
+
+  it('rejects Portuguese assistant meta-responses', () => {
+    const metaResponses = [
+      'Claro, por favor me diga o que você gostaria que fosse transcrito. Se tiver um áudio ou uma fala específica, descreva o conteúdo.',
+      'Claro! Por favor, envie o áudio que deseja transcrever.',
+      'Desculpe, não consigo transcrever este áudio.',
+      'Não consigo acessar o áudio enviado.',
+      'Parece que não há áudio na mensagem.',
+      'Infelizmente não recebi nenhum áudio para transcrever.',
+      'Por favor, envie o áudio novamente.',
+    ];
+    for (const text of metaResponses) {
+      expect(detectInvalidTranscription(text)).toBeDefined();
+    }
+  });
+
+  it('rejects English assistant meta-responses', () => {
+    const metaResponses = [
+      'Sure, please provide the audio you would like transcribed.',
+      "I'm sorry, I cannot transcribe this audio.",
+      'I don’t have access to the audio you mentioned.',
+      'It seems there is no audio attached to this message.',
+      'Unfortunately, no audio was provided.',
+      'Please provide the audio file you want transcribed.',
+      'Could you please send the audio again?',
+    ];
+    for (const text of metaResponses) {
+      expect(detectInvalidTranscription(text)).toBeDefined();
+    }
+  });
+
+  it('accepts ordinary transcripts, including ones starting with "Claro"', () => {
+    const transcripts = [
+      'Oi, tudo bem? Queria marcar a consulta pra quinta-feira de manhã.',
+      'Claro que eu vou na festa, pode me esperar lá pelas oito.',
+      'Sure thing, I will send the report by Friday afternoon.',
+      'Desculpa aí o horário, mas preciso remarcar a reunião de amanhã.'.repeat(6),
+      'Sorry pelo atraso, o trânsito estava impossível hoje.'.repeat(8),
+    ];
+    for (const text of transcripts) {
+      expect(detectInvalidTranscription(text)).toBeUndefined();
+    }
+  });
+
+  it('accepts long transcripts even when they open with a meta-response phrase', () => {
+    const longTranscript = `Claro, por favor me avisa quando você chegar. ${'Então, sobre o projeto, a gente precisa revisar o cronograma e alinhar com o time de produto antes da sprint. '.repeat(4)}`;
+    expect(detectInvalidTranscription(longTranscript)).toBeUndefined();
+  });
+});

--- a/packages/media-processing/src/index.ts
+++ b/packages/media-processing/src/index.ts
@@ -68,3 +68,6 @@ export {
 
 // Pricing
 export { calculateCost, getPricingRate, PRICING_REGISTRY } from './pricing';
+
+// Transcription guard
+export { detectInvalidTranscription } from './transcription-guard';

--- a/packages/media-processing/src/models.ts
+++ b/packages/media-processing/src/models.ts
@@ -19,10 +19,14 @@ export const GEMINI_MODEL = 'gemini-3-flash-preview';
 /** Fallback model for image description (when Gemini unavailable) */
 export const OPENAI_VISION_MODEL = 'gpt-4o-mini';
 
-/** Fallback model for audio transcription (when Groq unavailable) */
+/**
+ * Chat-lane fallback for audio transcription. Never the primary: chat models
+ * reply conversationally instead of failing on unusable audio (issue #942),
+ * so their output is validated by the transcription guard.
+ */
 export const OPENAI_AUDIO_CHAT_MODEL = 'gpt-audio-mini';
 
-/** Stable fallback OpenAI transcription model */
+/** Primary OpenAI transcription model (purpose-built STT endpoint) */
 export const OPENAI_TRANSCRIBE_MODEL = 'gpt-4o-transcribe';
 
 /** Backward-compatible alias for OpenAI transcription fallback */

--- a/packages/media-processing/src/processors/audio.ts
+++ b/packages/media-processing/src/processors/audio.ts
@@ -2,8 +2,11 @@
  * Audio Processor
  *
  * Quality-first transcription for Omni media/backfill:
- * OpenAI gpt-audio-mini primary, OpenAI gpt-4o-transcribe stable fallback,
- * Gemini 3.1 Flash Lite omni-modal fallback, Groq Whisper fast fallback.
+ * OpenAI gpt-4o-transcribe primary (a purpose-built STT endpoint that fails
+ * loudly on bad audio), OpenAI gpt-audio-mini chat-lane fallback, Gemini
+ * omni-modal fallback, Groq Whisper fast fallback. Chat-lane output is
+ * validated before it can stop the chain — chat models reply conversationally
+ * instead of failing when the audio is unusable (issue #942).
  *
  * Uses centralized retry + circuit breaker for resilience.
  */
@@ -19,6 +22,7 @@ import type { Uploadable } from 'openai/uploads';
 
 import { GEMINI_AUDIO_MODEL, GROQ_WHISPER_MODEL, OPENAI_AUDIO_CHAT_MODEL, OPENAI_TRANSCRIBE_MODEL } from '../models';
 import { calculateCost } from '../pricing';
+import { detectInvalidTranscription } from '../transcription-guard';
 import type { ProcessOptions, ProcessingResult } from '../types';
 import { getMediaTimeouts } from '../types';
 import { BaseProcessor } from './base';
@@ -125,15 +129,15 @@ export class AudioProcessor extends BaseProcessor {
     getNormalizedAudio: () => Promise<NormalizedAudioFile>,
   ): Array<() => Promise<ProcessingResult>> {
     if (provider === 'openai') {
+      // Bind the preferred model to the lane that can actually serve it:
+      // gpt-audio-* is a chat model and 400s on /audio/transcriptions, while
+      // transcription models are rejected by /chat/completions.
+      const isChatModel = preferredModel?.startsWith('gpt-audio') ?? false;
+      const transcribeModel = preferredModel && !isChatModel ? preferredModel : OPENAI_TRANSCRIBE_MODEL;
+      const chatModel = preferredModel && isChatModel ? preferredModel : OPENAI_AUDIO_CHAT_MODEL;
       return [
-        () =>
-          this.transcribeWithOpenAiAudioChat(
-            language,
-            options,
-            preferredModel ?? OPENAI_AUDIO_CHAT_MODEL,
-            getNormalizedAudio,
-          ),
-        () => this.transcribeWithOpenAiTranscriptions(language, options, OPENAI_TRANSCRIBE_MODEL, getNormalizedAudio),
+        () => this.transcribeWithOpenAiTranscriptions(language, options, transcribeModel, getNormalizedAudio),
+        () => this.transcribeWithOpenAiAudioChat(language, options, chatModel, getNormalizedAudio),
         () => this.transcribeWithGemini(language, options, this.resolveGeminiAudioModel(undefined), getNormalizedAudio),
         () => this.transcribeWithGroq(language, getNormalizedAudio),
       ];
@@ -148,7 +152,7 @@ export class AudioProcessor extends BaseProcessor {
             this.resolveGeminiAudioModel(options?.model),
             getNormalizedAudio,
           ),
-        () => this.transcribeWithOpenAiAudioChat(language, options, OPENAI_AUDIO_CHAT_MODEL, getNormalizedAudio),
+        () => this.transcribeWithOpenAiTranscriptions(language, options, OPENAI_TRANSCRIBE_MODEL, getNormalizedAudio),
         () => this.transcribeWithGroq(language, getNormalizedAudio),
       ];
     }
@@ -229,6 +233,10 @@ export class AudioProcessor extends BaseProcessor {
         },
         { timeoutMs: timeouts.audioTimeoutMs },
       );
+      // Chat models reply conversationally instead of failing when the audio
+      // is unusable; that must surface as a failure so the chain continues.
+      const rejection = detectInvalidTranscription(text);
+      if (rejection) return this.createFailedResult(rejection, 'openai', model);
       return this.createSuccessResult(text, 'openai', model, language);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -370,9 +378,12 @@ export class AudioProcessor extends BaseProcessor {
   }
 
   private createSuccessResult(text: string, provider: string, model: string, language: string): ProcessingResult {
+    const content = text.trim();
+    // An empty transcript must not become a chain-stopping success.
+    if (!content) return this.createFailedResult('Transcription returned empty text', provider, model);
     return {
       success: true,
-      content: text.trim(),
+      content,
       contentFormat: 'text',
       processingType: 'transcription',
       provider,

--- a/packages/media-processing/src/transcription-guard.ts
+++ b/packages/media-processing/src/transcription-guard.ts
@@ -1,0 +1,57 @@
+/**
+ * Transcription output guard.
+ *
+ * Chat-completion audio models (gpt-audio-*) answer conversationally when the
+ * audio is missing or undecodable instead of failing: HTTP 200 with "Claro,
+ * por favor me diga o que você gostaria que fosse transcrito…". Without a
+ * content check that reply masquerades as a successful transcription and
+ * short-circuits the real STT fallback chain (issue #942).
+ *
+ * Patterns are anchored to the string start and only applied to short outputs
+ * so legitimate transcripts that happen to open with "Claro" survive.
+ */
+
+/**
+ * Meta-responses are short requests for input or refusals; real transcripts
+ * that trip a pattern opener are overwhelmingly longer than this.
+ */
+const META_RESPONSE_MAX_LENGTH = 320;
+
+const META_RESPONSE_PATTERNS: readonly RegExp[] = [
+  // pt-BR: "Claro, por favor me diga/envie…"
+  /^claro[,!.]?\s+(por favor|me (diga|envie|mande|informe|forneça)|envie|preciso|posso ajudar)/i,
+  // pt-BR: apologies and refusals
+  /^(desculpe|sinto muito|perd[ãa]o)\b/i,
+  /^n[ãa]o (consigo|posso|tenho acesso|h[áa] [áa]udio)/i,
+  /^parece que (n[ãa]o|o [áa]udio)/i,
+  /^infelizmente\b/i,
+  // pt-BR: "Por favor, envie/forneça o áudio…"
+  /^por favor,?\s+(envie|forne[çc]a|compartilhe|me (diga|envie|mande))/i,
+  // en: "Sure, please provide…"
+  /^sure[,!.]?\s+(please|provide|send|go ahead)/i,
+  // en: apologies and refusals
+  /^(i['’]?m sorry|sorry[,.]|i apologize)\b/i,
+  /^i (can['’]?t|cannot|am unable|don['’]?t have access|do not have access)\b/i,
+  // en: "It seems there is no audio…"
+  /^it (seems|appears|looks like)\b.{0,40}\b(no|not|any|missing|unable|audio)\b/i,
+  /^unfortunately\b/i,
+  // en: "Please provide/send/upload the audio…"
+  /^please (provide|send|share|upload|attach)\b/i,
+  /^could you (please )?(provide|send|share|upload)\b/i,
+];
+
+/**
+ * Judge whether a model's output is a usable transcript.
+ *
+ * Returns a human-readable rejection reason when the output is empty or reads
+ * as an assistant meta-response instead of a transcription, or `undefined`
+ * when the text should be accepted.
+ */
+export function detectInvalidTranscription(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return 'Transcription returned empty text';
+  if (trimmed.length <= META_RESPONSE_MAX_LENGTH && META_RESPONSE_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return `Model returned a conversational reply instead of a transcript: "${trimmed.slice(0, 120)}"`;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

With `STT_PROVIDER=openai`, the audio fallback chain led with the **gpt-audio-mini chat model**, which answers conversationally (HTTP 200) when the audio is unusable instead of failing. `shouldStopAudioFallback` only checked `result.success`, so the chat reply ("Claro, por favor me diga o que você gostaria que fosse transcrito…") masqueraded as a successful transcript and `gpt-4o-transcribe` never ran.

Closes #942

## Changes

**`@omni/media-processing`**
- Reorder the openai chain: `/audio/transcriptions` (`gpt-4o-transcribe`) is now attempt #1; the chat lane is demoted to fallback. The preferred model is bound to the lane that can serve it — `gpt-audio-*` goes to the chat lane, never to the transcriptions endpoint (where it would 400).
- New shared `transcription-guard`: rejects empty output and pt/en assistant meta-responses (start-anchored, length-bounded so legitimate transcripts opening with "Claro, por favor" survive). Chat-lane rejections become `success:false` with the real reason, so the chain continues.
- `createSuccessResult` treats an empty/whitespace transcript from **any** provider as a failure, not a chain-stopping success.
- The gemini chain's OpenAI fallback now targets the transcriptions endpoint instead of the chat model.

**`@omni/api`** (second independent instance of the bug — `OpenAiSttProvider` had no fallback at all)
- `stt.openai.model` defaults to `gpt-4o-transcribe` (settings registry, media-processor plugin, batch jobs); `gpt-audio-*` remains an opt-in chat lane.
- The chat lane validates its output via the shared guard, throws on conversational/empty replies, and falls back to the transcriptions endpoint on any failure.

## Tests

- 5 chain-behavior regression tests in `processors.test.ts`: transcriptions-first order, chat model never sent to the transcriptions endpoint, a conversational 200 reply does not stop the chain, an empty result does not stop the chain, gemini→transcriptions fallback routing.
- New `transcription-guard.test.ts` unit suite (pt/en meta-responses rejected; ordinary and long "Claro…" transcripts accepted).
- 3 new `stt.test.ts` cases: default lane routing, meta-response fallback, empty-reply fallback.

## Verification

- `make check` green (typecheck, biome, knip, migration contract, tests); the only local failures are the 4 pre-existing environmental-baseline suites, re-verified identical on clean `origin/dev` via stash.
- `make test-pg-gate` passed: 297 assertions across 31 suites, 0 skipped, on a fresh disposable cluster.

Pricing entries for `gpt-audio-mini` are intentionally kept — the model remains in the chain as a fallback.