### PR TITLE
ci(migration-gate): fall back to the base branch when HEAD^1 is unfetchable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,14 @@ jobs:
         # sequence, monotonic `when`) are base-independent and still run on
         # every event, which catches parallel-PR numbering collisions after
         # auto-merge. Not the same tool as verify-schema-drift.ts (live-DB audit).
+        # HEAD^1 has its own race (#996): if auto-merge lands the PR while this
+        # run is in flight, GitHub deletes refs/pull/N/merge, the deepen fetch
+        # no longer advertises the checked-out merge commit, its parents never
+        # arrive, and `rev-parse HEAD^1` dies — failing the gate on PRs that
+        # touch no migrations (bit PR #991, merged 21s before this step ran).
+        # In that case fall back to the base-branch tip: the run is already
+        # superseded, so re-widening the #977 newer-base window is harmless,
+        # and the base-independent journal checks still run either way.
         env:
           MIGRATION_BASE_BRANCH: ${{ github.base_ref == 'main' && 'dev' || github.base_ref || 'dev' }}
           USE_MERGE_PARENT: ${{ github.event_name == 'pull_request' && github.base_ref != 'main' }}
@@ -143,7 +151,13 @@ jobs:
           bun test scripts/verify-migration-contract.test.ts
           if [ "$USE_MERGE_PARENT" = "true" ]; then
             git fetch --no-tags --deepen=1 origin
-            bun scripts/verify-migration-contract.ts --base "$(git rev-parse HEAD^1)"
+            if BASE=$(git rev-parse --verify -q HEAD^1); then
+              bun scripts/verify-migration-contract.ts --base "$BASE"
+            else
+              echo "::notice::HEAD^1 unresolvable (PR merged mid-run?) — falling back to origin/${MIGRATION_BASE_BRANCH} (#996)"
+              git fetch --no-tags --depth=1 origin "+refs/heads/${MIGRATION_BASE_BRANCH}:refs/remotes/origin/${MIGRATION_BASE_BRANCH}"
+              bun scripts/verify-migration-contract.ts --base "origin/${MIGRATION_BASE_BRANCH}"
+            fi
           else
             git fetch --no-tags --depth=1 origin "+refs/heads/${MIGRATION_BASE_BRANCH}:refs/remotes/origin/${MIGRATION_BASE_BRANCH}"
             bun scripts/verify-migration-contract.ts --base "origin/${MIGRATION_BASE_BRANCH}"


### PR DESCRIPTION
## What

Fixes #996 — the auto-merge race that failed PR #991's Quality Gate in 41s on a diff with zero migration changes.

## Why

On `pull_request` the gate pins its comparison point to `HEAD^1` of GitHub's test merge commit (the race-free base from the #977/#978 fix). But when **auto-merge lands the PR while the run is still in flight**, GitHub deletes `refs/pull/N/merge`; the `--deepen=1` fetch then no longer advertises the checked-out commit, its parents never arrive, and `git rev-parse HEAD^1` dies with `Needed a single revision`. On #991 the timeline was explicit: merged at 19:37:46Z, step failed at 19:38:07Z.

## How

Guard the rev-parse (`--verify -q` inside the `if` condition, safe under `set -e`) and fall back to fetching + comparing against `origin/${MIGRATION_BASE_BRANCH}` — `resolveComparePoint()` in the script already handles a branch ref correctly (merge-base when history allows, tip otherwise). The fallback only re-widens the #977 newer-base window in the case where the PR is *already merged* and the run superseded, so a false pairing complaint there is harmless; the base-independent journal-integrity checks run either way. Comment block updated with the same rationale.

## Validation

- `bunx js-yaml .github/workflows/ci.yml` — parses clean.
- Simulated the step under `set -e` with `rev-parse` forced to fail — takes the fallback branch and exits 0.
- `make verify-migrations` in the worktree — 38 gate self-tests pass, contract OK vs origin/dev.
- Happy path is byte-equivalent to today's behavior (`--base "$BASE"` with the same rev).