### PR TITLE
feat(automations): chatless call_agent dispatch — event→agent without a chat context (#1010)

### DIFF
--- a/packages/api/src/plugins/__tests__/automation-actions-chatless.test.ts
+++ b/packages/api/src/plugins/__tests__/automation-actions-chatless.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Chatless call_agent adapter (#1010, RFC #925 G4 runtime half).
+ *
+ * When the core action extracts a CHATLESS AgentCallContext (no instance, no
+ * chat resolvable from the triggering event), the engine-deps `callAgent`
+ * callback must resolve the provider from the AGENT row alone and land on
+ * `agentRunner.runChatless` — never on the instance lookup or the chat-id
+ * resolution of the chat-ful path.
+ *
+ * Pinned here:
+ *   - no instances/chats read happens for a chatless context;
+ *   - the agents row supplies provider id, dispatch type, provider-internal
+ *     agent id (metadata.providerAgentId ?? configPath ?? name), and tenant;
+ *   - a missing agent row or an agent without a provider fails with a clear
+ *     error instead of dispatching;
+ *   - config overrides (agentType, timeoutMs) reach runChatless;
+ *   - the chat-ful path is untouched (still runs runOrStream via instance).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AgentCallContext } from '@omni/core';
+import type { Database } from '@omni/db';
+import type { ChatlessRunContext } from '../../services/agent-runner';
+import { buildAutomationEngineDeps } from '../automation-actions';
+
+interface AgentRowShape {
+  name: string;
+  agentProviderId: string | null;
+  agentType: string;
+  metadata: Record<string, unknown> | null;
+  configPath: string | null;
+  tenantId: string | null;
+}
+
+interface Harness {
+  deps: ReturnType<typeof buildAutomationEngineDeps>;
+  chatlessRuns: ChatlessRunContext[];
+  runOrStreamCalls: Array<Record<string, unknown>>;
+  instanceLookups: string[];
+  chatLookups: string[];
+}
+
+function harness(agentRow: AgentRowShape | null): Harness {
+  const chatlessRuns: ChatlessRunContext[] = [];
+  const runOrStreamCalls: Array<Record<string, unknown>> = [];
+  const instanceLookups: string[] = [];
+  const chatLookups: string[] = [];
+
+  const selectChain = () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => (agentRow ? [agentRow] : []),
+      }),
+    }),
+  });
+  const db = {
+    select: selectChain,
+    // A threaded tenant opens a short worker scope (one transaction per
+    // discrete read block) — serve the same agent row inside it.
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({ execute: async () => [], select: selectChain }),
+  } as unknown as Database;
+
+  const services = {
+    instances: {
+      getById: async (id: string) => {
+        instanceLookups.push(id);
+        return { id, agentId: null, tenantId: null };
+      },
+    },
+    chats: {
+      getById: async (id: string) => {
+        chatLookups.push(id);
+        return { externalId: id };
+      },
+    },
+    agentRunner: {
+      runChatless: async (context: ChatlessRunContext) => {
+        chatlessRuns.push(context);
+        return {
+          parts: ['done'],
+          metadata: { runId: 'run-1', sessionId: context.sessionKey, status: 'completed' as const },
+        };
+      },
+      runOrStream: async (context: Record<string, unknown>) => {
+        runOrStreamCalls.push(context);
+        return { parts: ['chat'], metadata: { runId: 'run-2', sessionId: 'sess', status: 'completed' as const } };
+      },
+    },
+  } as unknown as Parameters<typeof buildAutomationEngineDeps>[0];
+
+  return {
+    deps: buildAutomationEngineDeps(services, db),
+    chatlessRuns,
+    runOrStreamCalls,
+    instanceLookups,
+    chatLookups,
+  };
+}
+
+function chatlessContext(overrides: Partial<AgentCallContext> = {}): AgentCallContext {
+  return {
+    chatless: true,
+    instanceId: '',
+    agentId: 'agent-uuid-1',
+    sessionKey: 'automation:auto-1:corr-1',
+    automationId: 'auto-1',
+    chatId: 'automation:auto-1:corr-1',
+    senderId: 'automation:auto-1:corr-1',
+    messages: ['{"type":"custom.github.push"}'],
+    event: { id: 'evt-1', type: 'custom.github.push', correlationId: 'corr-1' },
+    ...overrides,
+  };
+}
+
+const AGENT_ROW: AgentRowShape = {
+  name: 'triage',
+  agentProviderId: 'prov-1',
+  agentType: 'assistant',
+  metadata: null,
+  configPath: null,
+  tenantId: null,
+};
+
+describe('automation-actions — chatless callAgent (#1010)', () => {
+  test('resolves the provider from the agent row and dispatches runChatless — no instance/chat reads', async () => {
+    const h = harness(AGENT_ROW);
+    const result = await h.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, null);
+
+    expect(h.instanceLookups).toEqual([]);
+    expect(h.chatLookups).toEqual([]);
+    expect(h.runOrStreamCalls).toEqual([]);
+    expect(h.chatlessRuns).toHaveLength(1);
+    const run = h.chatlessRuns[0];
+    expect(run?.agentProviderId).toBe('prov-1');
+    expect(run?.agentInternalId).toBe('triage'); // name fallback
+    expect(run?.agentType).toBe('agent'); // assistant → agent
+    expect(run?.sessionKey).toBe('automation:auto-1:corr-1');
+    expect(run?.messages).toEqual(['{"type":"custom.github.push"}']);
+    expect(run?.timeoutSeconds).toBeUndefined();
+
+    expect(result.metadata.status).toBe('completed');
+    expect(result.fullResponse).toBe('done');
+  });
+
+  test('provider-internal agent id prefers metadata.providerAgentId, then configPath, then name', async () => {
+    const viaMetadata = harness({ ...AGENT_ROW, metadata: { providerAgentId: 'provider-internal' } });
+    await viaMetadata.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, null);
+    expect(viaMetadata.chatlessRuns[0]?.agentInternalId).toBe('provider-internal');
+
+    const viaConfigPath = harness({ ...AGENT_ROW, configPath: '/agents/triage.md' });
+    await viaConfigPath.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, null);
+    expect(viaConfigPath.chatlessRuns[0]?.agentInternalId).toBe('/agents/triage.md');
+  });
+
+  test('config agentType and timeoutMs override the agent-row defaults', async () => {
+    const h = harness({ ...AGENT_ROW, agentType: 'team' });
+    await h.deps.callAgent(
+      chatlessContext(),
+      { agentId: 'agent-uuid-1', agentType: 'workflow', timeoutMs: 45500 },
+      null,
+    );
+    expect(h.chatlessRuns[0]?.agentType).toBe('workflow');
+    expect(h.chatlessRuns[0]?.timeoutSeconds).toBe(46);
+  });
+
+  test("the agent row's persisted tenant is threaded; trustedTenantId is the fallback", async () => {
+    const TENANT_OWNED = '11111111-1111-4111-8111-1111111111aa';
+    const TENANT_THREADED = '22222222-2222-4222-8222-2222222222bb';
+
+    const owned = harness({ ...AGENT_ROW, tenantId: TENANT_OWNED });
+    await owned.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, TENANT_THREADED);
+    expect(owned.chatlessRuns[0]?.tenantId).toBe(TENANT_OWNED);
+
+    const unowned = harness(AGENT_ROW);
+    await unowned.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, TENANT_THREADED);
+    expect(unowned.chatlessRuns[0]?.tenantId).toBe(TENANT_THREADED);
+  });
+
+  test('a missing agent row refuses the dispatch', async () => {
+    const h = harness(null);
+    await expect(h.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, null)).rejects.toThrow(
+      'Agent not found: agent-uuid-1',
+    );
+    expect(h.chatlessRuns).toEqual([]);
+  });
+
+  test('an agent without a provider refuses the dispatch with a clear error', async () => {
+    const h = harness({ ...AGENT_ROW, agentProviderId: null });
+    await expect(h.deps.callAgent(chatlessContext(), { agentId: 'agent-uuid-1' }, null)).rejects.toThrow(
+      /has no agent provider configured/,
+    );
+    expect(h.chatlessRuns).toEqual([]);
+  });
+
+  test('a chatless context without an agentId refuses the dispatch', async () => {
+    const h = harness(AGENT_ROW);
+    await expect(h.deps.callAgent(chatlessContext({ agentId: undefined }), { agentId: '' }, null)).rejects.toThrow(
+      'chatless call_agent requires config.agentId',
+    );
+  });
+
+  test('a chat-ful context still takes the instance path (runOrStream), untouched', async () => {
+    const h = harness(AGENT_ROW);
+    const ctx: AgentCallContext = {
+      instanceId: 'inst-1',
+      agentId: 'agent-uuid-1',
+      chatId: 'chat-1',
+      senderId: 'user-1',
+      messages: ['hello'],
+    };
+    await h.deps.callAgent(ctx, { agentId: 'agent-uuid-1' }, null);
+    expect(h.instanceLookups).toEqual(['inst-1']);
+    expect(h.runOrStreamCalls).toHaveLength(1);
+    expect(h.chatlessRuns).toEqual([]);
+  });
+});

