### PR TITLE
feat(cli): --event-type-mapping flag on omni webhooks create/update (#1011)

### DIFF
--- a/docs/runbooks/clickup-webhook-source.md
+++ b/docs/runbooks/clickup-webhook-source.md
@@ -105,8 +105,7 @@ Field by field:
 | `eventTypeMapping` | Reads the body's `event` field and emits `custom.clickup.{event}` after token normalization (lowercase): `taskStatusUpdated` → `custom.clickup.taskstatusupdated`, `taskCreated` → `custom.clickup.taskcreated`, `taskUpdated` → `custom.clickup.taskupdated`, `taskDeleted` → `custom.clickup.taskdeleted`. Deliveries without a usable `event` field fall back to `custom.webhook.clickup`. |
 | `expectedIntervalSeconds` | Declared liveness cadence (#961): "≥1 event **or heartbeat** per 24 h". See step 5. |
 
-CLI alternative (everything except `eventTypeMapping`, which has no CLI flag
-yet — add it with the `PATCH` below):
+CLI alternative:
 
 ```bash
 omni webhooks create --name clickup \
@@ -115,8 +114,16 @@ omni webhooks create --name clickup \
   --signature-header X-Signature \
   --signature-secret-env CLICKUP_WEBHOOK_SECRET \
   --idempotency-key-template 'clickup:{payload.history_items.0.id}' \
+  --event-type-mapping '{"source":"body","path":"event"}' \
   --expected-interval 86400
+```
 
+The flag also takes `@path/to/mapping.json`, and `omni webhooks update <id>
+--event-type-mapping ...` retrofits an existing source
+(`--clear-event-type-mapping` removes the mapping). Raw-API fallback for the
+same retrofit:
+
+```bash
 curl -sS -X PATCH https://omni.example.com/api/v2/webhook-sources/<id> \
   -H "x-api-key: $OMNI_API_KEY" -H 'Content-Type: application/json' \
   -d '{"eventTypeMapping":{"source":"body","path":"event"}}'
@@ -237,7 +244,7 @@ omni webhooks get clickup                # totalReceived vs totalDuplicates
 |---|---|
 | Every delivery 401 | Secret mismatch — the omni row must hold the `webhook.secret` ClickUp returned at creation (recreate the ClickUp webhook = new secret), or the source has no `signatureConfig`, or it is disabled. All collapse into the same 401 intentionally; the real reason is in the API log (`Webhook ingress rejected`). |
 | Delivery 400 `VALIDATION` | The payload violates a registered schema — check `omni dead-letters list` for `schema_validation_failed`. |
-| Events land as `custom.webhook.clickup` | `eventTypeMapping` missing on the source row (the CLI cannot set it yet — use the `PATCH` from step 2), or the delivery had no usable `event` field. |
+| Events land as `custom.webhook.clickup` | `eventTypeMapping` missing on the source row — retrofit it with `omni webhooks update clickup --event-type-mapping '{"source":"body","path":"event"}'` — or the delivery had no usable `event` field. |
 | Duplicate events on retry | `idempotencyKeyTemplate` not set to `clickup:{payload.history_items.0.id}` (check `omni webhooks get clickup`). |
 | Warn log "idempotency template placeholder unresolved" | Expected for `taskDeleted` (no `history_items`): the key falls back to the body hash, which still dedups byte-identical retries. |
 | Events stop arriving entirely | ClickUp auto-suspends persistently failing webhooks — check `health.status` (step 4). The liveness stall (#961) is the designed alarm for this. |

--- a/docs/runbooks/github-webhook-source.md
+++ b/docs/runbooks/github-webhook-source.md
@@ -75,8 +75,7 @@ Field by field:
 | `eventTypeMapping` | Reads `X-GitHub-Event` and emits `custom.github.{event}`: `push` → `custom.github.push`, `pull_request` → `custom.github.pull_request`, `issues` → `custom.github.issues`, `release` → `custom.github.release`. Deliveries without the header fall back to `custom.webhook.github`. |
 | `expectedIntervalSeconds` | Declared liveness cadence (#961): "≥1 event **or heartbeat** per 24 h". See step 4. |
 
-CLI alternative (everything except `eventTypeMapping`, which has no CLI flag
-yet — add it with the `PATCH` below):
+CLI alternative:
 
 ```bash
 omni webhooks create --name github \
@@ -86,8 +85,16 @@ omni webhooks create --name github \
   --signature-prefix sha256= \
   --signature-secret-env GITHUB_WEBHOOK_SECRET \
   --idempotency-key-template 'github:{headers.x-github-delivery}' \
+  --event-type-mapping '{"source":"header","header":"X-GitHub-Event"}' \
   --expected-interval 86400
+```
 
+The flag also takes `@path/to/mapping.json`, and `omni webhooks update <id>
+--event-type-mapping ...` retrofits an existing source
+(`--clear-event-type-mapping` removes the mapping). Raw-API fallback for the
+same retrofit:
+
+```bash
 curl -sS -X PATCH https://omni.example.com/api/v2/webhook-sources/<id> \
   -H "x-api-key: $OMNI_API_KEY" -H 'Content-Type: application/json' \
   -d '{"eventTypeMapping":{"source":"header","header":"X-GitHub-Event"}}'
@@ -220,7 +227,7 @@ omni webhooks get github                 # totalReceived vs totalDuplicates
 |---|---|
 | Every delivery 401 | Secret mismatch (omni row vs GitHub settings), or the source has no `signatureConfig`, or it is disabled. All collapse into the same 401 intentionally; the real reason is in the API log (`Webhook ingress rejected`). |
 | Delivery 400 `VALIDATION` | Content type is form-encoded (must be `application/json`), or the payload violates a registered schema — check `omni dead-letters list` for `schema_validation_failed`. |
-| Events land as `custom.webhook.github` | `eventTypeMapping` missing on the source row (the CLI cannot set it yet — use the `PATCH` from step 1). |
+| Events land as `custom.webhook.github` | `eventTypeMapping` missing on the source row — retrofit it with `omni webhooks update github --event-type-mapping '{"source":"header","header":"X-GitHub-Event"}'`. |
 | Duplicate events on redelivery | `idempotencyKeyTemplate` not set to `github:{headers.x-github-delivery}` (check `omni webhooks get github`). |
 | `system.connector.stalled` during a quiet week | Expected: that is the declared contract doing its job. Heartbeat (step 4) to distinguish quiet from dead, or lengthen/clear the cadence. |
 

--- a/packages/cli/src/commands/__tests__/webhooks.test.ts
+++ b/packages/cli/src/commands/__tests__/webhooks.test.ts
@@ -1,15 +1,24 @@
 /**
- * CLI `omni webhooks create|update` — signature secret sources.
+ * CLI `omni webhooks create|update` — signature secret sources and the
+ * `--event-type-mapping` flag (#1011).
  *
  * The secret can come from argv (kept for scripting; visible in shell history),
  * an environment variable, or stdin. Exactly one source, validated against the
  * API's bounds before any request is sent.
+ *
+ * The event-type mapping comes as inline JSON or `@file`, validated against
+ * the API's mapping schema before any request is sent; on update it is
+ * undefined-when-omitted so the PATCH never clobbers a stored mapping.
  */
 
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { __testables } from '../webhooks';
 
-const { resolveSignatureSecret, assertPairedSignatureOnCreate } = __testables;
+const { resolveSignatureSecret, assertPairedSignatureOnCreate, resolveEventTypeMapping, buildUpdateSourcePatch } =
+  __testables;
 
 const ENV_VAR = 'OMNI_TEST_WEBHOOK_SECRET';
 
@@ -82,6 +91,94 @@ describe('resolveSignatureSecret', () => {
     await expect(resolveSignatureSecret({ signatureSecretEnv: ENV_VAR })).rejects.toThrow('at most 512 characters');
     await expect(resolveSignatureSecret({ signatureSecretStdin: true }, async () => 'tiny\n')).rejects.toThrow(
       'at least 8 characters',
+    );
+  });
+});
+
+describe('resolveEventTypeMapping', () => {
+  test('returns undefined when the flag was not given', () => {
+    expect(resolveEventTypeMapping(undefined)).toBeUndefined();
+  });
+
+  test('accepts the header-source variant inline', () => {
+    expect(resolveEventTypeMapping('{"source":"header","header":"X-GitHub-Event"}')).toEqual({
+      source: 'header',
+      header: 'X-GitHub-Event',
+    });
+  });
+
+  test('accepts the body-source variant inline (#984)', () => {
+    expect(resolveEventTypeMapping('{"source":"body","path":"event"}')).toEqual({
+      source: 'body',
+      path: 'event',
+    });
+  });
+
+  test('reads the mapping from @file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omni-1011-'));
+    try {
+      const file = join(dir, 'mapping.json');
+      writeFileSync(file, '{"source":"body","path":"event"}\n');
+      expect(resolveEventTypeMapping(`@${file}`)).toEqual({ source: 'body', path: 'event' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an unreadable @file fails before any request is sent', () => {
+    expect(() => resolveEventTypeMapping('@/nonexistent/omni-1011-mapping.json')).toThrow(
+      "Cannot read --event-type-mapping file '/nonexistent/omni-1011-mapping.json'",
+    );
+  });
+
+  test('invalid JSON fails before any request is sent', () => {
+    expect(() => resolveEventTypeMapping('{source:header}')).toThrow('Invalid JSON for --event-type-mapping');
+  });
+
+  test('a schema-invalid mapping fails before any request is sent', () => {
+    // Wrong discriminator
+    expect(() => resolveEventTypeMapping('{"source":"query","name":"event"}')).toThrow('Invalid --event-type-mapping');
+    // Right discriminator, wrong companion field
+    expect(() => resolveEventTypeMapping('{"source":"header","path":"event"}')).toThrow('Invalid --event-type-mapping');
+    // Bounds (1-200 chars) applied client-side like the API
+    expect(() => resolveEventTypeMapping(`{"source":"body","path":"${'x'.repeat(201)}"}`)).toThrow(
+      'path must be 1-200 characters',
+    );
+    expect(() => resolveEventTypeMapping('{"source":"header","header":""}')).toThrow('header must be 1-200 characters');
+  });
+});
+
+describe('buildUpdateSourcePatch — eventTypeMapping', () => {
+  test('omitted → the PATCH body has no eventTypeMapping key (no clobber)', async () => {
+    const updates = await buildUpdateSourcePatch({ name: 'renamed' });
+    expect('eventTypeMapping' in updates).toBe(false);
+    expect(updates).toEqual({ name: 'renamed' });
+  });
+
+  test('--event-type-mapping sets the mapping', async () => {
+    const updates = await buildUpdateSourcePatch({
+      eventTypeMapping: '{"source":"header","header":"X-GitHub-Event"}',
+    });
+    expect(updates.eventTypeMapping).toEqual({ source: 'header', header: 'X-GitHub-Event' });
+  });
+
+  test('--clear-event-type-mapping sends an explicit null', async () => {
+    const updates = await buildUpdateSourcePatch({ clearEventTypeMapping: true });
+    expect(updates.eventTypeMapping).toBeNull();
+  });
+
+  test('set and clear together are rejected', async () => {
+    await expect(
+      buildUpdateSourcePatch({
+        eventTypeMapping: '{"source":"body","path":"event"}',
+        clearEventTypeMapping: true,
+      }),
+    ).rejects.toThrow('Use only one of --event-type-mapping and --clear-event-type-mapping');
+  });
+
+  test('an invalid mapping rejects the whole update before any request is sent', async () => {
+    await expect(buildUpdateSourcePatch({ eventTypeMapping: 'not json' })).rejects.toThrow(
+      'Invalid JSON for --event-type-mapping',
     );
   });
 });

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -13,7 +13,8 @@
  * or stdin (`--signature-secret-stdin`, for `pass show ... | omni webhooks ...`).
  */
 
