### PR TITLE
feat(automations): compile agent manifests into managed routing automations (#986)

### DIFF
--- a/packages/api/src/routes/v2/__tests__/automations-managed.test.ts
+++ b/packages/api/src/routes/v2/__tests__/automations-managed.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Managed-automation protection at the API boundary (RFC #925 G4b, #986).
+ *
+ * Automations with `managedByAgentId` set are the compiled plan of an agent's
+ * event manifest. The normal automations API must REJECT manual mutation of
+ * them (409 Conflict, message pointing at the owning agent's manifest) so the
+ * compiled plan cannot drift silently — there is deliberately no force
+ * override; the manifest is the only edit path. Hand-made rows (NULL marker)
+ * keep full CRUD.
+ *
+ * Uses the REAL AutomationService over a mocked Database so the service-level
+ * guard and its HTTP mapping (ConflictError → 409 via errorHandler) are both
+ * exercised.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { ValidationError } from '@omni/core';
+import type { Automation, Database } from '@omni/db';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import { AutomationService } from '../../../services/automations';
+import type { AppVariables } from '../../../types';
+import { automationsRoutes } from '../automations';
+
+const MANAGED_ID = '33333333-3333-4333-8333-333333333333';
+const OWNER_AGENT_ID = '11111111-1111-4111-8111-111111111111';
+
+function managedAutomation(): Automation {
+  return {
+    id: MANAGED_ID,
+    tenantId: null,
+    name: `manifest:${OWNER_AGENT_ID}:message.received#abcdef123456`,
+    description: 'compiled row',
+    triggerEventType: 'message.received',
+    triggerConditions: null,
+    conditionLogic: 'and',
+    actions: [{ type: 'call_agent', config: { agentId: OWNER_AGENT_ID } }],
+    debounce: null,
+    enabled: true,
+    priority: 0,
+    transactionalEmissions: false,
+    managedByAgentId: OWNER_AGENT_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Automation;
+}
+
+/** Minimal Database double: getById's select chain resolves to the row. */
+function mockDb(row: Automation): Database {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([row]),
+        }),
+      }),
+    }),
+  } as unknown as Database;
+}
+
+function buildApp(row: Automation) {
+  const services = { automations: new AutomationService(mockDb(row), null) } as unknown as AppVariables['services'];
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', services);
+    await next();
+  });
+  app.route('/automations', automationsRoutes);
+  return app;
+}
+
+describe('managed automations refuse manual mutation (#986)', () => {
+  test('PATCH /automations/:id → 409 pointing at the owning agent manifest', async () => {
+    const res = await buildApp(managedAutomation()).request(`/automations/${MANAGED_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed by hand' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain(OWNER_AGENT_ID);
+    expect(body.error.message).toContain('manifest');
+  });
+
+  test('DELETE /automations/:id → 409 (no force override — edit the manifest)', async () => {
+    const res = await buildApp(managedAutomation()).request(`/automations/${MANAGED_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(409);
+  });
+
+  test('POST /automations/:id/disable → 409 (enable/disable is an update)', async () => {
+    const res = await buildApp(managedAutomation()).request(`/automations/${MANAGED_ID}/disable`, { method: 'POST' });
+    expect(res.status).toBe(409);
+  });
+
+  test('GET /automations/:id stays readable and exposes managedByAgentId', async () => {
+    const res = await buildApp(managedAutomation()).request(`/automations/${MANAGED_ID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { managedByAgentId: string } };
+    expect(body.data.managedByAgentId).toBe(OWNER_AGENT_ID);
+  });
+
+  test('hand-made rows (NULL marker) still update through the same path', async () => {
+    const handMade = { ...managedAutomation(), managedByAgentId: null } as Automation;
+    // The update chain is only reached when the guard passes.
+    const db = {
+      ...mockDb(handMade),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([{ ...handMade, name: 'renamed' }]),
+          }),
+        }),
+      }),
+    } as unknown as Database;
+
+    const services = { automations: new AutomationService(db, null) } as unknown as AppVariables['services'];
+    const app = new Hono<{ Variables: AppVariables }>();
+    app.onError(errorHandler);
+    app.use('*', async (c, next) => {
+      c.set('services', services);
+      await next();
+    });
+    app.route('/automations', automationsRoutes);
+
+    const res = await app.request(`/automations/${MANAGED_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('service-level create refuses caller-supplied provenance', () => {
+    const service = new AutomationService(mockDb(managedAutomation()), null);
+    expect(
+      service.create({
+        name: 'sneaky',
+        triggerEventType: 'message.received',
+        actions: [],
+        managedByAgentId: OWNER_AGENT_ID,
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/packages/api/src/schemas/openapi/automations.ts
+++ b/packages/api/src/schemas/openapi/automations.ts
@@ -113,6 +113,15 @@ export const AutomationSchema = z.object({
       "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
       'only when every action succeeded; a failed run publishes zero',
   }),
+  managedByAgentId: z
+    .string()
+    .uuid()
+    .nullable()
+    .openapi({
+      description:
+        'Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); ' +
+        'null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead',
+    }),
   createdAt: z.string().datetime().openapi({ description: 'Creation timestamp' }),
   updatedAt: z.string().datetime().openapi({ description: 'Last update timestamp' }),
 });

--- a/packages/api/src/services/__tests__/automations.test.ts
+++ b/packages/api/src/services/__tests__/automations.test.ts
@@ -42,6 +42,7 @@ function createMockAutomation(overrides: Partial<Automation> = {}): Automation {
     enabled: true,
     priority: 0,
     transactionalEmissions: false,
+    managedByAgentId: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts
+++ b/packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts
@@ -88,7 +88,7 @@ postgresDescribe('manifest compilation + reconciliation (real PostgreSQL)', () =
     const bus = recordingBus(journal);
     automationService = new AutomationService(db, bus);
     agentService = new AgentService(db, bus);
-    agentService.setManifestReconciler(new ManifestCompilerService(db, bus, automationService));
+    agentService.setManifestReconciler(new ManifestCompilerService(bus, automationService));
   });
 
   afterAll(async () => {

--- a/packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts
+++ b/packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Manifest compilation + reconciliation over real PostgreSQL (issue #986,
+ * RFC #925 G4b).
+ *
+ * Proves migration 0063 and the full G4b loop against a disposable database
+ * with every migration applied:
+ *
+ *   * applying a manifest compiles one MANAGED automation per accepts entry
+ *     (deterministic name, filter → eq/AND conditions, call_agent action,
+ *     `managed_by_agent_id` provenance);
+ *   * recompiling an unchanged manifest is a strict no-op — same rows, same
+ *     updatedAt, no `system.agent.manifest.compiled` event;
+ *   * a manifest change creates/deletes exactly the diff and keeps unchanged
+ *     rows (stable ids);
+ *   * out-of-band drift on a managed row is converged back to the manifest;
+ *   * AutomationService rejects manual mutation of managed rows (409-mapped
+ *     ConflictError) while hand-made rows stay fully mutable and untouched
+ *     by reconciliation;
+ *   * agent soft delete tears the compiled plan down; a hard DELETE of the
+ *     agents row cascades via the 0063 FK;
+ *   * end to end: an event consumed by the automation engine fires the
+ *     compiled automation's call_agent to the declaring agent, honoring the
+ *     compiled filter conditions.
+ *
+ * Set `OMNI_G1_POSTGRES_URL` to a DISPOSABLE superuser URL; `scripts/pg-gate.ts`
+ * does that for you. No ambient `DATABASE_URL` is read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { AgentEventManifest, Automation as CoreAutomation, EventBus, OmniEvent, Subscription } from '@omni/core';
+import { ConflictError, createAutomationEngine } from '@omni/core';
+import { type Database, automations, createDbHandle } from '@omni/db';
+import { agents as agentsTable } from '@omni/db';
+import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { eq } from 'drizzle-orm';
+import { AgentService } from '../agents';
+import { AutomationService } from '../automations';
+import { ManifestCompilerService } from '../manifest-compiler';
+
+const superUrl = process.env.OMNI_G1_POSTGRES_URL ?? '';
+const postgresDescribe = superUrl.length > 0 ? describe : describe.skip;
+const psqlBin = process.env.OMNI_G1_PSQL_BIN ?? 'psql';
+
+function urlFor(base: string, database: string): string {
+  const url = new URL(base);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+interface PublishedEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/** An EventBus fake that records publishes for assertions. */
+function recordingBus(events: PublishedEvent[]): EventBus {
+  return {
+    publishGeneric: async (type: string, payload: Record<string, unknown>) => {
+      events.push({ type, payload });
+      return { id: crypto.randomUUID(), ok: true };
+    },
+  } as unknown as EventBus;
+}
+
+const manifest: AgentEventManifest = {
+  accepts: [
+    { event: 'custom.clickup.task.status_changed', filter: { list_id: '901300373349' } },
+    { event: 'message.received' },
+  ],
+  publishes: [{ event: 'custom.review.parecer.ready' }],
+};
+
+postgresDescribe('manifest compilation + reconciliation (real PostgreSQL)', () => {
+  const dbName = `omni_986_compiler_${crypto.randomUUID().replaceAll('-', '')}`;
+  const closers: (() => Promise<void>)[] = [];
+  let db: Database;
+  let journal: PublishedEvent[];
+  let agentService: AgentService;
+  let automationService: AutomationService;
+
+  beforeAll(() => {
+    provisionMigratedDatabase({ superUrl, psqlBin }, dbName);
+    const handle = createDbHandle({ url: urlFor(superUrl, dbName), maxConnections: 3 });
+    closers.push(() => handle.close().catch(() => undefined));
+    db = handle.db;
+
+    journal = [];
+    const bus = recordingBus(journal);
+    automationService = new AutomationService(db, bus);
+    agentService = new AgentService(db, bus);
+    agentService.setManifestReconciler(new ManifestCompilerService(db, bus, automationService));
+  });
+
+  afterAll(async () => {
+    for (const close of closers) await close();
+  });
+
+  async function compiledRows(agentId: string) {
+    return db.select().from(automations).where(eq(automations.managedByAgentId, agentId));
+  }
+
+  function compiledEvents(): PublishedEvent[] {
+    return journal.filter((event) => event.type === 'system.agent.manifest.compiled');
+  }
+
+  test('applying a manifest compiles one managed automation per accepts entry', async () => {
+    const agent = await agentService.create({ name: 'compiler-apply-agent', provider: 'claude' });
+    journal.length = 0;
+
+    await agentService.updateManifest(agent.id, manifest);
+
+    const rows = await compiledRows(agent.id);
+    expect(rows).toHaveLength(2);
+
+    const filtered = rows.find((row) => row.triggerEventType === 'custom.clickup.task.status_changed');
+    expect(filtered).toBeDefined();
+    expect(filtered?.name).toStartWith(`manifest:${agent.id}:custom.clickup.task.status_changed#`);
+    expect(filtered?.triggerConditions).toEqual([{ field: 'list_id', operator: 'eq', value: '901300373349' }]);
+    expect(filtered?.conditionLogic).toBe('and');
+    expect(filtered?.actions).toEqual([{ type: 'call_agent', config: { agentId: agent.id } }]);
+    expect(filtered?.enabled).toBe(true);
+
+    const unfiltered = rows.find((row) => row.triggerEventType === 'message.received');
+    expect(unfiltered?.triggerConditions).toBeNull();
+
+    expect(journal.map((event) => event.type)).toEqual([
+      'system.agent.manifest.updated',
+      'system.agent.manifest.compiled',
+    ]);
+    expect(compiledEvents()[0]?.payload).toMatchObject({ agentId: agent.id, created: 2, updated: 0, deleted: 0 });
+  });
+
+  test('recompiling an unchanged manifest is a strict no-op: no churn, no events', async () => {
+    const agent = await agentService.create({ name: 'compiler-noop-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, manifest);
+
+    const before = await compiledRows(agent.id);
+    journal.length = 0;
+
+    await agentService.updateManifest(agent.id, manifest);
+
+    const after = await compiledRows(agent.id);
+    // Same rows: identical ids AND identical updatedAt — zero row churn.
+    const key = (rows: typeof after) => rows.map((row) => `${row.id}:${row.updatedAt.toISOString()}`).sort();
+    expect(key(after)).toEqual(key(before));
+
+    // Only the manifest.updated state-change event — no compiled event.
+    expect(journal.map((event) => event.type)).toEqual(['system.agent.manifest.updated']);
+  });
+
+  test('a manifest change creates/deletes exactly the diff and keeps unchanged rows', async () => {
+    const agent = await agentService.create({ name: 'compiler-diff-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, manifest);
+    const before = await compiledRows(agent.id);
+    const keptId = before.find((row) => row.triggerEventType === 'message.received')?.id;
+    journal.length = 0;
+
+    const next: AgentEventManifest = {
+      accepts: [{ event: 'message.received' }, { event: 'chat.archived' }],
+      publishes: [],
+    };
+    await agentService.updateManifest(agent.id, next);
+
+    const after = await compiledRows(agent.id);
+    expect(after.map((row) => row.triggerEventType).sort()).toEqual(['chat.archived', 'message.received']);
+    // The unchanged declaration keeps its row (stable id).
+    expect(after.find((row) => row.triggerEventType === 'message.received')?.id).toBe(keptId);
+    expect(compiledEvents()[0]?.payload).toMatchObject({ created: 1, updated: 0, deleted: 1 });
+  });
+
+  test('out-of-band drift on a managed row is converged back to the manifest', async () => {
+    const agent = await agentService.create({ name: 'compiler-drift-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, manifest);
+    const [row] = await compiledRows(agent.id);
+    expect(row).toBeDefined();
+    if (!row) throw new Error('expected a compiled row');
+
+    // Drift the row behind the service's back (raw SQL path).
+    await db.update(automations).set({ enabled: false, priority: 99 }).where(eq(automations.id, row.id));
+    journal.length = 0;
+
+    await agentService.updateManifest(agent.id, manifest);
+
+    const [converged] = (await compiledRows(agent.id)).filter((candidate) => candidate.id === row.id);
+    expect(converged?.enabled).toBe(true);
+    expect(converged?.priority).toBe(0);
+    expect(compiledEvents()[0]?.payload).toMatchObject({ created: 0, updated: 1, deleted: 0 });
+  });
+
+  test('manual mutation of managed rows is rejected; hand-made rows stay mutable and untouched', async () => {
+    const agent = await agentService.create({ name: 'compiler-protect-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, manifest);
+    const [managed] = await compiledRows(agent.id);
+    if (!managed) throw new Error('expected a compiled row');
+
+    expect(automationService.update(managed.id, { name: 'hand edit' })).rejects.toThrow(ConflictError);
+    expect(automationService.delete(managed.id)).rejects.toThrow(ConflictError);
+    expect(automationService.disable(managed.id)).rejects.toThrow(ConflictError);
+
+    // A hand-made automation on the SAME trigger is invisible to reconciliation.
+    const handMade = await automationService.create({
+      name: 'hand-made sibling',
+      triggerEventType: 'message.received',
+      actions: [{ type: 'log', config: { level: 'info', message: 'hi' } }],
+    });
+    await agentService.updateManifest(agent.id, manifest);
+    const survivor = await automationService.getById(handMade.id);
+    expect(survivor.name).toBe('hand-made sibling');
+    await automationService.update(handMade.id, { name: 'renamed by hand' });
+    await automationService.delete(handMade.id);
+  });
+
+  test('agent soft delete tears the compiled plan down', async () => {
+    const agent = await agentService.create({ name: 'compiler-softdelete-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, manifest);
+    expect(await compiledRows(agent.id)).toHaveLength(2);
+    journal.length = 0;
+
+    await agentService.delete(agent.id);
+
+    expect(await compiledRows(agent.id)).toHaveLength(0);
+    expect(compiledEvents()[0]?.payload).toMatchObject({ created: 0, updated: 0, deleted: 2 });
+  });
+
+  test('hard-deleting the agent row cascades compiled automations (0063 FK)', async () => {
+    const agent = await agentService.create({ name: 'compiler-cascade-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, manifest);
+    expect(await compiledRows(agent.id)).toHaveLength(2);
+
+    await db.delete(agentsTable).where(eq(agentsTable.id, agent.id));
+
+    expect(await compiledRows(agent.id)).toHaveLength(0);
+  });
+
+  test('end to end: a matching event fires the compiled call_agent to the declaring agent', async () => {
+    const agent = await agentService.create({ name: 'compiler-e2e-agent', provider: 'claude' });
+    await agentService.updateManifest(agent.id, {
+      accepts: [{ event: 'custom.clickup.task.status_changed', filter: { list_id: 'L-1' } }],
+      publishes: [],
+    });
+
+    // Engine harness: capture subscriptions so events can be delivered
+    // directly, record call_agent dispatches.
+    const handlers = new Map<string, (event: OmniEvent) => Promise<void>>();
+    const engineBus = {
+      publishGeneric: async () => ({ id: 'pub' }),
+      subscribePattern: async (pattern: string, handler: (event: OmniEvent) => Promise<void>) => {
+        handlers.set(pattern, handler);
+        return { unsubscribe: async () => {} } as Subscription;
+      },
+    } as unknown as EventBus;
+
+    const agentCalls: Array<{ agentId?: string; configAgentId: string }> = [];
+    const engine = createAutomationEngine({ defaultConcurrency: 1, reconcileIntervalMs: 0 });
+    engine.setLogger(async () => {});
+    const enabled = (await automationService.list({ enabled: true })).filter(
+      (row) => row.managedByAgentId === agent.id,
+    );
+    expect(enabled).toHaveLength(1);
+    await engine.start(engineBus, enabled as unknown as CoreAutomation[], {
+      callAgent: async (ctx, config) => {
+        agentCalls.push({ agentId: ctx.agentId, configAgentId: config.agentId });
+        return { parts: ['ok'], fullResponse: 'ok', metadata: { runId: 'r', sessionId: 's', status: 'completed' } };
+      },
+    });
+
+    try {
+      const handler = handlers.get('custom.clickup.task.status_changed.>');
+      expect(handler).toBeDefined();
+      if (!handler) throw new Error('engine did not subscribe to the compiled trigger');
+
+      const fire = (listId: string) =>
+        handler({
+          id: crypto.randomUUID(),
+          type: 'custom.clickup.task.status_changed',
+          payload: {
+            instanceId: 'inst-1',
+            chatId: 'chat-1',
+            from: { id: 'person-1', name: 'P' },
+            content: 'task moved',
+            list_id: listId,
+          },
+          metadata: { correlationId: 'corr-1' },
+          timestamp: Date.now(),
+        } as OmniEvent);
+
+      // Filter mismatch: compiled eq condition refuses the event.
+      await fire('other-list');
+      expect(agentCalls).toHaveLength(0);
+
+      // Filter match: call_agent dispatches to the DECLARING agent.
+      await fire('L-1');
+      expect(agentCalls).toHaveLength(1);
+      expect(agentCalls[0]?.configAgentId).toBe(agent.id);
+      expect(agentCalls[0]?.agentId).toBe(agent.id);
+    } finally {
+      await engine.stop();
+    }
+  });
+});

--- a/packages/api/src/services/__tests__/manifest-compiler.test.ts
+++ b/packages/api/src/services/__tests__/manifest-compiler.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Manifest compiler — pure compilation + diff logic (RFC #925 G4b, #986).
+ *
+ * Covers the manifest → desired-set translation (one managed automation per
+ * `accepts` entry, filter → eq/AND conditions, call_agent action to the
+ * declaring agent), the deterministic naming scheme reconciliation keys on,
+ * and the desired-vs-existing diff (create/update/delete + strict no-op for
+ * an unchanged manifest). The database-backed reconciliation path is proven
+ * in `manifest-compiler-postgres.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AgentEventManifest } from '@omni/core';
+import type { Automation } from '@omni/db';
+import {
+  type DesiredCompiledAutomation,
+  compileManifest,
+  compiledAutomationName,
+  diffCompiledAutomations,
+  filterToConditions,
+  stableStringify,
+} from '../manifest-compiler';
+
+const AGENT = { id: '11111111-1111-4111-8111-111111111111', name: 'reviewer' };
+
+const manifest: AgentEventManifest = {
+  accepts: [
+    { event: 'custom.clickup.task.status_changed', filter: { list_id: '901300373349' } },
+    { event: 'message.received' },
+  ],
+  publishes: [{ event: 'custom.review.parecer.ready' }],
+};
+
+/** Materialize a desired row as if it had been inserted and read back. */
+function asExistingRow(desired: DesiredCompiledAutomation, id: string = crypto.randomUUID()): Automation {
+  return {
+    id,
+    tenantId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...desired,
+  } as Automation;
+}
+
+describe('filterToConditions', () => {
+  test('translates each filter key into a dot-path eq condition, sorted', () => {
+    expect(filterToConditions({ 'task.status': 'done', list_id: '901' })).toEqual([
+      { field: 'list_id', operator: 'eq', value: '901' },
+      { field: 'task.status', operator: 'eq', value: 'done' },
+    ]);
+  });
+
+  test('non-string values are preserved verbatim', () => {
+    expect(filterToConditions({ count: 3, flag: true })).toEqual([
+      { field: 'count', operator: 'eq', value: 3 },
+      { field: 'flag', operator: 'eq', value: true },
+    ]);
+  });
+
+  test('absent or empty filter compiles to null (unconditional trigger)', () => {
+    expect(filterToConditions(undefined)).toBeNull();
+    expect(filterToConditions({})).toBeNull();
+  });
+});
+
+describe('compiledAutomationName', () => {
+  test('is deterministic for the same declaration', () => {
+    const entry = { event: 'custom.a.b', filter: { x: 1, y: 2 } };
+    expect(compiledAutomationName(AGENT.id, entry)).toBe(compiledAutomationName(AGENT.id, entry));
+  });
+
+  test('is insensitive to filter key order (canonical hash input)', () => {
+    expect(compiledAutomationName(AGENT.id, { event: 'custom.a.b', filter: { x: 1, y: 2 } })).toBe(
+      compiledAutomationName(AGENT.id, { event: 'custom.a.b', filter: { y: 2, x: 1 } }),
+    );
+  });
+
+  test('distinguishes same event with different filters', () => {
+    const a = compiledAutomationName(AGENT.id, { event: 'custom.a.b', filter: { x: 1 } });
+    const b = compiledAutomationName(AGENT.id, { event: 'custom.a.b', filter: { x: 2 } });
+    const c = compiledAutomationName(AGENT.id, { event: 'custom.a.b' });
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  test('embeds agent id and event, and always fits varchar(255)', () => {
+    const name = compiledAutomationName(AGENT.id, { event: 'custom.clickup.task.status_changed' });
+    expect(name.startsWith(`manifest:${AGENT.id}:custom.clickup.task.status_changed#`)).toBe(true);
+
+    const longEvent = `custom.${'x'.repeat(300)}.done`;
+    const longName = compiledAutomationName(AGENT.id, { event: longEvent });
+    expect(longName.length).toBeLessThanOrEqual(255);
+  });
+});
+
+describe('stableStringify', () => {
+  test('sorts object keys recursively and drops undefined values', () => {
+    expect(stableStringify({ b: 1, a: { d: undefined, c: [2, { f: 3, e: 4 }] } })).toBe(
+      '{"a":{"c":[2,{"e":4,"f":3}]},"b":1}',
+    );
+  });
+});
+
+describe('compileManifest', () => {
+  test('produces one managed call_agent automation per accepts entry', () => {
+    const desired = compileManifest(AGENT, manifest);
+
+    expect(desired).toHaveLength(2);
+    const [filtered, unfiltered] = desired;
+
+    expect(filtered?.triggerEventType).toBe('custom.clickup.task.status_changed');
+    expect(filtered?.triggerConditions).toEqual([{ field: 'list_id', operator: 'eq', value: '901300373349' }]);
+    expect(filtered?.conditionLogic).toBe('and');
+    expect(filtered?.actions).toEqual([{ type: 'call_agent', config: { agentId: AGENT.id } }]);
+    expect(filtered?.managedByAgentId).toBe(AGENT.id);
+    expect(filtered?.enabled).toBe(true);
+    expect(filtered?.priority).toBe(0);
+    expect(filtered?.debounce).toBeNull();
+
+    expect(unfiltered?.triggerEventType).toBe('message.received');
+    expect(unfiltered?.triggerConditions).toBeNull();
+  });
+
+  test('publishes entries do not compile (routing is accepts-only)', () => {
+    const desired = compileManifest(AGENT, { accepts: [], publishes: [{ event: 'custom.review.parecer.ready' }] });
+    expect(desired).toEqual([]);
+  });
+
+  test('duplicate declarations collapse to one row', () => {
+    const desired = compileManifest(AGENT, {
+      accepts: [
+        { event: 'message.received', filter: { chatId: 'c1' } },
+        { event: 'message.received', filter: { chatId: 'c1' } },
+      ],
+      publishes: [],
+    });
+    expect(desired).toHaveLength(1);
+  });
+
+  test('a null manifest compiles to the empty set', () => {
+    expect(compileManifest(AGENT, null)).toEqual([]);
+  });
+});
+
+describe('diffCompiledAutomations', () => {
+  test('an unchanged manifest is a strict no-op (idempotent recompile)', () => {
+    const desired = compileManifest(AGENT, manifest);
+    const existing = desired.map((row) => asExistingRow(row));
+
+    const diff = diffCompiledAutomations(compileManifest(AGENT, manifest), existing);
+
+    expect(diff.toCreate).toEqual([]);
+    expect(diff.toUpdate).toEqual([]);
+    expect(diff.toDelete).toEqual([]);
+  });
+
+  test('normalizes DB null conditionLogic against the compiled "and"', () => {
+    const desired = compileManifest(AGENT, manifest);
+    const existing = desired.map((row) => ({ ...asExistingRow(row), conditionLogic: null }) as Automation);
+
+    const diff = diffCompiledAutomations(desired, existing);
+    expect(diff.toUpdate).toEqual([]);
+  });
+
+  test('creates missing, deletes undeclared', () => {
+    const desired = compileManifest(AGENT, manifest);
+    const stale = asExistingRow(
+      compileManifest(AGENT, { accepts: [{ event: 'chat.archived' }], publishes: [] })[0] as DesiredCompiledAutomation,
+      'stale-id',
+    );
+
+    const diff = diffCompiledAutomations(desired, [stale]);
+
+    expect(diff.toCreate.map((row) => row.triggerEventType).sort()).toEqual([
+      'custom.clickup.task.status_changed',
+      'message.received',
+    ]);
+    expect(diff.toDelete).toEqual([{ id: 'stale-id', name: stale.name }]);
+    expect(diff.toUpdate).toEqual([]);
+  });
+
+  test('converges rows that drifted out-of-band', () => {
+    const desired = compileManifest(AGENT, manifest);
+    const drifted = desired.map((row, index) =>
+      index === 0
+        ? ({ ...asExistingRow(row, 'drifted-id'), enabled: false, actions: [] } as Automation)
+        : asExistingRow(row),
+    );
+
+    const diff = diffCompiledAutomations(desired, drifted);
+
+    expect(diff.toCreate).toEqual([]);
+    expect(diff.toDelete).toEqual([]);
+    expect(diff.toUpdate).toHaveLength(1);
+    expect(diff.toUpdate[0]?.id).toBe('drifted-id');
+    expect(diff.toUpdate[0]?.desired.enabled).toBe(true);
+  });
+});

--- a/packages/api/src/services/agents.ts
+++ b/packages/api/src/services/agents.ts
@@ -33,6 +33,20 @@ export interface ListAgentsOptions {
   isActive?: boolean;
 }
 
+/**
+ * The manifest-compiler seam (RFC #925 G4b, #986): converges the agent's
+ * compiled automations onto its manifest. Wired by `createServices` via
+ * `setManifestReconciler` — a structural interface (not the concrete
+ * `ManifestCompilerService`) so tests can inject a recorder and this module
+ * does not depend on the compiler implementation.
+ */
+export interface ManifestReconciler {
+  reconcileAgent(
+    agent: { id: string; name: string },
+    manifest: AgentEventManifest | null,
+  ): Promise<{ created: number; updated: number; deleted: number }>;
+}
+
 export class AgentService {
   /**
    * The handle every query in this service uses.
@@ -50,6 +64,13 @@ export class AgentService {
     private readonly pool: Database,
     private eventBus: EventBus | null,
   ) {}
+
+  private manifestReconciler: ManifestReconciler | null = null;
+
+  /** Wire the G4b manifest compiler (see `ManifestReconciler`). */
+  setManifestReconciler(reconciler: ManifestReconciler): void {
+    this.manifestReconciler = reconciler;
+  }
 
   /**
    * List agents with optional filters (paginated)
@@ -180,22 +201,38 @@ export class AgentService {
       });
     }
 
+    // G4b (#986): converge the compiled automations onto the new manifest in
+    // the same call (and, inside a tenant scope, the same transaction) as the
+    // manifest write — a direct call rather than a bus subscription so apply
+    // + compile succeed or fail together and cannot race a second apply. The
+    // compiler publishes `system.agent.manifest.compiled` when the plan
+    // actually changed.
+    await this.manifestReconciler?.reconcileAgent({ id: updated.id, name: updated.name }, manifest);
+
     return updated;
   }
 
   /**
-   * Delete an agent (soft delete — sets isActive = false)
+   * Delete an agent (soft delete — sets isActive = false).
+   *
+   * Also tears down the agent's COMPILED automations (G4b, #986): the row
+   * survives as inactive, so the `managed_by_agent_id` ON DELETE CASCADE
+   * never fires here — that FK only covers hard deletes at the DB level. A
+   * deactivated agent must stop being dispatched to, so its compiled plan is
+   * reconciled against a null manifest (= deleted).
    */
   async delete(id: string): Promise<void> {
     const [updated] = await this.db
       .update(agents)
       .set({ isActive: false, updatedAt: new Date() })
       .where(eq(agents.id, id))
-      .returning({ id: agents.id });
+      .returning({ id: agents.id, name: agents.name });
 
     if (!updated) {
       throw new NotFoundError('Agent', id);
     }
+
+    await this.manifestReconciler?.reconcileAgent({ id: updated.id, name: updated.name }, null);
   }
 
   /**

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -10,8 +10,10 @@ import {
   type AutomationAction,
   type AutomationEngine,
   type CallAgentActionConfig,
+  ConflictError,
   type Automation as CoreAutomation,
   NotFoundError,
+  ValidationError,
   createAutomationEngine,
   createTemplateContext,
   executeActions,
@@ -169,9 +171,35 @@ export class AutomationService {
   }
 
   /**
+   * Refuse manual mutation of a compiler-managed automation (RFC #925 G4b,
+   * #986). Rows with `managedByAgentId` set are the compiled plan of that
+   * agent's event manifest; the manifest is the source of truth, so edits
+   * must go through it — there is deliberately no force/override path. The
+   * compiler itself writes through the raw handle, never this service's CRUD.
+   */
+  private assertNotManaged(automation: Automation): void {
+    if (!automation.managedByAgentId) return;
+    throw new ConflictError(
+      'Automation',
+      `automation ${automation.id} is compiled from the event manifest of agent ${automation.managedByAgentId} and cannot be modified directly — update that agent's manifest instead (omni agents manifest apply)`,
+      { automationId: automation.id, managedByAgentId: automation.managedByAgentId },
+    );
+  }
+
+  /** Refuse caller-supplied provenance: `managedByAgentId` is compiler-owned. */
+  private assertNoProvenance(data: Partial<NewAutomation>): void {
+    if (data.managedByAgentId === undefined || data.managedByAgentId === null) return;
+    throw new ValidationError(
+      'managedByAgentId is compiler-owned: automations compiled from an agent manifest are ' +
+        "created by applying the agent's manifest (omni agents manifest apply), not through automation CRUD",
+    );
+  }
+
+  /**
    * Create a new automation
    */
   async create(data: NewAutomation): Promise<Automation> {
+    this.assertNoProvenance(data);
     const [created] = await this.db.insert(automations).values(data).returning();
 
     if (!created) {
@@ -185,9 +213,12 @@ export class AutomationService {
   }
 
   /**
-   * Update an automation
+   * Update an automation. Rejected (409) for compiler-managed rows — see
+   * `assertNotManaged`.
    */
   async update(id: string, data: Partial<NewAutomation>): Promise<Automation> {
+    this.assertNoProvenance(data);
+    this.assertNotManaged(await this.getById(id));
     const [updated] = await this.db
       .update(automations)
       .set({ ...data, updatedAt: new Date() })
@@ -205,9 +236,11 @@ export class AutomationService {
   }
 
   /**
-   * Delete an automation
+   * Delete an automation. Rejected (409) for compiler-managed rows: remove
+   * the `accepts` entry from the owning agent's manifest instead.
    */
   async delete(id: string): Promise<void> {
+    this.assertNotManaged(await this.getById(id));
     const result = await this.db.delete(automations).where(eq(automations.id, id)).returning();
 
     if (!result.length) {

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -252,6 +252,44 @@ export class AutomationService {
   }
 
   /**
+   * INTERNAL compiler read path (RFC #925 G4b, #986): the compiled rows an
+   * agent's manifest currently materializes. Used by the manifest compiler to
+   * diff desired vs existing; not exposed as a route.
+   */
+  async listCompiledForAgent(agentId: string): Promise<Automation[]> {
+    return this.db.select().from(automations).where(eq(automations.managedByAgentId, agentId));
+  }
+
+  /**
+   * INTERNAL compiler write path (RFC #925 G4b, #986). Applies a reconciled
+   * diff of COMPILED rows in one pass and reloads the engine once. This is
+   * the deliberate bypass of `assertNotManaged`/`assertNoProvenance`: the
+   * manifest compiler is the sole legitimate writer of managed rows, and it
+   * must be able to stamp `managedByAgentId` and mutate/delete what the
+   * public CRUD refuses to touch. Only `ManifestCompilerService` calls this;
+   * it is not reachable from any route.
+   */
+  async applyCompiledDiff(diff: {
+    create: NewAutomation[];
+    update: Array<{ id: string; data: Partial<NewAutomation> }>;
+    deleteIds: string[];
+  }): Promise<void> {
+    for (const row of diff.create) {
+      await this.db.insert(automations).values(row);
+    }
+    for (const { id, data } of diff.update) {
+      await this.db
+        .update(automations)
+        .set({ ...data, updatedAt: new Date() })
+        .where(eq(automations.id, id));
+    }
+    for (const id of diff.deleteIds) {
+      await this.db.delete(automations).where(eq(automations.id, id));
+    }
+    await this.reloadEngine();
+  }
+
+  /**
    * Enable an automation
    */
   async enable(id: string): Promise<Automation> {

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -231,7 +231,7 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
   // agent's COMPILED automations through the compiler (a direct service call,
   // not a bus subscription — apply + compile share the request's transaction).
   const automationsService = new AutomationService(db, eventBus);
-  const manifestCompiler = new ManifestCompilerService(db, eventBus, automationsService);
+  const manifestCompiler = new ManifestCompilerService(eventBus, automationsService);
   const agentsService = new AgentService(db, eventBus);
   agentsService.setManifestReconciler(manifestCompiler);
 

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -45,6 +45,7 @@ import { FollowUpLifecycleService } from './follow-up-lifecycle';
 import { FollowUpSweeperService } from './follow-up-sweeper';
 import { GenieHostsService } from './genie-hosts';
 import { InstanceService } from './instances';
+import { ManifestCompilerService } from './manifest-compiler';
 import { MediaStorageService } from './media-storage';
 import { MessageService } from './messages';
 import { PayloadStoreService } from './payload-store';
@@ -88,6 +89,12 @@ export interface Services {
   eventSchemas: EventSchemaService;
   webhooks: WebhookService;
   automations: AutomationService;
+  /**
+   * G4b manifest compiler (RFC #925, #986): compiles `agents.event_manifest`
+   * `accepts` entries into MANAGED routing automations and reconciles them on
+   * manifest apply/update and agent deletion (wired into `agents` below).
+   */
+  manifestCompiler: ManifestCompilerService;
   chats: ChatService;
   messages: MessageService;
   syncJobs: SyncJobService;
@@ -220,8 +227,16 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
   const agentRunner = new AgentRunnerService(db);
   providers.onProviderChanged((providerId) => agentRunner.clearCache(providerId));
 
+  // G4b (#986): manifest apply/update and agent deletion reconcile the
+  // agent's COMPILED automations through the compiler (a direct service call,
+  // not a bus subscription — apply + compile share the request's transaction).
+  const automationsService = new AutomationService(db, eventBus);
+  const manifestCompiler = new ManifestCompilerService(db, eventBus, automationsService);
+  const agentsService = new AgentService(db, eventBus);
+  agentsService.setManifestReconciler(manifestCompiler);
+
   return {
-    agents: new AgentService(db, eventBus),
+    agents: agentsService,
     agentState: new AgentStateService(eventBus),
     agentTasks: new AgentTaskService(db, eventBus),
     apiKeys,
@@ -240,7 +255,8 @@ export function createServices(db: Database, eventBus: EventBus | null): Service
     eventOps,
     eventSchemas,
     webhooks: new WebhookService(db, eventBus, eventSchemas, deadLetters),
-    automations: new AutomationService(db, eventBus),
+    automations: automationsService,
+    manifestCompiler,
     chats: new ChatService(db, eventBus),
     messages: new MessageService(db, eventBus),
     syncJobs: new SyncJobService(db, eventBus),

--- a/packages/api/src/services/manifest-compiler.ts
+++ b/packages/api/src/services/manifest-compiler.ts
@@ -1,0 +1,279 @@
+/**
+ * Manifest compiler (RFC #925 G4b, issue #986).
+ *
+ * Compiles an agent's declarative event manifest (`agents.event_manifest`,
+ * stored by G4a/#985) into MANAGED routing automations: one automation per
+ * `accepts` entry, triggering on the entry's event type, narrowed by the
+ * entry's `filter` translated into automation conditions (dot-path field →
+ * `eq`, AND — the exact matcher semantics the manifest schema's JSDoc
+ * references), and dispatching a `call_agent` action to the declaring agent.
+ *
+ * Compiled rows carry `managed_by_agent_id` (migration 0063): the manifest is
+ * the source of truth and the `automations` table is the compiled plan, not
+ * the source of truth. Manual CRUD of managed rows is rejected by
+ * `AutomationService`; this service is the ONLY writer, and it writes through
+ * the raw scoped handle (the internal path) rather than the service CRUD.
+ *
+ * Reconciliation mirrors the automation engine's subscription reconciler
+ * (engine.ts `doReconcileSubscriptions`): diff desired vs existing, create the
+ * missing, converge the drifted, delete the no-longer-declared. Recompiling an
+ * unchanged manifest is a strict no-op — no row churn, no events.
+ */
+
+import { createHash } from 'node:crypto';
+import type { AgentEventManifest, AutomationAction, AutomationCondition, EventBus } from '@omni/core';
+import { createLogger } from '@omni/core';
+import type { Database } from '@omni/db';
+import { type Automation, automations } from '@omni/db';
+import { eq } from 'drizzle-orm';
+import { scopedHandle } from '../tenancy/tenant-scope';
+import type { AutomationService } from './automations';
+
+const logger = createLogger('api:manifest-compiler');
+
+/** The agent identity the compiler needs (a subset of the `agents` row). */
+export interface CompiledAgentRef {
+  id: string;
+  name: string;
+}
+
+/**
+ * The desired shape of one compiled automation — exactly the columns the
+ * reconciler owns. Everything outside this shape (id, timestamps, tenant) is
+ * left to the database.
+ */
+export interface DesiredCompiledAutomation {
+  name: string;
+  description: string;
+  triggerEventType: string;
+  triggerConditions: AutomationCondition[] | null;
+  conditionLogic: 'and';
+  actions: AutomationAction[];
+  debounce: null;
+  enabled: boolean;
+  priority: number;
+  transactionalEmissions: boolean;
+  managedByAgentId: string;
+}
+
+/** The reconciliation outcome, also the payload of the compiled event. */
+export interface ReconcileResult {
+  created: number;
+  updated: number;
+  deleted: number;
+}
+
+/** Automations `name` is varchar(255); compiled names must always fit. */
+const MAX_AUTOMATION_NAME_LENGTH = 255;
+
+/**
+ * JSON.stringify with objects' keys sorted recursively, so semantically equal
+ * filters always serialize identically (hash input + drift comparison).
+ */
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .filter((key) => (value as Record<string, unknown>)[key] !== undefined)
+      .map((key) => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+/**
+ * Translate a manifest `filter` into automation conditions: each key is a
+ * dot-notation payload path matched with `eq`, combined with AND — the
+ * matcher semantics documented on `ManifestAcceptsEntrySchema`. Keys are
+ * sorted so the compiled conditions are deterministic. An absent or empty
+ * filter compiles to NULL (unconditional trigger).
+ */
+export function filterToConditions(filter: Record<string, unknown> | undefined): AutomationCondition[] | null {
+  if (!filter) return null;
+  const fields = Object.keys(filter).sort();
+  if (fields.length === 0) return null;
+  return fields.map((field) => ({ field, operator: 'eq' as const, value: filter[field] }));
+}
+
+/**
+ * Deterministic name for one compiled automation:
+ * `manifest:{agentId}:{event}#{hash12}` where the hash covers event + filter.
+ * The hash makes two entries for the same event with different filters
+ * distinct, and the name is the reconciliation key — stable across recompiles
+ * of the same declaration. The event segment is truncated if (and only if) the
+ * name would overflow the varchar(255) column; identity stays in the hash.
+ */
+export function compiledAutomationName(
+  agentId: string,
+  entry: { event: string; filter?: Record<string, unknown> },
+): string {
+  const digest = createHash('sha256')
+    .update(stableStringify({ event: entry.event, filter: entry.filter ?? null }))
+    .digest('hex')
+    .slice(0, 12);
+  const prefix = `manifest:${agentId}:`;
+  const suffix = `#${digest}`;
+  const room = MAX_AUTOMATION_NAME_LENGTH - prefix.length - suffix.length;
+  const event = entry.event.length > room ? entry.event.slice(0, room) : entry.event;
+  return `${prefix}${event}${suffix}`;
+}
+
+/**
+ * Compile a manifest into the DESIRED set of managed automations for an
+ * agent — one per `accepts` entry, deduplicated by compiled name (two
+ * identical declarations collapse to one row). A null manifest compiles to
+ * the empty set (reconciliation then deletes every compiled row).
+ */
+export function compileManifest(
+  agent: CompiledAgentRef,
+  manifest: AgentEventManifest | null,
+): DesiredCompiledAutomation[] {
+  const desired = new Map<string, DesiredCompiledAutomation>();
+  for (const entry of manifest?.accepts ?? []) {
+    const name = compiledAutomationName(agent.id, entry);
+    desired.set(name, {
+      name,
+      description: `Compiled from the event manifest of agent ${agent.id} (RFC #925 G4b). Do not edit by hand — apply the agent's manifest instead (omni agents manifest apply).`,
+      triggerEventType: entry.event,
+      triggerConditions: filterToConditions(entry.filter),
+      conditionLogic: 'and',
+      // Minimal event→agent dispatch config: the runtime derives instance,
+      // chat, sender, and message content from the triggering event's payload
+      // (see extractAgentCallContext in @omni/core automations/actions.ts).
+      actions: [{ type: 'call_agent', config: { agentId: agent.id } }],
+      debounce: null,
+      enabled: true,
+      priority: 0,
+      transactionalEmissions: false,
+      managedByAgentId: agent.id,
+    });
+  }
+  return [...desired.values()];
+}
+
+/** The columns the reconciler owns, projected from an existing row. */
+function ownedShape(row: DesiredCompiledAutomation | Automation): Record<string, unknown> {
+  return {
+    name: row.name,
+    description: row.description ?? null,
+    triggerEventType: row.triggerEventType,
+    triggerConditions: row.triggerConditions ?? null,
+    // The DB column defaults to 'and' and allows NULL; both mean AND.
+    conditionLogic: row.conditionLogic ?? 'and',
+    actions: row.actions,
+    debounce: row.debounce ?? null,
+    enabled: row.enabled,
+    priority: row.priority,
+    transactionalEmissions: row.transactionalEmissions ?? false,
+  };
+}
+
+/** Deep equality over the reconciler-owned columns. */
+function isConverged(desired: DesiredCompiledAutomation, existing: Automation): boolean {
+  return stableStringify(ownedShape(desired)) === stableStringify(ownedShape(existing));
+}
+
+export interface CompiledDiff {
+  toCreate: DesiredCompiledAutomation[];
+  toUpdate: Array<{ id: string; desired: DesiredCompiledAutomation }>;
+  toDelete: Array<{ id: string; name: string }>;
+}
+
+/**
+ * Diff the desired set against the agent's existing compiled rows, keyed by
+ * the deterministic name. Pure — exercised directly by unit tests.
+ */
+export function diffCompiledAutomations(desired: DesiredCompiledAutomation[], existing: Automation[]): CompiledDiff {
+  const existingByName = new Map(existing.map((row) => [row.name, row]));
+  const desiredNames = new Set(desired.map((row) => row.name));
+
+  const toCreate: CompiledDiff['toCreate'] = [];
+  const toUpdate: CompiledDiff['toUpdate'] = [];
+  for (const want of desired) {
+    const have = existingByName.get(want.name);
+    if (!have) {
+      toCreate.push(want);
+    } else if (!isConverged(want, have)) {
+      toUpdate.push({ id: have.id, desired: want });
+    }
+  }
+
+  const toDelete = existing.filter((row) => !desiredNames.has(row.name)).map((row) => ({ id: row.id, name: row.name }));
+
+  return { toCreate, toUpdate, toDelete };
+}
+
+export class ManifestCompilerService {
+  /**
+   * The handle every query uses — the request's tenant-stamped transaction
+   * inside a tenant scope, the ambient pool otherwise (same contract as every
+   * other service; see `tenancy/tenant-scope.ts`).
+   */
+  private get db(): Database {
+    return scopedHandle(this.pool);
+  }
+
+  constructor(
+    private readonly pool: Database,
+    private readonly eventBus: EventBus | null,
+    /**
+     * The compiler bypasses AutomationService CRUD (managed rows reject it)
+     * but still needs `reloadEngine()` so a converged plan is picked up by
+     * the running engine, exactly as hand-made CRUD does.
+     */
+    private readonly automations: AutomationService,
+  ) {}
+
+  /**
+   * Converge the agent's compiled automations onto its manifest: create the
+   * missing, update the drifted, delete the no-longer-declared. Idempotent —
+   * an unchanged manifest produces zero writes, no engine reload, and no
+   * event. Publishes `system.agent.manifest.compiled` when the plan changed.
+   *
+   * Pass `manifest: null` to tear the compiled plan down (agent deletion).
+   */
+  async reconcileAgent(agent: CompiledAgentRef, manifest: AgentEventManifest | null): Promise<ReconcileResult> {
+    const desired = compileManifest(agent, manifest);
+    const existing = await this.db.select().from(automations).where(eq(automations.managedByAgentId, agent.id));
+    const { toCreate, toUpdate, toDelete } = diffCompiledAutomations(desired, existing);
+
+    const result: ReconcileResult = {
+      created: toCreate.length,
+      updated: toUpdate.length,
+      deleted: toDelete.length,
+    };
+    if (result.created === 0 && result.updated === 0 && result.deleted === 0) {
+      return result;
+    }
+
+    for (const row of toCreate) {
+      await this.db.insert(automations).values(row);
+    }
+    for (const { id, desired: want } of toUpdate) {
+      await this.db
+        .update(automations)
+        .set({ ...want, updatedAt: new Date() })
+        .where(eq(automations.id, id));
+    }
+    for (const { id } of toDelete) {
+      await this.db.delete(automations).where(eq(automations.id, id));
+    }
+
+    await this.automations.reloadEngine();
+
+    logger.info('Reconciled compiled automations from agent manifest', { agentId: agent.id, ...result });
+
+    if (this.eventBus) {
+      await this.eventBus.publishGeneric('system.agent.manifest.compiled', {
+        agentId: agent.id,
+        name: agent.name,
+        ...result,
+      });
+    }
+
+    return result;
+  }
+}

--- a/packages/api/src/services/manifest-compiler.ts
+++ b/packages/api/src/services/manifest-compiler.ts
@@ -11,8 +11,9 @@
  * Compiled rows carry `managed_by_agent_id` (migration 0063): the manifest is
  * the source of truth and the `automations` table is the compiled plan, not
  * the source of truth. Manual CRUD of managed rows is rejected by
- * `AutomationService`; this service is the ONLY writer, and it writes through
- * the raw scoped handle (the internal path) rather than the service CRUD.
+ * `AutomationService`; this service is the ONLY legitimate writer and goes
+ * through `AutomationService.applyCompiledDiff` — the internal path that
+ * bypasses the managed-row guards.
  *
  * Reconciliation mirrors the automation engine's subscription reconciler
  * (engine.ts `doReconcileSubscriptions`): diff desired vs existing, create the
@@ -23,10 +24,7 @@
 import { createHash } from 'node:crypto';
 import type { AgentEventManifest, AutomationAction, AutomationCondition, EventBus } from '@omni/core';
 import { createLogger } from '@omni/core';
-import type { Database } from '@omni/db';
-import { type Automation, automations } from '@omni/db';
-import { eq } from 'drizzle-orm';
-import { scopedHandle } from '../tenancy/tenant-scope';
+import type { Automation } from '@omni/db';
 import type { AutomationService } from './automations';
 
 const logger = createLogger('api:manifest-compiler');
@@ -207,22 +205,14 @@ export function diffCompiledAutomations(desired: DesiredCompiledAutomation[], ex
 }
 
 export class ManifestCompilerService {
-  /**
-   * The handle every query uses — the request's tenant-stamped transaction
-   * inside a tenant scope, the ambient pool otherwise (same contract as every
-   * other service; see `tenancy/tenant-scope.ts`).
-   */
-  private get db(): Database {
-    return scopedHandle(this.pool);
-  }
-
   constructor(
-    private readonly pool: Database,
     private readonly eventBus: EventBus | null,
     /**
-     * The compiler bypasses AutomationService CRUD (managed rows reject it)
-     * but still needs `reloadEngine()` so a converged plan is picked up by
-     * the running engine, exactly as hand-made CRUD does.
+     * All database access goes through AutomationService's INTERNAL compiler
+     * path (`listCompiledForAgent` / `applyCompiledDiff`) — the one deliberate
+     * bypass of the managed-row CRUD guards, which also keeps every write to
+     * the `automations` tenant table inside the registered writer
+     * (tenancy-writer-coverage.ts) and reloads the engine exactly once.
      */
     private readonly automations: AutomationService,
   ) {}
@@ -237,7 +227,7 @@ export class ManifestCompilerService {
    */
   async reconcileAgent(agent: CompiledAgentRef, manifest: AgentEventManifest | null): Promise<ReconcileResult> {
     const desired = compileManifest(agent, manifest);
-    const existing = await this.db.select().from(automations).where(eq(automations.managedByAgentId, agent.id));
+    const existing = await this.automations.listCompiledForAgent(agent.id);
     const { toCreate, toUpdate, toDelete } = diffCompiledAutomations(desired, existing);
 
     const result: ReconcileResult = {
@@ -249,20 +239,11 @@ export class ManifestCompilerService {
       return result;
     }
 
-    for (const row of toCreate) {
-      await this.db.insert(automations).values(row);
-    }
-    for (const { id, desired: want } of toUpdate) {
-      await this.db
-        .update(automations)
-        .set({ ...want, updatedAt: new Date() })
-        .where(eq(automations.id, id));
-    }
-    for (const { id } of toDelete) {
-      await this.db.delete(automations).where(eq(automations.id, id));
-    }
-
-    await this.automations.reloadEngine();
+    await this.automations.applyCompiledDiff({
+      create: toCreate,
+      update: toUpdate.map(({ id, desired: data }) => ({ id, data })),
+      deleteIds: toDelete.map(({ id }) => id),
+    });
 
     logger.info('Reconciled compiled automations from agent manifest', { agentId: agent.id, ...result });
 

--- a/packages/cli/src/commands/__tests__/agents-manifest.test.ts
+++ b/packages/cli/src/commands/__tests__/agents-manifest.test.ts
@@ -10,8 +10,15 @@
 import { describe, expect, test } from 'bun:test';
 import { __testables } from '../agents';
 
-const { detectManifestFormat, parseManifestSource, validateManifestDocument, buildGraphRows, buildTypeRows } =
-  __testables;
+const {
+  detectManifestFormat,
+  parseManifestSource,
+  validateManifestDocument,
+  buildGraphRows,
+  buildTypeRows,
+  countManagedAutomations,
+  formatCompiledIndicator,
+} = __testables;
 
 const validManifest = {
   accepts: [{ event: 'custom.clickup.task.status_changed', filter: { list_id: '901300373349' } }],
@@ -70,10 +77,10 @@ describe('validateManifestDocument', () => {
 describe('buildGraphRows', () => {
   test('one row per declaring agent; undeclared agents are omitted', () => {
     const rows = buildGraphRows([
-      { name: 'reviewer', eventManifest: validManifest },
-      { name: 'silent', eventManifest: null },
-      { name: 'empty', eventManifest: { accepts: [], publishes: [] } },
-      { name: 'emitter', eventManifest: { publishes: [{ event: 'custom.alerts.raised' }] } },
+      { id: 'a-1', name: 'reviewer', eventManifest: validManifest },
+      { id: 'a-2', name: 'silent', eventManifest: null },
+      { id: 'a-3', name: 'empty', eventManifest: { accepts: [], publishes: [] } },
+      { id: 'a-4', name: 'emitter', eventManifest: { publishes: [{ event: 'custom.alerts.raised' }] } },
     ]);
 
     expect(rows).toEqual([
@@ -81,22 +88,66 @@ describe('buildGraphRows', () => {
         agent: 'reviewer',
         consumes: 'custom.clickup.task.status_changed (filtered)',
         produces: 'custom.review.parecer.ready',
+        compiled: 'unknown',
       },
-      { agent: 'emitter', consumes: '-', produces: 'custom.alerts.raised' },
+      { agent: 'emitter', consumes: '-', produces: 'custom.alerts.raised', compiled: '-' },
     ]);
   });
 
+  test('compiled column reports materialized vs declared accepts (#986)', () => {
+    const counts = new Map([['a-1', 1]]);
+    const rows = buildGraphRows(
+      [
+        { id: 'a-1', name: 'reviewer', eventManifest: validManifest },
+        {
+          id: 'a-5',
+          name: 'uncompiled',
+          eventManifest: { accepts: [{ event: 'message.received' }, { event: 'chat.archived' }] },
+        },
+      ],
+      counts,
+    );
+
+    expect(rows[0]?.compiled).toBe('1/1');
+    // Declared but not yet materialized — counts map present, agent absent.
+    expect(rows[1]?.compiled).toBe('0/2');
+  });
+
   test('unfiltered accepts render without the (filtered) marker', () => {
-    const rows = buildGraphRows([{ name: 'a', eventManifest: { accepts: [{ event: 'message.received' }] } }]);
+    const rows = buildGraphRows([
+      { id: 'a-1', name: 'a', eventManifest: { accepts: [{ event: 'message.received' }] } },
+    ]);
     expect(rows[0]?.consumes).toBe('message.received');
+  });
+});
+
+describe('countManagedAutomations / formatCompiledIndicator (#986)', () => {
+  test('counts only manifest-managed automations, grouped by owning agent', () => {
+    const counts = countManagedAutomations([
+      { managedByAgentId: 'a-1' },
+      { managedByAgentId: 'a-1' },
+      { managedByAgentId: 'a-2' },
+      { managedByAgentId: null },
+      {},
+    ]);
+    expect(counts.get('a-1')).toBe(2);
+    expect(counts.get('a-2')).toBe(1);
+    expect(counts.size).toBe(2);
+  });
+
+  test('indicator: dash when nothing declared, unknown without data, n/m otherwise', () => {
+    expect(formatCompiledIndicator(0, undefined)).toBe('-');
+    expect(formatCompiledIndicator(2, undefined)).toBe('unknown');
+    expect(formatCompiledIndicator(2, 2)).toBe('2/2');
+    expect(formatCompiledIndicator(2, 0)).toBe('0/2');
   });
 });
 
 describe('buildTypeRows', () => {
   const agents = [
-    { name: 'reviewer', eventManifest: validManifest },
-    { name: 'emitter', eventManifest: { publishes: [{ event: 'custom.clickup.task.status_changed' }] } },
-    { name: 'silent', eventManifest: null },
+    { id: 'a-1', name: 'reviewer', eventManifest: validManifest },
+    { id: 'a-2', name: 'emitter', eventManifest: { publishes: [{ event: 'custom.clickup.task.status_changed' }] } },
+    { id: 'a-3', name: 'silent', eventManifest: null },
   ];
 
   test('lists consumers (with their filter) and producers of the type', () => {

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -204,6 +204,7 @@ function validateManifestDocument(raw: unknown): AgentEventManifest {
 
 /** Minimal agent shape the graph helpers need (matches SDK list output). */
 interface GraphAgentInput {
+  id: string;
   name: string;
   eventManifest?: {
     accepts?: { event: string; filter?: Record<string, unknown> }[];
@@ -215,6 +216,35 @@ interface GraphRow {
   agent: string;
   consumes: string;
   produces: string;
+  compiled: string;
+}
+
+/**
+ * Count compiled (manifest-managed) automations per owning agent (#986).
+ * Input is the SDK automations list; rows without `managedByAgentId` are
+ * hand-made and ignored.
+ */
+function countManagedAutomations(automations: Array<{ managedByAgentId?: string | null }>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const automation of automations) {
+    const agentId = automation.managedByAgentId;
+    if (!agentId) continue;
+    counts.set(agentId, (counts.get(agentId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Render the declared-vs-materialized indicator for one agent:
+ *   - `-` when nothing is declared (nothing to compile),
+ *   - `unknown` when the automations list was unavailable,
+ *   - `materialized/declared` otherwise (e.g. `2/2`; `0/2` = declared but
+ *     not yet compiled — the manifest predates the G4b compiler).
+ */
+function formatCompiledIndicator(declared: number, materialized: number | undefined): string {
+  if (declared === 0) return '-';
+  if (materialized === undefined) return 'unknown';
+  return `${materialized}/${declared}`;
 }
 
 /** Render one accepts entry for the graph table ("event (filtered)" when narrowed). */
@@ -226,8 +256,12 @@ function formatAcceptsEntry(entry: { event: string; filter?: Record<string, unkn
 /**
  * Build the producer/consumer table: one row per agent that declares at least
  * one accepts/publishes entry. Agents without a manifest are omitted.
+ *
+ * `managedCounts` (from `countManagedAutomations`, #986) drives the
+ * `compiled` column — declared vs materialized state; pass undefined when the
+ * automations list could not be fetched.
  */
-function buildGraphRows(agents: GraphAgentInput[]): GraphRow[] {
+function buildGraphRows(agents: GraphAgentInput[], managedCounts?: Map<string, number>): GraphRow[] {
   const rows: GraphRow[] = [];
   for (const agent of agents) {
     const manifest = agent.eventManifest;
@@ -238,6 +272,7 @@ function buildGraphRows(agents: GraphAgentInput[]): GraphRow[] {
       agent: agent.name,
       consumes: accepts.length > 0 ? accepts.map(formatAcceptsEntry).join(', ') : '-',
       produces: publishes.length > 0 ? publishes.map((entry) => entry.event).join(', ') : '-',
+      compiled: formatCompiledIndicator(accepts.length, managedCounts ? (managedCounts.get(agent.id) ?? 0) : undefined),
     });
   }
   return rows;
@@ -276,6 +311,8 @@ export const __testables = {
   validateManifestDocument,
   buildGraphRows,
   buildTypeRows,
+  countManagedAutomations,
+  formatCompiledIndicator,
 };
 
 export function createAgentsCommand(): Command {
@@ -518,7 +555,7 @@ export function createAgentsCommand(): Command {
 
   agents.addCommand(manifest);
 
-  // omni agents graph [--type <event>] — pure read over declared manifests
+  // omni agents graph [--type <event>] — declared manifests + compiled state
   agents
     .command('graph')
     .description('Show declared event producers/consumers across agents (living documentation)')
@@ -535,7 +572,17 @@ export function createAgentsCommand(): Command {
           return;
         }
 
-        const rows = buildGraphRows(items);
+        // Compiled indicator (#986): declared accepts vs materialized managed
+        // automations. Best-effort — an older server without the automations
+        // surface still renders the graph (compiled shows `unknown`).
+        let managedCounts: Map<string, number> | undefined;
+        try {
+          managedCounts = countManagedAutomations(await client.automations.list({}));
+        } catch {
+          managedCounts = undefined;
+        }
+
+        const rows = buildGraphRows(items, managedCounts);
         output.list(rows, { emptyMessage: 'No agent declares an event manifest.' });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/cli/src/commands/automations.ts
+++ b/packages/cli/src/commands/automations.ts
@@ -136,6 +136,9 @@ export function createAutomationsCommand(): Command {
           trigger: a.triggerEventType,
           enabled: a.enabled ? 'yes' : 'no',
           priority: a.priority,
+          // Compiled from an agent manifest (#986) — managed rows reject
+          // manual mutation; edit the owning agent's manifest instead.
+          managed: a.managedByAgentId ? 'manifest' : '-',
         }));
 
         output.list(items, { emptyMessage: 'No automations found.' });

--- a/packages/core/src/automations/types.ts
+++ b/packages/core/src/automations/types.ts
@@ -203,6 +203,13 @@ export interface Automation {
    * publishing.
    */
   transactionalEmissions?: boolean;
+  /**
+   * Manifest-compilation provenance (RFC #925 G4b, #986): set when the row
+   * was compiled from an agent's event manifest; null/absent = hand-made.
+   * The engine treats managed and hand-made automations identically — the
+   * marker only gates manual CRUD in the API service layer.
+   */
+  managedByAgentId?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/db/drizzle/0063_automation_manifest_provenance.sql
+++ b/packages/db/drizzle/0063_automation_manifest_provenance.sql
@@ -1,0 +1,32 @@
+-- Manifest-compilation provenance on automations (#986, RFC #925 G4b).
+--
+-- Adds `automations.managed_by_agent_id`: set when the row was COMPILED from
+-- `agents.event_manifest` by the manifest compiler
+-- (packages/api/src/services/manifest-compiler.ts); NULL = hand-made. The
+-- agent's manifest is the source of truth and `automations` becomes the
+-- compiled plan for these rows — the API rejects manual create/update/delete
+-- of a managed automation so the plan cannot drift silently.
+--
+-- The FK is ON DELETE CASCADE so a hard agent delete removes its compiled
+-- plan at the DB level (the service-level soft delete reconciles compiled
+-- rows away explicitly before that ever matters). NOT VALID mirrors the 0041
+-- precedent: no scan on deploy; every new write is checked.
+--
+-- Hand-written following the 0043/0044/0052 precedent (additive, idempotent).
+--
+-- NOTE: no explicit BEGIN/COMMIT — the boot migrator executes this file on a
+-- pooled postgres-js connection, which rejects raw transaction control.
+
+ALTER TABLE "automations" ADD COLUMN IF NOT EXISTS "managed_by_agent_id" uuid;
+--> statement-breakpoint
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'automations_managed_by_agent_fk' AND conrelid = '"automations"'::regclass
+    ) THEN
+        ALTER TABLE "automations" ADD CONSTRAINT "automations_managed_by_agent_fk" FOREIGN KEY ("managed_by_agent_id") REFERENCES "agents" ("id") ON DELETE CASCADE NOT VALID;
+    END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "automations_managed_by_agent_idx" ON "automations" ("managed_by_agent_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1786200000000,
       "tag": "0062_agent_event_manifest",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1786300000000,
+      "tag": "0063_automation_manifest_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3109,6 +3109,17 @@ export const automations = pgTable(
      */
     transactionalEmissions: boolean('transactional_emissions').notNull().default(false),
 
+    /**
+     * G4b manifest-compilation provenance (RFC #925, issue #986): set when
+     * this automation was COMPILED from `agents.event_manifest` by the
+     * manifest compiler; NULL = hand-made. Managed rows reject manual
+     * create/update/delete through AutomationService — the agent's manifest
+     * is the source of truth and this table is the compiled plan. ON DELETE
+     * CASCADE covers hard agent deletes at the DB level; the service-level
+     * soft delete reconciles compiled rows away explicitly.
+     */
+    managedByAgentId: uuid('managed_by_agent_id').references((): AnyPgColumn => agents.id, { onDelete: 'cascade' }),
+
     // Timestamps
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
@@ -3122,6 +3133,7 @@ export const automations = pgTable(
     triggerIdx: index('automations_trigger_idx').on(table.triggerEventType),
     enabledIdx: index('automations_enabled_idx').on(table.enabled),
     priorityIdx: index('automations_priority_idx').on(table.priority),
+    managedByAgentIdx: index('automations_managed_by_agent_idx').on(table.managedByAgentId),
   }),
 );
 

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -5598,6 +5598,11 @@ export interface components {
             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
             transactionalEmissions: boolean;
             /**
+             * Format: uuid
+             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+             */
+            managedByAgentId: string | null;
+            /**
              * Format: date-time
              * @description Creation timestamp
              */
@@ -17034,6 +17039,11 @@ export interface operations {
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
                             /**
+                             * Format: uuid
+                             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+                             */
+                            managedByAgentId: string | null;
+                            /**
                              * Format: date-time
                              * @description Creation timestamp
                              */
@@ -17317,6 +17327,11 @@ export interface operations {
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
                             /**
+                             * Format: uuid
+                             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+                             */
+                            managedByAgentId: string | null;
+                            /**
                              * Format: date-time
                              * @description Creation timestamp
                              */
@@ -17492,6 +17507,11 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /**
+                             * Format: uuid
+                             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+                             */
+                            managedByAgentId: string | null;
                             /**
                              * Format: date-time
                              * @description Creation timestamp
@@ -17847,6 +17867,11 @@ export interface operations {
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
                             /**
+                             * Format: uuid
+                             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+                             */
+                            managedByAgentId: string | null;
+                            /**
                              * Format: date-time
                              * @description Creation timestamp
                              */
@@ -18023,6 +18048,11 @@ export interface operations {
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
                             /**
+                             * Format: uuid
+                             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+                             */
+                            managedByAgentId: string | null;
+                            /**
                              * Format: date-time
                              * @description Creation timestamp
                              */
@@ -18198,6 +18228,11 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /**
+                             * Format: uuid
+                             * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
+                             */
+                            managedByAgentId: string | null;
                             /**
                              * Format: date-time
                              * @description Creation timestamp


### PR DESCRIPTION
Closes #986 — RFC #925 **G4, step 2 of 3** (builds on G4a manifest storage, #1006). The stored manifest's `accepts` becomes executable: it compiles into routing automations, making the `automations` table **the compiled plan, not the source of truth** for those rows.

## What landed

- **DB — migration 0063** (`0063_automation_manifest_provenance.sql`, journal idx 63, hand-written per the 0043/0044/0052 precedent): nullable `automations.managed_by_agent_id` uuid — NULL = hand-made, set = compiled from that agent's manifest — with an FK to `agents` **ON DELETE CASCADE NOT VALID** (0041 style) and a lookup index. `make verify-migrations` green.
- **Compiler** (`packages/api/src/services/manifest-compiler.ts`): pure `compileManifest` produces the DESIRED set — one managed automation per `accepts` entry: trigger = the entry's event, conditions = the entry's `filter` translated to the automation-conditions matcher the schema JSDoc references (each dot-path key → `eq`, AND, keys sorted), action = `call_agent` to the declaring agent, `managedByAgentId` stamped. Deterministic naming `manifest:{agentId}:{event}#{sha256[:12] of canonical(event+filter)}` — the reconciliation key; two filters on the same event stay distinct; always fits varchar(255).
- **Reconciliation**: `reconcileAgent` diffs desired vs existing compiled rows (`WHERE managed_by_agent_id = agent`), creates the missing, converges the drifted, deletes the no-longer-declared, then reloads the engine once. **Idempotent**: an unchanged manifest is a strict no-op — zero row churn, no engine reload, no events (asserted in tests). Publishes `system.agent.manifest.compiled` (created/updated/deleted counts) only when the plan changed.
- **Managed-row protection**: `AutomationService.update/delete/enable/disable` on a managed row → **409 Conflict** with a message naming the owning agent and pointing at `omni agents manifest apply`; `create`/`update` also refuse caller-supplied `managedByAgentId` (400). The compiler's writes go through an explicit internal path (`applyCompiledDiff`, see below).
- **Surface**: `omni agents graph` gains a `compiled` column (materialized/declared, e.g. `2/2`; `0/2` = declared but not yet compiled; `unknown` when the automations list is unavailable). `omni automations list` marks managed rows (`managed=manifest`). API `Automation` responses expose `managedByAgentId` (OpenAPI + `make sdk-generate`).

## Design decisions

- **Reconcile trigger point — direct call from `AgentService.updateManifest`/`delete`, not a bus subscription.** Apply + compile succeed or fail together (inside a tenant scope they share the request transaction), cannot race a second apply, and reordering/redelivery semantics never enter the picture. The seam is a structural `ManifestReconciler` interface (`setManifestReconciler`), so `AgentService` does not depend on the compiler implementation and existing tests run unchanged. `system.agent.manifest.updated` still fires (observers can react), and the compiler adds `system.agent.manifest.compiled` when the plan changed.
- **Protection policy — no force/override on managed rows, including DELETE.** An override would be exactly the silent-drift hole this issue closes: the next reconcile would resurrect or fight the manual edit. The single edit path is the manifest (`omni agents manifest apply`); removing an `accepts` entry deletes its compiled row deterministically. `execute`/`test` (debugging) remain available on managed rows.
- **Internal write path lives in `AutomationService` (`listCompiledForAgent` / `applyCompiledDiff`)**, not raw handles in the compiler: the tenancy db-access ratchet forbids a new direct-db site on the `automations` tenant table (pending-G4/G5 ceiling may shrink, never grow), and this keeps every write inside the registered writer while making the guard bypass one explicit, documented method.
- **Cascade findings — agent delete is a SOFT delete** (`isActive=false`), so no FK fires on the service path: `AgentService.delete` now reconciles against a null manifest, tearing the compiled plan down explicitly. The 0063 FK `ON DELETE CASCADE` covers hard deletes at the DB level (proven in the postgres suite).
- **Compiled `call_agent` config is minimal: `{ agentId }`.** Verified against the post-#934 runtime: `extractAgentCallContext` derives instanceId/chatId/senderId/message from the triggering event's payload, so nothing else belongs in the compiled config. Note #934 explicitly deferred chatless dispatch (`chatId`/`senderId` still required from the payload) — a compiled automation for a payload without chat context will fail at action execution with the existing clear error; lifting that is runtime work (#929 follow-up), not compiler work.
- **Naming/dedup**: duplicate `accepts` declarations collapse to one row; drift comparison uses canonical (sorted-key) serialization over exactly the reconciler-owned columns, so DB `conditionLogic NULL` vs compiled `'and'` does not churn.

## Migration number

**0063** (`0063_automation_manifest_provenance`, journal `when` = prev + 100000000). Sibling branch #987 should need no migration; if CI collides anyway, second-to-merge renumbers per the parallel-worktree contract.

## Test evidence

- `make verify-migrations` — green (1 new migration, journal consistent)
- `make typecheck` — green (turbo, all tasks)
- `make lint` — green (biome, 0 errors, 0 warnings)
- New suites, all green:
  - `packages/api/src/services/__tests__/manifest-compiler.test.ts` (16 pass — filter translation, deterministic/canonical naming incl. varchar-255 fit, dedupe, diff create/update/delete, strict no-op, NULL-vs-'and' normalization)
  - `packages/api/src/routes/v2/__tests__/automations-managed.test.ts` (6 pass — PATCH/DELETE/disable on a managed row → 409 naming the owning agent; GET stays readable and exposes `managedByAgentId`; hand-made rows still mutate; service `create` refuses caller provenance)
  - `packages/cli/src/commands/__tests__/agents-manifest.test.ts` (14 pass — graph `compiled` column incl. `0/2` and `unknown`, managed counting)
- Existing suites green: api package 2254 pass / 0 fail, core automations 334 pass, CLI 677 pass, `@omni/db` tenancy guards green (writer-coverage + db-access ratchet unchanged)
- `make test-pg-gate` — **PASSED: 366 assertions across 38 suites, 0 skipped**, including the new `manifest-compiler-postgres.test.ts` (proves 0063 + the full loop on a disposable cluster: compile shape, idempotent re-apply with zero churn and no spurious events, diff keeps unchanged rows' ids, out-of-band drift converged, managed-row 409s, hand-made sibling untouched, soft-delete teardown, hard-delete FK cascade, and end-to-end: event → engine → compiled automation fires `call_agent` to the declaring agent, honoring the compiled filter)
