### PR TITLE
feat(cli,sdk): omni tenants command group + SDK platform-tenant client methods

### DIFF
--- a/packages/cli/src/__tests__/sdk-coverage.test.ts
+++ b/packages/cli/src/__tests__/sdk-coverage.test.ts
@@ -302,6 +302,20 @@ const CLI_COMMANDS: Record<string, string> = {
   'slack.search': 'slack search',
 
   // ============================================================================
+  // PLATFORM CONTROL PLANE (tenants + memberships — issue #981)
+  // ============================================================================
+  'platform.tenants.list': 'tenants list --reason <text>',
+  'platform.tenants.get': 'tenants get <id> --reason <text>',
+  'platform.tenants.create': 'tenants create --slug --name --max-key-ttl --max-key-rate --max-key-budget --reason',
+  'platform.tenants.suspend': 'tenants suspend <id> --reason <text>',
+  'platform.tenants.archive': 'tenants archive <id> --reason <text>',
+  'platform.tenants.memberships.list': 'tenants memberships list <tenant-id> --reason <text>',
+  'platform.tenants.memberships.attach': 'tenants memberships add <tenant-id> --principal --role --reason',
+  'platform.tenants.memberships.disable': 'tenants memberships disable <tenant-id> <membership-id> --reason <text>',
+  'platform.tenants.memberships.setStatus': 'tenants memberships status <tenant-id> <membership-id> --status --reason',
+  'platform.tenants.memberships.setRole': 'tenants memberships role <tenant-id> <membership-id> --role --reason',
+
+  // ============================================================================
   // SYSTEM
   // ============================================================================
   'system.health': 'status',

--- a/packages/cli/src/commands/__tests__/tenants.test.ts
+++ b/packages/cli/src/commands/__tests__/tenants.test.ts
@@ -1,0 +1,327 @@
+/**
+ * CLI `omni tenants` — command → SDK mapping, reason enforcement, and
+ * control-plane failure UX (issue #981).
+ *
+ * Covers:
+ *   - every handler calls the matching `client.platform.tenants.*` method with
+ *     the audited reason in the position the SDK expects (arg or body field)
+ *   - every handler refuses to run without `--reason` BEFORE any SDK call
+ *   - 404 on an unmounted control plane explains OMNI_MULTITENANCY_ENABLED /
+ *     server-too-old instead of dumping the raw error
+ *   - 401/403 explain that a PLATFORM-class credential is required (the
+ *     legacy-credential dual-world contract — messages pinned verbatim)
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { OmniApiError, type OmniClient } from '@omni/sdk';
+
+// `error` throws (instead of printing + process.exit) so tests can assert the
+// exact operator-facing message. Same precedent as history.test.ts.
+mock.module('../../output.js', () => ({
+  error: (msg: string): never => {
+    throw new Error(msg);
+  },
+  success: mock(),
+  info: mock(),
+  warn: mock(),
+  raw: mock(),
+  data: mock(),
+  list: mock(),
+  keyValue: mock(),
+  header: mock(),
+  dim: mock(),
+  tip: mock(),
+  disableColors: mock(),
+  areColorsEnabled: () => true,
+  setMaxCellWidth: mock(),
+  getCurrentFormat: () => 'human',
+  flushStdout: () => Promise.resolve(),
+}));
+
+const { __testables } = await import('../tenants');
+const {
+  requireReason,
+  renderPlatformError,
+  handleList,
+  handleGet,
+  handleCreate,
+  handleSuspend,
+  handleArchive,
+  handleMembershipsList,
+  handleMembershipsAdd,
+  handleMembershipsDisable,
+  handleMembershipsStatus,
+  handleMembershipsRole,
+} = __testables;
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+const MEMBERSHIP_ID = '22222222-2222-4222-8222-222222222222';
+const PRINCIPAL_ID = '33333333-3333-4333-8333-333333333333';
+
+const tenant = {
+  id: TENANT_ID,
+  slug: 'acme',
+  displayName: 'Acme Corp',
+  status: 'active',
+  maxKeyTtlSeconds: 3600,
+  maxKeyRateLimit: 100,
+  maxKeyBudget: 1000,
+  createdAt: new Date().toISOString(),
+};
+
+const membership = {
+  id: MEMBERSHIP_ID,
+  tenantId: TENANT_ID,
+  principalId: PRINCIPAL_ID,
+  role: 'tenant-operator',
+  status: 'active',
+  invitedByPrincipalId: null,
+  createdAt: new Date().toISOString(),
+};
+
+interface CapturedCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeFakeClient(): { client: OmniClient; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const record =
+    (method: string, result: unknown) =>
+    async (...args: unknown[]) => {
+      calls.push({ method, args });
+      return result;
+    };
+
+  const client = {
+    platform: {
+      tenants: {
+        list: record('tenants.list', { items: [tenant] }),
+        get: record('tenants.get', tenant),
+        create: record('tenants.create', tenant),
+        suspend: record('tenants.suspend', tenant),
+        archive: record('tenants.archive', tenant),
+        memberships: {
+          list: record('memberships.list', { items: [membership] }),
+          attach: record('memberships.attach', membership),
+          disable: record('memberships.disable', membership),
+          setStatus: record('memberships.setStatus', { ...membership, status: 'disabled' }),
+          setRole: record('memberships.setRole', { ...membership, role: 'tenant-admin' }),
+        },
+      },
+    },
+  } as unknown as OmniClient;
+
+  return { client, calls };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('requireReason', () => {
+  test('accepts and trims a valid reason', () => {
+    expect(requireReason('  audit Q3  ', 'list tenants')).toBe('audit Q3');
+  });
+
+  test('refuses a missing reason with an actionable message', () => {
+    expect(() => requireReason(undefined, 'list tenants')).toThrow(
+      '--reason is required to list tenants. Every platform control-plane call is audited; ' +
+        'provide a justification of 3-500 characters, e.g. --reason "onboarding request OPS-1421".',
+    );
+  });
+
+  test('refuses a too-short reason', () => {
+    expect(() => requireReason('ok', 'suspend a tenant')).toThrow('--reason is required to suspend a tenant');
+  });
+
+  test('refuses a too-long reason', () => {
+    expect(() => requireReason('x'.repeat(501), 'archive a tenant')).toThrow('--reason is required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('command → SDK mapping (reason included where each route expects it)', () => {
+  test('list → platform.tenants.list(reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleList(client, { reason: 'quarterly audit' });
+    expect(calls).toEqual([{ method: 'tenants.list', args: ['quarterly audit'] }]);
+  });
+
+  test('get → platform.tenants.get(id, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleGet(client, TENANT_ID, { reason: 'support ticket 42' });
+    expect(calls).toEqual([{ method: 'tenants.get', args: [TENANT_ID, 'support ticket 42'] }]);
+  });
+
+  test('create → platform.tenants.create(body with reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleCreate(client, {
+      slug: 'acme',
+      name: 'Acme Corp',
+      maxKeyTtl: 3600,
+      maxKeyRate: 100,
+      maxKeyBudget: 1000,
+      reason: 'onboarding request OPS-1421',
+    });
+    expect(calls).toEqual([
+      {
+        method: 'tenants.create',
+        args: [
+          {
+            slug: 'acme',
+            displayName: 'Acme Corp',
+            maxKeyTtlSeconds: 3600,
+            maxKeyRateLimit: 100,
+            maxKeyBudget: 1000,
+            reason: 'onboarding request OPS-1421',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('suspend → platform.tenants.suspend(id, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleSuspend(client, TENANT_ID, { reason: 'billing overdue' });
+    expect(calls).toEqual([{ method: 'tenants.suspend', args: [TENANT_ID, 'billing overdue'] }]);
+  });
+
+  test('archive → platform.tenants.archive(id, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleArchive(client, TENANT_ID, { reason: 'contract ended' });
+    expect(calls).toEqual([{ method: 'tenants.archive', args: [TENANT_ID, 'contract ended'] }]);
+  });
+
+  test('memberships list → platform.tenants.memberships.list(tenantId, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleMembershipsList(client, TENANT_ID, { reason: 'access review' });
+    expect(calls).toEqual([{ method: 'memberships.list', args: [TENANT_ID, 'access review'] }]);
+  });
+
+  test('memberships add → platform.tenants.memberships.attach(tenantId, body with reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleMembershipsAdd(client, TENANT_ID, {
+      principal: PRINCIPAL_ID,
+      role: 'tenant-operator',
+      reason: 'new hire',
+    });
+    expect(calls).toEqual([
+      {
+        method: 'memberships.attach',
+        args: [TENANT_ID, { principalId: PRINCIPAL_ID, role: 'tenant-operator', reason: 'new hire' }],
+      },
+    ]);
+  });
+
+  test('memberships disable → platform.tenants.memberships.disable(tenantId, membershipId, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleMembershipsDisable(client, TENANT_ID, MEMBERSHIP_ID, { reason: 'offboarding' });
+    expect(calls).toEqual([{ method: 'memberships.disable', args: [TENANT_ID, MEMBERSHIP_ID, 'offboarding'] }]);
+  });
+
+  test('memberships status → platform.tenants.memberships.setStatus(..., status, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleMembershipsStatus(client, TENANT_ID, MEMBERSHIP_ID, { status: 'disabled', reason: 'security hold' });
+    expect(calls).toEqual([
+      { method: 'memberships.setStatus', args: [TENANT_ID, MEMBERSHIP_ID, 'disabled', 'security hold'] },
+    ]);
+  });
+
+  test('memberships role → platform.tenants.memberships.setRole(..., role, reason)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleMembershipsRole(client, TENANT_ID, MEMBERSHIP_ID, { role: 'tenant-admin', reason: 'promotion' });
+    expect(calls).toEqual([
+      { method: 'memberships.setRole', args: [TENANT_ID, MEMBERSHIP_ID, 'tenant-admin', 'promotion'] },
+    ]);
+  });
+
+  test('invalid --role is refused locally with the valid roles listed', async () => {
+    const { client, calls } = makeFakeClient();
+    await expect(
+      handleMembershipsAdd(client, TENANT_ID, { principal: PRINCIPAL_ID, role: 'superuser', reason: 'new hire' }),
+    ).rejects.toThrow(
+      'Invalid --role "superuser". Valid roles: tenant-owner, tenant-admin, tenant-operator, tenant-viewer',
+    );
+    expect(calls).toEqual([]);
+  });
+
+  test('invalid --status is refused locally with the valid statuses listed', async () => {
+    const { client, calls } = makeFakeClient();
+    await expect(
+      handleMembershipsStatus(client, TENANT_ID, MEMBERSHIP_ID, { status: 'paused', reason: 'security hold' }),
+    ).rejects.toThrow('Invalid --status "paused". Valid statuses: active, disabled');
+    expect(calls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('every command refuses to run without --reason', () => {
+  const cases: Array<[string, (client: OmniClient) => Promise<void>]> = [
+    ['list', (c) => handleList(c, {})],
+    ['get', (c) => handleGet(c, TENANT_ID, {})],
+    [
+      'create',
+      (c) => handleCreate(c, { slug: 'acme', name: 'Acme Corp', maxKeyTtl: 3600, maxKeyRate: 100, maxKeyBudget: 1000 }),
+    ],
+    ['suspend', (c) => handleSuspend(c, TENANT_ID, {})],
+    ['archive', (c) => handleArchive(c, TENANT_ID, {})],
+    ['memberships list', (c) => handleMembershipsList(c, TENANT_ID, {})],
+    ['memberships add', (c) => handleMembershipsAdd(c, TENANT_ID, { principal: PRINCIPAL_ID, role: 'tenant-viewer' })],
+    ['memberships disable', (c) => handleMembershipsDisable(c, TENANT_ID, MEMBERSHIP_ID, {})],
+    ['memberships status', (c) => handleMembershipsStatus(c, TENANT_ID, MEMBERSHIP_ID, { status: 'active' })],
+    ['memberships role', (c) => handleMembershipsRole(c, TENANT_ID, MEMBERSHIP_ID, { role: 'tenant-viewer' })],
+  ];
+
+  for (const [name, run] of cases) {
+    test(`${name} refuses without --reason and never calls the SDK`, async () => {
+      const { client, calls } = makeFakeClient();
+      await expect(run(client)).rejects.toThrow('--reason is required');
+      expect(calls).toEqual([]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+
+describe('control-plane failure UX', () => {
+  test('an unmounted control plane (endpoint 404) explains the multitenancy flag', () => {
+    const err = new OmniApiError('Endpoint not found: GET /api/v2/platform/tenants', 'NOT_FOUND', undefined, 404);
+    // Message pinned verbatim — this is the operator-facing explanation.
+    expect(() => renderPlatformError(err, 'list tenants')).toThrow(
+      'Failed to list tenants: the platform control plane is not available on this server. ' +
+        'Either multitenancy is disabled (start the API with OMNI_MULTITENANCY_ENABLED=true) ' +
+        'or the server predates the tenant control plane — upgrade it.',
+    );
+  });
+
+  test('a genuine tenant 404 stays a plain not-found, not a flag explanation', () => {
+    const err = new OmniApiError('tenant not found', 'NOT_FOUND', undefined, 404);
+    expect(() => renderPlatformError(err, 'get the tenant')).toThrow('Failed to get the tenant: tenant not found');
+  });
+
+  test('401 explains that only PLATFORM-class credentials are accepted (pinned verbatim)', () => {
+    const err = new OmniApiError('Platform credential required', 'UNAUTHORIZED', undefined, 401);
+    expect(() => renderPlatformError(err, 'list tenants')).toThrow(
+      'Failed to list tenants: the server rejected the credential (401). ' +
+        'The platform control plane accepts only PLATFORM-class credentials — legacy admin/god keys and ' +
+        'tenant data-plane keys are denied by design. Authenticate with a platform key: ' +
+        'omni auth login --api-key <platform-key>.',
+    );
+  });
+
+  test('403 explains the scope requirement for an authenticated non-platform key (pinned verbatim)', () => {
+    const err = new OmniApiError('Forbidden', 'FORBIDDEN', undefined, 403);
+    expect(() => renderPlatformError(err, 'create the tenant')).toThrow(
+      'Failed to create the tenant: the credential authenticated but is not allowed (403). ' +
+        'A PLATFORM-class credential with the matching platform:* scope is required — tenant-class ' +
+        'credentials can never reach the control plane, and platform keys act only within their scopes.',
+    );
+  });
+
+  test('other errors render as a plain failure with the original message', () => {
+    expect(() => renderPlatformError(new Error('connection refused'), 'list tenants')).toThrow(
+      'Failed to list tenants: connection refused',
+    );
+  });
+});

--- a/packages/cli/src/commands/tenants.ts
+++ b/packages/cli/src/commands/tenants.ts
@@ -1,0 +1,451 @@
+/**
+ * Platform Tenant Control-Plane Commands (`omni tenants`)
+ *
+ * Tenant lifecycle (list/get/create/suspend/archive) and memberships
+ * (list/add/disable/status/role) over the platform control plane
+ * (issue #981; wish: omni-full-multitenancy, Group G1; ADR-0005).
+ *
+ * Every command carries an audited `--reason` and refuses to run without it —
+ * the server enforces the same rule (reads validate the `x-platform-reason`
+ * header, mutations validate body `reason`), but a local check turns a
+ * validation 400 into an actionable message before any request is sent.
+ *
+ * The control plane is feature-flagged server-side: when
+ * `OMNI_MULTITENANCY_ENABLED` is not `true` the whole surface 404s, and only
+ * PLATFORM-class credentials are accepted. Both failure modes are rendered as
+ * explanations, not raw HTTP dumps.
+ *
+ * The `keys issue-root` subcommand is intentionally absent — the route ships
+ * separately (#979) and the subcommand follows it.
+ */
+
+import { OmniApiError, type OmniClient, type PlatformTenant, type PlatformTenantMembership } from '@omni/sdk';
+import { Command } from 'commander';
+import { getClient } from '../client.js';
+import * as output from '../output.js';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/** Mirrors `tenantRoles` in @omni/db — validated server-side as well */
+const TENANT_ROLES = ['tenant-owner', 'tenant-admin', 'tenant-operator', 'tenant-viewer'] as const;
+type TenantRoleFlag = (typeof TENANT_ROLES)[number];
+
+const MEMBERSHIP_STATUSES = ['active', 'disabled'] as const;
+type MembershipStatusFlag = (typeof MEMBERSHIP_STATUSES)[number];
+
+interface ReasonOption {
+  reason?: string;
+}
+
+interface CreateOptions extends ReasonOption {
+  slug: string;
+  name: string;
+  maxKeyTtl: number;
+  maxKeyRate: number;
+  maxKeyBudget: number;
+}
+
+interface MembershipAddOptions extends ReasonOption {
+  principal: string;
+  role: string;
+}
+
+interface MembershipStatusOptions extends ReasonOption {
+  status: string;
+}
+
+interface MembershipRoleOptions extends ReasonOption {
+  role: string;
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+const REASON_REQUIRED_HINT =
+  'Every platform control-plane call is audited; ' +
+  'provide a justification of 3-500 characters, e.g. --reason "onboarding request OPS-1421".';
+
+const CONTROL_PLANE_UNAVAILABLE =
+  'the platform control plane is not available on this server. ' +
+  'Either multitenancy is disabled (start the API with OMNI_MULTITENANCY_ENABLED=true) ' +
+  'or the server predates the tenant control plane — upgrade it.';
+
+const CREDENTIAL_REJECTED_401 =
+  'the server rejected the credential (401). ' +
+  'The platform control plane accepts only PLATFORM-class credentials — legacy admin/god keys and ' +
+  'tenant data-plane keys are denied by design. Authenticate with a platform key: ' +
+  'omni auth login --api-key <platform-key>.';
+
+const CREDENTIAL_FORBIDDEN_403 =
+  'the credential authenticated but is not allowed (403). ' +
+  'A PLATFORM-class credential with the matching platform:* scope is required — tenant-class ' +
+  'credentials can never reach the control plane, and platform keys act only within their scopes.';
+
+/**
+ * Enforce the audited `--reason` before any request is sent. The server
+ * requires 3-500 characters; mirroring the bounds here keeps the refusal
+ * local, immediate, and explained.
+ */
+function requireReason(reason: string | undefined, action: string): string {
+  const trimmed = reason?.trim() ?? '';
+  if (trimmed.length < 3 || trimmed.length > 500) {
+    output.error(`--reason is required to ${action}. ${REASON_REQUIRED_HINT}`, undefined, 1);
+  }
+  return trimmed;
+}
+
+function parseRole(value: string): TenantRoleFlag {
+  if (!(TENANT_ROLES as readonly string[]).includes(value)) {
+    output.error(`Invalid --role "${value}". Valid roles: ${TENANT_ROLES.join(', ')}`, undefined, 1);
+  }
+  return value as TenantRoleFlag;
+}
+
+function parseStatus(value: string): MembershipStatusFlag {
+  if (!(MEMBERSHIP_STATUSES as readonly string[]).includes(value)) {
+    output.error(`Invalid --status "${value}". Valid statuses: ${MEMBERSHIP_STATUSES.join(', ')}`, undefined, 1);
+  }
+  return value as MembershipStatusFlag;
+}
+
+/**
+ * Render a control-plane failure as an explanation, not a raw HTTP dump.
+ *
+ * - An "Endpoint not found" 404 means the surface is unmounted: multitenancy
+ *   is disabled (`OMNI_MULTITENANCY_ENABLED`) or the server predates the
+ *   control plane. Any other 404 is a genuine missing tenant/membership
+ *   (the API is deliberately non-enumerating there).
+ * - 401/403 mean the configured key is not a PLATFORM-class credential with
+ *   the required scope — tenant and legacy data-plane keys are denied by
+ *   design, so "log in harder" is not the fix; a platform credential is.
+ */
+function renderPlatformError(err: unknown, action: string): never {
+  if (err instanceof OmniApiError) {
+    if (err.status === 404 && err.message.startsWith('Endpoint not found')) {
+      output.error(`Failed to ${action}: ${CONTROL_PLANE_UNAVAILABLE}`, undefined, 1);
+    }
+    if (err.status === 401) {
+      output.error(`Failed to ${action}: ${CREDENTIAL_REJECTED_401}`, undefined, 1);
+    }
+    if (err.status === 403) {
+      output.error(`Failed to ${action}: ${CREDENTIAL_FORBIDDEN_403}`, undefined, 1);
+    }
+  }
+  const message = err instanceof Error ? err.message : 'Unknown error';
+  output.error(`Failed to ${action}: ${message}`);
+}
+
+function formatTenantRow(tenant: PlatformTenant): Record<string, string | number> {
+  return {
+    id: tenant.id,
+    slug: tenant.slug,
+    name: tenant.displayName,
+    status: tenant.status,
+    keyTtl: tenant.maxKeyTtlSeconds,
+    keyRate: tenant.maxKeyRateLimit,
+    keyBudget: tenant.maxKeyBudget,
+    created: new Date(tenant.createdAt).toLocaleDateString(),
+  };
+}
+
+function formatMembershipRow(membership: PlatformTenantMembership): Record<string, string> {
+  return {
+    id: membership.id,
+    principal: membership.principalId,
+    role: membership.role,
+    status: membership.status,
+    invitedBy: membership.invitedByPrincipalId ?? '-',
+    created: new Date(membership.createdAt).toLocaleDateString(),
+  };
+}
+
+// ============================================================================
+// HANDLERS — tenant lifecycle
+// ============================================================================
+
+async function handleList(client: OmniClient, options: ReasonOption): Promise<void> {
+  const reason = requireReason(options.reason, 'list tenants');
+  const result = await client.platform.tenants.list(reason);
+  output.list(result.items.map(formatTenantRow), {
+    emptyMessage: 'No tenants found.',
+    rawData: result.items,
+  });
+}
+
+async function handleGet(client: OmniClient, id: string, options: ReasonOption): Promise<void> {
+  const reason = requireReason(options.reason, 'read a tenant');
+  const tenant = await client.platform.tenants.get(id, reason);
+  output.data(tenant);
+}
+
+async function handleCreate(client: OmniClient, options: CreateOptions): Promise<void> {
+  const reason = requireReason(options.reason, 'create a tenant');
+  const tenant = await client.platform.tenants.create({
+    slug: options.slug,
+    displayName: options.name,
+    maxKeyTtlSeconds: options.maxKeyTtl,
+    maxKeyRateLimit: options.maxKeyRate,
+    maxKeyBudget: options.maxKeyBudget,
+    reason,
+  });
+  output.success(`Tenant created: ${tenant.slug} (${tenant.id})`);
+  output.data(tenant);
+}
+
+async function handleSuspend(client: OmniClient, id: string, options: ReasonOption): Promise<void> {
+  const reason = requireReason(options.reason, 'suspend a tenant');
+  const tenant = await client.platform.tenants.suspend(id, reason);
+  output.success(`Tenant suspended: ${tenant.slug} (${tenant.id})`);
+  output.info(`Reason: ${reason}`);
+}
+
+async function handleArchive(client: OmniClient, id: string, options: ReasonOption): Promise<void> {
+  const reason = requireReason(options.reason, 'archive a tenant');
+  const tenant = await client.platform.tenants.archive(id, reason);
+  output.success(`Tenant archived: ${tenant.slug} (${tenant.id})`);
+  output.warn('Archived is terminal — there is no un-archive and no hard delete.');
+  output.info(`Reason: ${reason}`);
+}
+
+// ============================================================================
+// HANDLERS — memberships
+// ============================================================================
+
+async function handleMembershipsList(client: OmniClient, tenantId: string, options: ReasonOption): Promise<void> {
+  const reason = requireReason(options.reason, 'list memberships');
+  const result = await client.platform.tenants.memberships.list(tenantId, reason);
+  output.list(result.items.map(formatMembershipRow), {
+    emptyMessage: 'No memberships found.',
+    rawData: result.items,
+  });
+}
+
+async function handleMembershipsAdd(
+  client: OmniClient,
+  tenantId: string,
+  options: MembershipAddOptions,
+): Promise<void> {
+  const reason = requireReason(options.reason, 'attach a membership');
+  const role = parseRole(options.role);
+  const membership = await client.platform.tenants.memberships.attach(tenantId, {
+    principalId: options.principal,
+    role,
+    reason,
+  });
+  output.success(`Membership attached: ${membership.principalId} as ${membership.role} (${membership.id})`);
+}
+
+async function handleMembershipsDisable(
+  client: OmniClient,
+  tenantId: string,
+  membershipId: string,
+  options: ReasonOption,
+): Promise<void> {
+  const reason = requireReason(options.reason, 'disable a membership');
+  const membership = await client.platform.tenants.memberships.disable(tenantId, membershipId, reason);
+  output.success(`Membership disabled: ${membership.id}`);
+  output.info(`Reason: ${reason}`);
+}
+
+async function handleMembershipsStatus(
+  client: OmniClient,
+  tenantId: string,
+  membershipId: string,
+  options: MembershipStatusOptions,
+): Promise<void> {
+  const reason = requireReason(options.reason, 'set a membership status');
+  const status = parseStatus(options.status);
+  const membership = await client.platform.tenants.memberships.setStatus(tenantId, membershipId, status, reason);
+  output.success(`Membership ${membership.id} status set to ${membership.status}`);
+}
+
+async function handleMembershipsRole(
+  client: OmniClient,
+  tenantId: string,
+  membershipId: string,
+  options: MembershipRoleOptions,
+): Promise<void> {
+  const reason = requireReason(options.reason, 'set a membership role');
+  const role = parseRole(options.role);
+  const membership = await client.platform.tenants.memberships.setRole(tenantId, membershipId, role, reason);
+  output.success(`Membership ${membership.id} role set to ${membership.role}`);
+}
+
+// ============================================================================
+// COMMAND
+// ============================================================================
+
+const REASON_HELP = 'Audited justification (required, 3-500 chars)';
+
+export function createTenantsCommand(): Command {
+  const tenants = new Command('tenants').description(
+    'Platform tenant control plane (requires a PLATFORM-class credential and OMNI_MULTITENANCY_ENABLED=true)',
+  );
+
+  tenants
+    .command('list')
+    .description('List tenants, newest first (the read itself is audited)')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (options: ReasonOption) => {
+      const client = getClient();
+      try {
+        await handleList(client, options);
+      } catch (err) {
+        renderPlatformError(err, 'list tenants');
+      }
+    });
+
+  tenants
+    .command('get <id>')
+    .description('Get one tenant by id')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (id: string, options: ReasonOption) => {
+      const client = getClient();
+      try {
+        await handleGet(client, id, options);
+      } catch (err) {
+        renderPlatformError(err, 'get the tenant');
+      }
+    });
+
+  tenants
+    .command('create')
+    .description('Create a tenant with its mandatory credential ceilings')
+    .requiredOption('--slug <slug>', 'Immutable lowercase DNS-like slug (e.g. acme)')
+    .requiredOption('--name <name>', 'Human-readable tenant name')
+    .requiredOption('--max-key-ttl <seconds>', 'Ceiling for credential TTL, in seconds', Number.parseInt)
+    .requiredOption('--max-key-rate <n>', 'Ceiling for credential rate limit', Number.parseInt)
+    .requiredOption('--max-key-budget <n>', 'Ceiling for credential budget', Number.parseInt)
+    .option('--reason <text>', REASON_HELP)
+    .action(async (options: CreateOptions) => {
+      const client = getClient();
+      try {
+        await handleCreate(client, options);
+      } catch (err) {
+        renderPlatformError(err, 'create the tenant');
+      }
+    });
+
+  tenants
+    .command('suspend <id>')
+    .description('Suspend a tenant (bumps its revocation epoch, invalidating tenant credentials)')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (id: string, options: ReasonOption) => {
+      const client = getClient();
+      try {
+        await handleSuspend(client, id, options);
+      } catch (err) {
+        renderPlatformError(err, 'suspend the tenant');
+      }
+    });
+
+  tenants
+    .command('archive <id>')
+    .description('Archive a tenant (TERMINAL — no un-archive, no hard delete)')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (id: string, options: ReasonOption) => {
+      const client = getClient();
+      try {
+        await handleArchive(client, id, options);
+      } catch (err) {
+        renderPlatformError(err, 'archive the tenant');
+      }
+    });
+
+  const memberships = new Command('memberships').description('Manage tenant memberships');
+
+  memberships
+    .command('list <tenant-id>')
+    .description('List the memberships of one tenant (the read itself is audited)')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (tenantId: string, options: ReasonOption) => {
+      const client = getClient();
+      try {
+        await handleMembershipsList(client, tenantId, options);
+      } catch (err) {
+        renderPlatformError(err, 'list memberships');
+      }
+    });
+
+  memberships
+    .command('add <tenant-id>')
+    .description('Grant a principal a role in the tenant')
+    .requiredOption('--principal <uuid>', 'Principal to grant access to')
+    .requiredOption('--role <role>', `Tenant role: ${TENANT_ROLES.join(' | ')}`)
+    .option('--reason <text>', REASON_HELP)
+    .action(async (tenantId: string, options: MembershipAddOptions) => {
+      const client = getClient();
+      try {
+        await handleMembershipsAdd(client, tenantId, options);
+      } catch (err) {
+        renderPlatformError(err, 'attach the membership');
+      }
+    });
+
+  memberships
+    .command('disable <tenant-id> <membership-id>')
+    .description('Disable a membership (memberships are never hard-deleted)')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (tenantId: string, membershipId: string, options: ReasonOption) => {
+      const client = getClient();
+      try {
+        await handleMembershipsDisable(client, tenantId, membershipId, options);
+      } catch (err) {
+        renderPlatformError(err, 'disable the membership');
+      }
+    });
+
+  memberships
+    .command('status <tenant-id> <membership-id>')
+    .description('Activate or disable an existing membership')
+    .requiredOption('--status <status>', `New status: ${MEMBERSHIP_STATUSES.join(' | ')}`)
+    .option('--reason <text>', REASON_HELP)
+    .action(async (tenantId: string, membershipId: string, options: MembershipStatusOptions) => {
+      const client = getClient();
+      try {
+        await handleMembershipsStatus(client, tenantId, membershipId, options);
+      } catch (err) {
+        renderPlatformError(err, 'set the membership status');
+      }
+    });
+
+  memberships
+    .command('role <tenant-id> <membership-id>')
+    .description('Change the role an existing membership acts under')
+    .requiredOption('--role <role>', `New role: ${TENANT_ROLES.join(' | ')}`)
+    .option('--reason <text>', REASON_HELP)
+    .action(async (tenantId: string, membershipId: string, options: MembershipRoleOptions) => {
+      const client = getClient();
+      try {
+        await handleMembershipsRole(client, tenantId, membershipId, options);
+      } catch (err) {
+        renderPlatformError(err, 'set the membership role');
+      }
+    });
+
+  tenants.addCommand(memberships);
+
+  return tenants;
+}
+
+/**
+ * Exported for tests — lets us exercise reason enforcement, SDK-call mapping,
+ * and control-plane error rendering without reaching into Commander internals.
+ */
+export const __testables = {
+  requireReason,
+  renderPlatformError,
+  handleList,
+  handleGet,
+  handleCreate,
+  handleSuspend,
+  handleArchive,
+  handleMembershipsList,
+  handleMembershipsAdd,
+  handleMembershipsDisable,
+  handleMembershipsStatus,
+  handleMembershipsRole,
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,6 +62,7 @@ import { createSpeakCommand } from './commands/speak.js';
 import { createStartCommand } from './commands/start.js';
 import { createStatusCommand } from './commands/status.js';
 import { createStopCommand } from './commands/stop.js';
+import { createTenantsCommand } from './commands/tenants.js';
 import { createTrustCommand } from './commands/trust.js';
 import { createTtsCommand } from './commands/tts.js';
 import { createTurnsCommand } from './commands/turns.js';
@@ -356,6 +357,12 @@ const COMMANDS: CommandDef[] = [
     category: 'core',
     helpGroup: 'Management',
     helpDescription: 'API key management',
+  },
+  {
+    create: createTenantsCommand,
+    category: 'advanced',
+    helpGroup: 'Management',
+    helpDescription: 'Platform tenant control plane (multitenancy)',
   },
   {
     create: createTrustCommand,

--- a/packages/sdk/src/__tests__/platform-tenants.test.ts
+++ b/packages/sdk/src/__tests__/platform-tenants.test.ts
@@ -1,0 +1,233 @@
+/**
+ * SDK platform control-plane surface (issue #981).
+ *
+ * Pins the method → route mapping for all ten tenant/membership operations,
+ * and — the part the server audits — WHERE the reason travels: reads send the
+ * `x-platform-reason` header, mutations send `reason` in the JSON body.
+ * A local Bun server records every request so the assertions are on the actual
+ * wire shape, not on mocks of our own code.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import type { Server } from 'bun';
+import { OmniApiError, type OmniClient, createOmniClient } from '../index';
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  reasonHeader: string | null;
+  body: Record<string, unknown> | null;
+}
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+const MEMBERSHIP_ID = '22222222-2222-4222-8222-222222222222';
+const PRINCIPAL_ID = '33333333-3333-4333-8333-333333333333';
+
+const tenant = {
+  id: TENANT_ID,
+  slug: 'acme',
+  displayName: 'Acme Corp',
+  status: 'active',
+  policyVersion: 1,
+  revocationEpoch: 0,
+  maxKeyTtlSeconds: 3600,
+  maxKeyRateLimit: 100,
+  maxKeyBudget: 1000,
+  createdByPrincipalId: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  suspendedAt: null,
+  archivedAt: null,
+};
+
+const membership = {
+  id: MEMBERSHIP_ID,
+  tenantId: TENANT_ID,
+  principalId: PRINCIPAL_ID,
+  role: 'tenant-operator',
+  status: 'active',
+  invitedByPrincipalId: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  disabledAt: null,
+};
+
+describe('platform control plane', () => {
+  let server: Server;
+  let client: OmniClient;
+  const requests: RecordedRequest[] = [];
+
+  // Exact-match route table — every test request targets the fixture ids.
+  const TENANTS = '/api/v2/platform/tenants';
+  const MEMBERSHIPS = `${TENANTS}/${TENANT_ID}/memberships`;
+  const routes: Record<string, () => Response> = {
+    [`GET ${TENANTS}`]: () => Response.json({ items: [tenant] }),
+    [`POST ${TENANTS}`]: () => Response.json({ data: tenant }, { status: 201 }),
+    [`GET ${TENANTS}/${TENANT_ID}`]: () => Response.json({ data: tenant }),
+    [`POST ${TENANTS}/${TENANT_ID}/suspend`]: () => Response.json({ data: tenant }),
+    [`POST ${TENANTS}/${TENANT_ID}/archive`]: () => Response.json({ data: tenant }),
+    [`GET ${MEMBERSHIPS}`]: () => Response.json({ items: [membership] }),
+    [`POST ${MEMBERSHIPS}`]: () => Response.json({ data: membership }, { status: 201 }),
+    [`POST ${MEMBERSHIPS}/${MEMBERSHIP_ID}/disable`]: () => Response.json({ data: membership }),
+    [`POST ${MEMBERSHIPS}/${MEMBERSHIP_ID}/status`]: () => Response.json({ data: membership }),
+    [`POST ${MEMBERSHIPS}/${MEMBERSHIP_ID}/role`]: () => Response.json({ data: membership }),
+  };
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const body = req.method === 'POST' ? ((await req.json()) as Record<string, unknown>) : null;
+        requests.push({
+          method: req.method,
+          path: url.pathname,
+          reasonHeader: req.headers.get('x-platform-reason'),
+          body,
+        });
+
+        const handler = routes[`${req.method} ${url.pathname}`];
+        if (handler) return handler();
+
+        // Mirrors the API's app.notFound shape for unmounted surfaces.
+        return Response.json(
+          { error: { code: 'NOT_FOUND', message: `Endpoint not found: ${req.method} ${url.pathname}` } },
+          { status: 404 },
+        );
+      },
+    });
+    client = createOmniClient({ baseUrl: `http://localhost:${server.port}`, apiKey: 'test-key' });
+  });
+
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  function lastRequest(): RecordedRequest {
+    expect(requests.length).toBe(1);
+    return requests[0];
+  }
+
+  // ── Reads: reason travels as the x-platform-reason header ────────────────
+
+  test('tenants.list → GET /platform/tenants with reason header', async () => {
+    const result = await client.platform.tenants.list('quarterly audit');
+    expect(result.items).toHaveLength(1);
+    const req = lastRequest();
+    expect(req.method).toBe('GET');
+    expect(req.path).toBe('/api/v2/platform/tenants');
+    expect(req.reasonHeader).toBe('quarterly audit');
+    expect(req.body).toBeNull();
+  });
+
+  test('tenants.get → GET /platform/tenants/:id with reason header', async () => {
+    const result = await client.platform.tenants.get(TENANT_ID, 'support ticket 42');
+    expect(result.id).toBe(TENANT_ID);
+    const req = lastRequest();
+    expect(req.method).toBe('GET');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}`);
+    expect(req.reasonHeader).toBe('support ticket 42');
+  });
+
+  test('memberships.list → GET /platform/tenants/:id/memberships with reason header', async () => {
+    const result = await client.platform.tenants.memberships.list(TENANT_ID, 'access review');
+    expect(result.items).toHaveLength(1);
+    const req = lastRequest();
+    expect(req.method).toBe('GET');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/memberships`);
+    expect(req.reasonHeader).toBe('access review');
+  });
+
+  // ── Mutations: reason travels in the JSON body ───────────────────────────
+
+  test('tenants.create → POST /platform/tenants with reason in body', async () => {
+    await client.platform.tenants.create({
+      slug: 'acme',
+      displayName: 'Acme Corp',
+      maxKeyTtlSeconds: 3600,
+      maxKeyRateLimit: 100,
+      maxKeyBudget: 1000,
+      reason: 'onboarding request OPS-1421',
+    });
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe('/api/v2/platform/tenants');
+    expect(req.reasonHeader).toBeNull();
+    expect(req.body).toEqual({
+      slug: 'acme',
+      displayName: 'Acme Corp',
+      maxKeyTtlSeconds: 3600,
+      maxKeyRateLimit: 100,
+      maxKeyBudget: 1000,
+      reason: 'onboarding request OPS-1421',
+    });
+  });
+
+  test('tenants.suspend → POST /platform/tenants/:id/suspend with reason in body', async () => {
+    await client.platform.tenants.suspend(TENANT_ID, 'billing overdue');
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/suspend`);
+    expect(req.reasonHeader).toBeNull();
+    expect(req.body).toEqual({ reason: 'billing overdue' });
+  });
+
+  test('tenants.archive → POST /platform/tenants/:id/archive with reason in body', async () => {
+    await client.platform.tenants.archive(TENANT_ID, 'contract ended');
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/archive`);
+    expect(req.body).toEqual({ reason: 'contract ended' });
+  });
+
+  test('memberships.attach → POST /platform/tenants/:id/memberships with reason in body', async () => {
+    await client.platform.tenants.memberships.attach(TENANT_ID, {
+      principalId: PRINCIPAL_ID,
+      role: 'tenant-operator',
+      reason: 'new hire',
+    });
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/memberships`);
+    expect(req.reasonHeader).toBeNull();
+    expect(req.body).toEqual({ principalId: PRINCIPAL_ID, role: 'tenant-operator', reason: 'new hire' });
+  });
+
+  test('memberships.disable → POST .../memberships/:id/disable with reason in body', async () => {
+    await client.platform.tenants.memberships.disable(TENANT_ID, MEMBERSHIP_ID, 'offboarding');
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/memberships/${MEMBERSHIP_ID}/disable`);
+    expect(req.body).toEqual({ reason: 'offboarding' });
+  });
+
+  test('memberships.setStatus → POST .../memberships/:id/status with status + reason in body', async () => {
+    await client.platform.tenants.memberships.setStatus(TENANT_ID, MEMBERSHIP_ID, 'disabled', 'security hold');
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/memberships/${MEMBERSHIP_ID}/status`);
+    expect(req.body).toEqual({ status: 'disabled', reason: 'security hold' });
+  });
+
+  test('memberships.setRole → POST .../memberships/:id/role with role + reason in body', async () => {
+    await client.platform.tenants.memberships.setRole(TENANT_ID, MEMBERSHIP_ID, 'tenant-admin', 'promotion');
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/memberships/${MEMBERSHIP_ID}/role`);
+    expect(req.body).toEqual({ role: 'tenant-admin', reason: 'promotion' });
+  });
+
+  // ── Errors surface as OmniApiError with the server's message ─────────────
+
+  test('an unmounted control plane surfaces as OmniApiError 404 with the endpoint message', async () => {
+    const promise = client.platform.tenants.get('99999999-9999-4999-8999-999999999999', 'check');
+    const err = (await promise.catch((e: unknown) => e)) as OmniApiError;
+    expect(err).toBeInstanceOf(OmniApiError);
+    expect(err.status).toBe(404);
+    expect(err.message).toStartWith('Endpoint not found:');
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1227,6 +1227,38 @@ export interface CreateApiKeyResult extends ApiKeyRecord {
 }
 
 // ============================================================================
+// PLATFORM CONTROL PLANE TYPES (tenants + memberships)
+// ============================================================================
+//
+// Derived from the generated OpenAPI operations so they can never drift from
+// the API contract. Every read sends the audited reason as the
+// `x-platform-reason` header; every mutation carries `reason` in the body.
+
+/** A platform tenant, as returned by the control plane */
+export type PlatformTenant =
+  operations['listPlatformTenants']['responses'][200]['content']['application/json']['items'][number];
+
+/** A tenant membership, as returned by the control plane */
+export type PlatformTenantMembership =
+  operations['listPlatformMemberships']['responses'][200]['content']['application/json']['items'][number];
+
+/** Tenant role a membership acts under */
+export type PlatformTenantRole = PlatformTenantMembership['role'];
+
+/** Membership status */
+export type PlatformMembershipStatus = PlatformTenantMembership['status'];
+
+/** Body for creating a tenant (includes the audited `reason`) */
+export type CreatePlatformTenantBody = NonNullable<
+  operations['createPlatformTenant']['requestBody']
+>['content']['application/json'];
+
+/** Body for attaching a membership (includes the audited `reason`) */
+export type AttachPlatformMembershipBody = NonNullable<
+  operations['attachPlatformMembership']['requestBody']
+>['content']['application/json'];
+
+// ============================================================================
 // Presence & Read Receipt Types (api-completeness)
 // ============================================================================
 
@@ -3444,6 +3476,198 @@ export function createOmniClient(config: OmniClientConfig) {
           method: 'DELETE',
         });
         if (!resp.ok) throw OmniApiError.from(await resp.json(), resp.status);
+      },
+    },
+
+    // ========================================================================
+    // PLATFORM CONTROL PLANE (tenants + memberships)
+    // ========================================================================
+
+    /**
+     * Platform tenant control plane.
+     *
+     * Mounted by the server only when `OMNI_MULTITENANCY_ENABLED=true`; when
+     * the flag is off the whole surface 404s. Requires a PLATFORM-class
+     * credential — tenant and legacy data-plane keys are denied (401/403).
+     *
+     * Every call carries an audited `reason`: reads send it as the
+     * `x-platform-reason` header, mutations send it in the JSON body. The
+     * server rejects calls without it; these methods make it non-optional so
+     * the requirement is visible at the type level.
+     */
+    platform: {
+      tenants: {
+        /**
+         * List tenants, newest first. The read itself is audited.
+         */
+        async list(reason: string): Promise<{ items: PlatformTenant[] }> {
+          const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants`, {
+            headers: { 'x-platform-reason': reason },
+          });
+          const json = (await resp.json()) as { items?: PlatformTenant[] };
+          if (!resp.ok) throw OmniApiError.from(json, resp.status);
+          return { items: json?.items ?? [] };
+        },
+
+        /**
+         * Fetch one tenant. The read itself is audited.
+         */
+        async get(id: string, reason: string): Promise<PlatformTenant> {
+          const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants/${id}`, {
+            headers: { 'x-platform-reason': reason },
+          });
+          const json = (await resp.json()) as { data?: PlatformTenant };
+          if (!resp.ok) throw OmniApiError.from(json, resp.status);
+          if (!json?.data) throw new OmniApiError('Tenant not found', 'NOT_FOUND', undefined, 404);
+          return json.data;
+        },
+
+        /**
+         * Create a tenant with its mandatory credential ceilings.
+         * `body.reason` is the audited justification.
+         */
+        async create(body: CreatePlatformTenantBody): Promise<PlatformTenant> {
+          const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+          const json = (await resp.json()) as { data?: PlatformTenant };
+          if (!resp.ok) throw OmniApiError.from(json, resp.status);
+          if (!json?.data) throw new OmniApiError('Failed to create tenant', 'CREATE_FAILED', undefined, resp.status);
+          return json.data;
+        },
+
+        /**
+         * Suspend a tenant and bump its revocation epoch (invalidates the
+         * tenant's credentials on their next auth-bootstrap lookup).
+         */
+        async suspend(id: string, reason: string): Promise<PlatformTenant> {
+          const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants/${id}/suspend`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reason }),
+          });
+          const json = (await resp.json()) as { data?: PlatformTenant };
+          if (!resp.ok) throw OmniApiError.from(json, resp.status);
+          if (!json?.data) throw new OmniApiError('Failed to suspend tenant', 'SUSPEND_FAILED', undefined, resp.status);
+          return json.data;
+        },
+
+        /**
+         * Archive a tenant. Archived is TERMINAL — there is no un-archive and
+         * no hard delete anywhere on this surface.
+         */
+        async archive(id: string, reason: string): Promise<PlatformTenant> {
+          const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants/${id}/archive`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reason }),
+          });
+          const json = (await resp.json()) as { data?: PlatformTenant };
+          if (!resp.ok) throw OmniApiError.from(json, resp.status);
+          if (!json?.data) throw new OmniApiError('Failed to archive tenant', 'ARCHIVE_FAILED', undefined, resp.status);
+          return json.data;
+        },
+
+        memberships: {
+          /**
+           * List the memberships of one tenant. The read itself is audited.
+           */
+          async list(tenantId: string, reason: string): Promise<{ items: PlatformTenantMembership[] }> {
+            const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants/${tenantId}/memberships`, {
+              headers: { 'x-platform-reason': reason },
+            });
+            const json = (await resp.json()) as { items?: PlatformTenantMembership[] };
+            if (!resp.ok) throw OmniApiError.from(json, resp.status);
+            return { items: json?.items ?? [] };
+          },
+
+          /**
+           * Grant a principal a role in the tenant.
+           * `body.reason` is the audited justification.
+           */
+          async attach(tenantId: string, body: AttachPlatformMembershipBody): Promise<PlatformTenantMembership> {
+            const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants/${tenantId}/memberships`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(body),
+            });
+            const json = (await resp.json()) as { data?: PlatformTenantMembership };
+            if (!resp.ok) throw OmniApiError.from(json, resp.status);
+            if (!json?.data)
+              throw new OmniApiError('Failed to attach membership', 'ATTACH_FAILED', undefined, resp.status);
+            return json.data;
+          },
+
+          /**
+           * Detach a principal from the tenant by disabling the membership.
+           * Memberships are never hard-deleted.
+           */
+          async disable(tenantId: string, membershipId: string, reason: string): Promise<PlatformTenantMembership> {
+            const resp = await apiFetch(
+              `${baseUrl}/api/v2/platform/tenants/${tenantId}/memberships/${membershipId}/disable`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ reason }),
+              },
+            );
+            const json = (await resp.json()) as { data?: PlatformTenantMembership };
+            if (!resp.ok) throw OmniApiError.from(json, resp.status);
+            if (!json?.data)
+              throw new OmniApiError('Failed to disable membership', 'DISABLE_FAILED', undefined, resp.status);
+            return json.data;
+          },
+
+          /**
+           * Activate or disable an existing membership.
+           */
+          async setStatus(
+            tenantId: string,
+            membershipId: string,
+            status: PlatformMembershipStatus,
+            reason: string,
+          ): Promise<PlatformTenantMembership> {
+            const resp = await apiFetch(
+              `${baseUrl}/api/v2/platform/tenants/${tenantId}/memberships/${membershipId}/status`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status, reason }),
+              },
+            );
+            const json = (await resp.json()) as { data?: PlatformTenantMembership };
+            if (!resp.ok) throw OmniApiError.from(json, resp.status);
+            if (!json?.data)
+              throw new OmniApiError('Failed to set membership status', 'STATUS_FAILED', undefined, resp.status);
+            return json.data;
+          },
+
+          /**
+           * Change the role an existing membership acts under.
+           */
+          async setRole(
+            tenantId: string,
+            membershipId: string,
+            role: PlatformTenantRole,
+            reason: string,
+          ): Promise<PlatformTenantMembership> {
+            const resp = await apiFetch(
+              `${baseUrl}/api/v2/platform/tenants/${tenantId}/memberships/${membershipId}/role`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ role, reason }),
+              },
+            );
+            const json = (await resp.json()) as { data?: PlatformTenantMembership };
+            if (!resp.ok) throw OmniApiError.from(json, resp.status);
+            if (!json?.data)
+              throw new OmniApiError('Failed to set membership role', 'ROLE_FAILED', undefined, resp.status);
+            return json.data;
+          },
+        },
       },
     },
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -155,6 +155,13 @@ export type {
   UpdateApiKeyBody,
   RevokeApiKeyBody,
   ListApiKeysParams,
+  // Platform control plane types (tenants + memberships)
+  PlatformTenant,
+  PlatformTenantMembership,
+  PlatformTenantRole,
+  PlatformMembershipStatus,
+  CreatePlatformTenantBody,
+  AttachPlatformMembershipBody,
 } from './client';
 
 // Errors


