### PR TITLE
feat(sources): plug in ClickUp as second external source — config-only proof (#984)

### DIFF
--- a/docs/examples/event-schemas/clickup/custom.clickup.taskcreated.json
+++ b/docs/examples/event-schemas/clickup/custom.clickup.taskcreated.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.clickup.taskcreated",
+  "description": "ClickUp taskCreated webhook delivery (body field event: taskCreated). Minimal-but-real contract: the fields consumers rely on are required; everything else ClickUp sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["event", "task_id", "webhook_id"],
+  "properties": {
+    "event": {
+      "const": "taskCreated",
+      "description": "ClickUp event name (also the source of the semantic type via eventTypeMapping)"
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Id of the created task"
+    },
+    "webhook_id": {
+      "type": "string",
+      "description": "Id of the ClickUp webhook configuration that fired"
+    },
+    "history_items": {
+      "type": "array",
+      "description": "Creation history entries (statuses, assignees, ...)",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "date": { "type": "string" },
+          "field": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/event-schemas/clickup/custom.clickup.taskdeleted.json
+++ b/docs/examples/event-schemas/clickup/custom.clickup.taskdeleted.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.clickup.taskdeleted",
+  "description": "ClickUp taskDeleted webhook delivery (body field event: taskDeleted). NOTE: unlike other task events this payload carries NO history_items — just event, task_id and webhook_id — so its idempotency key falls back to the body hash (see the runbook). Minimal-but-real contract with additionalProperties: true; revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["event", "task_id", "webhook_id"],
+  "properties": {
+    "event": {
+      "const": "taskDeleted",
+      "description": "ClickUp event name (also the source of the semantic type via eventTypeMapping)"
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Id of the deleted task"
+    },
+    "webhook_id": {
+      "type": "string",
+      "description": "Id of the ClickUp webhook configuration that fired"
+    }
+  }
+}

--- a/docs/examples/event-schemas/clickup/custom.clickup.taskstatusupdated.json
+++ b/docs/examples/event-schemas/clickup/custom.clickup.taskstatusupdated.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.clickup.taskstatusupdated",
+  "description": "ClickUp taskStatusUpdated webhook delivery (body field event: taskStatusUpdated — the RFC #925 motivating case: card status changes replace pollers). Minimal-but-real contract: the fields consumers rely on are required; everything else ClickUp sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["event", "task_id", "webhook_id", "history_items"],
+  "properties": {
+    "event": {
+      "const": "taskStatusUpdated",
+      "description": "ClickUp event name (also the source of the semantic type via eventTypeMapping)"
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Id of the task whose status changed"
+    },
+    "webhook_id": {
+      "type": "string",
+      "description": "Id of the ClickUp webhook configuration that fired"
+    },
+    "history_items": {
+      "type": "array",
+      "description": "The change that triggered the event; before/after carry the old and new status",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable per-event history id — the delivery identity used by the idempotency key template"
+          },
+          "date": { "type": "string", "description": "Unix timestamp in milliseconds, as a string" },
+          "field": { "type": "string", "description": "Changed attribute, e.g. status" },
+          "user": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "id": { "type": "integer" },
+              "username": { "type": "string" },
+              "email": { "type": "string" }
+            }
+          },
+          "before": {
+            "type": ["object", "null"],
+            "additionalProperties": true,
+            "properties": {
+              "status": { "type": "string" },
+              "type": { "type": "string" },
+              "color": { "type": "string" }
+            }
+          },
+          "after": {
+            "type": ["object", "null"],
+            "additionalProperties": true,
+            "properties": {
+              "status": { "type": "string" },
+              "type": { "type": "string" },
+              "color": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/event-schemas/clickup/custom.clickup.taskupdated.json
+++ b/docs/examples/event-schemas/clickup/custom.clickup.taskupdated.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "custom.clickup.taskupdated",
+  "description": "ClickUp taskUpdated webhook delivery (body field event: taskUpdated — also sent alongside more specific updates such as taskStatusUpdated). Minimal-but-real contract: the fields consumers rely on are required; everything else ClickUp sends passes through (additionalProperties: true). Evolution rule: revisions must be additive-optional (issue #959).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["event", "task_id", "webhook_id", "history_items"],
+  "properties": {
+    "event": {
+      "const": "taskUpdated",
+      "description": "ClickUp event name (also the source of the semantic type via eventTypeMapping)"
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Id of the updated task"
+    },
+    "webhook_id": {
+      "type": "string",
+      "description": "Id of the ClickUp webhook configuration that fired"
+    },
+    "history_items": {
+      "type": "array",
+      "description": "The change(s) that triggered the event",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable per-event history id — the delivery identity used by the idempotency key template"
+          },
+          "date": { "type": "string" },
+          "field": { "type": "string", "description": "Changed attribute, e.g. name, description, assignee" }
+        }
+      }
+    }
+  }
+}

