### PR TITLE
feat(api): expose platform root-key issuance route

### DIFF
--- a/packages/api/src/routes/v2/__tests__/platform-tenants.test.ts
+++ b/packages/api/src/routes/v2/__tests__/platform-tenants.test.ts
@@ -49,9 +49,36 @@ function tenantCtx() {
   };
 }
 
+/**
+ * A realistic issued-root-key shape. `keyHash` is present exactly because the
+ * real lineage row never carries one — the credential index does — so a route
+ * that spreads whatever the service returns instead of projecting explicit
+ * fields is caught leaking it.
+ */
+const issuedRootLineage = {
+  id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+  tenantId: '11111111-1111-1111-1111-111111111111',
+  principalId: '22222222-2222-2222-2222-222222222222',
+  membershipId: '33333333-3333-3333-3333-333333333333',
+  actorRole: 'tenant-admin',
+  name: 'bootstrap root',
+  keyPrefix: 'abcd1234',
+  scopes: ['tenant:*', 'keys:delegate'],
+  resourceConstraints: {},
+  status: 'active',
+  parentKeyId: null,
+  rootKeyId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+  depth: 0,
+  expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+  rateLimit: 100,
+  budget: 1000,
+  keyHash: 'deadbeef'.repeat(8),
+};
+
 function buildApp(
   authResult: AuthResult,
   controlPlaneOverrides: Record<string, unknown> = {},
+  tenantKeyOverrides: Record<string, unknown> = {},
 ): { app: Hono; spy: Spy } {
   const spy: Spy = { calls: [] };
   const record =
@@ -75,9 +102,15 @@ function buildApp(
     ...controlPlaneOverrides,
   };
 
+  const tenantKeys = {
+    issueRootKey: record('issueRootKey', { lineage: issuedRootLineage, plainTextKey: 'omni_tk_rootPlaintextOnce' }),
+    ...tenantKeyOverrides,
+  };
+
   const services = {
     authBootstrap: { lookupBySecret: async () => authResult },
     tenantControlPlane,
+    tenantKeys,
   };
 
   const app = new Hono<{ Variables: AppVariables }>();
@@ -339,6 +372,178 @@ describe('tenant lifecycle — platform positive paths', () => {
       body: JSON.stringify({ reason: 'must not select globally' }),
     });
     expect([404, 405]).toContain(oldGlobalPath.status);
+  });
+});
+
+describe('root key issuance — POST /tenants/:id/keys/root (#979)', () => {
+  const TENANT_ID = '11111111-1111-1111-1111-111111111111';
+  const ISSUE_SCOPES = ['platform:tenant-keys:write', 'platform:tenants:write'];
+  const validBody = {
+    principalId: '22222222-2222-2222-2222-222222222222',
+    membershipId: '33333333-3333-3333-3333-333333333333',
+    role: 'tenant-admin',
+    name: 'bootstrap root',
+    scopes: ['tenant:*', 'keys:delegate'],
+    expiresAt: '2027-01-01T00:00:00.000Z',
+    rateLimit: 100,
+    budget: 1000,
+    reason: 'bootstrap issuance OPS-1',
+  };
+  const issue = (app: Hono, body: unknown = validBody, tenantId = TENANT_ID) =>
+    app.request(`/api/v2/platform/tenants/${tenantId}/keys/root`, {
+      method: 'POST',
+      ...AUTH,
+      body: JSON.stringify(body),
+    });
+  const throwing = (message: string) => ({
+    issueRootKey: async () => {
+      throw new Error(message);
+    },
+  });
+
+  test('happy path: 201, actor bound to the action and the path tenant, plaintext returned once', async () => {
+    const { app, spy } = buildApp({ ok: true, context: platformCtx(ISSUE_SCOPES) });
+    const res = await issue(app);
+    expect(res.status).toBe(201);
+
+    const call = spy.calls.find((c) => c.method === 'issueRootKey');
+    expect(call).toBeDefined();
+    const options = call?.args[0] as {
+      actor: { platformAction: string; targetTenantId: string | null };
+      tenantId: string;
+      actorRole: string;
+      scopes: string[];
+      reason: string;
+      expiresAt: Date;
+    };
+    expect(options.actor.platformAction).toBe('tenant_key.issue_root');
+    expect(options.actor.targetTenantId).toBe(TENANT_ID);
+    expect(options.tenantId).toBe(TENANT_ID);
+    expect(options.actorRole).toBe('tenant-admin');
+    expect(options.scopes).toEqual(['tenant:*', 'keys:delegate']);
+    expect(options.reason).toBe('bootstrap issuance OPS-1');
+    expect(options.expiresAt).toBeInstanceOf(Date);
+
+    const text = await res.text();
+    const { data } = JSON.parse(text) as { data: Record<string, unknown> };
+    expect(data.plainTextKey).toBe('omni_tk_rootPlaintextOnce');
+    // Exactly once in the whole payload.
+    expect(text.split('omni_tk_rootPlaintextOnce').length - 1).toBe(1);
+    expect(data.delegationDepth).toBe(0);
+    expect(data.tenantId).toBe(TENANT_ID);
+    // The credential-index material never leaves the service.
+    expect(data.keyHash).toBeUndefined();
+    expect(data.keyPrefix).toBeUndefined();
+    expect(text).not.toContain('deadbeef');
+  });
+
+  test('unauthenticated (no credential) → 401', async () => {
+    const { app, spy } = buildApp({ ok: true, context: platformCtx(ISSUE_SCOPES) });
+    const res = await app.request(`/api/v2/platform/tenants/${TENANT_ID}/keys/root`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(401);
+    expect(spy.calls.find((c) => c.method === 'issueRootKey')).toBeUndefined();
+  });
+
+  test('legacy/unknown credential (not in the auth index) → uniform 401', async () => {
+    const { app, spy } = buildApp({ ok: false, reason: 'not_found' });
+    expect((await issue(app)).status).toBe(401);
+    expect(spy.calls.find((c) => c.method === 'issueRootKey')).toBeUndefined();
+  });
+
+  test('tenant-class credential → 403, service never reached', async () => {
+    const { app, spy } = buildApp({ ok: true, context: tenantCtx() });
+    expect((await issue(app)).status).toBe(403);
+    expect(spy.calls.find((c) => c.method === 'issueRootKey')).toBeUndefined();
+  });
+
+  test('platform credential without platform:tenant-keys:write → 403, service never reached', async () => {
+    const { app, spy } = buildApp({
+      ok: true,
+      context: platformCtx(['platform:tenants:write', 'platform:memberships:write']),
+    });
+    expect((await issue(app)).status).toBe(403);
+    expect(spy.calls.find((c) => c.method === 'issueRootKey')).toBeUndefined();
+  });
+
+  test('missing reason → 400, service never reached', async () => {
+    const { app, spy } = buildApp({ ok: true, context: platformCtx(ISSUE_SCOPES) });
+    const { reason: _omitted, ...withoutReason } = validBody;
+    expect((await issue(app, withoutReason)).status).toBe(400);
+    expect(spy.calls.find((c) => c.method === 'issueRootKey')).toBeUndefined();
+  });
+
+  test('empty scopes → 400 before the service is reached', async () => {
+    const { app, spy } = buildApp({ ok: true, context: platformCtx(ISSUE_SCOPES) });
+    expect((await issue(app, { ...validBody, scopes: [] })).status).toBe(400);
+    expect(spy.calls.find((c) => c.method === 'issueRootKey')).toBeUndefined();
+  });
+
+  test('wildcard/platform scopes fail closed as 400', async () => {
+    const { app } = buildApp(
+      { ok: true, context: platformCtx(ISSUE_SCOPES) },
+      {},
+      throwing('invalid root key request: scope "*" grants platform/wildcard authority'),
+    );
+    const res = await issue(app, { ...validBody, scopes: ['*'] });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('unknown tenant and cross-tenant subject are the SAME bare 404 — no membership oracle', async () => {
+    const { app: unknownTenant } = buildApp(
+      { ok: true, context: platformCtx(ISSUE_SCOPES) },
+      {},
+      throwing('tenant not found'),
+    );
+    const { app: foreignSubject } = buildApp(
+      { ok: true, context: platformCtx(ISSUE_SCOPES) },
+      {},
+      throwing('invalid root key subject: membership not found'),
+    );
+    const a = await issue(unknownTenant);
+    const b = await issue(foreignSubject);
+    expect(a.status).toBe(404);
+    expect(b.status).toBe(404);
+    expect(await a.text()).toBe(await b.text());
+  });
+
+  test('inactive tenant → 409 without echoing the lifecycle state', async () => {
+    const { app } = buildApp({ ok: true, context: platformCtx(ISSUE_SCOPES) }, {}, throwing('tenant is suspended'));
+    const res = await issue(app);
+    expect(res.status).toBe(409);
+    expect(await res.text()).not.toContain('suspended');
+  });
+
+  test('tenant policy ceiling violation → 403', async () => {
+    const { app } = buildApp(
+      { ok: true, context: platformCtx(ISSUE_SCOPES) },
+      {},
+      throwing('root key exceeds tenant policy: rate limit exceeds tenant policy'),
+    );
+    expect((await issue(app)).status).toBe(403);
+  });
+
+  test('a stale/underprivileged issuer is a 403, not a 500', async () => {
+    const { app } = buildApp(
+      { ok: true, context: platformCtx(ISSUE_SCOPES) },
+      {},
+      throwing('unauthorized root key issuer: platform credential is revoked'),
+    );
+    expect((await issue(app)).status).toBe(403);
+  });
+
+  test('an issuer lacking platform:tenants:write is refused by the service and mapped to 403', async () => {
+    const { app } = buildApp(
+      { ok: true, context: platformCtx(['platform:tenant-keys:write']) },
+      {},
+      throwing('root key issuance requires platform:tenants:write'),
+    );
+    expect((await issue(app)).status).toBe(403);
   });
 });
 

--- a/packages/api/src/routes/v2/platform-tenants.ts
+++ b/packages/api/src/routes/v2/platform-tenants.ts
@@ -28,6 +28,7 @@ import type { AppVariables } from '../../types';
 const SCOPE_TENANTS_READ = 'platform:tenants:read';
 const SCOPE_TENANTS_WRITE = 'platform:tenants:write';
 const SCOPE_MEMBERSHIPS_WRITE = 'platform:memberships:write';
+const SCOPE_TENANT_KEYS_WRITE = 'platform:tenant-keys:write';
 
 const reason = z.string().trim().min(3).max(500);
 const idParam = z.object({ id: z.string().uuid() });
@@ -263,6 +264,122 @@ platformTenantRoutes.post(
     return lifecycleResponse(c, result);
   },
 );
+
+// ── Root key issuance (#979) ────────────────────────────────────────────────
+
+const issueRootKeySchema = z.object({
+  principalId: z.string().uuid(),
+  membershipId: z.string().uuid(),
+  role: roleEnum,
+  name: z.string().min(1).max(255),
+  /** Explicit scopes only. `issueRootKey` refuses platform/wildcard authority. */
+  scopes: z.array(z.string().min(1)).min(1),
+  expiresAt: z.string().datetime({ offset: true }),
+  rateLimit: z.number().int().positive(),
+  budget: z.number().int().positive(),
+  resourceConstraints: z.record(z.array(z.string())).optional(),
+  reason,
+});
+
+/**
+ * Issue the initial tenant ROOT key for a membership. Pure wiring over the
+ * already-transactional `TenantKeyService.issueRootKey`, which enforces every
+ * invariant under `FOR UPDATE`: actor freshness, tenant active + policy
+ * ceilings, principal/membership/role subject binding, and the refusal of
+ * platform/wildcard scopes. The route only shapes errors — non-enumerating —
+ * and returns the plaintext exactly once. It never logs it.
+ *
+ * The route scope is `platform:tenant-keys:write`; the service additionally
+ * requires the credential to carry `platform:tenants:write`, so issuance needs
+ * both authorities.
+ */
+platformTenantRoutes.post(
+  '/tenants/:id/keys/root',
+  platformAuthMiddleware(SCOPE_TENANT_KEYS_WRITE, 'tenant_key.issue_root'),
+  zValidator('param', idParam),
+  zValidator('json', issueRootKeySchema),
+  async (c) => {
+    const platform = c.get('platformAuth');
+    if (!platform) return c.json({ error: { code: 'UNAUTHORIZED', message: 'Platform credential required' } }, 401);
+    const { id } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const operation = bindPlatformOperation(platform, 'tenant_key.issue_root', id);
+    try {
+      const { lineage, plainTextKey } = await c.get('services').tenantKeys.issueRootKey({
+        actor: operation,
+        tenantId: id,
+        actorRole: body.role,
+        name: body.name,
+        reason: body.reason,
+        scopes: body.scopes,
+        principalId: body.principalId,
+        membershipId: body.membershipId,
+        ...(body.resourceConstraints ? { resourceConstraints: body.resourceConstraints } : {}),
+        expiresAt: new Date(body.expiresAt),
+        rateLimit: body.rateLimit,
+        budget: body.budget,
+      });
+      // An explicit projection, never the lineage row: the credential index row
+      // carries hashes, and a spread would publish whatever lands there next.
+      return c.json(
+        {
+          data: {
+            id: lineage.id,
+            tenantId: lineage.tenantId,
+            principalId: lineage.principalId,
+            membershipId: lineage.membershipId,
+            name: lineage.name,
+            role: lineage.actorRole,
+            scopes: lineage.scopes,
+            constraints: lineage.resourceConstraints ?? {},
+            delegationDepth: lineage.depth,
+            expiresAt: lineage.expiresAt,
+            rateLimit: lineage.rateLimit,
+            budget: lineage.budget,
+            /** Returned ONCE. Never persisted or logged by the caller. */
+            plainTextKey,
+          },
+        },
+        201,
+      );
+    } catch (err) {
+      const mapped = rootIssuanceFailureResponse(c, err);
+      if (mapped) return mapped;
+      throw err;
+    }
+  },
+);
+
+/**
+ * Map `issueRootKey` failures to non-enumerating 4xx responses.
+ *
+ * An unknown tenant and an ineligible subject (cross-tenant or inactive
+ * principal/membership, role mismatch) collapse into the SAME bare 404 — the
+ * service already makes cross-tenant membership indistinguishable from absence,
+ * and this keeps the route from re-opening that oracle. Anything unrecognised
+ * re-throws to the 500 handler rather than guessing a status.
+ */
+function rootIssuanceFailureResponse(c: Context<{ Variables: AppVariables }>, err: unknown): Response | null {
+  if (!(err instanceof Error)) return null;
+  const message = err.message;
+  if (message === 'tenant not found' || message.startsWith('invalid root key subject:')) {
+    return c.json({ error: { code: 'NOT_FOUND', message: 'not found' } }, 404);
+  }
+  if (message.startsWith('tenant is ')) {
+    return c.json({ error: { code: 'CONFLICT', message: 'tenant is not active' } }, 409);
+  }
+  if (message.startsWith('invalid root key request:')) {
+    // Reflects only the caller's own input (scopes/expiry/limits), never state.
+    return c.json({ error: { code: 'VALIDATION_ERROR', message } }, 400);
+  }
+  if (message.startsWith('root key exceeds tenant policy:')) {
+    return c.json({ error: { code: 'FORBIDDEN', message: 'root key exceeds tenant policy' } }, 403);
+  }
+  if (message.startsWith('unauthorized root key issuer:') || message.startsWith('root key issuance')) {
+    return c.json({ error: { code: 'FORBIDDEN', message: 'Platform credential with required scope required' } }, 403);
+  }
+  return null;
+}
 
 function lifecycleResponse(
   c: Context<{ Variables: AppVariables }>,

--- a/packages/api/src/schemas/openapi/platform-tenants.ts
+++ b/packages/api/src/schemas/openapi/platform-tenants.ts
@@ -5,18 +5,19 @@
  * WHY THESE ARE DOCUMENTED AT ALL
  * -------------------------------
  * The repository rule is "no REST endpoints without OpenAPI docs", and it has no
- * exception for flag-gated surfaces: `routes/v2/platform-tenants.ts` serves ten
- * real endpoints, so ten operations belong in the document. Gating changes WHEN
+ * exception for flag-gated surfaces: `routes/v2/platform-tenants.ts` serves eleven
+ * real endpoints, so eleven operations belong in the document. Gating changes WHEN
  * they answer, not WHETHER they exist. Every operation below therefore states
  * the flag gate in its description, so a reader of the document knows a 404
  * here means "flag off", not "wrong URL".
  *
  * WHAT IS DELIBERATELY ABSENT
  * ---------------------------
- * Nothing credential-class is documented, because nothing credential-class is
- * returned. The routes return `tenants` and `tenant_memberships` rows, which
- * hold policy/lifecycle metadata and principal references — no key material, no
- * digests, no auth-plane secrets. `__tests__/openapi-credential-exposure.test.ts`
+ * The lifecycle/membership routes return `tenants` and `tenant_memberships`
+ * rows, which hold policy/lifecycle metadata and principal references — no key
+ * material, no digests, no auth-plane secrets. The ONE exception is root-key
+ * issuance (#979): its response carries `plainTextKey` exactly once, by design,
+ * and nothing else credential-class (never a hash, never a stored secret). `__tests__/openapi-credential-exposure.test.ts`
  * pins the exposure contract on `POST /auth/validate`; the schemas here stay on
  * the safe side of it by construction, and the `platformApiKeyId` /
  * `principalId` values that appear are opaque identifiers the caller already
@@ -144,6 +145,46 @@ export const MembershipRoleRequestSchema = z.object({ role: tenantRoleEnum, reas
 
 const ReasonRequestSchema = z.object({ reason: reasonField });
 
+export const IssueRootKeyRequestSchema = z.object({
+  principalId: z.string().uuid().openapi({ description: 'Principal the key acts as; must hold the membership' }),
+  membershipId: z.string().uuid().openapi({ description: 'Active membership binding the principal to the tenant' }),
+  role: tenantRoleEnum,
+  name: z.string().min(1).max(255).openapi({ description: 'Human-readable key name' }),
+  scopes: z
+    .array(z.string().min(1))
+    .min(1)
+    .openapi({ description: 'Explicit tenant scopes. Platform and wildcard scopes are refused.' }),
+  expiresAt: z
+    .string()
+    .datetime({ offset: true })
+    .openapi({ description: 'Expiry (ISO 8601). Must be in the future and within the tenant TTL ceiling' }),
+  rateLimit: z.number().int().positive().openapi({ description: 'Rate limit; capped by the tenant policy ceiling' }),
+  budget: z.number().int().positive().openapi({ description: 'Budget; capped by the tenant policy ceiling' }),
+  resourceConstraints: z
+    .record(z.array(z.string()))
+    .optional()
+    .openapi({ description: 'Optional resource allowlists (e.g. instanceAllowlist)' }),
+  reason: reasonField,
+});
+
+export const IssuedRootKeySchema = z.object({
+  id: z.string().uuid().openapi({ description: 'Key lineage id' }),
+  tenantId: z.string().uuid().openapi({ description: 'Tenant the key is bound to' }),
+  principalId: z.string().uuid().nullable().openapi({ description: 'Bound principal' }),
+  membershipId: z.string().uuid().nullable().openapi({ description: 'Bound membership' }),
+  name: z.string().openapi({ description: 'Human-readable key name' }),
+  role: tenantRoleEnum,
+  scopes: z.array(z.string()).openapi({ description: 'Granted tenant scopes' }),
+  constraints: z.record(z.array(z.string())).openapi({ description: 'Effective resource constraints' }),
+  delegationDepth: z.number().int().openapi({ description: 'Always 0 for a root key' }),
+  expiresAt: z.string().datetime().openapi({ description: 'Expiry timestamp' }),
+  rateLimit: z.number().int().openapi({ description: 'Granted rate limit' }),
+  budget: z.number().int().openapi({ description: 'Granted budget' }),
+  plainTextKey: z
+    .string()
+    .openapi({ description: 'The plaintext credential. Returned exactly ONCE; it can never be retrieved again.' }),
+});
+
 /**
  * `x-platform-reason` is a REQUIRED header on the read operations.
  *
@@ -182,6 +223,8 @@ export function registerPlatformTenantSchemas(registry: OpenAPIRegistry): void {
   registry.register('PlatformMembership', PlatformMembershipSchema);
   registry.register('CreateTenantRequest', CreateTenantRequestSchema);
   registry.register('AttachMembershipRequest', AttachMembershipRequestSchema);
+  registry.register('IssueRootKeyRequest', IssueRootKeyRequestSchema);
+  registry.register('IssuedRootKey', IssuedRootKeySchema);
 
   // ── Tenant lifecycle ──────────────────────────────────────────────────────
 
@@ -272,6 +315,45 @@ export function registerPlatformTenantSchemas(registry: OpenAPIRegistry): void {
         content: { 'application/json': { schema: z.object({ data: PlatformTenantSchema }) } },
       },
       401: unauthorized,
+      404: notFound,
+      409: conflict,
+    },
+  });
+
+  // ── Root key issuance ─────────────────────────────────────────────────────
+
+  const ISSUE_ROOT_KEY_PROSE =
+    'Issue the initial tenant-class ROOT key (delegation depth 0) for an active membership of the tenant. ' +
+    'All invariants are enforced transactionally: the principal/membership must belong to the tenant and match ' +
+    'the requested role, the tenant must be active, expiry/rate-limit/budget must fit the tenant policy ' +
+    'ceilings, and platform/wildcard scopes are refused. The plaintext key is returned exactly once and is ' +
+    'never retrievable again.';
+
+  registry.registerPath({
+    method: 'post',
+    path: '/platform/tenants/{id}/keys/root',
+    operationId: 'issuePlatformTenantRootKey',
+    tags: [TAG],
+    summary: 'Issue a tenant root key',
+    description: `${ISSUE_ROOT_KEY_PROSE} ${GATE_NOTE} Scope: \`platform:tenant-keys:write\` (the credential must also carry \`platform:tenants:write\`).`,
+    request: {
+      params: tenantIdParam,
+      body: { content: { 'application/json': { schema: IssueRootKeyRequestSchema } } },
+    },
+    responses: {
+      201: {
+        description: 'Root key issued. `plainTextKey` is returned once and never again.',
+        content: { 'application/json': { schema: z.object({ data: IssuedRootKeySchema }) } },
+      },
+      400: {
+        description: 'Request violates root-key invariants (wildcard/platform scope, past expiry, bad limits)',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
+      401: unauthorized,
+      403: {
+        description: 'Insufficient platform scope, or the request exceeds the tenant key policy ceiling',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
       404: notFound,
       409: conflict,
     },

--- a/packages/api/src/tenancy/__tests__/http-two-tenant-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/http-two-tenant-postgres.test.ts
@@ -9,9 +9,10 @@
  * It cannot prove that a request ever GETS one — its own header note records
  * that gap and defers it here.
  *
- * This suite closes it. Nothing is synthesised: the credentials are minted by
- * `TenantKeyService.issueRootKey` against a real platform actor, presented as a
- * plaintext `x-api-key` header over `app.request(...)`, and resolved by the
+ * This suite closes it. Nothing is synthesised: the credentials are minted over
+ * HTTP through `POST /platform/tenants/:id/keys/root` (#979) by a real platform
+ * credential, presented as a plaintext `x-api-key` header over
+ * `app.request(...)`, and resolved by the
  * real `tenancyMiddleware` → `authMiddleware` → `scopeEnforcerMiddleware` chain
  * in the same order `app.ts` mounts it, against real route modules, over a real
  * PostgreSQL database with RLS enforced and the runtime role's grants applied.
@@ -58,6 +59,7 @@ import { instancesRoutes } from '../../routes/v2/instances';
 import { keysRoutes } from '../../routes/v2/keys';
 import { messagesRoutes } from '../../routes/v2/messages';
 import { personsRoutes } from '../../routes/v2/persons';
+import { platformTenantRoutes } from '../../routes/v2/platform-tenants';
 import type { Services } from '../../services';
 import { ApiKeyService } from '../../services/api-keys';
 import { AuthBootstrapService } from '../../services/auth-bootstrap';
@@ -68,7 +70,6 @@ import { MessageService } from '../../services/messages';
 import { PersonService } from '../../services/persons';
 import { TenantKeyService } from '../../services/tenant-keys';
 import type { AppVariables } from '../../types';
-import { type PlatformAuthContext, bindPlatformOperation, freezeContext } from '../auth-context';
 import { MULTITENANCY_FLAG_ENV } from '../feature-flag';
 import { generateSecret, hashSecret, secretPrefix } from '../hash';
 import { MembershipSelectionService, RequestAuthenticator } from '../request-auth';
@@ -79,6 +80,8 @@ const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
 
 const TENANT_A = '11111111-1111-4111-8111-11111111111a';
 const TENANT_B = '22222222-2222-4222-8222-22222222222b';
+/** Seeded SUSPENDED — exists only so root issuance against an inactive tenant can be probed. */
+const TENANT_C_SUSPENDED = '22222222-2222-4222-8222-22222222222c';
 const PRINCIPAL_A = '33333333-3333-4333-8333-33333333333a';
 const PRINCIPAL_B = '33333333-3333-4333-8333-33333333333b';
 /** Holds an ACTIVE membership in BOTH tenants — the header-confusion case that matters. */
@@ -88,6 +91,8 @@ const MEMBERSHIP_A = '44444444-4444-4444-8444-44444444444a';
 const MEMBERSHIP_B = '44444444-4444-4444-8444-44444444444b';
 const MEMBERSHIP_DUAL_A = '44444444-4444-4444-8444-4444444444d1';
 const MEMBERSHIP_DUAL_B = '44444444-4444-4444-8444-4444444444d2';
+/** PRINCIPAL_A's membership in the suspended tenant C. */
+const MEMBERSHIP_C = '44444444-4444-4444-8444-44444444444c';
 const PLATFORM_KEY_ID = '4444aaaa-4444-4444-8444-4444444444f0';
 const PLATFORM_CREDENTIAL_ID = '4444bbbb-4444-4444-8444-4444444444f1';
 const INSTANCE_A = '55555555-5555-4555-8555-55555555555a';
@@ -157,7 +162,7 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
 
   let app: Hono<{ Variables: AppVariables }>;
   /** Plaintext secrets, minted once in `beforeAll`. Never logged or persisted. */
-  const keys = { a: '', b: '', dualA: '', legacy: '' };
+  const keys = { a: '', b: '', dualA: '', legacy: '', platform: '' };
 
   function openDb(url: string, maxConnections: number): Database {
     const handle = createDbHandle({ url, maxConnections });
@@ -180,7 +185,11 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
     const platformSecret = generateSecret();
     const platformHash = await hashSecret(platformSecret);
     const platformPrefix = secretPrefix(platformSecret);
-    const platformScopes = ['platform:tenants:write'];
+    // Root issuance over HTTP needs BOTH: the route guard checks
+    // `platform:tenant-keys:write`, and `issueRootKey` itself re-checks
+    // `platform:tenants:write` inside the transaction.
+    const platformScopes = ['platform:tenants:write', 'platform:tenant-keys:write'];
+    keys.platform = platformSecret;
 
     // A REAL legacy key, in the exact storage form `ApiKeyService.validate`
     // expects: the `omni_sk_` prefix its format check requires, and the SHA-256
@@ -201,6 +210,12 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
         ('${TENANT_A}', 'tenant-a', 'Tenant A', 86400, 1000, 1000),
         ('${TENANT_B}', 'tenant-b', 'Tenant B', 86400, 1000, 1000);
 
+      -- Suspended from birth: exists solely so the root-issuance probes can
+      -- show an inactive tenant refusing issuance, without suspending A or B
+      -- (which would bump their revocation epochs and break every minted key).
+      INSERT INTO tenants (id, slug, display_name, status, max_key_ttl_seconds, max_key_rate_limit, max_key_budget)
+      VALUES ('${TENANT_C_SUSPENDED}', 'tenant-c', 'Tenant C', 'suspended', 86400, 1000, 1000);
+
       INSERT INTO principals (id, type, subject) VALUES
         ('${PRINCIPAL_A}', 'human', 'subject-a'),
         ('${PRINCIPAL_B}', 'human', 'subject-b'),
@@ -212,7 +227,9 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
         ('${MEMBERSHIP_B}', '${TENANT_B}', '${PRINCIPAL_B}', 'tenant-admin'),
         -- The dual-membership principal: genuinely entitled in BOTH tenants.
         ('${MEMBERSHIP_DUAL_A}', '${TENANT_A}', '${PRINCIPAL_DUAL}', 'tenant-admin'),
-        ('${MEMBERSHIP_DUAL_B}', '${TENANT_B}', '${PRINCIPAL_DUAL}', 'tenant-admin');
+        ('${MEMBERSHIP_DUAL_B}', '${TENANT_B}', '${PRINCIPAL_DUAL}', 'tenant-admin'),
+        -- A perfectly valid membership in the SUSPENDED tenant C.
+        ('${MEMBERSHIP_C}', '${TENANT_C_SUSPENDED}', '${PRINCIPAL_A}', 'tenant-admin');
 
       INSERT INTO platform_api_keys (id, name, key_prefix, key_hash, scopes, principal_id) VALUES
         ('${PLATFORM_KEY_ID}', 'g4-http-issuer', '${platformPrefix}', '${platformHash}',
@@ -315,47 +332,6 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
     await applyTenantRlsEnforcement(provisioner);
     await applyTenancyRoles(provisioner, passwords, DEFAULT_ROLE_NAMES, dbName);
 
-    // Mint the tenant credentials through the REAL issuance path, on the
-    // provisioning identity — issuance is a control-plane act that happens
-    // before any request exists, so it is fixture setup, not part of what is
-    // under test. What is under test is what those credentials can then do.
-    const issuer = new TenantKeyService(provisioner);
-    // The UNBOUND platform identity. It deliberately carries no action and no
-    // target tenant: `bindPlatformOperation` below is what narrows it to one
-    // operation against one tenant, which is the same call the platform routes
-    // make. `issueRootKey` refuses an actor whose binding does not match the
-    // tenant being minted, so a fixture that reused one binding across both
-    // tenants would fail — the binding is proven per mint, not asserted once.
-    const platformIdentity: PlatformAuthContext = freezeContext({
-      credentialClass: 'platform',
-      requestId: 'fixture-issuance',
-      principalId: PLATFORM_PRINCIPAL,
-      credentialId: PLATFORM_CREDENTIAL_ID,
-      scopes: platformScopes,
-      platformApiKeyId: PLATFORM_KEY_ID,
-      platformAction: null,
-      targetTenantId: null,
-    });
-    const expiresAt = new Date(Date.now() + 3_600_000);
-    const mint = (tenantId: string, principalId: string, membershipId: string, name: string) =>
-      issuer.issueRootKey({
-        actor: bindPlatformOperation(platformIdentity, 'tenant_key.issue_root', tenantId),
-        tenantId,
-        actorRole: 'tenant-admin',
-        name,
-        reason: 'g4 http two-tenant acceptance fixture',
-        scopes: ['tenant:*', 'keys:delegate'],
-        principalId,
-        membershipId,
-        expiresAt,
-        rateLimit: 1000,
-        budget: 1000,
-      });
-
-    keys.a = (await mint(TENANT_A, PRINCIPAL_A, MEMBERSHIP_A, 'tenant-a-root')).plainTextKey;
-    keys.b = (await mint(TENANT_B, PRINCIPAL_B, MEMBERSHIP_B, 'tenant-b-root')).plainTextKey;
-    keys.dualA = (await mint(TENANT_A, PRINCIPAL_DUAL, MEMBERSHIP_DUAL_A, 'dual-a-root')).plainTextKey;
-
     // ONE physical runtime connection, shared by every request: cross-request
     // scope bleed shows up here rather than being hidden by pool luck.
     const runtimeDb = openDb(
@@ -399,6 +375,10 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
       c.set('channelRegistry', null);
       await next();
     });
+    // Mounted BEFORE the tenancy/auth/scope chain, exactly as `app.ts` mounts
+    // it on the root app outside `protectedApp`: the control plane carries its
+    // own platform-class guard and the legacy middleware never sees it.
+    app.route('/api/v2/platform', platformTenantRoutes);
     // The production order, from `app.ts`: the tenancy edge decides the world,
     // then legacy auth, then scope enforcement.
     app.use('*', tenancyMiddleware);
@@ -409,6 +389,44 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
     app.route('/api/v2/messages', messagesRoutes);
     app.route('/api/v2/persons', personsRoutes);
     app.route('/api/v2/keys', keysRoutes);
+
+    // Mint the tenant credentials through the REAL issuance path — over HTTP,
+    // through `POST /platform/tenants/:id/keys/root` (#979), with the seeded
+    // platform credential presented as `x-api-key`. Issuance is a control-plane
+    // act that happens before any tenant request exists, so it is fixture
+    // setup; but reaching it through the route means the whole supported
+    // bootstrap chain (platform guard → action/tenant binding → transactional
+    // `issueRootKey`) is what mints every credential this suite then probes.
+    const expiresAt = new Date(Date.now() + 3_600_000).toISOString();
+    const mint = async (tenantId: string, principalId: string, membershipId: string, name: string) => {
+      const res = await app.request(`/api/v2/platform/tenants/${tenantId}/keys/root`, {
+        method: 'POST',
+        headers: { 'x-api-key': keys.platform, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          principalId,
+          membershipId,
+          role: 'tenant-admin',
+          name,
+          scopes: ['tenant:*', 'keys:delegate'],
+          expiresAt,
+          rateLimit: 1000,
+          budget: 1000,
+          reason: 'g4 http two-tenant acceptance fixture',
+        }),
+      });
+      if (res.status !== 201) throw new Error(`fixture root issuance failed for ${name}: ${res.status}`);
+      const { data } = (await res.json()) as {
+        data: { tenantId: string; delegationDepth: number; plainTextKey: string };
+      };
+      if (data.tenantId !== tenantId || data.delegationDepth !== 0) {
+        throw new Error(`fixture root issuance returned a mis-bound credential for ${name}`);
+      }
+      return data.plainTextKey;
+    };
+
+    keys.a = await mint(TENANT_A, PRINCIPAL_A, MEMBERSHIP_A, 'tenant-a-root');
+    keys.b = await mint(TENANT_B, PRINCIPAL_B, MEMBERSHIP_B, 'tenant-b-root');
+    keys.dualA = await mint(TENANT_A, PRINCIPAL_DUAL, MEMBERSHIP_DUAL_A, 'dual-a-root');
   }, 180_000);
 
   afterAll(async () => {
@@ -663,6 +681,95 @@ postgresDescribe('two-tenant containment over HTTP (real PostgreSQL)', () => {
       // No `keys:delegate`, so `keys:write` is never projected and the scope
       // enforcer refuses the route outright.
       expect((await post({ name: 'grandchild', scopes: ['tenant:read'] }, data.plainTextKey)).status).toBe(403);
+    });
+  });
+
+  describe('root key issuance over HTTP (#979)', () => {
+    const issueBody = (overrides: Record<string, unknown> = {}) => ({
+      principalId: PRINCIPAL_A,
+      membershipId: MEMBERSHIP_A,
+      role: 'tenant-admin',
+      name: `root-probe-${crypto.randomUUID().slice(0, 8)}`,
+      scopes: ['tenant:*', 'keys:delegate'],
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      rateLimit: 100,
+      budget: 100,
+      reason: 'root issuance adversarial probe',
+      ...overrides,
+    });
+    const issue = (tenantId: string, body: Record<string, unknown>, key: string) =>
+      app.request(`/api/v2/platform/tenants/${tenantId}/keys/root`, {
+        method: 'POST',
+        headers: { 'x-api-key': key, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    test('the platform credential issues a working tenant-class root over HTTP', async () => {
+      const res = await issue(TENANT_A, issueBody({ name: 'extra-root-a' }), keys.platform);
+      expect(res.status).toBe(201);
+      const { data } = (await res.json()) as {
+        data: { tenantId: string; delegationDepth: number; plainTextKey: string };
+      };
+      expect(data.tenantId).toBe(TENANT_A);
+      expect(data.delegationDepth).toBe(0);
+
+      // The issued credential authenticates as tenant A and is contained to it.
+      const own = await get('/api/v2/instances', data.plainTextKey);
+      expect(own.status).toBe(200);
+      expect(((await own.json()) as { items: { id: string }[] }).items.map((i) => i.id)).toEqual([INSTANCE_A]);
+      expect((await get(`/api/v2/instances/${INSTANCE_B}`, data.plainTextKey)).status).toBe(404);
+
+      // And it can mint a strictly narrower child through POST /keys.
+      const child = await app.request('/api/v2/keys', {
+        method: 'POST',
+        headers: { 'x-api-key': data.plainTextKey, 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'child-of-extra-root', scopes: ['tenant:read'], reason: 'probe' }),
+      });
+      expect(child.status).toBe(201);
+      expect(((await child.json()) as { data: { tenantId: string } }).data.tenantId).toBe(TENANT_A);
+    });
+
+    test('a tenant credential cannot reach the surface (403), a legacy key is a uniform 401', async () => {
+      expect((await issue(TENANT_A, issueBody(), keys.a)).status).toBe(403);
+      expect((await issue(TENANT_A, issueBody(), keys.legacy)).status).toBe(401);
+      expect((await issue(TENANT_A, issueBody(), 'not-a-key-at-all')).status).toBe(401);
+    });
+
+    test('a cross-tenant subject is indistinguishable from one that never existed', async () => {
+      // MEMBERSHIP_B genuinely exists — in tenant B. Issuing under tenant A
+      // must answer exactly as if it did not exist at all.
+      const foreign = await issue(
+        TENANT_A,
+        issueBody({ principalId: PRINCIPAL_B, membershipId: MEMBERSHIP_B }),
+        keys.platform,
+      );
+      const absent = await issue(TENANT_A, issueBody({ membershipId: NEVER_EXISTED }), keys.platform);
+      expect(foreign.status).toBe(404);
+      expect(absent.status).toBe(404);
+      expect(await foreign.text()).toBe(await absent.text());
+    });
+
+    test('an inactive tenant refuses issuance even for its own valid membership', async () => {
+      const res = await issue(
+        TENANT_C_SUSPENDED,
+        issueBody({ principalId: PRINCIPAL_A, membershipId: MEMBERSHIP_C }),
+        keys.platform,
+      );
+      expect(res.status).toBe(409);
+      // The lifecycle state itself is not echoed.
+      expect(await res.text()).not.toContain('suspended');
+    });
+
+    test('a request above the tenant policy ceiling is refused', async () => {
+      const res = await issue(TENANT_A, issueBody({ rateLimit: 1_000_000 }), keys.platform);
+      expect(res.status).toBe(403);
+    });
+
+    test('wildcard and platform scopes fail closed', async () => {
+      expect((await issue(TENANT_A, issueBody({ scopes: ['*'] }), keys.platform)).status).toBe(400);
+      expect((await issue(TENANT_A, issueBody({ scopes: ['platform:tenants:write'] }), keys.platform)).status).toBe(
+        400,
+      );
     });
   });
 

--- a/packages/api/src/tenancy/route-ownership.ts
+++ b/packages/api/src/tenancy/route-ownership.ts
@@ -751,6 +751,7 @@ const PLATFORM_ADMIN_ROUTES: readonly RouteKey[] = [
   'GET /api/v2/platform/tenants/:id/memberships',
   'POST /api/v2/platform/tenants',
   'POST /api/v2/platform/tenants/:id/archive',
+  'POST /api/v2/platform/tenants/:id/keys/root',
   'POST /api/v2/platform/tenants/:id/memberships',
   'POST /api/v2/platform/tenants/:id/suspend',
   'POST /api/v2/platform/tenants/:tenantId/memberships/:id/disable',

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2560,6 +2560,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/platform/tenants/{id}/keys/root": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Issue a tenant root key
+         * @description Issue the initial tenant-class ROOT key (delegation depth 0) for an active membership of the tenant. All invariants are enforced transactionally: the principal/membership must belong to the tenant and match the requested role, the tenant must be active, expiry/rate-limit/budget must fit the tenant policy ceilings, and platform/wildcard scopes are refused. The plaintext key is returned exactly once and is never retrievable again. Platform control plane. Mounted only when `OMNI_MULTITENANCY_ENABLED=true`; when the flag is off the entire surface returns 404. Requires a PLATFORM-class credential with the listed scope — tenant and legacy data-plane keys are denied. Every state change requires a reason and writes an append-only platform audit row. Scope: `platform:tenant-keys:write` (the credential must also carry `platform:tenants:write`).
+         */
+        post: operations["issuePlatformTenantRootKey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/platform/tenants/{id}/memberships": {
         parameters: {
             query?: never;
@@ -6282,6 +6302,93 @@ export interface components {
              * @example onboarding request OPS-1421
              */
             reason: string;
+        };
+        IssueRootKeyRequest: {
+            /**
+             * Format: uuid
+             * @description Principal the key acts as; must hold the membership
+             */
+            principalId: string;
+            /**
+             * Format: uuid
+             * @description Active membership binding the principal to the tenant
+             */
+            membershipId: string;
+            /**
+             * @description Tenant role
+             * @enum {string}
+             */
+            role: "tenant-owner" | "tenant-admin" | "tenant-operator" | "tenant-viewer";
+            /** @description Human-readable key name */
+            name: string;
+            /** @description Explicit tenant scopes. Platform and wildcard scopes are refused. */
+            scopes: string[];
+            /**
+             * Format: date-time
+             * @description Expiry (ISO 8601). Must be in the future and within the tenant TTL ceiling
+             */
+            expiresAt: string;
+            /** @description Rate limit; capped by the tenant policy ceiling */
+            rateLimit: number;
+            /** @description Budget; capped by the tenant policy ceiling */
+            budget: number;
+            /** @description Optional resource allowlists (e.g. instanceAllowlist) */
+            resourceConstraints?: {
+                [key: string]: string[];
+            };
+            /**
+             * @description Audited justification for the change
+             * @example onboarding request OPS-1421
+             */
+            reason: string;
+        };
+        IssuedRootKey: {
+            /**
+             * Format: uuid
+             * @description Key lineage id
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @description Tenant the key is bound to
+             */
+            tenantId: string;
+            /**
+             * Format: uuid
+             * @description Bound principal
+             */
+            principalId: string | null;
+            /**
+             * Format: uuid
+             * @description Bound membership
+             */
+            membershipId: string | null;
+            /** @description Human-readable key name */
+            name: string;
+            /**
+             * @description Tenant role
+             * @enum {string}
+             */
+            role: "tenant-owner" | "tenant-admin" | "tenant-operator" | "tenant-viewer";
+            /** @description Granted tenant scopes */
+            scopes: string[];
+            /** @description Effective resource constraints */
+            constraints: {
+                [key: string]: string[];
+            };
+            /** @description Always 0 for a root key */
+            delegationDepth: number;
+            /**
+             * Format: date-time
+             * @description Expiry timestamp
+             */
+            expiresAt: string;
+            /** @description Granted rate limit */
+            rateLimit: number;
+            /** @description Granted budget */
+            budget: number;
+            /** @description The plaintext credential. Returned exactly ONCE; it can never be retrieved again. */
+            plainTextKey: string;
         };
     };
     responses: never;
@@ -21488,6 +21595,224 @@ export interface operations {
             };
             /** @description Missing, non-platform, or insufficiently scoped credential */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Not found. Non-enumerating: an unknown id yields a bare 404 with no metadata. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Lifecycle conflict (e.g. duplicate slug, or a transition out of the terminal archived state) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    issuePlatformTenantRootKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description Principal the key acts as; must hold the membership
+                     */
+                    principalId: string;
+                    /**
+                     * Format: uuid
+                     * @description Active membership binding the principal to the tenant
+                     */
+                    membershipId: string;
+                    /**
+                     * @description Tenant role
+                     * @enum {string}
+                     */
+                    role: "tenant-owner" | "tenant-admin" | "tenant-operator" | "tenant-viewer";
+                    /** @description Human-readable key name */
+                    name: string;
+                    /** @description Explicit tenant scopes. Platform and wildcard scopes are refused. */
+                    scopes: string[];
+                    /**
+                     * Format: date-time
+                     * @description Expiry (ISO 8601). Must be in the future and within the tenant TTL ceiling
+                     */
+                    expiresAt: string;
+                    /** @description Rate limit; capped by the tenant policy ceiling */
+                    rateLimit: number;
+                    /** @description Budget; capped by the tenant policy ceiling */
+                    budget: number;
+                    /** @description Optional resource allowlists (e.g. instanceAllowlist) */
+                    resourceConstraints?: {
+                        [key: string]: string[];
+                    };
+                    /**
+                     * @description Audited justification for the change
+                     * @example onboarding request OPS-1421
+                     */
+                    reason: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Root key issued. `plainTextKey` is returned once and never again. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /**
+                             * Format: uuid
+                             * @description Key lineage id
+                             */
+                            id: string;
+                            /**
+                             * Format: uuid
+                             * @description Tenant the key is bound to
+                             */
+                            tenantId: string;
+                            /**
+                             * Format: uuid
+                             * @description Bound principal
+                             */
+                            principalId: string | null;
+                            /**
+                             * Format: uuid
+                             * @description Bound membership
+                             */
+                            membershipId: string | null;
+                            /** @description Human-readable key name */
+                            name: string;
+                            /**
+                             * @description Tenant role
+                             * @enum {string}
+                             */
+                            role: "tenant-owner" | "tenant-admin" | "tenant-operator" | "tenant-viewer";
+                            /** @description Granted tenant scopes */
+                            scopes: string[];
+                            /** @description Effective resource constraints */
+                            constraints: {
+                                [key: string]: string[];
+                            };
+                            /** @description Always 0 for a root key */
+                            delegationDepth: number;
+                            /**
+                             * Format: date-time
+                             * @description Expiry timestamp
+                             */
+                            expiresAt: string;
+                            /** @description Granted rate limit */
+                            rateLimit: number;
+                            /** @description Granted budget */
+                            budget: number;
+                            /** @description The plaintext credential. Returned exactly ONCE; it can never be retrieved again. */
+                            plainTextKey: string;
+                        };
+                    };
+                };
+            };
+            /** @description Request violates root-key invariants (wildcard/platform scope, past expiry, bad limits) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Missing, non-platform, or insufficiently scoped credential */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Insufficient platform scope, or the request exceeds the tenant key policy ceiling */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## What

Adds `POST /api/v2/platform/tenants/:id/keys/root`, exposing the already-complete, production-tested `TenantKeyService.issueRootKey()` over HTTP. This closes the bootstrap dead-end where a platform operator could create a tenant and attach a membership but no supported operation could issue that membership's initial tenant root key (`POST /api/v2/keys` only works once a root exists).

## How

- **Route** (`packages/api/src/routes/v2/platform-tenants.ts`): guarded by `platformAuthMiddleware` with the new explicit scope `platform:tenant-keys:write` and the audited action `tenant_key.issue_root`; the tenant id comes from the path and is bound via `bindPlatformOperation`. The body (principal, membership, role, name, explicit scopes, expiry, rate limit, budget, optional resource constraints, audited `reason`) is Zod-validated; every invariant is delegated to `issueRootKey()`, which enforces actor freshness, tenant-active + policy ceilings, subject binding, and platform/wildcard-scope refusal transactionally under `FOR UPDATE`.
- **Error shaping** is non-enumerating: unknown tenant and an ineligible subject (cross-tenant or inactive principal/membership, role mismatch) collapse into the same bare 404; ceiling violations are 403; request-shape violations 400; inactive tenant 409 without echoing the lifecycle state. Anything unrecognised re-throws.
- **Plaintext** is returned exactly once via an explicit response projection (never a lineage/credential spread), and is never logged.
- **OpenAPI** (`packages/api/src/schemas/openapi/platform-tenants.ts`): new `IssueRootKeyRequest`/`IssuedRootKey` schemas and the `issuePlatformTenantRootKey` operation; SDK types regenerated (`packages/sdk/src/types.generated.ts`).
- **Route ownership**: registered as `platform-admin` in `packages/api/src/tenancy/route-ownership.ts`.

Note: issuance requires BOTH `platform:tenant-keys:write` (route guard) and `platform:tenants:write` (re-checked by the service inside the transaction).

## Tests

- `routes/v2/__tests__/platform-tenants.test.ts`: happy path (actor/action/tenant binding, plaintext returned exactly once, no key-hash leakage), 401 for missing/legacy credentials, 403 for tenant-class and under-scoped platform credentials, 400 validation, and the full failure-mapping matrix including the non-enumeration equality of unknown-tenant vs cross-tenant-subject responses.
- `tenancy/__tests__/http-two-tenant-postgres.test.ts`: the two-tenant HTTP acceptance suite now mints every fixture root key **through the new route** (real platform credential over `x-api-key`) instead of calling the service directly, and adds adversarial probes over real PostgreSQL with RLS enforced: issued root authenticates, is contained to its tenant, and mints a narrower child via `POST /keys`; tenant/legacy credentials denied; cross-tenant subject indistinguishable from a nonexistent one; suspended tenant refuses issuance; policy-ceiling and wildcard/platform-scope requests fail closed. (34/34 green on a disposable cluster.)

## Gates

- `make typecheck` ✓, `make lint` ✓ (zero warnings)
- `bun test packages/api/src`: 2187 pass / 0 fail (542 skips are the env-gated real-PostgreSQL suites; the modified one was run separately on a disposable cluster: 34 pass / 0 fail)
- `make sdk-generate` ✓ (static, no server needed)
- No schema changes, no migrations.

Closes #979