### PR TITLE
feat(automations): transactional publication — buffer a run's emissions, flush on success (#988)

### DIFF
--- a/packages/api/src/routes/v2/automations.ts
+++ b/packages/api/src/routes/v2/automations.ts
@@ -131,6 +131,13 @@ const createAutomationSchema = z.object({
   debounce: debounceSchema.optional().describe('Message debounce configuration'),
   enabled: z.boolean().default(true).describe('Whether automation is enabled'),
   priority: z.number().int().default(0).describe('Priority (higher runs first)'),
+  transactionalEmissions: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
+        'only when every action succeeded; a failed run publishes zero. Default false = immediate publishing',
+    ),
 });
 
 // Update automation schema

--- a/packages/api/src/schemas/openapi/automations.ts
+++ b/packages/api/src/schemas/openapi/automations.ts
@@ -108,6 +108,11 @@ export const AutomationSchema = z.object({
   debounce: DebounceSchema.nullable().openapi({ description: 'Debounce config' }),
   enabled: z.boolean().openapi({ description: 'Whether enabled' }),
   priority: z.number().int().openapi({ description: 'Priority' }),
+  transactionalEmissions: z.boolean().openapi({
+    description:
+      "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
+      'only when every action succeeded; a failed run publishes zero',
+  }),
   createdAt: z.string().datetime().openapi({ description: 'Creation timestamp' }),
   updatedAt: z.string().datetime().openapi({ description: 'Last update timestamp' }),
 });
@@ -126,6 +131,14 @@ export const CreateAutomationSchema = z.object({
   debounce: DebounceSchema.optional().openapi({ description: 'Debounce config' }),
   enabled: z.boolean().default(true).openapi({ description: 'Whether enabled' }),
   priority: z.number().int().default(0).openapi({ description: 'Priority' }),
+  transactionalEmissions: z
+    .boolean()
+    .default(false)
+    .openapi({
+      description:
+        "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
+        'only when every action succeeded; a failed run publishes zero. Default false = immediate publishing',
+    }),
 });
 
 // Automation log schema