-import type { WebhookSignatureConfigBody } from '@omni/sdk';
+import { readFileSync } from 'node:fs';
+import type { WebhookEventTypeMappingBody, WebhookSignatureConfigBody } from '@omni/sdk';
 import { Command } from 'commander';
 import { z } from 'zod';
 import { getClient } from '../client.js';
@@ -114,6 +115,59 @@ function buildSignatureConfig(options: {
   return { algorithm, header: signatureHeader, prefix: signaturePrefix };
 }
 
+/**
+ * Same shape the API enforces on `eventTypeMapping`
+ * (schemas/openapi/webhooks.ts, #959/#984): header-source or body-source.
+ */
+const eventTypeMappingSchema = z.discriminatedUnion('source', [
+  z.object({
+    source: z.literal('header'),
+    header: z.string().min(1, 'header must be 1-200 characters').max(200, 'header must be 1-200 characters'),
+  }),
+  z.object({
+    source: z.literal('body'),
+    path: z.string().min(1, 'path must be 1-200 characters').max(200, 'path must be 1-200 characters'),
+  }),
+]);
+
+const EVENT_TYPE_MAPPING_HINT =
+  'expected {"source":"header","header":"X-GitHub-Event"} or {"source":"body","path":"event"}';
+
+/**
+ * Parse `--event-type-mapping` — inline JSON, or `@path/to/file.json` (the
+ * repo's existing @file convention, cf. follow-up's JSON args) — and validate
+ * it against the API's mapping schema. Returns undefined when the flag was
+ * not given; throws (caught by the command's error path) BEFORE any request
+ * is sent on an unreadable file, invalid JSON, or a schema-invalid mapping.
+ */
+function resolveEventTypeMapping(raw: string | undefined): WebhookEventTypeMappingBody | undefined {
+  if (raw === undefined) return undefined;
+  let text = raw;
+  if (raw.startsWith('@')) {
+    const path = raw.slice(1);
+    try {
+      text = readFileSync(path, 'utf-8');
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'Unknown error';
+      throw new Error(`Cannot read --event-type-mapping file '${path}': ${reason}`);
+    }
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON for --event-type-mapping; ${EVENT_TYPE_MAPPING_HINT}`);
+  }
+  const result = eventTypeMappingSchema.safeParse(parsed);
+  if (!result.success) {
+    const reason = result.error.issues
+      .map((issue) => (issue.path.length > 0 ? `${issue.path.join('.')}: ${issue.message}` : issue.message))
+      .join('; ');
+    throw new Error(`Invalid --event-type-mapping: ${reason}; ${EVENT_TYPE_MAPPING_HINT}`);
+  }
+  return result.data;
+}
+
 interface UpdateSourceOptions extends SignatureSecretOptions {
   name?: string;
   description?: string;
@@ -127,6 +181,10 @@ interface UpdateSourceOptions extends SignatureSecretOptions {
   // Strict schema mode (#1000): commander negatable pair — true from
   // --strict-schemas, false from --no-strict-schemas, undefined = untouched.
   strictSchemas?: boolean;
+  // Semantic event-type extraction (#1011): set vs clear vs untouched,
+  // following the --clear-signature / --clear-cadence precedent.
+  eventTypeMapping?: string;
+  clearEventTypeMapping?: boolean;
   // Connector lifecycle contract (#961)
   expectedInterval?: string;
   clearCadence?: boolean;
@@ -142,6 +200,7 @@ interface UpdateSourcePatch {
   signatureSecret?: string;
   idempotencyKeyTemplate?: string;
   strictSchemas?: boolean;
+  eventTypeMapping?: WebhookEventTypeMappingBody | null;
   expectedIntervalSeconds?: number | null;
   windowSemantics?: (typeof WINDOW_SEMANTICS)[number];
   mutationPolicy?: (typeof MUTATION_POLICIES)[number];
@@ -154,6 +213,12 @@ async function buildUpdateSourcePatch(options: UpdateSourceOptions): Promise<Upd
   if (options.description) updates.description = options.description;
   if (options.idempotencyKeyTemplate) updates.idempotencyKeyTemplate = options.idempotencyKeyTemplate;
   if (options.strictSchemas !== undefined) updates.strictSchemas = options.strictSchemas;
+  if (options.clearEventTypeMapping && options.eventTypeMapping !== undefined) {
+    throw new Error('Use only one of --event-type-mapping and --clear-event-type-mapping');
+  }
+  if (options.clearEventTypeMapping) updates.eventTypeMapping = null;
+  const eventTypeMapping = resolveEventTypeMapping(options.eventTypeMapping);
+  if (eventTypeMapping !== undefined) updates.eventTypeMapping = eventTypeMapping;
   if (options.enable) updates.enabled = true;
   if (options.disable) updates.enabled = false;
   if (options.clearSignature) {
@@ -327,6 +392,12 @@ export function createWebhooksCommand(): Command {
         'schema_not_registered, #1000). Recommended for new sources. Defaults to off',
     )
     .option(
+      '--event-type-mapping <json>',
+      'Semantic event-type extraction (#959): inline JSON or @path/to/file.json, e.g. ' +
+        '\'{"source":"header","header":"X-GitHub-Event"}\' or \'{"source":"body","path":"event"}\'. ' +
+        'A mapped source emits custom.{source}.{event} instead of the collapsed custom.webhook.{source}',
+    )
+    .option(
       '--expected-interval <seconds>',
       'Declared cadence: >=1 event or heartbeat per N seconds. Arms liveness supervision (#961)',
     )
@@ -346,6 +417,7 @@ export function createWebhooksCommand(): Command {
         signatureSecretStdin?: boolean;
         idempotencyKeyTemplate?: string;
         strictSchemas?: boolean;
+        eventTypeMapping?: string;
         expectedInterval?: string;
         windowSemantics?: string;
         mutationPolicy?: string;
@@ -375,6 +447,7 @@ export function createWebhooksCommand(): Command {
             signatureSecret,
             idempotencyKeyTemplate: options.idempotencyKeyTemplate,
             strictSchemas: options.strictSchemas,
+            eventTypeMapping: resolveEventTypeMapping(options.eventTypeMapping),
             expectedIntervalSeconds: parseExpectedInterval(options.expectedInterval),
             windowSemantics: parseWindowSemantics(options.windowSemantics),
             mutationPolicy: parseMutationPolicy(options.mutationPolicy),
@@ -426,6 +499,15 @@ export function createWebhooksCommand(): Command {
         'schema_not_registered, #1000)',
     )
     .option('--no-strict-schemas', 'Return the source to opt-in pass-through for unregistered event types')
+    .option(
+      '--event-type-mapping <json>',
+      'Semantic event-type extraction (#959): inline JSON or @path/to/file.json, e.g. ' +
+        '\'{"source":"header","header":"X-GitHub-Event"}\' or \'{"source":"body","path":"event"}\'',
+    )
+    .option(
+      '--clear-event-type-mapping',
+      'Remove the mapping (deliveries fall back to the collapsed custom.webhook.{source} type)',
+    )
     .option(
       '--expected-interval <seconds>',
       'Declared cadence: >=1 event or heartbeat per N seconds. (Re)arms liveness supervision (#961)',
@@ -530,4 +612,10 @@ export function createWebhooksCommand(): Command {
 }
 
 /** Test-only surface — not part of the CLI contract. */
-export const __testables = { resolveSignatureSecret, buildSignatureConfig, assertPairedSignatureOnCreate };
+export const __testables = {
+  resolveSignatureSecret,
+  buildSignatureConfig,
+  assertPairedSignatureOnCreate,
+  resolveEventTypeMapping,
+  buildUpdateSourcePatch,
+};

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -739,6 +739,13 @@ export interface ListWebhookSourcesParams {
 export type WebhookSignatureConfigBody = components['schemas']['WebhookSignatureConfig'];
 
 /**
+ * Semantic event-type extraction contract for a webhook source (#959/#984):
+ * header-source or body-source. Derived from the generated OpenAPI component
+ * so it cannot drift from the API.
+ */
+export type WebhookEventTypeMappingBody = components['schemas']['WebhookEventTypeMapping'];
+
+/**
  * Body for creating a webhook source.
  *
  * Hand-written on purpose: the generated `CreateWebhookSourceRequest` marks
@@ -774,6 +781,13 @@ export interface CreateWebhookSourceBody {
    * passing through. Defaults to false server-side (opt-in pass-through).
    */
   strictSchemas?: boolean;
+  /**
+   * Semantic event-type extraction (#959/#984): a mapped source emits
+   * `custom.{source}.{event}` (event name read from a header or a body
+   * dot-path) instead of the collapsed `custom.webhook.{source}`. Null or
+   * absent keeps the collapsed type; null clears it on update.
+   */
+  eventTypeMapping?: WebhookEventTypeMappingBody | null;
   /** Defaults to true server-side */
   enabled?: boolean;
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -99,6 +99,7 @@ export type {
   WebhookSource,
   ListWebhookSourcesParams,
   WebhookSignatureConfigBody,
+  WebhookEventTypeMappingBody,
   CreateWebhookSourceBody,
   TriggerEventBody,
   WebhookHeartbeatResponse,


### PR DESCRIPTION
Closes #1011.

Both Phase 3 runbooks (PRs #1002/#1004) broke out of the CLI with a raw `PATCH /api/v2/webhook-sources/:id` curl because `eventTypeMapping` had no flag. This closes the gap — CLI + docs + a small SDK type passthrough; no API or migration changes.

## What

- `omni webhooks create --event-type-mapping <json>` and `omni webhooks update <id> --event-type-mapping <json>`: accepts inline JSON (`'{"source":"header","header":"X-GitHub-Event"}'`, `'{"source":"body","path":"event"}'`) or `@path/to/file.json`.
- `omni webhooks update <id> --clear-event-type-mapping`: sends an explicit `null` (deliveries fall back to the collapsed `custom.webhook.{source}` type).
- Client-side validation against the API's mapping schema (discriminated union, header-source + body-source per #959/#984, 1-200 char bounds) BEFORE any network call, with actionable error messages including the expected shapes.
- Both runbooks (`docs/runbooks/github-webhook-source.md`, `clickup-webhook-source.md`) now use the flag in the create step; the PATCH curl is kept as a raw-API fallback note, and the troubleshooting rows point at `omni webhooks update ... --event-type-mapping`.

## Decisions

- **@file over a separate `--event-type-mapping-file` flag**: the CLI already has an `@file` convention for JSON args (`readJsonArg` in `packages/cli/src/commands/follow-up.ts` — inline, `@path`, `-` for stdin). Followed it for inline + `@path`; deliberately skipped `-`/stdin, which is already claimed by `--signature-secret-stdin` on the same commands.
- **Clearing form: `--clear-event-type-mapping`**, not `--no-event-type-mapping` or `--event-type-mapping ""`. The `--strict-schemas`/`--no-strict-schemas` negatable pair fits a boolean; for *nullable structured* fields this CLI's established precedent is `--clear-signature` and `--clear-cadence`, so the new flag mirrors those. Same spirit as the strict-schemas precedent where it matters: **omitting both flags leaves `eventTypeMapping` out of the PATCH body entirely**, so an unrelated update never clobbers a stored mapping (test-verified). Set + clear together is rejected.

## Passthrough findings

- The **API already accepts** `eventTypeMapping` on both create and update: the PATCH validator is `CreateWebhookSourceSchema.partial()` (`packages/api/src/routes/v2/webhooks.ts`), and `CreateWebhookSourceSchema` has carried the field since #959/#984. No API change.
- The **SDK's hand-written `CreateWebhookSourceBody` lacked the field** (the generated `WebhookEventTypeMapping` OpenAPI component already existed in `types.generated.ts`), so typed callers couldn't pass it. Added `eventTypeMapping?: WebhookEventTypeMappingBody | null` plus the exported `WebhookEventTypeMappingBody` alias derived from the generated component. No `make sdk-generate` needed — the generated types were already current.
- No new SDK methods → `sdk-coverage.test.ts` unchanged (verified green).

## Tests

`packages/cli/src/commands/__tests__/webhooks.test.ts` (via `__testables`, same pattern as the signature-secret suite):

- header-source and body-source variants accepted inline; `@file` variant read from disk
- unreadable `@file`, invalid JSON, wrong discriminator, wrong companion field (`{"source":"header","path":...}`), and out-of-bounds values all rejected client-side before any request
- update patch: omitted → no `eventTypeMapping` key in the body; set → mapping; clear → explicit `null`; set+clear → rejected

Evidence: `make test-file F=packages/cli/src/commands/__tests__/webhooks.test.ts` → 24 pass / 0 fail; `sdk-coverage.test.ts` → 2 pass; `packages/sdk` `bun test` → 47 pass; `make typecheck` (25/25 tasks) and `make lint` clean; full pre-push gate passed on push.