### PR DESCRIPTION
## Summary

Closes #981.

The platform tenant control-plane API (10 routes in `packages/api/src/routes/v2/platform-tenants.ts`) was fully delivered but unreachable from any supported client. This PR adds:

**SDK — `client.platform.tenants`** (`packages/sdk/src/client.ts`)
- Tenant lifecycle: `list`, `get`, `create`, `suspend`, `archive`
- Memberships: `memberships.list`, `attach`, `disable`, `setStatus`, `setRole`
- Typed against the generated OpenAPI operations (`PlatformTenant`, `PlatformTenantMembership`, `CreatePlatformTenantBody`, `AttachPlatformMembershipBody` re-exported from `@omni/sdk`)
- Reason placement matches the routes exactly: reads send the audited reason as the `x-platform-reason` header; mutations send body `reason`

**CLI — `omni tenants`** (`packages/cli/src/commands/tenants.ts`)
```
omni tenants list | get <id> | create --slug --name --max-key-ttl --max-key-rate --max-key-budget
omni tenants suspend <id> | archive <id>
omni tenants memberships list <id> | add <id> --principal --role | disable <id> <mid> | status <id> <mid> --status | role <id> <mid> --role
```
- Every command requires `--reason` and refuses locally (clear, audited-call message) before any request is sent; the server enforces the same rule
- Unmounted control plane (endpoint 404) renders as "multitenancy is disabled (OMNI_MULTITENANCY_ENABLED) or the server predates the control plane", distinguished from a genuine tenant/membership 404
- 401/403 explain that a PLATFORM-class credential with the matching `platform:*` scope is required (legacy/tenant data-plane keys are denied by design) — messages pinned verbatim in tests per the G4 dual-world contract
- `--role` / `--status` validated client-side with the valid values listed

## Scope note

`omni tenants keys issue-root` is intentionally **not** included — the root-key issuance route ships separately in #979, and the issue-root subcommand follows #979.

## Tests

- `packages/sdk/src/__tests__/platform-tenants.test.ts` — wire-level command→route mapping for all 10 operations against a recording Bun server, incl. reason placement (header vs body) and OmniApiError propagation for the unmounted-surface 404
- `packages/cli/src/commands/__tests__/tenants.test.ts` — handler→SDK mapping for all 10 commands, refusal without `--reason` for every command (SDK never called), reason bounds (3–500, trimmed), role/status client-side validation, and the 404/401/403 UX messages pinned verbatim
- `sdk-coverage.test.ts` updated with the 10 new `platform.tenants.*` mappings

## Gates

- `make typecheck` — 25/25 green
- `make lint` — clean (zero warnings)
- `bun test` in packages/sdk — 45 pass / 0 fail
- `bun test` in packages/cli — 646 pass / 0 fail