### PR TITLE
feat(api): platform credential bootstrap without direct SQL

### DIFF
--- a/docs/deployment/platform-credential-bootstrap.md
+++ b/docs/deployment/platform-credential-bootstrap.md
@@ -1,0 +1,91 @@
+# Platform credential bootstrap
+
+How an operator of a fresh deployment creates the first PLATFORM-class
+credential — the identity used to create tenants and delegate tenant-scoped
+keys — **without direct SQL**. This is the sanctioned path the CLI's god-key
+refusal points at: under `OMNI_DB_ENFORCEMENT=on` no data-plane god key can be
+minted, so platform authority starts here.
+
+## What it creates
+
+One converged triple in the auth plane:
+
+| Row | Purpose |
+|-----|---------|
+| `principals` | Stable operator identity (`--subject`, unique) |
+| `platform_api_keys` | Platform key metadata (`--key-name`, unique) |
+| `auth_credentials` (`credential_class='platform'`) | The hash-lookup index row the API authenticates against |
+
+The rows satisfy every invariant the auth plane checks at resolution time
+(matching key hash, principal, and scopes; no tenant bindings; active status).
+After writing, the command verifies the credential **in-process** through the
+same `AuthBootstrapService` lookup the API uses — no running API is required.
+
+## Usage
+
+Run server-side, wherever the deployment's database is reachable:
+
+```bash
+# Explicit URL (placeholders — substitute your own values):
+bun scripts/bootstrap-platform-credential.ts --url postgres://DB_USER:DB_PASSWORD@DB_HOST:5432/omni
+
+# Or rely on the environment the API itself uses:
+DATABASE_URL=postgres://DB_USER:DB_PASSWORD@DB_HOST:5432/omni \
+  bun scripts/bootstrap-platform-credential.ts
+```
+
+Useful options (see `--help` for all):
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--subject` | `platform-operator` | Principal subject (stable identity) |
+| `--key-name` | `platform-operator` | `platform_api_keys.name` |
+| `--scope` | `platform:*` | Repeatable; scopes carried by the credential |
+| `--rotate` | off | Replace the credential material for the same key |
+| `--acknowledge-legacy-keys` | off | Proceed past the legacy god-key worklist |
+
+The plaintext secret (`omni_sk_...`) is printed **exactly once** to stdout and
+is never stored, logged, or included in the JSON report. Save it immediately —
+recovery is `--rotate`, which invalidates the old secret.
+
+## Idempotency, rotation, drift
+
+- **Re-run = converge.** Running again with the same `--subject`/`--key-name`
+  validates the existing triple and reports `converged`. No duplicate
+  principals, keys, or credentials are ever created; no new secret is printed.
+- **Rotation is explicit.** `--rotate` generates new material for the *same*
+  principal and key row and re-verifies. The previous secret stops resolving
+  immediately.
+- **Drift is fail-closed.** If the stored rows disagree (tampered scopes,
+  missing index row, mismatched hash), the run reports `blocked` with redacted
+  reasons and writes nothing. Fix deliberately — usually with `--rotate`.
+  A key bound to a different principal, or a revoked key, is never rebound or
+  resurrected; choose a new `--key-name` instead.
+
+## Legacy god keys
+
+If the deployment still has legacy `api_keys` rows with the `*` scope or no
+instance restriction, the command surfaces them through the report-only
+classification worklist and **stops** (exit code 2). Those keys require an
+explicit owner + purpose decision; the bootstrap never converts, promotes, or
+revokes them. After reviewing the worklist, either revoke/scope the legacy
+keys or re-run with `--acknowledge-legacy-keys` to proceed while leaving them
+untouched.
+
+## After bootstrapping
+
+Use the platform credential against the platform control plane (for example
+`POST /api/v2/platform/tenants` with an `x-platform-reason` header) to create
+tenants, attach memberships, and issue tenant root keys — the delegation chain
+the enforcement world expects. Day-to-day work should use tenant-scoped keys
+delegated from this credential, not the platform credential itself.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | created / converged / rotated, and in-process verification passed |
+| 1 | usage or connection error |
+| 2 | legacy god-key worklist requires an explicit decision (nothing written) |
+| 3 | blocked: drift or identity conflict (nothing written) |
+| 4 | rows written but in-process verification failed — investigate |

--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,8 @@
         "scripts/test-messaging.ts",
         "scripts/kill-stale-test-daemons.ts",
         "scripts/pg-gate.ts",
-        "scripts/pg-gate-warm.ts"
+        "scripts/pg-gate-warm.ts",
+        "scripts/bootstrap-platform-credential.ts"
       ],
       "project": ["scripts/**/*.ts"],
       "ignore": [

--- a/packages/api/src/services/__tests__/platform-bootstrap-postgres.test.ts
+++ b/packages/api/src/services/__tests__/platform-bootstrap-postgres.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Platform credential bootstrap against real PostgreSQL (issue #980).
+ *
+ * Proves the operator bootstrap path end-to-end on a migrated schema:
+ *   - first run creates principal + `platform_api_keys` + PLATFORM-class
+ *     `auth_credentials`, and the credential resolves through the REAL
+ *     `AuthBootstrapService` lookup (every class-binding invariant holds);
+ *   - a second run converges (no duplicate principals/keys/credentials);
+ *   - explicit rotation replaces the material and kills the old secret;
+ *   - drift/tamper is blocked (fail-closed), never silently repaired;
+ *   - a legacy `*` god key is NEVER auto-promoted into the auth plane;
+ *   - the report carries no secret material.
+ *
+ * Set `OMNI_G3_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type Database, apiKeys, authCredentials, createDbHandle, platformApiKeys, principals } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { eq, sql } from 'drizzle-orm';
+import { generateSecret, hashSecret, secretPrefix } from '../../tenancy/hash';
+import { AuthBootstrapService } from '../auth-bootstrap';
+import { PlatformBootstrapService } from '../platform-bootstrap';
+
+const superUrl = process.env.OMNI_G3_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G3_PSQL_BIN ?? 'psql';
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+const SUBJECT = 'platform-operator';
+const KEY_NAME = 'platform-operator';
+
+postgresDescribe('platform credential bootstrap (real PostgreSQL)', () => {
+  const dbName = `omni_980_bootstrap_${crypto.randomUUID().replaceAll('-', '')}`;
+  let db: Database;
+  let service: PlatformBootstrapService;
+  let authPlane: AuthBootstrapService;
+  const closers: (() => Promise<void>)[] = [];
+
+  beforeAll(() => {
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
+    const handle = createDbHandle({ url: urlFor(superUrl, dbName), maxConnections: 4 });
+    closers.push(() => handle.close().catch(() => undefined));
+    db = handle.db;
+    service = new PlatformBootstrapService(db);
+    authPlane = new AuthBootstrapService(db);
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+    const admin = createDbHandle({ url: superUrl, maxConnections: 1 });
+    await admin.db.execute(sql.raw(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`));
+    await admin.close();
+  });
+
+  let firstSecret = '';
+
+  test('first run creates the full platform triple and passes real auth resolution', async () => {
+    const { report, secret } = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME });
+
+    expect(report.status).toBe('created');
+    expect(secret).toStartWith('omni_sk_');
+    expect(report.verification).toEqual({ attempted: true, ok: true, credentialClass: 'platform' });
+    expect(report.principal?.created).toBe(true);
+    firstSecret = secret ?? '';
+
+    // The credential resolves through the production auth path.
+    const resolved = await authPlane.lookupBySecret(firstSecret, 'req-bootstrap-1');
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) throw new Error('unreachable');
+    expect(resolved.context.credentialClass).toBe('platform');
+    expect([...resolved.context.scopes]).toEqual(['platform:*']);
+
+    // Every resolvePlatformContext class-binding invariant holds on the rows.
+    const [credential] = await db
+      .select()
+      .from(authCredentials)
+      .where(eq(authCredentials.keyHash, await hashSecret(firstSecret)));
+    expect(credential?.credentialClass).toBe('platform');
+    expect(credential?.tenantId).toBeNull();
+    expect(credential?.membershipId).toBeNull();
+    expect(credential?.tenantKeyLineageId).toBeNull();
+    expect(credential?.actorRole).toBeNull();
+    expect(credential?.platformApiKeyId).not.toBeNull();
+    const [key] = await db.select().from(platformApiKeys).where(eq(platformApiKeys.name, KEY_NAME));
+    expect(key?.keyHash).toBe(credential?.keyHash ?? '');
+    expect(key?.principalId).toBe(credential?.principalId ?? '');
+    expect(key?.scopes).toEqual([...(credential?.scopes ?? [])]);
+  });
+
+  test('the report carries no secret material', async () => {
+    const { report, secret } = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME });
+    const serialized = JSON.stringify(report);
+    expect(secret).toBeNull(); // converged run — nothing to leak anyway
+    expect(serialized).not.toContain(firstSecret);
+    expect(serialized).not.toContain(await hashSecret(firstSecret));
+    // No full credential shape anywhere (the 8-char display prefix is allowed).
+    expect(serialized).not.toMatch(/omni_sk_[A-Za-z0-9]{9,}/);
+  });
+
+  test('a second run converges: no duplicate principals, keys, or credentials', async () => {
+    const { report, secret } = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME });
+
+    expect(report.status).toBe('converged');
+    expect(secret).toBeNull();
+    expect(report.verification.ok).toBe(true);
+
+    expect(await db.select().from(principals).where(eq(principals.subject, SUBJECT))).toHaveLength(1);
+    expect(await db.select().from(platformApiKeys).where(eq(platformApiKeys.name, KEY_NAME))).toHaveLength(1);
+    expect(await db.select().from(authCredentials).where(eq(authCredentials.credentialClass, 'platform'))).toHaveLength(
+      1,
+    );
+
+    // The original secret still resolves — convergence rotated nothing.
+    const resolved = await authPlane.lookupBySecret(firstSecret, 'req-bootstrap-2');
+    expect(resolved.ok).toBe(true);
+  });
+
+  test('a legacy `*` god key is never promoted into the auth plane', async () => {
+    const legacySecret = generateSecret();
+    const legacyHash = await hashSecret(legacySecret);
+    await db.insert(apiKeys).values({
+      name: 'legacy-god-key',
+      keyPrefix: secretPrefix(legacySecret),
+      keyHash: legacyHash,
+      scopes: ['*'],
+    });
+
+    const { report } = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME });
+    expect(report.status).toBe('converged');
+
+    // The legacy key did not become a platform credential.
+    expect(await db.select().from(authCredentials).where(eq(authCredentials.keyHash, legacyHash))).toHaveLength(0);
+    const resolved = await authPlane.lookupBySecret(legacySecret, 'req-bootstrap-legacy');
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) throw new Error('unreachable');
+    expect(resolved.reason).toBe('not_found');
+  });
+
+  test('tampered credential state is blocked without --rotate, never silently repaired', async () => {
+    await db
+      .update(authCredentials)
+      .set({ scopes: ['platform:tenants:read'] })
+      .where(eq(authCredentials.credentialClass, 'platform'));
+
+    const { report, secret } = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME });
+    expect(report.status).toBe('blocked');
+    expect(secret).toBeNull();
+    expect(report.reasons.join(' ')).toContain('--rotate');
+
+    // Nothing was repaired behind the operator's back.
+    const [credential] = await db.select().from(authCredentials).where(eq(authCredentials.credentialClass, 'platform'));
+    expect(credential?.scopes).toEqual(['platform:tenants:read']);
+  });
+
+  test('explicit rotation replaces the material and kills the old secret', async () => {
+    const { report, secret } = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME, rotate: true });
+
+    expect(report.status).toBe('rotated');
+    expect(secret).toStartWith('omni_sk_');
+    expect(secret).not.toBe(firstSecret);
+    expect(report.verification.ok).toBe(true);
+
+    const oldResolved = await authPlane.lookupBySecret(firstSecret, 'req-bootstrap-old');
+    expect(oldResolved.ok).toBe(false);
+    const newResolved = await authPlane.lookupBySecret(secret ?? '', 'req-bootstrap-new');
+    expect(newResolved.ok).toBe(true);
+    if (!newResolved.ok) throw new Error('unreachable');
+    expect([...newResolved.context.scopes]).toEqual(['platform:*']);
+
+    // Still exactly one of everything.
+    expect(await db.select().from(principals).where(eq(principals.subject, SUBJECT))).toHaveLength(1);
+    expect(await db.select().from(platformApiKeys).where(eq(platformApiKeys.name, KEY_NAME))).toHaveLength(1);
+    expect(await db.select().from(authCredentials).where(eq(authCredentials.credentialClass, 'platform'))).toHaveLength(
+      1,
+    );
+    firstSecret = secret ?? '';
+  });
+
+  test('a key name bound to a different principal is blocked and rolls back everything', async () => {
+    const { report, secret } = await service.bootstrap({ subject: 'other-operator', keyName: KEY_NAME });
+    expect(report.status).toBe('blocked');
+    expect(secret).toBeNull();
+    expect(report.reasons.join(' ')).toContain('different principal');
+
+    // The blocked run wrote nothing — not even the new principal.
+    expect(await db.select().from(principals).where(eq(principals.subject, 'other-operator'))).toHaveLength(0);
+  });
+
+  test('a disabled principal is blocked — re-enabling is not a bootstrap side effect', async () => {
+    await db
+      .insert(principals)
+      .values({ type: 'service', subject: 'disabled-operator', status: 'disabled', disabledAt: new Date() });
+
+    const { report } = await service.bootstrap({ subject: 'disabled-operator', keyName: 'disabled-operator-key' });
+    expect(report.status).toBe('blocked');
+    expect(report.reasons.join(' ')).toContain('disabled');
+    expect(
+      await db.select().from(platformApiKeys).where(eq(platformApiKeys.name, 'disabled-operator-key')),
+    ).toHaveLength(0);
+  });
+
+  test('an expired key blocks convergence but rotates explicitly (expiry reset)', async () => {
+    await db
+      .update(platformApiKeys)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(platformApiKeys.name, KEY_NAME));
+
+    const blocked = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME });
+    expect(blocked.report.status).toBe('blocked');
+    expect(blocked.report.reasons.join(' ')).toContain('expired');
+
+    const rotated = await service.bootstrap({ subject: SUBJECT, keyName: KEY_NAME, rotate: true });
+    expect(rotated.report.status).toBe('rotated');
+    expect(rotated.report.verification.ok).toBe(true);
+    const [key] = await db.select().from(platformApiKeys).where(eq(platformApiKeys.name, KEY_NAME));
+    expect(key?.expiresAt).toBeNull();
+  });
+});

--- a/packages/api/src/services/platform-bootstrap.ts
+++ b/packages/api/src/services/platform-bootstrap.ts
@@ -1,0 +1,450 @@
+/**
+ * Platform credential bootstrap (issue #980; split from #908 acceptance
+ * criterion 1: "a fresh supported deployment can bootstrap one platform
+ * operator without direct SQL").
+ *
+ * The ONLY production code path that mints a PLATFORM-class credential. It is
+ * a server-side operator action (`scripts/bootstrap-platform-credential.ts`),
+ * never an HTTP surface: it must be runnable before any API credential exists,
+ * and no HTTP route may ever mint platform authority (mirrors the CLI's
+ * god-key refusal under enforcement).
+ *
+ * Contract:
+ *   - Idempotent. A re-run with the same subject + key name CONVERGES: it
+ *     validates the existing principal / `platform_api_keys` / `auth_credentials`
+ *     triple against every invariant `AuthBootstrapService.resolvePlatformContext`
+ *     checks and reports `converged` without touching anything.
+ *   - Explicit rotation only. `rotate: true` replaces the credential material
+ *     for the SAME principal + key row; nothing rotates implicitly.
+ *   - Fail-closed on drift. A mismatched or tampered triple is reported as
+ *     `blocked` with redacted reasons — never silently repaired, rebound to a
+ *     different principal, or un-revoked.
+ *   - Secret-once. The plaintext is returned separately from the report and is
+ *     never logged or embedded in the report; only the display prefix is.
+ *   - Never touches legacy `api_keys`. Legacy god-key handling is a REPORT-ONLY
+ *     concern of the operator entrypoint (G6 classifier); nothing here converts
+ *     or revokes a legacy key.
+ *
+ * Verification is in-process: after any write (and on convergence) the
+ * credential is resolved through the real `AuthBootstrapService` lookup, so a
+ * bootstrap only reports success when the exact production auth path accepts
+ * the credential. No running API is required.
+ */
+
+import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import {
+  type AuthCredential,
+  type PlatformApiKey,
+  type Principal,
+  authCredentials,
+  platformApiKeys,
+  principals,
+} from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { generateSecret, hashSecret, secretPrefix } from '../tenancy/hash';
+import { AuthBootstrapService } from './auth-bootstrap';
+
+const log = createLogger('platform-bootstrap');
+
+// ============================================================================
+// Options (Zod-validated boundary — the script passes raw CLI input through)
+// ============================================================================
+
+export const PlatformBootstrapOptionsSchema = z.object({
+  /** Stable principal subject (unique). E.g. `platform-operator`. */
+  subject: z.string().min(1).max(255),
+  /** Unique `platform_api_keys.name` for this credential. */
+  keyName: z.string().min(1).max(255),
+  /** Display name applied when the principal is created. */
+  displayName: z.string().min(1).max(255).optional(),
+  /** Principal type when created. Operator bootstrap defaults to `service`. */
+  principalType: z.enum(['human', 'service']).default('service'),
+  /**
+   * Platform scopes carried by the credential. `platform:*` covers every
+   * current platform control-plane route without granting the data-plane `*`.
+   */
+  scopes: z.array(z.string().min(1)).nonempty().default(['platform:*']),
+  /** Replace the credential material for the same principal + key row. */
+  rotate: z.boolean().default(false),
+  /** Optional `platform_api_keys.description`. */
+  description: z.string().max(2000).optional(),
+});
+
+export type PlatformBootstrapOptions = z.input<typeof PlatformBootstrapOptionsSchema>;
+type ResolvedOptions = z.output<typeof PlatformBootstrapOptionsSchema>;
+
+// ============================================================================
+// Report — NEVER carries secret material (the entrypoint redaction-scans it)
+// ============================================================================
+
+export type PlatformBootstrapStatus = 'created' | 'converged' | 'rotated' | 'blocked';
+
+export interface PlatformBootstrapReport {
+  status: PlatformBootstrapStatus;
+  /** Redacted, human-readable reasons. Populated only when `blocked`. */
+  reasons: string[];
+  principal: { id: string; subject: string; type: string; status: string; created: boolean } | null;
+  platformApiKey: { id: string; name: string; keyPrefix: string; scopes: string[]; status: string } | null;
+  credentialId: string | null;
+  /** In-process resolution through the real AuthBootstrapService lookup. */
+  verification: { attempted: boolean; ok: boolean; credentialClass?: string; failureReason?: string };
+}
+
+export interface PlatformBootstrapResult {
+  report: PlatformBootstrapReport;
+  /**
+   * Plaintext credential — present ONLY for `created` / `rotated`. The caller
+   * prints it exactly once and must never log or persist it.
+   */
+  secret: string | null;
+}
+
+/** Internal: aborts the transaction so a blocked run writes NOTHING. */
+class BootstrapBlocked extends Error {
+  constructor(readonly reasons: string[]) {
+    super(`platform bootstrap blocked: ${reasons.join('; ')}`);
+    this.name = 'BootstrapBlocked';
+  }
+}
+
+type Tx = Parameters<Parameters<Database['transaction']>[0]>[0];
+
+interface WriteOutcome {
+  status: 'created' | 'converged' | 'rotated';
+  principal: Principal;
+  principalCreated: boolean;
+  key: PlatformApiKey;
+  credentialId: string;
+  /** Only for created/rotated. */
+  secret: string | null;
+  /** Hash to verify with when no plaintext exists (converged). */
+  keyHash: string;
+}
+
+// ============================================================================
+// Drift checks — every invariant resolvePlatformContext enforces, plus intent
+// ============================================================================
+
+function sameScopeSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+/** Redacted drift reasons between the key row, the credential row, and intent. */
+function credentialDriftReasons(
+  key: PlatformApiKey,
+  credential: AuthCredential | undefined,
+  options: ResolvedOptions,
+): string[] {
+  const reasons: string[] = [];
+  if (!sameScopeSet(key.scopes, options.scopes)) {
+    reasons.push('platform_api_keys.scopes differ from the requested scopes');
+  }
+  if (!credential) {
+    reasons.push('no auth_credentials row is bound to this platform key');
+    return reasons;
+  }
+  if (credential.credentialClass !== 'platform') reasons.push('auth_credentials row is not platform-class');
+  if (credential.keyHash !== key.keyHash) {
+    reasons.push('auth_credentials.key_hash does not match platform_api_keys.key_hash');
+  }
+  if (credential.keyPrefix !== key.keyPrefix) {
+    reasons.push('auth_credentials.key_prefix does not match platform_api_keys.key_prefix');
+  }
+  if (credential.principalId !== key.principalId) {
+    reasons.push('auth_credentials.principal_id does not match platform_api_keys.principal_id');
+  }
+  if (!sameScopeSet(credential.scopes, key.scopes)) {
+    reasons.push('auth_credentials.scopes do not match platform_api_keys.scopes');
+  }
+  if (credential.tenantId || credential.membershipId || credential.tenantKeyLineageId || credential.actorRole) {
+    reasons.push('auth_credentials row carries tenant-class bindings');
+  }
+  if (credential.status !== 'active' || credential.revokedAt) {
+    reasons.push('auth_credentials row is not active');
+  }
+  if (credential.expiresAt && credential.expiresAt.getTime() <= Date.now()) {
+    reasons.push('auth_credentials row is expired');
+  }
+  return reasons;
+}
+
+// ============================================================================
+// Service
+// ============================================================================
+
+export class PlatformBootstrapService {
+  constructor(private db: Database) {}
+
+  /**
+   * Create, validate, or rotate the platform operator credential. See the
+   * module contract above. All writes happen in ONE transaction; a blocked
+   * outcome rolls back everything (including a just-created principal).
+   */
+  async bootstrap(rawOptions: PlatformBootstrapOptions): Promise<PlatformBootstrapResult> {
+    const options = PlatformBootstrapOptionsSchema.parse(rawOptions);
+
+    let outcome: WriteOutcome;
+    try {
+      outcome = await this.db.transaction(async (tx) => this.converge(tx, options));
+    } catch (error) {
+      if (error instanceof BootstrapBlocked) {
+        return {
+          report: {
+            status: 'blocked',
+            reasons: error.reasons,
+            principal: null,
+            platformApiKey: null,
+            credentialId: null,
+            verification: { attempted: false, ok: false },
+          },
+          secret: null,
+        };
+      }
+      throw error;
+    }
+
+    const verification = await this.verify(outcome);
+    log.info('platform bootstrap finished', {
+      status: outcome.status,
+      subject: options.subject,
+      keyName: options.keyName,
+      verified: verification.ok,
+    });
+
+    return {
+      report: {
+        status: outcome.status,
+        reasons: [],
+        principal: {
+          id: outcome.principal.id,
+          subject: outcome.principal.subject,
+          type: outcome.principal.type,
+          status: outcome.principal.status,
+          created: outcome.principalCreated,
+        },
+        platformApiKey: {
+          id: outcome.key.id,
+          name: outcome.key.name,
+          keyPrefix: outcome.key.keyPrefix,
+          scopes: [...outcome.key.scopes],
+          status: outcome.key.status,
+        },
+        credentialId: outcome.credentialId,
+        verification,
+      },
+      secret: outcome.secret,
+    };
+  }
+
+  /** Resolve the credential through the REAL auth path (in-process). */
+  private async verify(outcome: WriteOutcome): Promise<PlatformBootstrapReport['verification']> {
+    const bootstrap = new AuthBootstrapService(this.db);
+    const requestId = `platform-bootstrap-${crypto.randomUUID()}`;
+    const result = outcome.secret
+      ? await bootstrap.lookupBySecret(outcome.secret, requestId)
+      : await bootstrap.lookupBySecretHash(outcome.keyHash, requestId);
+    if (!result.ok) return { attempted: true, ok: false, failureReason: result.reason };
+    if (result.context.credentialClass !== 'platform') {
+      return { attempted: true, ok: false, failureReason: 'resolved_non_platform_class' };
+    }
+    return { attempted: true, ok: true, credentialClass: result.context.credentialClass };
+  }
+
+  private async converge(tx: Tx, options: ResolvedOptions): Promise<WriteOutcome> {
+    const { principal, created: principalCreated } = await this.ensurePrincipal(tx, options);
+
+    const [existingKey] = await tx
+      .select()
+      .from(platformApiKeys)
+      .where(eq(platformApiKeys.name, options.keyName))
+      .limit(1)
+      .for('update');
+
+    if (!existingKey) {
+      const fresh = await this.createCredential(tx, principal, options);
+      return { ...fresh, principal, principalCreated, status: 'created' };
+    }
+
+    // Fail-closed identity checks — never rebind, never resurrect.
+    if (existingKey.principalId !== principal.id) {
+      throw new BootstrapBlocked([
+        `platform key name '${options.keyName}' is already bound to a different principal — choose a different --key-name; bootstrap never rebinds credentials`,
+      ]);
+    }
+    if (existingKey.status !== 'active' || existingKey.revokedAt) {
+      throw new BootstrapBlocked([
+        `platform key '${options.keyName}' is revoked — revocation is permanent; issue a new key under a new name`,
+      ]);
+    }
+    const [credential] = await tx
+      .select()
+      .from(authCredentials)
+      .where(eq(authCredentials.platformApiKeyId, existingKey.id))
+      .limit(1);
+
+    // Explicit rotation is the sanctioned recovery path: it replaces the
+    // material (and resets expiry) for the same principal + key row.
+    if (options.rotate) {
+      const rotated = await this.rotateCredential(tx, existingKey, credential, principal, options);
+      return { ...rotated, principal, principalCreated, status: 'rotated' };
+    }
+
+    if (existingKey.expiresAt && existingKey.expiresAt.getTime() <= Date.now()) {
+      throw new BootstrapBlocked([`platform key '${options.keyName}' is expired — rotate it explicitly with --rotate`]);
+    }
+
+    const drift = credentialDriftReasons(existingKey, credential, options);
+    if (drift.length > 0 || !credential) {
+      throw new BootstrapBlocked([
+        ...drift,
+        'existing credential state does not converge — re-run with --rotate to replace the credential material',
+      ]);
+    }
+
+    return {
+      status: 'converged',
+      principal,
+      principalCreated,
+      key: existingKey,
+      credentialId: credential.id,
+      secret: null,
+      keyHash: existingKey.keyHash,
+    };
+  }
+
+  private async ensurePrincipal(tx: Tx, options: ResolvedOptions): Promise<{ principal: Principal; created: boolean }> {
+    const [existing] = await tx
+      .select()
+      .from(principals)
+      .where(eq(principals.subject, options.subject))
+      .limit(1)
+      .for('update');
+    if (existing) {
+      if (existing.status !== 'active') {
+        throw new BootstrapBlocked([
+          `principal '${options.subject}' exists but is disabled — re-enabling is a deliberate operator action, not a bootstrap side effect`,
+        ]);
+      }
+      return { principal: existing, created: false };
+    }
+    const [inserted] = await tx
+      .insert(principals)
+      .values({
+        type: options.principalType,
+        subject: options.subject,
+        displayName: options.displayName ?? options.subject,
+        status: 'active',
+      })
+      .returning();
+    if (!inserted) throw new Error('failed to create platform principal');
+    return { principal: inserted, created: true };
+  }
+
+  private async createCredential(
+    tx: Tx,
+    principal: Principal,
+    options: ResolvedOptions,
+  ): Promise<Pick<WriteOutcome, 'key' | 'credentialId' | 'secret' | 'keyHash'>> {
+    const secret = generateSecret();
+    const keyHash = await hashSecret(secret);
+    const keyPrefix = secretPrefix(secret);
+
+    const [key] = await tx
+      .insert(platformApiKeys)
+      .values({
+        name: options.keyName,
+        description: options.description ?? null,
+        keyPrefix,
+        keyHash,
+        scopes: options.scopes,
+        status: 'active',
+        principalId: principal.id,
+      })
+      .returning();
+    if (!key) throw new Error('failed to create platform_api_keys row');
+
+    const [credential] = await tx
+      .insert(authCredentials)
+      .values({
+        credentialClass: 'platform',
+        keyHash,
+        keyPrefix,
+        tenantId: null,
+        principalId: principal.id,
+        membershipId: null,
+        actorRole: null,
+        scopes: options.scopes,
+        status: 'active',
+        tenantKeyLineageId: null,
+        platformApiKeyId: key.id,
+      })
+      .returning();
+    if (!credential) throw new Error('failed to create platform auth_credentials row');
+
+    return { key, credentialId: credential.id, secret, keyHash };
+  }
+
+  private async rotateCredential(
+    tx: Tx,
+    existingKey: PlatformApiKey,
+    credential: AuthCredential | undefined,
+    principal: Principal,
+    options: ResolvedOptions,
+  ): Promise<Pick<WriteOutcome, 'key' | 'credentialId' | 'secret' | 'keyHash'>> {
+    const secret = generateSecret();
+    const keyHash = await hashSecret(secret);
+    const keyPrefix = secretPrefix(secret);
+    const now = new Date();
+
+    const [key] = await tx
+      .update(platformApiKeys)
+      .set({ keyHash, keyPrefix, scopes: options.scopes, expiresAt: null, updatedAt: now })
+      .where(eq(platformApiKeys.id, existingKey.id))
+      .returning();
+    if (!key) throw new Error('failed to rotate platform_api_keys row');
+
+    if (credential) {
+      const [updated] = await tx
+        .update(authCredentials)
+        .set({
+          keyHash,
+          keyPrefix,
+          scopes: options.scopes,
+          status: 'active',
+          expiresAt: null,
+          revokedAt: null,
+          updatedAt: now,
+        })
+        .where(eq(authCredentials.id, credential.id))
+        .returning();
+      if (!updated) throw new Error('failed to rotate platform auth_credentials row');
+      return { key, credentialId: updated.id, secret, keyHash };
+    }
+
+    // Recovery: the index row was lost/never written — recreate it bound to the
+    // same key + principal, with the freshly rotated material.
+    const [inserted] = await tx
+      .insert(authCredentials)
+      .values({
+        credentialClass: 'platform',
+        keyHash,
+        keyPrefix,
+        tenantId: null,
+        principalId: principal.id,
+        membershipId: null,
+        actorRole: null,
+        scopes: options.scopes,
+        status: 'active',
+        tenantKeyLineageId: null,
+        platformApiKeyId: key.id,
+      })
+      .returning();
+    if (!inserted) throw new Error('failed to recreate platform auth_credentials row');
+    return { key, credentialId: inserted.id, secret, keyHash };
+  }
+}

--- a/packages/db/src/backfill/legacy-key-gate.test.ts
+++ b/packages/db/src/backfill/legacy-key-gate.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Legacy god-key gate for the platform bootstrap (issue #980). Pure — the
+ * classifier's SQL read is stubbed with fixture rows; no server.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ToolingSql } from './db';
+import { auditLegacyKeysForBootstrap } from './legacy-key-gate';
+
+interface FixtureRow {
+  id: string;
+  name: string;
+  key_prefix: string;
+  scopes: string[] | null;
+  instance_ids: string[] | null;
+  instance_allowlist: string[] | null;
+  status: string;
+}
+
+function stubSql(rows: FixtureRow[]): ToolingSql {
+  return { unsafe: async () => rows } as unknown as ToolingSql;
+}
+
+function row(over: Partial<FixtureRow>): FixtureRow {
+  return {
+    id: crypto.randomUUID(),
+    name: 'legacy-key',
+    key_prefix: 'abcdefgh',
+    scopes: ['messages:read'],
+    instance_ids: ['aaaaaaaa-0000-4000-8000-0000000000a1'],
+    instance_allowlist: null,
+    status: 'active',
+    ...over,
+  };
+}
+
+describe('legacy god-key gate (platform bootstrap)', () => {
+  test('an active `*` god key requires an explicit decision — never auto-classified as platform', async () => {
+    const report = await auditLegacyKeysForBootstrap(stubSql([row({ scopes: ['*'], instance_ids: null })]));
+    expect(report.requiresExplicitDecision).toBe(true);
+    expect(report.godKeyWorklist).toHaveLength(1);
+    expect(report.godKeyWorklist[0]?.classification).toBe('platform-credential');
+    expect(report.godKeyWorklist[0]?.requiresOwnerAndPurpose).toBe(true);
+  });
+
+  test('an unrestricted key (no instance restriction) is on the worklist too', async () => {
+    const report = await auditLegacyKeysForBootstrap(
+      stubSql([row({ scopes: ['messages:read'], instance_ids: null, instance_allowlist: null })]),
+    );
+    expect(report.requiresExplicitDecision).toBe(true);
+  });
+
+  test('a revoked god key does not block the bootstrap', async () => {
+    const report = await auditLegacyKeysForBootstrap(
+      stubSql([row({ scopes: ['*'], instance_ids: null, status: 'revoked' })]),
+    );
+    expect(report.requiresExplicitDecision).toBe(false);
+    expect(report.godKeyWorklist).toHaveLength(0);
+    // The classifier still counted it — only the ACTIVE worklist gates.
+    expect(report.counts['platform-credential']).toBe(1);
+  });
+
+  test('restricted keys do not require a decision', async () => {
+    const report = await auditLegacyKeysForBootstrap(stubSql([row({})]));
+    expect(report.requiresExplicitDecision).toBe(false);
+    expect(report.totalLegacyKeys).toBe(1);
+  });
+
+  test('the gate report never carries hash or secret material', async () => {
+    const report = await auditLegacyKeysForBootstrap(stubSql([row({ scopes: ['*'], instance_ids: null })]));
+    expect(JSON.stringify(report)).not.toMatch(/hash|omni_sk_[A-Za-z0-9]{9,}/i);
+  });
+});

--- a/packages/db/src/backfill/legacy-key-gate.ts
+++ b/packages/db/src/backfill/legacy-key-gate.ts
@@ -1,0 +1,63 @@
+/**
+ * Legacy god-key gate for the platform-credential bootstrap (issue #980).
+ *
+ * A thin, REPORT-ONLY composition over the G6 legacy-key classifier: before an
+ * operator mints the first PLATFORM-class credential, any legacy `api_keys`
+ * rows that classify as `platform-credential` (unrestricted / god scope `*`)
+ * are surfaced as a worklist that requires an EXPLICIT operator decision. This
+ * module never mutates, mints, converts, or revokes anything — exactly like
+ * `key-classification.ts` it wraps.
+ *
+ * Tooling-only, like every module in this directory: imported by direct path
+ * from `scripts/bootstrap-platform-credential.ts` and tests, never barrelled
+ * through `@omni/db` and never imported by runtime code
+ * (see `runtime-isolation.test.ts`).
+ */
+
+import type { ToolingSql } from './db';
+import { type KeyClass, type KeyClassification, classifyLegacyKeys } from './key-classification';
+import type { InstanceTenantMap } from './mapping-engine';
+import { assertNoSecrets } from './redaction';
+
+export interface LegacyKeyGateReport {
+  /** Total legacy `api_keys` rows inspected. */
+  totalLegacyKeys: number;
+  /** Classification counts across all legacy keys. */
+  counts: Record<KeyClass, number>;
+  /**
+   * ACTIVE keys classified `platform-credential` (god scope `*` or no instance
+   * restriction). Each requires an explicit owner + purpose decision before it
+   * may ever move classes — the bootstrap NEVER converts one automatically.
+   */
+  godKeyWorklist: KeyClassification[];
+  /**
+   * True when active god keys exist: the bootstrap entrypoint stops and
+   * requires the operator to explicitly acknowledge the worklist before
+   * proceeding (proceeding still converts nothing).
+   */
+  requiresExplicitDecision: boolean;
+}
+
+/**
+ * Classify legacy keys and extract the god-key worklist. Pass the operator
+ * instance->tenant map when one exists; the default empty map is safe for the
+ * god-key gate because unrestricted/god keys classify `platform-credential`
+ * regardless of any mapping.
+ */
+export async function auditLegacyKeysForBootstrap(
+  sql: ToolingSql,
+  instanceMap: InstanceTenantMap = new Map(),
+): Promise<LegacyKeyGateReport> {
+  const classification = await classifyLegacyKeys(sql, instanceMap);
+  const godKeyWorklist = classification.keys.filter(
+    (key) => key.classification === 'platform-credential' && key.status === 'active',
+  );
+  const report: LegacyKeyGateReport = {
+    totalLegacyKeys: classification.keys.length,
+    counts: classification.counts,
+    godKeyWorklist,
+    requiresExplicitDecision: godKeyWorklist.length > 0,
+  };
+  assertNoSecrets(report, 'legacy key gate report');
+  return report;
+}

--- a/scripts/bootstrap-platform-credential.ts
+++ b/scripts/bootstrap-platform-credential.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+/**
+ * Platform credential bootstrap — operator entrypoint (issue #980).
+ *
+ * Creates (or validates / rotates) the ONE platform operator identity a fresh
+ * deployment needs: an active principal, a `platform_api_keys` row, and its
+ * PLATFORM-class `auth_credentials` index row — satisfying every invariant
+ * `AuthBootstrapService.resolvePlatformContext` checks. Runs server-side
+ * against the database directly, so it works before any API credential exists
+ * and does not require a running API (verification resolves the credential
+ * through the real in-process auth path).
+ *
+ * Safety properties:
+ *   - Idempotent: a re-run with the same --subject/--key-name converges.
+ *   - Rotation is explicit (--rotate); drift is reported, never auto-repaired.
+ *   - Legacy god keys (`*` scope / unrestricted `api_keys`) are surfaced via
+ *     the G6 report-only classifier and require --acknowledge-legacy-keys to
+ *     proceed. NOTHING is ever converted or revoked.
+ *   - The plaintext secret is printed exactly ONCE to stdout, never logged,
+ *     and never part of the JSON report (which is redaction-scanned).
+ *
+ * Usage:
+ *   bun scripts/bootstrap-platform-credential.ts --url postgres://USER:PASSWORD@DB_HOST:5432/omni
+ *   bun scripts/bootstrap-platform-credential.ts                # uses DATABASE_URL
+ *   bun scripts/bootstrap-platform-credential.ts --rotate       # replace credential material
+ *   bun scripts/bootstrap-platform-credential.ts --acknowledge-legacy-keys
+ *
+ * Exit codes: 0 success (created/converged/rotated + verified), 1 usage/error,
+ * 2 legacy god-key worklist requires a decision, 3 blocked (drift/conflict),
+ * 4 credential written but failed in-process verification.
+ */
+
+import { parseArgs } from 'node:util';
+import { z } from 'zod';
+import { PlatformBootstrapService } from '../packages/api/src/services/platform-bootstrap';
+import type { ToolingSql } from '../packages/db/src/backfill/db';
+import { auditLegacyKeysForBootstrap } from '../packages/db/src/backfill/legacy-key-gate';
+import { assertNoSecrets } from '../packages/db/src/backfill/redaction';
+import { createDbHandle, createPostgresClient } from '../packages/db/src/client';
+
+const USAGE = `Usage: bun scripts/bootstrap-platform-credential.ts [options]
+
+Options:
+  --url <postgres-url>        Database URL (defaults to DATABASE_URL)
+  --subject <subject>         Principal subject (default: platform-operator)
+  --key-name <name>           platform_api_keys name (default: platform-operator)
+  --display-name <name>       Display name when creating the principal
+  --principal-type <type>     human | service (default: service)
+  --scope <scope>             Credential scope, repeatable (default: platform:*)
+  --description <text>        Optional platform key description
+  --rotate                    Replace the credential material for the same key
+  --acknowledge-legacy-keys   Proceed despite an unclassified legacy god-key
+                              worklist (converts NOTHING; the worklist remains)
+  --help                      Show this help
+`;
+
+const ArgsSchema = z.object({
+  url: z.string().url(),
+  subject: z.string().min(1),
+  keyName: z.string().min(1),
+  displayName: z.string().min(1).optional(),
+  principalType: z.enum(['human', 'service']),
+  scopes: z.array(z.string().min(1)).nonempty(),
+  description: z.string().optional(),
+  rotate: z.boolean(),
+  acknowledgeLegacyKeys: z.boolean(),
+});
+
+function parseCliArgs(argv: string[]): z.infer<typeof ArgsSchema> | null {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      url: { type: 'string' },
+      subject: { type: 'string', default: 'platform-operator' },
+      'key-name': { type: 'string', default: 'platform-operator' },
+      'display-name': { type: 'string' },
+      'principal-type': { type: 'string', default: 'service' },
+      scope: { type: 'string', multiple: true },
+      description: { type: 'string' },
+      rotate: { type: 'boolean', default: false },
+      'acknowledge-legacy-keys': { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+  });
+  if (values.help) {
+    process.stdout.write(USAGE);
+    return null;
+  }
+  const url = values.url ?? process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error('no database target: pass --url or set DATABASE_URL');
+  }
+  return ArgsSchema.parse({
+    url,
+    subject: values.subject,
+    keyName: values['key-name'],
+    displayName: values['display-name'],
+    principalType: values['principal-type'],
+    scopes: values.scope && values.scope.length > 0 ? values.scope : ['platform:*'],
+    description: values.description,
+    rotate: values.rotate,
+    acknowledgeLegacyKeys: values['acknowledge-legacy-keys'],
+  });
+}
+
+/** Display form of the target with credentials stripped. */
+function describeTarget(url: string): string {
+  const parsed = new URL(url);
+  return `${parsed.hostname}:${parsed.port || '5432'}${parsed.pathname}`;
+}
+
+async function main(): Promise<number> {
+  const args = parseCliArgs(process.argv.slice(2));
+  if (!args) return 0;
+
+  process.stdout.write(`platform-bootstrap: target ${describeTarget(args.url)}\n`);
+
+  // Direct client for the report-only legacy-key classifier.
+  const sql = createPostgresClient({ url: args.url, maxConnections: 1 }) as unknown as ToolingSql;
+  const handle = createDbHandle({ url: args.url, maxConnections: 4 });
+  try {
+    // 1. Legacy god-key gate — report-only, requires an explicit decision.
+    const legacyKeys = await auditLegacyKeysForBootstrap(sql);
+    if (legacyKeys.requiresExplicitDecision && !args.acknowledgeLegacyKeys) {
+      process.stdout.write(`${JSON.stringify({ legacyKeys }, null, 2)}\n`);
+      process.stderr.write(
+        `platform-bootstrap: ${legacyKeys.godKeyWorklist.length} active legacy god key(s) (scope '*' or unrestricted) need an explicit owner + purpose classification decision. Nothing was written.\nReview the worklist above, then either revoke/scope those keys or re-run with --acknowledge-legacy-keys to bootstrap anyway (the legacy keys are NEVER converted or revoked).\n`,
+      );
+      return 2;
+    }
+
+    // 2. Converge the platform principal + key + credential triple.
+    const service = new PlatformBootstrapService(handle.db);
+    const { report, secret } = await service.bootstrap({
+      subject: args.subject,
+      keyName: args.keyName,
+      displayName: args.displayName,
+      principalType: args.principalType,
+      scopes: args.scopes,
+      rotate: args.rotate,
+      description: args.description,
+    });
+
+    // 3. Emit the redaction-scanned report (never contains the secret).
+    const fullReport = { bootstrap: report, legacyKeys };
+    assertNoSecrets(fullReport, 'platform bootstrap report');
+    process.stdout.write(`${JSON.stringify(fullReport, null, 2)}\n`);
+
+    if (report.status === 'blocked') {
+      process.stderr.write('platform-bootstrap: blocked — nothing was written. See reasons above.\n');
+      return 3;
+    }
+    if (!report.verification.ok) {
+      process.stderr.write(
+        'platform-bootstrap: credential state was written but FAILED in-process verification — ' +
+          'investigate before using it.\n',
+      );
+      return 4;
+    }
+
+    // 4. Plaintext shown exactly once. Never logged, never stored, not in the report.
+    if (secret) {
+      process.stdout.write(
+        `\nPLATFORM CREDENTIAL SECRET — shown once, never stored or logged. Save it now:\n${secret}\n`,
+      );
+    } else {
+      process.stdout.write('\nConverged: the existing credential is valid. No new secret was generated.\n');
+    }
+    return 0;
+  } finally {
+    await handle.close().catch(() => undefined);
+    await sql.end({ timeout: 5 }).catch(() => undefined);
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((error) => {
+    process.stderr.write(`platform-bootstrap: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes #980

## What

A safe, idempotent operator path that creates the first PLATFORM-class credential — the previously unsatisfiable prerequisite behind the CLI god-key refusal message and #908 acceptance criterion 1 ("a fresh supported deployment can bootstrap one platform operator without direct SQL").

## Design

Server-side command (runnable before any API credential exists, no running API needed), split across the existing boundaries:

- **`packages/api/src/services/platform-bootstrap.ts`** — `PlatformBootstrapService`: single-transaction converge/create/rotate of the `principals` + `platform_api_keys` + `auth_credentials` triple, satisfying every class-binding invariant `AuthBootstrapService.resolvePlatformContext` checks. Verification is in-process through the real `AuthBootstrapService` lookup. Fail-closed: drift/tamper is `blocked` with redacted reasons (never repaired silently), key names are never rebound to another principal, revoked keys are never resurrected, disabled principals are never re-enabled. Rotation is explicit and resets expiry. Zod-validated options; secret returned separately from the report and never logged. Lives on the runtime graph but imports no G6 tooling (runtime-isolation guard stays green).
- **`packages/db/src/backfill/legacy-key-gate.ts`** — report-only wrapper over the existing G6 `key-classification` classifier: surfaces ACTIVE legacy god keys (`*` scope / unrestricted) as a worklist that requires an explicit operator decision. Converts and revokes nothing, ever. Redaction-scanned via `assertNoSecrets`.
- **`scripts/bootstrap-platform-credential.ts`** — operator entrypoint (`bun scripts/bootstrap-platform-credential.ts --url ...`), following the `backfill-agents.ts` script precedent. Runs the god-key gate first (exit 2 without `--acknowledge-legacy-keys`), then converges, redaction-scans the JSON report, and prints the plaintext secret exactly once to stdout.
- **`docs/deployment/platform-credential-bootstrap.md`** — operator doc, generic placeholders only.

No schema changes, no migrations — existing tables only.

## Tests

- `packages/api/src/services/__tests__/platform-bootstrap-postgres.test.ts` (real PostgreSQL, `OMNI_G3_POSTGRES_URL`, gate-discovered): create + real auth resolution + every class-binding invariant, idempotent convergence (no duplicates), rotation (old secret dies), tamper blocked without `--rotate`, legacy `*` key never promoted (`not_found` through the auth plane), blocked runs roll back everything, expired-key recovery via rotate, report secret hygiene.
- `packages/db/src/backfill/legacy-key-gate.test.ts` (pure): god/unrestricted keys require an explicit decision, revoked ones don't gate, no hash/secret material in the report.
- End-to-end script run against a disposable cluster verified created→converged→gate(exit 2)→acknowledge→rotate, secret printed exactly once.

## Gates

- `make typecheck` ✅  `make lint` ✅ (zero warnings)  `make dead-code` ✅
- `make test-pg-gate` ✅ — 317 assertions across 33 suites, 0 skipped (includes the new suite)
- `turbo run test --filter=@omni/api --filter=@omni/db` ✅