### PR TITLE
feat(slack): record thread roots, reply counters and pin state (#889 tail)

### DIFF
--- a/packages/api/src/plugins/__tests__/message-persistence-thread-root.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-thread-root.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for thread-root linking (#889).
+ *
+ * 0048 added thread_root_message_id / reply_count / latest_reply_at with no
+ * writer. linkThreadRoot fills them in at persist time; these tests pin down
+ * its guard conditions and the SQL the service methods generate.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import { isSQLWrapper } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { Services } from '../../services';
+import { MessageService } from '../../services/messages';
+import { linkThreadRoot } from '../message-persistence';
+
+const REPLIED_AT = new Date('2026-09-07T12:00:00Z');
+
+function makeServices(rootId: string | null, resolverError?: Error) {
+  const resolveReplyToMessage = mock(async () => {
+    if (resolverError) throw resolverError;
+    return rootId;
+  });
+  const setThreadRoot = mock(async () => {});
+  const recordThreadReply = mock(async () => {});
+  const services = {
+    messages: { resolveReplyToMessage, setThreadRoot, recordThreadReply },
+  } as unknown as Services;
+  return { services, resolveReplyToMessage, setThreadRoot, recordThreadReply };
+}
+
+describe('linkThreadRoot', () => {
+  test('does nothing when the message is not in a thread', async () => {
+    const { services, resolveReplyToMessage } = makeServices('root-uuid');
+
+    await linkThreadRoot(services, 'chat-1', 'msg-uuid', '1725700000.000100', undefined, REPLIED_AT);
+
+    expect(resolveReplyToMessage).not.toHaveBeenCalled();
+  });
+
+  test('does nothing for the root itself (thread_ts equals its own ts)', async () => {
+    const { services, resolveReplyToMessage } = makeServices('root-uuid');
+
+    await linkThreadRoot(services, 'chat-1', 'msg-uuid', '1725700000.000100', '1725700000.000100', REPLIED_AT);
+
+    expect(resolveReplyToMessage).not.toHaveBeenCalled();
+  });
+
+  test('links the reply and bumps the root bookkeeping when the root exists', async () => {
+    const { services, setThreadRoot, recordThreadReply } = makeServices('root-uuid');
+
+    await linkThreadRoot(services, 'chat-1', 'msg-uuid', '1725700099.000200', '1725700000.000100', REPLIED_AT);
+
+    expect(setThreadRoot).toHaveBeenCalledWith('msg-uuid', 'root-uuid');
+    expect(recordThreadReply).toHaveBeenCalledWith('root-uuid', REPLIED_AT);
+  });
+
+  test('skips linking when the root was never stored (no backfill, 0048 decision)', async () => {
+    const { services, setThreadRoot, recordThreadReply } = makeServices(null);
+
+    await linkThreadRoot(services, 'chat-1', 'msg-uuid', '1725700099.000200', '1725700000.000100', REPLIED_AT);
+
+    expect(setThreadRoot).not.toHaveBeenCalled();
+    expect(recordThreadReply).not.toHaveBeenCalled();
+  });
+
+  test('swallows service errors — linking must never fail the persist', async () => {
+    const { services } = makeServices('root-uuid', new Error('db down'));
+
+    await expect(
+      linkThreadRoot(services, 'chat-1', 'msg-uuid', '1725700099.000200', '1725700000.000100', REPLIED_AT),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ============================================================================
+// MessageService.setThreadRoot / recordThreadReply — generated SQL
+// ============================================================================
+
+interface UpdateCapture {
+  values?: Record<string, unknown>;
+  whereSql?: string;
+  whereParams?: unknown[];
+}
+
+function toQuery(condition: unknown): { sql: string; params: unknown[] } {
+  if (!isSQLWrapper(condition)) {
+    throw new Error('Expected a Drizzle SQLWrapper');
+  }
+  const query = new PgDialect().sqlToQuery(condition.getSQL());
+  return { sql: query.sql.replace(/\s+/g, ' ').trim().toLowerCase(), params: query.params };
+}
+
+function createUpdateCaptureDb(capture: UpdateCapture) {
+  const update = (_table: unknown) => ({
+    set: (values: Record<string, unknown>) => ({
+      where: (condition: unknown) => {
+        capture.values = values;
+        const query = toQuery(condition);
+        capture.whereSql = query.sql;
+        capture.whereParams = query.params;
+        return Promise.resolve();
+      },
+    }),
+  });
+  return { update } as unknown as Database;
+}
+
+describe('MessageService.setThreadRoot', () => {
+  test('points the reply row at the root by primary key', async () => {
+    const capture: UpdateCapture = {};
+    const service = new MessageService(createUpdateCaptureDb(capture), null);
+
+    await service.setThreadRoot('msg-uuid', 'root-uuid');
+
+    expect(capture.values?.threadRootMessageId).toBe('root-uuid');
+    expect(capture.whereSql).toContain('"id" =');
+    expect(capture.whereParams).toEqual(['msg-uuid']);
+  });
+});
+
+describe('MessageService.recordThreadReply', () => {
+  test('increments reply_count and never drags latest_reply_at backwards', async () => {
+    const capture: UpdateCapture = {};
+    const service = new MessageService(createUpdateCaptureDb(capture), null);
+
+    await service.recordThreadReply('root-uuid', REPLIED_AT);
+
+    const replyCount = toQuery(capture.values?.replyCount);
+    expect(replyCount.sql).toContain('reply_count');
+    expect(replyCount.sql).toContain('+ 1');
+
+    // GREATEST(COALESCE(latest_reply_at, $repliedAt), $repliedAt): an
+    // out-of-order history-sync reply must not move the timestamp backwards.
+    const latestReplyAt = toQuery(capture.values?.latestReplyAt);
+    expect(latestReplyAt.sql).toContain('greatest');
+    expect(latestReplyAt.sql).toContain('coalesce');
+    expect(latestReplyAt.sql).toContain('latest_reply_at');
+    expect(latestReplyAt.params).toEqual([REPLIED_AT, REPLIED_AT]);
+
+    expect(capture.whereParams).toEqual(['root-uuid']);
+  });
+});

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -9,6 +9,7 @@
  * - message.received (history-sync) → find/create chat → create message (source: 'sync')
  * - message.sent → find/create chat → create message (source: 'realtime', isFromMe: true)
  * - message.delivered/read → update message delivery status
+ * - message.pinned/unpinned → update per-message pin state (#889)
  *
  * @see unified-messages wish
  *
@@ -16,7 +17,7 @@
  * -----------------------------
  * This is the dominant inbound consumer: every message on every channel lands
  * here and writes `chats`, `messages`, `chat_participants`, `chat_id_mappings`,
- * `platform_identities` and `instances`. All five handlers are consumer-only —
+ * `platform_identities` and `instances`. All of its handlers are consumer-only —
  * a NATS subscription, no request, no credential — so until this leg every one
  * of those writes reached the ambient pool, which is why nine db-access-guard
  * sites stayed `pending-G5-conversion` long after their route callers were
@@ -55,7 +56,7 @@
  * byte-identical down to the call order.
  */
 
-import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
+import type { EventBus, MessageReceivedPayload, MessageSentPayload, TypedOmniEvent } from '@omni/core';
 import { classifyEnvelope, createLogger } from '@omni/core';
 import type { ChannelType, ChatType, MessageType } from '@omni/db';
 import * as Sentry from '@sentry/bun';
@@ -786,6 +787,45 @@ async function linkReplyTarget(
 }
 
 /**
+ * Link a thread reply to its root and bump the root's denormalized reply
+ * bookkeeping (#889).
+ *
+ * 0048 added `thread_root_message_id` / `reply_count` / `latest_reply_at`
+ * alongside `thread_external_id`, but only the external id ever got a writer.
+ * This resolves the root by external id (Slack's `thread_ts` is the root's own
+ * ts) and fills in the other three.
+ *
+ * Best-effort, like linkReplyTarget: 0048 deliberately shipped without a
+ * backfill, so a reply can reference a root that predates the column — and a
+ * history sync can deliver the reply before the root. Neither may fail the
+ * persist. Called only when the row was just created, so a redelivered event
+ * cannot double-count.
+ */
+export async function linkThreadRoot(
+  services: Services,
+  chatId: string,
+  messageId: string,
+  messageExternalId: string,
+  threadExternalId: string | undefined,
+  repliedAt: Date,
+): Promise<void> {
+  // The root carries its own ts as thread_ts once it has replies — not a reply.
+  if (!threadExternalId || threadExternalId === messageExternalId) return;
+  try {
+    const rootMessageId = await services.messages.resolveReplyToMessage(chatId, threadExternalId);
+    if (!rootMessageId) return;
+    await services.messages.setThreadRoot(messageId, rootMessageId);
+    await services.messages.recordThreadReply(rootMessageId, repliedAt);
+  } catch (error) {
+    log.debug('Could not link thread root', {
+      chatId,
+      threadExternalId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
  * Handle message.received event - main processing logic
  */
 async function handleMessageReceived(
@@ -923,6 +963,14 @@ async function handleMessageReceived(
     log.debug('Created message', { externalId: payload.externalId, chatId: chat.id });
 
     await linkReplyTarget(services, chat.id, message.id, payload.replyToId);
+    await linkThreadRoot(
+      services,
+      chat.id,
+      message.id,
+      messageExternalId,
+      truncate(payload.threadId, 255),
+      platformTimestamp ?? new Date(eventTimestamp),
+    );
   }
 
   // Step 6: Record participant activity
@@ -963,6 +1011,42 @@ function logMessageReceivedError(payload: MessageReceivedPayload, error: unknown
     },
     longFields: Object.keys(longFields).length > 0 ? longFields : undefined,
   });
+}
+
+/**
+ * Handle message.pinned / message.unpinned — record per-message pin state (#889).
+ *
+ * Non-critical like delivery status: a failed update leaves the pin column
+ * stale, never a message missing, so errors are logged and not re-thrown.
+ */
+async function handleMessagePinState(
+  services: Services,
+  event: TypedOmniEvent<'message.pinned' | 'message.unpinned'>,
+  pinned: boolean,
+): Promise<void> {
+  const payload = event.payload;
+  const metadata = event.metadata;
+  if (!metadata.instanceId) return;
+  const instanceId = metadata.instanceId;
+
+  try {
+    // Lookup + pin update are one work item: one worker transaction.
+    await runConsumerInTenantContext(services.db, event, async () => {
+      const chat = await services.chats.findByExternalIdSmart(instanceId, payload.chatId);
+      if (!chat) {
+        log.debug('Chat not found for pin update', { chatId: payload.chatId });
+        return;
+      }
+
+      await services.messages.setPinned(chat.id, payload.messageId, pinned, payload.from);
+      log.debug('Updated message pin state', { chatId: chat.id, messageId: payload.messageId, pinned });
+    });
+  } catch (error) {
+    log.error('Failed to update pin state', {
+      messageId: payload.messageId,
+      error: String(error),
+    });
+  }
 }
 
 // ============================================================================
@@ -1107,6 +1191,17 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
               // our own thread replies read back as top-level channel messages.
               threadExternalId: truncate(payload.threadId, 255),
             });
+
+            if (created) {
+              await linkThreadRoot(
+                services,
+                chat.id,
+                message.id,
+                messageExternalId,
+                truncate(payload.threadId, 255),
+                new Date(event.timestamp),
+              );
+            }
 
             return { chat, message, created };
           });
@@ -1262,6 +1357,25 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
         concurrency: 10,
       },
     );
+
+    // Subscribe to message.pinned / message.unpinned — per-message pin state (#889)
+    await eventBus.subscribe('message.pinned', (event) => handleMessagePinState(services, event, true), {
+      durable: 'message-persistence-pinned',
+      queue: 'message-persistence',
+      maxRetries: 2,
+      retryDelayMs: 500,
+      startFrom: 'first',
+      concurrency: 10,
+    });
+
+    await eventBus.subscribe('message.unpinned', (event) => handleMessagePinState(services, event, false), {
+      durable: 'message-persistence-unpinned',
+      queue: 'message-persistence',
+      maxRetries: 2,
+      retryDelayMs: 500,
+      startFrom: 'first',
+      concurrency: 10,
+    });
 
     // Subscribe to instance.connected for post-reconnect backfill detection
     await eventBus.subscribe(

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -963,4 +963,32 @@ export class MessageService {
   async updateReplyToReference(id: string, replyToMessageId: string): Promise<void> {
     await this.db.update(messages).set({ replyToMessageId, updatedAt: new Date() }).where(eq(messages.id, id));
   }
+
+  /**
+   * Point a thread reply at its root row (#889).
+   *
+   * 0048 added `thread_root_message_id` with nothing writing it — replies
+   * carried only the platform `threadExternalId`, so joining a thread to its
+   * root needed a second lookup by external id.
+   */
+  async setThreadRoot(id: string, threadRootMessageId: string): Promise<void> {
+    await this.db.update(messages).set({ threadRootMessageId, updatedAt: new Date() }).where(eq(messages.id, id));
+  }
+
+  /**
+   * Bump the denormalized reply bookkeeping on a thread root (#889).
+   *
+   * GREATEST guards out-of-order arrival: history sync can deliver an old
+   * reply after a newer one, and it must not drag latestReplyAt backwards.
+   */
+  async recordThreadReply(rootMessageId: string, repliedAt: Date): Promise<void> {
+    await this.db
+      .update(messages)
+      .set({
+        replyCount: sql`${messages.replyCount} + 1`,
+        latestReplyAt: sql`GREATEST(COALESCE(${messages.latestReplyAt}, ${repliedAt}), ${repliedAt})`,
+        updatedAt: new Date(),
+      })
+      .where(eq(messages.id, rootMessageId));
+  }
 }

--- a/packages/channel-sdk/src/base/BaseChannelPlugin.ts
+++ b/packages/channel-sdk/src/base/BaseChannelPlugin.ts
@@ -17,9 +17,11 @@ import type {
   EmitMediaReceivedParams,
   EmitMessageDeliveredParams,
   EmitMessageFailedParams,
+  EmitMessagePinnedParams,
   EmitMessageReadParams,
   EmitMessageReceivedParams,
   EmitMessageSentParams,
+  EmitMessageUnpinnedParams,
   EmitPollParams,
   EmitPollVoteParams,
   EmitReactionReceivedParams,
@@ -435,6 +437,22 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
   protected async emitReactionRemoved(params: EmitReactionRemovedParams): Promise<void> {
     const { instanceId, ...payload } = params;
     await this.publishEventInternal('reaction.removed', payload, instanceId);
+  }
+
+  /**
+   * Emit message.pinned event (#889)
+   */
+  protected async emitMessagePinned(params: EmitMessagePinnedParams): Promise<void> {
+    const { instanceId, ...payload } = params;
+    await this.publishEventInternal('message.pinned', payload, instanceId);
+  }
+
+  /**
+   * Emit message.unpinned event (#889)
+   */
+  protected async emitMessageUnpinned(params: EmitMessageUnpinnedParams): Promise<void> {
+    const { instanceId, ...payload } = params;
+    await this.publishEventInternal('message.unpinned', payload, instanceId);
   }
 
   /**

--- a/packages/channel-sdk/src/helpers/events.ts
+++ b/packages/channel-sdk/src/helpers/events.ts
@@ -227,6 +227,46 @@ export interface EmitReactionReceivedParams {
 }
 
 /**
+ * Parameters for emitMessagePinned (#889)
+ */
+export interface EmitMessagePinnedParams {
+  /** Instance where the pin happened */
+  instanceId: string;
+
+  /** The message that was pinned (platform external id) */
+  messageId: string;
+
+  /** Chat where the message lives (platform external id) */
+  chatId: string;
+
+  /** Platform user who pinned it */
+  from?: string;
+
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for emitMessageUnpinned (#889)
+ */
+export interface EmitMessageUnpinnedParams {
+  /** Instance where the unpin happened */
+  instanceId: string;
+
+  /** The message that was unpinned (platform external id) */
+  messageId: string;
+
+  /** Chat where the message lives (platform external id) */
+  chatId: string;
+
+  /** Platform user who unpinned it */
+  from?: string;
+
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
+}
+
+/**
  * Parameters for emitReactionRemoved
  */
 export interface EmitReactionRemovedParams {

--- a/packages/channel-slack/src/handlers/pins.test.ts
+++ b/packages/channel-slack/src/handlers/pins.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the pin_added / pin_removed handlers (#889)
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import type { Logger } from '@omni/channel-sdk';
+import type { App } from '@slack/bolt';
+import { setupPinHandlers } from './pins';
+
+function makeLogger(): Logger {
+  return {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    child: mock(() => makeLogger()),
+  } as unknown as Logger;
+}
+
+/** Minimal Bolt app double that records event registrations. */
+function makeApp() {
+  const listeners = new Map<string, (args: { event: unknown }) => Promise<void>>();
+  const app = {
+    event: mock((name: string, listener: (args: { event: unknown }) => Promise<void>) => {
+      listeners.set(name, listener);
+    }),
+  };
+  return { app: app as unknown as App, listeners };
+}
+
+type PinCall = {
+  instanceId: string;
+  messageId: string;
+  chatId: string;
+  userId: string | undefined;
+  action: 'pin' | 'unpin';
+};
+
+function setup() {
+  const { app, listeners } = makeApp();
+  const calls: PinCall[] = [];
+  setupPinHandlers(
+    app,
+    'inst-1',
+    {
+      onPin: async (instanceId, messageId, chatId, userId, action) => {
+        calls.push({ instanceId, messageId, chatId, userId, action });
+      },
+    },
+    makeLogger(),
+  );
+  return { listeners, calls };
+}
+
+describe('setupPinHandlers', () => {
+  it('registers listeners for pin_added and pin_removed', () => {
+    const { listeners } = setup();
+
+    expect(listeners.has('pin_added')).toBe(true);
+    expect(listeners.has('pin_removed')).toBe(true);
+  });
+
+  it('maps pin_added into a pin callback', async () => {
+    const { listeners, calls } = setup();
+
+    await listeners.get('pin_added')?.({
+      event: {
+        type: 'pin_added',
+        user: 'U123ABC456',
+        channel_id: 'C0123ABC456',
+        item: {
+          type: 'message',
+          channel: 'C0123ABC456',
+          message: { ts: '1725700000.000100', text: 'pinned text' },
+        },
+        event_ts: '1725700100.000200',
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        instanceId: 'inst-1',
+        messageId: '1725700000.000100',
+        chatId: 'C0123ABC456',
+        userId: 'U123ABC456',
+        action: 'pin',
+      },
+    ]);
+  });
+
+  it('maps pin_removed into an unpin callback', async () => {
+    const { listeners, calls } = setup();
+
+    await listeners.get('pin_removed')?.({
+      event: {
+        type: 'pin_removed',
+        user: 'U123ABC456',
+        item: {
+          type: 'message',
+          channel: 'C0123ABC456',
+          message: { ts: '1725700000.000100' },
+        },
+      },
+    });
+
+    expect(calls.map((c) => c.action)).toEqual(['unpin']);
+  });
+
+  it('falls back to channel_id when the item carries no channel', async () => {
+    const { listeners, calls } = setup();
+
+    await listeners.get('pin_added')?.({
+      event: {
+        type: 'pin_added',
+        user: 'U123ABC456',
+        channel_id: 'C0123ABC456',
+        item: { type: 'message', message: { ts: '1725700000.000100' } },
+      },
+    });
+
+    expect(calls[0]?.chatId).toBe('C0123ABC456');
+  });
+
+  it('ignores pinned files — only messages have a row to update', async () => {
+    const { listeners, calls } = setup();
+
+    await listeners.get('pin_added')?.({
+      event: {
+        type: 'pin_added',
+        user: 'U123ABC456',
+        channel_id: 'C0123ABC456',
+        item: { type: 'file', file: { id: 'F123' } },
+      },
+    });
+
+    expect(calls).toEqual([]);
+  });
+
+  it('ignores events without a message ts', async () => {
+    const { listeners, calls } = setup();
+
+    await listeners.get('pin_added')?.({
+      event: {
+        type: 'pin_added',
+        user: 'U123ABC456',
+        channel_id: 'C0123ABC456',
+        item: { type: 'message', message: {} },
+      },
+    });
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/channel-slack/src/handlers/pins.ts
+++ b/packages/channel-slack/src/handlers/pins.ts
@@ -1,0 +1,53 @@
+/**
+ * Pin event handler for Slack
+ *
+ * Handles pin_added and pin_removed events (#889). The manifest has subscribed
+ * to both since the user-token work landed; this is the consumer that turns
+ * them into core events so `messages.pinned_at` / `pinned_by` reflect reality.
+ *
+ * Unlike reactions, the bot's own pins are NOT filtered out: a pin made
+ * through our own tools (pins.add) is still platform state worth recording,
+ * and recording it cannot loop — persistence only writes a column.
+ */
+
+import type { Logger } from '@omni/channel-sdk';
+import type { App } from '@slack/bolt';
+
+export interface PinHandlerCallbacks {
+  onPin: (
+    instanceId: string,
+    messageId: string,
+    chatId: string,
+    userId: string | undefined,
+    action: 'pin' | 'unpin',
+  ) => Promise<void>;
+}
+
+/**
+ * Set up pin handlers on a Bolt.js app
+ */
+export function setupPinHandlers(app: App, instanceId: string, callbacks: PinHandlerCallbacks, logger: Logger): void {
+  const handlePinEvent =
+    (action: 'pin' | 'unpin') =>
+    async ({ event }: { event: unknown }) => {
+      const evt = event as Record<string, unknown>;
+      const item = evt.item as Record<string, unknown> | undefined;
+      // Files and file comments can be pinned too; only messages have a row.
+      if (!item || item.type !== 'message') return;
+
+      const message = item.message as Record<string, unknown> | undefined;
+      const channelId = (item.channel as string) ?? (evt.channel_id as string) ?? '';
+      const messageTs = (message?.ts as string) ?? '';
+      if (!channelId || !messageTs) return;
+
+      const userId = evt.user as string | undefined;
+      logger.debug(action === 'pin' ? 'Pin added' : 'Pin removed', { instanceId, channelId, messageTs, userId });
+
+      await callbacks.onPin(instanceId, messageTs, channelId, userId, action);
+    };
+
+  app.event('pin_added', handlePinEvent('pin'));
+  app.event('pin_removed', handlePinEvent('unpin'));
+
+  logger.info('Pin handlers registered', { instanceId });
+}

--- a/packages/channel-slack/src/plugin.ts
+++ b/packages/channel-slack/src/plugin.ts
@@ -47,6 +47,7 @@ import { setupCommandHandlers } from './handlers/commands';
 import { downloadSlackFile, extractFileInfo, getContentTypeFromMime } from './handlers/files';
 import { setupInteractionHandlers } from './handlers/interactions';
 import { type SlackDebouncedArgs, setupMessageHandlers } from './handlers/messages';
+import { setupPinHandlers } from './handlers/pins';
 import { setupReactionHandlers } from './handlers/reactions';
 import { type SlackStatusMethod, clearTypingStatus, setSlackThreadStatus } from './handlers/typing';
 import { uploadFile, uploadFileFromUrl } from './senders/media';
@@ -1660,6 +1661,23 @@ export class SlackPlugin extends BaseChannelPlugin {
       {
         onReaction: async (instId, messageId, chatId, userId, emoji, action) => {
           await this.handleReactionReceived(instId, messageId, chatId, userId, emoji, action);
+        },
+      },
+      this.logger,
+    );
+
+    // Pin handlers (#889) — the manifest subscribes to pin_added/pin_removed;
+    // these turn them into message.pinned/unpinned so core records the state.
+    setupPinHandlers(
+      connection.app,
+      instanceId,
+      {
+        onPin: async (instId, messageId, chatId, userId, action) => {
+          if (action === 'pin') {
+            await this.emitMessagePinned({ instanceId: instId, messageId, chatId, from: userId });
+          } else {
+            await this.emitMessageUnpinned({ instanceId: instId, messageId, chatId, from: userId });
+          }
         },
       },
       this.logger,

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -19,6 +19,8 @@ export const CORE_EVENT_TYPES = [
   'message.delivered',
   'message.read',
   'message.failed',
+  'message.pinned',
+  'message.unpinned',
 
   // Interactive UI
   'message.button_click',
@@ -683,6 +685,34 @@ export interface ReactionRemovedPayload {
   isCustomEmoji?: boolean;
 }
 
+/**
+ * Message pin lifecycle payloads (#889)
+ *
+ * Pinning is per-message platform state (Slack `pin_added`/`pin_removed`),
+ * distinct from pinning a whole chat in the sidebar (`ChatSettings.pinned`).
+ */
+export interface MessagePinnedPayload {
+  /** The message that was pinned (platform external id) */
+  messageId: string;
+  /** Chat where the message lives (platform external id) */
+  chatId: string;
+  /** Platform user who pinned it (absent when the platform does not report one) */
+  from?: string;
+  /** Raw platform payload for channel-specific data */
+  rawPayload?: Record<string, unknown>;
+}
+
+export interface MessageUnpinnedPayload {
+  /** The message that was unpinned (platform external id) */
+  messageId: string;
+  /** Chat where the message lives (platform external id) */
+  chatId: string;
+  /** Platform user who unpinned it */
+  from?: string;
+  /** Raw platform payload for channel-specific data */
+  rawPayload?: Record<string, unknown>;
+}
+
 // ─── Session Events ────────────────────────────────────────
 export interface SessionResetPayload {
   /** Instance that the session belongs to */
@@ -1062,6 +1092,8 @@ export interface EventPayloadMap {
   'message.delivered': MessageDeliveredPayload;
   'message.read': MessageReadPayload;
   'message.failed': MessageFailedPayload;
+  'message.pinned': MessagePinnedPayload;
+  'message.unpinned': MessageUnpinnedPayload;
   'message.button_click': MessageButtonClickPayload;
   'message.poll': MessagePollPayload;
   'message.poll_vote': MessagePollVotePayload;


### PR DESCRIPTION
## What

Finishes the unwired tail of #889 (implemented in bulk by #896). Two gaps remained:

1. **Thread bookkeeping columns were dead.** `thread_root_message_id`, `reply_count` and `latest_reply_at` shipped in migration 0048 but had no writer. Persistence now links every newly created thread reply (inbound **and** outbound, keeping the two paths symmetric) to its root row and bumps the root's denormalized counters.
2. **Pin events were subscribed but never consumed.** The Slack manifest has carried `pin_added`/`pin_removed` since #896; nothing handled them. A new `handlers/pins.ts` maps them to new `message.pinned`/`message.unpinned` core events, and message-persistence records them through the existing `MessageService.setPinned`.

## Design notes

- **No migrations** — all columns already exist (0048/0051). New event types ride the existing `MESSAGE` stream (`message.>`), so no NATS changes either.
- **Idempotent under redelivery**: thread linking runs only when the row was just created, so a retried event cannot double-count `reply_count`.
- **Out-of-order safe**: `latest_reply_at` is updated via `GREATEST(COALESCE(...))` so a history-sync reply that arrives late cannot drag it backwards.
- **Best-effort like `linkReplyTarget`**: 0048 deliberately shipped without a backfill, so a reply can reference a root we never stored — that must never fail the persist.
- **Bot pins are not self-filtered** (unlike reactions): a pin made through our own `pins.add` tools is still platform state worth recording, and recording it cannot loop.
- Pinned **files** are ignored — only messages have a row to update.

## Explicitly NOT done (declined #889 leftovers)

- `chat_participants.lastReadExternalId`, `canCreateThread` (covered by `canHandleThreads`), promoting `searchMessages` to the SDK contract (xoxp-only, stays Slack-local), and the `rich_text` blocks migration (the mrkdwn bugs that motivated it were fixed in #896). Rationale in the #889 closing comment.

## Tests

- `packages/channel-slack/src/handlers/pins.test.ts` — 6 tests: registration, pin/unpin mapping, `channel_id` fallback, file-pin and missing-ts guards.
- `packages/api/src/plugins/__tests__/message-persistence-thread-root.test.ts` — 7 tests: `linkThreadRoot` guards (not-a-thread, root-itself, missing root, error swallowing) and the generated SQL for `setThreadRoot`/`recordThreadReply` (increment + GREATEST/COALESCE).
- Full gates green locally: typecheck, biome, knip, and the core/channel-sdk/channel-slack/api suites (25/25 pre-push tasks).

Closes #889