### PR TITLE
feat: omni tenants keys issue-root CLI subcommand + SDK issueRoot method

### DIFF
--- a/packages/cli/src/__tests__/sdk-coverage.test.ts
+++ b/packages/cli/src/__tests__/sdk-coverage.test.ts
@@ -314,6 +314,8 @@ const CLI_COMMANDS: Record<string, string> = {
   'platform.tenants.memberships.disable': 'tenants memberships disable <tenant-id> <membership-id> --reason <text>',
   'platform.tenants.memberships.setStatus': 'tenants memberships status <tenant-id> <membership-id> --status --reason',
   'platform.tenants.memberships.setRole': 'tenants memberships role <tenant-id> <membership-id> --role --reason',
+  'platform.tenants.keys.issueRoot':
+    'tenants keys issue-root <tenant-id> --principal --membership --role --name --scopes --expires --rate-limit --budget --reason',
 
   // ============================================================================
   // SYSTEM

--- a/packages/cli/src/commands/__tests__/tenants.test.ts
+++ b/packages/cli/src/commands/__tests__/tenants.test.ts
@@ -12,8 +12,22 @@
  *     legacy-credential dual-world contract — messages pinned verbatim)
  */
 
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { OmniApiError, type OmniClient } from '@omni/sdk';
+
+/**
+ * Every non-throwing output call is recorded so the issue-root tests can
+ * assert WHERE the one-shot plaintext key lands (exactly one `raw` line in
+ * human mode, only inside the `data` payload in JSON mode) and that it never
+ * leaks into success/info/warn messages.
+ */
+const outputCalls: Array<{ fn: string; args: unknown[] }> = [];
+let currentFormat: 'human' | 'json' = 'human';
+const capture =
+  (fn: string) =>
+  (...args: unknown[]): void => {
+    outputCalls.push({ fn, args });
+  };
 
 // `error` throws (instead of printing + process.exit) so tests can assert the
 // exact operator-facing message. Same precedent as history.test.ts.
@@ -21,27 +35,36 @@ mock.module('../../output.js', () => ({
   error: (msg: string): never => {
     throw new Error(msg);
   },
-  success: mock(),
-  info: mock(),
-  warn: mock(),
-  raw: mock(),
-  data: mock(),
-  list: mock(),
-  keyValue: mock(),
-  header: mock(),
-  dim: mock(),
-  tip: mock(),
+  success: capture('success'),
+  info: capture('info'),
+  warn: capture('warn'),
+  raw: capture('raw'),
+  data: capture('data'),
+  list: capture('list'),
+  keyValue: capture('keyValue'),
+  header: capture('header'),
+  dim: capture('dim'),
+  tip: capture('tip'),
   disableColors: mock(),
   areColorsEnabled: () => true,
   setMaxCellWidth: mock(),
-  getCurrentFormat: () => 'human',
+  getCurrentFormat: () => currentFormat,
   flushStdout: () => Promise.resolve(),
 }));
+
+beforeEach(() => {
+  outputCalls.length = 0;
+  currentFormat = 'human';
+});
 
 const { __testables } = await import('../tenants');
 const {
   requireReason,
   renderPlatformError,
+  renderRootKeyError,
+  parseScopes,
+  parseConstraints,
+  handleKeysIssueRoot,
   handleList,
   handleGet,
   handleCreate,
@@ -79,6 +102,37 @@ const membership = {
   createdAt: new Date().toISOString(),
 };
 
+const PLAINTEXT_KEY = 'omni_root_plaintext_shown_once';
+const EXPIRES_AT = new Date(Date.now() + 3600_000).toISOString();
+
+const rootKey = {
+  id: '44444444-4444-4444-8444-444444444444',
+  tenantId: TENANT_ID,
+  principalId: PRINCIPAL_ID,
+  membershipId: MEMBERSHIP_ID,
+  name: 'acme-root',
+  role: 'tenant-owner',
+  scopes: ['messages:send', 'chats:read'],
+  constraints: {},
+  delegationDepth: 0,
+  expiresAt: EXPIRES_AT,
+  rateLimit: 60,
+  budget: 500,
+  plainTextKey: PLAINTEXT_KEY,
+};
+
+const issueRootOptions = {
+  principal: PRINCIPAL_ID,
+  membership: MEMBERSHIP_ID,
+  role: 'tenant-owner',
+  name: 'acme-root',
+  scopes: 'messages:send, chats:read',
+  expires: EXPIRES_AT,
+  rateLimit: 60,
+  budget: 500,
+  reason: 'bootstrap tenant OPS-1421',
+};
+
 interface CapturedCall {
   method: string;
   args: unknown[];
@@ -107,6 +161,9 @@ function makeFakeClient(): { client: OmniClient; calls: CapturedCall[] } {
           disable: record('memberships.disable', membership),
           setStatus: record('memberships.setStatus', { ...membership, status: 'disabled' }),
           setRole: record('memberships.setRole', { ...membership, role: 'tenant-admin' }),
+        },
+        keys: {
+          issueRoot: record('keys.issueRoot', rootKey),
         },
       },
     },
