### PR TITLE
fix(test-harness): stop shared MinIO container via bun:test lifecycle, reap non-running leaks

### DIFF
--- a/packages/api/src/__tests__/minio-harness-cleanup.test.ts
+++ b/packages/api/src/__tests__/minio-harness-cleanup.test.ts
@@ -51,6 +51,8 @@ interface FakePsRow {
   id: string;
   session: string;
   createdAt: string;
+  /** Docker container state; defaults to 'running'. */
+  state?: 'created' | 'exited' | 'running';
 }
 
 class FakeDocker {
@@ -91,7 +93,7 @@ class FakeDocker {
     if (operation === 'pull') return { exitCode: 0, stdout: '', stderr: '' };
     if (operation === 'run') return this.handleRun();
     if (operation === 'inspect') return this.handleInspect(command);
-    if (operation === 'ps') return this.handlePs();
+    if (operation === 'ps') return this.handlePs(command);
     if (operation === 'rm') return this.handleRm(command.at(-1)!);
     if (operation === 'logs') return { exitCode: 0, stdout: 'fake MinIO log\n', stderr: '' };
     if (operation === 'stop') return this.handleStop(command.at(-1)!);
@@ -115,9 +117,15 @@ class FakeDocker {
       : { exitCode: 1, stdout: '', stderr: 'no such container' };
   }
 
-  private handlePs(): { exitCode: number; stdout: string; stderr: string } {
+  private handlePs(command: string[]): { exitCode: number; stdout: string; stderr: string } {
     if (this.psFails) return { exitCode: 1, stdout: '', stderr: 'fake docker ps failure' };
-    const rows = this.psRows.map((row) => `${row.id}\t${row.session}`).join('\n');
+    // Real `docker ps` hides non-running containers unless `-a` is passed —
+    // the exact blindness that made Created-state leaks permanent (#999), so
+    // the fake must model it for the reaper tests to prove anything.
+    const visible = command.includes('-a')
+      ? this.psRows
+      : this.psRows.filter((row) => (row.state ?? 'running') === 'running');
+    const rows = visible.map((row) => `${row.id}\t${row.session}`).join('\n');
     return { exitCode: 0, stdout: rows ? `${rows}\n` : '', stderr: '' };
   }
 
@@ -170,6 +178,7 @@ function setup(
   events: string[];
   setReady(ready: boolean): void;
   getSharedMinio: ReturnType<typeof createSharedMinioHarness>['getSharedMinio'];
+  releaseSharedMinio: ReturnType<typeof createSharedMinioHarness>['releaseSharedMinio'];
 } {
   let clock = options.initialClockMs ?? 0;
   let ready = options.ready ?? true;
@@ -213,6 +222,7 @@ function setup(
       ready = value;
     },
     getSharedMinio: harness.getSharedMinio,
+    releaseSharedMinio: harness.releaseSharedMinio,
   };
 }
 
@@ -262,6 +272,36 @@ describe('shared MinIO harness cleanup', () => {
       expect(ps).toContain('label=com.automagik.omni.test-harness=minio');
     }
     expect(fake.docker.operations('rm')).toHaveLength(0);
+  });
+
+  test('bun:test lifecycle teardown stops the tracked container when process exit never fires, and the next suite file restarts on demand', async () => {
+    const fake = setup(['container-file-one', 'container-file-two']);
+
+    await fake.getSharedMinio();
+    // Simulate the per-file afterAll — the ONLY teardown a normal green
+    // `bun test` run ever fires, since bun never emits process 'exit' there
+    // (#999). Note: no exit or signal event is emitted in this test.
+    fake.releaseSharedMinio();
+
+    expect(fake.docker.operations('stop')).toEqual([['docker', 'stop', '--time', '10', 'container-file-one']]);
+
+    // A later MinIO suite file in the same process must get a FRESH container,
+    // not a cached handle to the stopped one.
+    await expect(fake.getSharedMinio()).resolves.toMatchObject({ endpoint: 'http://127.0.0.1:30000' });
+    expect(fake.docker.operations('run')).toHaveLength(2);
+    // The image pull verdict is remembered across the per-file restart.
+    expect(fake.docker.operations('pull')).toHaveLength(1);
+
+    // That file's own afterAll stops the second container; further firings and
+    // a plain-bun process 'exit' are no-ops — nothing is tracked any more.
+    fake.releaseSharedMinio();
+    fake.releaseSharedMinio();
+    fake.process.emit('exit');
+
+    expect(fake.docker.operations('stop')).toEqual([
+      ['docker', 'stop', '--time', '10', 'container-file-one'],
+      ['docker', 'stop', '--time', '10', 'container-file-two'],
+    ]);
   });
 
   test('registers handlers before launch and closes a SIGTERM race around the blocking run command', async () => {
@@ -657,6 +697,37 @@ describe('stale MinIO container reaper', () => {
       .filter((command) => command[3]?.includes('.Created'))
       .map((command) => command.at(-1));
     expect(inspectedIds).toEqual(['leaked-old', 'fresh-foreign']);
+    expect(fake.cleanupFailures).toEqual([]);
+  });
+
+  test('lists with -a and reaps an old foreign-session Created container that plain docker ps never shows', async () => {
+    const fake = setup(['container-normal'], {
+      initialClockMs: STALE_CLOCK,
+      psRows: [
+        { id: 'leaked-created', session: 'session-dead', createdAt: EPOCH, state: 'created' },
+        { id: 'fresh-created-foreign', session: 'session-live', createdAt: THIRTY_MIN, state: 'created' },
+        { id: 'own-created', session: 'session-123', createdAt: EPOCH, state: 'created' },
+      ],
+    });
+
+    await fake.getSharedMinio();
+
+    // The exact listing shape matters: without `-a` every one of these
+    // Created-state rows would be invisible and the leak permanent (#999).
+    expect(fake.docker.operations('ps')).toEqual([
+      [
+        'docker',
+        'ps',
+        '-a',
+        '--filter',
+        'label=com.automagik.omni.test-harness=minio',
+        '--format',
+        '{{.ID}}\t{{.Label "com.automagik.omni.test-session"}}',
+      ],
+    ]);
+    // Same guards as for running containers: only the old foreign-session
+    // leak goes; the young foreign one and this session's own are untouched.
+    expect(fake.docker.operations('rm')).toEqual([['docker', 'rm', '-f', 'leaked-created']]);
     expect(fake.cleanupFailures).toEqual([]);
   });
 

--- a/packages/api/src/__tests__/minio-harness.ts
+++ b/packages/api/src/__tests__/minio-harness.ts
@@ -6,12 +6,25 @@
  * whole suite in ONE `bun test` process, so four `beforeAll`s racing to start
  * four containers concurrently starve Docker and blow the readiness deadline.
  *
- * This module starts exactly ONE container per test process (a cached Promise
- * shared across every importing file) and hands each file its own bucket via
- * `uniqueBucket`, so they never clobber each other. The container is stopped
- * exactly once on process exit — no per-file teardown races.
+ * This module starts at most ONE container at a time (a cached Promise shared
+ * across every suite in the current test file) and hands each file its own
+ * bucket via `uniqueBucket`, so suites never clobber each other. Teardown is
+ * layered, because no single hook covers every way a bun process ends (#999):
+ *
+ *  - Under `bun test` the PRIMARY teardown is a per-file `afterAll` armed by
+ *    `minioIntegrationEnabled`: it stops the container when the file finishes,
+ *    and the next MinIO suite file lazily starts a fresh one. Bun runs test
+ *    files strictly sequentially, so at most one container is ever alive.
+ *    This hook exists because `bun test` NEVER emits process 'exit' (verified
+ *    on Bun 1.3.x: a plain `bun` script runs 'exit' handlers, `bun test` does
+ *    not) — before #999 every normal green run leaked the container.
+ *  - Under plain `bun`, and on SIGINT/SIGTERM/SIGHUP, the 'exit' and signal
+ *    handlers in MinioContainerLifecycle DO fire and stop tracked IDs.
+ *  - On SIGKILL/OOM nothing in-process can run; `reapStaleContainers` sweeps
+ *    the leak from a later launch instead.
  */
 
+import { afterAll } from 'bun:test';
 import { createHash, createHmac, randomUUID } from 'node:crypto';
 
 /**
@@ -66,12 +79,36 @@ function dockerAvailable(): boolean {
  * otherwise they skip deterministically. `MINIO_INTEGRATION=1` also bypasses
  * the publishability probe (locally too), as the escape hatch for a
  * false-negative probe on a badly overloaded machine.
+ *
+ * Every MinIO suite calls this at module top level (to feed `describe.skipIf`),
+ * which is exactly bun's collection phase for that file — so a positive verdict
+ * also arms the per-file `afterAll` teardown here. That placement is
+ * load-bearing: an `afterAll` registered at collection time fires after the
+ * registering FILE's tests, while one registered later (inside a running hook)
+ * fires at the wrong time entirely (before the file's tests, verified on Bun
+ * 1.3.x).
  */
 export function minioIntegrationEnabled(): boolean {
   if (!dockerAvailable()) return false;
   if (process.env.CI === 'true' && process.env.MINIO_INTEGRATION !== '1') return false;
-  if (process.env.MINIO_INTEGRATION === '1') return true;
-  return dockerCanPublishPorts();
+  const enabled = process.env.MINIO_INTEGRATION === '1' || dockerCanPublishPorts();
+  if (enabled) armTestFileTeardown();
+  return enabled;
+}
+
+/**
+ * Register the container stop with the bun:test lifecycle, scoped to whichever
+ * test file is currently being collected. This is the only teardown that runs
+ * on a normal green `bun test` exit (see the module header); the stop itself
+ * is idempotent, so six suites arming six hooks is harmless.
+ */
+function armTestFileTeardown(): void {
+  try {
+    afterAll(() => sharedMinioHarness.releaseSharedMinio());
+  } catch {
+    // Outside the bun test runner afterAll() throws — and there the process
+    // 'exit' handler DOES fire, so teardown is covered without this hook.
+  }
 }
 
 function sha256hex(data: string): string {
@@ -437,7 +474,9 @@ export class MinioContainerLifecycle {
     if (!this.liveContainerIds.has(containerId)) return true;
 
     // Synchronous stop is intentional: exit and signal handlers cannot await,
-    // and `--rm` removes exactly this tracked container after it stops.
+    // and the bun:test afterAll teardown reuses the same path so every caller
+    // gets identical semantics. `--rm` removes exactly this tracked container
+    // after it stops.
     let result: SyncCommandResult;
     try {
       result = this.dependencies.runSync(['docker', 'stop', '--time', '10', containerId]);
@@ -460,7 +499,13 @@ export class MinioContainerLifecycle {
     return false;
   }
 
-  private cleanup = (): void => {
+  /**
+   * Stop every tracked container. Shared by all three teardown paths — the
+   * per-file bun:test afterAll (via releaseSharedMinio), the process 'exit'
+   * handler (plain `bun` only; `bun test` never emits it), and the signal
+   * handlers — and idempotent, so overlapping registrations are harmless.
+   */
+  cleanup = (): void => {
     for (const containerId of [...this.liveContainerIds]) {
       try {
         this.stop(containerId);
@@ -496,6 +541,8 @@ export class MinioContainerLifecycle {
   private registerHandlers(): void {
     if (this.handlersRegistered) return;
     this.handlersRegistered = true;
+    // 'exit' only ever fires under plain `bun` — `bun test` skips it (#999).
+    // Kept for that path; under `bun test` the per-file afterAll is primary.
     this.dependencies.process.once('exit', this.cleanup);
 
     for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
@@ -520,21 +567,30 @@ export class MinioContainerLifecycle {
  * A live suite run holds its container for a few minutes at most (readiness
  * budget is 120s, the suites themselves finish well inside pre-push), so half
  * an hour of age means the owning process is long gone — while a concurrent
- * agent's freshly started container is never touched.
+ * agent's freshly started container is never touched. Deliberately KEPT at
+ * 30 min after #999: with the afterAll teardown in place, leaks only come
+ * from SIGKILL/OOM, so a tighter window would buy little while raising the
+ * odds of reaping a live foreign-session container on a badly loaded machine.
  */
 export const STALE_CONTAINER_MIN_AGE_MS = 30 * 60 * 1000;
 
 /**
  * Reap MinIO test containers leaked by PREVIOUS test processes.
  *
- * The exit/signal teardown in MinioContainerLifecycle cannot run when the test
+ * The in-process teardown in MinioContainerLifecycle cannot run when the test
  * process dies to SIGKILL — which is exactly what the OOM killer delivers (the
  * observed exit-144 incidents when two agents ran the full suite at once).
  * Each leaked container keeps 512MB reserved and slowly degrades the Docker
  * daemon until the readiness probe itself starts flaking. So the moment a new
- * container is about to launch is also the moment to sweep: any RUNNING
- * container carrying our harness label, from a different session, older than
- * STALE_CONTAINER_MIN_AGE_MS is unambiguously abandoned and force-removed.
+ * container is about to launch is also the moment to sweep: any container
+ * carrying our harness label — in ANY state, hence `ps -a` — from a different
+ * session, older than STALE_CONTAINER_MIN_AGE_MS is unambiguously abandoned
+ * and force-removed. `-a` matters (#999): a `docker run` interrupted between
+ * create and start leaves a Created container that plain `docker ps` never
+ * lists, so such leaks were previously invisible forever (a week-old one was
+ * observed during #948). `docker rm -f` handles every state, and the
+ * session + age guards keep a concurrent agent's fresh container — including
+ * one briefly visible in Created or `--rm` Removing state — untouchable.
  * Entirely best-effort — a reap failure is reported and never blocks the
  * launch.
  */
@@ -542,6 +598,7 @@ export function reapStaleContainers(dependencies: SharedMinioHarnessDependencies
   const list = dependencies.runSync([
     'docker',
     'ps',
+    '-a',
     '--filter',
     'label=com.automagik.omni.test-harness=minio',
     '--format',
@@ -582,9 +639,25 @@ function reapStaleContainersGuarded(dependencies: SharedMinioHarnessDependencies
 
 export function createSharedMinioHarness(dependencies: SharedMinioHarnessDependencies): {
   getSharedMinio(): Promise<SharedMinio>;
+  releaseSharedMinio(): void;
 } {
   const lifecycle = new MinioContainerLifecycle(dependencies);
   let sharedMinioPromise: Promise<SharedMinio> | undefined;
+  let imagePulled = false;
+
+  // Pre-pull explicitly so a cold image cache (fresh CI runner) cannot eat
+  // into the readiness budget or fail the run with an opaque timeout. One
+  // successful pull is remembered for the whole process: the per-file
+  // teardown makes later suite files restart the container, and re-checking
+  // the registry on every restart would add a network round-trip apiece.
+  function ensureImagePulled(): void {
+    if (imagePulled) return;
+    const pull = dependencies.runSync(['docker', 'pull', 'minio/minio']);
+    if (pull.exitCode !== 0) {
+      throw new Error(`docker pull minio/minio failed: ${pull.stderr}`);
+    }
+    imagePulled = true;
+  }
 
   async function startSharedMinio(): Promise<SharedMinio> {
     // Register signal/exit cleanup before any blocking Docker operation and
@@ -595,12 +668,7 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
     // never allowed to fail or delay this launch.
     reapStaleContainersGuarded(dependencies);
 
-    // Pre-pull explicitly so a cold image cache (fresh CI runner) cannot eat
-    // into the readiness budget or fail the run with an opaque timeout.
-    const pull = dependencies.runSync(['docker', 'pull', 'minio/minio']);
-    if (pull.exitCode !== 0) {
-      throw new Error(`docker pull minio/minio failed: ${pull.stderr}`);
-    }
+    ensureImagePulled();
 
     // Random high port avoids collisions with a locally running MinIO.
     const port = 20000 + Math.floor(dependencies.random() * 20000);
@@ -646,6 +714,14 @@ export function createSharedMinioHarness(dependencies: SharedMinioHarnessDepende
       });
       return sharedMinioPromise;
     },
+    // The per-file afterAll teardown: stop whatever is tracked and forget the
+    // cached promise, so a LATER MinIO suite file in the same process lazily
+    // starts a fresh container instead of receiving a handle to a dead one.
+    // Idempotent — with nothing tracked it is a no-op.
+    releaseSharedMinio() {
+      lifecycle.cleanup();
+      sharedMinioPromise = undefined;
+    },
   };
 }
 
@@ -678,8 +754,11 @@ const sharedMinioHarness = createSharedMinioHarness({
 });
 
 /**
- * Lazily start ONE shared `minio/minio` container for this test process and
- * return its connection info. Every importing file gets the same container.
+ * Lazily start ONE shared `minio/minio` container and return its connection
+ * info. Every suite in the current test file gets the same container; the
+ * per-file afterAll armed by `minioIntegrationEnabled` stops it when the file
+ * finishes, and the next MinIO suite file starts a fresh one (files run
+ * sequentially, so there is never more than one alive).
  *
  * A FAILED start is not cached: the next suite retries with a fresh container
  * (and a fresh random port). Without this, one transient startup failure


### PR DESCRIPTION
Closes #999

## Root causes

1. **`bun test` never fires `process.once('exit')` handlers** (verified on Bun 1.3.13: a plain `bun` script runs them, `bun test` does not — and `beforeExit` doesn't fire either). The harness's exit-handler teardown was therefore dead code on the common path, so every normal green run leaked the shared MinIO container (512MB reserved apiece) until a later run's 30-minute reaper swept it.
2. **The stale reaper listed with `docker ps` (no `-a`)**, so harness-labeled containers in Created or Exited state were invisible to it forever — a week-old Created leak (`94a1d341265d`) was observed during the #948 work.

## Fix

- **Primary teardown that actually runs under `bun test`:** a per-file `afterAll` armed by `minioIntegrationEnabled()`, which every MinIO suite already calls at module top level — i.e. during bun's collection phase for that file, the one moment where a registered `afterAll` provably fires after that file's tests (an `afterAll` registered later, inside a running hook, fires at the wrong time entirely; both behaviors verified by repro). The hook stops the tracked container and resets the cached promise, so a later MinIO suite file in the same process lazily restarts a fresh one. Bun runs test files strictly sequentially (also verified by repro), so at most one container is ever alive — the concurrent-start starvation the harness was built to prevent cannot return. The `exit`/signal registrations stay for the plain-`bun` and interrupt paths, and `docker pull` success is now cached per process so the per-file restarts stay cheap (~2-3s per additional MinIO suite file, measured).
- **Reaper widened to `docker ps -a`** with the same label + session + 30-min age guards; `docker rm -f` already handles every state, and the guards keep a concurrent agent's fresh container (including one briefly in Created or `--rm` Removing state) untouchable.
- **`STALE_CONTAINER_MIN_AGE_MS` deliberately kept at 30 min:** with the lifecycle teardown in place the reaper is back to being a SIGKILL/OOM backstop only; a tighter window would buy little while raising the odds of reaping a live foreign-session container on a badly loaded machine.

## Verification

- Unit tests extended in `minio-harness-cleanup.test.ts` (hermetic, fake docker/process): lifecycle teardown stops the tracked container with no exit event ever emitted and the next file restarts on demand; the fake `docker ps` now models the real `-a` visibility rule, and the reaper reaps an old foreign-session Created container while leaving young-foreign and own-session ones alone.
- Real-Docker acceptance on this machine: ran the S3 suite alone, two MinIO suites in one process, and the full `make check` (all six MinIO suites) — `docker ps -a --filter label=com.automagik.omni.test-harness=minio` shows no containers from those runs immediately after each exit, and the first run's widened reaper removed the observed week-old Created leak plus two >30-min abandoned running leaks while leaving a younger foreign-session container untouched.
- `make check` fully green (25/25 tasks, 0 fail).