### PR TITLE
fix(slack): verify the Socket Mode WebSocket instead of trusting app.start()

### DIFF
--- a/packages/channel-slack/src/__tests__/bolt-client-http.test.ts
+++ b/packages/channel-slack/src/__tests__/bolt-client-http.test.ts
@@ -39,10 +39,18 @@ mock.module('@slack/bolt', () => {
     }
   }
 
+  // SocketModeReceiver mock exposing a client, as createSocketBoltApp now
+  // constructs the receiver itself to reach the SocketModeClient (#941).
+  class MockSocketModeReceiver {
+    client = Object.assign(new EventEmitter(), {
+      websocket: { isActive: () => true },
+    });
+  }
+
   return {
     App: MockApp,
     HTTPReceiver: MockHTTPReceiver,
-    SocketModeReceiver: class {},
+    SocketModeReceiver: MockSocketModeReceiver,
   };
 });
 
@@ -187,6 +195,9 @@ describe('BoltConnection structure', () => {
     expect(conn.app).toBeDefined();
     expect(conn.client).toBeDefined();
     expect(conn.botToken).toBe('xoxb-fake');
+    // #941: the socket client must be reachable for health/startup verification
+    expect(conn.socketClient).toBeDefined();
+    expect(conn.socketState).toBe('pending');
   });
 
   it('HTTP mode connection has app, client, and httpHandler', () => {

--- a/packages/channel-slack/src/__tests__/bolt-client-user-mode.test.ts
+++ b/packages/channel-slack/src/__tests__/bolt-client-user-mode.test.ts
@@ -38,6 +38,9 @@ function makeConnection(overrides: Partial<BoltConnection> = {}): {
     actingClient: {},
     botToken: 'xoxb-fake',
     mode: 'socket',
+    // The post-start verification (#941) inspects the socket client; report an
+    // open WebSocket so these tests keep exercising the user-mode invariant.
+    socketClient: { websocket: { isActive: () => true } },
     ...overrides,
   } as unknown as BoltConnection;
   return { conn, started: () => startCount };

--- a/packages/channel-slack/src/__tests__/socket-health.test.ts
+++ b/packages/channel-slack/src/__tests__/socket-health.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Socket Mode health & recovery (#941).
+ *
+ * The failure this guards against: `app.start()` resolved, the plugin logged
+ * 'started successfully in Socket Mode' and cached 'connected', yet no
+ * WebSocket to Slack existed — the instance was deaf, `checkBoltHealth`
+ * (auth.test over HTTPS) said healthy, `instances connect` answered 'already
+ * connected', and the instance monitor never saw anything to fix.
+ *
+ * Four layers, each tested here with fake Bolt objects (no real Slack):
+ *  1. startup assertion — start resolves but the socket never opens → throw
+ *  2. runtime detection — a socket dying after a good start drives status
+ *  3. socket-aware health — checkBoltHealth false while auth.test is ok
+ *  4. getStatus override — cached 'connected' + closed socket → 'error'
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import type { ConnectionStatus, InstanceConfig, PluginContext } from '@omni/channel-sdk';
+import type { BoltConnection, SlackSocketClient, SocketConnectionState } from '../connection/bolt-client';
+import {
+  checkBoltHealth,
+  destroyBoltConnection,
+  isSocketOpen,
+  startBoltConnection,
+  watchSocketLifecycle,
+} from '../connection/bolt-client';
+import { SlackPlugin } from '../plugin';
+import { SlackError, SlackErrorCode } from '../types';
+
+const noop = () => {};
+const noopLogger = { debug: noop, info: noop, warn: noop, error: noop, child: () => noopLogger };
+
+// ─────────────────────────────────────────────────────────────
+// Fakes
+// ─────────────────────────────────────────────────────────────
+
+interface FakeSocketClient {
+  client: SlackSocketClient;
+  emitter: EventEmitter;
+  setActive: (active: boolean) => void;
+}
+
+/** EventEmitter standing in for the SocketModeClient, with a togglable WebSocket. */
+function makeSocketClient(active: boolean): FakeSocketClient {
+  let isActive = active;
+  const emitter = Object.assign(new EventEmitter(), {
+    websocket: { isActive: () => isActive },
+  });
+  return {
+    client: emitter as unknown as SlackSocketClient,
+    emitter,
+    setActive: (a: boolean) => {
+      isActive = a;
+    },
+  };
+}
+
+/** Minimal socket-mode BoltConnection with observable app.start/app.stop. */
+function makeConnection(overrides: Partial<BoltConnection> = {}): {
+  conn: BoltConnection;
+  counts: { start: number; stop: number };
+} {
+  const counts = { start: 0, stop: 0 };
+  const conn = {
+    app: {
+      client: {
+        auth: { test: async () => ({ ok: true, user_id: 'U0BOT', user: 'bot', team_id: 'T1', team: 'team' }) },
+      },
+      start: async () => {
+        counts.start++;
+      },
+      stop: async () => {
+        counts.stop++;
+      },
+    },
+    client: { auth: { test: async () => ({ ok: true }) } },
+    actingClient: {},
+    botToken: 'xoxb-fake',
+    mode: 'socket',
+    socketState: 'pending',
+    ...overrides,
+  } as unknown as BoltConnection;
+  return { conn, counts };
+}
+
+function makePluginContext(): PluginContext {
+  return {
+    eventBus: { publish: async () => {}, subscribe: () => {} },
+    storage: {},
+    logger: noopLogger,
+    config: {},
+    db: {},
+  } as unknown as PluginContext;
+}
+
+/** Typed access to the plugin internals the tests must seed/inspect. */
+interface PluginInternals {
+  connections: Map<string, BoltConnection>;
+  watchSocketState(instanceId: string, config: InstanceConfig, connection: BoltConnection): void;
+  updateInstanceStatus(instanceId: string, config: InstanceConfig, status: ConnectionStatus): Promise<void>;
+}
+
+async function makePlugin(): Promise<{ plugin: SlackPlugin; internals: PluginInternals }> {
+  const plugin = new SlackPlugin();
+  await plugin.initialize(makePluginContext());
+  return { plugin, internals: plugin as unknown as PluginInternals };
+}
+
+const INSTANCE = 'inst-941';
+const CONFIG: InstanceConfig = { instanceId: INSTANCE, credentials: {}, options: {} };
+
+// ─────────────────────────────────────────────────────────────
+// 1. Startup assertion — startBoltConnection
+// ─────────────────────────────────────────────────────────────
+
+describe('startBoltConnection — post-start socket verification (#941)', () => {
+  it('resolves when the WebSocket is already open after start()', async () => {
+    const socket = makeSocketClient(true);
+    const { conn, counts } = makeConnection({ socketClient: socket.client });
+
+    await startBoltConnection(conn, noopLogger as never);
+    expect(counts.start).toBe(1);
+  });
+
+  it('resolves when the socket opens shortly after start() (connected event)', async () => {
+    const socket = makeSocketClient(false);
+    const { conn } = makeConnection({ socketClient: socket.client, socketConnectTimeoutMs: 500 });
+
+    setTimeout(() => {
+      socket.setActive(true);
+      socket.emitter.emit('connected');
+    }, 5);
+
+    await startBoltConnection(conn, noopLogger as never);
+    expect(isSocketOpen(conn)).toBe(true);
+  });
+
+  it('throws CONNECTION_FAILED when start() resolves but the socket never opens', async () => {
+    const socket = makeSocketClient(false);
+    const { conn, counts } = makeConnection({ socketClient: socket.client, socketConnectTimeoutMs: 30 });
+
+    const err = await startBoltConnection(conn, noopLogger as never).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(counts.start).toBe(1); // start() DID resolve — the lie the assertion catches
+    expect(err).toBeInstanceOf(SlackError);
+    expect((err as SlackError).channelCode).toBe(SlackErrorCode.CONNECTION_FAILED);
+    expect((err as SlackError).recoverable).toBe(true);
+  });
+
+  it('throws (never logs silent success) when a socket-mode connection has no socket client', async () => {
+    const { conn } = makeConnection(); // no socketClient at all
+
+    const err = await startBoltConnection(conn, noopLogger as never).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(SlackError);
+    expect((err as SlackError).channelCode).toBe(SlackErrorCode.CONNECTION_FAILED);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// 2. Runtime detection — watchSocketLifecycle
+// ─────────────────────────────────────────────────────────────
+
+describe('watchSocketLifecycle — socket events become connection state (#941)', () => {
+  it('tracks connected / reconnecting / disconnected transitions', () => {
+    const socket = makeSocketClient(false);
+    const { conn } = makeConnection({ socketClient: socket.client });
+    const seen: SocketConnectionState[] = [];
+    watchSocketLifecycle(conn, noopLogger as never);
+    conn.onSocketStateChange = (state) => seen.push(state);
+
+    socket.emitter.emit('connected');
+    expect(conn.socketState).toBe('connected');
+
+    socket.emitter.emit('reconnecting');
+    expect(conn.socketState).toBe('reconnecting');
+
+    socket.emitter.emit('disconnected');
+    expect(conn.socketState).toBe('disconnected');
+
+    expect(seen).toEqual(['connected', 'reconnecting', 'disconnected']);
+  });
+
+  it('destroyBoltConnection clears the state-change hook (deliberate stop ≠ lost socket)', async () => {
+    const socket = makeSocketClient(true);
+    const { conn, counts } = makeConnection({ socketClient: socket.client });
+    watchSocketLifecycle(conn, noopLogger as never);
+    conn.onSocketStateChange = () => {
+      throw new Error('must not fire after destroy');
+    };
+
+    await destroyBoltConnection(conn, noopLogger as never);
+
+    expect(counts.stop).toBe(1);
+    expect(conn.onSocketStateChange).toBeUndefined();
+    socket.emitter.emit('disconnected'); // state still tracked, but no hook fired
+    expect(conn.socketState).toBe('disconnected');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// 3. Socket-aware health — checkBoltHealth / isSocketOpen
+// ─────────────────────────────────────────────────────────────
+
+describe('checkBoltHealth — socket state included for socket mode (#941)', () => {
+  it('is false when the socket is closed even though auth.test succeeds', async () => {
+    const socket = makeSocketClient(false);
+    const { conn } = makeConnection({ socketClient: socket.client });
+
+    // auth.test (HTTPS) is ok — exactly the deaf-instance shape from the issue
+    expect(await checkBoltHealth(conn)).toBe(false);
+  });
+
+  it('is true when the socket is open and auth.test succeeds', async () => {
+    const socket = makeSocketClient(true);
+    const { conn } = makeConnection({ socketClient: socket.client });
+
+    expect(await checkBoltHealth(conn)).toBe(true);
+  });
+
+  it('is false when the socket is open but auth.test fails', async () => {
+    const socket = makeSocketClient(true);
+    const { conn } = makeConnection({
+      socketClient: socket.client,
+      client: {
+        auth: {
+          test: async () => {
+            throw new Error('invalid_auth');
+          },
+        },
+      } as unknown as BoltConnection['client'],
+    });
+
+    expect(await checkBoltHealth(conn)).toBe(false);
+  });
+
+  it('keeps auth.test as the sole criterion for HTTP mode', async () => {
+    const { conn } = makeConnection({ mode: 'http' });
+    expect(await checkBoltHealth(conn)).toBe(true);
+  });
+
+  it('isSocketOpen falls back to the tracked lifecycle state without a websocket handle', () => {
+    const emitter = new EventEmitter(); // no .websocket property
+    const { conn } = makeConnection({
+      socketClient: emitter as unknown as SlackSocketClient,
+      socketState: 'connected',
+    });
+    expect(isSocketOpen(conn)).toBe(true);
+
+    conn.socketState = 'disconnected';
+    expect(isSocketOpen(conn)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// 4. Plugin — getStatus override
+// ─────────────────────────────────────────────────────────────
+
+describe('SlackPlugin.getStatus — reports the real socket, not the cache (#941)', () => {
+  it('turns a cached connected status into a retryable error when the socket is closed', async () => {
+    const { plugin, internals } = await makePlugin();
+    const socket = makeSocketClient(false);
+    const { conn } = makeConnection({ socketClient: socket.client });
+
+    internals.connections.set(INSTANCE, conn);
+    await internals.updateInstanceStatus(INSTANCE, CONFIG, { state: 'connected', since: new Date() });
+
+    const status = await plugin.getStatus(INSTANCE);
+    expect(status.state).toBe('error');
+    expect(status.error?.code).toBe(SlackErrorCode.CONNECTION_FAILED);
+    expect(status.error?.retryable).toBe(true);
+  });
+
+  it('passes the cached connected status through when the socket is open', async () => {
+    const { plugin, internals } = await makePlugin();
+    const socket = makeSocketClient(true);
+    const { conn } = makeConnection({ socketClient: socket.client });
+
+    internals.connections.set(INSTANCE, conn);
+    await internals.updateInstanceStatus(INSTANCE, CONFIG, { state: 'connected', since: new Date() });
+
+    const status = await plugin.getStatus(INSTANCE);
+    expect(status.state).toBe('connected');
+  });
+
+  it('leaves non-connected cached states untouched', async () => {
+    const { plugin, internals } = await makePlugin();
+    await internals.updateInstanceStatus(INSTANCE, CONFIG, { state: 'connecting', since: new Date() });
+
+    const status = await plugin.getStatus(INSTANCE);
+    expect(status.state).toBe('connecting');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// 5. Plugin — socket death after a good start drives status
+// ─────────────────────────────────────────────────────────────
+
+describe('SlackPlugin — socket dying post-start transitions instance status (#941)', () => {
+  async function wire(): Promise<{
+    plugin: SlackPlugin;
+    internals: PluginInternals;
+    socket: FakeSocketClient;
+    conn: BoltConnection;
+  }> {
+    const { plugin, internals } = await makePlugin();
+    const socket = makeSocketClient(true);
+    const { conn } = makeConnection({ socketClient: socket.client });
+    watchSocketLifecycle(conn, noopLogger as never);
+
+    internals.connections.set(INSTANCE, conn);
+    await internals.updateInstanceStatus(INSTANCE, CONFIG, { state: 'connected', since: new Date() });
+    internals.watchSocketState(INSTANCE, CONFIG, conn);
+    return { plugin, internals, socket, conn };
+  }
+
+  it('disconnected → status error (retryable), reconnecting → status reconnecting', async () => {
+    const { plugin, socket } = await wire();
+
+    socket.setActive(false);
+    socket.emitter.emit('disconnected');
+    const afterDeath = await plugin.getStatus(INSTANCE);
+    expect(afterDeath.state).toBe('error');
+    expect(afterDeath.error?.retryable).toBe(true);
+
+    socket.emitter.emit('reconnecting');
+    const whileRetrying = await plugin.getStatus(INSTANCE);
+    expect(whileRetrying.state).toBe('reconnecting');
+  });
+
+  it('a recovered socket transitions the instance back to connected', async () => {
+    const { plugin, socket } = await wire();
+
+    socket.setActive(false);
+    socket.emitter.emit('disconnected');
+    expect((await plugin.getStatus(INSTANCE)).state).toBe('error');
+
+    socket.setActive(true);
+    socket.emitter.emit('connected');
+    expect((await plugin.getStatus(INSTANCE)).state).toBe('connected');
+  });
+
+  it('transitions from a replaced (stale) connection are ignored', async () => {
+    const { plugin, internals, socket } = await wire();
+
+    // Instance was rebuilt: the map now holds a NEW healthy connection
+    const fresh = makeConnection({ socketClient: makeSocketClient(true).client }).conn;
+    internals.connections.set(INSTANCE, fresh);
+
+    socket.emitter.emit('disconnected'); // old connection's event
+    expect((await plugin.getStatus(INSTANCE)).state).toBe('connected');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// 6. Plugin — connect() on a deaf instance rebuilds
+// ─────────────────────────────────────────────────────────────
+
+describe('SlackPlugin.connect — deaf instance rebuilds instead of "already connected" (#941)', () => {
+  it('returns early (no teardown) when the existing connection is genuinely healthy', async () => {
+    const { plugin, internals } = await makePlugin();
+    const socket = makeSocketClient(true);
+    const { conn, counts } = makeConnection({ socketClient: socket.client });
+    internals.connections.set(INSTANCE, conn);
+
+    await plugin.connect(INSTANCE, CONFIG);
+
+    expect(counts.stop).toBe(0);
+    expect(internals.connections.get(INSTANCE)).toBe(conn);
+  });
+
+  it('tears the deaf connection down and attempts a rebuild', async () => {
+    const { plugin, internals } = await makePlugin();
+    const socket = makeSocketClient(false); // socket dead, auth.test still ok
+    const { conn, counts } = makeConnection({ socketClient: socket.client });
+    internals.connections.set(INSTANCE, conn);
+
+    // Empty config makes the rebuild fail fast at token resolution — the
+    // point is that connect() gets PAST the 'already connected' dead-end.
+    const err = await plugin.connect(INSTANCE, CONFIG).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(counts.stop).toBe(1); // stale connection destroyed
+    expect(internals.connections.get(INSTANCE)).toBeUndefined();
+    expect(err).toBeInstanceOf(SlackError);
+    expect((await plugin.getStatus(INSTANCE)).state).toBe('error');
+  });
+});

--- a/packages/channel-slack/src/connection/bolt-client.ts
+++ b/packages/channel-slack/src/connection/bolt-client.ts
@@ -12,13 +12,31 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Logger } from '@omni/channel-sdk';
-import { App, type AppOptions, HTTPReceiver } from '@slack/bolt';
+import { App, type AppOptions, HTTPReceiver, SocketModeReceiver } from '@slack/bolt';
 import { WebClient } from '@slack/web-api';
 import type { SlackConnectionOptions } from '../types';
 import { SlackError, SlackErrorCode } from '../types';
 
 /** Maximum body size for HTTP mode (1 MB, aligned with OpenClaw) */
 const HTTP_MAX_BODY_BYTES = 1024 * 1024;
+
+/**
+ * How long to wait for the Socket Mode WebSocket to actually be open after
+ * `app.start()` resolves before declaring the start failed (#941).
+ */
+const SOCKET_OPEN_TIMEOUT_MS = 10_000;
+
+/**
+ * The SocketModeClient managed by Bolt's SocketModeReceiver. Derived from the
+ * receiver type so `@slack/socket-mode` does not become a direct dependency.
+ */
+export type SlackSocketClient = SocketModeReceiver['client'];
+
+/**
+ * Socket Mode lifecycle state, tracked from the SocketModeClient's own events.
+ * 'pending' until the first hello frame confirms the WebSocket is live.
+ */
+export type SocketConnectionState = 'pending' | 'connected' | 'reconnecting' | 'disconnected';
 
 /**
  * Build the client used for outbound ACTIONS.
@@ -87,6 +105,23 @@ export interface BoltConnection {
    * Undefined for socket mode.
    */
   httpHandler?: (req: IncomingMessage, res: ServerResponse) => void;
+  /**
+   * The Socket Mode client behind the receiver (socket mode only). Exposed so
+   * the startup assertion and health check can inspect the REAL WebSocket
+   * state instead of trusting `app.start()` having resolved (#941).
+   */
+  socketClient?: SlackSocketClient;
+  /** Last observed Socket Mode lifecycle state (socket mode only). */
+  socketState?: SocketConnectionState;
+  /**
+   * Hook invoked on every Socket Mode lifecycle transition. plugin.ts assigns
+   * it after a verified start so a socket dying later drives a real instance
+   * status change (#941). Cleared by destroyBoltConnection so a deliberate
+   * stop is not reported as a lost socket.
+   */
+  onSocketStateChange?: (state: SocketConnectionState) => void;
+  /** Bound for the post-start WebSocket verification (default 10s). */
+  socketConnectTimeoutMs?: number;
 }
 
 /**
@@ -115,9 +150,18 @@ export function createBoltApp(options: SlackConnectionOptions, logger: Logger): 
 function createSocketBoltApp(options: SlackConnectionOptions, logger: Logger): BoltConnection {
   logger.info('Creating Bolt.js app with Socket Mode (not started yet)');
 
+  if (!options.appToken) {
+    throw new SlackError(SlackErrorCode.CONNECTION_FAILED, 'appToken (xapp-...) is required for Socket Mode');
+  }
+
+  // Construct the receiver explicitly (instead of letting `socketMode: true`
+  // build one inside App) so the SocketModeClient is reachable in a typed way —
+  // the startup assertion and health check need its real WebSocket state (#941).
+  const receiver = new SocketModeReceiver({ appToken: options.appToken });
+
   const appOptions: AppOptions = {
     token: options.botToken,
-    appToken: options.appToken,
+    receiver,
     socketMode: true,
     clientOptions: {
       retryConfig: {
@@ -130,10 +174,6 @@ function createSocketBoltApp(options: SlackConnectionOptions, logger: Logger): B
     },
   };
 
-  if (options.signingSecret) {
-    appOptions.signingSecret = options.signingSecret;
-  }
-
   const app = new App(appOptions);
 
   // Register global error handler to surface Socket Mode issues
@@ -141,13 +181,58 @@ function createSocketBoltApp(options: SlackConnectionOptions, logger: Logger): B
     logger.error('Bolt.js global error', { error: String(error) });
   });
 
-  return {
+  const connection: BoltConnection = {
     app,
     client: app.client,
     ...buildActingClients(options, app.client),
     botToken: options.botToken,
     mode: 'socket',
+    socketClient: receiver.client,
+    socketState: 'pending',
+    socketConnectTimeoutMs: options.socketConnectTimeoutMs,
   };
+
+  watchSocketLifecycle(connection, logger);
+
+  return connection;
+}
+
+/**
+ * Forward SocketModeClient lifecycle events onto the connection (#941).
+ *
+ * Bolt only surfaces middleware errors through app.error(); the
+ * SocketModeClient reports a dying WebSocket on its own emitter, which nothing
+ * forwarded — a socket that died after a good start was invisible and the
+ * instance stayed 'connected' forever. Every transition is logged, mirrored
+ * onto connection.socketState, and forwarded to connection.onSocketStateChange
+ * once the plugin wires one. (@slack/socket-mode v2 has no
+ * `unable_to_socket_mode_start` event; start failures surface via 'error' and
+ * the bounded post-start verification in waitForSocketOpen.)
+ */
+export function watchSocketLifecycle(connection: BoltConnection, logger: Logger): void {
+  const socketClient = connection.socketClient;
+  if (!socketClient) return;
+
+  const transition = (state: SocketConnectionState): void => {
+    connection.socketState = state;
+    connection.onSocketStateChange?.(state);
+  };
+
+  socketClient.on('connected', () => {
+    logger.info('Slack Socket Mode WebSocket connected');
+    transition('connected');
+  });
+  socketClient.on('reconnecting', () => {
+    logger.warn('Slack Socket Mode WebSocket reconnecting');
+    transition('reconnecting');
+  });
+  socketClient.on('disconnected', () => {
+    logger.warn('Slack Socket Mode WebSocket disconnected');
+    transition('disconnected');
+  });
+  socketClient.on('error', (error: unknown) => {
+    logger.error('Slack Socket Mode client error', { error: String(error) });
+  });
 }
 
 /**
@@ -294,38 +379,7 @@ function buildBodyLimitHandler(
  *   available for external-server integration if preferred.
  */
 export async function startBoltConnection(connection: BoltConnection, logger: Logger): Promise<BoltConnection> {
-  // Resolve bot identity first to avoid race conditions in Socket Mode where
-  // messages can arrive before botUserId is set (self-message filtering requires it).
-  try {
-    const authResult = await connection.app.client.auth.test();
-    connection.botUserId = authResult.user_id ?? undefined;
-    connection.botName = authResult.user ?? undefined;
-    connection.teamId = authResult.team_id ?? undefined;
-    connection.teamName = authResult.team ?? undefined;
-    logger.info('Bot identity resolved', {
-      botUserId: connection.botUserId,
-      botName: connection.botName,
-      teamId: connection.teamId,
-      teamName: connection.teamName,
-    });
-
-    // In user mode, resolve the authorizing human too (#889). Self-filtering
-    // needs it: a message that person types themselves carries no bot_id and
-    // their own user id, so comparing only against botUserId would let the
-    // agent answer on their behalf in their own conversation.
-    if (connection.userClient) {
-      const userAuth = await connection.userClient.auth.test();
-      connection.actingUserId = (userAuth.user_id as string | undefined) ?? undefined;
-      logger.info('Acting user identity resolved', {
-        actingUserId: connection.actingUserId,
-        actingUser: userAuth.user,
-      });
-    }
-  } catch (error) {
-    logger.warn('Failed to resolve bot identity before start — self-message filtering may be unreliable', {
-      error: String(error),
-    });
-  }
+  await resolveIdentities(connection, logger);
 
   // User mode (#889) MUST NOT start without a resolved acting-user id. Self-
   // filtering compares the human's own typing against actingUserId; when it is
@@ -356,17 +410,125 @@ export async function startBoltConnection(connection: BoltConnection, logger: Lo
     return connection;
   }
 
-  // Socket Mode: connect via WebSocket
+  // Socket Mode: connect via WebSocket, then VERIFY the socket really opened.
+  // `app.start()` resolving is not proof of a live connection (#941): an
+  // instance produced the full success log sequence with zero TCP connections
+  // to Slack. Success is only logged once the WebSocket state confirms it.
   try {
     await connection.app.start();
-    logger.info('Bolt.js app started successfully in Socket Mode');
+    await waitForSocketOpen(connection);
+    logger.info('Bolt.js app started in Socket Mode (WebSocket verified open)');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error('Failed to start Bolt.js app', { error: message });
+    if (error instanceof SlackError) throw error;
     throw new SlackError(SlackErrorCode.CONNECTION_FAILED, `Failed to start Slack connection: ${message}`);
   }
 
   return connection;
+}
+
+/**
+ * Resolve bot identity first to avoid race conditions in Socket Mode where
+ * messages can arrive before botUserId is set (self-message filtering requires
+ * it). Failures are logged, not thrown — startBoltConnection enforces the one
+ * hard invariant (user mode without a resolved acting-user id) itself.
+ */
+async function resolveIdentities(connection: BoltConnection, logger: Logger): Promise<void> {
+  try {
+    const authResult = await connection.app.client.auth.test();
+    connection.botUserId = authResult.user_id ?? undefined;
+    connection.botName = authResult.user ?? undefined;
+    connection.teamId = authResult.team_id ?? undefined;
+    connection.teamName = authResult.team ?? undefined;
+    logger.info('Bot identity resolved', {
+      botUserId: connection.botUserId,
+      botName: connection.botName,
+      teamId: connection.teamId,
+      teamName: connection.teamName,
+    });
+
+    // In user mode, resolve the authorizing human too (#889). Self-filtering
+    // needs it: a message that person types themselves carries no bot_id and
+    // their own user id, so comparing only against botUserId would let the
+    // agent answer on their behalf in their own conversation.
+    if (connection.userClient) {
+      const userAuth = await connection.userClient.auth.test();
+      connection.actingUserId = (userAuth.user_id as string | undefined) ?? undefined;
+      logger.info('Acting user identity resolved', {
+        actingUserId: connection.actingUserId,
+        actingUser: userAuth.user,
+      });
+    }
+  } catch (error) {
+    logger.warn('Failed to resolve bot identity before start — self-message filtering may be unreliable', {
+      error: String(error),
+    });
+  }
+}
+
+/**
+ * Wait (bounded) until the Socket Mode WebSocket is actually open.
+ *
+ * Resolves immediately when the socket is already open; otherwise waits for
+ * the client's 'connected' event up to connection.socketConnectTimeoutMs
+ * (default {@link SOCKET_OPEN_TIMEOUT_MS}) and throws a recoverable
+ * CONNECTION_FAILED so the caller marks the instance 'error' — the state the
+ * instance monitor knows how to recover — instead of a lying 'connected'.
+ */
+async function waitForSocketOpen(connection: BoltConnection): Promise<void> {
+  const socketClient = connection.socketClient;
+  if (!socketClient) {
+    throw new SlackError(
+      SlackErrorCode.CONNECTION_FAILED,
+      'Socket Mode client unavailable after start — cannot verify the WebSocket opened',
+    );
+  }
+
+  if (isSocketOpen(connection)) return;
+
+  const timeoutMs = connection.socketConnectTimeoutMs ?? SOCKET_OPEN_TIMEOUT_MS;
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      socketClient.removeListener('connected', onConnected);
+    };
+    const onConnected = (): void => {
+      cleanup();
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new SlackError(
+          SlackErrorCode.CONNECTION_FAILED,
+          `Socket Mode WebSocket did not open within ${timeoutMs}ms of app.start() resolving`,
+          true,
+        ),
+      );
+    }, timeoutMs);
+    timer.unref?.();
+    socketClient.on('connected', onConnected);
+  });
+}
+
+/**
+ * Whether the Socket Mode WebSocket is open right now.
+ *
+ * Ground truth is the underlying ws readyState (SlackWebSocket.isActive), not
+ * the cached instance status and not auth.test() — the Web API answers over
+ * HTTPS and is happily ok on a process whose WSS never opened (#941). Falls
+ * back to the tracked lifecycle state when the client exposes no websocket
+ * (before start(), or with mocked clients). Always true for HTTP mode — there
+ * is no socket to inspect.
+ */
+export function isSocketOpen(connection: BoltConnection): boolean {
+  if (connection.mode !== 'socket') return true;
+  const socketClient = connection.socketClient;
+  if (!socketClient) return false;
+  const websocket = socketClient.websocket;
+  if (websocket) return websocket.isActive();
+  return connection.socketState === 'connected';
 }
 
 /**
@@ -384,6 +546,8 @@ export async function createBoltConnection(options: SlackConnectionOptions, logg
  * Stop and disconnect a Bolt.js App
  */
 export async function destroyBoltConnection(connection: BoltConnection, logger: Logger): Promise<void> {
+  // A deliberate stop must not be reported as a lost socket (#941).
+  connection.onSocketStateChange = undefined;
   try {
     await connection.app.stop();
     logger.info('Bolt.js connection stopped');
@@ -393,9 +557,15 @@ export async function destroyBoltConnection(connection: BoltConnection, logger: 
 }
 
 /**
- * Check if a Bolt.js connection is healthy
+ * Check if a Bolt.js connection is healthy.
+ *
+ * auth.test() only proves the Web API (HTTPS) is reachable; in socket mode the
+ * events transport is the WSS connection, so a deaf socket must fail the check
+ * even while auth.test() succeeds (#941) — otherwise connect() answers
+ * 'already connected' and there is no recovery path from the CLI.
  */
 export async function checkBoltHealth(connection: BoltConnection): Promise<boolean> {
+  if (!isSocketOpen(connection)) return false;
   try {
     const result = await connection.client.auth.test();
     return result.ok === true;

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -16,6 +16,7 @@ import {
 } from '@omni/channel-sdk';
 import type {
   ChannelCapabilities,
+  ConnectionStatus,
   DedupeCache,
   FetchHistoryOptions,
   FetchHistoryResult,
@@ -33,7 +34,13 @@ import type { ChannelType, ContentType } from '@omni/core/types';
 import { SLACK_CAPABILITIES } from './capabilities';
 import { resolveStreamMode, resolveStreamThrottle } from './config/stream-mode';
 import type { BoltConnection } from './connection/bolt-client';
-import { checkBoltHealth, createBoltApp, destroyBoltConnection, startBoltConnection } from './connection/bolt-client';
+import {
+  checkBoltHealth,
+  createBoltApp,
+  destroyBoltConnection,
+  isSocketOpen,
+  startBoltConnection,
+} from './connection/bolt-client';
 import { setupAgentSessionHandlers } from './handlers/agent-sessions';
 import type { CommandPayload } from './handlers/commands';
 import { setupCommandHandlers } from './handlers/commands';
@@ -246,6 +253,9 @@ export class SlackPlugin extends BaseChannelPlugin {
         this.logger.warn('Instance already connected', { instanceId });
         return;
       }
+      // The health check is socket-aware (#941): a deaf Socket Mode instance
+      // lands here and is torn down and rebuilt instead of 'already connected'.
+      this.logger.warn('Existing connection failed health check — rebuilding', { instanceId });
       await destroyBoltConnection(existing, this.logger);
       this.connections.delete(instanceId);
       this.disposeInstanceCaches(instanceId);
@@ -327,6 +337,10 @@ export class SlackPlugin extends BaseChannelPlugin {
         ownerIdentifier: connection.botUserId,
       });
 
+      // Runtime detection (#941): from here on, a socket dying drives a real
+      // status transition instead of leaving a stale cached 'connected'.
+      this.watchSocketState(instanceId, config, connection);
+
       this.logger.info('Slack instance connected', {
         instanceId,
         botName: connection.botName,
@@ -385,6 +399,93 @@ export class SlackPlugin extends BaseChannelPlugin {
     this.disposeInstanceCaches(instanceId);
 
     await this.emitInstanceDisconnected(instanceId, 'User requested disconnect');
+  }
+
+  /**
+   * Report status from the REAL socket, not just the cached transition (#941).
+   *
+   * BaseChannelPlugin caches the last written status, and 'connected' used to
+   * be written once at connect() and never revisited — a deaf socket reported
+   * connected forever and the instance monitor had nothing to act on. When the
+   * cache says connected but the Socket Mode WebSocket is not open, report a
+   * retryable error instead; needsReconnect() in the instance monitor treats
+   * that as a signal to rebuild the instance automatically.
+   */
+  override async getStatus(instanceId: string): Promise<ConnectionStatus> {
+    const status = await super.getStatus(instanceId);
+    if (status.state !== 'connected') return status;
+
+    const connection = this.connections.get(instanceId);
+    if (!connection || isSocketOpen(connection)) return status;
+
+    return {
+      state: 'error',
+      since: new Date(),
+      message: 'Socket Mode WebSocket is not open despite cached connected state',
+      error: {
+        code: SlackErrorCode.CONNECTION_FAILED,
+        message: 'Socket Mode WebSocket is not open',
+        retryable: true,
+      },
+    };
+  }
+
+  /**
+   * Mirror Socket Mode lifecycle transitions into instance status (#941).
+   *
+   * Each transition maps to a state the instance monitor already knows how to
+   * act on: 'error' → schedule reconnect; a fresh 'reconnecting' → leave
+   * Bolt's own retry loop alone (going stale hands it to the monitor); a
+   * recovered socket → back to 'connected'.
+   */
+  private watchSocketState(instanceId: string, config: InstanceConfig, connection: BoltConnection): void {
+    if (connection.mode !== 'socket') return;
+
+    const setStatus = (status: ConnectionStatus): void => {
+      this.updateInstanceStatus(instanceId, config, status).catch((err) => {
+        this.logger.warn('Failed to update instance status from socket transition', {
+          instanceId,
+          error: String(err),
+        });
+      });
+    };
+
+    connection.onSocketStateChange = (state) => {
+      // A rebuilt instance leaves the old connection's transitions behind.
+      if (this.connections.get(instanceId) !== connection) return;
+
+      if (state === 'connected') {
+        this.logger.info('Slack Socket Mode connection restored', { instanceId });
+        setStatus({
+          state: 'connected',
+          since: new Date(),
+          metadata: {
+            profileName: connection.botName,
+            ownerIdentifier: connection.botUserId,
+          },
+        });
+        return;
+      }
+
+      if (state === 'reconnecting') {
+        this.logger.warn('Slack Socket Mode reconnecting', { instanceId });
+        setStatus({ state: 'reconnecting', since: new Date() });
+        return;
+      }
+
+      if (state === 'disconnected') {
+        this.logger.error('Slack Socket Mode connection lost', { instanceId });
+        setStatus({
+          state: 'error',
+          since: new Date(),
+          error: {
+            code: SlackErrorCode.CONNECTION_FAILED,
+            message: 'Socket Mode WebSocket disconnected',
+            retryable: true,
+          },
+        });
+      }
+    };
   }
 
   /**

--- a/packages/channel-slack/src/types.ts
+++ b/packages/channel-slack/src/types.ts
@@ -165,6 +165,11 @@ export interface SlackConnectionOptions {
   mode?: SlackConnectionMode;
   /** Port for the built-in HTTP receiver (HTTP mode only, default: 3001) */
   httpPort?: number;
+  /**
+   * How long to wait for the Socket Mode WebSocket to be verifiably open after
+   * `app.start()` resolves before failing the start (#941). Default: 10s.
+   */
+  socketConnectTimeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #941

## Problem

The Slack plugin logged `Bolt.js app started successfully in Socket Mode` and cached the instance as `connected` on nothing more than `app.start()` resolving. When the WebSocket never actually opened — or died after a good start — the instance went deaf with zero signal:

- `checkBoltHealth` probed `auth.test()`, an **HTTPS** Web API call that answers `ok` even when the WSS transport is dead → `instances connect` replied `Instance already connected` and returned (the CLI dead-end from the issue).
- The plugin never overrode `getStatus`, so the cached in-memory `connected` was reported forever and the instance monitor's `needsReconnect` never fired.
- Bolt's `SocketModeClient` lifecycle events (`disconnected` / `reconnecting` / `error`) were never forwarded — only `app.error()` was registered.

## Fix (four layers, all keyed off the SocketModeClient's real state)

The socket-mode `SocketModeReceiver` is now constructed explicitly so its `SocketModeClient` is reachable in a typed way (`connection.socketClient`); ground truth is the underlying `ws` readyState via `SlackWebSocket.isActive()`.

1. **Startup assertion** (`bolt-client.ts`): after `app.start()`, wait (bounded, 10s default via `socketConnectTimeoutMs`) until the WebSocket is verifiably open; otherwise throw a recoverable `SlackError(CONNECTION_FAILED)` so `connect()` marks the instance `error` — a state `needsReconnect` already acts on. Success is never logged unconditionally anymore.
2. **Runtime detection**: `connected` / `reconnecting` / `disconnected` / `error` events are logged, tracked on `connection.socketState`, and mirrored into instance status by the plugin (`error` retryable on loss, `reconnecting` while Bolt retries — fresh transitions leave Bolt's own retry loop alone, stale ones get taken over by the monitor's existing 10-min rule — back to `connected` on recovery). A deliberate `destroyBoltConnection` clears the hook so shutdown isn't reported as a lost socket. (`@slack/socket-mode` v2 has no `unable_to_socket_mode_start` event; those failures surface via `error` plus the bounded post-start verification.)
3. **Socket-aware health**: `checkBoltHealth` now requires an open socket in socket mode (keeping `auth.test()` for the Web API half), so `connect()` on a deaf instance tears it down and rebuilds instead of answering `already connected` — restoring CLI recovery.
4. **`getStatus` override**: a cached `connected` is downgraded to a retryable `error` whenever the socket is not open, which hands the instance monitor automatic recovery with no monitor changes.

## Tests

New `socket-health.test.ts` (19 tests, fake Bolt objects, no real Slack): start-resolves-but-socket-never-opens → throw; lifecycle forwarding + hook cleared on destroy; health false with a closed socket even while `auth.test` is ok (the exact deaf shape from the issue); `getStatus` override; post-start death → `error` → `reconnecting` → recovered `connected` plus the stale-connection guard; and `connect()` rebuilding a deaf instance vs. early-returning on a healthy one. Existing `bolt-client-user-mode` / `bolt-client-http` fakes extended for the new socket surface.

`make check` green (typecheck, biome, knip, migration contract, tests). No schema or migration changes.