### PR TITLE
ci(quality-gate): support merge-queue combined-state testing (#990)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  # Merge-queue support (#990): when a merge queue is enabled on dev, GitHub
+  # synthesizes gh-readonly-queue/* merge commits (PR + dev + any PRs queued
+  # ahead) and requires the branch-protection checks to pass on THEM before
+  # merging. That is the combined-state test per-PR CI cannot perform: PRs
+  # #964 and #965 were each green in isolation but red merged together (a
+  # suite relying on ambient global fetch met a sibling that replaces it —
+  # fixed after the fact in #963). Every job below runs on merge_group; the
+  # quality gate takes the full single-process sweep path, the one
+  # configuration where such cross-file state leaks reproduce.
+  # Enabling the queue itself is a one-time settings change — see
+  # docs/ci/merge-queue.md.
+  merge_group:
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -144,6 +157,10 @@ jobs:
         # In that case fall back to the base-branch tip: the run is already
         # superseded, so re-widening the #977 newer-base window is harmless,
         # and the base-independent journal checks still run either way.
+        # merge_group events have an empty github.base_ref, so both expressions
+        # below fall through to their defaults: the contract base is origin/dev
+        # (correct for a dev queue, and per the carry-exact promotion rule
+        # above, correct even for a main queue).
         env:
           MIGRATION_BASE_BRANCH: ${{ github.base_ref == 'main' && 'dev' || github.base_ref || 'dev' }}
           USE_MERGE_PARENT: ${{ github.event_name == 'pull_request' && github.base_ref != 'main' }}
@@ -251,13 +268,17 @@ jobs:
           export NODE_ENV=test LOG_LEVEL=silent
           bun run test
 
-      - name: Test (pushes — full single-process sweep)
+      - name: Test (pushes and merge groups — full single-process sweep)
         # Pushes to dev/main re-prove everything with the pre-#967 sweep: no
         # cache replay on the integration branch, and the one-process run is
         # also the only configuration where cross-file state leaks (e.g.
         # globalThis.fetch pollution, issue #967 comment) reproduce. Scope to
         # omni packages + the ui app; apps/khal-ui is a decoupled sub-project
         # (private @khal-os deps) with its own test run.
+        # merge_group events (#990) take this same path deliberately: the
+        # queue's speculative merge commit is exactly the state dev would
+        # become, so sweeping it catches green-in-isolation/red-in-combination
+        # PR pairs (the #964+#965 global-fetch clash) BEFORE they land.
         if: ${{ github.event_name != 'pull_request' }}
         run: bun test packages apps/ui --env-file=.env
         env:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,6 +3,13 @@ name: Commitlint
 on:
   pull_request:
     branches: [main, dev]
+  # Merge-queue support (#990): a required check that never reports on
+  # merge_group stalls every queue entry until the queue times it out. The
+  # job below skips itself on merge groups (skipped satisfies a required
+  # check) — the commits were already linted on the pull_request event, and
+  # the queue's synthesized merge commits are not conventional-commit input.
+  merge_group:
+    branches: [main, dev]
 
 concurrency:
   group: commitlint-${{ github.ref }}
@@ -17,6 +24,9 @@ jobs:
     name: Commit Messages
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
+    # Skipped (= passing, for required checks) on merge_group — see the
+    # trigger comment above.
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,0 +1,135 @@
+---
+title: "Merge queue on dev — combined-state gate"
+created: 2026-09-08
+tags: [ci, merge-queue, quality-gate]
+status: current
+---
+
+# Merge queue on `dev` — the combined-state gate (#990)
+
+> Decision record for issue #990, implemented in the PR that adds the
+> `merge_group` triggers to `.github/workflows/ci.yml` and
+> `.github/workflows/commitlint.yml`. The workflow side ships in-repo; the
+> queue itself is a **one-time repository-settings change a human must make**
+> (checklist below).
+
+## The failure class
+
+PRs #964 and #965 were each green in isolation but **broke `dev` in
+combination**: one suite relied on the ambient global `fetch`, a sibling suite
+replaced `globalThis.fetch`, and the merge product was red (fixed after the
+fact in #963 by pinning native fetch). Per-PR CI cannot see this class *by
+construction* — each PR is tested against the `dev` that existed when its run
+started, never against `dev` + the other in-flight PRs it will actually land
+with. PR #971's push-time sweep catches the breakage, but only **after** it is
+already on `dev`.
+
+## Decision: GitHub merge queue (option 2)
+
+Issue #990 listed three options. The merge queue wins because the repo's CI is
+already shaped for it:
+
+1. **"Require branches to be up to date" (strict checks)** — rejected. With N
+   concurrent auto-merge PRs every merge invalidates the other N−1, forcing a
+   branch-update + full re-run storm per landing. The agent auto-merge flow
+   would spend most of its time rebasing, and nothing ever tests more than one
+   PR ahead.
+2. **Merge queue** — chosen. The queue synthesizes a
+   `gh-readonly-queue/dev/...` merge commit (PR + current `dev` + every PR
+   queued ahead of it), runs the required checks on **that commit**, and only
+   merges green groups. The combined state is tested before merge by
+   construction. Crucially, `ci.yml` already routes non-`pull_request` events
+   to the **full single-process sweep** (`bun test packages apps/ui`) — the
+   only configuration where cross-file state leaks like the
+   `globalThis.fetch` clash reproduce — so `merge_group` runs inherit exactly
+   the right test mode with no new machinery. Batching also means one
+   combined run can land several PRs.
+3. **Speculative-merge sweep workflow** — rejected as primary. It re-implements
+   the queue by hand (choose PRs, build the octopus merge, map failures back
+   to a culprit, race against auto-merge landing PRs mid-run) and it reports
+   *advisory* red after the fact rather than blocking the merge. The
+   push-to-`dev` sweep already provides the after-the-fact backstop; it stays.
+
+## What ships in-repo (this PR)
+
+- `ci.yml` gains a `merge_group` trigger (`branches: [main, dev]`). All four
+  jobs — Quality Gate, PostgreSQL Isolation Gate, Remote Media, Smoke Test —
+  run on merge groups with no per-job changes needed:
+  - The quality gate's test step split (`pull_request` → turbo-cached
+    per-package run, everything else → single-process sweep) sends merge
+    groups down the **sweep** path.
+  - The migration contract gate's `github.base_ref` expressions fall through
+    to `origin/dev` on merge groups (empty `base_ref`), which is the correct
+    contract base.
+  - `secrets-scan` skips (it is push-only and non-blocking by design).
+  - The `ci-${{ github.ref }}` concurrency group is safe: each merge group
+    has a unique `gh-readonly-queue/...` ref.
+- `commitlint.yml` gains a `merge_group` trigger whose job **skips itself**
+  on merge groups. Skipped satisfies a required check; without the trigger, a
+  required "Commit Messages" check would stall every queue entry until the
+  queue timed it out. The commits were already linted on the `pull_request`
+  event, and the queue's synthesized merge commits are not conventional-commit
+  input.
+
+Nothing here can be exercised before the queue exists: `merge_group` only
+fires for an enabled merge queue, and there is no local simulation. The
+workflows were validated with `actionlint` and the release-workflow contract
+gate; the first queued PR is the real test.
+
+## One-time settings change (human, repo admin)
+
+On <https://github.com/automagik-dev/omni/settings/branches>, edit the
+protection rule for `dev` (it exists today with **no** required status
+checks — verified 2026-09-08):
+
+1. **Enable "Require status checks to pass before merging"** and select:
+   - `Quality Gate (typecheck + lint + test)`
+   - `PostgreSQL Isolation Gate (tenancy/RLS)`
+   - `Remote Media (S3/MinIO integration)`
+   - `Smoke Test (Fresh Environment)`
+   - `Commit Messages` (optional but recommended — safe for the queue as of
+     this PR)
+
+   Leave **"Require branches to be up to date before merging" OFF** — the
+   queue supersedes it, and strict mode would reintroduce option 1's re-run
+   storm for entering the queue.
+   Do **not** select any other check until its workflow also handles
+   `merge_group`; a silent check blocks the queue.
+2. **Enable "Require merge queue"** on the same `dev` rule.
+   - Merge method: **merge commit** (matches the repo's merge-not-rebase
+     convention).
+   - Defaults are fine for the rest; "Only merge non-failing pull requests"
+     stays on.
+3. **Leave `main` untouched.** Promotion PRs are human-merged against `main`'s
+   existing strict required checks; a queue there adds nothing and would
+   insert queue-made merge commits into the carry-exact promotion path.
+
+## Interactions with the existing flow (checked)
+
+- **Auto-merge-when-green**: unchanged in spirit. With a queue enabled,
+  `gh pr merge --auto` / "Merge when ready" **adds the PR to the queue**
+  instead of merging directly. Agents keep issuing the same command.
+- **Direct commits to `dev`** ("fixes = direct commit to dev"): a required
+  merge queue rejects direct pushes from non-exempt users, but the `dev` rule
+  has `enforce_admins` **disabled**, so repository admins — the accounts that
+  make those direct pushes today — are exempt and keep the flow. Direct
+  pushes bypass the queue and are backstopped by the existing push-event
+  sweep, exactly as before.
+- **`version.yml`**: fires on `pull_request: types: [closed]` for `dev`;
+  queue-merged PRs still close normally, so per-merge dev versioning is
+  unaffected.
+- **Rolling promotion (`dev` → `main`)**: targets `main`, which gets no
+  queue; unaffected.
+- **The #996 HEAD^1 race** (auto-merge deleting `refs/pull/N/merge` mid-run)
+  becomes rarer: queue merges happen after the merge-group run, not during
+  the PR run.
+
+## Verifying it caught the class
+
+Re-run the #964+#965 narrative mentally against the queue: both PRs green,
+both queued. The queue builds group 1 = `dev` + #964 (green, merges), then
+group 2 = `dev` + #964 + #965. The single-process sweep on group 2 runs the
+fetch-replacing suite and the ambient-fetch suite in one process and fails —
+#965 is bounced out of the queue with a red merge-group run, `dev` stays
+green, and the author gets the failure *before* merge instead of the
+integration branch turning red after it.


### PR DESCRIPTION
Closes #990

## The failure class

PRs #964 and #965 were each green in isolation but **broke `dev` in combination**: one suite relied on the ambient global `fetch`, a sibling suite replaces `globalThis.fetch`, and the merge product was red (fixed after the fact in #963). Per-PR CI cannot see this class by construction — each PR is tested against the `dev` that existed when its run started, never against `dev` + the other in-flight PRs it will actually land with. #971's push-time sweep catches it only **after** it is on `dev`.

## Decision: GitHub merge queue (option 2 of #990)

Full rationale in `docs/ci/merge-queue.md` (added here). Short version:

- **Strict up-to-date checks (option 1)** — rejected: with N concurrent auto-merge PRs, every landing invalidates the other N−1 → a branch-update + full-CI re-run storm, and nothing ever tests more than one PR ahead.
- **Merge queue (option 2)** — chosen: the queue synthesizes a `gh-readonly-queue/dev/...` merge commit (PR + current `dev` + every PR queued ahead) and requires the checks to pass on **that commit** before merging. The combined state is tested before merge by construction, and it plugs straight into the auto-merge flow: `gh pr merge --auto` becomes "add to queue".
- **Hand-rolled speculative-merge sweep (option 3)** — rejected as primary: it re-implements the queue (pick PRs, build the merge, attribute failures, race auto-merge) and reports advisory red after the fact instead of blocking the merge. The existing push-to-`dev` sweep stays as the backstop for direct pushes.

The repo's CI is already shaped for the queue: `ci.yml` routes non-`pull_request` events to the **full single-process sweep** — the only configuration where cross-file state leaks like the fetch clash reproduce — so `merge_group` runs inherit exactly the right test mode with no new machinery. Replaying the #964+#965 scenario: both queued → group 1 = `dev`+#964 (green, merges) → group 2 = `dev`+#964+#965 → the sweep runs both suites in one process, fails, and #965 is bounced **before** merge with `dev` still green.

## What this PR changes (workflows + docs only, no product code)

- **`.github/workflows/ci.yml`**: adds a `merge_group` trigger (`branches: [main, dev]`). All four jobs run on merge groups unchanged:
  - quality gate test split sends merge groups down the sweep path (`github.event_name != 'pull_request'`);
  - migration contract gate's `github.base_ref` expressions fall through to `origin/dev` on merge groups (empty `base_ref`) — the correct contract base;
  - `secrets-scan` skips (push-only, non-blocking by design);
  - `ci-${{ github.ref }}` concurrency is safe — each merge group has a unique ref.
- **`.github/workflows/commitlint.yml`**: adds `merge_group` with a job-level skip. A required check that never reports on `merge_group` stalls every queue entry until timeout; a skipped job satisfies a required check, and the commits were already linted on the `pull_request` event.
- **`docs/ci/merge-queue.md`**: decision record + the exact one-time settings change.

## Human action required (repo admin, one-time — this PR does not and must not change settings)

On the `dev` branch protection rule (currently has **no** required status checks — verified read-only 2026-09-08):

1. Enable **"Require status checks to pass before merging"** and select:
   - `Quality Gate (typecheck + lint + test)`
   - `PostgreSQL Isolation Gate (tenancy/RLS)`
   - `Remote Media (S3/MinIO integration)`
   - `Smoke Test (Fresh Environment)`
   - `Commit Messages` (optional but recommended — queue-safe as of this PR)

   Leave **"Require branches to be up to date" OFF** (the queue supersedes it). Do not select any other check until its workflow also handles `merge_group`.
2. Enable **"Require merge queue"** on the same `dev` rule; merge method **merge commit**; other defaults are fine.
3. Leave **`main` untouched** — promotion PRs stay human-merged against `main`'s existing strict checks.

Interactions checked (details in the doc): auto-merge keeps working (`gh pr merge --auto` queues), direct-to-`dev` fixes survive (`enforce_admins` is off on `dev`, so admins bypass the queue and the push-event sweep backstops them), `version.yml` still fires on queue merges (`pull_request: closed`), and the rolling promotion PR is unaffected.

## Validation

There is no way to fire a real `merge_group` event before the queue exists — no local simulation, and the event only triggers for an enabled queue. What was verified instead:

- `actionlint` v1.7.7 (the pinned CI version) clean across all workflows;
- `scripts/release/release-workflow-contract.test.sh` passes (Python 3.14);
- job wiring on `merge_group` traced by hand for every job/step condition in `ci.yml` (see the workflow comments);
- pre-push gate green (full turbo test run).

The first queued PR after the settings flip is the real end-to-end test; if a queue entry stalls on a missing check, the fix is to deselect that check or add `merge_group` handling to its workflow.