@@ -252,6 +309,124 @@ describe('command → SDK mapping (reason included where each route expects it)'
     ).rejects.toThrow('Invalid --status "paused". Valid statuses: active, disabled');
     expect(calls).toEqual([]);
   });
+
+  test('keys issue-root → platform.tenants.keys.issueRoot(tenantId, body with reason and parsed scopes)', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleKeysIssueRoot(client, TENANT_ID, { ...issueRootOptions });
+    expect(calls).toEqual([
+      {
+        method: 'keys.issueRoot',
+        args: [
+          TENANT_ID,
+          {
+            principalId: PRINCIPAL_ID,
+            membershipId: MEMBERSHIP_ID,
+            role: 'tenant-owner',
+            name: 'acme-root',
+            scopes: ['messages:send', 'chats:read'],
+            expiresAt: EXPIRES_AT,
+            rateLimit: 60,
+            budget: 500,
+            reason: 'bootstrap tenant OPS-1421',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('keys issue-root forwards --constraints JSON as resourceConstraints', async () => {
+    const { client, calls } = makeFakeClient();
+    await handleKeysIssueRoot(client, TENANT_ID, {
+      ...issueRootOptions,
+      constraints: '{"instanceAllowlist":["instance-1","instance-2"]}',
+    });
+    expect(calls).toHaveLength(1);
+    const body = calls[0].args[1] as Record<string, unknown>;
+    expect(body.resourceConstraints).toEqual({ instanceAllowlist: ['instance-1', 'instance-2'] });
+  });
+
+  test('keys issue-root refuses an invalid --role locally', async () => {
+    const { client, calls } = makeFakeClient();
+    await expect(handleKeysIssueRoot(client, TENANT_ID, { ...issueRootOptions, role: 'superuser' })).rejects.toThrow(
+      'Invalid --role "superuser". Valid roles: tenant-owner, tenant-admin, tenant-operator, tenant-viewer',
+    );
+    expect(calls).toEqual([]);
+  });
+
+  test('keys issue-root refuses empty --scopes locally', async () => {
+    const { client, calls } = makeFakeClient();
+    await expect(handleKeysIssueRoot(client, TENANT_ID, { ...issueRootOptions, scopes: ' , ' })).rejects.toThrow(
+      '--scopes must list at least one explicit tenant scope',
+    );
+    expect(calls).toEqual([]);
+  });
+
+  test('keys issue-root refuses malformed --constraints locally', async () => {
+    const { client, calls } = makeFakeClient();
+    await expect(
+      handleKeysIssueRoot(client, TENANT_ID, { ...issueRootOptions, constraints: '{"a":"not-an-array"}' }),
+    ).rejects.toThrow('Invalid --constraints');
+    expect(calls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('parseScopes / parseConstraints', () => {
+  test('splits a comma list, trimming whitespace and dropping empties', () => {
+    expect(parseScopes(' messages:send , chats:read ,, ')).toEqual(['messages:send', 'chats:read']);
+  });
+
+  test('accepts a JSON object of string arrays', () => {
+    expect(parseConstraints('{"instanceAllowlist":["a","b"]}')).toEqual({ instanceAllowlist: ['a', 'b'] });
+  });
+
+  test('refuses non-JSON, non-object, and non-string-array constraints', () => {
+    expect(() => parseConstraints('not json')).toThrow('Invalid --constraints');
+    expect(() => parseConstraints('["array"]')).toThrow('Invalid --constraints');
+    expect(() => parseConstraints('{"a":[1]}')).toThrow('Invalid --constraints');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('keys issue-root — one-shot plaintext handling', () => {
+  test('human mode prints the plaintext exactly once, via raw, never via success/info/warn/data', async () => {
+    const { client } = makeFakeClient();
+    await handleKeysIssueRoot(client, TENANT_ID, { ...issueRootOptions });
+
+    const containing = outputCalls.filter(({ args }) => JSON.stringify(args).includes(PLAINTEXT_KEY));
+    expect(containing).toHaveLength(1);
+    expect(containing[0].fn).toBe('raw');
+    expect(containing[0].args).toEqual([`\n  ${PLAINTEXT_KEY}\n`]);
+
+    // The metadata dump excludes the plaintext…
+    const dataCalls = outputCalls.filter(({ fn }) => fn === 'data');
+    expect(dataCalls).toHaveLength(1);
+    expect(dataCalls[0].args[0]).not.toHaveProperty('plainTextKey');
+    // …and the operator is warned that the key is shown once.
+    const warnCalls = outputCalls.filter(({ fn }) => fn === 'warn');
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0].args[0]).toContain('shown ONCE');
+  });
+
+  test('json mode emits the plaintext only inside the JSON data payload, exactly once', async () => {
+    currentFormat = 'json';
+    const { client } = makeFakeClient();
+    await handleKeysIssueRoot(client, TENANT_ID, { ...issueRootOptions });
+
+    const containing = outputCalls.filter(({ args }) => JSON.stringify(args).includes(PLAINTEXT_KEY));
+    expect(containing).toHaveLength(1);
+    expect(containing[0].fn).toBe('data');
+    expect((containing[0].args[0] as Record<string, unknown>).plainTextKey).toBe(PLAINTEXT_KEY);
+
+    // No raw/success lines that would corrupt (or duplicate into) stdout JSON.
+    expect(outputCalls.filter(({ fn }) => fn === 'raw' || fn === 'success')).toHaveLength(0);
+    // The one-shot warning still reaches the operator (stderr in JSON mode).
+    const warnCalls = outputCalls.filter(({ fn }) => fn === 'warn');
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0].args[0]).toContain('shown once');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -271,6 +446,7 @@ describe('every command refuses to run without --reason', () => {
     ['memberships disable', (c) => handleMembershipsDisable(c, TENANT_ID, MEMBERSHIP_ID, {})],
     ['memberships status', (c) => handleMembershipsStatus(c, TENANT_ID, MEMBERSHIP_ID, { status: 'active' })],
     ['memberships role', (c) => handleMembershipsRole(c, TENANT_ID, MEMBERSHIP_ID, { role: 'tenant-viewer' })],
+    ['keys issue-root', (c) => handleKeysIssueRoot(c, TENANT_ID, { ...issueRootOptions, reason: undefined })],
   ];
 
   for (const [name, run] of cases) {
@@ -322,6 +498,63 @@ describe('control-plane failure UX', () => {
   test('other errors render as a plain failure with the original message', () => {
     expect(() => renderPlatformError(new Error('connection refused'), 'list tenants')).toThrow(
       'Failed to list tenants: connection refused',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('keys issue-root failure UX', () => {
+  test('409 explains that only an active tenant accepts root keys (pinned verbatim)', () => {
+    const err = new OmniApiError('tenant is not active', 'CONFLICT', undefined, 409);
+    expect(() => renderRootKeyError(err, 'issue the root key')).toThrow(
+      'Failed to issue the root key: the tenant is not active (409). Root keys can be issued only while the ' +
+        'tenant is active — a suspended or archived tenant refuses new credentials.',
+    );
+  });
+
+  test("400 relays the server's own message (it reflects the caller's input) without invented detail", () => {
+    const err = new OmniApiError(
+      'invalid root key request: wildcard scopes are not allowed',
+      'VALIDATION_ERROR',
+      undefined,
+      400,
+    );
+    expect(() => renderRootKeyError(err, 'issue the root key')).toThrow(
+      'Failed to issue the root key: invalid root key request: wildcard scopes are not allowed',
+    );
+  });
+
+  test('a policy-ceiling 403 explains the ceilings, not the credential', () => {
+    const err = new OmniApiError('root key exceeds tenant policy', 'FORBIDDEN', undefined, 403);
+    expect(() => renderRootKeyError(err, 'issue the root key')).toThrow(
+      'Failed to issue the root key: the request exceeds the tenant policy ceilings (403). Keep --expires ' +
+        'within the tenant max-key-ttl and --rate-limit/--budget at or below the tenant ceilings ' +
+        '(see: omni tenants get <id>).',
+    );
+  });
+
+  test('a credential 403 falls through to the platform-credential explanation', () => {
+    const err = new OmniApiError('Platform credential with required scope required', 'FORBIDDEN', undefined, 403);
+    expect(() => renderRootKeyError(err, 'issue the root key')).toThrow(
+      'the credential authenticated but is not allowed (403)',
+    );
+  });
+
+  test('the non-enumerating 404 stays a plain not-found', () => {
+    const err = new OmniApiError('not found', 'NOT_FOUND', undefined, 404);
+    expect(() => renderRootKeyError(err, 'issue the root key')).toThrow('Failed to issue the root key: not found');
+  });
+
+  test('an unmounted control plane still explains the multitenancy flag', () => {
+    const err = new OmniApiError(
+      'Endpoint not found: POST /api/v2/platform/tenants/x/keys/root',
+      'NOT_FOUND',
+      undefined,
+      404,
+    );
+    expect(() => renderRootKeyError(err, 'issue the root key')).toThrow(
+      'the platform control plane is not available on this server',
     );
   });
 });

--- a/packages/cli/src/commands/tenants.ts
+++ b/packages/cli/src/commands/tenants.ts
@@ -15,11 +15,19 @@
  * PLATFORM-class credentials are accepted. Both failure modes are rendered as
  * explanations, not raw HTTP dumps.
  *
- * The `keys issue-root` subcommand is intentionally absent — the route ships
- * separately (#979) and the subcommand follows it.
+ * `keys issue-root` issues the initial tenant ROOT credential (#979). The
+ * server returns the plaintext key exactly ONCE; this command prints it to
+ * stdout exactly once (inside the JSON payload in `--json` mode) and never
+ * routes it through logs, config, or files.
  */
 
-import { OmniApiError, type OmniClient, type PlatformTenant, type PlatformTenantMembership } from '@omni/sdk';
+import {
+  type IssuePlatformTenantRootKeyBody,
+  OmniApiError,
+  type OmniClient,
+  type PlatformTenant,
+  type PlatformTenantMembership,
+} from '@omni/sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
@@ -58,6 +66,18 @@ interface MembershipStatusOptions extends ReasonOption {
 
 interface MembershipRoleOptions extends ReasonOption {
   role: string;
+}
+
+interface KeysIssueRootOptions extends ReasonOption {
+  principal: string;
+  membership: string;
+  role: string;
+  name: string;
+  scopes: string;
+  expires: string;
+  rateLimit: number;
+  budget: number;
+  constraints?: string;
 }
 
 // ============================================================================
@@ -112,6 +132,55 @@ function parseStatus(value: string): MembershipStatusFlag {
 }
 
 /**
+ * Parse the mandatory `--scopes` comma-list into explicit scope strings.
+ * The server refuses platform/wildcard authority on root keys; the empty-list
+ * refusal here just keeps that 400 local and immediate.
+ */
+function parseScopes(value: string): string[] {
+  const scopes = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (scopes.length === 0) {
+    output.error(
+      '--scopes must list at least one explicit tenant scope (comma-separated), e.g. --scopes "messages:send,chats:read".',
+      undefined,
+      1,
+    );
+  }
+  return scopes;
+}
+
+/**
+ * Parse the optional `--constraints` JSON into resource allowlists
+ * (string-array values only, e.g. {"instanceAllowlist":["uuid"]}).
+ */
+function parseConstraints(value: string): Record<string, string[]> {
+  const invalid = (): never =>
+    output.error(
+      `Invalid --constraints "${value}". Expected a JSON object of string arrays, e.g. '{"instanceAllowlist":["<instance-id>"]}'.`,
+      undefined,
+      1,
+    );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    invalid();
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    invalid();
+  }
+  const record = parsed as Record<string, unknown>;
+  for (const entry of Object.values(record)) {
+    if (!Array.isArray(entry) || entry.some((item) => typeof item !== 'string')) {
+      invalid();
+    }
+  }
+  return record as Record<string, string[]>;
+}
+
+/**
  * Render a control-plane failure as an explanation, not a raw HTTP dump.
  *
  * - An "Endpoint not found" 404 means the surface is unmounted: multitenancy
@@ -136,6 +205,40 @@ function renderPlatformError(err: unknown, action: string): never {
   }
   const message = err instanceof Error ? err.message : 'Unknown error';
   output.error(`Failed to ${action}: ${message}`);
+}
+
+const TENANT_NOT_ACTIVE_409 =
+  'the tenant is not active (409). Root keys can be issued only while the tenant is active — ' +
+  'a suspended or archived tenant refuses new credentials.';
+
+const ROOT_KEY_EXCEEDS_POLICY_403 =
+  'the request exceeds the tenant policy ceilings (403). Keep --expires within the tenant ' +
+  'max-key-ttl and --rate-limit/--budget at or below the tenant ceilings (see: omni tenants get <id>).';
+
+/**
+ * Root-key issuance failures the generic renderer would mislabel:
+ *
+ * - 409 means the tenant exists but is not active — only active tenants accept
+ *   new root credentials.
+ * - 400 reflects the caller's OWN input (scopes/expiry/limits); the server's
+ *   message is relayed as-is, without inventing detail.
+ * - A 403 whose message is the policy-ceiling refusal is about the REQUEST,
+ *   not the credential — explained as such. Any other 403 (and 401/404) falls
+ *   through to `renderPlatformError`.
+ */
+function renderRootKeyError(err: unknown, action: string): never {
+  if (err instanceof OmniApiError) {
+    if (err.status === 409) {
+      output.error(`Failed to ${action}: ${TENANT_NOT_ACTIVE_409}`, undefined, 1);
+    }
+    if (err.status === 400) {
+      output.error(`Failed to ${action}: ${err.message}`, undefined, 1);
+    }
+    if (err.status === 403 && err.message.includes('exceeds tenant policy')) {
+      output.error(`Failed to ${action}: ${ROOT_KEY_EXCEEDS_POLICY_403}`, undefined, 1);
+    }
+  }
+  renderPlatformError(err, action);
 }
 
 function formatTenantRow(tenant: PlatformTenant): Record<string, string | number> {
@@ -272,6 +375,52 @@ async function handleMembershipsRole(
   const role = parseRole(options.role);
   const membership = await client.platform.tenants.memberships.setRole(tenantId, membershipId, role, reason);
   output.success(`Membership ${membership.id} role set to ${membership.role}`);
+}
+
+// ============================================================================
+// HANDLERS — root key issuance
+// ============================================================================
+
+/**
+ * Issue the initial tenant ROOT key. The plaintext credential exists in
+ * exactly one place — the server's 201 response — and this handler prints it
+ * to stdout exactly once: on its own line in human mode, inside the JSON
+ * payload in `--json` mode. It never travels through `info`/`warn`/`success`
+ * (which land on stderr in JSON mode) and is never written anywhere else.
+ */
+async function handleKeysIssueRoot(client: OmniClient, tenantId: string, options: KeysIssueRootOptions): Promise<void> {
+  const reason = requireReason(options.reason, 'issue a root key');
+  const role = parseRole(options.role);
+  const scopes = parseScopes(options.scopes);
+  const constraints = options.constraints === undefined ? undefined : parseConstraints(options.constraints);
+
+  const body: IssuePlatformTenantRootKeyBody = {
+    principalId: options.principal,
+    membershipId: options.membership,
+    role,
+    name: options.name,
+    scopes,
+    expiresAt: options.expires,
+    rateLimit: options.rateLimit,
+    budget: options.budget,
+    ...(constraints ? { resourceConstraints: constraints } : {}),
+    reason,
+  };
+  const result = await client.platform.tenants.keys.issueRoot(tenantId, body);
+
+  if (output.getCurrentFormat() === 'json') {
+    // Warning goes to stderr (warn does that in JSON mode); the plaintext key
+    // appears once, inside the JSON document on stdout.
+    output.warn('plainTextKey is shown once and can never be retrieved again — store it now.');
+    output.data(result);
+    return;
+  }
+
+  const { plainTextKey, ...issued } = result;
+  output.success(`Root key issued: ${issued.name} (${issued.id})`);
+  output.warn('The key below is shown ONCE and can never be retrieved again — store it now.');
+  output.raw(`\n  ${plainTextKey}\n`);
+  output.data(issued);
 }
 
 // ============================================================================
@@ -428,6 +577,32 @@ export function createTenantsCommand(): Command {
 
   tenants.addCommand(memberships);
 
+  const keys = new Command('keys').description('Manage tenant credentials');
+
+  keys
+    .command('issue-root <tenant-id>')
+    .description('Issue the initial tenant ROOT key (the plaintext is shown ONCE and never again)')
+    .requiredOption('--principal <uuid>', 'Principal the key acts as (must hold the membership)')
+    .requiredOption('--membership <uuid>', 'Active membership binding the principal to the tenant')
+    .requiredOption('--role <role>', `Tenant role: ${TENANT_ROLES.join(' | ')}`)
+    .requiredOption('--name <name>', 'Human-readable key name')
+    .requiredOption('--scopes <list>', 'Comma-separated explicit tenant scopes (platform/wildcard scopes are refused)')
+    .requiredOption('--expires <iso>', 'Expiry (ISO 8601); must be in the future and within the tenant TTL ceiling')
+    .requiredOption('--rate-limit <n>', 'Rate limit; capped by the tenant policy ceiling', Number.parseInt)
+    .requiredOption('--budget <n>', 'Budget; capped by the tenant policy ceiling', Number.parseInt)
+    .option('--constraints <json>', 'Optional resource allowlists as JSON, e.g. \'{"instanceAllowlist":["<id>"]}\'')
+    .option('--reason <text>', REASON_HELP)
+    .action(async (tenantId: string, options: KeysIssueRootOptions) => {
+      const client = getClient();
+      try {
+        await handleKeysIssueRoot(client, tenantId, options);
+      } catch (err) {
+        renderRootKeyError(err, 'issue the root key');
+      }
+    });
+
+  tenants.addCommand(keys);
+
   return tenants;
 }
 
@@ -438,6 +613,10 @@ export function createTenantsCommand(): Command {
 export const __testables = {
   requireReason,
   renderPlatformError,
+  renderRootKeyError,
+  parseScopes,
+  parseConstraints,
+  handleKeysIssueRoot,
   handleList,
   handleGet,
   handleCreate,

--- a/packages/sdk/src/__tests__/platform-tenants.test.ts
+++ b/packages/sdk/src/__tests__/platform-tenants.test.ts
@@ -1,9 +1,10 @@
 /**
  * SDK platform control-plane surface (issue #981).
  *
- * Pins the method → route mapping for all ten tenant/membership operations,
- * and — the part the server audits — WHERE the reason travels: reads send the
- * `x-platform-reason` header, mutations send `reason` in the JSON body.
+ * Pins the method → route mapping for the tenant/membership operations and
+ * root-key issuance, and — the part the server audits — WHERE the reason
+ * travels: reads send the `x-platform-reason` header, mutations send `reason`
+ * in the JSON body.
  * A local Bun server records every request so the assertions are on the actual
  * wire shape, not on mocks of our own code.
  */
@@ -52,6 +53,22 @@ const membership = {
   disabledAt: null,
 };
 
+const rootKey = {
+  id: '44444444-4444-4444-8444-444444444444',
+  tenantId: TENANT_ID,
+  principalId: PRINCIPAL_ID,
+  membershipId: MEMBERSHIP_ID,
+  name: 'acme-root',
+  role: 'tenant-owner',
+  scopes: ['messages:send'],
+  constraints: {},
+  delegationDepth: 0,
+  expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  rateLimit: 60,
+  budget: 500,
+  plainTextKey: 'omni_root_plaintext_only_once',
+};
+
 describe('platform control plane', () => {
   let server: Server;
   let client: OmniClient;
@@ -71,6 +88,7 @@ describe('platform control plane', () => {
     [`POST ${MEMBERSHIPS}/${MEMBERSHIP_ID}/disable`]: () => Response.json({ data: membership }),
     [`POST ${MEMBERSHIPS}/${MEMBERSHIP_ID}/status`]: () => Response.json({ data: membership }),
     [`POST ${MEMBERSHIPS}/${MEMBERSHIP_ID}/role`]: () => Response.json({ data: membership }),
+    [`POST ${TENANTS}/${TENANT_ID}/keys/root`]: () => Response.json({ data: rootKey }, { status: 201 }),
   };
 
   beforeAll(() => {
@@ -219,6 +237,58 @@ describe('platform control plane', () => {
     expect(req.method).toBe('POST');
     expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/memberships/${MEMBERSHIP_ID}/role`);
     expect(req.body).toEqual({ role: 'tenant-admin', reason: 'promotion' });
+  });
+
+  test('tenants.keys.issueRoot → POST /platform/tenants/:id/keys/root with reason in body', async () => {
+    const expiresAt = rootKey.expiresAt;
+    const result = await client.platform.tenants.keys.issueRoot(TENANT_ID, {
+      principalId: PRINCIPAL_ID,
+      membershipId: MEMBERSHIP_ID,
+      role: 'tenant-owner',
+      name: 'acme-root',
+      scopes: ['messages:send'],
+      expiresAt,
+      rateLimit: 60,
+      budget: 500,
+      resourceConstraints: { instanceAllowlist: ['instance-1'] },
+      reason: 'bootstrap tenant OPS-1421',
+    });
+    // The one-shot plaintext comes back to the caller untouched.
+    expect(result.plainTextKey).toBe('omni_root_plaintext_only_once');
+    expect(result.id).toBe(rootKey.id);
+    const req = lastRequest();
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe(`/api/v2/platform/tenants/${TENANT_ID}/keys/root`);
+    expect(req.reasonHeader).toBeNull();
+    expect(req.body).toEqual({
+      principalId: PRINCIPAL_ID,
+      membershipId: MEMBERSHIP_ID,
+      role: 'tenant-owner',
+      name: 'acme-root',
+      scopes: ['messages:send'],
+      expiresAt,
+      rateLimit: 60,
+      budget: 500,
+      resourceConstraints: { instanceAllowlist: ['instance-1'] },
+      reason: 'bootstrap tenant OPS-1421',
+    });
+  });
+
+  test('tenants.keys.issueRoot omits resourceConstraints from the body when not given', async () => {
+    await client.platform.tenants.keys.issueRoot(TENANT_ID, {
+      principalId: PRINCIPAL_ID,
+      membershipId: MEMBERSHIP_ID,
+      role: 'tenant-owner',
+      name: 'acme-root',
+      scopes: ['messages:send'],
+      expiresAt: rootKey.expiresAt,
+      rateLimit: 60,
+      budget: 500,
+      reason: 'bootstrap tenant OPS-1421',
+    });
+    const req = lastRequest();
+    expect(req.body).not.toBeNull();
+    expect(Object.keys(req.body ?? {})).not.toContain('resourceConstraints');
   });
 
   // ── Errors surface as OmniApiError with the server's message ─────────────

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1278,6 +1278,19 @@ export type AttachPlatformMembershipBody = NonNullable<
   operations['attachPlatformMembership']['requestBody']
 >['content']['application/json'];
 
+/** Body for issuing a tenant ROOT key (includes the audited `reason`) */
+export type IssuePlatformTenantRootKeyBody = NonNullable<
+  operations['issuePlatformTenantRootKey']['requestBody']
+>['content']['application/json'];
+
+/**
+ * An issued tenant ROOT key. `plainTextKey` is present exactly ONCE — in this
+ * response — and can never be retrieved again. Callers must hand it to the
+ * operator immediately and must never persist or log it.
+ */
+export type PlatformTenantRootKey =
+  operations['issuePlatformTenantRootKey']['responses'][201]['content']['application/json']['data'];
+
 // ============================================================================
 // Presence & Read Receipt Types (api-completeness)
 // ============================================================================
@@ -3685,6 +3698,29 @@ export function createOmniClient(config: OmniClientConfig) {
             if (!resp.ok) throw OmniApiError.from(json, resp.status);
             if (!json?.data)
               throw new OmniApiError('Failed to set membership role', 'ROLE_FAILED', undefined, resp.status);
+            return json.data;
+          },
+        },
+
+        keys: {
+          /**
+           * Issue the initial tenant ROOT key for a membership.
+           * `body.reason` is the audited justification.
+           *
+           * The response carries `plainTextKey` exactly ONCE — the server never
+           * returns it again. Hand it to the operator immediately; never
+           * persist or log it.
+           */
+          async issueRoot(tenantId: string, body: IssuePlatformTenantRootKeyBody): Promise<PlatformTenantRootKey> {
+            const resp = await apiFetch(`${baseUrl}/api/v2/platform/tenants/${tenantId}/keys/root`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(body),
+            });
+            const json = (await resp.json()) as { data?: PlatformTenantRootKey };
+            if (!resp.ok) throw OmniApiError.from(json, resp.status);
+            if (!json?.data)
+              throw new OmniApiError('Failed to issue root key', 'ISSUE_ROOT_FAILED', undefined, resp.status);
             return json.data;
           },
         },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -163,6 +163,8 @@ export type {
   PlatformMembershipStatus,
   CreatePlatformTenantBody,
   AttachPlatformMembershipBody,
+  IssuePlatformTenantRootKeyBody,
+  PlatformTenantRootKey,
 } from './client';
 
 // Errors


### PR DESCRIPTION
## Summary

Completes the deferred piece of the tenant control-plane CLI/SDK work: the `omni tenants keys issue-root` subcommand and its `client.platform.tenants.keys.issueRoot` SDK method, over the `POST /api/v2/platform/tenants/:id/keys/root` route that landed in #993.

Follow-up to #981 / #992 (the subcommand was intentionally left out of #992 pending the route).

## SDK (`@omni/sdk`)

- `client.platform.tenants.keys.issueRoot(tenantId, body)`, typed from the generated `issuePlatformTenantRootKey` operation (body and one-shot `plainTextKey` response can never drift from the API contract).
- New exported types: `IssuePlatformTenantRootKeyBody`, `PlatformTenantRootKey`.
- Wire-level recording-server tests pin method, path, `reason` in the JSON body, and that `resourceConstraints` is omitted when not given.

## CLI (`omni tenants keys issue-root <tenant-id>`)

- Flags follow the file's conventions: `--principal --membership --role --name --scopes --expires --rate-limit --budget [--constraints <json>] --reason`.
- `--reason` (3-500 chars), `--role`, `--scopes` (comma-list, non-empty), and `--constraints` (JSON object of string arrays) are all validated locally before any request is sent.
- **One-shot plaintext handling** (the critical part): the server returns the key exactly once, and the CLI prints it to stdout exactly once — a bare `raw` line with a "shown ONCE, store it now" warning in human mode; inside the JSON payload only in `--json` mode (warning goes to stderr so stdout stays valid JSON). It never travels through logs, config, or files, and the human-mode metadata dump excludes it. Tests pin all of this.
- Error UX: reuses `renderPlatformError` for the shared 404/401/403 explanations, with issue-root-specific rendering for 409 (tenant not active), 400 (server message relayed verbatim — it reflects the caller's own input), and the policy-ceiling 403 (points at the tenant ceilings, not the credential).
- SDK-coverage gate updated with the `platform.tenants.keys.issueRoot` mapping.

## Gates

- `make typecheck` — green
- `make lint` — green (zero warnings)
- SDK package tests: 47 pass / 0 fail
- CLI package tests: 671 pass / 0 fail (includes 48 in tenants.test.ts and the SDK-coverage gate at 100%)