### PR TITLE
feat: multitenancy posture visibility on auth validate and omni status

### DIFF
--- a/packages/api/src/__tests__/openapi-credential-exposure.test.ts
+++ b/packages/api/src/__tests__/openapi-credential-exposure.test.ts
@@ -117,3 +117,37 @@ describe('the x-omni-credential-exposure extension is a checkable contract', () 
     expect(validateOperation()['x-omni-scope']).toBe('auth:validate');
   });
 });
+
+describe('OpenAPI documents the server tenancy posture (issue #982)', () => {
+  /** The `server` sub-schema, or a hard failure — never a silent undefined. */
+  function postureSchema(): Record<string, unknown> {
+    const properties = successDataSchema().properties as Record<string, Record<string, unknown>> | undefined;
+    const server = properties?.server;
+    if (!server) throw new Error('the validate response schema has no `server` object');
+    return server;
+  }
+
+  test('the documented posture fields are exactly the ones the route returns', () => {
+    const fields = Object.keys((postureSchema().properties ?? {}) as Record<string, unknown>);
+    expect(fields.sort()).toEqual(['controlPlaneMounted', 'dbEnforcement', 'multitenancyEnabled']);
+  });
+
+  test('the posture block is REQUIRED, because this server always reports it', () => {
+    // Absence is the OLD-server signal, and this document describes THIS
+    // server. A generated client for this version may rely on the block.
+    const data = successDataSchema();
+    expect((data.required as string[] | undefined) ?? []).toContain('server');
+  });
+
+  test('dbEnforcement documents exactly the two posture values', () => {
+    const properties = postureSchema().properties as Record<string, Record<string, unknown>>;
+    expect((properties.dbEnforcement?.enum as string[]).sort()).toEqual(['enforced', 'legacy']);
+  });
+
+  test('no posture field name reads like key material or tenant inventory', () => {
+    const fields = Object.keys((postureSchema().properties ?? {}) as Record<string, unknown>);
+    for (const field of fields) {
+      expect(field).not.toMatch(/secret|hash|keyMaterial|plainText|password|token|tenantId|slug|count/i);
+    }
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/auth-credential-exposure.test.ts
+++ b/packages/api/src/routes/v2/__tests__/auth-credential-exposure.test.ts
@@ -13,10 +13,20 @@
  * TWO WORLDS, ONE ROUTE
  * ---------------------
  * The exposure is keyed on the presence of a tenant auth context, not on the
- * feature flag. A legacy credential never has one, so its response body is
- * byte-for-byte what it was before G4 — asserted here by exact object equality
- * rather than by "contains", because an additive field is exactly the kind of
- * change that a `toMatchObject` assertion would wave through.
+ * feature flag. A legacy credential never has one, so its response body carries
+ * no credential block — asserted here by exact object equality rather than by
+ * "contains", because an additive field is exactly the kind of change that a
+ * `toMatchObject` assertion would wave through.
+ *
+ * ONE SANCTIONED ADDITION: THE SERVER POSTURE BLOCK (issue #982)
+ * --------------------------------------------------------------
+ * Every authenticated caller — legacy included, deliberately — now also gets a
+ * `server` block naming the deployment's tenancy posture (flag state, control
+ * plane mounted, DB enforcement). The exact-equality assertions below INCLUDE
+ * it, so any further addition to the legacy body still fails loudly. The
+ * posture suite at the bottom pins all four flag/enforcement combinations
+ * against `mixedTenancyStateWarning` semantics, and pins that an
+ * unauthenticated caller gets none of it.
  *
  * WHAT MUST NEVER APPEAR
  * ----------------------
@@ -26,12 +36,42 @@
  * a field to the context, which a hand-listed allowlist of fields would not.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
 import { Hono } from 'hono';
 import { type TenantAuthContext, freezeContext } from '../../../tenancy/auth-context';
+import { mixedTenancyStateWarning } from '../../../tenancy/enforcement-posture';
+import { MULTITENANCY_FLAG_ENV } from '../../../tenancy/feature-flag';
 import type { ApiKeyData, AppVariables } from '../../../types';
 import { authRoutes } from '../auth';
+
+const ENFORCEMENT_ENV = 'OMNI_DB_ENFORCEMENT';
+
+/**
+ * The posture block reads the live environment, so every suite here pins both
+ * variables to the default world (flag off, legacy enforcement) and restores
+ * whatever the ambient process had. The posture suite overrides per-case.
+ */
+const savedEnv: Record<string, string | undefined> = {};
+beforeEach(() => {
+  savedEnv[MULTITENANCY_FLAG_ENV] = process.env[MULTITENANCY_FLAG_ENV];
+  savedEnv[ENFORCEMENT_ENV] = process.env[ENFORCEMENT_ENV];
+  delete process.env[MULTITENANCY_FLAG_ENV];
+  delete process.env[ENFORCEMENT_ENV];
+});
+afterEach(() => {
+  for (const key of [MULTITENANCY_FLAG_ENV, ENFORCEMENT_ENV]) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+/** The posture the default world must report. */
+const DEFAULT_POSTURE = {
+  multitenancyEnabled: false,
+  controlPlaneMounted: false,
+  dbEnforcement: 'legacy',
+} as const;
 
 const CREDENTIAL_ID = '99999999-9999-4999-8999-999999999992';
 const TENANT_ID = '11111111-1111-4111-8111-11111111111a';
@@ -98,18 +138,20 @@ function mount(vars: { apiKey?: ApiKeyData; authContext?: TenantAuthContext }) {
 
 const validate = (app: Hono<{ Variables: AppVariables }>) => app.request('/auth/validate', { method: 'POST' });
 
-describe('POST /auth/validate — legacy world is untouched', () => {
-  test('a legacy credential gets exactly the pre-G4 body, with no credential block', async () => {
+describe('POST /auth/validate — legacy world gains only the sanctioned posture block', () => {
+  test('a legacy credential gets exactly the pre-G4 body plus `server`, with no credential block', async () => {
     const response = await validate(mount({ apiKey: legacyApiKey() }));
     expect(response.status).toBe(200);
-    // Exact equality, not containment: the dual-world invariant is that NOTHING
-    // was added here, and only an exact comparison can assert "nothing".
+    // Exact equality, not containment: the only sanctioned addition to the
+    // legacy body is the `server` posture block (issue #982), and only an
+    // exact comparison can assert that nothing ELSE was added.
     expect(await response.json()).toEqual({
       data: {
         valid: true,
         keyPrefix: 'omni_sk_12345678...',
         keyName: 'ops-key',
         scopes: ['messages:read'],
+        server: DEFAULT_POSTURE,
       },
     });
   });
@@ -203,5 +245,72 @@ describe('POST /auth/validate — no secret, hash, or key material', () => {
     const app = mount({ apiKey: { ...legacyApiKey(), id: CREDENTIAL_ID }, authContext: tenantContext() });
     const body = (await (await validate(app)).json()) as { data: { credential: Record<string, unknown> } };
     expect(Object.values(body.data.credential)).not.toContain(CREDENTIAL_ID);
+  });
+});
+
+describe('POST /auth/validate — server tenancy posture (issue #982)', () => {
+  /**
+   * All four flag/enforcement combinations, named the way
+   * `enforcement-posture.ts` names them. `mixed` marks the one advisory-only
+   * state; the assertion below derives it from the posture the route reports
+   * and requires `mixedTenancyStateWarning` to agree, so the route and the
+   * boot warning can never tell the operator two different stories.
+   */
+  const COMBINATIONS = [
+    { name: 'flag off + legacy (default)', flag: undefined, enforcement: undefined, enabled: false, db: 'legacy' },
+    { name: 'flag off + enforced', flag: undefined, enforcement: 'on', enabled: false, db: 'enforced' },
+    { name: 'flag on + legacy (mixed)', flag: 'true', enforcement: undefined, enabled: true, db: 'legacy' },
+    { name: 'flag on + enforced (finished)', flag: 'true', enforcement: 'on', enabled: true, db: 'enforced' },
+  ] as const;
+
+  const setWorld = (flag: string | undefined, enforcement: string | undefined) => {
+    if (flag === undefined) delete process.env[MULTITENANCY_FLAG_ENV];
+    else process.env[MULTITENANCY_FLAG_ENV] = flag;
+    if (enforcement === undefined) delete process.env[ENFORCEMENT_ENV];
+    else process.env[ENFORCEMENT_ENV] = enforcement;
+  };
+
+  for (const combo of COMBINATIONS) {
+    test(`${combo.name} reports its posture and agrees with the boot warning`, async () => {
+      setWorld(combo.flag, combo.enforcement);
+      const body = (await (await validate(mount({ apiKey: legacyApiKey() }))).json()) as {
+        data: { server: { multitenancyEnabled: boolean; controlPlaneMounted: boolean; dbEnforcement: string } };
+      };
+
+      expect(body.data.server).toEqual({
+        multitenancyEnabled: combo.enabled,
+        controlPlaneMounted: combo.enabled,
+        dbEnforcement: combo.db,
+      });
+
+      // The route's posture and the boot warning must name the same mixed
+      // state: warning fires exactly when the reported pair is advisory-only.
+      const reportedMixed = body.data.server.multitenancyEnabled && body.data.server.dbEnforcement === 'legacy';
+      const warning = mixedTenancyStateWarning(combo.db, process.env);
+      expect(warning !== null).toBe(reportedMixed);
+    });
+  }
+
+  test('a tenant caller gets the same posture block alongside its credential', async () => {
+    setWorld('true', 'on');
+    const app = mount({ apiKey: legacyApiKey(), authContext: tenantContext() });
+    const body = (await (await validate(app)).json()) as { data: Record<string, unknown> };
+    expect(body.data.server).toEqual({
+      multitenancyEnabled: true,
+      controlPlaneMounted: true,
+      dbEnforcement: 'enforced',
+    });
+    expect(body.data.credential).toBeDefined();
+  });
+
+  test('an unauthenticated caller gets no posture, in any world', async () => {
+    // The block exists to make the server legible to its OWN operators, not to
+    // anonymous probes — even the 401 error body says nothing.
+    for (const combo of COMBINATIONS) {
+      setWorld(combo.flag, combo.enforcement);
+      const response = await validate(mount({}));
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({ error: { code: 'UNAUTHORIZED', message: 'Invalid API key' } });
+    }
   });
 });

--- a/packages/api/src/routes/v2/auth.ts
+++ b/packages/api/src/routes/v2/auth.ts
@@ -14,17 +14,31 @@
  * TWO RULES GOVERN THE BLOCK
  * --------------------------
  *   1. It appears only when a tenant auth context exists. A legacy credential
- *      never has one, so a legacy caller's body is byte-for-byte its pre-G4
- *      body — the dual-world invariant, asserted by exact equality in
+ *      never has one, so a legacy caller's body carries no credential block —
+ *      the dual-world invariant, asserted by exact equality in
  *      `__tests__/auth-credential-exposure.test.ts`.
  *   2. It carries only facts about the CALLER'S OWN context, and never a
  *      secret, a hash, key material, the full credential id, or anything about
  *      another principal or tenant. It reads no tenant business data, so it
  *      cannot become an inventory oracle.
+ *
+ * THE SERVER POSTURE BLOCK (issue #982)
+ * -------------------------------------
+ * Alongside the caller's own facts, every AUTHENTICATED caller — legacy and
+ * tenant alike — gets a `server` block naming the deployment's tenancy
+ * posture: multitenancy flag state, whether the platform control plane is
+ * mounted, and the DB enforcement posture. This is the sanctioned, deliberate
+ * extension of the legacy body: an operator holding a legacy key is exactly
+ * who needs to distinguish "flag off" from "server too old" from "wrong
+ * credential class" (#908), so withholding it from legacy callers would defeat
+ * the point. The block is deployment-level and non-enumerating (three flags,
+ * no names, no counts) and appears ONLY here, never on an unauthenticated
+ * surface — `public-surface-privacy.test.ts` pins that.
  */
 
 import { Hono } from 'hono';
 import type { TenantAuthContext } from '../../tenancy/auth-context';
+import { serverTenancyPosture } from '../../tenancy/server-posture';
 import type { AppVariables } from '../../types';
 
 const authRoutes = new Hono<{ Variables: AppVariables }>();
@@ -86,6 +100,10 @@ authRoutes.post('/validate', async (c) => {
       keyName: apiKey.name === '__primary__' ? 'primary' : apiKey.name,
       scopes: apiKey.scopes,
       ...(context ? { credential: publishableCredential(context) } : {}),
+      // Deployment-level tenancy posture, for every authenticated caller
+      // (issue #982). Absent only on servers that predate it — which is
+      // itself the signal an up-to-date CLI uses.
+      server: serverTenancyPosture(),
     },
   });
 });

--- a/packages/api/src/schemas/openapi/auth.ts
+++ b/packages/api/src/schemas/openapi/auth.ts
@@ -49,6 +49,29 @@ export const AuthCredentialContextSchema = z.object({
 export const CREDENTIAL_EXPOSURE_FIELDS: readonly string[] = Object.keys(AuthCredentialContextSchema.shape);
 
 /**
+ * Deployment-level tenancy posture (issue #982).
+ *
+ * Present for EVERY authenticated caller — legacy and tenant alike — because
+ * the operator who needs to distinguish "multitenancy flag off" from "server
+ * predates the control plane" from "wrong credential class" is usually holding
+ * a legacy key. Three deployment flags, nothing tenant-enumerating; the same
+ * facts appear nowhere unauthenticated (health-route privacy contract).
+ */
+export const ServerTenancyPostureSchema = z.object({
+  multitenancyEnabled: z
+    .boolean()
+    .openapi({ description: 'OMNI_MULTITENANCY_ENABLED flag state (exact-string "true" semantics)' }),
+  controlPlaneMounted: z
+    .boolean()
+    .openapi({ description: 'Whether the /api/v2/platform control plane is mounted on this server' }),
+  dbEnforcement: z.enum(['legacy', 'enforced']).openapi({
+    description:
+      'Database enforcement posture. "enforced" means forced row-level security is installed; ' +
+      '"legacy" with multitenancy enabled means the tenant boundary is advisory only (migration state).',
+  }),
+});
+
+/**
  * Auth validation response schema
  */
 export const AuthValidateResponseSchema = z.object({
@@ -61,6 +84,9 @@ export const AuthValidateResponseSchema = z.object({
     scopes: z.array(z.string()).openapi({ description: 'Scopes granted to this key', example: ['*'] }),
     credential: AuthCredentialContextSchema.optional().openapi({
       description: 'Tenant credential context; absent for a legacy credential',
+    }),
+    server: ServerTenancyPostureSchema.openapi({
+      description: 'Deployment tenancy posture; absent only on servers that predate it',
     }),
   }),
 });

--- a/packages/api/src/tenancy/__tests__/public-surface-privacy.test.ts
+++ b/packages/api/src/tenancy/__tests__/public-surface-privacy.test.ts
@@ -135,6 +135,15 @@ const FORBIDDEN_COUNTS: readonly number[] = [
  */
 const BENIGN_FIELDS: ReadonlySet<string> = new Set(['uptime', 'timestamp', 'version']);
 
+/**
+ * The server tenancy posture (issue #982) is an AUTHENTICATED exposure only:
+ * it lives on `POST /auth/validate` and nowhere else. These are its field
+ * names; none of them may ever appear on a public surface, in either world —
+ * an anonymous caller learning a deployment's enforcement posture is doing
+ * reconnaissance, not liveness checking.
+ */
+const POSTURE_KEYS: readonly string[] = ['multitenancyEnabled', 'controlPlaneMounted', 'dbEnforcement'];
+
 const WORLDS: readonly (string | undefined)[] = [undefined, 'true'];
 
 describe.each(WORLDS.map((flag) => [flag === 'true' ? 'tenant mode on' : 'legacy mode (flag off)', flag] as const))(
@@ -165,7 +174,7 @@ describe.each(WORLDS.map((flag) => [flag === 'true' ? 'tenant mode on' : 'legacy
       // Structural guard: a leak arriving under one of the aggregation keys is
       // caught by shape alone. (`connected` is intentionally NOT checked here —
       // it is a legitimate key on the NATS check, `checks.nats.details.connected`.)
-      for (const key of ['instances', 'byChannel', 'total', 'active']) {
+      for (const key of ['instances', 'byChannel', 'total', 'active', ...POSTURE_KEYS]) {
         expect(keysDeep(body)).not.toContain(key);
       }
       // Value guard for a leak arriving under some OTHER key: the seeded counts
@@ -185,7 +194,7 @@ describe.each(WORLDS.map((flag) => [flag === 'true' ? 'tenant mode on' : 'legacy
       expect(body.version).toBeDefined();
       expect(body.instances).toBeUndefined();
       // /info carries no NATS check, so every aggregation key is unambiguous here.
-      for (const key of ['instances', 'byChannel', 'total', 'active', 'connected']) {
+      for (const key of ['instances', 'byChannel', 'total', 'active', 'connected', ...POSTURE_KEYS]) {
         expect(keysDeep(body)).not.toContain(key);
       }
       const values = scalars(body, BENIGN_FIELDS);
@@ -209,6 +218,7 @@ describe.each(WORLDS.map((flag) => [flag === 'true' ? 'tenant mode on' : 'legacy
       expect(keysDeep(body)).not.toContain('consumers');
       expect(keysDeep(body)).not.toContain('lastSequence');
       expect(keysDeep(body)).not.toContain('lastEventId');
+      for (const key of POSTURE_KEYS) expect(keysDeep(body)).not.toContain(key);
       // Even the count is inventory: it tells an anonymous caller how many
       // consumers — and therefore how much pipeline — a deployment runs.
       expect(keysDeep(body)).not.toContain('totalTracked');

--- a/packages/api/src/tenancy/__tests__/server-posture.test.ts
+++ b/packages/api/src/tenancy/__tests__/server-posture.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Server tenancy posture (issue #982).
+ *
+ * The posture is the authenticated answer to the question a route-level 404
+ * cannot answer: which of the four flag/enforcement worlds is this server in?
+ * Its two predicates already have their own strictness suites
+ * (`feature-flag.test.ts`, `enforcement-posture.test.ts`); what is pinned here
+ * is the COMPOSITION — all four combinations render correctly, the mounted
+ * fact tracks the same predicate the `app.ts` mount site uses, and the mixed
+ * state the posture implies is exactly the one `mixedTenancyStateWarning`
+ * warns about, so the two surfaces can never disagree.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mixedTenancyStateWarning } from '../enforcement-posture';
+import { serverTenancyPosture } from '../server-posture';
+
+const worlds = [
+  { name: 'flag off + legacy (default)', env: {}, enabled: false, db: 'legacy' },
+  { name: 'flag off + enforced', env: { OMNI_DB_ENFORCEMENT: 'on' }, enabled: false, db: 'enforced' },
+  { name: 'flag on + legacy (mixed)', env: { OMNI_MULTITENANCY_ENABLED: 'true' }, enabled: true, db: 'legacy' },
+  {
+    name: 'flag on + enforced (finished)',
+    env: { OMNI_MULTITENANCY_ENABLED: 'true', OMNI_DB_ENFORCEMENT: 'on' },
+    enabled: true,
+    db: 'enforced',
+  },
+] as const;
+
+describe('all four flag/enforcement combinations render correctly', () => {
+  for (const world of worlds) {
+    test(world.name, () => {
+      expect(serverTenancyPosture(world.env as NodeJS.ProcessEnv)).toEqual({
+        multitenancyEnabled: world.enabled,
+        controlPlaneMounted: world.enabled,
+        dbEnforcement: world.db,
+      });
+    });
+  }
+});
+
+describe('the posture and the boot warning name the same mixed state', () => {
+  for (const world of worlds) {
+    test(`${world.name}: warning fires iff the posture is advisory-only`, () => {
+      const posture = serverTenancyPosture(world.env as NodeJS.ProcessEnv);
+      const advisoryOnly = posture.multitenancyEnabled && posture.dbEnforcement === 'legacy';
+      const warning = mixedTenancyStateWarning(posture.dbEnforcement, world.env as NodeJS.ProcessEnv);
+      expect(warning !== null).toBe(advisoryOnly);
+    });
+  }
+});
+
+describe('both predicates keep their exact-string strictness through the composition', () => {
+  test('a truthy-looking flag that is not the literal "true" is off', () => {
+    for (const value of ['1', 'yes', 'TRUE', 'false', '']) {
+      const posture = serverTenancyPosture({ OMNI_MULTITENANCY_ENABLED: value } as NodeJS.ProcessEnv);
+      expect(posture.multitenancyEnabled).toBe(false);
+      expect(posture.controlPlaneMounted).toBe(false);
+    }
+  });
+
+  test('an enforcement value that is not the literal "on" is legacy', () => {
+    for (const value of ['1', 'yes', 'ON', 'true', '']) {
+      const posture = serverTenancyPosture({ OMNI_DB_ENFORCEMENT: value } as NodeJS.ProcessEnv);
+      expect(posture.dbEnforcement).toBe('legacy');
+    }
+  });
+});

--- a/packages/api/src/tenancy/route-ownership.ts
+++ b/packages/api/src/tenancy/route-ownership.ts
@@ -395,7 +395,9 @@ const CONTROL_PLANE_ROUTE_JUSTIFICATIONS: readonly RouteOwnershipDeclaration[] =
     justification:
       'Credential introspection. Returns ONLY facts about the caller’s own authenticated context — ' +
       'credential class, tenant id/slug, role, scopes, constraints, expiry — and never a secret, hash, or key ' +
-      'material, and never another principal’s context. Reads no tenant business data.',
+      'material, and never another principal’s context. Reads no tenant business data. Also carries the ' +
+      'deployment-level tenancy posture (three flags, nothing tenant-enumerating; issue #982), which is why ' +
+      'this stays the ONE authenticated surface that says which world the server is in.',
   },
 ];
 

--- a/packages/api/src/tenancy/server-posture.ts
+++ b/packages/api/src/tenancy/server-posture.ts
@@ -1,0 +1,61 @@
+/**
+ * Non-sensitive server tenancy posture for authenticated callers
+ * (issue #982; wish: omni-full-multitenancy, follow-up to Group G4).
+ *
+ * THE PROBLEM THIS SOLVES
+ * -----------------------
+ * A route-level 404 on `/api/v2/platform/**` is ambiguous three ways: the
+ * multitenancy flag may be off, the server may predate the control plane
+ * entirely, or the caller may hold the wrong credential class. An operator
+ * diagnosing a deployment needs the server to SAY which world it is in — on an
+ * authenticated surface, never an anonymous one.
+ *
+ * WHAT MAY BE SAID, AND WHERE
+ * ---------------------------
+ * Three deployment-level booleans/enums, nothing more:
+ *
+ *   * `multitenancyEnabled` — the `OMNI_MULTITENANCY_ENABLED` flag state.
+ *   * `controlPlaneMounted` — whether `/api/v2/platform` exists on this server.
+ *   * `dbEnforcement` — `legacy` | `enforced`, the same posture value the boot
+ *     path feeds `warnOnMixedTenancyState` (enforcement-posture.ts).
+ *
+ * None of these name a tenant, count anything, or reveal resource existence,
+ * so the block cannot become an inventory oracle. It still lives ONLY behind
+ * auth (`POST /auth/validate`): the health-route privacy contract
+ * (routes/health.ts) is untouched, and `public-surface-privacy.test.ts`
+ * asserts these field names never appear on an unauthenticated surface.
+ *
+ * WHY THE ENVIRONMENT IS READ PER CALL
+ * ------------------------------------
+ * Both underlying predicates (`isMultitenancyEnabled`, `resolveEnforcementMode`)
+ * deliberately read the environment on every call so tests can toggle them
+ * without import-order coupling; this module follows suit. `controlPlaneMounted`
+ * is derived from the exact predicate the mount site in `app.ts` uses, so in
+ * any process whose environment is stable after boot — every real deployment —
+ * it equals the actual mount decision. The field exists separately from
+ * `multitenancyEnabled` because ABSENCE of the whole block is the third state:
+ * a server too old to report posture at all, which is exactly the ambiguity
+ * the block exists to resolve.
+ */
+
+import { resolveEnforcementMode } from '@omni/db';
+import type { DbEnforcementPosture } from './enforcement-posture';
+import { isMultitenancyEnabled } from './feature-flag';
+
+export interface ServerTenancyPosture {
+  /** `OMNI_MULTITENANCY_ENABLED` flag state (exact-string `"true"` semantics). */
+  readonly multitenancyEnabled: boolean;
+  /** Whether `/api/v2/platform` is mounted — same predicate as the `app.ts` mount site. */
+  readonly controlPlaneMounted: boolean;
+  /** Database enforcement posture, mirroring `warnOnMixedTenancyState`'s input. */
+  readonly dbEnforcement: DbEnforcementPosture;
+}
+
+export function serverTenancyPosture(env: NodeJS.ProcessEnv = process.env): ServerTenancyPosture {
+  const enabled = isMultitenancyEnabled(env);
+  return {
+    multitenancyEnabled: enabled,
+    controlPlaneMounted: enabled,
+    dbEnforcement: resolveEnforcementMode(env),
+  };
+}

--- a/packages/cli/src/__tests__/credential-status.test.ts
+++ b/packages/cli/src/__tests__/credential-status.test.ts
@@ -18,9 +18,15 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { createOmniClient } from '@omni/sdk';
-import { credentialStatusFields } from '../lib/credential-status';
+import { credentialStatusFields, serverPostureFields } from '../lib/credential-status';
 
 const TENANT_ID = '11111111-1111-4111-8111-11111111111a';
+
+const SERVER_POSTURE = {
+  multitenancyEnabled: true,
+  controlPlaneMounted: true,
+  dbEnforcement: 'enforced' as const,
+};
 
 const TENANT_CREDENTIAL = {
   class: 'tenant' as const,
@@ -44,7 +50,8 @@ describe('the SDK carries the credential block through', () => {
       fetch(request) {
         const { pathname } = new URL(request.url);
         if (pathname !== '/api/v2/auth/validate') return new Response('not found', { status: 404 });
-        const tenant = request.headers.get('x-api-key') === 'tenant-key';
+        const key = request.headers.get('x-api-key');
+        const tenant = key === 'tenant-key';
         return Response.json({
           data: {
             valid: true,
@@ -52,6 +59,10 @@ describe('the SDK carries the credential block through', () => {
             keyName: tenant ? 'tenant:tenant-operator' : 'ops-key',
             scopes: ['messages:read'],
             ...(tenant ? { credential: TENANT_CREDENTIAL } : {}),
+            // A posture-reporting server sends the block to every
+            // authenticated caller; 'old-server-key' simulates one that
+            // predates it (issue #982).
+            ...(key === 'old-server-key' ? {} : { server: SERVER_POSTURE }),
           },
         });
       },
@@ -73,6 +84,19 @@ describe('the SDK carries the credential block through', () => {
     expect(result.valid).toBe(true);
     expect(result.keyName).toBe('ops-key');
     expect(result.credential).toBeUndefined();
+  });
+
+  test('the server posture block arrives intact for any authenticated caller', async () => {
+    const client = createOmniClient({ baseUrl, apiKey: 'legacy-key' });
+    const result = await client.auth.validate();
+    expect(result.server).toEqual(SERVER_POSTURE);
+  });
+
+  test('an old server that reports no posture yields an absent field, not defaults', async () => {
+    const client = createOmniClient({ baseUrl, apiKey: 'old-server-key' });
+    const result = await client.auth.validate();
+    expect(result.valid).toBe(true);
+    expect(result.server).toBeUndefined();
   });
 });
 
@@ -137,6 +161,68 @@ describe('the CLI renders the credential context', () => {
     });
     for (const key of Object.keys(fields)) {
       expect(key).not.toMatch(/secret|hash|plainText|password|token/i);
+    }
+  });
+});
+
+describe('the CLI renders the server tenancy posture (issue #982)', () => {
+  const validateWith = (server?: (typeof SERVER_POSTURE & { dbEnforcement: 'legacy' | 'enforced' }) | undefined) => ({
+    valid: true,
+    keyPrefix: 'p',
+    keyName: 'ops-key',
+    scopes: ['messages:read'],
+    ...(server ? { server } : {}),
+  });
+
+  /**
+   * All four flag/enforcement combinations, matching the API's
+   * `mixedTenancyStateWarning` semantics: the warning field appears exactly in
+   * the one advisory-only combination and never in the three coherent ones.
+   */
+  const COMBINATIONS = [
+    { name: 'flag off + legacy (default)', enabled: false, db: 'legacy' as const, warns: false },
+    { name: 'flag off + enforced', enabled: false, db: 'enforced' as const, warns: false },
+    { name: 'flag on + legacy (mixed)', enabled: true, db: 'legacy' as const, warns: true },
+    { name: 'flag on + enforced (finished)', enabled: true, db: 'enforced' as const, warns: false },
+  ];
+
+  for (const combo of COMBINATIONS) {
+    test(`${combo.name} renders correctly`, () => {
+      const fields = serverPostureFields(
+        validateWith({
+          multitenancyEnabled: combo.enabled,
+          controlPlaneMounted: combo.enabled,
+          dbEnforcement: combo.db,
+        }),
+      );
+
+      expect(fields.serverMultitenancy).toBe(combo.enabled ? 'enabled' : 'disabled');
+      expect(fields.serverControlPlane).toBe(combo.enabled ? 'mounted' : 'not mounted');
+      expect(fields.serverDbEnforcement).toBe(combo.db);
+
+      if (combo.warns) {
+        expect(String(fields.tenancyWarning)).toContain('advisory');
+      } else {
+        expect('tenancyWarning' in fields).toBe(false);
+      }
+    });
+  }
+
+  test('a server that reports no posture adds NOTHING, so old-server output is unchanged', () => {
+    // The dual-world invariant extended to versions: `omni status` against a
+    // server predating posture reporting must print exactly the fields it
+    // prints today — same empty-object contract as the credential projection.
+    expect(serverPostureFields(validateWith(undefined))).toEqual({});
+  });
+
+  test('posture field names collide with neither the credential projection nor existing status keys', () => {
+    const posture = serverPostureFields(validateWith(SERVER_POSTURE));
+    const credential = credentialStatusFields({ ...validateWith(SERVER_POSTURE), credential: TENANT_CREDENTIAL });
+    // `omni auth status` already prints `server` (the config entry name) and
+    // `scopes`; a collision would silently overwrite an existing field.
+    const reserved = new Set(['server', 'scopes', 'keyName', 'keyPrefix', 'apiUrl', ...Object.keys(credential)]);
+    for (const key of Object.keys(posture)) {
+      expect(reserved.has(key)).toBe(false);
     }
   });
 });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -20,7 +20,7 @@ import {
   saveConfig,
   saveLocalRuntimeConfig,
 } from '../config.js';
-import { credentialStatusFields } from '../lib/credential-status.js';
+import { credentialStatusFields, serverPostureFields } from '../lib/credential-status.js';
 import * as output from '../output.js';
 import { PM2_PROCESSES, capturePm2, isPm2Available, runPm2 } from '../pm2.js';
 import { buildRuntimeEnv } from '../runtime-env.js';
@@ -406,6 +406,8 @@ one, or the entry named by the global flag:
           scopes: result.scopes,
           // Empty for a legacy credential (wish: omni-full-multitenancy, G4).
           ...credentialStatusFields(result),
+          // Empty when the server reports no tenancy posture (issue #982).
+          ...serverPostureFields(result),
           configDir: getConfigDir(),
         });
       } catch (err) {

--- a/packages/cli/src/commands/multitenancy.ts
+++ b/packages/cli/src/commands/multitenancy.ts
@@ -1,0 +1,57 @@
+/**
+ * Multitenancy Commands (read-only; issue #982)
+ *
+ * omni multitenancy status - Show the server's tenancy posture
+ *
+ * STRICTLY VISIBILITY, BY DESIGN
+ * ------------------------------
+ * There is deliberately no `enable`, no cutover, and no write of any kind
+ * here: production cutover is receipt-gated and belongs to the separate
+ * private production authority. `status` wraps the posture the server already
+ * reports on the authenticated `POST /auth/validate` surface — it issues no
+ * additional server-side queries.
+ *
+ * A server that reports no posture is itself an answer: it predates posture
+ * reporting (and therefore the tenant control plane), which is one of the
+ * three states an operator staring at a `/api/v2/platform` 404 needs to tell
+ * apart. That case prints an explanation rather than fabricated defaults.
+ */
+
+import { Command } from 'commander';
+import { getClient } from '../client.js';
+import { serverPostureFields } from '../lib/credential-status.js';
+import * as output from '../output.js';
+
+export function createMultitenancyCommand(): Command {
+  const multitenancy = new Command('multitenancy').description('Multitenancy posture (read-only)');
+
+  multitenancy
+    .command('status')
+    .description("Show the server's multitenancy flag, control plane, and DB enforcement posture")
+    .action(async () => {
+      const client = getClient();
+
+      try {
+        const result = await client.auth.validate();
+
+        if (!result.server) {
+          // Nothing invented: absence of the block IS the finding.
+          output.data({
+            posture: 'unreported',
+            note:
+              'This server does not report tenancy posture — it predates posture reporting ' +
+              '(and likely the tenant control plane). Platform commands will 404 regardless of flags. ' +
+              'Upgrade the server to get posture visibility.',
+          });
+          return;
+        }
+
+        output.data(serverPostureFields(result));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to read server posture: ${message}`, undefined, 2);
+      }
+    });
+
+  return multitenancy;
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -8,7 +8,7 @@ import type { OmniClient } from '@omni/sdk';
 import { Command } from 'commander';
 import { getOptionalClient } from '../client.js';
 import { getConfigDir, hasAuth, loadConfig } from '../config.js';
-import { credentialStatusFields } from '../lib/credential-status.js';
+import { credentialStatusFields, serverPostureFields } from '../lib/credential-status.js';
 import * as output from '../output.js';
 import { capturePm2, isPm2Available } from '../pm2.js';
 import { CLI_VERSION_HEADER, SERVER_VERSION_HEADER, VERSION, formatStatusVersionHint } from '../version.js';
@@ -133,6 +133,9 @@ async function validateAuthKey(statusInfo: Record<string, unknown>, client: Omni
     // Empty for a legacy credential, so legacy output keeps exactly its
     // pre-G4 fields (wish: omni-full-multitenancy, Group G4).
     Object.assign(statusInfo, credentialStatusFields(auth));
+    // Empty when the server reports no posture (older server), so output
+    // against an old server stays field-for-field unchanged (issue #982).
+    Object.assign(statusInfo, serverPostureFields(auth));
   } catch {
     statusInfo.keyValid = false;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,7 @@ import { createListenCommand } from './commands/listen.js';
 import { createLogsCommand } from './commands/logs.js';
 import { createMediaCommand } from './commands/media.js';
 import { createMessagesCommand } from './commands/messages.js';
+import { createMultitenancyCommand } from './commands/multitenancy.js';
 import { createMusicCommand } from './commands/music.js';
 import { createOpenCommand } from './commands/open.js';
 import { createPayloadsCommand } from './commands/payloads.js';
@@ -397,6 +398,12 @@ const COMMANDS: CommandDef[] = [
   },
   { create: createEventsCommand, category: 'standard', helpGroup: 'System', helpDescription: 'Query message history' },
   { create: createAuthCommand, category: 'core', helpGroup: 'System', helpDescription: 'Authentication management' },
+  {
+    create: createMultitenancyCommand,
+    category: 'advanced',
+    helpGroup: 'System',
+    helpDescription: 'Server multitenancy posture (read-only)',
+  },
   {
     create: createServerCommand,
     category: 'core',

--- a/packages/cli/src/lib/credential-status.ts
+++ b/packages/cli/src/lib/credential-status.ts
@@ -43,3 +43,38 @@ export function credentialStatusFields(auth: AuthValidateResponse): Record<strin
     delegationDepth: credential.delegationDepth,
   };
 }
+
+/**
+ * Project the server's tenancy posture into display fields (issue #982).
+ *
+ * Same empty-object contract as above, for the same reason: a server that does
+ * not report posture — any server predating it — must add NOTHING, so output
+ * against an old server stays field-for-field what it is today. "Absent" is
+ * itself the operator's signal that the server predates the control plane.
+ *
+ * Field names are prefixed `server*` so they cannot collide with the
+ * credential projection or the existing status fields (`omni auth status`
+ * already prints a `server` key naming the config entry).
+ *
+ * The `tenancyWarning` field mirrors `mixedTenancyStateWarning` semantics on
+ * the API side: it appears exactly when the flag is on but the database is in
+ * legacy enforcement — the advisory-only migration state — and never in the
+ * three coherent combinations.
+ */
+export function serverPostureFields(auth: AuthValidateResponse): Record<string, unknown> {
+  const posture = auth.server;
+  if (!posture) return {};
+
+  const fields: Record<string, unknown> = {
+    serverMultitenancy: posture.multitenancyEnabled ? 'enabled' : 'disabled',
+    serverControlPlane: posture.controlPlaneMounted ? 'mounted' : 'not mounted',
+    serverDbEnforcement: posture.dbEnforcement,
+  };
+
+  if (posture.multitenancyEnabled && posture.dbEnforcement === 'legacy') {
+    fields.tenancyWarning =
+      'isolation not enforced: multitenancy is enabled but DB enforcement is legacy — the tenant boundary is advisory only (migration state)';
+  }
+
+  return fields;
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1150,6 +1150,24 @@ export interface AuthCredentialContext {
 }
 
 /**
+ * Deployment-level tenancy posture, as returned by `POST /auth/validate`
+ * (issue #982).
+ *
+ * Present for EVERY authenticated caller on servers that report it, and
+ * absent entirely on older servers — which is why the field is optional on
+ * `AuthValidateResponse`: absence means "this server predates posture
+ * reporting", a state a CLI must render as nothing rather than as defaults.
+ */
+export interface ServerTenancyPosture {
+  /** `OMNI_MULTITENANCY_ENABLED` flag state (exact-string `"true"` semantics). */
+  multitenancyEnabled: boolean;
+  /** Whether the `/api/v2/platform` control plane is mounted on this server. */
+  controlPlaneMounted: boolean;
+  /** Database enforcement posture: forced RLS installed, or legacy. */
+  dbEnforcement: 'legacy' | 'enforced';
+}
+
+/**
  * Auth validation response
  */
 export interface AuthValidateResponse {
@@ -1159,6 +1177,8 @@ export interface AuthValidateResponse {
   scopes: string[];
   /** Present only for a tenant-class credential. */
   credential?: AuthCredentialContext;
+  /** Deployment tenancy posture; absent on servers that predate it. */
+  server?: ServerTenancyPosture;
 }
 
 // ============================================================================

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,6 +71,7 @@ export type {
   // Auth types
   AuthCredentialContext,
   AuthValidateResponse,
+  ServerTenancyPosture,
   // A2A types
   A2ADiscoverableAgent,
   A2AJsonRpcResponse,

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -2839,6 +2839,18 @@ export interface components {
                     /** @description Delegation depth: 0 = root key, 1 = child key */
                     delegationDepth: number;
                 };
+                /** @description Deployment tenancy posture; absent only on servers that predate it */
+                server: {
+                    /** @description OMNI_MULTITENANCY_ENABLED flag state (exact-string "true" semantics) */
+                    multitenancyEnabled: boolean;
+                    /** @description Whether the /api/v2/platform control plane is mounted on this server */
+                    controlPlaneMounted: boolean;
+                    /**
+                     * @description Database enforcement posture. "enforced" means forced row-level security is installed; "legacy" with multitenancy enabled means the tenant boundary is advisory only (migration state).
+                     * @enum {string}
+                     */
+                    dbEnforcement: "legacy" | "enforced";
+                };
             };
         };
         HealthCheck: {
@@ -6905,6 +6917,18 @@ export interface operations {
                                 expiresAt: string | null;
                                 /** @description Delegation depth: 0 = root key, 1 = child key */
                                 delegationDepth: number;
+                            };
+                            /** @description Deployment tenancy posture; absent only on servers that predate it */
+                            server: {
+                                /** @description OMNI_MULTITENANCY_ENABLED flag state (exact-string "true" semantics) */
+                                multitenancyEnabled: boolean;
+                                /** @description Whether the /api/v2/platform control plane is mounted on this server */
+                                controlPlaneMounted: boolean;
+                                /**
+                                 * @description Database enforcement posture. "enforced" means forced row-level security is installed; "legacy" with multitenancy enabled means the tenant boundary is advisory only (migration state).
+                                 * @enum {string}
+                                 */
+                                dbEnforcement: "legacy" | "enforced";
                             };
                         };
                     };


### PR DESCRIPTION
Closes #982

## What

Operators diagnosing a `/api/v2/platform/**` 404 can now distinguish "multitenancy flag off" from "server predates the control plane" from "wrong credential class".

### API — authenticated posture surface
- `POST /auth/validate` now returns a `server` block for **every** authenticated caller (legacy included, deliberately — that's who diagnoses deployments): `multitenancyEnabled`, `controlPlaneMounted`, `dbEnforcement` (`legacy`/`enforced`).
- New `packages/api/src/tenancy/server-posture.ts` composes the existing predicates (`isMultitenancyEnabled`, `resolveEnforcementMode`) — same per-call env reads as the mount site and the boot warning, **no DB queries**.
- Nothing tenant-enumerating; nothing unauthenticated. `routes/health.ts` is untouched, and `public-surface-privacy.test.ts` now pins that the posture field names never appear on `/health`, `/info`, or `/health/consumers` in either world.
- OpenAPI schema extended (`ServerTenancyPostureSchema`); `x-omni-credential-exposure` contract unchanged; route-ownership justification updated.

### SDK
- `types.generated.ts` regenerated offline via `make sdk-generate` (static spec import — no running server needed; clean 24-line additive diff).
- Hand-written `AuthValidateResponse` gains optional `server?: ServerTenancyPosture` — optional because **absence is the old-server signal**.

### CLI
- `omni status` and `omni auth status` render `serverMultitenancy`, `serverControlPlane`, `serverDbEnforcement` via `serverPostureFields`, a sibling of `credentialStatusFields` with the same empty-object contract: a server that reports no posture adds **nothing**, so output against an old server stays field-for-field identical (G4-style pinning test added). `tenancyWarning` appears exactly in the advisory-only mixed state, mirroring `mixedTenancyStateWarning` semantics. Existing CLI↔server version hint untouched.
- Stretch scope: read-only `omni multitenancy status` (wraps the same authenticated surface; explains an unreported posture instead of inventing defaults).

### Deliberately out of scope
- No `omni multitenancy enable` / cutover execution (receipt-gated, private production authority).
- `omni multitenancy preflight|verify` skipped: they'd need `readEnforcementState()` / backfill readers exposed server-side, i.e. new DB-backed surface beyond what this issue's visibility scope warrants.

## Tests
- All four flag/enforcement combinations render correctly (API route, posture module, CLI), each cross-checked against `mixedTenancyStateWarning` so route and boot warning can never disagree.
- Legacy credential body: exact-equality pinning amended to include only the sanctioned `server` block; 401 bodies unchanged (posture only when authenticated, pinned across all four worlds).
- Old-server CLI output unchanged (empty-projection pinning), SDK passthrough round-trip against a real local HTTP server.
- Health/info/consumers privacy contract extended to forbid posture keys.

## Gates
- `make typecheck` ✅, `make lint` ✅ (zero warnings), `make verify-migrations` ✅ (no migrations).
- API package: 2194 pass / 0 fail (536 skips are the `OMNI_G4_POSTGRES_URL`-gated real-Postgres suites, run via `make test-pg-gate`; `make test-api` needs a live shared DB + `.env` this worktree deliberately lacks, so the suite was run directly with `bun test packages/api/src`).
- CLI package: 596/597 pass with one known-flaky test on first run, clean on rerun. SDK package: 34/34.