--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -48,6 +48,82 @@ const log = createLogger('automation-actions');
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** agents.agent_type (entity taxonomy) → provider dispatch type. */
+const AGENT_TYPE_MAP: Record<string, 'agent' | 'team' | 'workflow'> = {
+  assistant: 'agent',
+  tool: 'agent',
+  workflow: 'workflow',
+  team: 'team',
+};
+
+/**
+ * Chatless `call_agent` dispatch (#1010, RFC #925 G4 runtime half): the
+ * triggering event resolved no instance and no chat, so the provider is
+ * resolved from the AGENT row alone and the run is keyed by the core action's
+ * event-scoped `sessionKey`. Same discrete-read-block discipline as the
+ * chat-ful path: the `agents` lookup runs in its own short worker tenant
+ * scope, and the agent run executes strictly AFTER the scope closed.
+ *
+ * There is NO implicit reply: nothing is sent to any chat; the response only
+ * feeds `responseAs` variable chaining. The agent acts via its own tools.
+ */
+async function runChatlessCallAgent(
+  services: Services,
+  db: Database,
+  ctx: AgentCallContext,
+  cfg: CallAgentActionConfig,
+  trustedTenantId: string | null,
+): Promise<AgentRunResult> {
+  const agentFkId = ctx.agentId;
+  if (!agentFkId) throw new Error('chatless call_agent requires config.agentId');
+
+  // Discrete read block: the agents row (provider coordinates + persisted
+  // tenant ownership — the chatless analogue of `instance.tenantId`).
+  const [agentRow] = await runTenantWorkDb(db, trustedTenantId, () =>
+    scopedHandle(db)
+      .select({
+        name: agents.name,
+        agentProviderId: agents.agentProviderId,
+        agentType: agents.agentType,
+        metadata: agents.metadata,
+        configPath: agents.configPath,
+        tenantId: agents.tenantId,
+      })
+      .from(agents)
+      .where(eq(agents.id, agentFkId))
+      .limit(1),
+  );
+  if (!agentRow) throw new Error(`Agent not found: ${agentFkId}`);
+  if (!agentRow.agentProviderId) {
+    throw new Error(`Agent ${agentFkId} has no agent provider configured (required for chatless call_agent)`);
+  }
+
+  const providerAgentId =
+    ((agentRow.metadata as Record<string, unknown> | null)?.providerAgentId as string | undefined) ??
+    agentRow.configPath ??
+    agentRow.name;
+
+  // Agent run strictly OUTSIDE the resolution scope (the G4 leg-2 trap).
+  const result = await services.agentRunner.runChatless({
+    agentProviderId: agentRow.agentProviderId,
+    agentInternalId: providerAgentId,
+    agentType: cfg.agentType ?? AGENT_TYPE_MAP[agentRow.agentType] ?? 'agent',
+    tenantId: agentRow.tenantId ?? trustedTenantId ?? null,
+    sessionKey: ctx.sessionKey ?? ctx.chatId,
+    messages: ctx.messages,
+    timeoutSeconds: cfg.timeoutMs ? Math.ceil(cfg.timeoutMs / 1000) : undefined,
+  });
+  return {
+    parts: result.parts,
+    fullResponse: result.parts.join('\n'),
+    metadata: {
+      runId: result.metadata.runId,
+      sessionId: result.metadata.sessionId,
+      status: result.metadata.status,
+    },
+  };
+}
+
 /**
  * Resolve chat UUID → channel-native external_id for a call_agent invocation.
  *
@@ -237,6 +313,12 @@ export function buildAutomationEngineDeps(
     },
 
     callAgent: async (ctx, cfg, trustedTenantId = null) => {
+      // Chatless dispatch (#1010): no instance and no chat resolved from the
+      // triggering event — provider comes from the agent row instead.
+      if (ctx.chatless) {
+        return runChatlessCallAgent(services, db, ctx, cfg, trustedTenantId);
+      }
+
       // Discrete read block #1: the instance row.
       const instance = await runTenantWorkDb(db, trustedTenantId, () => services.instances.getById(ctx.instanceId));
       if (!instance) throw new Error(`Instance not found: ${ctx.instanceId}`);
@@ -274,12 +356,6 @@ export function buildAutomationEngineDeps(
       );
       if (!agentRow) throw new Error(`Agent not found: ${agentFkId}`);
 
-      const typeMap: Record<string, 'agent' | 'team' | 'workflow'> = {
-        assistant: 'agent',
-        tool: 'agent',
-        workflow: 'workflow',
-        team: 'team',
-      };
       const providerAgentId =
         ((agentRow.metadata as Record<string, unknown> | null)?.providerAgentId as string | undefined) ??
         agentRow.configPath ??
@@ -288,7 +364,7 @@ export function buildAutomationEngineDeps(
       const runInstance = {
         ...instance,
         agentProviderId: agentRow.agentProviderId ?? null,
-        agentType: cfg.agentType ?? typeMap[agentRow.agentType] ?? 'agent',
+        agentType: cfg.agentType ?? AGENT_TYPE_MAP[agentRow.agentType] ?? 'agent',
         agentInternalId: providerAgentId,
         agentSessionStrategy: cfg.sessionStrategy ?? instance.agentSessionStrategy,
         agentPrefixSenderName: cfg.prefixSenderName ?? instance.agentPrefixSenderName,

--- a/packages/api/src/services/__tests__/agent-runner-chatless.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner-chatless.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Chatless agent runs (#1010, RFC #925 G4 runtime half).
+ *
+ * `runChatless` dispatches an agent with only its provider coordinates and an
+ * event-scoped session key — no instance, no chat, no sender. Pinned here:
+ *
+ *   - the provider request carries the session key verbatim as BOTH
+ *     `sessionId` and `userId` (HTTP providers scope conversations by it;
+ *     the claude-code client ignores non-UUID session ids and starts fresh);
+ *   - NO platform/chat/sender blocks are sent — there is no channel identity;
+ *   - the session store is never touched: no agent_sessions read or write
+ *     (chatless runs have no instances-row FK to persist under);
+ *   - the response is returned un-split and un-prefixed (no implicit reply).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { IAgentClient, ProviderRequest, ProviderResponse } from '@omni/core';
+import type { Database } from '@omni/db';
+import { AgentRunnerService } from '../agent-runner';
+
+/** A db stand-in that records every touch — chatless runs must make none. */
+function untouchableDb(touches: string[]): Database {
+  const record =
+    (op: string) =>
+    (..._args: unknown[]) => {
+      touches.push(op);
+      throw new Error(`chatless run must not touch the db (${op})`);
+    };
+  return {
+    select: record('select'),
+    insert: record('insert'),
+    update: record('update'),
+    delete: record('delete'),
+    transaction: record('transaction'),
+    execute: record('execute'),
+  } as unknown as Database;
+}
+
+function fakeClient(requests: ProviderRequest[], schema: string, service: AgentRunnerService): void {
+  const client: IAgentClient = {
+    run: async (request: ProviderRequest): Promise<ProviderResponse> => {
+      requests.push(request);
+      return {
+        content: 'acted on the event\n\nvia my own tools',
+        runId: 'run-1',
+        sessionId: request.sessionId ?? 'fresh',
+        status: 'completed',
+      };
+    },
+    stream: (): AsyncGenerator<never> => {
+      throw new Error('chatless runs are sync-only');
+    },
+  } as unknown as IAgentClient;
+  (service as unknown as { getClient: () => Promise<{ client: IAgentClient; schema: string }> }).getClient =
+    async () => ({ client, schema });
+}
+
+describe('agent-runner — runChatless (#1010)', () => {
+  test('dispatches with the session key as sessionId/userId and no chat identity', async () => {
+    const touches: string[] = [];
+    const requests: ProviderRequest[] = [];
+    const service = new AgentRunnerService(untouchableDb(touches));
+    fakeClient(requests, 'agno', service);
+
+    const result = await service.runChatless({
+      agentProviderId: 'prov-1',
+      agentInternalId: 'triage-agent',
+      agentType: 'agent',
+      tenantId: null,
+      sessionKey: 'automation:auto-1:corr-1',
+      messages: ['{"type":"custom.github.push"}'],
+      timeoutSeconds: 120,
+    });
+
+    expect(requests).toHaveLength(1);
+    const request = requests[0];
+    expect(request?.message).toBe('{"type":"custom.github.push"}');
+    expect(request?.agentId).toBe('triage-agent');
+    expect(request?.agentType).toBe('agent');
+    expect(request?.stream).toBe(false);
+    expect(request?.sessionId).toBe('automation:auto-1:corr-1');
+    expect(request?.userId).toBe('automation:auto-1:corr-1');
+    expect(request?.timeoutMs).toBe(120000);
+    // No channel identity is fabricated for a chatless run.
+    expect(request?.platform).toBeUndefined();
+    expect(request?.chat).toBeUndefined();
+    expect(request?.sender).toBeUndefined();
+    expect(request?.mcpUrlParams).toBeUndefined();
+
+    // No implicit reply and no auto-split: the full response comes back whole.
+    expect(result.parts).toEqual(['acted on the event\n\nvia my own tools']);
+    expect(result.metadata.status).toBe('completed');
+    expect(result.metadata.sessionId).toBe('automation:auto-1:corr-1');
+
+    // The session store (agent_sessions) was never touched.
+    expect(touches).toEqual([]);
+  });
+
+  test('claude-code schema: same request, still no session-store mapping', async () => {
+    // The claude-code CLIENT only resumes UUID session ids, so the non-UUID
+    // chatless key means a fresh provider session each run — and runChatless
+    // must not attempt the key→UUID store mapping (no instances-row FK).
+    const touches: string[] = [];
+    const requests: ProviderRequest[] = [];
+    const service = new AgentRunnerService(untouchableDb(touches));
+    fakeClient(requests, 'claude-code', service);
+
+    await service.runChatless({
+      agentProviderId: 'prov-cc',
+      agentInternalId: 'claude-code',
+      sessionKey: 'automation:auto-2:corr-9',
+      messages: ['envelope'],
+    });
+
+    expect(requests[0]?.sessionId).toBe('automation:auto-2:corr-9');
+    expect(touches).toEqual([]);
+  });
+
+  test('defaults: agentType agent, 600s timeout, messages joined with the run separator', async () => {
+    const requests: ProviderRequest[] = [];
+    const service = new AgentRunnerService(untouchableDb([]));
+    fakeClient(requests, 'agno', service);
+
+    await service.runChatless({
+      agentProviderId: 'prov-1',
+      agentInternalId: 'triage-agent',
+      sessionKey: 'automation:manual:x',
+      messages: ['one', 'two'],
+    });
+
+    expect(requests[0]?.agentType).toBe('agent');
+    expect(requests[0]?.timeoutMs).toBe(600000);
+    expect(requests[0]?.message).toBe('one\n---\ntwo');
+  });
+});

