### PR TITLE
feat(events): enforce the publishes allowlist on agent emissions (#987)

### DIFF
--- a/docs/runbooks/agent-publish-governance.md
+++ b/docs/runbooks/agent-publish-governance.md
@@ -1,0 +1,78 @@
+# Agent publish governance (RFC #925 G4c)
+
+The `publishes` half of an agent's event manifest (`agents.event_manifest`,
+see #985) is an **emission allowlist**: an agent-attributed `emit_event` may
+only publish event types the agent declared. Per the RFC: *"Emission outside
+the manifest → refused + DLQ."* Enforcement landed with #987.
+
+## Semantics: absent vs empty `publishes`
+
+| Stored state | Effect on agent-attributed emissions |
+|---|---|
+| No manifest (`event_manifest` is NULL) | **Ungoverned** — today's behavior, no flag day |
+| Manifest **without** a `publishes` key | **Ungoverned** — the document never spoke about publishing |
+| `publishes: []` | **Deny all** — the agent explicitly declared "publishes nothing" |
+| `publishes: [{ event: ... }, ...]` | Only the exactly-declared types pass (no wildcard/prefix matching) |
+
+Two consequences worth internalizing:
+
+- **Applying any manifest opts the agent into publish governance.** The
+  validated apply path (`PUT /api/v2/agents/:id/manifest`, `omni agents
+  manifest apply`) parses with `AgentEventManifestSchema`, which defaults an
+  omitted `publishes` to `[]`. A manifest that declares only `accepts`
+  therefore stores `publishes: []` — deny-all. Declare what the agent emits,
+  or don't apply a manifest at all. The "manifest without a `publishes` key"
+  row is only reachable for jsonb written outside the validated path.
+- **An empty allowlist is an allowlist.** `publishes: []` is an explicit
+  declaration, not an absence.
+
+The pure check lives in `@omni/core`
+(`checkPublishAllowed`, `packages/core/src/schemas/agent-manifest.ts`).
+
+## Order of checks at emission time
+
+1. **Publish allowlist** (#987) — the type must be declared, or the emission
+   is refused with reason `publish_not_declared`. Checked first: an
+   undeclared type is refused before its payload is even examined.
+2. **Schema registry** (#959) — a registered type's payload must satisfy its
+   schema (`schema_validation_failed`); with
+   `OMNI_STRICT_EMIT_EVENT_SCHEMAS=true` an unregistered type is refused as
+   `schema_not_registered` (#1000).
+
+## Refusal path (DLQ)
+
+A refused emission publishes **nothing** and journals **nothing**. Its only
+record is a `dead_letter_events` row whose `error` starts with the reason
+token — `publish_not_declared` for allowlist refusals — with
+`next_auto_retry_at` NULL (manual intervention only: retrying an unchanged
+undeclared emission can never succeed; fix the manifest, then retry).
+
+```bash
+omni dead-letters list            # filter on error prefix publish_not_declared
+omni dead-letters retry <id>      # after declaring the type in the manifest
+```
+
+## What is enforced today, and what awaits #986
+
+Enforcement runs in the automation `emit_event` gate
+(`validateEmitEvent` in `packages/api/src/plugins/automation-actions.ts`) and
+activates when the executing automation carries a managing agent
+(`context.automation.managedByAgentId`). Wiring status:
+
+- **Compiled automations (#986)** — the G4b compiler stamps
+  `managed_by_agent_id` on automations compiled from a manifest's `accepts`
+  entries; the engine threads it into the emit path and enforcement is live
+  for them the moment #986 lands. The seam is already in place
+  (`Automation.managedByAgentId` → `TemplateContext.automation` →
+  `validateEmitEvent`'s `emitterAgentId`).
+- **Hand-authored automations** — no managing agent, ungoverned (unchanged).
+- **`POST /events/trigger`** — currently ungoverned: API keys carry no agent
+  identity, so there is no principal→agent mapping to enforce against. If
+  agent-bound credentials ever exist, the trigger path should thread that
+  agent id into the same gate.
+- **Agent dispatcher runs** — agents deliver messages/lifecycle events via
+  dedicated services and have no `emit_event` surface; nothing to gate.
+
+Edge case: if the managing agent's row has been deleted, the emission
+degrades to ungoverned (fail-open, consistent with the emit path's other
+resolution reads).

--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -34,7 +34,7 @@
  */
 
 import type { AgentCallContext, AgentRunResult, CallAgentActionConfig } from '@omni/core';
-import { SCHEMA_NOT_REGISTERED, createLogger, generateId } from '@omni/core';
+import { PUBLISH_NOT_DECLARED, SCHEMA_NOT_REGISTERED, checkPublishAllowed, createLogger, generateId } from '@omni/core';
 import type { Database, EventType } from '@omni/db';
 import { agents, omniEvents } from '@omni/db';
 import { eq } from 'drizzle-orm';
@@ -93,6 +93,67 @@ async function resolveCallAgentChatIds(
   }
 }
 
+/**
+ * Dead-letter an emission refused by one of the emit gates (#959, #987,
+ * #1000). Manual-retry only — the DLQ row is the refused event's only record.
+ * Failure to file the row is logged, never thrown: the action already fails
+ * with the gate's reason, and a DLQ hiccup must not mask it.
+ */
+async function deadLetterRefusedEmission(
+  services: Services,
+  db: Database,
+  trustedTenantId: string | null,
+  input: { eventType: string; payload: Record<string, unknown>; errors: string[]; reason?: string },
+): Promise<void> {
+  try {
+    await runTenantWorkDb(db, trustedTenantId, () =>
+      services.deadLetters.createSchemaValidationFailure({
+        eventId: generateId(),
+        eventType: input.eventType,
+        subject: input.eventType,
+        payload: input.payload,
+        errors: input.errors,
+        reason: input.reason,
+      }),
+    );
+  } catch (error) {
+    log.error('Failed to dead-letter refused emit_event payload', {
+      eventType: input.eventType,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Publish-allowlist check for an agent-attributed emission (RFC #925 G4c,
+ * issue #987). Reads the RAW `agents.event_manifest` jsonb through the same
+ * `scopedHandle` worker-scope seam as the `call_agent` agents lookup above
+ * (this file's registered `agents` db-access site) and applies
+ * `checkPublishAllowed`: no manifest, or a manifest without a `publishes`
+ * key, is ungoverned; `publishes: []` denies everything; otherwise only
+ * declared types pass. A missing agent row (the managing agent was deleted)
+ * degrades to ungoverned, matching this file's other fail-open resolution
+ * reads. Returns the refusal errors, or `null` when the emission is allowed.
+ */
+async function refusePublishNotDeclared(
+  db: Database,
+  trustedTenantId: string | null,
+  emitterAgentId: string,
+  eventType: string,
+): Promise<string[] | null> {
+  const [row] = await runTenantWorkDb(db, trustedTenantId, () =>
+    scopedHandle(db)
+      .select({ eventManifest: agents.eventManifest })
+      .from(agents)
+      .where(eq(agents.id, emitterAgentId))
+      .limit(1),
+  );
+  if (checkPublishAllowed(row?.eventManifest ?? null, eventType)) {
+    return null;
+  }
+  return [`event type '${eventType}' is not declared in the publishes manifest of agent ${emitterAgentId}`];
+}
+
 /** The dependency shape `AutomationService.startEngine` accepts. */
 export interface AutomationEngineDeps {
   sendMessage: (instanceId: string, to: string, content: string, trustedTenantId?: string | null) => Promise<void>;
@@ -124,7 +185,8 @@ export interface AutomationEngineDeps {
     eventType: string,
     payload: Record<string, unknown>,
     trustedTenantId?: string | null,
-  ) => Promise<{ valid: boolean; errors?: string[] }>;
+    emitterAgentId?: string | null,
+  ) => Promise<{ valid: boolean; errors?: string[]; reason?: string }>;
 }
 
 /** Injectable seams (tests only — production uses the module defaults). */
@@ -320,17 +382,41 @@ export function buildAutomationEngineDeps(
       await scopedHandle(db).delete(omniEvents).where(eq(omniEvents.id, eventId));
     },
 
-    // Schema-registry gate for emit_event (issue #959). The engine calls this
-    // BEFORE publish; an unregistered type reports valid (opt-in per type) —
-    // unless `OMNI_STRICT_EMIT_EVENT_SCHEMAS=true` (issue #1000, the RFC #925
-    // G1 policy switch for internal emitters; default off), in which case an
-    // unregistered type is refused with the distinct reason
-    // `schema_not_registered`. An invalid payload is dead-lettered here
-    // (reason `schema_validation_failed`, manual-retry only — the refused
-    // event's only record) and the action then fails without publishing. Each
-    // DB block runs through `runTenantWorkDb` like every other callback:
-    // scoped in the tenant world, ambient passthrough in legacy.
-    validateEmitEvent: async (eventType, payload, trustedTenantId = null) => {
+    // Emission gates for emit_event, in order (per issue #987):
+    //
+    //   1. Publish allowlist (RFC #925 G4c, issue #987) — only when the
+    //      engine threaded an emitter agent (`automation.managedByAgentId`,
+    //      stamped by the #986 compiler): the type must be declared in the
+    //      agent's manifest `publishes` list or the emission is dead-lettered
+    //      with the distinct reason `publish_not_declared` BEFORE the payload
+    //      is examined. No emitter threaded → the gate is inert.
+    //   2. Schema registry (issue #959) — an unregistered type reports valid
+    //      (opt-in per type) unless `OMNI_STRICT_EMIT_EVENT_SCHEMAS=true`
+    //      (issue #1000; default off) refuses it as `schema_not_registered`;
+    //      an invalid payload is refused as `schema_validation_failed`.
+    //
+    // Every refusal is dead-lettered (manual-retry only — the refused event's
+    // only record) and the action then fails without publishing. Each DB
+    // block runs through `runTenantWorkDb` like every other callback: scoped
+    // in the tenant world, ambient passthrough in legacy.
+    validateEmitEvent: async (eventType, payload, trustedTenantId = null, emitterAgentId = null) => {
+      if (emitterAgentId) {
+        const refusal = await refusePublishNotDeclared(db, trustedTenantId, emitterAgentId, eventType);
+        if (refusal) {
+          log.warn('emit_event refused: type not declared in the agent publishes manifest', {
+            eventType,
+            emitterAgentId,
+          });
+          await deadLetterRefusedEmission(services, db, trustedTenantId, {
+            eventType,
+            payload,
+            errors: refusal,
+            reason: PUBLISH_NOT_DECLARED,
+          });
+          return { valid: false, errors: refusal, reason: PUBLISH_NOT_DECLARED };
+        }
+      }
+
       const verdict = await runTenantWorkDb(db, trustedTenantId, () =>
         services.eventSchemas.validate(eventType, payload),
       );
@@ -349,23 +435,7 @@ export function buildAutomationEngineDeps(
         : verdict.errors;
       const reason = refusedUnregistered ? SCHEMA_NOT_REGISTERED : undefined;
 
-      try {
-        await runTenantWorkDb(db, trustedTenantId, () =>
-          services.deadLetters.createSchemaValidationFailure({
-            eventId: generateId(),
-            eventType,
-            subject: eventType,
-            payload,
-            errors,
-            reason,
-          }),
-        );
-      } catch (error) {
-        log.error('Failed to dead-letter refused emit_event payload', {
-          eventType,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      await deadLetterRefusedEmission(services, db, trustedTenantId, { eventType, payload, errors, reason });
       return { valid: false, errors, reason };
     },
   };

--- a/packages/api/src/services/__tests__/publish-allowlist-postgres.test.ts
+++ b/packages/api/src/services/__tests__/publish-allowlist-postgres.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Agent publish-allowlist enforcement over real PostgreSQL (issue #987,
+ * RFC #925 G4c — "Emission outside the manifest → refused + DLQ").
+ *
+ * Drives the REAL emit path — `executeAction('emit_event')` over
+ * `buildAutomationEngineDeps` — against a disposable database with every
+ * migration applied, proving the acceptance criteria:
+ *
+ *   * declared type + valid payload → publishes normally (journal claim row
+ *     under the #958 provenance, event on the bus);
+ *   * undeclared type → action fails `publish_not_declared`, a
+ *     dead_letter_events row with that reason (manual-retry only), NOTHING
+ *     published and ZERO journal rows;
+ *   * declared type + invalid payload → the EXISTING
+ *     `schema_validation_failed` path, unchanged;
+ *   * check ORDER: an undeclared type with an invalid payload refuses as
+ *     `publish_not_declared` (allowlist first, schema second);
+ *   * `publishes: []` → deny-all (an empty allowlist is an allowlist);
+ *   * manifest-less agent, missing agent row, and automations with no
+ *     managing agent → ungoverned, today's behavior unchanged.
+ *
+ * Set `OMNI_G1_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { AgentEventManifest, EventBus, TemplateContext } from '@omni/core';
+import { executeAction } from '@omni/core';
+import { type Database, type EventType, createDbHandle, deadLetterEvents, omniEvents } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { eq } from 'drizzle-orm';
+import { buildAutomationEngineDeps } from '../../plugins/automation-actions';
+import { AgentService } from '../agents';
+import { DeadLetterService } from '../dead-letters';
+import { EventSchemaService } from '../event-schemas';
+import type { Services } from '../index';
+
+const superUrl = process.env.OMNI_G1_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G1_PSQL_BIN ?? 'psql';
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+interface PublishedEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/** An EventBus fake that records publishes — the bus side of the journal. */
+function recordingBus(events: PublishedEvent[]): EventBus {
+  return {
+    publishGeneric: async (type: string, payload: Record<string, unknown>) => {
+      events.push({ type, payload });
+      return { id: crypto.randomUUID(), ok: true };
+    },
+  } as unknown as EventBus;
+}
+
+/** The schema every custom.acme.order payload must satisfy in this suite. */
+const ORDER_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: {
+    orderId: { type: 'string' },
+  },
+  required: ['orderId'],
+};
+
+const GOVERNED_MANIFEST: AgentEventManifest = {
+  accepts: [{ event: 'custom.clickup.task.status_changed' }],
+  publishes: [{ event: 'custom.acme.order' }],
+};
+
+postgresDescribe('agent publish-allowlist enforcement (real PostgreSQL)', () => {
+  const dbName = `omni_987_publishes_${crypto.randomUUID().replaceAll('-', '')}`;
+  const closers: (() => Promise<void>)[] = [];
+  let db: Database;
+  let journal: PublishedEvent[];
+  let deps: ReturnType<typeof buildAutomationEngineDeps>;
+  let governedAgentId: string;
+  let denyAllAgentId: string;
+  let manifestlessAgentId: string;
+
+  function journalOf(type: string): PublishedEvent[] {
+    return journal.filter((e) => e.type === type);
+  }
+
+  async function dlqRows() {
+    return db.select().from(deadLetterEvents);
+  }
+
+  /** Journal claim rows the #958 idempotency path inserted for a type. */
+  async function journaledEvents(eventType: string) {
+    return db
+      .select()
+      .from(omniEvents)
+      .where(eq(omniEvents.eventType, eventType as EventType));
+  }
+
+  /** Run one emit_event on the real engine deps, attributed to an agent. */
+  async function emitAs(agentId: string | null, eventType: string, payload: Record<string, unknown>) {
+    const context: TemplateContext = {
+      payload,
+      variables: {},
+      env: {},
+      automation: { id: 'auto-987', ...(agentId === null ? {} : { managedByAgentId: agentId }) },
+    };
+    return executeAction(
+      { type: 'emit_event', config: { eventType } },
+      context,
+      { ...deps, eventBus: recordingBus(journal) },
+      null,
+      0,
+      // parentEventId lands in the claim row's uuid causation_id column.
+      { parentEventId: crypto.randomUUID(), automationId: 'auto-987' },
+    );
+  }
+
+  beforeAll(async () => {
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
+    const handle = createDbHandle({ url: urlFor(superUrl, dbName), maxConnections: 3 });
+    closers.push(() => handle.close().catch(() => undefined));
+    db = handle.db;
+
+    journal = [];
+    const bus = recordingBus(journal);
+    const eventSchemas = new EventSchemaService(db);
+    const deadLetters = new DeadLetterService(db, bus);
+    const agents = new AgentService(db, bus);
+    deps = buildAutomationEngineDeps({ eventSchemas, deadLetters } as unknown as Services, db);
+
+    await eventSchemas.register({ eventType: 'custom.acme.order', schema: ORDER_SCHEMA });
+
+    const governed = await agents.create({ name: 'governed-agent', provider: 'claude' });
+    governedAgentId = governed.id;
+    await agents.updateManifest(governedAgentId, GOVERNED_MANIFEST);
+
+    const denyAll = await agents.create({ name: 'deny-all-agent', provider: 'claude' });
+    denyAllAgentId = denyAll.id;
+    await agents.updateManifest(denyAllAgentId, { accepts: [], publishes: [] });
+
+    const manifestless = await agents.create({ name: 'manifestless-agent', provider: 'claude' });
+    manifestlessAgentId = manifestless.id;
+
+    journal.length = 0;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+  });
+
+  test('declared type + valid payload → publishes normally with a journal claim row', async () => {
+    const result = await emitAs(governedAgentId, 'custom.acme.order', { orderId: 'ord-1' });
+
+    expect(result.status).toBe('success');
+    expect(journalOf('custom.acme.order').length).toBe(1);
+    expect((await journaledEvents('custom.acme.order')).length).toBe(1);
+    expect((await dlqRows()).length).toBe(0);
+  });
+
+  test('undeclared type → refused publish_not_declared, DLQ row, nothing published or journaled', async () => {
+    const result = await emitAs(governedAgentId, 'custom.acme.refund', { refundId: 'ref-1' });
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.startsWith('publish_not_declared')).toBe(true);
+    expect(result.error).toContain(governedAgentId);
+
+    const rows = await dlqRows();
+    expect(rows.length).toBe(1);
+    const entry = rows[0];
+    expect(entry?.eventType).toBe('custom.acme.refund');
+    expect(entry?.error.startsWith('publish_not_declared')).toBe(true);
+    // Redeclaring the type is the fix; retrying unchanged can never succeed.
+    expect(entry?.nextAutoRetryAt).toBeNull();
+    expect(entry?.payload).toMatchObject({ refundId: 'ref-1' });
+
+    // Neither the bus nor the journal (idempotency claim rows) saw the event.
+    expect(journalOf('custom.acme.refund')).toEqual([]);
+    expect((await journaledEvents('custom.acme.refund')).length).toBe(0);
+    // The only bus traffic for the refusal was the DLQ system announcement.
+    expect(journalOf('system.dead_letter').length).toBe(1);
+  });
+
+  test('declared type + invalid payload → the existing schema_validation_failed path', async () => {
+    const result = await emitAs(governedAgentId, 'custom.acme.order', { orderId: 42 });
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.startsWith('schema_validation_failed')).toBe(true);
+
+    const rows = await dlqRows();
+    expect(rows.length).toBe(2);
+    const entry = rows.find((r) => r.error.startsWith('schema_validation_failed'));
+    expect(entry?.eventType).toBe('custom.acme.order');
+    expect(entry?.nextAutoRetryAt).toBeNull();
+    expect(journalOf('custom.acme.order').length).toBe(1); // unchanged
+  });
+
+  test('check order: undeclared type with an invalid payload refuses as publish_not_declared', async () => {
+    // custom.acme.order's schema would also reject this payload — but the
+    // allowlist is checked FIRST, so an undeclared type never reaches it.
+    const result = await emitAs(governedAgentId, 'custom.acme.audit', { orderId: 42 });
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.startsWith('publish_not_declared')).toBe(true);
+    const entry = (await dlqRows()).find((r) => r.eventType === 'custom.acme.audit');
+    expect(entry?.error.startsWith('publish_not_declared')).toBe(true);
+  });
+
+  test('publishes: [] → deny-all (the agent declared "publishes nothing")', async () => {
+    const result = await emitAs(denyAllAgentId, 'custom.acme.order', { orderId: 'ord-2' });
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.startsWith('publish_not_declared')).toBe(true);
+    expect((await journaledEvents('custom.acme.order')).length).toBe(1); // unchanged
+  });
+
+  test('manifest-less agent → ungoverned, emission unaffected', async () => {
+    const result = await emitAs(manifestlessAgentId, 'custom.freeform.anything', { anything: 'goes' });
+
+    expect(result.status).toBe('success');
+    expect(journalOf('custom.freeform.anything').length).toBe(1);
+  });
+
+  test('missing agent row → ungoverned (fail-open, the managing agent was deleted)', async () => {
+    const result = await emitAs('00000000-0000-4000-8000-000000000000', 'custom.freeform.orphaned', { ok: true });
+
+    expect(result.status).toBe('success');
+    expect(journalOf('custom.freeform.orphaned').length).toBe(1);
+  });
+
+  test('automation with no managing agent → gate inert, today behavior unchanged', async () => {
+    const dlqBefore = (await dlqRows()).length;
+    const result = await emitAs(null, 'custom.freeform.unmanaged', { ok: true });
+
+    expect(result.status).toBe('success');
+    expect(journalOf('custom.freeform.unmanaged').length).toBe(1);
+    expect((await dlqRows()).length).toBe(dlqBefore);
+  });
+});

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -84,12 +84,15 @@ export class AutomationService {
       trustedTenantId?: string | null,
     ) => Promise<boolean>;
     releaseEmittedEventClaim?: (eventId: string) => Promise<void>;
-    // Schema-registry gate for emit_event (issue #959) — see automation-actions.ts.
+    // Emission gates for emit_event: the publish allowlist (issue #987, keyed
+    // by the emitting automation's managing agent) and the schema registry
+    // (issue #959) — see automation-actions.ts.
     validateEmitEvent?: (
       eventType: string,
       payload: Record<string, unknown>,
       trustedTenantId?: string | null,
-    ) => Promise<{ valid: boolean; errors?: string[] }>;
+      emitterAgentId?: string | null,
+    ) => Promise<{ valid: boolean; errors?: string[]; reason?: string }>;
   }): Promise<void> {
     if (!this.eventBus) {
       return;

--- a/packages/api/src/services/dead-letters.ts
+++ b/packages/api/src/services/dead-letters.ts
@@ -174,13 +174,14 @@ export class DeadLetterService {
   }
 
   /**
-   * Dead-letter a payload refused by a schema-registry validation gate
-   * (issue #959). The refused event never entered the journal — this row IS
-   * its only record, with `error` starting with `schema_validation_failed`
-   * (or, for a strict gate refusing an unregistered type — issue #1000 — the
-   * caller-supplied `schema_not_registered`).
+   * Dead-letter a payload refused by an emission/ingress governance gate.
+   * The refused event never entered the journal — this row IS its only
+   * record, with `error` starting with the refusing reason token:
+   * `schema_validation_failed` (issue #959, the default), the strict gate's
+   * `schema_not_registered` (issue #1000), or the publish-allowlist gate's
+   * `publish_not_declared` (RFC #925 G4c, issue #987).
    *
-   * `nextAutoRetryAt` stays null: retrying an unchanged invalid payload can
+   * `nextAutoRetryAt` stays null: retrying an unchanged refused payload can
    * never succeed, so these rows are manual-intervention only.
    */
   async createSchemaValidationFailure(input: {
@@ -189,7 +190,11 @@ export class DeadLetterService {
     subject: string;
     payload: Record<string, unknown>;
     errors: string[];
-    /** DLQ reason token prefixing `error`; defaults to `schema_validation_failed`. */
+    /**
+     * DLQ reason token prefixing `error`; defaults to
+     * `schema_validation_failed` (`SCHEMA_NOT_REGISTERED` and
+     * `PUBLISH_NOT_DECLARED` are the caller-supplied siblings).
+     */
     reason?: string;
   }): Promise<DeadLetterEntry> {
     const [result] = await this.db

--- a/packages/core/src/automations/__tests__/actions.test.ts
+++ b/packages/core/src/automations/__tests__/actions.test.ts
@@ -441,3 +441,72 @@ describe('emit_event derived-key idempotency (#958)', () => {
     expect(claimedKeys.size).toBe(0);
   });
 });
+
+/**
+ * emit_event publish-allowlist threading (RFC #925 G4c, #987): the engine
+ * stamps `context.automation.managedByAgentId` (from the #986 compiler) and
+ * the emit path must hand it to the `validateEmitEvent` gate, whose refusal
+ * fails the action with the gate's reason prefix and publishes nothing.
+ */
+describe('emit_event publish-allowlist gate threading (#987)', () => {
+  const emitAction = { type: 'emit_event', config: { eventType: 'custom.review.parecer.ready' } } as Parameters<
+    typeof executeAction
+  >[0];
+
+  function makeBus(published: string[]) {
+    return {
+      publishGeneric: mock(async (type: string) => {
+        published.push(type);
+        return { id: 'evt-1', type, timestamp: Date.now(), metadata: {}, payload: {} };
+      }),
+    } as never;
+  }
+
+  test('threads context.automation.managedByAgentId as the gate emitterAgentId', async () => {
+    const published: string[] = [];
+    const validateEmitEvent = mock(
+      async (_type: string, _payload: Record<string, unknown>, _tenant?: string | null, _agent?: string | null) => ({
+        valid: true,
+      }),
+    );
+
+    const context = makeContext({ automation: { id: 'auto-1', managedByAgentId: 'agent-42' } });
+    const result = await executeAction(emitAction, context, { eventBus: makeBus(published), validateEmitEvent });
+
+    expect(result.status).toBe('success');
+    expect(validateEmitEvent).toHaveBeenCalledTimes(1);
+    expect(validateEmitEvent.mock.calls[0]![3]).toBe('agent-42');
+    expect(published).toEqual(['custom.review.parecer.ready']);
+  });
+
+  test('no managing agent (hand-authored automation) threads null', async () => {
+    const published: string[] = [];
+    const validateEmitEvent = mock(
+      async (_type: string, _payload: Record<string, unknown>, _tenant?: string | null, _agent?: string | null) => ({
+        valid: true,
+      }),
+    );
+
+    const context = makeContext({ automation: { id: 'auto-1' } });
+    await executeAction(emitAction, context, { eventBus: makeBus(published), validateEmitEvent });
+
+    expect(validateEmitEvent.mock.calls[0]![3]).toBeNull();
+  });
+
+  test('a publish_not_declared refusal fails the action and publishes nothing', async () => {
+    const published: string[] = [];
+    const validateEmitEvent = mock(async () => ({
+      valid: false,
+      errors: ["event type 'custom.review.parecer.ready' is not declared in the publishes manifest of agent agent-42"],
+      reason: 'publish_not_declared',
+    }));
+
+    const context = makeContext({ automation: { id: 'auto-1', managedByAgentId: 'agent-42' } });
+    const result = await executeAction(emitAction, context, { eventBus: makeBus(published), validateEmitEvent });
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toStartWith('publish_not_declared');
+    expect(result.error).toContain('not declared in the publishes manifest');
+    expect(published).toEqual([]);
+  });
+});

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -181,20 +181,30 @@ export interface ActionDependencies {
     trustedTenantId?: string | null,
   ) => Promise<{ skip: boolean; reason?: string; claimToken?: string }>;
   /**
-   * Optional schema-registry gate for `emit_event` (issue #959). Invoked with
+   * Optional emission gate for `emit_event` (issues #959, #987). Invoked with
    * the resolved event type and payload BEFORE publish; an invalid verdict
    * fails the action and nothing enters the journal. The implementation
-   * (packages/api `automation-actions.ts`) consults the `event_schemas`
-   * registry and dead-letters the refused payload with reason
-   * `schema_validation_failed` — or `schema_not_registered` when the strict
-   * switch (issue #1000) refuses an unregistered type; the verdict's `reason`
-   * carries that token and prefixes the action error. Omitted (existing
-   * tests, route-side manual execute) → no gate, behavior unchanged.
+   * (packages/api `automation-actions.ts`) runs two checks IN ORDER:
+   *
+   *   1. Publish allowlist (RFC #925 G4c, #987) — only when `emitterAgentId`
+   *      is threaded: the type must be declared in that agent's manifest
+   *      `publishes` list or the emission is dead-lettered with reason
+   *      `publish_not_declared`.
+   *   2. Schema registry (#959) — dead-letters an invalid payload with reason
+   *      `schema_validation_failed`, or `schema_not_registered` when the
+   *      strict switch (issue #1000) refuses an unregistered type.
+   *
+   * The verdict's `reason` carries the refusing token and prefixes the action
+   * error. `emitterAgentId` comes from `context.automation.managedByAgentId`
+   * (stamped by the #986 compiler; absent/null → check 1 is inert). Omitted
+   * dep (existing tests, route-side manual execute) → no gate, behavior
+   * unchanged.
    */
   validateEmitEvent?: (
     eventType: string,
     payload: Record<string, unknown>,
     trustedTenantId?: string | null,
+    emitterAgentId?: string | null,
   ) => Promise<{ valid: boolean; errors?: string[]; reason?: string }>;
   /**
    * Release a claim previously granted by `staleIdleTimeoutGate`. The gate
@@ -427,25 +437,28 @@ async function releaseEmissionClaim(
 }
 
 /**
- * Schema-registry gate for emit_event (issue #959): a registered type's
- * payload must satisfy its schema or the emit fails BEFORE publish (the gate
- * impl dead-letters it). Unregistered types pass through — opt-in per type —
- * unless the gate impl enforces the strict switch (issue #1000), in which
- * case the verdict's `reason` (`schema_not_registered`) prefixes the error.
- * Runs BEFORE the idempotency claim (#958): a refused payload must not
- * journal an event or burn the slot's derived key.
+ * Emission gates for emit_event (issues #959, #987): the publish allowlist of
+ * the emitting agent's manifest (checked first, only when the engine threaded
+ * `context.automation.managedByAgentId`) and the schema-registry contract. A
+ * refusal fails the emit BEFORE publish (the gate impl dead-letters it with
+ * its reason — `publish_not_declared`, `schema_validation_failed`, or
+ * `schema_not_registered` under the strict switch, issue #1000) and the
+ * verdict's `reason` prefixes the error. Runs BEFORE the idempotency claim
+ * (#958): a refused payload must not journal an event or burn the slot's
+ * derived key.
  */
-async function enforceEmitEventSchema(
+async function enforceEmitEventGates(
   deps: ActionDependencies,
   eventType: string,
   payload: GenericEventPayload,
   trustedTenantId?: string | null,
+  emitterAgentId?: string | null,
 ): Promise<string | null> {
   if (!deps.validateEmitEvent) return null;
-  const verdict = await deps.validateEmitEvent(eventType, payload, trustedTenantId);
+  const verdict = await deps.validateEmitEvent(eventType, payload, trustedTenantId, emitterAgentId);
   if (verdict.valid) return null;
   const detail = verdict.errors?.length ? `: ${verdict.errors.join('; ')}` : '';
-  logger.warn('Emit event refused by schema registry', { eventType, errors: verdict.errors });
+  logger.warn('Emit event refused by emission gate', { eventType, emitterAgentId, errors: verdict.errors });
   return `${verdict.reason ?? SCHEMA_VALIDATION_FAILED}${detail}`;
 }
 
@@ -500,11 +513,17 @@ async function prepareEmitEvent(
 
   const eventType = substituteTemplate(config.eventType, context) as CustomEventType;
 
-  // Schema-registry gate (issue #959, strict switch #1000) — see
-  // `enforceEmitEventSchema`.
-  const schemaError = await enforceEmitEventSchema(deps, eventType, payload, trustedTenantId);
-  if (schemaError !== null) {
-    return { error: schemaError };
+  // Emission gates (publish allowlist #987, schema registry #959, strict
+  // switch #1000) — see `enforceEmitEventGates`.
+  const gateError = await enforceEmitEventGates(
+    deps,
+    eventType,
+    payload,
+    trustedTenantId,
+    context.automation?.managedByAgentId ?? null,
+  );
+  if (gateError !== null) {
+    return { error: gateError };
   }
 
   // Correlation rides the same threading (#956): the next hop continues the

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -554,7 +554,7 @@ export class AutomationEngine {
     // payload fields.
     const context = createTemplateContext(event.payload as Record<string, unknown>, {
       event: { id: event.id, type: event.type, timestamp: event.timestamp, metadata: event.metadata },
-      automation: { id: automation.id },
+      automation: { id: automation.id, managedByAgentId: automation.managedByAgentId ?? null },
     });
 
     await this.queueExecution(automation, event, context, instanceId);
@@ -615,7 +615,7 @@ export class AutomationEngine {
           timestamp: syntheticEvent.timestamp,
           metadata: syntheticEvent.metadata,
         },
-        automation: { id: automation.id },
+        automation: { id: automation.id, managedByAgentId: automation.managedByAgentId ?? null },
       });
 
       await this.queueExecution(automation, syntheticEvent, context, instanceId);

--- a/packages/core/src/automations/templates.ts
+++ b/packages/core/src/automations/templates.ts
@@ -101,8 +101,14 @@ export interface TemplateContext {
   followUp?: TemplateFollowUpContext;
   /** Envelope of the triggering event — threaded by the engine, see TemplateEventContext. */
   event?: TemplateEventContext;
-  /** The automation being executed — threaded by the engine (delivery-id derivation, #960). */
-  automation?: { id: string };
+  /**
+   * The automation being executed — threaded by the engine (delivery-id
+   * derivation, #960). `managedByAgentId` is the agent whose manifest governs
+   * this automation's emissions (RFC #925 G4c, #987): stamped by the G4b
+   * compiler (#986) on compiled automations, `null`/absent for hand-authored
+   * ones — with no emitter agent the publish-allowlist gate is inert.
+   */
+  automation?: { id: string; managedByAgentId?: string | null };
 }
 
 /**
@@ -329,7 +335,7 @@ export function createTemplateContext(
     debounce?: TemplateContext['debounce'];
     followUp?: TemplateFollowUpContext;
     event?: TemplateEventContext;
-    automation?: { id: string };
+    automation?: TemplateContext['automation'];
   } = {},
 ): TemplateContext {
   const followUp = options.followUp ?? deriveFollowUpFromPayload(payload);

--- a/packages/core/src/automations/types.ts
+++ b/packages/core/src/automations/types.ts
@@ -203,6 +203,15 @@ export interface Automation {
    * publishing.
    */
   transactionalEmissions?: boolean;
+  /**
+   * Agent whose event manifest governs this automation (RFC #925 G4).
+   * Stamped by the G4b compiler (#986) when the automation is compiled from a
+   * manifest's `accepts` entries; the engine threads it into the emit path so
+   * the G4c publish-allowlist gate (#987) enforces the agent's `publishes`
+   * declarations. Optional and absent/`null` for hand-authored automations —
+   * their emissions stay ungoverned.
+   */
+  managedByAgentId?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/core/src/schemas/__tests__/agent-manifest.test.ts
+++ b/packages/core/src/schemas/__tests__/agent-manifest.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { AgentEventManifestSchema, ManifestEventTypeSchema } from '../agent-manifest';
+import { AgentEventManifestSchema, ManifestEventTypeSchema, checkPublishAllowed } from '../agent-manifest';
 
 describe('ManifestEventTypeSchema', () => {
   test('accepts core event types', () => {
@@ -89,5 +89,71 @@ describe('AgentEventManifestSchema', () => {
 
   test('rejects plain-string entries (entries are objects, matching the RFC YAML)', () => {
     expect(AgentEventManifestSchema.safeParse({ publishes: ['custom.review.parecer.ready'] }).success).toBe(false);
+  });
+});
+
+/**
+ * Publish-allowlist semantics (RFC #925 G4c — issue #987).
+ *
+ * The decided contract, exhaustively:
+ *   - no manifest → ungoverned (allowed)
+ *   - manifest without a `publishes` key → ungoverned (allowed) — the
+ *     document never spoke about publishing (only reachable for jsonb
+ *     written outside the validated apply path, which defaults absent → [])
+ *   - `publishes: []` → deny ALL (the agent declared "publishes nothing")
+ *   - non-empty `publishes` → exact declared types only
+ */
+describe('checkPublishAllowed', () => {
+  const declared = { publishes: [{ event: 'custom.review.parecer.ready' }, { event: 'custom.alerts.raised' }] };
+
+  test('no manifest (null/undefined) → allowed (ungoverned, no flag day)', () => {
+    expect(checkPublishAllowed(null, 'custom.anything.goes')).toBe(true);
+    expect(checkPublishAllowed(undefined, 'custom.anything.goes')).toBe(true);
+  });
+
+  test('manifest without a publishes key → allowed (the document does not govern publishing)', () => {
+    expect(checkPublishAllowed({}, 'custom.anything.goes')).toBe(true);
+    expect(checkPublishAllowed({ publishes: undefined }, 'custom.anything.goes')).toBe(true);
+    expect(checkPublishAllowed({ publishes: null }, 'custom.anything.goes')).toBe(true);
+  });
+
+  test('malformed publishes (non-array jsonb) → allowed, matching the absent-key stance', () => {
+    expect(checkPublishAllowed({ publishes: 'custom.x.y' } as unknown as { publishes: [] }, 'custom.x.y')).toBe(true);
+  });
+
+  test('empty publishes array → deny ALL (an empty allowlist is an allowlist)', () => {
+    expect(checkPublishAllowed({ publishes: [] }, 'custom.review.parecer.ready')).toBe(false);
+    expect(checkPublishAllowed({ publishes: [] }, 'message.received')).toBe(false);
+  });
+
+  test('declared type → allowed', () => {
+    expect(checkPublishAllowed(declared, 'custom.review.parecer.ready')).toBe(true);
+    expect(checkPublishAllowed(declared, 'custom.alerts.raised')).toBe(true);
+  });
+
+  test('undeclared type → denied', () => {
+    expect(checkPublishAllowed(declared, 'custom.review.parecer.draft')).toBe(false);
+    expect(checkPublishAllowed(declared, 'custom.alerts')).toBe(false);
+  });
+
+  test('matching is exact — no prefix/wildcard semantics', () => {
+    expect(checkPublishAllowed(declared, 'custom.review.parecer.ready.v2')).toBe(false);
+    expect(checkPublishAllowed({ publishes: [{ event: 'custom.review' }] }, 'custom.review.parecer.ready')).toBe(false);
+  });
+
+  test('a parsed full manifest (accepts + publishes) governs by its publishes half only', () => {
+    const manifest = AgentEventManifestSchema.parse({
+      accepts: [{ event: 'custom.clickup.task.status_changed' }],
+      publishes: [{ event: 'custom.review.parecer.ready' }],
+    });
+    expect(checkPublishAllowed(manifest, 'custom.review.parecer.ready')).toBe(true);
+    // Accepting a type does NOT grant the right to publish it.
+    expect(checkPublishAllowed(manifest, 'custom.clickup.task.status_changed')).toBe(false);
+  });
+
+  test('an apply-path manifest that omitted publishes governs as deny-all (Zod defaults absent → [])', () => {
+    const manifest = AgentEventManifestSchema.parse({ accepts: [{ event: 'message.received' }] });
+    expect(manifest.publishes).toEqual([]);
+    expect(checkPublishAllowed(manifest, 'custom.anything.goes')).toBe(false);
   });
 });

--- a/packages/core/src/schemas/agent-manifest.ts
+++ b/packages/core/src/schemas/agent-manifest.ts
@@ -6,9 +6,12 @@
  * want git history keep a YAML/JSON file in their repo and apply it with
  * `omni agents manifest apply <agent> --file <path>`.
  *
- * This slice is STORAGE + READ SURFACE ONLY:
- *   - G4b (#986) compiles `accepts` entries into automations (routing).
- *   - G4c (#987) enforces `publishes` at emission time.
+ * Slices:
+ *   - G4a (#985) — storage + read surface (the schemas below).
+ *   - G4b (#986) — compiles `accepts` entries into automations (routing).
+ *   - G4c (#987) — enforces `publishes` at emission time
+ *     (`checkPublishAllowed` below; the gate implementation lives in the API's
+ *     emit path, packages/api `automation-actions.ts`).
  * Nothing in this module implements matching or routing behavior.
  */
 
@@ -91,3 +94,48 @@ export const AgentEventManifestSchema = z
   .strict();
 
 export type AgentEventManifest = z.infer<typeof AgentEventManifestSchema>;
+
+/**
+ * Dead-letter reason for an agent-attributed emission refused because its
+ * event type is not declared in the emitting agent's `publishes` manifest
+ * (RFC #925 G4c — issue #987: "Emission outside the manifest → refused +
+ * DLQ"). The DLQ row's `error` column starts with this token so operators can
+ * filter on it, mirroring `schema_validation_failed` / `schema_not_registered`.
+ */
+export const PUBLISH_NOT_DECLARED = 'publish_not_declared';
+
+/**
+ * The slice of a stored manifest the publish gate reads. Deliberately looser
+ * than {@link AgentEventManifest}: the gate consumes the RAW
+ * `agents.event_manifest` jsonb, which may predate the `publishes` concept or
+ * have been written outside the validated PUT path, so `publishes` may be
+ * absent entirely.
+ */
+export type PublishGovernanceManifest = {
+  readonly publishes?: readonly { readonly event: string }[] | null;
+} | null;
+
+/**
+ * Publish-allowlist check (RFC #925 G4c — issue #987). Pure and side-effect
+ * free; callers own refusal (DLQ reason {@link PUBLISH_NOT_DECLARED}).
+ *
+ * Semantics — absent vs empty `publishes`:
+ *   - **No manifest** (`null`/`undefined`) → allowed. Agents without a
+ *     manifest keep today's ungoverned behavior; enforcement has no flag day.
+ *   - **Manifest without a `publishes` key** (or a malformed non-array value)
+ *     → allowed. The document never spoke about publishing, so it does not
+ *     govern it. Only reachable for jsonb written outside the validated
+ *     apply path — `AgentEventManifestSchema` defaults an omitted `publishes`
+ *     to `[]` on PUT, so applying ANY manifest through the API/CLI opts the
+ *     agent into publish governance.
+ *   - **`publishes: []`** → deny ALL emissions. The agent explicitly declared
+ *     "publishes nothing"; an empty allowlist is an allowlist.
+ *   - **Non-empty `publishes`** → allowed only for an exactly-declared type.
+ */
+export function checkPublishAllowed(manifest: PublishGovernanceManifest | undefined, eventType: string): boolean {
+  const publishes = manifest?.publishes;
+  if (!Array.isArray(publishes)) {
+    return true;
+  }
+  return publishes.some((entry) => entry?.event === eventType);
+}


### PR DESCRIPTION
Closes #987 — RFC #925 **G4, step 3 of 3**. The manifest's `publishes` list (stored by #985 / PR #1006) becomes an enforcement gate on agent-attributed emissions: an agent only emits declared event types, payloads still validated against the schema registry (#959). Per the RFC: *"Emission outside the manifest → refused + DLQ."*

## What landed

- **Core helper (`@omni/core`)**: `checkPublishAllowed(manifest, eventType)` in `packages/core/src/schemas/agent-manifest.ts` — pure, side-effect free — plus the DLQ reason token `PUBLISH_NOT_DECLARED` (`publish_not_declared`), a sibling of `schema_validation_failed` / `schema_not_registered`.
- **Emit-path seam (core)**: `Automation.managedByAgentId` (optional) → threaded by the engine into `TemplateContext.automation` → handed to the `validateEmitEvent` gate as a new trailing `emitterAgentId` argument. All optional, all `null`-safe: nothing threads it today, so behavior is byte-identical until #986's compiler stamps it.
- **Gate implementation (API)**: `validateEmitEvent` in `packages/api/src/plugins/automation-actions.ts` now runs two checks **in order** (per the issue):
  1. **Publish allowlist** (#987) — only when an emitter agent is threaded: the type must be declared in the agent's manifest `publishes` list, or the emission is dead-lettered with reason `publish_not_declared` (manual-retry only, `next_auto_retry_at` NULL) and the action fails — **nothing published, nothing journaled**. Checked before the payload is even examined.
  2. **Schema registry** (#959/#1000) — the existing `schema_validation_failed` / `schema_not_registered` path, unchanged (shared dead-letter helper extracted).
- **DLQ**: reuses `DeadLetterService.createSchemaValidationFailure`'s existing `reason` parameter (the #1003 pattern) — no schema change, reasons are strings.
- **Docs**: `docs/runbooks/agent-publish-governance.md` — semantics table, check order, DLQ triage, wiring status.
- **No migration** — the manifest column (0062) and DLQ reasons already exist.

## Semantics decision: absent vs empty `publishes`

| Stored state | Effect |
|---|---|
| No manifest (NULL) | Ungoverned — no flag day |
| Manifest **without** a `publishes` key | Ungoverned — the document never spoke about publishing |
| `publishes: []` | **Deny all** — the agent explicitly declared "publishes nothing"; an empty allowlist is an allowlist |
| Non-empty | Exactly-declared types only (no wildcard/prefix matching) |

Caveat, documented in the helper, the runbook, and a dedicated test: the validated apply path (`PUT /agents/:id/manifest`, CLI) parses with `AgentEventManifestSchema`, which defaults an omitted `publishes` to `[]` — so **applying any manifest opts the agent into publish governance** (an accepts-only manifest stores `publishes: []` = deny-all). The "absent key" row is only reachable for jsonb written outside the validated path, which is exactly the backward-compat population.

## Wiring findings (what carries agent identity today)

Investigated every emission surface for an agent-attributed path:

- **`POST /events/trigger`** (`webhooks.ts`) — authenticated by API key only; `api_keys` has **no agent linkage**, so there is no principal→agent mapping to enforce against. Left ungoverned, documented in the runbook as the seam if agent-bound credentials ever exist.
- **Agent dispatcher** (`agent-dispatcher.ts`) — confirmed #988's finding: no `emit_event` surface; agent runs deliver via dedicated message/lifecycle services. Nothing to gate.
- **Automation `emit_event`** — the real seam. Enforcement is fully wired and integration-proven end-to-end (agent row → manifest → gate → DLQ) and **activates the moment #986's compiler stamps `managed_by_agent_id`**: the engine already threads `automation.managedByAgentId` into the gate. No code in this PR depends on #986's branch; hand-authored automations (no managing agent) stay ungoverned.
- Route-level `publishGeneric` calls (`agent-routes.ts`, `voice.ts`) are system CRUD notifications, not agent-attributed emissions.

Edge case: a deleted managing agent (no row) degrades to ungoverned — fail-open, consistent with the emit path's other resolution reads, covered by a test.

## Test evidence

- `make typecheck` — green (25/25)
- `make lint` — green (0 errors, 0 warnings)
- `make verify-migrations` — green (0 new migrations)
- `packages/core/src/schemas/__tests__/agent-manifest.test.ts` — 42 pass (incl. exhaustive `checkPublishAllowed`: null/undefined manifest, absent key, malformed jsonb, empty = deny-all, declared/undeclared, exact matching, accepts ≠ publish grant, apply-path normalization)
- `packages/core/src/automations/__tests__/actions.test.ts` — threading tests: `managedByAgentId` reaches the gate, null for hand-authored automations, `publish_not_declared` refusal fails the action and publishes nothing
- **New** `packages/api/src/services/__tests__/publish-allowlist-postgres.test.ts` (8 pass) — real `executeAction` over `buildAutomationEngineDeps` on a migrated disposable DB: declared+valid publishes with a #958 journal claim row; undeclared → DLQ `publish_not_declared`, zero journal rows, nothing on the bus; declared+invalid → existing `schema_validation_failed`; check ORDER (undeclared+invalid refuses as `publish_not_declared`); `publishes: []` deny-all; manifest-less / deleted-agent / unmanaged-automation ungoverned
- `make test-pg-gate` — full gate green on a fresh disposable cluster (see CI)
