### PR TITLE
feat(sources): plug in GitHub as first real external source (#983)

### DIFF
--- a/docs/examples/event-schemas/github/custom.github.issues.json
+++ b/docs/examples/event-schemas/github/custom.github.issues.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.github.issues",
+  "description": "GitHub issues webhook delivery (X-GitHub-Event: issues). Minimal-but-real contract: the fields consumers rely on are required; everything else GitHub sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["action", "issue", "repository", "sender"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "description": "What happened: opened, closed, edited, labeled, ..."
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["number"],
+      "properties": {
+        "number": { "type": "integer", "description": "Issue number" },
+        "title": { "type": "string" },
+        "state": { "type": "string" },
+        "html_url": { "type": "string" }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["full_name"],
+      "properties": {
+        "full_name": {
+          "type": "string",
+          "description": "owner/repo, e.g. automagik-dev/omni"
+        }
+      }
+    },
+    "sender": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["login"],
+      "properties": {
+        "login": {
+          "type": "string",
+          "description": "GitHub username that triggered the delivery"
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/event-schemas/github/custom.github.pull_request.json
+++ b/docs/examples/event-schemas/github/custom.github.pull_request.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.github.pull_request",
+  "description": "GitHub pull_request webhook delivery (X-GitHub-Event: pull_request). Minimal-but-real contract: the fields consumers rely on are required; everything else GitHub sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["action", "number", "repository", "sender"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "description": "What happened: opened, closed, synchronize, reopened, ..."
+    },
+    "number": {
+      "type": "integer",
+      "description": "Pull request number"
+    },
+    "pull_request": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "title": { "type": "string" },
+        "state": { "type": "string" },
+        "merged": { "type": "boolean" },
+        "html_url": { "type": "string" }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["full_name"],
+      "properties": {
+        "full_name": {
+          "type": "string",
+          "description": "owner/repo, e.g. automagik-dev/omni"
+        }
+      }
+    },
+    "sender": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["login"],
+      "properties": {
+        "login": {
+          "type": "string",
+          "description": "GitHub username that triggered the delivery"
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/event-schemas/github/custom.github.push.json
+++ b/docs/examples/event-schemas/github/custom.github.push.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.github.push",
+  "description": "GitHub push webhook delivery (X-GitHub-Event: push). Minimal-but-real contract: the fields consumers rely on are required; everything else GitHub sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["ref", "repository", "sender"],
+  "properties": {
+    "ref": {
+      "type": "string",
+      "description": "Full git ref that was pushed, e.g. refs/heads/main"
+    },
+    "before": {
+      "type": "string",
+      "description": "SHA of the most recent commit on ref before the push"
+    },
+    "after": {
+      "type": "string",
+      "description": "SHA of the most recent commit on ref after the push"
+    },
+    "commits": {
+      "type": "array",
+      "description": "Commits in the push (GitHub caps this at 2048 entries)",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "message": { "type": "string" },
+          "url": { "type": "string" }
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["full_name"],
+      "properties": {
+        "full_name": {
+          "type": "string",
+          "description": "owner/repo, e.g. automagik-dev/omni"
+        }
+      }
+    },
+    "sender": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["login"],
+      "properties": {
+        "login": {
+          "type": "string",
+          "description": "GitHub username that triggered the delivery"
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/event-schemas/github/custom.github.release.json
+++ b/docs/examples/event-schemas/github/custom.github.release.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.github.release",
+  "description": "GitHub release webhook delivery (X-GitHub-Event: release). Minimal-but-real contract: the fields consumers rely on are required; everything else GitHub sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["action", "release", "repository", "sender"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "description": "What happened: published, created, edited, released, ..."
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["tag_name"],
+      "properties": {
+        "tag_name": { "type": "string", "description": "Git tag of the release, e.g. v2.260907.4" },
+        "name": { "type": "string" },
+        "draft": { "type": "boolean" },
+        "prerelease": { "type": "boolean" },
+        "html_url": { "type": "string" }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["full_name"],
+      "properties": {
+        "full_name": {
+          "type": "string",
+          "description": "owner/repo, e.g. automagik-dev/omni"
+        }
+      }
+    },
+    "sender": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["login"],
+      "properties": {
+        "login": {
+          "type": "string",
+          "description": "GitHub username that triggered the delivery"
+        }
+      }
+    }
+  }
+}

--- a/docs/runbooks/github-webhook-source.md
+++ b/docs/runbooks/github-webhook-source.md
@@ -1,0 +1,235 @@
+# Runbook — GitHub as a webhook source
+
+> Issue #983 — RFC #925 Phase 3, source 1 of 2. Walks from GitHub repo webhook
+> settings to a firing automation using ONLY configuration: one
+> `webhook_sources` row, four registered event schemas, one idempotency key
+> template, one declared liveness cadence. **Zero new ingress code.**
+>
+> Pinned end-to-end (fake GitHub deliveries through the real HTTP ingress and
+> a real PostgreSQL journal) by
+> `packages/api/src/__tests__/webhook-github-source-postgres.test.ts`.
+
+## What you get
+
+Every delivery GitHub sends to `POST /api/v2/webhooks/ingress/github` is:
+
+1. **verified** — HMAC-SHA256 over the raw body against `X-Hub-Signature-256`
+   (issue #928; `packages/api/src/services/webhooks.ts`);
+2. **typed** — `X-GitHub-Event: push` lands as `custom.github.push` (not the
+   collapsed `custom.webhook.github`) via the source's `eventTypeMapping`
+   (issue #959);
+3. **schema-checked** — payloads for the four registered types must satisfy
+   their JSON Schema contract or they are dead-lettered, never journaled
+   (issue #959);
+4. **deduplicated** — GitHub redelivers on any non-2xx/timeout and offers a
+   manual "Redeliver" button; the `github:{headers.x-github-delivery}` key
+   template makes every redelivery ack with `duplicate: true` and exactly ONE
+   journal event (issue #958);
+5. **supervised** — a declared cadence means silence beyond the window emits
+   `system.connector.stalled` + a DLQ entry instead of failing silently
+   (issue #961, see [[../architecture/connector-contract|Connector Lifecycle Contract]]).
+
+## Prerequisites
+
+- An omni API reachable from github.com (public URL or tunnel), called
+  `https://omni.example.com` below.
+- The `omni` CLI configured with an admin API key (`omni config`), or a raw
+  API key for the `curl` variants.
+- A webhook secret: `openssl rand -hex 32` — you will paste the same value
+  into omni (step 1) and GitHub (step 3).
+
+## Step 1 — create the `webhook_sources` row
+
+One API call declares the whole contract. The public ingress refuses any
+source without a `signatureConfig`, so the endpoint is unreachable until this
+row exists:
+
+```bash
+export GITHUB_WEBHOOK_SECRET="<output of openssl rand -hex 32>"
+
+curl -sS -X POST https://omni.example.com/api/v2/webhook-sources \
+  -H "x-api-key: $OMNI_API_KEY" -H 'Content-Type: application/json' \
+  -d @- <<JSON
+{
+  "name": "github",
+  "description": "GitHub repo webhooks (RFC #925 Phase 3 recipe)",
+  "signatureConfig": {
+    "algorithm": "hmac-sha256",
+    "header": "X-Hub-Signature-256",
+    "prefix": "sha256="
+  },
+  "signatureSecret": "$GITHUB_WEBHOOK_SECRET",
+  "idempotencyKeyTemplate": "github:{headers.x-github-delivery}",
+  "eventTypeMapping": { "source": "header", "header": "X-GitHub-Event" },
+  "expectedIntervalSeconds": 86400
+}
+JSON
+```
+
+Field by field:
+
+| Field | Why |
+|---|---|
+| `signatureConfig` | GitHub signs every delivery with `X-Hub-Signature-256: sha256=<hex hmac>` — HMAC-SHA256 of the **raw body bytes** under the shared secret. Omni verifies over the raw body before anything is published; the secret is write-only (never returned by the API). |
+| `idempotencyKeyTemplate` | `X-GitHub-Delivery` is GitHub's per-delivery GUID and is **stable across redeliveries**. The template resolves to e.g. `github:72d3162e-cc78-11e3-81ab-4c9367dc0958`; the unique index on `omni_events.idempotency_key` is the dedup authority. Note the header placeholder is lowercase: `{headers.x-github-delivery}`. If the header were ever missing, derivation falls back to `github:{sha256(body)}`. |
+| `eventTypeMapping` | Reads `X-GitHub-Event` and emits `custom.github.{event}`: `push` → `custom.github.push`, `pull_request` → `custom.github.pull_request`, `issues` → `custom.github.issues`, `release` → `custom.github.release`. Deliveries without the header fall back to `custom.webhook.github`. |
+| `expectedIntervalSeconds` | Declared liveness cadence (#961): "≥1 event **or heartbeat** per 24 h". See step 4. |
+
+CLI alternative (everything except `eventTypeMapping`, which has no CLI flag
+yet — add it with the `PATCH` below):
+
+```bash
+omni webhooks create --name github \
+  --description "GitHub repo webhooks" \
+  --signature-algorithm hmac-sha256 \
+  --signature-header X-Hub-Signature-256 \
+  --signature-prefix sha256= \
+  --signature-secret-env GITHUB_WEBHOOK_SECRET \
+  --idempotency-key-template 'github:{headers.x-github-delivery}' \
+  --expected-interval 86400
+
+curl -sS -X PATCH https://omni.example.com/api/v2/webhook-sources/<id> \
+  -H "x-api-key: $OMNI_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"eventTypeMapping":{"source":"header","header":"X-GitHub-Event"}}'
+```
+
+## Step 2 — register the four event schemas
+
+The JSON Schema artifacts live next to this runbook in
+[`docs/examples/event-schemas/github/`](../examples/event-schemas/github/).
+They are minimal-but-real: the fields consumers rely on are required
+(`repository.full_name`, `sender.login`; `ref`/`commits` for push,
+`action`+`number` for PR, `action`+`issue.number` for issues,
+`release.tag_name` for releases) and everything else GitHub sends passes
+through (`additionalProperties: true`).
+
+```bash
+cd docs/examples/event-schemas/github
+
+omni events schema register custom.github.push \
+  --file custom.github.push.json --description "GitHub push deliveries"
+omni events schema register custom.github.pull_request \
+  --file custom.github.pull_request.json --description "GitHub pull_request deliveries"
+omni events schema register custom.github.issues \
+  --file custom.github.issues.json --description "GitHub issues deliveries"
+omni events schema register custom.github.release \
+  --file custom.github.release.json --description "GitHub release deliveries"
+
+omni events schema list --enabled
+```
+
+From now on a delivery for one of these types that violates its contract is
+refused with 400 and dead-lettered (`schema_validation_failed`, visible via
+`omni dead-letters list`) — it never enters the journal. Revisions must be
+additive-optional; an incompatible change is refused with 409 and must ship as
+a new versioned type (e.g. `custom.github.push.v2`).
+
+## Step 3 — configure the webhook on GitHub
+
+Repo → **Settings → Webhooks → Add webhook** (org-level works the same):
+
+| GitHub field | Value |
+|---|---|
+| Payload URL | `https://omni.example.com/api/v2/webhooks/ingress/github` |
+| Content type | **`application/json`** — required. The ingress rejects form-encoded bodies (400), and the HMAC is over the raw JSON bytes. |
+| Secret | the same `$GITHUB_WEBHOOK_SECRET` from step 1 |
+| SSL verification | enabled |
+| Events | "Let me select individual events" → **Pushes**, **Pull requests**, **Issues**, **Releases** |
+
+Save. GitHub immediately sends a `ping` delivery — it carries
+`X-GitHub-Event: ping`, so it lands as `custom.github.ping` (unregistered
+type → passes the schema gate untouched). A 200 under "Recent Deliveries"
+proves the signature contract is right.
+
+No API key appears anywhere on this surface: the ingress route is
+auth-exempt and authenticity comes exclusively from the signature. All
+rejections (unknown source, disabled, unconfigured, bad signature) collapse
+into one 401 shape by design.
+
+## Step 4 — liveness cadence
+
+`expectedIntervalSeconds: 86400` declares "GitHub produces ≥1 event or
+heartbeat per day". Real repos are quiet on weekends, so pair the declaration
+with a cheap daily heartbeat — a scheduled GitHub Actions workflow is the
+natural home (it also proves the repo→omni path end to end):
+
+```yaml
+# .github/workflows/omni-heartbeat.yml
+name: omni-heartbeat
+on:
+  schedule:
+    - cron: '17 6 * * *'
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -fsS -X POST "$OMNI_URL/api/v2/webhooks/github/heartbeat" \
+            -H "x-api-key: ${{ secrets.OMNI_API_KEY }}"
+        env:
+          OMNI_URL: https://omni.example.com
+```
+
+(`omni webhooks heartbeat github` does the same from a cron box.) Heartbeats
+create NO journal events — only the `system.connector.stalled` /
+`system.connector.recovered` **transitions** are journaled, once each, and a
+stall also files a manual-resolution dead-letter entry. Health is visible in
+`omni webhooks list` / `omni webhooks get github` (`livenessStatus`).
+
+## Step 5 — a firing automation
+
+Automations trigger on the exact semantic type. Example: announce merged
+pushes in a chat:
+
+```bash
+omni automations create \
+  --name "GitHub push notifier" \
+  --trigger custom.github.push \
+  --action send_message \
+  --config '{
+    "instanceId": "<instance uuid>",
+    "chatId": "<chat id>",
+    "message": "push to {{payload.repository.full_name}} ({{payload.ref}}) by {{payload.sender.login}}"
+  }'
+```
+
+Because redelivery dedup happens **before** publish, a GitHub redelivery can
+never double-fire this automation: one delivery = one journal event = at most
+one firing.
+
+Route the liveness transitions the same way (`--trigger
+system.connector.stalled` + a `webhook`/`send_message` action) to be paged
+when the source goes quiet.
+
+## Step 6 — verify
+
+```bash
+# Push a commit, open/close a PR, publish a release; then:
+omni events list --type 'custom.github.*'
+omni events trace <eventId>              # roots at the ingress claim row
+
+# Redelivery drill: GitHub → Settings → Webhooks → Recent Deliveries →
+# "Redeliver" on any delivery. Expect HTTP 200 with {"duplicate": true} and
+# NO new event in the journal:
+omni webhooks get github                 # totalReceived vs totalDuplicates
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Every delivery 401 | Secret mismatch (omni row vs GitHub settings), or the source has no `signatureConfig`, or it is disabled. All collapse into the same 401 intentionally; the real reason is in the API log (`Webhook ingress rejected`). |
+| Delivery 400 `VALIDATION` | Content type is form-encoded (must be `application/json`), or the payload violates a registered schema — check `omni dead-letters list` for `schema_validation_failed`. |
+| Events land as `custom.webhook.github` | `eventTypeMapping` missing on the source row (the CLI cannot set it yet — use the `PATCH` from step 1). |
+| Duplicate events on redelivery | `idempotencyKeyTemplate` not set to `github:{headers.x-github-delivery}` (check `omni webhooks get github`). |
+| `system.connector.stalled` during a quiet week | Expected: that is the declared contract doing its job. Heartbeat (step 4) to distinguish quiet from dead, or lengthen/clear the cadence. |
+
+## The claim this recipe proves
+
+RFC #925: *"each source = 1 webhook source row + N registered schemas + a key
+template, zero new ingress code."* This runbook is pure configuration —
+signature verification, semantic typing, schema gating, redelivery dedup and
+liveness supervision all execute on the pre-existing ingress
+(`packages/api/src/services/webhooks.ts`, untouched by #983). The
+end-to-end proof is
+`packages/api/src/__tests__/webhook-github-source-postgres.test.ts`.

--- a/packages/api/src/__tests__/webhook-github-source-postgres.test.ts
+++ b/packages/api/src/__tests__/webhook-github-source-postgres.test.ts
@@ -1,0 +1,341 @@
+/**
+ * The GitHub source recipe, end-to-end over the REAL HTTP ingress and real
+ * PostgreSQL (issue #983, RFC #925 Phase 3 — source 1 of 2).
+ *
+ * This suite is the proof of the RFC's claim: "each source = 1 webhook source
+ * row + N registered schemas + a key template, ZERO new ingress code". The
+ * source row and the four schema artifacts below are EXACTLY what
+ * docs/runbooks/github-webhook-source.md tells an operator to configure —
+ * the schemas are loaded from the shipped artifacts in
+ * docs/examples/event-schemas/github/, so registering them here also proves
+ * they compile. Faked GitHub deliveries then go through the unmodified
+ * public ingress route (POST /api/v2/webhooks/ingress/github):
+ *
+ *   * a correctly signed delivery (HMAC-SHA256 over the raw body,
+ *     X-Hub-Signature-256, sha256= prefix) is accepted; a bad signature gets
+ *     the uniform 401 and journals NOTHING;
+ *   * X-GitHub-Event maps deliveries to the semantic types
+ *     custom.github.push / .pull_request / .issues / .release (#959);
+ *   * a REDELIVERY (same X-GitHub-Delivery — GitHub's GUID is stable across
+ *     redeliveries) responds 200 BOTH times but creates exactly ONE journal
+ *     event and ONE bus publish (→ at most one automation firing), with the
+ *     source's duplicate counter bumped (#958);
+ *   * a signed delivery violating its registered schema is refused with 400
+ *     and dead-lettered, never journaled (#959);
+ *   * declaring the cadence armed liveness supervision on create (#961).
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { EventBus } from '@omni/core';
+import { type Database, createDbHandle, deadLetterEvents, omniEvents, webhookSources } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { eq } from 'drizzle-orm';
+import { createApp } from '../app';
+import { EventSchemaService } from '../services/event-schemas';
+import { WebhookService } from '../services/webhooks';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+const SECRET = 'gh-recipe-shared-secret-983';
+const ARTIFACTS_DIR = join(import.meta.dir, '../../../../docs/examples/event-schemas/github');
+const GITHUB_EVENT_TYPES = [
+  'custom.github.push',
+  'custom.github.pull_request',
+  'custom.github.issues',
+  'custom.github.release',
+] as const;
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-983-github-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+interface PublishedEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/** An EventBus fake that records generic publishes (all this path uses). */
+function recordingBus(events: PublishedEvent[]): EventBus {
+  return {
+    publishGeneric: async (type: string, payload: Record<string, unknown>, metadata?: Record<string, unknown>) => {
+      events.push({ type, payload });
+      return { id: crypto.randomUUID(), type, timestamp: Date.now(), payload, metadata };
+    },
+  } as unknown as EventBus;
+}
+
+/** Sign a raw body exactly the way GitHub does. */
+function sign(body: string): string {
+  return `sha256=${createHmac('sha256', SECRET).update(body).digest('hex')}`;
+}
+
+interface GitHubDeliveryOptions {
+  /** Overrides the valid signature (e.g. a tampered one). */
+  signature?: string;
+  /** Drop the X-GitHub-Event header entirely. */
+  omitEventHeader?: boolean;
+}
+
+interface ReceiveResponse {
+  received?: boolean;
+  eventId?: string;
+  eventType?: string;
+  duplicate?: boolean;
+  error?: { code: string; message: string };
+}
+
+/** Realistic-but-minimal GitHub webhook payloads (the runbook's four types). */
+const REPO = { full_name: 'automagik-dev/omni' };
+const SENDER = { login: 'vasconceloscezar' };
+const PAYLOADS: Record<string, Record<string, unknown>> = {
+  push: {
+    ref: 'refs/heads/main',
+    before: 'a'.repeat(40),
+    after: 'b'.repeat(40),
+    commits: [{ id: 'b'.repeat(40), message: 'feat(sources): recipe', url: 'https://github.com/x/c/b' }],
+    repository: REPO,
+    sender: SENDER,
+  },
+  pull_request: {
+    action: 'opened',
+    number: 983,
+    pull_request: { title: 'GitHub as first real source', state: 'open', merged: false },
+    repository: REPO,
+    sender: SENDER,
+  },
+  issues: {
+    action: 'closed',
+    issue: { number: 983, title: 'plug in GitHub', state: 'closed' },
+    repository: REPO,
+    sender: SENDER,
+  },
+  release: {
+    action: 'published',
+    release: { tag_name: 'v2.260907.4', name: 'v2.260907.4', draft: false, prerelease: false },
+    repository: REPO,
+    sender: SENDER,
+  },
+};
+
+postgresDescribe('GitHub source recipe end-to-end (#983, real PostgreSQL)', () => {
+  const dbName = `omni_983_github_${crypto.randomUUID().replaceAll('-', '')}`;
+  let db: Database;
+  let close: () => Promise<void>;
+  let app: ReturnType<typeof createApp>['app'];
+  const published: PublishedEvent[] = [];
+
+  /** POST a fake GitHub delivery through the real public ingress route. */
+  async function deliver(
+    githubEvent: string,
+    deliveryId: string,
+    payload: Record<string, unknown>,
+    options: GitHubDeliveryOptions = {},
+  ): Promise<{ status: number; json: ReceiveResponse }> {
+    const body = JSON.stringify(payload);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Hub-Signature-256': options.signature ?? sign(body),
+      'X-GitHub-Delivery': deliveryId,
+    };
+    if (!options.omitEventHeader) {
+      headers['X-GitHub-Event'] = githubEvent;
+    }
+    const res = await app.request('/api/v2/webhooks/ingress/github', { method: 'POST', body, headers });
+    return { status: res.status, json: (await res.json()) as ReceiveResponse };
+  }
+
+  async function journalRowsForKey(key: string) {
+    return db.select().from(omniEvents).where(eq(omniEvents.idempotencyKey, key));
+  }
+
+  beforeAll(async () => {
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
+    const handle = createDbHandle({ url: urlFor(superUrl, dbName), maxConnections: 3 });
+    db = handle.db;
+    close = handle.close;
+
+    // The runbook's step 1: one webhook_sources row declaring the whole
+    // contract. Created through the same service the API route uses.
+    await new WebhookService(db, null).create({
+      name: 'github',
+      description: 'GitHub repo webhooks (#983 recipe)',
+      signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Hub-Signature-256', prefix: 'sha256=' },
+      signatureSecret: SECRET,
+      idempotencyKeyTemplate: 'github:{headers.x-github-delivery}',
+      eventTypeMapping: { source: 'header', header: 'X-GitHub-Event' },
+      expectedIntervalSeconds: 86_400,
+    });
+
+    // The runbook's step 2: register the SHIPPED JSON Schema artifacts —
+    // loading them from docs/ proves the artifacts themselves compile.
+    const schemaService = new EventSchemaService(db);
+    for (const eventType of GITHUB_EVENT_TYPES) {
+      const artifact = JSON.parse(readFileSync(join(ARTIFACTS_DIR, `${eventType}.json`), 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      await schemaService.register({ eventType, schema: artifact, description: `${eventType} (#983)` });
+    }
+
+    // The real HTTP app over the real database — nothing stubbed.
+    ({ app } = createApp(db, recordingBus(published)));
+  }, 180_000);
+
+  afterAll(async () => {
+    await close?.().catch(() => undefined);
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('declaring the cadence armed liveness supervision on create (#961)', async () => {
+    const [source] = await db.select().from(webhookSources).where(eq(webhookSources.name, 'github'));
+    expect(source?.expectedIntervalSeconds).toBe(86_400);
+    expect(source?.livenessStatus).toBe('healthy');
+    expect(source?.livenessArmedAt).not.toBeNull();
+  });
+
+  test('a correctly signed push lands as custom.github.push under the delivery-id key', async () => {
+    const deliveryId = crypto.randomUUID();
+    const payload = PAYLOADS.push;
+    if (!payload) throw new Error('missing push fixture');
+
+    const { status, json } = await deliver('push', deliveryId, payload);
+
+    expect(status).toBe(200);
+    expect(json.received).toBe(true);
+    expect(json.eventType).toBe('custom.github.push');
+    expect(json.duplicate).toBeUndefined();
+
+    // The journal row exists under the RFC's exact key shape and shares the
+    // response's event id (#956/#958: one identity for row + event).
+    const rows = await journalRowsForKey(`github:${deliveryId}`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(json.eventId as string);
+    expect(rows[0]?.eventType).toBe('custom.github.push');
+
+    // One bus publish → at most one automation firing.
+    expect(published.filter((e) => e.type === 'custom.github.push')).toHaveLength(1);
+  });
+
+  test('a bad signature gets the uniform 401 and journals nothing', async () => {
+    const deliveryId = crypto.randomUUID();
+    const payload = PAYLOADS.push;
+    if (!payload) throw new Error('missing push fixture');
+
+    const { status, json } = await deliver('push', deliveryId, payload, { signature: 'sha256=deadbeef' });
+
+    expect(status).toBe(401);
+    expect(json.error?.message).toBe('Webhook verification failed');
+    expect(await journalRowsForKey(`github:${deliveryId}`)).toHaveLength(0);
+  });
+
+  test('a signature over DIFFERENT body bytes is rejected (raw-body HMAC, not re-serialization)', async () => {
+    const deliveryId = crypto.randomUUID();
+    const payload = PAYLOADS.push;
+    if (!payload) throw new Error('missing push fixture');
+
+    const { status } = await deliver('push', deliveryId, payload, {
+      signature: sign(JSON.stringify({ ...payload, after: 'c'.repeat(40) })),
+    });
+
+    expect(status).toBe(401);
+    expect(await journalRowsForKey(`github:${deliveryId}`)).toHaveLength(0);
+  });
+
+  test.each([
+    ['pull_request', 'custom.github.pull_request'],
+    ['issues', 'custom.github.issues'],
+    ['release', 'custom.github.release'],
+  ])('X-GitHub-Event: %s maps to %s (#959)', async (githubEvent, expectedType) => {
+    const payload = PAYLOADS[githubEvent];
+    if (!payload) throw new Error(`missing fixture for ${githubEvent}`);
+
+    const { status, json } = await deliver(githubEvent, crypto.randomUUID(), payload);
+
+    expect(status).toBe(200);
+    expect(json.eventType).toBe(expectedType);
+  });
+
+  test('a delivery without X-GitHub-Event falls back to the collapsed legacy type', async () => {
+    // GitHub always sends the header; the fallback is the ingress contract
+    // for a mapped source when the mapping cannot resolve (#959).
+    const { status, json } = await deliver('unused', crypto.randomUUID(), PAYLOADS.push ?? {}, {
+      omitEventHeader: true,
+    });
+
+    expect(status).toBe(200);
+    expect(json.eventType).toBe('custom.webhook.github');
+  });
+
+  test('CRITICAL: a redelivery (same X-GitHub-Delivery) is 200 both times but journals exactly ONE event', async () => {
+    const deliveryId = crypto.randomUUID();
+    const payload = PAYLOADS.release;
+    if (!payload) throw new Error('missing release fixture');
+    const publishedBefore = published.length;
+    const [sourceBefore] = await db.select().from(webhookSources).where(eq(webhookSources.name, 'github'));
+
+    const first = await deliver('release', deliveryId, payload);
+    const second = await deliver('release', deliveryId, payload);
+
+    // GitHub must see success both times so it stops redelivering.
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.json.duplicate).toBeUndefined();
+    expect(second.json.duplicate).toBe(true);
+    // The duplicate ack points at the ORIGINAL event.
+    expect(second.json.eventId).toBe(first.json.eventId);
+
+    // Exactly one journal event and one bus publish for the delivery.
+    expect(await journalRowsForKey(`github:${deliveryId}`)).toHaveLength(1);
+    expect(published.length).toBe(publishedBefore + 1);
+
+    // The redelivery is visible on the source's counters.
+    const [sourceAfter] = await db.select().from(webhookSources).where(eq(webhookSources.name, 'github'));
+    expect(sourceAfter?.totalDuplicates).toBe((sourceBefore?.totalDuplicates ?? 0) + 1);
+  });
+
+  test('a signed delivery violating its registered schema is 400 + dead-lettered, never journaled (#959)', async () => {
+    const deliveryId = crypto.randomUUID();
+    // `ref`, `repository` and `sender` are required by the shipped artifact.
+    const invalid = { commits: [] };
+
+    const { status, json } = await deliver('push', deliveryId, invalid);
+
+    expect(status).toBe(400);
+    expect(json.error?.message).toContain('schema_validation_failed');
+    expect(await journalRowsForKey(`github:${deliveryId}`)).toHaveLength(0);
+
+    const dlq = await db
+      .select()
+      .from(deadLetterEvents)
+      .where(eq(deadLetterEvents.eventType, 'custom.github.push'))
+      .limit(5);
+    expect(dlq.length).toBeGreaterThanOrEqual(1);
+    expect(dlq[0]?.error).toContain('schema_validation_failed');
+  });
+});


### PR DESCRIPTION
Closes #983

## Summary

RFC #925 Phase 3, source 1 of 2: GitHub plugged in as the first real external webhook source — **entirely by configuration**. The recipe is one `webhook_sources` row + four registered event schemas + a key template + a declared liveness cadence, and it is documented, shipped as artifacts, and proven end-to-end:

- **`docs/runbooks/github-webhook-source.md`** — from GitHub repo webhook settings to a firing automation: the `webhook_sources` row (`signatureConfig` for `X-Hub-Signature-256`, HMAC-SHA256 over the raw body; `idempotencyKeyTemplate: github:{headers.x-github-delivery}`; `eventTypeMapping` on `X-GitHub-Event`; `expectedIntervalSeconds: 86400` per #961 with a GitHub-Actions heartbeat pattern), schema registration via `omni events schema register`, GitHub-side settings, automation example, verification and troubleshooting.
- **`docs/examples/event-schemas/github/custom.github.{push,pull_request,issues,release}.json`** — minimal-but-real JSON Schema artifacts (draft-07): required fields are the ones consumers rely on (`repository.full_name`, `sender.login`; `ref`/`commits` for push; `action`+`number` for PRs; `action`+`issue.number` for issues; `release.tag_name` for releases); `additionalProperties: true`; additive-optional evolution per #959.
- **`packages/api/src/__tests__/webhook-github-source-postgres.test.ts`** — fakes GitHub deliveries through the real HTTP ingress route against a migrated disposable PostgreSQL database, registering the schemas from the shipped docs artifacts (so the artifacts themselves are proven to compile).

## Zero-ingress-code verdict: **HELD** ✅

The hard constraint was zero changes under `packages/api/src/services/` — and the diff has **zero changes to any existing file**: three new files only (runbook, artifacts, test). Signature verification (#928), semantic type mapping (#959), redelivery idempotency (#958), the schema gate (#959) and liveness supervision (#961) all executed unmodified for a real GitHub-shaped source.

One **tooling gap** (not an ingress defect, recorded in the runbook's troubleshooting table): `omni webhooks create|update` has no flag for `eventTypeMapping`, so the CLI-first path needs one `PATCH /api/v2/webhook-sources/:id` curl to set the mapping (the API/SDK support it fully). Worth a small follow-up CLI issue.

## Test evidence

New suite (auto-discovered by `scripts/pg-gate.ts`'s zero-skip contract):

```
bun test packages/api/src/__tests__/webhook-github-source-postgres.test.ts
 10 pass / 0 fail (37 expect() calls) against a disposable migrated cluster
```

Covers:
- valid `X-Hub-Signature-256` accepted (200, `custom.github.push`, journal row under `github:{delivery-guid}`);
- bad signature and signature-over-different-bytes → uniform 401, nothing journaled;
- `X-GitHub-Event` mapping → `custom.github.pull_request` / `.issues` / `.release`; missing header falls back to `custom.webhook.github`;
- **redelivery** (same `X-GitHub-Delivery`) → 200 both times, second response `duplicate: true` pointing at the original event id, exactly ONE journal row, ONE bus publish (→ at most one automation firing), `totalDuplicates` bumped;
- schema-violating delivery → 400 + `schema_validation_failed` dead letter, never journaled;
- declaring the cadence armed liveness (`livenessStatus: healthy`, `livenessArmedAt` set).

Gates: `make typecheck` ✅ · `make lint` ✅ · full real-PostgreSQL gate (`scripts/pg-gate.ts`, all suites incl. the new one) ✅

No migration needed — every field the recipe uses already exists on `webhook_sources`.