--- a/packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts
+++ b/packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts
@@ -27,14 +27,25 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import type { AgentEventManifest, Automation as CoreAutomation, EventBus, OmniEvent, Subscription } from '@omni/core';
+import type {
+  AgentEventManifest,
+  Automation as CoreAutomation,
+  EventBus,
+  IAgentClient,
+  OmniEvent,
+  ProviderRequest,
+  ProviderResponse,
+  Subscription,
+} from '@omni/core';
 import { ConflictError, createAutomationEngine } from '@omni/core';
-import { type Database, automations, createDbHandle } from '@omni/db';
+import { type Database, agentProviders, automations, createDbHandle } from '@omni/db';
 import { agents as agentsTable } from '@omni/db';
 import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
+import { buildAutomationEngineDeps } from '../../plugins/automation-actions';
 import { AgentService } from '../agents';
 import { AutomationService } from '../automations';
+import { createServices } from '../index';
 import { ManifestCompilerService } from '../manifest-compiler';
 
 const superUrl = process.env.OMNI_G1_POSTGRES_URL ?? '';
@@ -293,6 +304,125 @@ postgresDescribe('manifest compilation + reconciliation (real PostgreSQL)', () =
       expect(agentCalls).toHaveLength(1);
       expect(agentCalls[0]?.configAgentId).toBe(agent.id);
       expect(agentCalls[0]?.agentId).toBe(agent.id);
+    } finally {
+      await engine.stop();
+    }
+  });
+
+  test('end to end (#1010): a CHAT-LESS external event fires the compiled call_agent — the provider receives the OmniEvent envelope', async () => {
+    // The full RFC #925 motivating scenario, neither #1009 nor #1010 could
+    // prove alone: manifest `accepts` entry for an external-shaped type →
+    // compiler emits the minimal `call_agent {agentId}` config → an event
+    // with NO chat fields (no instanceId, no chatId, no sender) arrives →
+    // chatless dispatch resolves the provider from the AGENT row and the
+    // (faked) provider receives the full envelope, session-scoped by
+    // `automation:{automationId}:{correlationId}`.
+
+    // A real provider row (FK for agents.agent_provider_id); the provider
+    // CLIENT is faked below at the agent-runner's client seam.
+    const [providerRow] = await db
+      .insert(agentProviders)
+      .values({ name: 'e2e-chatless-provider', schema: 'agno', baseUrl: 'http://localhost:1', apiKey: 'k' })
+      .returning({ id: agentProviders.id });
+    if (!providerRow) throw new Error('provider insert failed');
+
+    const agent = await agentService.create({
+      name: 'github-triage',
+      provider: 'claude',
+      agentProviderId: providerRow.id,
+    });
+    await agentService.updateManifest(agent.id, {
+      accepts: [{ event: 'custom.github.push', filter: { repository: 'automagik-dev/omni' } }],
+      publishes: [],
+    });
+
+    const compiled = (await automationService.list({ enabled: true })).filter(
+      (row) => row.managedByAgentId === agent.id,
+    );
+    expect(compiled).toHaveLength(1);
+    const automationId = compiled[0]?.id;
+
+    // REAL engine deps over REAL services — only the provider client is faked.
+    const services = createServices(db, recordingBus(journal));
+    const providerRequests: ProviderRequest[] = [];
+    const fakeClient: IAgentClient = {
+      run: async (request: ProviderRequest): Promise<ProviderResponse> => {
+        providerRequests.push(request);
+        return { content: 'triaged', runId: 'run-e2e', sessionId: request.sessionId ?? '', status: 'completed' };
+      },
+      stream: (): AsyncGenerator<never> => {
+        throw new Error('chatless dispatch is sync-only');
+      },
+    } as unknown as IAgentClient;
+    (
+      services.agentRunner as unknown as { getClient: () => Promise<{ client: IAgentClient; schema: string }> }
+    ).getClient = async () => ({ client: fakeClient, schema: 'agno' });
+    const deps = buildAutomationEngineDeps(services, db);
+
+    const handlers = new Map<string, (event: OmniEvent) => Promise<void>>();
+    const engineBus = {
+      publishGeneric: async () => ({ id: 'pub' }),
+      subscribePattern: async (pattern: string, handler: (event: OmniEvent) => Promise<void>) => {
+        handlers.set(pattern, handler);
+        return { unsubscribe: async () => {} } as Subscription;
+      },
+    } as unknown as EventBus;
+
+    const engine = createAutomationEngine({ defaultConcurrency: 1, reconcileIntervalMs: 0 });
+    engine.setLogger(async () => {});
+    await engine.start(engineBus, compiled as unknown as CoreAutomation[], deps);
+
+    try {
+      const handler = handlers.get('custom.github.push.>');
+      expect(handler).toBeDefined();
+      if (!handler) throw new Error('engine did not subscribe to the compiled trigger');
+
+      // A root external fact: NO chat fields anywhere in the payload.
+      const fire = (repository: string, correlationId: string, eventId: string) =>
+        handler({
+          id: eventId,
+          type: 'custom.github.push',
+          payload: { source: 'github', repository, ref: 'refs/heads/main', commits: [{ id: 'abc123' }] },
+          metadata: { correlationId },
+          timestamp: 1757100000000,
+        } as OmniEvent);
+
+      // Compiled filter mismatch: refused before any dispatch.
+      await fire('someone-else/repo', 'corr-x', 'evt-x');
+      expect(providerRequests).toHaveLength(0);
+
+      // Match: the provider receives the FULL envelope, chatless.
+      await fire('automagik-dev/omni', 'corr-gh-1', 'evt-gh-1');
+      expect(providerRequests).toHaveLength(1);
+      const request = providerRequests[0];
+      expect(request?.agentId).toBe('github-triage'); // provider-internal id: name fallback
+      expect(request?.sessionId).toBe(`automation:${automationId}:corr-gh-1`);
+      expect(request?.userId).toBe(`automation:${automationId}:corr-gh-1`);
+      expect(request?.platform).toBeUndefined();
+      expect(request?.chat).toBeUndefined();
+      const envelope = JSON.parse(request?.message ?? '{}');
+      expect(envelope).toEqual({
+        id: 'evt-gh-1',
+        type: 'custom.github.push',
+        payload: {
+          source: 'github',
+          repository: 'automagik-dev/omni',
+          ref: 'refs/heads/main',
+          commits: [{ id: 'abc123' }],
+        },
+        metadata: { correlationId: 'corr-gh-1' },
+        timestamp: 1757100000000,
+      });
+
+      // Session scoping: an unrelated event gets its own session…
+      await fire('automagik-dev/omni', 'corr-gh-2', 'evt-gh-2');
+      expect(providerRequests).toHaveLength(2);
+      expect(providerRequests[1]?.sessionId).toBe(`automation:${automationId}:corr-gh-2`);
+
+      // …while a causal chain (same correlationId) shares the first one.
+      await fire('automagik-dev/omni', 'corr-gh-1', 'evt-gh-3');
+      expect(providerRequests).toHaveLength(3);
+      expect(providerRequests[2]?.sessionId).toBe(`automation:${automationId}:corr-gh-1`);
     } finally {
       await engine.stop();
     }

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -78,6 +78,38 @@ export interface AgentRunContext {
   files?: ProviderFile[];
 }
 
+/**
+ * Context for a chatless agent run (#1010, RFC #925 G4 runtime half): an
+ * event→agent dispatch with no instance, no chat, and no sender — only the
+ * agent's provider coordinates and an event-scoped session key.
+ */
+export interface ChatlessRunContext {
+  /** The agent's provider (from the agents row, not an instance). */
+  agentProviderId: string;
+  /** Provider-internal agent id (metadata.providerAgentId ?? configPath ?? name). */
+  agentInternalId: string;
+  /** Agent type — routes the provider client internally (default 'agent'). */
+  agentType?: 'agent' | 'team' | 'workflow';
+  /**
+   * Tenant the provider credential is opened (and the client cached) under —
+   * the agent row's persisted ownership, mirroring how the instance path
+   * threads `instance.tenantId`. Null in the legacy world.
+   */
+  tenantId?: string | null;
+  /**
+   * Event-scoped session key (`automation:{automationId}:{correlationId}`).
+   * HTTP providers receive it verbatim as `sessionId`/`userId`, so a causal
+   * chain shares one provider-side conversation and unrelated events never
+   * collide. claude-code only resumes UUID session ids, so every chatless
+   * claude-code run starts a FRESH provider session (see runChatless).
+   */
+  sessionKey: string;
+  /** The run's input — for the default chatless path, the OmniEvent envelope JSON. */
+  messages: string[];
+  /** Timeout in seconds (default 600). */
+  timeoutSeconds?: number | null;
+}
+
 export interface AgentRunResult {
   /** Response content (may be split into parts) */
   parts: string[];
@@ -670,6 +702,71 @@ export class AgentRunnerService {
       runId: response.runId,
       status: response.status,
       parts: parts.length,
+    });
+
+    return {
+      parts,
+      metadata: {
+        runId: response.runId,
+        sessionId: response.sessionId,
+        status: response.status,
+        metrics: response.metrics,
+      },
+    };
+  }
+
+  /**
+   * Run a CHATLESS agent call (#1010): dispatch an agent with only its
+   * provider coordinates and the triggering event — no instance, no chat.
+   *
+   * Deliberate differences from `run()` (all consequences of having no
+   * instance/chat, documented per issue #1010):
+   *   - no `platform`/`chat`/`sender` blocks on the provider request — there
+   *     is no channel identity to report;
+   *   - `sessionId` and `userId` are BOTH the event-scoped `sessionKey`
+   *     (`automation:{automationId}:{correlationId}`). HTTP/API-key providers
+   *     take the session id verbatim, so a causal chain shares one
+   *     conversation and unrelated events get separate ones. The claude-code
+   *     client only resumes valid UUID session ids (it ignores this key), so
+   *     every chatless claude-code run starts a fresh provider session — the
+   *     key→UUID mapping store (`agent_sessions`) requires an instances-row
+   *     FK that chatless runs do not have, and a fresh session is the safe
+   *     "no collision" default;
+   *   - always a sync run: there is no `instance.agentStreamMode` to honor;
+   *   - no response auto-split and no sender-name prefixing: the response is
+   *     not routed to a chat — there is NO implicit reply. The agent acts
+   *     through its own tools; the returned text only feeds `responseAs`
+   *     variable chaining.
+   */
+  async runChatless(context: ChatlessRunContext): Promise<AgentRunResult> {
+    const { client } = await this.getClient(context.agentProviderId, context.tenantId ?? null);
+
+    const combinedMessage = context.messages.join('\n---\n');
+
+    log.info('Running agent (chatless)', {
+      agentProviderId: context.agentProviderId,
+      agentInternalId: context.agentInternalId,
+      agentType: context.agentType ?? 'agent',
+      sessionKey: context.sessionKey,
+      messageCount: context.messages.length,
+    });
+
+    const response = await client.run({
+      message: combinedMessage,
+      agentId: context.agentInternalId,
+      agentType: context.agentType ?? 'agent',
+      stream: false,
+      sessionId: context.sessionKey,
+      userId: context.sessionKey,
+      timeoutMs: (context.timeoutSeconds ?? 600) * 1000,
+    });
+
+    const parts = [response.content.trim()].filter(Boolean);
+
+    log.info('Chatless agent run complete', {
+      runId: response.runId,
+      status: response.status,
+      sessionId: response.sessionId,
     });
 
     return {

--- a/packages/core/src/automations/__tests__/call-agent-chatless.test.ts
+++ b/packages/core/src/automations/__tests__/call-agent-chatless.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Chatless call_agent dispatch (#1010, RFC #925 G4 runtime half).
+ *
+ * A chat-less external event (custom.github.push et al.) resolves neither an
+ * instance nor a chat from its payload. When the action config names an agent,
+ * the action must dispatch it anyway with the FULL OmniEvent envelope as the
+ * run's input (the #960 envelope-forwarding shape) and an event-scoped session
+ * key (`automation:{automationId}:{correlationId}`) instead of chat ids.
+ *
+ * Pinned here:
+ *   - chatless dispatch fires with the envelope, no chat fields, and the
+ *     derived session key;
+ *   - session scoping: unrelated events → different keys; a causal chain
+ *     (same correlationId) → the same key;
+ *   - chat-ful behavior is byte-for-byte unchanged (chatless is a fallback);
+ *   - without config.agentId the legacy errors are unchanged;
+ *   - promptOverride wins over the envelope in chatless mode;
+ *   - envelope-less invocations fall back to the bare payload.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventMetadata } from '../../events/types';
+import type { AgentCallContext, AgentRunResult } from '../actions';
+import { executeAction } from '../actions';
+import type { TemplateContext } from '../templates';
+import type { CallAgentActionConfig } from '../types';
+
+function makeAgentResult(): AgentRunResult {
+  return {
+    parts: ['ok'],
+    fullResponse: 'ok',
+    metadata: { runId: 'r1', sessionId: 's1', status: 'completed' },
+  };
+}
+
+/** A chat-less external event context, the way the engine threads it. */
+function githubPushContext(overrides: Partial<TemplateContext> = {}): TemplateContext {
+  return {
+    payload: {
+      source: 'github',
+      repository: 'automagik-dev/omni',
+      ref: 'refs/heads/main',
+      commits: [{ id: 'abc123', message: 'feat: thing' }],
+    },
+    variables: {},
+    env: {},
+    event: {
+      id: 'evt-100',
+      type: 'custom.github.push',
+      timestamp: 1757100000000,
+      metadata: { correlationId: 'corr-1' },
+    },
+    automation: { id: 'auto-1', managedByAgentId: 'agent-1' },
+    ...overrides,
+  };
+}
+
+function callAgentMock() {
+  return mock(async (_ctx: AgentCallContext, _cfg: CallAgentActionConfig) => makeAgentResult());
+}
+
+async function dispatch(config: CallAgentActionConfig, context: TemplateContext) {
+  const callAgent = callAgentMock();
+  const result = await executeAction({ type: 'call_agent', config }, context, {
+    eventBus: null,
+    callAgent,
+  });
+  return { callAgent, result };
+}
+
+describe('call_agent — chatless dispatch (#1010)', () => {
+  test('an event with no chat fields dispatches chatless with the full envelope', async () => {
+    const { callAgent, result } = await dispatch({ agentId: 'agent-1' }, githubPushContext());
+
+    expect(result.status).toBe('success');
+    expect(callAgent).toHaveBeenCalledTimes(1);
+    const ctx = callAgent.mock.calls[0]?.[0] as AgentCallContext;
+
+    expect(ctx.chatless).toBe(true);
+    expect(ctx.agentId).toBe('agent-1');
+    expect(ctx.instanceId).toBe('');
+    expect(ctx.automationId).toBe('auto-1');
+    expect(ctx.sessionKey).toBe('automation:auto-1:corr-1');
+    // Synthesized identifiers, never channel-native ids.
+    expect(ctx.chatId).toBe('automation:auto-1:corr-1');
+    expect(ctx.senderId).toBe('automation:auto-1:corr-1');
+
+    // The run's input is the #960 envelope shape: id, type, payload, metadata, timestamp.
+    expect(ctx.messages).toHaveLength(1);
+    const envelope = JSON.parse(ctx.messages[0] ?? '{}');
+    expect(envelope).toEqual({
+      id: 'evt-100',
+      type: 'custom.github.push',
+      payload: {
+        source: 'github',
+        repository: 'automagik-dev/omni',
+        ref: 'refs/heads/main',
+        commits: [{ id: 'abc123', message: 'feat: thing' }],
+      },
+      metadata: { correlationId: 'corr-1' },
+      timestamp: 1757100000000,
+    });
+  });
+
+  test('session scoping: unrelated events get different keys, a causal chain shares one', async () => {
+    const contextA = githubPushContext();
+    const contextB = githubPushContext({
+      event: { id: 'evt-200', type: 'custom.github.push', timestamp: 2, metadata: { correlationId: 'corr-2' } },
+    });
+    const contextChain = githubPushContext({
+      event: { id: 'evt-300', type: 'custom.github.push', timestamp: 3, metadata: { correlationId: 'corr-1' } },
+    });
+
+    const a = await dispatch({ agentId: 'agent-1' }, contextA);
+    const b = await dispatch({ agentId: 'agent-1' }, contextB);
+    const chain = await dispatch({ agentId: 'agent-1' }, contextChain);
+
+    const keyA = (a.callAgent.mock.calls[0]?.[0] as AgentCallContext).sessionKey;
+    const keyB = (b.callAgent.mock.calls[0]?.[0] as AgentCallContext).sessionKey;
+    const keyChain = (chain.callAgent.mock.calls[0]?.[0] as AgentCallContext).sessionKey;
+
+    expect(keyA).not.toBe(keyB);
+    expect(keyChain).toBe(keyA);
+  });
+
+  test('an envelope without correlationId scopes by the event id', async () => {
+    // EventMetadata types correlationId as required, but pre-#956 producers
+    // and defensive paths can thread an envelope without one — pin the
+    // event-id fallback.
+    const context = githubPushContext({
+      event: { id: 'evt-400', type: 'custom.github.push', timestamp: 4, metadata: {} as EventMetadata },
+    });
+    const { callAgent } = await dispatch({ agentId: 'agent-1' }, context);
+    const ctx = callAgent.mock.calls[0]?.[0] as AgentCallContext;
+    expect(ctx.sessionKey).toBe('automation:auto-1:evt-400');
+  });
+
+  test('envelope-less invocation (manual execute) sends the bare payload and a fresh scope', async () => {
+    const context = githubPushContext({ event: undefined, automation: undefined });
+    const { callAgent, result } = await dispatch({ agentId: 'agent-1' }, context);
+
+    expect(result.status).toBe('success');
+    const ctx = callAgent.mock.calls[0]?.[0] as AgentCallContext;
+    expect(ctx.chatless).toBe(true);
+    expect(ctx.automationId).toBe('manual');
+    expect(ctx.sessionKey).toMatch(/^automation:manual:.+$/);
+    expect(ctx.event).toBeUndefined();
+    expect(JSON.parse(ctx.messages[0] ?? '{}')).toEqual(context.payload);
+  });
+
+  test('promptOverride replaces the envelope as the chatless input', async () => {
+    const { callAgent } = await dispatch(
+      { agentId: 'agent-1', promptOverride: 'Push to {{repository}} on {{ref}}' },
+      githubPushContext(),
+    );
+    const ctx = callAgent.mock.calls[0]?.[0] as AgentCallContext;
+    expect(ctx.chatless).toBe(true);
+    expect(ctx.messages).toEqual(['Push to automagik-dev/omni on refs/heads/main']);
+  });
+
+  test('without config.agentId the legacy instanceId error is unchanged', async () => {
+    const { callAgent, result } = await dispatch({ agentId: '' }, githubPushContext());
+    expect(callAgent).not.toHaveBeenCalled();
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('instanceId is required (from payload or config.providerId template)');
+  });
+
+  test('an event with instanceId but no chat still errors without an agentId', async () => {
+    const context = githubPushContext();
+    context.payload.instanceId = 'wa-001';
+    const { callAgent, result } = await dispatch({ agentId: '' }, context);
+    expect(callAgent).not.toHaveBeenCalled();
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('chatId not found in payload');
+  });
+
+  test('the minimal compiled config — call_agent {agentId} — dispatches chatless (#986/#1009 readiness)', async () => {
+    // Exactly what the manifest compiler emits: { agentId } and nothing else.
+    const { callAgent, result } = await dispatch({ agentId: 'agent-uuid-1' }, githubPushContext());
+    expect(result.status).toBe('success');
+    expect((callAgent.mock.calls[0]?.[0] as AgentCallContext).chatless).toBe(true);
+  });
+});
+
+describe('call_agent — chat-ful path unchanged by the chatless fallback', () => {
+  test('a chat event produces the exact pre-#1010 context (no chatless fields)', async () => {
+    const context: TemplateContext = {
+      payload: {
+        instanceId: 'wa-001',
+        from: { id: 'user-1', name: 'Alice' },
+        chatId: 'chat-1',
+        content: 'hello there',
+      },
+      variables: {},
+      env: {},
+      event: {
+        id: 'evt-500',
+        type: 'message.received',
+        timestamp: 5,
+        metadata: { correlationId: 'corr-chat' },
+      },
+      automation: { id: 'auto-2' },
+    };
+    const { callAgent, result } = await dispatch({ agentId: 'agent-1' }, context);
+
+    expect(result.status).toBe('success');
+    const ctx = callAgent.mock.calls[0]?.[0] as AgentCallContext;
+    expect(ctx.chatless).toBeUndefined();
+    expect(ctx.sessionKey).toBeUndefined();
+    expect(ctx.automationId).toBeUndefined();
+    expect(ctx.instanceId).toBe('wa-001');
+    expect(ctx.chatId).toBe('chat-1');
+    expect(ctx.senderId).toBe('user-1');
+    expect(ctx.senderName).toBe('Alice');
+    expect(ctx.messages).toEqual(['hello there']);
+    expect(ctx.event).toEqual({ id: 'evt-500', type: 'message.received', correlationId: 'corr-chat' });
+  });
+
+  test('a chat event with no text content still fails (never silently falls back to chatless)', async () => {
+    const context: TemplateContext = {
+      payload: { instanceId: 'wa-001', chatId: 'chat-1', from: { id: 'user-1' } },
+      variables: {},
+      env: {},
+    };
+    const { callAgent, result } = await dispatch({ agentId: 'agent-1' }, context);
+    expect(callAgent).not.toHaveBeenCalled();
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('message content not found in payload');
+  });
+});

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -71,6 +71,30 @@ export interface AgentCallContext {
     type: string;
     correlationId?: string;
   };
+  /**
+   * Chatless dispatch (#1010, RFC #925 G4 runtime half): the triggering event
+   * carried no resolvable chat context (no instanceId and/or no chatId), and
+   * `config.agentId` names the agent to wake anyway. In this mode:
+   *   - `instanceId` is the EMPTY STRING — there is no instance; the callAgent
+   *     implementation must resolve the provider from the agent row instead;
+   *   - `chatId`/`senderId` carry the synthesized `sessionKey` (stable
+   *     event-scoped identifiers, never channel-native ids);
+   *   - `messages` carries the full OmniEvent envelope as JSON (the #960
+   *     envelope-forwarding shape), or the rendered `promptOverride`;
+   *   - there is NO implicit reply — the agent acts through its own
+   *     tools/actions; any response routing is the agent's job.
+   */
+  chatless?: boolean;
+  /**
+   * Session scoping key for chatless runs: `automation:{automationId}:{scope}`
+   * where scope is the triggering envelope's correlationId (falling back to
+   * the event id, or a fresh id for envelope-less invocations). Consecutive
+   * unrelated events therefore never collide into one conversation; a causal
+   * chain (shared correlationId) hitting the same automation shares one key.
+   */
+  sessionKey?: string;
+  /** Id of the automation that dispatched this chatless run ('manual' when unthreaded). */
+  automationId?: string;
 }
 
 /**
@@ -715,6 +739,79 @@ function extractMessages(context: TemplateContext, promptOverride?: string): str
 }
 
 /**
+ * Messages for a chatless run: the rendered `promptOverride` when configured,
+ * otherwise the FULL OmniEvent envelope as JSON — the same shape the webhook
+ * action's default body sends (#960: id, type, payload, metadata, timestamp).
+ * Envelope-less invocations (route-side manual execute) fall back to the bare
+ * payload, mirroring `buildDefaultWebhookBody`.
+ */
+function buildChatlessMessages(context: TemplateContext, promptOverride?: string): string[] | { error: string } {
+  if (promptOverride !== undefined) {
+    const rendered = substituteTemplate(promptOverride, context);
+    if (!rendered) return { error: 'promptOverride rendered to an empty string' };
+    return [rendered];
+  }
+  if (context.event) {
+    return [
+      JSON.stringify({
+        id: context.event.id,
+        type: context.event.type,
+        payload: context.payload,
+        metadata: context.event.metadata,
+        timestamp: context.event.timestamp,
+      }),
+    ];
+  }
+  return [JSON.stringify(context.payload)];
+}
+
+/**
+ * Build the chatless AgentCallContext (#1010): dispatch with only an agent id
+ * plus the triggering event. The session scope is
+ * `automation:{automationId}:{correlationId}` — correlationId falls back to
+ * the event id, and to a freshly minted id for envelope-less invocations (each
+ * manual execute is its own conversation). Consequence: unrelated events get
+ * separate sessions by default; a causal chain (same correlationId) hitting
+ * the same automation shares one.
+ */
+function buildChatlessAgentCallContext(
+  config: CallAgentActionConfig,
+  context: TemplateContext,
+  agentId: string,
+): { context: AgentCallContext } | { error: string } {
+  const messagesResult = buildChatlessMessages(context, config.promptOverride);
+  if ('error' in messagesResult) return messagesResult;
+
+  const automationId = context.automation?.id ?? 'manual';
+  const scope = context.event?.metadata.correlationId ?? context.event?.id ?? generateId();
+  const sessionKey = `automation:${automationId}:${scope}`;
+
+  return {
+    context: {
+      chatless: true,
+      // No instance exists for a chatless run — the callAgent implementation
+      // resolves the provider from the agent row.
+      instanceId: '',
+      agentId,
+      sessionKey,
+      automationId,
+      // Stable synthesized identifiers (never channel-native ids) so
+      // downstream logging/session code has non-empty values to key on.
+      chatId: sessionKey,
+      senderId: sessionKey,
+      messages: messagesResult,
+      event: context.event
+        ? {
+            id: context.event.id,
+            type: context.event.type,
+            correlationId: context.event.metadata.correlationId,
+          }
+        : undefined,
+    },
+  };
+}
+
+/**
  * Extract agent call context from automation payload
  * Returns extracted context or error string
  */
@@ -727,10 +824,6 @@ function extractAgentCallContext(
     ? substituteTemplate(config.providerId, context)
     : (context.payload.instanceId as string);
 
-  if (!instanceId) {
-    return { error: 'instanceId is required (from payload or config.providerId template)' };
-  }
-
   // Extract chat and sender info from payload
   const fromObj = context.payload.from as { id?: string; name?: string } | undefined;
   const chatId = (context.payload.chatId as string) ?? fromObj?.id;
@@ -740,6 +833,20 @@ function extractAgentCallContext(
   const senderName =
     fromObj?.name ?? (context.payload.senderName as string) ?? (context.payload.chatName as string | undefined);
 
+  // Chatless fallback (#1010): a chat-less external event (custom.github.push
+  // et al.) resolves neither an instance nor a chat. When the config names an
+  // agent, dispatch it anyway with the event envelope as the run's input.
+  // Chat-ful events resolve both fields and take the unchanged path below.
+  if (!instanceId || !chatId) {
+    const chatlessAgentId = config.agentId ? substituteTemplate(config.agentId, context) : '';
+    if (chatlessAgentId) {
+      return buildChatlessAgentCallContext(config, context, chatlessAgentId);
+    }
+  }
+
+  if (!instanceId) {
+    return { error: 'instanceId is required (from payload or config.providerId template)' };
+  }
   if (!chatId) return { error: 'chatId not found in payload' };
   if (!senderId) return { error: 'senderId not found in payload' };
 


### PR DESCRIPTION
Closes #1010 — the runtime half of RFC #925 G4: `call_agent` is now dispatchable with **only an agent id + the triggering event**. A chat-less external event (`custom.github.push`, `custom.clickup.taskstatusupdated`, …) can wake an agent without smuggling chat fields into its payload.

## What changed

**Core action (`packages/core/src/automations/actions.ts`)** — chatless is an additive *fallback*, not a rewrite:
- `extractAgentCallContext` resolves instance/chat/sender exactly as before. Only when **no instanceId or no chatId is resolvable** *and* the config names an `agentId` does it build a chatless `AgentCallContext` (`chatless: true`, `instanceId: ''`, synthesized `sessionKey`). Chat-ful extraction is byte-for-byte unchanged, and a config without `agentId` keeps the exact legacy errors.
- The chatless run's input is the **full OmniEvent envelope as JSON** — `{id, type, payload, metadata, timestamp}`, the same shape the webhook action's default body sends (#960 envelope-forwarding precedent). `promptOverride` still wins when configured; envelope-less invocations (route-side manual execute) fall back to the bare payload, mirroring `buildDefaultWebhookBody`.

**API adapter (`packages/api/src/plugins/automation-actions.ts`)** — a `ctx.chatless` branch resolves the provider from the **agents row alone** (one discrete worker-tenant-scoped read, same G5 discipline as the chat path: the agent run executes strictly after the scope closes). No instance read, no chat-UUID resolution. Missing agent row or an agent without `agent_provider_id` fails with a clear error.

**Runner (`packages/api/src/services/agent-runner.ts`)** — new `runChatless()`: sync-only, no `platform`/`chat`/`sender` blocks, no auto-split, no sender prefixing, no session-store access. The provider credential is opened under the agent row's persisted `tenantId` (fallback: the envelope-threaded trusted tenant) — the chatless analogue of the instance path's `instance.tenantId`.

## Design decisions

**Reply semantics — NO implicit send.** A chatless run has no chat to reply into and none is fabricated. The response is returned only for `responseAs` variable chaining; the agent acts through its own tools/actions (emit_event, webhooks, MCP), and any response routing is the agent's job. This is stated in the code at all three layers.

**Session scoping — `automation:{automationId}:{correlationId}`** (the key the issue suggested), with correlationId falling back to the event id, and to a freshly minted id per envelope-less manual execute. Consequences:
- two unrelated events → two session keys → never collide into one conversation (the default);
- a causal chain (same `correlationId`) hitting the same automation → one shared key;
- the key doubles as the synthesized `chatId`/`senderId`/`userId`, so providers that contractually want a chat/user identifier get a stable one derived from the scoping key instead of failing.

**Provider compatibility (both families verified):**
- *HTTP/API-key providers* (agno/a2a/ag-ui/…): `ProviderRequest.platform/chat/sender` are optional by contract; `sessionId`/`userId` receive the scoping key verbatim, so a correlation chain shares one provider-side conversation.
- *local claude-code (the #934 path)*: `getClient` builds the client from `schemaConfig` with an optional key (unchanged), and the claude-code client only `--resume`s **valid UUID** session ids (`claude-code-client.ts` — non-UUID ids are ignored), so every chatless claude-code run starts a **fresh provider session**. Deliberate and documented: the key→UUID mapping store (`agent_sessions`) has a `NOT NULL` FK to `instances`, which a chatless run doesn't have — and fresh-per-event is the safe no-collision default. Cross-event claude-code session continuity can be added later by relaxing that FK if wanted.

**Compiled-automation readiness (#986/#1009): VERDICT — works chatless as-is.** The compiler emits exactly `{ type: 'call_agent', config: { agentId: agent.id } }`; that minimal config is precisely the chatless trigger shape (agentId present, no providerId), and the combined postgres e2e below proves it end-to-end against the real compiler output. No compiler or schema change needed.

**No migration.** Nothing in this PR touches the DB schema (0063 was #1009's; the next free number remains 0064 for whoever needs it).

## Tests (all green)

- `packages/core/src/automations/__tests__/call-agent-chatless.test.ts` (10): chatless dispatch with the envelope + derived key; unrelated events → different keys / causal chain → shared key; event-id and manual fallbacks; promptOverride; **chat-ful path unchanged** (exact pre-#1010 context, and a chat event with no text still fails — never silently goes chatless); legacy errors unchanged without agentId; the minimal compiled config dispatches chatless.
- `packages/api/src/plugins/__tests__/automation-actions-chatless.test.ts` (8): no instances/chats reads for chatless; provider-internal id fallback chain (`metadata.providerAgentId` → `configPath` → `name`); config `agentType`/`timeoutMs` overrides; persisted-tenant vs threaded-tenant precedence; missing-agent / no-provider / no-agentId refusals; chat-ful path still lands on `runOrStream`.
- `packages/api/src/services/__tests__/agent-runner-chatless.test.ts` (3): provider request carries the key as `sessionId`+`userId`, no platform/chat/sender/mcpUrlParams; the db is **never touched** (no `agent_sessions` read/write); defaults (agent type, 600s, `\n---\n` join); claude-code-schema variant.
- `packages/api/src/services/__tests__/manifest-compiler-postgres.test.ts` — **the combined RFC #925 e2e** neither #1009 nor this PR could contain alone: manifest `accepts: custom.github.push {filter}` → real compiler → managed automation with the minimal config → real `buildAutomationEngineDeps` over real services (only the provider **client** faked at the runner's seam) → an event with **no chat fields** → the provider receives the full envelope, session-keyed `automation:{automationId}:{correlationId}`; filter mismatch refuses; second correlation gets its own session; the corr-1 chain resumes the first.

Validation: `make typecheck` clean, `make lint` clean (zero warnings), core package 1058 pass / api package 2267 pass / 0 fail, and **`make test-pg-gate` PASSED — 375 assertions across 39 suites, 0 skipped** (the extended compiler suite: 9 pass / 0 fail).