--- a/docs/runbooks/clickup-webhook-source.md
+++ b/docs/runbooks/clickup-webhook-source.md
@@ -1,0 +1,264 @@
+# Runbook — ClickUp as a webhook source
+
+> Issue #984 — RFC #925 Phase 3, source 2 of 2. Walks from a ClickUp webhook
+> to a firing automation: one `webhook_sources` row, four registered event
+> schemas, one idempotency key template, one declared liveness cadence.
+> ClickUp is the recipe's **body-first** proof: unlike GitHub it carries the
+> event name and the delivery identity in the JSON body, not in headers —
+> which needed two small generic ingress enablers (see
+> ["The claim this recipe tests"](#the-claim-this-recipe-tests) for the
+> honest config-only verdict).
+>
+> Pinned end-to-end (fake ClickUp deliveries through the real HTTP ingress
+> and a real PostgreSQL journal) by
+> `packages/api/src/__tests__/webhook-clickup-source-postgres.test.ts`.
+
+## What you get
+
+Every delivery ClickUp sends to `POST /api/v2/webhooks/ingress/clickup` is:
+
+1. **verified** — HMAC-SHA256 over the raw body against `X-Signature`
+   (issue #928; `packages/api/src/services/webhooks.ts`). ClickUp sends the
+   bare lowercase hex digest — no `sha256=` prefix — so the source's
+   `signatureConfig` simply omits `prefix`;
+2. **typed** — the body's `event` field lands as the semantic type:
+   `taskStatusUpdated` → `custom.clickup.taskstatusupdated` (the token
+   normalizer lowercases event names) via the source's body-sourced
+   `eventTypeMapping` (issues #959/#984);
+3. **schema-checked** — payloads for the four registered types must satisfy
+   their JSON Schema contract or they are dead-lettered, never journaled
+   (issue #959);
+4. **deduplicated** — ClickUp retries failed deliveries; the
+   `clickup:{payload.history_items.0.id}` key template keys every delivery on
+   the stable per-event history id, so a retry acks with `duplicate: true`
+   and exactly ONE journal event (issue #958);
+5. **supervised** — a declared cadence means silence beyond the window emits
+   `system.connector.stalled` + a DLQ entry instead of failing silently
+   (issue #961, see [[../architecture/connector-contract|Connector Lifecycle Contract]]).
+
+## Prerequisites
+
+- An omni API reachable from clickup.com (public URL or tunnel), called
+  `https://omni.example.com` below.
+- The `omni` CLI configured with an admin API key (`omni config`), or a raw
+  API key for the `curl` variants.
+- A ClickUp API token (personal token or OAuth) and your Workspace (team) id.
+- **No pre-chosen secret**: unlike GitHub, ClickUp *generates* the signing
+  secret and returns it when you create the webhook — so the ClickUp webhook
+  is created FIRST (step 1) and the omni row second (step 2).
+
+## Step 1 — create the webhook on ClickUp
+
+ClickUp webhooks are API-managed (there is no repo-settings UI form):
+
+```bash
+curl -sS -X POST "https://api.clickup.com/api/v2/team/$CLICKUP_TEAM_ID/webhook" \
+  -H "Authorization: $CLICKUP_API_TOKEN" -H 'Content-Type: application/json' \
+  -d '{
+    "endpoint": "https://omni.example.com/api/v2/webhooks/ingress/clickup",
+    "events": ["taskStatusUpdated", "taskCreated", "taskUpdated", "taskDeleted"]
+  }'
+```
+
+The response's `webhook.secret` is the HMAC key ClickUp will sign every
+delivery with — capture it:
+
+```bash
+export CLICKUP_WEBHOOK_SECRET="<webhook.secret from the response>"
+```
+
+(Scope the webhook to a Space/Folder/List by adding `space_id` / `folder_id`
+/ `list_id` to the body; `webhook.id` in the response is the `webhook_id`
+field you will see in every delivery.)
+
+## Step 2 — create the `webhook_sources` row
+
+One API call declares the whole contract. The public ingress refuses any
+source without a `signatureConfig`, so the endpoint is unreachable until this
+row exists:
+
+```bash
+curl -sS -X POST https://omni.example.com/api/v2/webhook-sources \
+  -H "x-api-key: $OMNI_API_KEY" -H 'Content-Type: application/json' \
+  -d @- <<JSON
+{
+  "name": "clickup",
+  "description": "ClickUp workspace webhooks (RFC #925 Phase 3 recipe)",
+  "signatureConfig": {
+    "algorithm": "hmac-sha256",
+    "header": "X-Signature"
+  },
+  "signatureSecret": "$CLICKUP_WEBHOOK_SECRET",
+  "idempotencyKeyTemplate": "clickup:{payload.history_items.0.id}",
+  "eventTypeMapping": { "source": "body", "path": "event" },
+  "expectedIntervalSeconds": 86400
+}
+JSON
+```
+
+Field by field:
+
+| Field | Why |
+|---|---|
+| `signatureConfig` | ClickUp signs every delivery with `X-Signature: <hex hmac>` — HMAC-SHA256 of the **raw body bytes** under the webhook's generated secret. No prefix (GitHub's `sha256=` has no ClickUp equivalent), so `prefix` is simply omitted. The secret is write-only (never returned by the API). |
+| `idempotencyKeyTemplate` | ClickUp does **not** send a top-level delivery id (the RFC's proposed `clickup:{event_id}` referenced a field that does not exist). The stable per-event identity is `history_items[0].id`, reached with a numeric array segment. The template resolves to e.g. `clickup:2800763136717140857`; the unique index on `omni_events.idempotency_key` is the dedup authority. `taskDeleted` carries no `history_items`, so those deliveries fall back to `clickup:{sha256(body)}` — still correct, since a retry resends the same bytes (the fallback logs a warning per delivery; acceptable at taskDeleted volumes). |
+| `eventTypeMapping` | Reads the body's `event` field and emits `custom.clickup.{event}` after token normalization (lowercase): `taskStatusUpdated` → `custom.clickup.taskstatusupdated`, `taskCreated` → `custom.clickup.taskcreated`, `taskUpdated` → `custom.clickup.taskupdated`, `taskDeleted` → `custom.clickup.taskdeleted`. Deliveries without a usable `event` field fall back to `custom.webhook.clickup`. |
+| `expectedIntervalSeconds` | Declared liveness cadence (#961): "≥1 event **or heartbeat** per 24 h". See step 5. |
+
+CLI alternative (everything except `eventTypeMapping`, which has no CLI flag
+yet — add it with the `PATCH` below):
+
+```bash
+omni webhooks create --name clickup \
+  --description "ClickUp workspace webhooks" \
+  --signature-algorithm hmac-sha256 \
+  --signature-header X-Signature \
+  --signature-secret-env CLICKUP_WEBHOOK_SECRET \
+  --idempotency-key-template 'clickup:{payload.history_items.0.id}' \
+  --expected-interval 86400
+
+curl -sS -X PATCH https://omni.example.com/api/v2/webhook-sources/<id> \
+  -H "x-api-key: $OMNI_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"eventTypeMapping":{"source":"body","path":"event"}}'
+```
+
+## Step 3 — register the four event schemas
+
+The JSON Schema artifacts live next to this runbook in
+[`docs/examples/event-schemas/clickup/`](../examples/event-schemas/clickup/).
+They are minimal-but-real: the fields consumers rely on are required
+(`event`, `task_id`, `webhook_id` everywhere; `history_items` with the
+per-event id — and before/after status objects for the status change — where
+ClickUp sends them) and everything else passes through
+(`additionalProperties: true`). Note `taskDeleted` deliberately does NOT
+require `history_items` — ClickUp omits it there.
+
+```bash
+cd docs/examples/event-schemas/clickup
+
+omni events schema register custom.clickup.taskstatusupdated \
+  --file custom.clickup.taskstatusupdated.json --description "ClickUp task status changes"
+omni events schema register custom.clickup.taskcreated \
+  --file custom.clickup.taskcreated.json --description "ClickUp task creations"
+omni events schema register custom.clickup.taskupdated \
+  --file custom.clickup.taskupdated.json --description "ClickUp task updates"
+omni events schema register custom.clickup.taskdeleted \
+  --file custom.clickup.taskdeleted.json --description "ClickUp task deletions"
+
+omni events schema list --enabled
+```
+
+From now on a delivery for one of these types that violates its contract is
+refused with 400 and dead-lettered (`schema_validation_failed`, visible via
+`omni dead-letters list`) — it never enters the journal. Revisions must be
+additive-optional; an incompatible change is refused with 409 and must ship
+as a new versioned type (e.g. `custom.clickup.taskstatusupdated.v2`).
+
+## Step 4 — verify the ClickUp side
+
+ClickUp has no "recent deliveries" UI; check the webhook's health via the
+API:
+
+```bash
+curl -sS "https://api.clickup.com/api/v2/team/$CLICKUP_TEAM_ID/webhook" \
+  -H "Authorization: $CLICKUP_API_TOKEN" | jq '.webhooks[] | {id, endpoint, health}'
+```
+
+`health.status: "active"` with `fail_count: 0` means omni is acking.
+ClickUp retries failed deliveries and will mark a persistently failing
+webhook `failing`/suspend it — at which point events silently stop, which is
+exactly what the liveness cadence (step 5) catches.
+
+No API key appears anywhere on this surface: the ingress route is
+auth-exempt and authenticity comes exclusively from the signature. All
+rejections (unknown source, disabled, unconfigured, bad signature) collapse
+into one 401 shape by design.
+
+## Step 5 — liveness cadence
+
+`expectedIntervalSeconds: 86400` declares "the workspace produces ≥1 event or
+heartbeat per day". Quiet workspaces (weekends, holidays) should pair the
+declaration with a cheap daily heartbeat from any cron box:
+
+```bash
+# crontab: 17 6 * * *
+omni webhooks heartbeat clickup
+# or: curl -fsS -X POST "$OMNI_URL/api/v2/webhooks/clickup/heartbeat" -H "x-api-key: $OMNI_API_KEY"
+```
+
+Heartbeats create NO journal events — only the `system.connector.stalled` /
+`system.connector.recovered` **transitions** are journaled, once each, and a
+stall also files a manual-resolution dead-letter entry. Health is visible in
+`omni webhooks list` / `omni webhooks get clickup` (`livenessStatus`). A
+stall is also your early warning that ClickUp auto-suspended the webhook
+(step 4).
+
+## Step 6 — a firing automation
+
+Automations trigger on the exact semantic type. The RFC's motivating case —
+"card status changes → replaces pollers":
+
+```bash
+omni automations create \
+  --name "ClickUp status change notifier" \
+  --trigger custom.clickup.taskstatusupdated \
+  --action send_message \
+  --config '{
+    "instanceId": "<instance uuid>",
+    "chatId": "<chat id>",
+    "message": "task {{payload.task_id}}: {{payload.history_items.0.before.status}} → {{payload.history_items.0.after.status}} (by {{payload.history_items.0.user.username}})"
+  }'
+```
+
+Because retry dedup happens **before** publish, a ClickUp retry can never
+double-fire this automation: one delivery = one journal event = at most one
+firing.
+
+Route the liveness transitions the same way (`--trigger
+system.connector.stalled` + a `webhook`/`send_message` action) to be paged
+when the source goes quiet.
+
+## Step 7 — verify end to end
+
+```bash
+# Drag a card to another status in ClickUp; then:
+omni events list --type 'custom.clickup.*'
+omni events trace <eventId>              # roots at the ingress claim row
+
+# Retry drill: temporarily 500 the endpoint (or replay the same delivery
+# bytes + signature). Expect HTTP 200 with {"duplicate": true} and NO new
+# journal event:
+omni webhooks get clickup                # totalReceived vs totalDuplicates
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Every delivery 401 | Secret mismatch — the omni row must hold the `webhook.secret` ClickUp returned at creation (recreate the ClickUp webhook = new secret), or the source has no `signatureConfig`, or it is disabled. All collapse into the same 401 intentionally; the real reason is in the API log (`Webhook ingress rejected`). |
+| Delivery 400 `VALIDATION` | The payload violates a registered schema — check `omni dead-letters list` for `schema_validation_failed`. |
+| Events land as `custom.webhook.clickup` | `eventTypeMapping` missing on the source row (the CLI cannot set it yet — use the `PATCH` from step 2), or the delivery had no usable `event` field. |
+| Duplicate events on retry | `idempotencyKeyTemplate` not set to `clickup:{payload.history_items.0.id}` (check `omni webhooks get clickup`). |
+| Warn log "idempotency template placeholder unresolved" | Expected for `taskDeleted` (no `history_items`): the key falls back to the body hash, which still dedups byte-identical retries. |
+| Events stop arriving entirely | ClickUp auto-suspends persistently failing webhooks — check `health.status` (step 4). The liveness stall (#961) is the designed alarm for this. |
+| `system.connector.stalled` during a quiet week | Expected: that is the declared contract doing its job. Heartbeat (step 5) to distinguish quiet from dead, or lengthen/clear the cadence. |
+
+## The claim this recipe tests
+
+RFC #925: *"each source = 1 webhook source row + N registered schemas + a key
+template, zero new ingress code."* For this second source the verdict is
+**config-only with two recorded gaps** (issue #984): the pre-existing ingress
+could not express a **body-first** provider, so two minimal generic enablers
+shipped alongside this runbook —
+
+1. `eventTypeMapping` gained a `{ "source": "body", "path": "..." }` variant
+   (it was header-only; ClickUp's event name lives in the body);
+2. the idempotency payload-path grammar gained numeric array indexing
+   (ClickUp's stable event id lives at `history_items.0.id`; the RFC's
+   proposed `{event_id}` field does not exist in real ClickUp payloads).
+
+Signature verification (#928, including no-prefix hex digests), the schema
+gate (#959), redelivery dedup (#958) and liveness supervision (#961) all
+executed unmodified. Everything in THIS runbook is configuration; the
+end-to-end proof is
+`packages/api/src/__tests__/webhook-clickup-source-postgres.test.ts`.

--- a/packages/api/src/__tests__/webhook-clickup-source-postgres.test.ts
+++ b/packages/api/src/__tests__/webhook-clickup-source-postgres.test.ts
@@ -1,0 +1,378 @@
+/**
+ * The ClickUp source recipe, end-to-end over the REAL HTTP ingress and real
+ * PostgreSQL (issue #984, RFC #925 Phase 3 — source 2 of 2).
+ *
+ * This suite tests the RFC's stronger claim for the SECOND source: "pure
+ * configuration, zero new ingress code". The honest verdict is config-only
+ * WITH two recorded generic enablers (see the runbook), because ClickUp is a
+ * body-first provider: the event name lives in the body's `event` field
+ * (body-sourced eventTypeMapping) and the stable delivery identity lives at
+ * `history_items[0].id` (numeric array segments in the payload-path
+ * grammar). The source row and the four schema artifacts below are EXACTLY
+ * what docs/runbooks/clickup-webhook-source.md tells an operator to
+ * configure — the schemas are loaded from the shipped artifacts in
+ * docs/examples/event-schemas/clickup/, so registering them here also proves
+ * they compile. Faked ClickUp deliveries then go through the public ingress
+ * route (POST /api/v2/webhooks/ingress/clickup):
+ *
+ *   * a correctly signed delivery (HMAC-SHA256 over the raw body,
+ *     X-Signature, bare lowercase hex — NO prefix, unlike GitHub) is
+ *     accepted; a bad signature gets the uniform 401 and journals NOTHING;
+ *   * the body's `event` field maps deliveries to the semantic types
+ *     custom.clickup.taskstatusupdated / .taskcreated / .taskupdated /
+ *     .taskdeleted (#959/#984);
+ *   * a RETRY (same history_items[0].id — ClickUp's per-event history id is
+ *     stable across retries) responds 200 BOTH times but creates exactly ONE
+ *     journal event and ONE bus publish (→ at most one automation firing),
+ *     with the source's duplicate counter bumped (#958);
+ *   * taskDeleted carries NO history_items, so its key falls back to the
+ *     body hash — byte-identical retries still dedup;
+ *   * a signed delivery violating its registered schema is refused with 400
+ *     and dead-lettered, never journaled (#959);
+ *   * declaring the cadence armed liveness supervision on create (#961).
+ *
+ * Set `OMNI_G4_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { createHash, createHmac } from 'node:crypto';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { EventBus } from '@omni/core';
+import { type Database, createDbHandle, deadLetterEvents, omniEvents, webhookSources } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { eq } from 'drizzle-orm';
+import { createApp } from '../app';
+import { EventSchemaService } from '../services/event-schemas';
+import { WebhookService } from '../services/webhooks';
+
+const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G4_PSQL_BIN ?? 'psql';
+
+/** ClickUp GENERATES the secret at webhook creation (runbook step 1). */
+const SECRET = 'clickup-generated-secret-984';
+const WEBHOOK_ID = '7fa3ec74-69a8-4530-a251-8a13730bd204';
+const ARTIFACTS_DIR = join(import.meta.dir, '../../../../docs/examples/event-schemas/clickup');
+const CLICKUP_EVENT_TYPES = [
+  'custom.clickup.taskstatusupdated',
+  'custom.clickup.taskcreated',
+  'custom.clickup.taskupdated',
+  'custom.clickup.taskdeleted',
+] as const;
+
+function runSqlOn(url: string, script: string): { exitCode: number; stderr: string } {
+  const file = join(tmpdir(), `omni-984-clickup-${crypto.randomUUID()}.sql`);
+  writeFileSync(file, script);
+  try {
+    const result = Bun.spawnSync({
+      cmd: [psqlBin, '-X', '--no-psqlrc', '-A', '-t', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '-f', file],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+interface PublishedEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/** An EventBus fake that records generic publishes (all this path uses). */
+function recordingBus(events: PublishedEvent[]): EventBus {
+  return {
+    publishGeneric: async (type: string, payload: Record<string, unknown>, metadata?: Record<string, unknown>) => {
+      events.push({ type, payload });
+      return { id: crypto.randomUUID(), type, timestamp: Date.now(), payload, metadata };
+    },
+  } as unknown as EventBus;
+}
+
+/** Sign a raw body exactly the way ClickUp does: bare hex digest, no prefix. */
+function sign(body: string): string {
+  return createHmac('sha256', SECRET).update(body).digest('hex');
+}
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/** Unique, ClickUp-shaped numeric history ids (stable per event). */
+let historyIdCounter = 0;
+function nextHistoryId(): string {
+  historyIdCounter += 1;
+  return `28007631367171408${String(historyIdCounter).padStart(3, '0')}`;
+}
+
+interface ReceiveResponse {
+  received?: boolean;
+  eventId?: string;
+  eventType?: string;
+  duplicate?: boolean;
+  error?: { code: string; message: string };
+}
+
+const USER = { id: 183, username: 'cezar', email: 'cezar@namastex.ai' };
+
+/** Realistic-but-minimal ClickUp webhook payloads (the runbook's four types). */
+function taskStatusUpdatedPayload(historyId: string): Record<string, unknown> {
+  return {
+    event: 'taskStatusUpdated',
+    history_items: [
+      {
+        id: historyId,
+        type: 1,
+        date: '1757300000000',
+        field: 'status',
+        parent_id: '900211139021',
+        data: { status_type: 'custom' },
+        source: null,
+        user: USER,
+        before: { status: 'in progress', color: '#5f55ee', type: 'custom', orderindex: 1 },
+        after: { status: 'done', color: '#008844', type: 'done', orderindex: 2 },
+      },
+    ],
+    task_id: '86dtxyz12',
+    webhook_id: WEBHOOK_ID,
+  };
+}
+
+function taskCreatedPayload(historyId: string): Record<string, unknown> {
+  return {
+    event: 'taskCreated',
+    history_items: [{ id: historyId, type: 1, date: '1757300000001', field: 'status', user: USER }],
+    task_id: '86dtxyz13',
+    webhook_id: WEBHOOK_ID,
+  };
+}
+
+function taskUpdatedPayload(historyId: string): Record<string, unknown> {
+  return {
+    event: 'taskUpdated',
+    history_items: [{ id: historyId, type: 1, date: '1757300000002', field: 'name', user: USER }],
+    task_id: '86dtxyz14',
+    webhook_id: WEBHOOK_ID,
+  };
+}
+
+/** taskDeleted really carries NO history_items — just these three fields. */
+function taskDeletedPayload(taskId = '86dtxyz15'): Record<string, unknown> {
+  return { event: 'taskDeleted', task_id: taskId, webhook_id: WEBHOOK_ID };
+}
+
+postgresDescribe('ClickUp source recipe end-to-end (#984, real PostgreSQL)', () => {
+  const dbName = `omni_984_clickup_${crypto.randomUUID().replaceAll('-', '')}`;
+  let db: Database;
+  let close: () => Promise<void>;
+  let app: ReturnType<typeof createApp>['app'];
+  const published: PublishedEvent[] = [];
+
+  /** POST a fake ClickUp delivery through the real public ingress route. */
+  async function deliver(
+    payload: Record<string, unknown>,
+    options: { signature?: string } = {},
+  ): Promise<{ status: number; json: ReceiveResponse; body: string }> {
+    const body = JSON.stringify(payload);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      // ClickUp sends ONLY the bare hex digest — no sha256= prefix, and no
+      // delivery-id or event-name headers (everything else is in the body).
+      'X-Signature': options.signature ?? sign(body),
+    };
+    const res = await app.request('/api/v2/webhooks/ingress/clickup', { method: 'POST', body, headers });
+    return { status: res.status, json: (await res.json()) as ReceiveResponse, body };
+  }
+
+  async function journalRowsForKey(key: string) {
+    return db.select().from(omniEvents).where(eq(omniEvents.idempotencyKey, key));
+  }
+
+  beforeAll(async () => {
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
+    const handle = createDbHandle({ url: urlFor(superUrl, dbName), maxConnections: 3 });
+    db = handle.db;
+    close = handle.close;
+
+    // The runbook's step 2: one webhook_sources row declaring the whole
+    // contract. Created through the same service the API route uses.
+    await new WebhookService(db, null).create({
+      name: 'clickup',
+      description: 'ClickUp workspace webhooks (#984 recipe)',
+      signatureConfig: { algorithm: 'hmac-sha256', header: 'X-Signature' },
+      signatureSecret: SECRET,
+      idempotencyKeyTemplate: 'clickup:{payload.history_items.0.id}',
+      eventTypeMapping: { source: 'body', path: 'event' },
+      expectedIntervalSeconds: 86_400,
+    });
+
+    // The runbook's step 3: register the SHIPPED JSON Schema artifacts —
+    // loading them from docs/ proves the artifacts themselves compile.
+    const schemaService = new EventSchemaService(db);
+    for (const eventType of CLICKUP_EVENT_TYPES) {
+      const artifact = JSON.parse(readFileSync(join(ARTIFACTS_DIR, `${eventType}.json`), 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      await schemaService.register({ eventType, schema: artifact, description: `${eventType} (#984)` });
+    }
+
+    // The real HTTP app over the real database — nothing stubbed.
+    ({ app } = createApp(db, recordingBus(published)));
+  }, 180_000);
+
+  afterAll(async () => {
+    await close?.().catch(() => undefined);
+    runSqlOn(superUrl, `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`);
+  });
+
+  test('declaring the cadence armed liveness supervision on create (#961)', async () => {
+    const [source] = await db.select().from(webhookSources).where(eq(webhookSources.name, 'clickup'));
+    expect(source?.expectedIntervalSeconds).toBe(86_400);
+    expect(source?.livenessStatus).toBe('healthy');
+    expect(source?.livenessArmedAt).not.toBeNull();
+  });
+
+  test('a correctly signed status change lands as custom.clickup.taskstatusupdated under the history-id key', async () => {
+    const historyId = nextHistoryId();
+
+    const { status, json } = await deliver(taskStatusUpdatedPayload(historyId));
+
+    expect(status).toBe(200);
+    expect(json.received).toBe(true);
+    expect(json.eventType).toBe('custom.clickup.taskstatusupdated');
+    expect(json.duplicate).toBeUndefined();
+
+    // The journal row exists under the runbook's exact key shape and shares
+    // the response's event id (#956/#958: one identity for row + event).
+    const rows = await journalRowsForKey(`clickup:${historyId}`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(json.eventId as string);
+    expect(rows[0]?.eventType).toBe('custom.clickup.taskstatusupdated');
+
+    // One bus publish → at most one automation firing.
+    expect(published.filter((e) => e.type === 'custom.clickup.taskstatusupdated')).toHaveLength(1);
+  });
+
+  test('a bad signature gets the uniform 401 and journals nothing', async () => {
+    const historyId = nextHistoryId();
+
+    const { status, json } = await deliver(taskStatusUpdatedPayload(historyId), { signature: 'deadbeef' });
+
+    expect(status).toBe(401);
+    expect(json.error?.message).toBe('Webhook verification failed');
+    expect(await journalRowsForKey(`clickup:${historyId}`)).toHaveLength(0);
+  });
+
+  test('a signature over DIFFERENT body bytes is rejected (raw-body HMAC, not re-serialization)', async () => {
+    const historyId = nextHistoryId();
+    const payload = taskStatusUpdatedPayload(historyId);
+
+    const { status } = await deliver(payload, {
+      signature: sign(JSON.stringify({ ...payload, task_id: 'tampered' })),
+    });
+
+    expect(status).toBe(401);
+    expect(await journalRowsForKey(`clickup:${historyId}`)).toHaveLength(0);
+  });
+
+  test.each([
+    ['taskCreated', 'custom.clickup.taskcreated', () => taskCreatedPayload(nextHistoryId())],
+    ['taskUpdated', 'custom.clickup.taskupdated', () => taskUpdatedPayload(nextHistoryId())],
+    ['taskDeleted', 'custom.clickup.taskdeleted', () => taskDeletedPayload()],
+  ])('body event %s maps to %s (#959/#984)', async (_clickupEvent, expectedType, makePayload) => {
+    const { status, json } = await deliver(makePayload());
+
+    expect(status).toBe(200);
+    expect(json.eventType).toBe(expectedType);
+  });
+
+  test('a delivery without a usable event field falls back to the collapsed legacy type', async () => {
+    // ClickUp always sends `event`; the fallback is the ingress contract for
+    // a mapped source when the body path cannot resolve (#959/#984).
+    const { status, json } = await deliver({ task_id: '86dtxyz99', webhook_id: WEBHOOK_ID });
+
+    expect(status).toBe(200);
+    expect(json.eventType).toBe('custom.webhook.clickup');
+  });
+
+  test('CRITICAL: a retry (same history_items[0].id) is 200 both times but journals exactly ONE event', async () => {
+    const historyId = nextHistoryId();
+    const payload = taskStatusUpdatedPayload(historyId);
+    const publishedBefore = published.length;
+    const [sourceBefore] = await db.select().from(webhookSources).where(eq(webhookSources.name, 'clickup'));
+
+    const first = await deliver(payload);
+    const second = await deliver(payload);
+
+    // ClickUp must see success both times so it stops retrying (and never
+    // marks the webhook as failing).
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.json.duplicate).toBeUndefined();
+    expect(second.json.duplicate).toBe(true);
+    // The duplicate ack points at the ORIGINAL event.
+    expect(second.json.eventId).toBe(first.json.eventId);
+
+    // Exactly one journal event and one bus publish for the delivery.
+    expect(await journalRowsForKey(`clickup:${historyId}`)).toHaveLength(1);
+    expect(published.length).toBe(publishedBefore + 1);
+
+    // The retry is visible on the source's counters.
+    const [sourceAfter] = await db.select().from(webhookSources).where(eq(webhookSources.name, 'clickup'));
+    expect(sourceAfter?.totalDuplicates).toBe((sourceBefore?.totalDuplicates ?? 0) + 1);
+  });
+
+  test('taskDeleted (no history_items) falls back to the body-hash key and STILL dedups retries', async () => {
+    const payload = taskDeletedPayload('86dtxyz42');
+    const publishedBefore = published.length;
+
+    const first = await deliver(payload);
+    const second = await deliver(payload);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.json.duplicate).toBe(true);
+
+    // The unresolved {payload.history_items.0.id} placeholder falls back to
+    // the documented body-hash default — correct because ClickUp retries
+    // resend the same bytes.
+    const rows = await journalRowsForKey(`clickup:${sha256Hex(first.body)}`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.eventType).toBe('custom.clickup.taskdeleted');
+    expect(published.length).toBe(publishedBefore + 1);
+  });
+
+  test('a signed delivery violating its registered schema is 400 + dead-lettered, never journaled (#959)', async () => {
+    const historyId = nextHistoryId();
+    // `task_id` and `webhook_id` are required by the shipped artifact.
+    const invalid = {
+      event: 'taskStatusUpdated',
+      history_items: [{ id: historyId }],
+    };
+
+    const { status, json } = await deliver(invalid);
+
+    expect(status).toBe(400);
+    expect(json.error?.message).toContain('schema_validation_failed');
+    expect(await journalRowsForKey(`clickup:${historyId}`)).toHaveLength(0);
+
+    const dlq = await db
+      .select()
+      .from(deadLetterEvents)
+      .where(eq(deadLetterEvents.eventType, 'custom.clickup.taskstatusupdated'))
+      .limit(5);
+    expect(dlq.length).toBeGreaterThanOrEqual(1);
+    expect(dlq[0]?.error).toContain('schema_validation_failed');
+  });
+});

--- a/packages/api/src/lib/__tests__/ingress-idempotency.test.ts
+++ b/packages/api/src/lib/__tests__/ingress-idempotency.test.ts
@@ -59,6 +59,36 @@ describe('deriveIdempotencyKey', () => {
     expect(key).toBe('slack:T1:C9:1725.0001');
   });
 
+  test('numeric payload path segments index arrays (ClickUp history_items, #984)', () => {
+    const key = deriveIdempotencyKey({
+      ...base,
+      sourceName: 'clickup',
+      template: 'clickup:{payload.history_items.0.id}',
+      payload: { event: 'taskStatusUpdated', history_items: [{ id: '2800763136717140857' }] },
+    });
+    expect(key).toBe('clickup:2800763136717140857');
+  });
+
+  test('a non-numeric segment against an array falls back to the body-hash default', () => {
+    const key = deriveIdempotencyKey({
+      ...base,
+      sourceName: 'clickup',
+      template: 'clickup:{payload.history_items.id}',
+      payload: { history_items: [{ id: 'h1' }] },
+    });
+    expect(key).toBe(`clickup:${sha256(base.rawBody)}`);
+  });
+
+  test('an out-of-range array index falls back to the body-hash default', () => {
+    const key = deriveIdempotencyKey({
+      ...base,
+      sourceName: 'clickup',
+      template: 'clickup:{payload.history_items.3.id}',
+      payload: { history_items: [{ id: 'h1' }] },
+    });
+    expect(key).toBe(`clickup:${sha256(base.rawBody)}`);
+  });
+
   test('an unresolvable placeholder falls back to the body-hash default', () => {
     const key = deriveIdempotencyKey({ ...base, template: 'github:{headers.x-github-delivery}' });
     expect(key).toBe(`github:${sha256(base.rawBody)}`);

--- a/packages/api/src/lib/ingress-idempotency.ts
+++ b/packages/api/src/lib/ingress-idempotency.ts
@@ -20,11 +20,12 @@
  *   {source}          the webhook source name
  *   {sha256(body)}    hex SHA-256 of the raw request body bytes
  *   {headers.<name>}  a request header (case-insensitive)
- *   {payload.<path>}  a dot-path into the JSON payload; scalars only
+ *   {payload.<path>}  a dot-path into the JSON payload; numeric segments
+ *                     index arrays (#984); scalars only
  *
  * Examples:
  *   github:  "github:{headers.x-github-delivery}"
- *   clickup: "clickup:{payload.event_id}"
+ *   clickup: "clickup:{payload.history_items.0.id}"
  *   slack:   "slack:{payload.team_id}:{payload.event.channel}:{payload.event.event_ts}"
  *   default: "{source}:{sha256(body)}"  (existing sources migrate onto this)
  *
@@ -56,11 +57,23 @@ function sha256Hex(input: string): string {
   return createHash('sha256').update(input).digest('hex');
 }
 
-/** Resolve a dot-path into the payload; only non-empty scalars are usable. */
-function resolvePayloadPath(payload: Record<string, unknown>, path: string): string | undefined {
+/**
+ * Resolve a dot-path into the payload; only non-empty scalars are usable.
+ * Numeric segments index arrays (#984 — providers like ClickUp carry the
+ * stable delivery identity inside an array, e.g. `history_items.0.id`).
+ *
+ * Shared with the semantic event-type mapping (`resolveWebhookEventType`),
+ * which reads body-sourced event names through the same grammar.
+ */
+export function resolvePayloadPath(payload: Record<string, unknown>, path: string): string | undefined {
   let current: unknown = payload;
   for (const part of path.split('.')) {
-    if (current === null || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    if (current === null || typeof current !== 'object') return undefined;
+    if (Array.isArray(current)) {
+      if (!/^(0|[1-9]\d*)$/.test(part)) return undefined;
+      current = current[Number(part)];
+      continue;
+    }
     current = (current as Record<string, unknown>)[part];
   }
   if (typeof current === 'string') return current.length > 0 ? current : undefined;

--- a/packages/api/src/schemas/openapi/webhooks.ts
+++ b/packages/api/src/schemas/openapi/webhooks.ts
@@ -55,14 +55,25 @@ export const WebhookSignatureConfigSchema = z
 // Semantic event-type extraction (issue #959). Like the signature contract
 // above, this is the ONE Zod definition: the route validator imports it, so
 // the published OpenAPI document and the runtime validation cannot drift.
-export const WebhookEventTypeMappingSchema = z.object({
-  source: z.literal('header').openapi({
-    description: 'Where the semantic event name is read from (only headers for now)',
+export const WebhookEventTypeMappingSchema = z.discriminatedUnion('source', [
+  z.object({
+    source: z.literal('header').openapi({
+      description: 'Read the semantic event name from a request header',
+    }),
+    header: z.string().min(1).max(200).openapi({
+      description: 'Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters',
+    }),
   }),
-  header: z.string().min(1).max(200).openapi({
-    description: 'Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters',
+  z.object({
+    source: z.literal('body').openapi({
+      description: 'Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)',
+    }),
+    path: z.string().min(1).max(200).openapi({
+      description:
+        'Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters',
+    }),
   }),
-});
+]);
 
 // Webhook source schema
 export const WebhookSourceSchema = z.object({

--- a/packages/api/src/services/__tests__/webhook-event-type-mapping.test.ts
+++ b/packages/api/src/services/__tests__/webhook-event-type-mapping.test.ts
@@ -2,15 +2,18 @@
  * Source→semantic-type mapping for the generic webhook ingress (issue #959).
  *
  * A mapped source extracts the semantic event name from the delivery
- * (`X-GitHub-Event: push` → `custom.github.push`) instead of collapsing every
- * delivery into `custom.webhook.{source}`; anything the mapping cannot
- * resolve falls back to the collapsed legacy type.
+ * (`X-GitHub-Event: push` → `custom.github.push`, or — for body-first
+ * providers like ClickUp (#984) — the `event` body field:
+ * `taskStatusUpdated` → `custom.clickup.taskstatusupdated`) instead of
+ * collapsing every delivery into `custom.webhook.{source}`; anything the
+ * mapping cannot resolve falls back to the collapsed legacy type.
  */
 
 import { describe, expect, test } from 'bun:test';
 import { resolveWebhookEventType } from '../webhooks';
 
 const GITHUB_MAPPING = { source: 'header', header: 'X-GitHub-Event' } as const;
+const CLICKUP_MAPPING = { source: 'body', path: 'event' } as const;
 
 describe('resolveWebhookEventType', () => {
   test('a mapped source emits custom.{source}.{event} from the header', () => {
@@ -47,5 +50,29 @@ describe('resolveWebhookEventType', () => {
   test('an oversized header value is capped at 64 characters', () => {
     const eventType = resolveWebhookEventType('github', GITHUB_MAPPING, { 'x-github-event': 'x'.repeat(200) });
     expect(eventType).toBe(`custom.github.${'x'.repeat(64)}`);
+  });
+
+  test('a body-mapped source reads the event name from the payload (#984)', () => {
+    expect(resolveWebhookEventType('clickup', CLICKUP_MAPPING, {}, { event: 'taskStatusUpdated' })).toBe(
+      'custom.clickup.taskstatusupdated',
+    );
+    expect(resolveWebhookEventType('clickup', CLICKUP_MAPPING, {}, { event: 'taskCreated' })).toBe(
+      'custom.clickup.taskcreated',
+    );
+  });
+
+  test('a body mapping resolves nested dot-paths', () => {
+    const mapping = { source: 'body', path: 'meta.kind' } as const;
+    expect(resolveWebhookEventType('acme', mapping, {}, { meta: { kind: 'invoice_paid' } })).toBe(
+      'custom.acme.invoice_paid',
+    );
+  });
+
+  test('a delivery without the mapped body field falls back to the collapsed type', () => {
+    expect(resolveWebhookEventType('clickup', CLICKUP_MAPPING, {}, {})).toBe('custom.webhook.clickup');
+    expect(resolveWebhookEventType('clickup', CLICKUP_MAPPING, {}, { event: '' })).toBe('custom.webhook.clickup');
+    expect(resolveWebhookEventType('clickup', CLICKUP_MAPPING, {}, { event: { nested: true } })).toBe(
+      'custom.webhook.clickup',
+    );
   });
 });

--- a/packages/api/src/services/webhooks.ts
+++ b/packages/api/src/services/webhooks.ts
@@ -31,7 +31,7 @@ import {
   webhookSources,
 } from '@omni/db';
 import { and, eq, isNotNull, sql } from 'drizzle-orm';
-import { deriveIdempotencyKey } from '../lib/ingress-idempotency';
+import { deriveIdempotencyKey, resolvePayloadPath } from '../lib/ingress-idempotency';
 import { openCredentialField, sealCredentialField } from '../tenancy/sealed-credentials';
 import { currentTenantScope, scopedHandle } from '../tenancy/tenant-scope';
 import type { DeadLetterService } from './dead-letters';
@@ -98,19 +98,26 @@ function sanitizeEventToken(raw: string | undefined): string | null {
  * Source→semantic-type mapping (issue #959). A source configured with an
  * `eventTypeMapping` emits `custom.{source}.{event}` (e.g. `X-GitHub-Event:
  * push` → `custom.github.push`) instead of collapsing every delivery into
- * `custom.webhook.{source}`. No mapping, or a delivery the mapping cannot
- * resolve (header absent/empty), falls back to the legacy collapsed type.
+ * `custom.webhook.{source}`. The event name comes from a header
+ * (`source: 'header'`) or, for body-first providers like ClickUp, from a
+ * dot-path into the JSON payload (`source: 'body'`, issue #984 — e.g.
+ * `event: taskStatusUpdated` → `custom.clickup.taskstatusupdated`). No
+ * mapping, or a delivery the mapping cannot resolve (header/path
+ * absent/empty), falls back to the legacy collapsed type.
  */
 export function resolveWebhookEventType(
   sourceName: string,
   mapping: WebhookEventTypeMapping | null,
   headers: Record<string, string>,
+  payload: Record<string, unknown> = {},
 ): CustomEventType {
   const fallback = `custom.webhook.${sourceName}` as CustomEventType;
-  if (!mapping || mapping.source !== 'header') {
+  if (!mapping) {
     return fallback;
   }
-  const token = sanitizeEventToken(headers[mapping.header.toLowerCase()]);
+  const raw =
+    mapping.source === 'header' ? headers[mapping.header.toLowerCase()] : resolvePayloadPath(payload, mapping.path);
+  const token = sanitizeEventToken(raw);
   return token ? (`custom.${sourceName}.${token}` as CustomEventType) : fallback;
 }
 
@@ -355,7 +362,7 @@ export class WebhookService {
 
     // Semantic type extraction (issue #959): a mapped source emits
     // custom.{source}.{event}; unmapped keeps the legacy collapsed type.
-    const eventType = resolveWebhookEventType(sourceName, source.eventTypeMapping, headers);
+    const eventType = resolveWebhookEventType(sourceName, source.eventTypeMapping, headers, payload);
     const eventPayload = {
       source: sourceName,
       ...payload,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2775,16 +2775,25 @@ export type ConnectorMutationPolicy = (typeof connectorMutationPolicies)[number]
  * Without a mapping every delivery from a source collapses into the fixed
  * `custom.webhook.{source}` type — GitHub push, PR, issue and release all
  * arrive indistinguishable. A mapping extracts the semantic event name from
- * the delivery (e.g. the `X-GitHub-Event` header) so the published type
+ * the delivery (e.g. the `X-GitHub-Event` header, or the `event` body field
+ * for body-first providers like ClickUp — issue #984) so the published type
  * becomes `custom.{source}.{event}` (`custom.github.push`). A delivery the
  * mapping cannot resolve falls back to the legacy collapsed type.
  */
-export interface WebhookEventTypeMapping {
-  /** Where the semantic event name is read from. Only headers for now. */
-  source: 'header';
-  /** Header carrying the semantic event name (e.g. 'X-GitHub-Event'). */
-  header: string;
-}
+// no-migration-needed: type-only widening of a jsonb column's TS shape (no DDL impact)
+export type WebhookEventTypeMapping =
+  | {
+      /** Read the semantic event name from a request header. */
+      source: 'header';
+      /** Header carrying the semantic event name (e.g. 'X-GitHub-Event'). */
+      header: string;
+    }
+  | {
+      /** Read the semantic event name from the JSON body (#984). */
+      source: 'body';
+      /** Dot-path to the event name (e.g. 'event'); numeric segments index arrays. */
+      path: string;
+    };
 
 /**
  * Webhook source configurations.

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -4178,12 +4178,20 @@ export interface components {
         };
         WebhookEventTypeMapping: {
             /**
-             * @description Where the semantic event name is read from (only headers for now)
+             * @description Read the semantic event name from a request header
              * @enum {string}
              */
             source: "header";
             /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
             header: string;
+        } | {
+            /**
+             * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+             * @enum {string}
+             */
+            source: "body";
+            /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+            path: string;
         };
         WebhookSource: {
             /**
@@ -4214,13 +4222,21 @@ export interface components {
             /** @description Semantic event-type extraction: a mapped source emits custom.{source}.{event} instead of the collapsed custom.webhook.{source} */
             eventTypeMapping: {
                 /**
-                 * @description Where the semantic event name is read from (only headers for now)
+                 * @description Read the semantic event name from a request header
                  * @enum {string}
                  */
                 source: "header";
                 /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                 header: string;
-            } | null;
+            } | {
+                /**
+                 * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                 * @enum {string}
+                 */
+                source: "body";
+                /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                path: string;
+            } | unknown;
             /** @description Whether a signature secret is stored (secret is write-only) */
             hasSignatureSecret: boolean;
             /** @description Idempotency key derivation template */
@@ -4309,13 +4325,21 @@ export interface components {
             /** @description Semantic event-type extraction (e.g. header X-GitHub-Event: push emits custom.{source}.push). Null or absent keeps the legacy collapsed custom.webhook.{source} type for every delivery. */
             eventTypeMapping?: {
                 /**
-                 * @description Where the semantic event name is read from (only headers for now)
+                 * @description Read the semantic event name from a request header
                  * @enum {string}
                  */
                 source: "header";
                 /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                 header: string;
-            } | null;
+            } | {
+                /**
+                 * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                 * @enum {string}
+                 */
+                source: "body";
+                /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                path: string;
+            } | unknown;
             /**
              * @description Whether enabled
              * @default true
@@ -11468,13 +11492,21 @@ export interface operations {
                             /** @description Semantic event-type extraction: a mapped source emits custom.{source}.{event} instead of the collapsed custom.webhook.{source} */
                             eventTypeMapping: {
                                 /**
-                                 * @description Where the semantic event name is read from (only headers for now)
+                                 * @description Read the semantic event name from a request header
                                  * @enum {string}
                                  */
                                 source: "header";
                                 /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                                 header: string;
-                            } | null;
+                            } | {
+                                /**
+                                 * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                                 * @enum {string}
+                                 */
+                                source: "body";
+                                /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                                path: string;
+                            } | unknown;
                             /** @description Whether a signature secret is stored (secret is write-only) */
                             hasSignatureSecret: boolean;
                             /** @description Idempotency key derivation template */
@@ -11577,13 +11609,21 @@ export interface operations {
                     /** @description Semantic event-type extraction (e.g. header X-GitHub-Event: push emits custom.{source}.push). Null or absent keeps the legacy collapsed custom.webhook.{source} type for every delivery. */
                     eventTypeMapping?: {
                         /**
-                         * @description Where the semantic event name is read from (only headers for now)
+                         * @description Read the semantic event name from a request header
                          * @enum {string}
                          */
                         source: "header";
                         /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                         header: string;
-                    } | null;
+                    } | {
+                        /**
+                         * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                         * @enum {string}
+                         */
+                        source: "body";
+                        /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                        path: string;
+                    } | unknown;
                     /**
                      * @description Whether enabled
                      * @default true
@@ -11641,13 +11681,21 @@ export interface operations {
                             /** @description Semantic event-type extraction: a mapped source emits custom.{source}.{event} instead of the collapsed custom.webhook.{source} */
                             eventTypeMapping: {
                                 /**
-                                 * @description Where the semantic event name is read from (only headers for now)
+                                 * @description Read the semantic event name from a request header
                                  * @enum {string}
                                  */
                                 source: "header";
                                 /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                                 header: string;
-                            } | null;
+                            } | {
+                                /**
+                                 * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                                 * @enum {string}
+                                 */
+                                source: "body";
+                                /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                                path: string;
+                            } | unknown;
                             /** @description Whether a signature secret is stored (secret is write-only) */
                             hasSignatureSecret: boolean;
                             /** @description Idempotency key derivation template */
@@ -11781,13 +11829,21 @@ export interface operations {
                             /** @description Semantic event-type extraction: a mapped source emits custom.{source}.{event} instead of the collapsed custom.webhook.{source} */
                             eventTypeMapping: {
                                 /**
-                                 * @description Where the semantic event name is read from (only headers for now)
+                                 * @description Read the semantic event name from a request header
                                  * @enum {string}
                                  */
                                 source: "header";
                                 /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                                 header: string;
-                            } | null;
+                            } | {
+                                /**
+                                 * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                                 * @enum {string}
+                                 */
+                                source: "body";
+                                /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                                path: string;
+                            } | unknown;
                             /** @description Whether a signature secret is stored (secret is write-only) */
                             hasSignatureSecret: boolean;
                             /** @description Idempotency key derivation template */
@@ -11961,13 +12017,21 @@ export interface operations {
                     /** @description Semantic event-type extraction (e.g. header X-GitHub-Event: push emits custom.{source}.push). Null or absent keeps the legacy collapsed custom.webhook.{source} type for every delivery. */
                     eventTypeMapping?: {
                         /**
-                         * @description Where the semantic event name is read from (only headers for now)
+                         * @description Read the semantic event name from a request header
                          * @enum {string}
                          */
                         source: "header";
                         /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                         header: string;
-                    } | null;
+                    } | {
+                        /**
+                         * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                         * @enum {string}
+                         */
+                        source: "body";
+                        /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                        path: string;
+                    } | unknown;
                     /**
                      * @description Whether enabled
                      * @default true
@@ -12025,13 +12089,21 @@ export interface operations {
                             /** @description Semantic event-type extraction: a mapped source emits custom.{source}.{event} instead of the collapsed custom.webhook.{source} */
                             eventTypeMapping: {
                                 /**
-                                 * @description Where the semantic event name is read from (only headers for now)
+                                 * @description Read the semantic event name from a request header
                                  * @enum {string}
                                  */
                                 source: "header";
                                 /** @description Header carrying the semantic event name (e.g. X-GitHub-Event). 1-200 characters */
                                 header: string;
-                            } | null;
+                            } | {
+                                /**
+                                 * @description Read the semantic event name from the JSON body (body-first providers like ClickUp, #984)
+                                 * @enum {string}
+                                 */
+                                source: "body";
+                                /** @description Dot-path to the event name in the payload (e.g. "event"); numeric segments index arrays. 1-200 characters */
+                                path: string;
+                            } | unknown;
                             /** @description Whether a signature secret is stored (secret is write-only) */
                             hasSignatureSecret: boolean;
                             /** @description Idempotency key derivation template */


### PR DESCRIPTION
Closes #984

## Summary

RFC #925 Phase 3, source 2 of 2: ClickUp plugged in as the second real external webhook source, mirroring the GitHub recipe from #983/#1002 — one `webhook_sources` row + four registered event schemas + a key template + a declared liveness cadence:

- **`docs/runbooks/clickup-webhook-source.md`** — from ClickUp webhook creation (API-managed; ClickUp *generates* the signing secret and returns it, so the ClickUp side comes first) to a firing automation: the `webhook_sources` row (`signatureConfig` for `X-Signature`, HMAC-SHA256 over the raw body as a **bare lowercase hex digest — no prefix**, so `prefix` is simply omitted; `idempotencyKeyTemplate: clickup:{payload.history_items.0.id}`; `eventTypeMapping: { source: "body", path: "event" }`; `expectedIntervalSeconds: 86400` per #961 with a cron heartbeat pattern), schema registration, ClickUp-side health checks, the RFC's motivating automation (card status change → message, replacing pollers), verification and troubleshooting.
- **`docs/examples/event-schemas/clickup/custom.clickup.{taskstatusupdated,taskcreated,taskupdated,taskdeleted}.json`** — minimal-but-real JSON Schema artifacts (draft-07): `event` (const-pinned), `task_id`, `webhook_id` required everywhere; `history_items` essentials (per-event `id`, `field`, `user`, `before`/`after` status objects for the status change) where ClickUp sends them — and deliberately NOT required for `taskDeleted`, which really carries none; `additionalProperties: true`; additive-optional evolution per #959.
- **`packages/api/src/__tests__/webhook-clickup-source-postgres.test.ts`** — fakes ClickUp deliveries through the real HTTP ingress route against a migrated disposable PostgreSQL database, registering the schemas from the shipped docs artifacts (so the artifacts themselves are proven to compile).

## Zero-ingress-code verdict: **NOT fully held** — two recorded gaps ⚠️

The hard constraint was zero changes under `packages/api/src/services/` for the second source. ClickUp is a **body-first** provider (event name and delivery identity both live in the JSON body, not in headers), and the pre-existing ingress could not express that. Two minimal generic enablers ship in a clearly separated first commit (`feat(webhooks): body-sourced eventTypeMapping + array indices in payload paths`):

1. **`eventTypeMapping` was header-only** (`{ source: 'header' }` in the DB type, the OpenAPI contract, and `resolveWebhookEventType`). It gains a `{ "source": "body", "path": "event" }` variant; `resolveWebhookEventType` now takes the parsed payload and resolves dot-paths through the shared grammar. Touches `packages/api/src/services/webhooks.ts` (+ `packages/db/src/schema.ts` type-only jsonb widening with `no-migration-needed`, the OpenAPI schema, regenerated SDK types).
2. **The idempotency payload-path grammar could not reach ClickUp's stable event id.** The RFC's proposed `clickup:{event_id}` (and the grammar doc's own example `clickup:{payload.event_id}`) reference a field ClickUp does not send — the real stable identity is `history_items[0].id`, inside an array, and `{payload.<path>}` rejected arrays. Numeric segments now index arrays (`packages/api/src/lib/ingress-idempotency.ts`; `resolvePayloadPath` exported and shared with the event-type mapping).

Everything else executed unmodified for a real ClickUp-shaped source: signature verification (#928 — the generic config from PR #936 handles the no-prefix bare-hex digest by simply omitting `prefix`), the schema gate (#959), redelivery dedup (#958), liveness supervision (#961). The second commit — runbook, artifacts, test — is pure configuration.

Also carried from #1002: `omni webhooks create|update` still has no `eventTypeMapping` flag, so the runbook's CLI path uses one `PATCH` curl. The issue's optional `omni webhooks source preset` CLI add-on is deferred — a CLI flag for `eventTypeMapping` (the follow-up suggested in #1002) covers the same pain with less machinery.

## Test evidence

New suite (auto-discovered by `scripts/pg-gate.ts`'s zero-skip contract):

```
bun test packages/api/src/__tests__/webhook-clickup-source-postgres.test.ts
 11 pass / 0 fail (43 expect() calls) against a disposable migrated cluster
```

Covers:
- valid bare-hex `X-Signature` accepted (200, `custom.clickup.taskstatusupdated`, journal row under `clickup:{history-item-id}`);
- bad signature and signature-over-different-bytes → uniform 401, nothing journaled;
- body `event` mapping → `custom.clickup.taskcreated` / `.taskupdated` / `.taskdeleted`; missing `event` falls back to `custom.webhook.clickup`;
- **retry** (same `history_items[0].id`) → 200 both times, second response `duplicate: true` pointing at the original event id, exactly ONE journal row, ONE bus publish (→ at most one automation firing), `totalDuplicates` bumped;
- **`taskDeleted` (no `history_items`)** → documented fallback to the body-hash key, byte-identical retries still dedup;
- schema-violating delivery → 400 + `schema_validation_failed` dead letter, never journaled;
- declaring the cadence armed liveness (`livenessStatus: healthy`, `livenessArmedAt` set).

Plus extended unit coverage: body-sourced `resolveWebhookEventType` (nested paths, fallbacks) and array-index payload paths (non-numeric segment against an array, out-of-range index → body-hash fallback).

Gates: `make typecheck` ✅ · `make lint` ✅ · full real-PostgreSQL gate (`scripts/pg-gate.ts`, all suites incl. the new one) ✅

No migration needed — the `eventTypeMapping` change is a type-only widening of an existing jsonb column (`no-migration-needed` marker on the schema.ts line, `make verify-migrations` green).

Note: PR #1002 (GitHub source) is open and touches disjoint files; no conflict expected in either merge order.