--- a/packages/api/src/services/__tests__/automations.test.ts
+++ b/packages/api/src/services/__tests__/automations.test.ts
@@ -41,6 +41,7 @@ function createMockAutomation(overrides: Partial<Automation> = {}): Automation {
     debounce: null,
     enabled: true,
     priority: 0,
+    transactionalEmissions: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -291,8 +291,20 @@ export class AutomationService {
       ...deps,
     };
 
-    // Execute actions
-    const results = await executeActions(automation.actions as AutomationAction[], context, actionDeps);
+    // Execute actions. Manual execution honors the automation's transactional
+    // publication flag (G5, #988) so a debugging run behaves like the engine's:
+    // emissions buffer and flush only when every action succeeded. No engine
+    // provenance is threaded here (no triggering envelope), matching before.
+    const results = await executeActions(
+      automation.actions as AutomationAction[],
+      context,
+      actionDeps,
+      undefined,
+      undefined,
+      {
+        transactionalEmissions: automation.transactionalEmissions,
+      },
+    );
 
     // Log the execution
     const status = results.every((r) => r.status === 'success') ? 'success' : 'failed';

--- a/packages/cli/src/commands/automations.ts
+++ b/packages/cli/src/commands/automations.ts
@@ -40,6 +40,9 @@ interface CreateOptions {
   description?: string;
   priority?: number;
   disabled?: boolean;
+  // Transactional publication (G5, #988): true from --transactional-emissions,
+  // undefined when the flag is not given (server default false applies).
+  transactionalEmissions?: boolean;
   agentId?: string;
   providerId?: string;
   responseAs?: string;
@@ -172,6 +175,11 @@ export function createAutomationsCommand(): Command {
     .option('--description <desc>', 'Automation description')
     .option('--priority <n>', 'Priority (higher = runs first)', (v) => Number.parseInt(v, 10))
     .option('--disabled', 'Create in disabled state')
+    .option(
+      '--transactional-emissions',
+      "Buffer the run's emit_event publishes and flush them in order only when every action succeeded; " +
+        'a failed run publishes zero (#988). Defaults to off (immediate publishing)',
+    )
     // call_agent specific options
     .option('--agent-id <id>', 'Agent ID (for call_agent action)')
     .option('--provider-id <id>', 'Provider ID (for call_agent action)')
@@ -208,6 +216,7 @@ export function createAutomationsCommand(): Command {
           ],
           priority: options.priority,
           enabled: !options.disabled,
+          transactionalEmissions: options.transactionalEmissions,
         });
 
         output.success(`Automation created: ${automation.id}`, {
@@ -229,26 +238,42 @@ export function createAutomationsCommand(): Command {
     .option('--name <name>', 'New name')
     .option('--description <desc>', 'New description')
     .option('--priority <n>', 'New priority', (v) => Number.parseInt(v, 10))
-    .action(async (id: string, options: { name?: string; description?: string; priority?: number }) => {
-      const client = getClient();
+    .option(
+      '--transactional-emissions',
+      "Buffer the run's emit_event publishes and flush them in order only when every action succeeded; " +
+        'a failed run publishes zero (#988)',
+    )
+    .option('--no-transactional-emissions', 'Return the automation to immediate mid-sequence publishing')
+    .action(
+      async (
+        id: string,
+        // Commander negatable pair (#988, mirrors --strict-schemas from #1000):
+        // true from --transactional-emissions, false from
+        // --no-transactional-emissions, undefined when neither flag is given —
+        // the field is then omitted from the PATCH and stays untouched.
+        options: { name?: string; description?: string; priority?: number; transactionalEmissions?: boolean },
+      ) => {
+        const client = getClient();
 
-      try {
-        const automationId = await resolveAutomationId(id);
-        const automation = await client.automations.update(automationId, {
-          name: options.name,
-          description: options.description,
-          priority: options.priority,
-        });
+        try {
+          const automationId = await resolveAutomationId(id);
+          const automation = await client.automations.update(automationId, {
+            name: options.name,
+            description: options.description,
+            priority: options.priority,
+            transactionalEmissions: options.transactionalEmissions,
+          });
 
-        output.success(`Automation updated: ${automation.id}`, {
-          id: automation.id,
-          name: automation.name,
-        });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        output.error(`Failed to update automation: ${message}`);
-      }
-    });
+          output.success(`Automation updated: ${automation.id}`, {
+            id: automation.id,
+            name: automation.name,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          output.error(`Failed to update automation: ${message}`);
+        }
+      },
+    );
 
   // omni automations delete <id>
   automations

--- a/packages/core/src/automations/__tests__/transactional-emissions.test.ts
+++ b/packages/core/src/automations/__tests__/transactional-emissions.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Transactional publication (G5, RFC #925, issue #988).
+ *
+ * With `automations.transactional_emissions` ON, a run's `emit_event`
+ * publishes are accumulated in a run-scoped buffer and flushed IN ORDER only
+ * when every action of the run succeeded — a failed run publishes zero.
+ * Non-emission actions keep the continue-on-failure semantics either way,
+ * and with the flag OFF behavior is byte-for-byte today's immediate
+ * mid-sequence publishing.
+ *
+ * The #958 derived idempotency keys
+ * (`derived:{parentEventId}:{automationId}:{actionIndex}`) are stamped at
+ * ENQUEUE time with the action's position in the automation, so a DLQ-retried
+ * run reproduces byte-identical keys and a successful retry cannot duplicate.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus, Subscription } from '../../events/bus';
+import type { EventType, OmniEvent } from '../../events/types';
+import { type ActionDependencies, executeActions } from '../actions';
+import { AutomationEngine } from '../engine';
+import type { TemplateContext } from '../templates';
+import type { Automation, AutomationAction } from '../types';
+
+// ============================================================================
+// Executor-level harness (injected publish fakes — the main vehicle)
+// ============================================================================
+
+interface CapturedPublish {
+  type: string;
+  payload: Record<string, unknown>;
+  options: Record<string, unknown> | undefined;
+}
+
+interface Timeline {
+  entries: string[];
+}
+
+function makeContext(overrides: Partial<TemplateContext> = {}): TemplateContext {
+  return {
+    payload: {
+      instanceId: 'wa-001',
+      from: { id: 'user-1', name: 'Alice' },
+      chatId: 'chat-1',
+      content: 'hello',
+    },
+    variables: {},
+    env: {},
+    ...overrides,
+  };
+}
+
+function makeDeps(options: {
+  published: CapturedPublish[];
+  timeline?: Timeline;
+  claimedKeys?: Set<string>;
+  claims?: Array<{ idempotencyKey: string; eventId: string }>;
+  releasedClaims?: string[];
+  failPublishOfType?: string;
+  withSendMessage?: boolean;
+}): ActionDependencies {
+  const deps: ActionDependencies = {
+    eventBus: {
+      publishGeneric: mock(async (type: string, payload: Record<string, unknown>, opts?: Record<string, unknown>) => {
+        if (options.failPublishOfType === type) {
+          throw new Error(`NATS down for ${type}`);
+        }
+        options.published.push({ type, payload, options: opts });
+        options.timeline?.entries.push(`publish:${type}`);
+        return { id: `pub-${options.published.length}`, type, timestamp: Date.now(), metadata: {}, payload };
+      }),
+    } as unknown as EventBus,
+  };
+  if (options.claimedKeys) {
+    const claimedKeys = options.claimedKeys;
+    deps.claimEmittedEvent = mock(async (claim: { idempotencyKey: string; eventId: string }) => {
+      options.claims?.push({ idempotencyKey: claim.idempotencyKey, eventId: claim.eventId });
+      if (claimedKeys.has(claim.idempotencyKey)) return false;
+      claimedKeys.add(claim.idempotencyKey);
+      return true;
+    });
+    deps.releaseEmittedEventClaim = mock(async (eventId: string) => {
+      options.releasedClaims?.push(eventId);
+      // Mirror the API implementation: the journal row (and its key) go away.
+      const claim = options.claims?.find((c) => c.eventId === eventId);
+      if (claim) claimedKeys.delete(claim.idempotencyKey);
+    });
+  }
+  if (options.withSendMessage) {
+    deps.sendMessage = mock(async (_instanceId: string, _to: string, _content: string) => {
+      options.timeline?.entries.push('send');
+    });
+  }
+  return deps;
+}
+
+function emit(eventType: string): AutomationAction {
+  return { type: 'emit_event', config: { eventType, payloadTemplate: { marker: eventType } } };
+}
+
+/** Deterministic failure: send_message without a sendMessage dependency. */
+const FAILING_ACTION: AutomationAction = {
+  type: 'send_message',
+  config: { instanceId: 'wa-001', to: 'chat-1', contentTemplate: 'x' },
+};
+
+const SEND_ACTION: AutomationAction = {
+  type: 'send_message',
+  config: { instanceId: 'wa-001', to: 'chat-1', contentTemplate: 'ok' },
+};
+
+const PROVENANCE = { parentEventId: 'evt-parent', automationId: 'auto-1' };
+
+describe('flag off — today behavior pinned byte-for-byte', () => {
+  test('emissions publish immediately, even after a failed earlier action', async () => {
+    const published: CapturedPublish[] = [];
+    const deps = makeDeps({ published });
+
+    const results = await executeActions(
+      [emit('custom.first'), FAILING_ACTION, emit('custom.second')],
+      makeContext(),
+      deps,
+      null,
+      PROVENANCE,
+    );
+
+    // Both emissions published despite the failed middle action.
+    expect(published.map((p) => p.type)).toEqual(['custom.first', 'custom.second']);
+    expect(results.map((r) => r.status)).toEqual(['success', 'failed', 'success']);
+  });
+
+  test('emissions interleave with other actions mid-sequence', async () => {
+    const published: CapturedPublish[] = [];
+    const timeline: Timeline = { entries: [] };
+    const deps = makeDeps({ published, timeline, withSendMessage: true });
+
+    await executeActions([emit('custom.a'), SEND_ACTION, emit('custom.b')], makeContext(), deps, null, PROVENANCE);
+
+    expect(timeline.entries).toEqual(['publish:custom.a', 'send', 'publish:custom.b']);
+  });
+});
+
+describe('flag on — successful run flushes in order after the last action', () => {
+  test('emissions publish only AFTER the last action, in enqueue order', async () => {
+    const published: CapturedPublish[] = [];
+    const timeline: Timeline = { entries: [] };
+    const deps = makeDeps({ published, timeline, withSendMessage: true });
+
+    const results = await executeActions(
+      [emit('custom.a'), SEND_ACTION, emit('custom.b')],
+      makeContext(),
+      deps,
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    // The send happens first; both publishes land after it, preserving order.
+    expect(timeline.entries).toEqual(['send', 'publish:custom.a', 'publish:custom.b']);
+    expect(results.map((r) => r.status)).toEqual(['success', 'success', 'success']);
+    // Flushed results carry the same shape immediate publishing produces.
+    expect(results[0]?.result).toEqual({ eventId: 'pub-1', eventType: 'custom.a' });
+    expect(results[2]?.result).toEqual({ eventId: 'pub-2', eventType: 'custom.b' });
+  });
+
+  test('buffered publishes carry an envelope identical to immediate publishing', async () => {
+    const immediate: CapturedPublish[] = [];
+    const immediateClaims: Array<{ idempotencyKey: string; eventId: string }> = [];
+    const buffered: CapturedPublish[] = [];
+    const bufferedClaims: Array<{ idempotencyKey: string; eventId: string }> = [];
+
+    const context = makeContext({
+      event: {
+        id: 'evt-parent',
+        type: 'custom.trigger' as never,
+        payload: {},
+        metadata: { correlationId: 'corr-1' },
+        timestamp: 1,
+      } as never,
+    });
+
+    await executeActions(
+      [emit('custom.a'), SEND_ACTION, emit('custom.b')],
+      context,
+      makeDeps({ published: immediate, claimedKeys: new Set(), claims: immediateClaims, withSendMessage: true }),
+      'tenant-1',
+      PROVENANCE,
+    );
+    await executeActions(
+      [emit('custom.a'), SEND_ACTION, emit('custom.b')],
+      context,
+      makeDeps({ published: buffered, claimedKeys: new Set(), claims: bufferedClaims, withSendMessage: true }),
+      'tenant-1',
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    // Same types, payloads, correlation/causation/tenant metadata — the
+    // publishEventId differs only by the random claim-row id, so compare the
+    // rest field-by-field.
+    expect(buffered.map((p) => p.type)).toEqual(immediate.map((p) => p.type));
+    expect(buffered.map((p) => p.payload)).toEqual(immediate.map((p) => p.payload));
+    for (const [i, publish] of buffered.entries()) {
+      const { publishEventId: _b, ...bufferedOptions } = publish.options ?? {};
+      const { publishEventId: _i, ...immediateOptions } = immediate[i]?.options ?? {};
+      expect(bufferedOptions).toEqual(immediateOptions);
+    }
+    // CRITICAL (#958 invariant): derived keys are byte-identical — actionIndex
+    // is stamped at ENQUEUE time from the action's position (0 and 2, not the
+    // buffer positions 0 and 1).
+    expect(bufferedClaims.map((c) => c.idempotencyKey)).toEqual([
+      'derived:evt-parent:auto-1:0',
+      'derived:evt-parent:auto-1:2',
+    ]);
+    expect(bufferedClaims.map((c) => c.idempotencyKey)).toEqual(immediateClaims.map((c) => c.idempotencyKey));
+  });
+});
+
+describe('flag on — failed run publishes zero', () => {
+  test('an action failure discards every buffered emission, nothing reaches the bus or the claim journal', async () => {
+    const published: CapturedPublish[] = [];
+    const claims: Array<{ idempotencyKey: string; eventId: string }> = [];
+    const deps = makeDeps({ published, claimedKeys: new Set(), claims });
+
+    const results = await executeActions(
+      [emit('custom.first'), FAILING_ACTION, emit('custom.second')],
+      makeContext(),
+      deps,
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    expect(published).toEqual([]);
+    // No claim rows burned either — the DLQ retry starts completely clean.
+    expect(claims).toEqual([]);
+    // The discard is visible in the run's action results.
+    expect(results[0]?.status).toBe('failed');
+    expect(results[0]?.error).toContain('discarded');
+    expect(results[0]?.result).toEqual({ eventType: 'custom.first', buffered: true, discarded: true });
+    expect(results[2]?.status).toBe('failed');
+    expect(results[2]?.error).toContain('discarded');
+  });
+
+  test('a failing emit_event PREPARE (schema gate) also discards the rest of the buffer', async () => {
+    const published: CapturedPublish[] = [];
+    const deps = makeDeps({ published });
+    deps.validateEmitEvent = mock(async (eventType: string) =>
+      eventType === 'custom.bad' ? { valid: false, errors: ['nope'] } : { valid: true },
+    );
+
+    const results = await executeActions(
+      [emit('custom.good'), emit('custom.bad')],
+      makeContext(),
+      deps,
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    expect(published).toEqual([]);
+    expect(results[0]?.status).toBe('failed');
+    expect(results[1]?.status).toBe('failed');
+    expect(results[1]?.error).toContain('nope');
+  });
+});
+
+describe('flag on — multi-emit ordering', () => {
+  test('three emissions flush in exact enqueue order', async () => {
+    const published: CapturedPublish[] = [];
+    const deps = makeDeps({ published });
+
+    await executeActions(
+      [emit('custom.one'), emit('custom.two'), emit('custom.three')],
+      makeContext(),
+      deps,
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    expect(published.map((p) => p.type)).toEqual(['custom.one', 'custom.two', 'custom.three']);
+  });
+});
+
+describe('flag on — retry semantics (#958 derived keys)', () => {
+  test('re-executing the same run reproduces identical keys and dedupes instead of duplicating', async () => {
+    const published: CapturedPublish[] = [];
+    const claimedKeys = new Set<string>();
+    const firstClaims: Array<{ idempotencyKey: string; eventId: string }> = [];
+    const secondClaims: Array<{ idempotencyKey: string; eventId: string }> = [];
+    const actions = [emit('custom.a'), emit('custom.b')];
+
+    const first = await executeActions(
+      actions,
+      makeContext(),
+      makeDeps({ published, claimedKeys, claims: firstClaims }),
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+    const second = await executeActions(
+      actions,
+      makeContext(),
+      makeDeps({ published, claimedKeys, claims: secondClaims }),
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    // Key equality is the invariant — the #958 dedup does the rest.
+    expect(secondClaims.map((c) => c.idempotencyKey)).toEqual(firstClaims.map((c) => c.idempotencyKey));
+    expect(firstClaims.map((c) => c.idempotencyKey)).toEqual([
+      'derived:evt-parent:auto-1:0',
+      'derived:evt-parent:auto-1:1',
+    ]);
+    expect(published.map((p) => p.type)).toEqual(['custom.a', 'custom.b']);
+    expect(first.map((r) => r.status)).toEqual(['success', 'success']);
+    expect(second.map((r) => r.status)).toEqual(['success', 'success']);
+    expect(second.map((r) => (r.result as { duplicate?: boolean }).duplicate)).toEqual([true, true]);
+  });
+
+  test('a mid-flush publish failure keeps published events an exact prefix and releases the failed claim', async () => {
+    const published: CapturedPublish[] = [];
+    const claimedKeys = new Set<string>();
+    const claims: Array<{ idempotencyKey: string; eventId: string }> = [];
+    const releasedClaims: string[] = [];
+    const deps = makeDeps({
+      published,
+      claimedKeys,
+      claims,
+      releasedClaims,
+      failPublishOfType: 'custom.two',
+    });
+
+    const results = await executeActions(
+      [emit('custom.one'), emit('custom.two'), emit('custom.three')],
+      makeContext(),
+      deps,
+      null,
+      PROVENANCE,
+      { transactionalEmissions: true },
+    );
+
+    // Prefix only: one published, the failed slot's claim released (so a DLQ
+    // retry can re-emit it), the rest discarded unclaimed.
+    expect(published.map((p) => p.type)).toEqual(['custom.one']);
+    expect(releasedClaims).toHaveLength(1);
+    expect(claimedKeys).toEqual(new Set(['derived:evt-parent:auto-1:0']));
+    expect(results.map((r) => r.status)).toEqual(['success', 'failed', 'failed']);
+    expect(results[1]?.error).toContain('NATS down');
+    expect(results[2]?.error).toContain('discarded');
+  });
+});
+
+// ============================================================================
+// Engine-level: the per-automation flag threads from the Automation row
+// ============================================================================
+
+function captureBus(): {
+  bus: EventBus;
+  handlers: Map<string, (event: OmniEvent) => Promise<void>>;
+  published: CapturedPublish[];
+} {
+  const handlers = new Map<string, (event: OmniEvent) => Promise<void>>();
+  const published: CapturedPublish[] = [];
+  const bus = {
+    publish: async () => ({ id: 'pub', timestamp: Date.now() }),
+    publishGeneric: async (type: string, payload: Record<string, unknown>, options?: Record<string, unknown>) => {
+      published.push({ type, payload, options });
+      return { id: 'pub-generic', timestamp: Date.now() };
+    },
+    subscribe: async () => ({ unsubscribe: async () => {} }) as Subscription,
+    subscribePattern: async (pattern: string, handler: (event: OmniEvent) => Promise<void>) => {
+      handlers.set(pattern, handler);
+      return { unsubscribe: async () => {} } as Subscription;
+    },
+    flush: async () => {},
+    close: async () => {},
+  } as unknown as EventBus;
+  return { bus, handlers, published };
+}
+
+function makeAutomation(overrides: Partial<Automation> & { actions: Automation['actions'] }): Automation {
+  return {
+    id: 'auto-1',
+    name: 'transactional probe',
+    enabled: true,
+    priority: 0,
+    triggerEventType: 'custom.txn-probe',
+    triggerConditions: [],
+    conditionLogic: 'and',
+    debounce: null,
+    ...overrides,
+  } as Automation;
+}
+
+function makeEvent(): OmniEvent {
+  return {
+    id: 'evt-1',
+    type: 'custom.txn-probe' as EventType,
+    payload: { instanceId: 'inst-1', chatId: 'chat-1', content: 'hi' },
+    metadata: { correlationId: 'corr-1', instanceId: 'inst-1' },
+    timestamp: Date.now(),
+  } as OmniEvent;
+}
+
+const ENGINE_ACTIONS: AutomationAction[] = [
+  { type: 'emit_event', config: { eventType: 'custom.engine-emit' } },
+  // Fails: the engine harness injects no sendMessage dependency.
+  { type: 'send_message', config: { instanceId: 'inst-1', to: 'chat-1', contentTemplate: 'x' } },
+];
+
+async function fireThroughEngine(automationRow: Automation): Promise<{ published: CapturedPublish[]; status: string }> {
+  const { bus, handlers, published } = captureBus();
+  const engine = new AutomationEngine({ defaultConcurrency: 2, reconcileIntervalMs: 0 });
+  let status = 'unknown';
+  engine.setLogger(async (log) => {
+    status = log.status as string;
+  });
+  await engine.start(bus, [automationRow], {});
+  try {
+    const handler = handlers.get('custom.txn-probe.>');
+    if (!handler) throw new Error('engine did not subscribe to the trigger');
+    await handler(makeEvent());
+  } finally {
+    await engine.stop();
+  }
+  return { published, status };
+}
+
+describe('engine threads automations.transactional_emissions (#988)', () => {
+  test('flag on: a failed run publishes zero', async () => {
+    const { published, status } = await fireThroughEngine(
+      makeAutomation({ actions: ENGINE_ACTIONS, transactionalEmissions: true }),
+    );
+    expect(status).toBe('failed');
+    expect(published).toEqual([]);
+  });
+
+  test('flag off (and flag absent): the emission still publishes despite the later failure', async () => {
+    const explicitOff = await fireThroughEngine(
+      makeAutomation({ actions: ENGINE_ACTIONS, transactionalEmissions: false }),
+    );
+    expect(explicitOff.status).toBe('failed');
+    expect(explicitOff.published.map((p) => p.type)).toEqual(['custom.engine-emit']);
+
+    const absent = await fireThroughEngine(makeAutomation({ actions: ENGINE_ACTIONS }));
+    expect(absent.status).toBe('failed');
+    expect(absent.published.map((p) => p.type)).toEqual(['custom.engine-emit']);
+  });
+});

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -450,65 +450,113 @@ async function enforceEmitEventSchema(
 }
 
 /**
- * Execute an emit_event action
+ * An emission with everything the publish needs, resolved at PREPARE time.
+ *
+ * Transactional publication (G5, #988) splits emit_event into prepare and
+ * publish phases so a buffered emission is byte-identical to an immediate one:
+ * templates, the schema gate, correlation/causation and the #958 slot
+ * provenance (idempotency-key ingredients, INCLUDING the enqueue-time
+ * actionIndex) are all captured here — a DLQ-retried run re-prepares the same
+ * values and therefore claims the same derived keys.
  */
-async function executeEmitEventAction(
+interface PreparedEmission {
+  eventBus: EventBus;
+  eventType: CustomEventType;
+  payload: GenericEventPayload;
+  correlationId?: string;
+  /** Claim-row causality (#957): `context.event?.id ?? provenance?.parentEventId`. */
+  causationId?: string;
+  /** What `publishGeneric` is handed as causationId today: `context.event?.id`. */
+  publishCausationId?: string;
+  /** #958 slot identity, actionIndex stamped at prepare/enqueue time. */
+  slotProvenance?: EmitProvenance & { actionIndex: number };
+  trustedTenantId?: string | null;
+}
+
+/**
+ * Resolve an emit_event action into a {@link PreparedEmission} — everything
+ * up to (but excluding) the idempotency claim and the publish. May throw on
+ * template errors; callers wrap it in the action-level try/catch.
+ */
+async function prepareEmitEvent(
   config: EmitEventActionConfig,
   context: TemplateContext,
   deps: ActionDependencies,
-  trustedTenantId?: string | null,
-  actionIndex = 0,
-  provenance?: EmitProvenance,
+  trustedTenantId: string | null | undefined,
+  actionIndex: number,
+  provenance: EmitProvenance | undefined,
+): Promise<{ prepared: PreparedEmission } | { error: string }> {
+  if (!deps.eventBus) {
+    return { error: 'eventBus not available' };
+  }
+
+  // Build payload
+  let payload: GenericEventPayload;
+  if (config.payloadTemplate) {
+    payload = substituteTemplateObject(config.payloadTemplate, context) as GenericEventPayload;
+  } else {
+    payload = context.payload;
+  }
+
+  const eventType = substituteTemplate(config.eventType, context) as CustomEventType;
+
+  // Schema-registry gate (issue #959, strict switch #1000) — see
+  // `enforceEmitEventSchema`.
+  const schemaError = await enforceEmitEventSchema(deps, eventType, payload, trustedTenantId);
+  if (schemaError !== null) {
+    return { error: schemaError };
+  }
+
+  // Correlation rides the same threading (#956): the next hop continues the
+  // TRIGGERING event's envelope correlation, never a payload claim. The
+  // payload fallback only applies to envelope-less invocations (route-side
+  // manual execute), which is the pre-#956 behavior unchanged.
+  // causationId (#957): the emitted event's immediate parent IS the event
+  // that triggered this automation — stamped explicitly (more precise than
+  // the ambient causality scope, same value).
+  const correlationId = context.event?.metadata.correlationId ?? (context.payload.correlationId as string) ?? undefined;
+  const causationId = context.event?.id ?? provenance?.parentEventId;
+
+  // Derived-key idempotency (#958): the slot identity is fixed here — at
+  // enqueue time for a transactional run — so re-running the same automation
+  // over the same event derives the same key. This dedupes REPLAY of the same
+  // (event, automation, action) slot only — two different parent events
+  // legitimately emit twice. The parent id prefers `context.event.id` (a
+  // debounced execution's LAST REAL event — stable across replay, unlike the
+  // synthetic flush id).
+  const slotProvenance = provenance
+    ? { ...provenance, parentEventId: context.event?.id ?? provenance.parentEventId, actionIndex }
+    : undefined;
+
+  return {
+    prepared: {
+      eventBus: deps.eventBus,
+      eventType,
+      payload,
+      correlationId,
+      causationId,
+      publishCausationId: context.event?.id,
+      slotProvenance,
+      trustedTenantId,
+    },
+  };
+}
+
+/**
+ * Claim the emission's #958 slot and publish it. Shared verbatim between the
+ * immediate path (flag off) and the transactional flush (flag on) so both
+ * produce identical envelopes, claim rows, and derived idempotency keys.
+ */
+async function publishPreparedEmission(
+  prepared: PreparedEmission,
+  deps: ActionDependencies,
 ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+  const { eventType, payload, correlationId, causationId, trustedTenantId } = prepared;
   try {
-    if (!deps.eventBus) {
-      return {
-        success: false,
-        error: 'eventBus not available',
-      };
-    }
-
-    // Build payload
-    let payload: GenericEventPayload;
-    if (config.payloadTemplate) {
-      payload = substituteTemplateObject(config.payloadTemplate, context) as GenericEventPayload;
-    } else {
-      payload = context.payload;
-    }
-
-    const eventType = substituteTemplate(config.eventType, context) as CustomEventType;
-
-    // Schema-registry gate (issue #959, strict switch #1000) — see
-    // `enforceEmitEventSchema`.
-    const schemaError = await enforceEmitEventSchema(deps, eventType, payload, trustedTenantId);
-    if (schemaError !== null) {
-      return { success: false, error: schemaError };
-    }
-
-    // Correlation rides the same threading (#956): the next hop continues the
-    // TRIGGERING event's envelope correlation, never a payload claim. The
-    // payload fallback only applies to envelope-less invocations (route-side
-    // manual execute), which is the pre-#956 behavior unchanged.
-    // causationId (#957): the emitted event's immediate parent IS the event
-    // that triggered this automation — stamped explicitly (more precise than
-    // the ambient causality scope, same value).
-    const correlationId =
-      context.event?.metadata.correlationId ?? (context.payload.correlationId as string) ?? undefined;
-    const causationId = context.event?.id ?? provenance?.parentEventId;
-
-    // Derived-key idempotency (#958): claim before publishing so re-running
-    // the same automation over the same event does not duplicate the
-    // emission. This dedupes REPLAY of the same (event, automation, action)
-    // slot only — two different parent events legitimately emit twice. The
-    // parent id prefers `context.event.id` (a debounced execution's LAST REAL
-    // event — stable across replay, unlike the synthetic flush id). The claim
-    // row is journaled with the emission's causality so the #957 `custom.>`
-    // consumer's insert lands on it (same id, ON CONFLICT DO NOTHING) and
-    // `omni events trace` walks through it.
-    const slotProvenance = provenance
-      ? { ...provenance, parentEventId: context.event?.id ?? provenance.parentEventId, actionIndex }
-      : undefined;
-    const claim = await claimEmissionSlot(deps, eventType, payload, trustedTenantId, slotProvenance, {
+    // The claim row is journaled with the emission's causality so the #957
+    // `custom.>` consumer's insert lands on it (same id, ON CONFLICT DO
+    // NOTHING) and `omni events trace` walks through it.
+    const claim = await claimEmissionSlot(deps, eventType, payload, trustedTenantId, prepared.slotProvenance, {
       correlationId,
       causationId,
     });
@@ -526,9 +574,9 @@ async function executeEmitEventAction(
     // publish stays byte-identical.
     let result: { id: string };
     try {
-      result = await deps.eventBus.publishGeneric(eventType, payload, {
+      result = await prepared.eventBus.publishGeneric(eventType, payload, {
         correlationId,
-        causationId: context.event?.id,
+        causationId: prepared.publishCausationId,
         // A claimed emission publishes UNDER the claim row's id (#958) so the
         // journal row and the event share one identity.
         ...(claim.claimedEventId ? { publishEventId: claim.claimedEventId } : {}),
@@ -552,6 +600,32 @@ async function executeEmitEventAction(
       error: errorMessage,
     };
   }
+}
+
+/**
+ * Execute an emit_event action (immediate path — flag off, and every direct
+ * `executeAction` call). Prepare + publish in one step, semantics unchanged.
+ */
+async function executeEmitEventAction(
+  config: EmitEventActionConfig,
+  context: TemplateContext,
+  deps: ActionDependencies,
+  trustedTenantId?: string | null,
+  actionIndex = 0,
+  provenance?: EmitProvenance,
+): Promise<{ success: boolean; result?: unknown; error?: string }> {
+  let preparation: { prepared: PreparedEmission } | { error: string };
+  try {
+    preparation = await prepareEmitEvent(config, context, deps, trustedTenantId, actionIndex, provenance);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Emit event action failed', { error: errorMessage });
+    return { success: false, error: errorMessage };
+  }
+  if ('error' in preparation) {
+    return { success: false, error: preparation.error };
+  }
+  return publishPreparedEmission(preparation.prepared, deps);
 }
 
 /**
@@ -794,10 +868,152 @@ export async function executeAction(
 }
 
 /**
+ * Options for {@link executeActions}.
+ */
+export interface ExecuteActionsOptions {
+  /**
+   * Transactional publication (G5, #988): when true, `emit_event` actions
+   * enqueue their fully-prepared emissions into a run-scoped buffer instead
+   * of publishing mid-sequence. The buffer is flushed IN ORDER only when the
+   * run completes with zero failed actions; otherwise every buffered emission
+   * is discarded (and the discard is logged). Non-emission actions keep the
+   * continue-on-failure semantics either way. Default false = today's
+   * immediate publishing, byte-for-byte.
+   */
+  transactionalEmissions?: boolean;
+}
+
+/**
+ * One enqueued emission of a transactional run: the prepared publish plus the
+ * action's result entry (mutated in place when the buffer settles).
+ */
+interface BufferedEmission {
+  prepared: PreparedEmission;
+  result: ActionExecutionResult;
+}
+
+/**
+ * Enqueue an emit_event action into the run's emission buffer instead of
+ * publishing (G5, #988). Everything the eventual publish needs — including
+ * the #958 idempotency-key ingredients with THIS actionIndex — is resolved
+ * now, so a retried run reproduces byte-identical keys. Prepare failures
+ * (missing bus, schema-gate refusal, template errors) fail the action
+ * exactly as the immediate path would.
+ */
+async function bufferEmitEventAction(
+  config: EmitEventActionConfig,
+  context: TemplateContext,
+  deps: ActionDependencies,
+  trustedTenantId: string | null | undefined,
+  actionIndex: number,
+  provenance: EmitProvenance | undefined,
+  buffer: BufferedEmission[],
+): Promise<ActionExecutionResult> {
+  const start = Date.now();
+  let preparation: { prepared: PreparedEmission } | { error: string };
+  try {
+    preparation = await prepareEmitEvent(config, context, deps, trustedTenantId, actionIndex, provenance);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Emit event action failed', { error: errorMessage });
+    preparation = { error: errorMessage };
+  }
+  if ('error' in preparation) {
+    return {
+      action: 'emit_event',
+      status: 'failed',
+      error: preparation.error,
+      durationMs: Date.now() - start,
+    };
+  }
+  const result: ActionExecutionResult = {
+    action: 'emit_event',
+    status: 'success',
+    result: { eventType: preparation.prepared.eventType, buffered: true },
+    durationMs: Date.now() - start,
+  };
+  buffer.push({ prepared: preparation.prepared, result });
+  return result;
+}
+
+/**
+ * Discard buffered emissions of a run that did not complete cleanly.
+ * Observability contract (#988): the discard is logged with the count and the
+ * event types, and each entry's action result is marked failed so the run log
+ * shows the emission never reached the bus.
+ */
+function discardBufferedEmissions(entries: BufferedEmission[], reason: string): void {
+  if (entries.length === 0) return;
+  logger.warn('Discarding buffered emissions (transactional run did not complete cleanly)', {
+    discardedCount: entries.length,
+    eventTypes: entries.map((entry) => entry.prepared.eventType),
+    reason,
+  });
+  for (const entry of entries) {
+    entry.result.status = 'failed';
+    entry.result.error = `emission discarded (${reason})`;
+    entry.result.result = { eventType: entry.prepared.eventType, buffered: true, discarded: true };
+  }
+}
+
+/**
+ * Settle a transactional run's emission buffer: discard everything when any
+ * action failed, otherwise flush in order through the SAME publish path as
+ * immediate emissions. A publish failure mid-flush fails that action, stops
+ * the flush, and discards the rest — published events stay an exact prefix of
+ * the buffer, and the DLQ retry re-derives the same keys: already-published
+ * slots dedupe as duplicates, the failed slot's released claim publishes.
+ */
+async function settleBufferedEmissions(
+  buffer: BufferedEmission[],
+  deps: ActionDependencies,
+  results: ActionExecutionResult[],
+): Promise<void> {
+  if (results.some((result) => result.status === 'failed')) {
+    discardBufferedEmissions(buffer, 'an action in the run failed');
+    return;
+  }
+  for (const [index, entry] of buffer.entries()) {
+    const outcome = await publishPreparedEmission(entry.prepared, deps);
+    if (!outcome.success) {
+      entry.result.status = 'failed';
+      entry.result.error = outcome.error;
+      entry.result.result = { eventType: entry.prepared.eventType, buffered: true, flushed: false };
+      discardBufferedEmissions(buffer.slice(index + 1), 'an earlier buffered emission failed to publish');
+      return;
+    }
+    entry.result.result = outcome.result;
+  }
+}
+
+/**
+ * Store a webhook/call_agent response as a variable for subsequent actions.
+ */
+function storeResponseVariable(
+  action: AutomationAction,
+  result: ActionExecutionResult,
+  variables: Record<string, unknown>,
+): void {
+  if (action.type === 'webhook' && action.config.responseAs && result.status === 'success' && result.result) {
+    variables[action.config.responseAs] = result.result;
+  }
+  if (action.type === 'call_agent' && action.config.responseAs && result.status === 'success' && result.result) {
+    // Store the full response for chaining
+    const agentResult = result.result as { response: string };
+    variables[action.config.responseAs] = agentResult.response;
+  }
+}
+
+/**
  * Execute a sequence of actions
  *
  * Actions are executed sequentially. If an action with waitForResponse: true
  * succeeds, its response is stored in variables[responseAs] for subsequent actions.
+ *
+ * With `options.transactionalEmissions` (G5, #988) the run's `emit_event`
+ * publishes are buffered and settle only after the last action — see
+ * {@link ExecuteActionsOptions}. All other actions behave identically in both
+ * modes.
  */
 export async function executeActions(
   actions: AutomationAction[],
@@ -805,33 +1021,47 @@ export async function executeActions(
   deps: ActionDependencies,
   trustedTenantId?: string | null,
   provenance?: EmitProvenance,
+  options?: ExecuteActionsOptions,
 ): Promise<ActionExecutionResult[]> {
+  const buffer: BufferedEmission[] | undefined = options?.transactionalEmissions ? [] : undefined;
   const results: ActionExecutionResult[] = [];
   const variables = { ...context.variables };
 
-  for (const [actionIndex, action] of actions.entries()) {
-    // Create context with updated variables
-    const actionContext: TemplateContext = {
-      ...context,
-      variables,
-    };
+  try {
+    for (const [actionIndex, action] of actions.entries()) {
+      // Create context with updated variables
+      const actionContext: TemplateContext = {
+        ...context,
+        variables,
+      };
 
-    const result = await executeAction(action, actionContext, deps, trustedTenantId, actionIndex, provenance);
-    results.push(result);
+      const result =
+        buffer && action.type === 'emit_event'
+          ? await bufferEmitEventAction(
+              action.config,
+              actionContext,
+              deps,
+              trustedTenantId,
+              actionIndex,
+              provenance,
+              buffer,
+            )
+          : await executeAction(action, actionContext, deps, trustedTenantId, actionIndex, provenance);
+      results.push(result);
 
-    // Store response as variable if configured (for webhook and call_agent)
-    if (action.type === 'webhook' && action.config.responseAs && result.status === 'success' && result.result) {
-      variables[action.config.responseAs] = result.result;
+      // Store response as variable if configured (for webhook and call_agent)
+      storeResponseVariable(action, result, variables);
+
+      // Note: We don't stop on failure - just log and continue
+      // This matches the wish requirement: "failures logged but don't stop sequence"
     }
-    if (action.type === 'call_agent' && action.config.responseAs && result.status === 'success' && result.result) {
-      // Store the full response for chaining
-      const agentResult = result.result as { response: string };
-      variables[action.config.responseAs] = agentResult.response;
-    }
-
-    // Note: We don't stop on failure - just log and continue
-    // This matches the wish requirement: "failures logged but don't stop sequence"
+  } catch (error) {
+    // A thrown/cancelled run is a failed run: nothing buffered may publish.
+    if (buffer) discardBufferedEmissions(buffer, 'run threw before completion');
+    throw error;
   }
+
+  if (buffer) await settleBufferedEmissions(buffer, deps, results);
 
   return results;
 }

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -760,6 +760,8 @@ export class AutomationEngine {
       // causal links never point at the synthetic flush id.
       // Emit provenance (#958) rides along so emit_event re-publishes derive
       // a stable idempotency key for this (event, automation, action) slot.
+      // Transactional publication (G5, #988): the per-automation flag buffers
+      // the run's emissions and flushes only on a fully successful run.
       const actionsExecuted = await runWithEventCausality(
         {
           correlationId: context.event?.metadata.correlationId ?? event.metadata.correlationId,
@@ -772,6 +774,7 @@ export class AutomationEngine {
             this.deps,
             trustedTenantId,
             { parentEventId: event.id, automationId: automation.id },
+            { transactionalEmissions: automation.transactionalEmissions ?? false },
           ),
       );
 

--- a/packages/core/src/automations/types.ts
+++ b/packages/core/src/automations/types.ts
@@ -196,6 +196,13 @@ export interface Automation {
   debounce: DebounceConfig | null;
   enabled: boolean;
   priority: number;
+  /**
+   * Transactional publication (G5, #988): buffer the run's emit_event
+   * publishes and flush in order only on a fully successful run. Optional so
+   * pre-flag callers/tests need no change; absent = false = immediate
+   * publishing.
+   */
+  transactionalEmissions?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/db/drizzle/0061_automation_transactional_emissions.sql
+++ b/packages/db/drizzle/0061_automation_transactional_emissions.sql
@@ -1,0 +1,26 @@
+-- Per-automation transactional publication flag (issue #988, RFC #925 G5).
+--
+-- The automation executor continues on action failure by design, so an
+-- `emit_event` that ran before a later failed action leaves a partial effect
+-- on the bus — "partial effects on the bus are the default" (RFC #925 G5).
+-- This adds the opt-in per-automation switch:
+--
+--   automations.transactional_emissions   when true, the run's emit_event
+--                                         publishes are accumulated in a
+--                                         run-scoped buffer and flushed IN
+--                                         ORDER only when every action of the
+--                                         run succeeded; a failed/cancelled
+--                                         run publishes zero. The DLQ retry
+--                                         restarts clean and the #958 derived
+--                                         idempotency keys guarantee a
+--                                         successful retry does not duplicate.
+--                                         Default false: existing automations
+--                                         keep today's immediate mid-sequence
+--                                         publishing byte-for-byte.
+--
+-- Hand-written following the 0043/0044/0052 precedent (additive, idempotent).
+-- No explicit BEGIN/COMMIT — the boot migrator executes this file on a pooled
+-- postgres-js connection, which rejects raw transaction control.
+
+ALTER TABLE "automations"
+  ADD COLUMN IF NOT EXISTS "transactional_emissions" boolean NOT NULL DEFAULT false;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1786000000000,
       "tag": "0060_webhook_source_strict_schemas",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1786100000000,
+      "tag": "0061_automation_transactional_emissions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3094,6 +3094,14 @@ export const automations = pgTable(
     enabled: boolean('enabled').notNull().default(true),
     priority: integer('priority').notNull().default(0), // Higher = runs first
 
+    /**
+     * G5 transactional publication (RFC #925, issue #988): when true, the
+     * run's `emit_event` publishes are buffered and flushed IN ORDER only
+     * when every action succeeded — a failed/cancelled run publishes zero.
+     * Default false = today's immediate mid-sequence publishing.
+     */
+    transactionalEmissions: boolean('transactional_emissions').notNull().default(false),
+
     // Timestamps
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -677,6 +677,12 @@ export interface CreateAutomationBody {
   debounce?: Record<string, unknown>;
   enabled?: boolean;
   priority?: number;
+  /**
+   * Transactional publication (G5, #988): buffer the run's emit_event
+   * publishes and flush them in order only when every action succeeded; a
+   * failed run publishes zero. Default false = immediate publishing.
+   */
+  transactionalEmissions?: boolean;
 }
 
 /**

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -5514,6 +5514,8 @@ export interface components {
             enabled: boolean;
             /** @description Priority */
             priority: number;
+            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+            transactionalEmissions: boolean;
             /**
              * Format: date-time
              * @description Creation timestamp
@@ -5646,6 +5648,11 @@ export interface components {
              * @default 0
              */
             priority: number;
+            /**
+             * @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero. Default false = immediate publishing
+             * @default false
+             */
+            transactionalEmissions: boolean;
         };
         AutomationLog: {
             /**
@@ -16631,6 +16638,8 @@ export interface operations {
                             enabled: boolean;
                             /** @description Priority */
                             priority: number;
+                            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+                            transactionalEmissions: boolean;
                             /**
                              * Format: date-time
                              * @description Creation timestamp
@@ -16777,6 +16786,11 @@ export interface operations {
                      * @default 0
                      */
                     priority?: number;
+                    /**
+                     * @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero. Default false = immediate publishing
+                     * @default false
+                     */
+                    transactionalEmissions?: boolean;
                 };
             };
         };
@@ -16907,6 +16921,8 @@ export interface operations {
                             enabled: boolean;
                             /** @description Priority */
                             priority: number;
+                            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+                            transactionalEmissions: boolean;
                             /**
                              * Format: date-time
                              * @description Creation timestamp
@@ -17081,6 +17097,8 @@ export interface operations {
                             enabled: boolean;
                             /** @description Priority */
                             priority: number;
+                            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+                            transactionalEmissions: boolean;
                             /**
                              * Format: date-time
                              * @description Creation timestamp
@@ -17298,6 +17316,11 @@ export interface operations {
                      * @default 0
                      */
                     priority?: number;
+                    /**
+                     * @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero. Default false = immediate publishing
+                     * @default false
+                     */
+                    transactionalEmissions?: boolean;
                 };
             };
         };
@@ -17428,6 +17451,8 @@ export interface operations {
                             enabled: boolean;
                             /** @description Priority */
                             priority: number;
+                            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+                            transactionalEmissions: boolean;
                             /**
                              * Format: date-time
                              * @description Creation timestamp
@@ -17602,6 +17627,8 @@ export interface operations {
                             enabled: boolean;
                             /** @description Priority */
                             priority: number;
+                            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+                            transactionalEmissions: boolean;
                             /**
                              * Format: date-time
                              * @description Creation timestamp
@@ -17776,6 +17803,8 @@ export interface operations {
                             enabled: boolean;
                             /** @description Priority */
                             priority: number;
+                            /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
+                            transactionalEmissions: boolean;
                             /**
                              * Format: date-time
                              * @description Creation timestamp


### PR DESCRIPTION
Closes #988. Part of RFC #925 — **G5 (transactional publication)**.

## What

`emit_event` emissions become transactional behind a per-automation flag. With `transactional_emissions` ON, a run's emissions are accumulated in a run-scoped buffer and published **in order only when the run completes with zero failed actions** — a failed/cancelled run publishes zero (and the discard is logged with count + event types). With the flag OFF (default), behavior is byte-for-byte today's immediate mid-sequence publishing. Non-emission actions (`log`, `send_message`, `webhook`, `call_agent`) keep the continue-on-failure semantics in both modes — the `actions.ts` "We don't stop on failure" contract is unchanged.

## How

- **Migration `0061_automation_transactional_emissions`** — `automations.transactional_emissions boolean NOT NULL DEFAULT false`, hand-written per the 0043/0044/0052 precedent (additive, idempotent, no BEGIN/COMMIT), journal entry appended by hand (`idx` 61, `when` 1786100000000). `make verify-migrations` green. Sibling branches may claim 0061 in parallel — whoever merges second renumbers per the repo contract.
- **Executor** (`packages/core/src/automations/actions.ts`) — `emit_event` split into `prepareEmitEvent` (templates, schema gate #959/#1000, correlation #956 / causation #957, and the #958 slot provenance) and `publishPreparedEmission` (claim + publish + release-on-failure), shared **verbatim** by the immediate path and the transactional flush, so buffered and immediate emissions produce identical envelopes and derived keys.
- **#958 invariant** — the derived idempotency key ingredients (`derived:{parentEventId}:{automationId}:{actionIndex}`) are stamped at **enqueue** time with the action's position in the automation (not its buffer position), so a DLQ-retried run reproduces byte-identical keys; a successful retry dedupes instead of duplicating. A failed run burns **zero** claim rows (claims happen at flush), so the retry starts completely clean. A mid-flush publish failure keeps published events an exact prefix of the buffer, releases the failed slot's claim, and discards (and fails) the rest.
- **Engine** threads `automation.transactionalEmissions ?? false` into `executeActions`; manual `POST /automations/{id}/execute` honors the flag too.
- **Surface** — route Zod + OpenAPI (`transactionalEmissions`, default false; PATCH leaves it untouched when omitted), SDK (`CreateAutomationBody` + regenerated `types.generated.ts` via `make sdk-generate`), CLI `--transactional-emissions` on create and the negatable `--transactional-emissions` / `--no-transactional-emissions` pair on update (mirrors `--strict-schemas` from #1003; verified commander leaves the option `undefined` when neither flag is given).

## Agent-run emissions: scoped out

The issue also names the agent dispatch path (`packages/api/src/plugins/agent-dispatcher.ts`). Investigated: the dispatcher has **no `publishGeneric`/emit_event path** — agent runs send messages and publish lifecycle events (turn open, `session.reset`) through dedicated services; there is no user-configurable emission to buffer. **Agent-run emissions: no current emission path to buffer; revisit with G4c (#987).**

## Tests

`packages/core/src/automations/__tests__/transactional-emissions.test.ts` (11 tests, injected publish fakes + a compact engine harness):

- flag off: emissions publish immediately even after a failed earlier action; mid-sequence interleaving pinned
- flag on, all succeed: publishes land only after the last action, in enqueue order; envelope (type/payload/correlation/causation/tenant metadata) deep-equal to what immediate publishing produces
- flag on, action fails (including an emit prepare/schema-gate failure): **zero** publishes, zero claim rows, discard visible in action results
- flag on, multi-emit ordering preserved
- retry: re-executed run produces byte-identical derived keys (`derived:evt-parent:auto-1:{0,2}` with a non-emit action between — actionIndex, not buffer index) and dedupes
- mid-flush publish failure: exact-prefix publication, claim released, remainder discarded
- engine-level: the flag threads from the Automation row (on → failed run publishes zero; off/absent → today's behavior)

Postgres-backed test: not added — the core executor tests with injected fakes are the sibling-pattern vehicle (the #958 postgres suite already covers claim persistence; nothing schema-behavioral changed there beyond the additive column).

### Evidence

- `make verify-migrations` — contract OK, 1 new migration, journal consistent
- `make typecheck` — 25/25 green
- `make lint` — 0 warnings
- `bun test packages/core` — 1023 pass / 0 fail
- `bun test packages/api` — 2220 pass / 594 skip (env-gated) / 0 fail
- `bun test packages/db` + sdk + cli sdk-coverage + OpenAPI contract tests — all green
- husky pre-push turbo gate — passed
