### PR TITLE
ci(release): deterministic, tested release-notes generator (replaces git-cliff)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ name: Release
 #   1. build           — workflow_call into build-tarballs.yml (matrix × 4 platforms)
 #   2. sign-attest     — workflow_call into sign-attest.yml (cosign keyless + GitHub-native provenance)
 #   3. publish         — workflow_call into release-publish.yml (GH release + assets)
-#   4. release-notes   — git-cliff changelog appended to the GH release body.
+#   4. release-notes   — deterministic generator (scripts/release/
+#                        generate-release-notes.ts) writes the GH release body.
 #
 # npm publishing happens in version.yml inline for dev auto-versioning.
 # Single source of truth — no duplicate publish step here. Codex P1 on PR #633 caught the gap when a previous
@@ -156,8 +157,10 @@ jobs:
       orchestrated: true
 
   # ---------------------------------------------------------------------------
-  # Release notes (git-cliff) — runs after publish so the GH release exists.
-  # Updates the release body with the generated changelog.
+  # Release notes — runs after publish so the GH release exists. Renders the
+  # release body with scripts/release/generate-release-notes.ts (deterministic
+  # Bun generator: highlights, breaking changes, new DB migrations, scope-grouped
+  # sections, verification instructions, compare link) and updates the release.
   #
   # NOTE: npm publish is NOT performed by this workflow. version.yml owns
   # `npm publish` for dev. A
@@ -172,7 +175,7 @@ jobs:
     needs: [sign-attest, publish]
     name: Generate release notes
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -232,22 +235,28 @@ jobs:
           echo "tag=${PREV:-}" >> "$GITHUB_OUTPUT"
           echo "Previous release tag: ${PREV:-none}"
 
-      - name: Generate changelog
-        # git-cliff-action can fail after writing the requested file when the
-        # generated multi-line changelog trips GitHub output delimiter parsing
-        # ("Invalid value. Matching delimiter not found 'EOF'"). The release
-        # artifact should not go red for that wrapper-output bug; the next step
-        # uses /tmp/release-notes.md if it exists and otherwise leaves the
-        # generated release body in place.
-        continue-on-error: true
-        uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772 # v4.7.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          config: cliff.toml
-          args: >-
-            ${{ steps.prev.outputs.tag && format('{0}..{1}', steps.prev.outputs.tag, steps.pkg.outputs.tag) || '' }}
-            --output /tmp/release-notes.md
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate changelog
+        # A notes-rendering bug must not turn the release artifact red: the
+        # next step uses /tmp/release-notes.md if it exists and otherwise
+        # leaves the placeholder release body in place.
+        continue-on-error: true
         env:
-          GITHUB_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.pkg.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.prev.outputs.tag }}
+        run: |
+          set -euo pipefail
+          args=(--to "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --output /tmp/release-notes.md)
+          if [[ -n "${PREVIOUS_TAG}" ]]; then
+            args+=(--from "${PREVIOUS_TAG}")
+          fi
+          bun scripts/release/generate-release-notes.ts "${args[@]}"
 
       - name: Update release body with changelog
         env:
@@ -260,5 +269,5 @@ jobs:
             gh release edit "${TAG}" --notes-file /tmp/release-notes.md
             echo "Updated release body for ${TAG}"
           else
-            echo "::warning::git-cliff produced empty notes; leaving auto-generated body in place"
+            echo "::warning::the notes generator produced empty notes; leaving the placeholder body in place"
           fi

--- a/knip.json
+++ b/knip.json
@@ -7,7 +7,8 @@
         "scripts/kill-stale-test-daemons.ts",
         "scripts/pg-gate.ts",
         "scripts/pg-gate-warm.ts",
-        "scripts/bootstrap-platform-credential.ts"
+        "scripts/bootstrap-platform-credential.ts",
+        "scripts/release/generate-release-notes.test.ts"
       ],
       "project": ["scripts/**/*.ts"],
       "ignore": [

--- a/scripts/release/generate-release-notes.test.ts
+++ b/scripts/release/generate-release-notes.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for scripts/release/generate-release-notes.ts (the deterministic
+ * release-body generator that replaced the git-cliff step in release.yml).
+ *
+ * The parsing/grouping/rendering functions are pure, so every case runs on
+ * synthetic fixtures. One integration test spawns the real CLI against the
+ * repository's own history to prove the git plumbing works.
+ *
+ * Run: bun test scripts/release/generate-release-notes.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type ParsedCommit,
+  type RawCommit,
+  detectBreaking,
+  extractPrNumber,
+  groupSections,
+  normalizeArea,
+  parseAddedMigrations,
+  parseCommit,
+  renderReleaseNotes,
+  selectHighlights,
+  splitLogRecords,
+  summarizeMigrationHeader,
+} from './generate-release-notes';
+
+const HASH = 'a'.repeat(40);
+
+function raw(subject: string, body = '', author = 'Alice'): RawCommit {
+  return { hash: HASH, author, subject, body };
+}
+
+function commit(overrides: Partial<ParsedCommit>): ParsedCommit {
+  return {
+    hash: HASH,
+    author: 'Alice',
+    type: 'feat',
+    scope: 'api',
+    area: 'api',
+    description: 'do something',
+    breaking: false,
+    breakingNote: null,
+    pr: null,
+    ...overrides,
+  };
+}
+
+describe('parseCommit', () => {
+  test('parses type, scope, and description', () => {
+    const parsed = parseCommit(raw('feat(api): add batch endpoint (#42)'));
+    expect(parsed).toMatchObject({
+      type: 'feat',
+      scope: 'api',
+      area: 'api',
+      description: 'add batch endpoint',
+      pr: 42,
+    });
+  });
+
+  test('defaults a missing scope to core', () => {
+    const parsed = parseCommit(raw('fix: stop the bleeding'));
+    expect(parsed).toMatchObject({ scope: 'core', area: 'core', description: 'stop the bleeding' });
+  });
+
+  test('skips unconventional subjects such as merge commits', () => {
+    expect(parseCommit(raw('Merge pull request #1015 from automagik-dev/feat/989'))).toBeNull();
+    expect(parseCommit(raw('random words with no colon'))).toBeNull();
+  });
+
+  test('skips chore(version) bump and chore(merge) sync noise', () => {
+    expect(parseCommit(raw('chore(version): bump to 2.260908.12'))).toBeNull();
+    expect(parseCommit(raw('chore(merge): resolve conflicts with main'))).toBeNull();
+    expect(parseCommit(raw('chore(deps): bump zod'))).not.toBeNull();
+  });
+
+  test('flags a ! marker as breaking', () => {
+    const parsed = parseCommit(raw('feat(api)!: drop the v1 surface'));
+    expect(parsed?.breaking).toBe(true);
+  });
+});
+
+describe('extractPrNumber', () => {
+  test('reads a trailing (#N) reference', () => {
+    expect(extractPrNumber('feat(cli): omni events consumers (#989)')).toBe(989);
+  });
+
+  test('reads merge-commit subjects', () => {
+    expect(extractPrNumber('Merge pull request #1015 from automagik-dev/x')).toBe(1015);
+  });
+
+  test('uses the last reference when several appear', () => {
+    expect(extractPrNumber('fix(api): follow-up to (#10) cleanup (#12)')).toBe(12);
+  });
+
+  test('returns null when no reference exists', () => {
+    expect(extractPrNumber('fix(api): no reference here')).toBeNull();
+  });
+});
+
+describe('detectBreaking', () => {
+  test('detects a BREAKING CHANGE footer with its note', () => {
+    const result = detectBreaking(false, 'Body text.\n\nBREAKING CHANGE: the /v1 routes are gone,\nuse /v2 instead.');
+    expect(result.breaking).toBe(true);
+    expect(result.note).toBe('the /v1 routes are gone, use /v2 instead.');
+  });
+
+  test('detects the BREAKING-CHANGE spelling', () => {
+    expect(detectBreaking(false, 'BREAKING-CHANGE: renamed config keys').breaking).toBe(true);
+  });
+
+  test('a bang alone is breaking with no note', () => {
+    expect(detectBreaking(true, 'ordinary body')).toEqual({ breaking: true, note: null });
+  });
+
+  test('plain commits are not breaking', () => {
+    expect(detectBreaking(false, 'ordinary body').breaking).toBe(false);
+  });
+});
+
+describe('normalizeArea', () => {
+  test('maps channel scopes under channels/', () => {
+    expect(normalizeArea('channel-whatsapp')).toBe('channels/whatsapp');
+    expect(normalizeArea('discord')).toBe('channels/discord');
+  });
+
+  test('keeps ordinary scopes as-is, lowercased', () => {
+    expect(normalizeArea('API')).toBe('api');
+    expect(normalizeArea('events')).toBe('events');
+  });
+
+  test('joins multi-scope commits with +', () => {
+    expect(normalizeArea('cli,sdk')).toBe('cli+sdk');
+    expect(normalizeArea('sdk, cli')).toBe('sdk+cli');
+  });
+});
+
+describe('groupSections', () => {
+  test('orders sections by type and omits empty ones', () => {
+    const sections = groupSections([
+      commit({ type: 'docs', description: 'a runbook' }),
+      commit({ type: 'fix', description: 'a fix' }),
+      commit({ type: 'feat', description: 'a feature' }),
+    ]);
+    expect(sections.map((s) => s.title)).toEqual(['🚀 Features', '🐛 Bug Fixes', '📚 Documentation']);
+  });
+
+  test('clusters a section by area while preserving history order within one', () => {
+    const sections = groupSections([
+      commit({ type: 'feat', area: 'db', description: 'db one' }),
+      commit({ type: 'feat', area: 'api', description: 'api one' }),
+      commit({ type: 'feat', area: 'db', description: 'db two' }),
+      commit({ type: 'feat', area: 'cli', description: 'cli one' }),
+    ]);
+    expect(sections[0]?.commits.map((c) => c.description)).toEqual(['api one', 'cli one', 'db one', 'db two']);
+  });
+
+  test('routes unknown types into Miscellaneous', () => {
+    const sections = groupSections([commit({ type: 'build', description: 'tarball tweak' })]);
+    expect(sections.map((s) => s.title)).toEqual(['🔧 Miscellaneous']);
+  });
+});
+
+describe('selectHighlights', () => {
+  test('returns nothing when there are no feat commits', () => {
+    expect(selectHighlights([commit({ type: 'fix' })])).toEqual([]);
+  });
+
+  test('groups feats by PR and represents the group by its most descriptive subject', () => {
+    const highlights = selectHighlights([
+      commit({ pr: 989, area: 'cli', description: 'short one' }),
+      commit({ pr: 989, area: 'api', description: 'durable consumer surface — register, pull, ack, lag' }),
+      commit({ pr: 989, area: 'db', description: 'registry table' }),
+      commit({ pr: 7, area: 'ui', description: 'tiny tweak' }),
+    ]);
+    expect(highlights).toHaveLength(2);
+    expect(highlights[0]).toMatchObject({ area: 'api', pr: 989, extraAreas: ['cli', 'db'] });
+    expect(highlights[1]).toMatchObject({ area: 'ui', pr: 7, extraAreas: [] });
+  });
+
+  test('ranks breaking changes first, then larger changes, then recency', () => {
+    const highlights = selectHighlights([
+      commit({ pr: 1, description: 'newest small feat' }),
+      commit({ pr: 2, description: 'big feat part one' }),
+      commit({ pr: 2, description: 'big feat part two!' }),
+      commit({ pr: 3, description: 'old breaking feat', breaking: true }),
+    ]);
+    expect(highlights.map((h) => h.pr)).toEqual([3, 2, 1]);
+  });
+
+  test('caps the list at six', () => {
+    const feats = Array.from({ length: 9 }, (_, i) => commit({ pr: i + 1, description: `feat ${i + 1}` }));
+    expect(selectHighlights(feats)).toHaveLength(6);
+  });
+});
+
+describe('parseAddedMigrations', () => {
+  test('keeps only added drizzle .sql files, sorted', () => {
+    const output = [
+      'A\tpackages/db/drizzle/0062_agent_event_manifest.sql',
+      'M\tpackages/db/drizzle/meta/_journal.json',
+      'A\tpackages/db/drizzle/0053_gupshup_handoff_options.sql',
+      'A\tpackages/db/drizzle/meta/0001_snapshot.json',
+      'D\tpackages/db/drizzle/0001_gone.sql',
+      'A\tpackages/db/src/schema.ts',
+    ].join('\n');
+    expect(parseAddedMigrations(output)).toEqual([
+      'packages/db/drizzle/0053_gupshup_handoff_options.sql',
+      'packages/db/drizzle/0062_agent_event_manifest.sql',
+    ]);
+  });
+
+  test('returns an empty list for an empty diff', () => {
+    expect(parseAddedMigrations('')).toEqual([]);
+  });
+});
+
+describe('summarizeMigrationHeader', () => {
+  test('returns the first header paragraph, stopping at a blank comment line', () => {
+    const sql = '-- Gupshup per-instance handoff options.\n--\n-- More detail.\nALTER TABLE x ADD COLUMN y;';
+    expect(summarizeMigrationHeader(sql)).toBe('Gupshup per-instance handoff options.');
+  });
+
+  test('joins a wrapped first paragraph into one line', () => {
+    const sql =
+      '-- Connector lifecycle contract (#961) — liveness, heartbeat, declared\n-- verbs.\n--\n-- Detail.\nSELECT 1;';
+    expect(summarizeMigrationHeader(sql)).toBe(
+      'Connector lifecycle contract (#961) — liveness, heartbeat, declared verbs.',
+    );
+  });
+
+  test('skips a leading empty comment line', () => {
+    expect(summarizeMigrationHeader('--\n-- The real summary.\nSELECT 1;')).toBe('The real summary.');
+  });
+
+  test('returns empty for a file without a header comment', () => {
+    expect(summarizeMigrationHeader('ALTER TABLE x ADD COLUMN y;')).toBe('');
+  });
+});
+
+describe('splitLogRecords', () => {
+  const FS = '\u001f';
+  const RS = '\u001e';
+
+  test('splits field- and record-separated git log output', () => {
+    const record = `${HASH}${FS}Alice${FS}feat(api): thing (#1)${FS}body line\n${RS}\n`;
+    const commits = splitLogRecords(record + record.replace(/^a{40}/, 'b'.repeat(40)));
+    expect(commits).toHaveLength(2);
+    expect(commits[0]).toMatchObject({ hash: HASH, author: 'Alice', subject: 'feat(api): thing (#1)' });
+  });
+
+  test('rejects malformed hashes via the Zod boundary', () => {
+    expect(() => splitLogRecords(`nothash${FS}A${FS}s${FS}b${RS}`)).toThrow();
+  });
+});
+
+describe('renderReleaseNotes', () => {
+  const repo = 'automagik-dev/omni';
+
+  test('renders every section for a full release and links PRs over commits', () => {
+    const body = renderReleaseNotes({
+      repo,
+      fromTag: 'v1.0.0',
+      toTag: 'v1.1.0',
+      commits: [
+        commit({ pr: 989, description: 'durable consumer surface' }),
+        commit({ type: 'fix', pr: null, description: 'unexport internal clamps' }),
+        commit({
+          type: 'feat',
+          pr: 12,
+          description: 'drop legacy flag',
+          breaking: true,
+          breakingNote: 'use --new instead',
+        }),
+      ],
+      migrations: [{ file: 'packages/db/drizzle/0056_x.sql', summary: 'Adds x.' }],
+    });
+    expect(body).toContain('### ✨ Highlights');
+    expect(body).toContain('### 💥 Breaking changes');
+    expect(body).toContain('use --new instead');
+    expect(body).toContain('### 🗄️ Database migrations');
+    expect(body).toContain(
+      '[`0056_x.sql`](https://github.com/automagik-dev/omni/blob/v1.1.0/packages/db/drizzle/0056_x.sql) — Adds x.',
+    );
+    expect(body).toContain('[#989](https://github.com/automagik-dev/omni/pull/989)');
+    expect(body).toContain(`[\`${HASH.slice(0, 7)}\`](https://github.com/automagik-dev/omni/commit/${HASH})`);
+    expect(body).toContain('### 👥 Contributors');
+    expect(body).toContain('gh attestation verify omni-1.1.0-<platform>.tar.gz --repo automagik-dev/omni');
+    expect(body).toContain('[v1.0.0...v1.1.0](https://github.com/automagik-dev/omni/compare/v1.0.0...v1.1.0)');
+  });
+
+  test('omits empty sections entirely', () => {
+    const body = renderReleaseNotes({
+      repo,
+      fromTag: null,
+      toTag: 'v1.0.0',
+      commits: [commit({ type: 'fix', description: 'one fix' })],
+      migrations: [],
+    });
+    expect(body).not.toContain('Highlights');
+    expect(body).not.toContain('Breaking changes');
+    expect(body).not.toContain('Database migrations');
+    expect(body).not.toContain('Full changelog');
+    expect(body).toContain('### 🐛 Bug Fixes');
+  });
+
+  test('excludes bot authors from contributors', () => {
+    const body = renderReleaseNotes({
+      repo,
+      fromTag: null,
+      toTag: 'v1.0.0',
+      commits: [commit({ author: 'github-actions[bot]', type: 'fix' }), commit({ author: 'Sofia', type: 'fix' })],
+      migrations: [],
+    });
+    expect(body).toContain('- Sofia');
+    expect(body).not.toContain('github-actions[bot]');
+  });
+});
+
+describe('CLI integration', () => {
+  test('renders notes for a real range in this repository', () => {
+    const result = Bun.spawnSync([
+      'bun',
+      'scripts/release/generate-release-notes.ts',
+      '--from',
+      'v2.260908.11',
+      '--to',
+      'v2.260908.12',
+      '--repo',
+      'automagik-dev/omni',
+    ]);
+    expect(result.exitCode).toBe(0);
+    const body = result.stdout.toString();
+    expect(body).toContain('### 🚀 Features');
+    expect(body).toContain('Full changelog');
+  });
+
+  test('rejects a malformed --to tag', () => {
+    const result = Bun.spawnSync(['bun', 'scripts/release/generate-release-notes.ts', '--to', 'not-a-tag']);
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/scripts/release/generate-release-notes.ts
+++ b/scripts/release/generate-release-notes.ts
@@ -1,0 +1,500 @@
+#!/usr/bin/env bun
+/**
+ * Deterministic release-notes generator for the GitHub release body.
+ *
+ * Replaces the git-cliff step in .github/workflows/release.yml. Reads the
+ * conventional-commit history and the packages/db/drizzle diff for a tag
+ * range, then renders:
+ *
+ *   - Highlights          — the few feat changes a user actually cares about
+ *   - Breaking changes    — `!` markers and BREAKING CHANGE footers
+ *   - Database migrations — new drizzle .sql files with their header summary
+ *   - Detail sections     — grouped by conventional type, clustered by scope
+ *   - Contributors, asset-verification instructions, and a compare link
+ *
+ * Everything is derived offline from git — no network calls — so the same
+ * range always renders the same notes.
+ *
+ * Usage:
+ *   bun scripts/release/generate-release-notes.ts \
+ *     --to v2.260908.12 [--from v2.260902.5] \
+ *     [--repo automagik-dev/omni] [--output /tmp/release-notes.md]
+ *
+ * The pure functions are exported for scripts/release/generate-release-notes.test.ts.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Types and schemas
+// ---------------------------------------------------------------------------
+
+export const RawCommitSchema = z.object({
+  hash: z.string().regex(/^[0-9a-f]{40}$/),
+  author: z.string(),
+  subject: z.string(),
+  body: z.string(),
+});
+
+export type RawCommit = z.infer<typeof RawCommitSchema>;
+
+export type ParsedCommit = {
+  hash: string;
+  author: string;
+  type: string;
+  /** Raw conventional scope, defaulted to "core" when absent. */
+  scope: string;
+  /** Normalized grouping area, e.g. "channels/whatsapp" for scope "channel-whatsapp". */
+  area: string;
+  /** Subject description with any trailing " (#N)" PR reference stripped. */
+  description: string;
+  breaking: boolean;
+  breakingNote: string | null;
+  pr: number | null;
+};
+
+export type MigrationEntry = {
+  /** Path relative to the repo root, e.g. packages/db/drizzle/0056_x.sql. */
+  file: string;
+  /** First header comment line of the migration, or "" when absent. */
+  summary: string;
+};
+
+export type Highlight = {
+  area: string;
+  description: string;
+  pr: number | null;
+  hash: string;
+  /** Other areas the same change (PR group) touched, excluding `area`. */
+  extraAreas: string[];
+};
+
+export type ReleaseNotesInput = {
+  repo: string;
+  fromTag: string | null;
+  toTag: string;
+  commits: ParsedCommit[];
+  migrations: MigrationEntry[];
+};
+
+// ---------------------------------------------------------------------------
+// Commit parsing
+// ---------------------------------------------------------------------------
+
+const CONVENTIONAL_SUBJECT = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?(?<bang>!)?:\s*(?<desc>.+)$/;
+const TRAILING_PR_REF = /\s*\(#\d+\)\s*$/;
+const BREAKING_FOOTER = /^BREAKING[ -]CHANGE:\s*(?<note>[^\n]*(?:\n(?!\n)[^\n]*)*)/m;
+
+const CHANNEL_SCOPES = new Set([
+  'baileys',
+  'discord',
+  'email',
+  'evolution',
+  'gupshup',
+  'instagram',
+  'slack',
+  'sms',
+  'telegram',
+  'whatsapp',
+]);
+
+/** Normalize a conventional scope into a grouping area. */
+export function normalizeArea(scope: string): string {
+  const lowered = scope.toLowerCase().replace(/\s*,\s*/g, '+');
+  if (lowered.startsWith('channel-')) return `channels/${lowered.slice('channel-'.length)}`;
+  if (CHANNEL_SCOPES.has(lowered)) return `channels/${lowered}`;
+  return lowered;
+}
+
+/** Extract a PR number from "Merge pull request #N ..." or a "(#N)" reference. */
+export function extractPrNumber(subject: string): number | null {
+  const merge = /^Merge pull request #(\d+)/.exec(subject);
+  if (merge?.[1]) return Number(merge[1]);
+  const refs = [...subject.matchAll(/\(#(\d+)\)/g)];
+  const last = refs.at(-1);
+  return last?.[1] ? Number(last[1]) : null;
+}
+
+/** Detect a breaking change from the subject `!` marker or a BREAKING CHANGE footer. */
+export function detectBreaking(bang: boolean, body: string): { breaking: boolean; note: string | null } {
+  const footer = BREAKING_FOOTER.exec(body);
+  const note = footer?.groups?.note?.replaceAll('\n', ' ').trim() || null;
+  return { breaking: bang || footer !== null, note };
+}
+
+/**
+ * Parse one raw commit. Returns null for commits the notes should skip:
+ * unconventional subjects (merge commits included) and chore(version) bumps.
+ */
+export function parseCommit(raw: RawCommit): ParsedCommit | null {
+  const match = CONVENTIONAL_SUBJECT.exec(raw.subject);
+  if (!match?.groups) return null;
+  const type = match.groups.type ?? '';
+  const scope = match.groups.scope?.trim() || 'core';
+  if (type === 'chore' && (scope === 'version' || scope === 'merge')) return null;
+  const { breaking, note } = detectBreaking(match.groups.bang === '!', raw.body);
+  const description = (match.groups.desc ?? '').replace(TRAILING_PR_REF, '').trim();
+  return {
+    hash: raw.hash,
+    author: raw.author,
+    type,
+    scope,
+    area: normalizeArea(scope),
+    description,
+    breaking,
+    breakingNote: note,
+    pr: extractPrNumber(raw.subject),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+
+const SECTIONS: ReadonlyArray<{ types: readonly string[]; title: string }> = [
+  { types: ['feat'], title: '🚀 Features' },
+  { types: ['fix'], title: '🐛 Bug Fixes' },
+  { types: ['perf'], title: '⚡ Performance' },
+  { types: ['refactor'], title: '♻️ Refactoring' },
+  { types: ['test'], title: '🧪 Testing' },
+  { types: ['docs'], title: '📚 Documentation' },
+  { types: ['ci'], title: '⚙️ CI/CD' },
+];
+const FALLBACK_SECTION = '🔧 Miscellaneous';
+
+/** Sort order for areas inside a section; unknown areas follow, alphabetically. */
+const AREA_ORDER: readonly string[] = ['api', 'cli', 'ui', 'channels/', 'events', 'automations', 'db', 'core', 'sdk'];
+
+function areaRank(area: string): number {
+  const index = AREA_ORDER.findIndex((entry) => (entry.endsWith('/') ? area.startsWith(entry) : area === entry));
+  return index === -1 ? AREA_ORDER.length : index;
+}
+
+function sectionTitle(type: string): string {
+  return SECTIONS.find((section) => section.types.includes(type))?.title ?? FALLBACK_SECTION;
+}
+
+/**
+ * Group commits into ordered sections by conventional type, clustering each
+ * section's entries by area (known areas first, then alphabetically), while
+ * preserving history order within an area. Empty sections are omitted.
+ */
+export function groupSections(commits: ParsedCommit[]): Array<{ title: string; commits: ParsedCommit[] }> {
+  const titles = [...SECTIONS.map((section) => section.title), FALLBACK_SECTION];
+  return titles
+    .map((title) => {
+      const members = commits
+        .map((commit, index) => ({ commit, index }))
+        .filter(({ commit }) => sectionTitle(commit.type) === title)
+        .sort((a, b) => {
+          const rank = areaRank(a.commit.area) - areaRank(b.commit.area);
+          if (rank !== 0) return rank;
+          const alpha = a.commit.area.localeCompare(b.commit.area);
+          if (alpha !== 0) return alpha;
+          return a.index - b.index;
+        })
+        .map(({ commit }) => commit);
+      return { title, commits: members };
+    })
+    .filter((section) => section.commits.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Highlights
+// ---------------------------------------------------------------------------
+
+const MAX_HIGHLIGHTS = 6;
+
+/**
+ * Pick the 3–6 feat changes a reader cares about. Feat commits are grouped by
+ * PR (commits without a PR reference stand alone); groups are ranked by
+ * breaking-change presence, then by how many commits the change spans, then
+ * by recency (history order). The group's representative line is its most
+ * descriptive commit subject.
+ */
+export function selectHighlights(commits: ParsedCommit[]): Highlight[] {
+  const feats = commits.filter((commit) => commit.type === 'feat');
+  const groups = new Map<string, ParsedCommit[]>();
+  for (const commit of feats) {
+    const key = commit.pr === null ? commit.hash : `#${commit.pr}`;
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(commit);
+    else groups.set(key, [commit]);
+  }
+  return [...groups.values()]
+    .map((group, index) => ({ group, index }))
+    .sort((a, b) => {
+      const breaking = Number(b.group.some((c) => c.breaking)) - Number(a.group.some((c) => c.breaking));
+      if (breaking !== 0) return breaking;
+      const size = b.group.length - a.group.length;
+      if (size !== 0) return size;
+      return a.index - b.index;
+    })
+    .slice(0, MAX_HIGHLIGHTS)
+    .map(({ group }) => {
+      const representative = group.reduce((best, candidate) =>
+        candidate.description.length > best.description.length ? candidate : best,
+      );
+      const extraAreas = [...new Set(group.map((c) => c.area))]
+        .filter((area) => area !== representative.area)
+        .sort((a, b) => areaRank(a) - areaRank(b) || a.localeCompare(b));
+      return {
+        area: representative.area,
+        description: representative.description,
+        pr: representative.pr,
+        hash: representative.hash,
+        extraAreas,
+      };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Migrations
+// ---------------------------------------------------------------------------
+
+/** Filter `git diff --name-status` output down to added drizzle migration files. */
+export function parseAddedMigrations(nameStatusOutput: string): string[] {
+  return nameStatusOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [status, ...rest] = line.split('\t');
+      return { status: status ?? '', path: rest.join('\t') };
+    })
+    .filter(({ status, path }) => status === 'A' && /^packages\/db\/drizzle\/[^/]+\.sql$/.test(path))
+    .map(({ path }) => path)
+    .sort();
+}
+
+/**
+ * First paragraph of a migration's `--` header comment, joined into one line.
+ * Stops at the first blank comment line (`--` alone) or non-comment line.
+ */
+export function summarizeMigrationHeader(sql: string): string {
+  const paragraph: string[] = [];
+  for (const line of sql.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('--')) break;
+    const text = trimmed.replace(/^--\s?/, '').trim();
+    if (text.length === 0) {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    paragraph.push(text);
+  }
+  return paragraph.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function commitUrl(repo: string, hash: string): string {
+  return `https://github.com/${repo}/commit/${hash}`;
+}
+
+function refLink(repo: string, pr: number | null, hash: string): string {
+  if (pr !== null) return `[#${pr}](https://github.com/${repo}/pull/${pr})`;
+  return `[\`${hash.slice(0, 7)}\`](${commitUrl(repo, hash)})`;
+}
+
+function renderHighlights(input: ReleaseNotesInput, lines: string[]): void {
+  const highlights = selectHighlights(input.commits);
+  if (highlights.length === 0) return;
+  lines.push('### ✨ Highlights', '');
+  for (const highlight of highlights) {
+    const spans = highlight.extraAreas.length > 0 ? ` — with changes across ${highlight.extraAreas.join(', ')}` : '';
+    lines.push(
+      `- **${highlight.area}:** ${capitalize(highlight.description)}${spans} (${refLink(input.repo, highlight.pr, highlight.hash)})`,
+    );
+  }
+  lines.push('');
+}
+
+function renderBreakingChanges(input: ReleaseNotesInput, lines: string[]): void {
+  const breaking = input.commits.filter((commit) => commit.breaking);
+  if (breaking.length === 0) return;
+  lines.push('### 💥 Breaking changes', '');
+  for (const commit of breaking) {
+    const note = commit.breakingNote ? ` — ${commit.breakingNote}` : '';
+    lines.push(
+      `- **${commit.area}:** ${capitalize(commit.description)}${note} (${refLink(input.repo, commit.pr, commit.hash)})`,
+    );
+  }
+  lines.push('');
+}
+
+function renderMigrations(input: ReleaseNotesInput, lines: string[]): void {
+  if (input.migrations.length === 0) return;
+  const plural = input.migrations.length === 1 ? 'migration' : 'migrations';
+  lines.push(
+    '### 🗄️ Database migrations',
+    '',
+    `This release adds ${input.migrations.length} database ${plural}. Migrations are additive and idempotent`,
+    'per the repository migration contract, and the API applies them automatically at boot',
+    '(`migrateDb()`) — no manual upgrade step is required. See `packages/db/drizzle/` for details.',
+    '',
+  );
+  for (const migration of input.migrations) {
+    const name = migration.file.split('/').at(-1) ?? migration.file;
+    const url = `https://github.com/${input.repo}/blob/${input.toTag}/${migration.file}`;
+    const summary = migration.summary.length > 0 ? ` — ${migration.summary}` : '';
+    lines.push(`- [\`${name}\`](${url})${summary}`);
+  }
+  lines.push('');
+}
+
+function renderDetailSections(input: ReleaseNotesInput, lines: string[]): void {
+  for (const section of groupSections(input.commits)) {
+    lines.push(`### ${section.title}`, '');
+    for (const commit of section.commits) {
+      lines.push(`- **${commit.area}:** ${commit.description} (${refLink(input.repo, commit.pr, commit.hash)})`);
+    }
+    lines.push('');
+  }
+}
+
+function renderContributors(input: ReleaseNotesInput, lines: string[]): void {
+  const contributors = [...new Set(input.commits.map((commit) => commit.author))].filter(
+    (author) => author.length > 0 && !author.endsWith('[bot]'),
+  );
+  if (contributors.length === 0) return;
+  lines.push('### 👥 Contributors', '');
+  for (const author of contributors) lines.push(`- ${author}`);
+  lines.push('');
+}
+
+function renderVerification(input: ReleaseNotesInput, lines: string[]): void {
+  const version = input.toTag.replace(/^v/, '');
+  lines.push(
+    '### 🔐 Verifying release assets',
+    '',
+    'Each platform tarball (`darwin-arm64`, `linux-arm64`, `linux-x64-glibc`, `linux-x64-musl`) ships with a',
+    'cosign keyless signature (`.bundle`) and GitHub-native build provenance (`.provenance.json`). Verify any',
+    'tarball with:',
+    '',
+    '```sh',
+    `gh attestation verify omni-${version}-<platform>.tar.gz --repo ${input.repo}`,
+    '```',
+    '',
+  );
+}
+
+/** Render the full release body. Empty sections are omitted. */
+export function renderReleaseNotes(input: ReleaseNotesInput): string {
+  const lines: string[] = [];
+  renderHighlights(input, lines);
+  renderBreakingChanges(input, lines);
+  renderMigrations(input, lines);
+  renderDetailSections(input, lines);
+  renderContributors(input, lines);
+  renderVerification(input, lines);
+  if (input.fromTag) {
+    lines.push(
+      `**Full changelog:** [${input.fromTag}...${input.toTag}](https://github.com/${input.repo}/compare/${input.fromTag}...${input.toTag})`,
+      '',
+    );
+  }
+  return `${lines.join('\n').trim()}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Git plumbing (thin, untested wrapper around the pure logic above)
+// ---------------------------------------------------------------------------
+
+const FIELD_SEPARATOR = '\u001f';
+const RECORD_SEPARATOR = '\u001e';
+const TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
+const REPO_PATTERN = /^[\w.-]+\/[\w.-]+$/;
+
+function runGit(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/** Split `git log` output produced with the %H%x1f%an%x1f%s%x1f%b%x1e format. */
+export function splitLogRecords(logOutput: string): RawCommit[] {
+  return logOutput
+    .split(RECORD_SEPARATOR)
+    .map((record) => record.replace(/^\n/, ''))
+    .filter((record) => record.trim().length > 0)
+    .map((record) => {
+      const [hash, author, subject, body] = record.split(FIELD_SEPARATOR);
+      return RawCommitSchema.parse({
+        hash: hash?.trim() ?? '',
+        author: author ?? '',
+        subject: subject ?? '',
+        body: body ?? '',
+      });
+    });
+}
+
+function collectCommits(fromTag: string | null, toTag: string): ParsedCommit[] {
+  const range = fromTag ? `${fromTag}..${toTag}` : toTag;
+  const output = runGit([
+    'log',
+    `--format=%H${FIELD_SEPARATOR}%an${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%b${RECORD_SEPARATOR}`,
+    range,
+  ]);
+  return splitLogRecords(output)
+    .map(parseCommit)
+    .filter((commit): commit is ParsedCommit => commit !== null);
+}
+
+function collectMigrations(fromTag: string | null, toTag: string): MigrationEntry[] {
+  if (!fromTag) return [];
+  const diff = runGit(['diff', '--name-status', `${fromTag}..${toTag}`, '--', 'packages/db/drizzle']);
+  return parseAddedMigrations(diff).map((file) => ({
+    file,
+    summary: summarizeMigrationHeader(runGit(['show', `${toTag}:${file}`])),
+  }));
+}
+
+function main(): void {
+  const { values } = parseArgs({
+    options: {
+      from: { type: 'string' },
+      to: { type: 'string' },
+      repo: { type: 'string' },
+      output: { type: 'string' },
+    },
+  });
+  const toTag = values.to ?? '';
+  if (!TAG_PATTERN.test(toTag)) {
+    throw new Error(`--to must be a vX.Y.Z release tag, got: ${toTag || '(missing)'}`);
+  }
+  const fromTag = values.from ?? null;
+  if (fromTag !== null && !TAG_PATTERN.test(fromTag)) {
+    throw new Error(`--from must be a vX.Y.Z release tag, got: ${fromTag}`);
+  }
+  const repo = values.repo ?? process.env.GITHUB_REPOSITORY ?? 'automagik-dev/omni';
+  if (!REPO_PATTERN.test(repo)) {
+    throw new Error(`repo must look like owner/name, got: ${repo}`);
+  }
+
+  const notes = renderReleaseNotes({
+    repo,
+    fromTag,
+    toTag,
+    commits: collectCommits(fromTag, toTag),
+    migrations: collectMigrations(fromTag, toTag),
+  });
+
+  if (values.output) {
+    writeFileSync(values.output, notes);
+    console.error(`wrote release notes for ${toTag} to ${values.output}`);
+  } else {
+    console.log(notes);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## What

Replaces the git-cliff release-notes step in `release.yml` with a deterministic, tested Bun generator: `scripts/release/generate-release-notes.ts`. The workflow step becomes a thin caller; all logic is pure, exported, and covered by `bun test`.

## Why

Current release bodies are a wall of commits: no summary, no scope grouping, version-bump/merge noise, no migration or breaking-change callouts, no compare link, and nothing telling a user how to verify the signed assets.

## What the new notes contain

- **✨ Highlights** — up to 6 feat changes, grouped by PR (breaking first, then change size, then recency), rendered as readable sentences with the other areas the change touched.
- **💥 Breaking changes** — from `!` markers and `BREAKING CHANGE:`/`BREAKING-CHANGE:` footers, with the footer note inline.
- **🗄️ Database migrations** — every `packages/db/drizzle/*.sql` file added in the range, linked at the release tag, with the first header-comment paragraph as its summary, plus the "auto-applied at boot via `migrateDb()`" upgrade pointer.
- **Detail sections** by conventional type (same emoji titles as before), entries clustered by normalized area (`api`, `cli`, `channels/<name>`, `events`, `db`, …), PR links (`#N`) when derivable from the subject, commit links as fallback.
- **👥 Contributors** (bots excluded), **🔐 verification instructions** matching the 12 signed assets the pipeline actually publishes (4 platform tarballs + cosign `.bundle` + `.provenance.json`), and a **`vPREV...vNEW` compare link**.
- `chore(version)` bumps, `chore(merge)` sync commits, and unconventional subjects (merge commits) are dropped. Empty sections are omitted.

## Contract safety

- The `Resolve release tag` step is untouched: notes remain bound to `needs.sign-attest.outputs.version` and the requested-vs-published version check stays (`stable-release-order.test.sh:614` and the adjacent assertion both pass).
- `oven-sh/setup-bun` is the same full-SHA pin used by `version.yml`/`ci.yml` (the pin rule scans all workflows).
- `continue-on-error` + the non-empty-file guard are preserved: a notes bug can never turn the release red.
- Both contract gates green: `release-workflow-contract.test.sh`, `stable-release-order.test.sh`.

## Boundary note

One deviation from the requested file scope: `knip.json` gained one `entry` line (`scripts/release/generate-release-notes.test.ts`) — without it `make check`'s dead-code gate reports the new test as an unused file. `cliff.toml` is now unused by workflows but left in place (deleting it felt out of scope; happy to remove in a follow-up).

## Validation

- `bun test scripts/release/generate-release-notes.test.ts` — 36 pass.
- `bash scripts/release/release-workflow-contract.test.sh` + `stable-release-order.test.sh` — PASS.
- `bun run lint`, `bunx knip`, `make verify-migrations`, `make typecheck` — green.
- Dry run against real history below.

## Sample output — `--from v2.260902.5 --to v2.260908.12`

<details>
<summary>Rendered release body (click to expand)</summary>

### ✨ Highlights

- **api:** Expose transactionalEmissions on automation create/update — with changes across cli, automations, db ([#988](https://github.com/automagik-dev/omni/pull/988))
- **db:** Add event_schemas registry table and webhook_sources.event_type_mapping — with changes across api, cli, core ([#959](https://github.com/automagik-dev/omni/pull/959))
- **api:** Durable consumer surface — register, pull from cursor, ack, lag — with changes across cli, db ([#989](https://github.com/automagik-dev/omni/pull/989))
- **cli:** Surface compiled state in agents graph and automations list — with changes across api, db ([#986](https://github.com/automagik-dev/omni/pull/986))
- **api:** Expose strictSchemas on webhook sources across API, SDK, and CLI — with changes across events, db ([#1000](https://github.com/automagik-dev/omni/pull/1000))
- **api:** Auth-required harness channel routes — say, transcript, tap, reset — with changes across channels/harness, cli+sdk ([#953](https://github.com/automagik-dev/omni/pull/953))

### 🗄️ Database migrations

This release adds 12 database migrations. Migrations are additive and idempotent
per the repository migration contract, and the API applies them automatically at boot
(`migrateDb()`) — no manual upgrade step is required. See `packages/db/drizzle/` for details.

- [`0053_gupshup_handoff_options.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0053_gupshup_handoff_options.sql) — Gupshup per-instance handoff options.
- [`0054_asc_flow_channel.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0054_asc_flow_channel.sql) — ASC platform Flow channel — per-instance configuration.
- [`0055_asc_flow_handoff_mode.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0055_asc_flow_handoff_mode.sql) — ASC platform Flow channel — which handoff destination an instance uses.
- [`0056_event_schema_registry.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0056_event_schema_registry.sql) — Event schema registry (issue #959, RFC #925 G1).
- [`0057_connector_lifecycle_contract.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0057_connector_lifecycle_contract.sql) — Connector lifecycle contract (#961) — liveness, heartbeat, declared window/mutation semantics on webhook_sources.
- [`0058_omni_events_causation_id.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0058_omni_events_causation_id.sql) — causationId in the persisted event journal (#957, RFC #925 G3 feature half).
- [`0059_ingress_idempotency.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0059_ingress_idempotency.sql) — Ingress idempotency (#958, RFC #925 G2).
- [`0060_webhook_source_strict_schemas.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0060_webhook_source_strict_schemas.sql) — Per-source strict schema validation (issue #1000, RFC #925 G1 tail).
- [`0061_automation_transactional_emissions.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0061_automation_transactional_emissions.sql) — Per-automation transactional publication flag (issue #988, RFC #925 G5).
- [`0062_agent_event_manifest.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0062_agent_event_manifest.sql) — Agent event subscription manifest (#985, RFC #925 G4a).
- [`0063_automation_manifest_provenance.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0063_automation_manifest_provenance.sql) — Manifest-compilation provenance on automations (#986, RFC #925 G4b).
- [`0064_durable_consumers.sql`](https://github.com/automagik-dev/omni/blob/v2.260908.12/packages/db/drizzle/0064_durable_consumers.sql) — Durable named event consumers (#989, RFC #925 G7 — the durable half of the event-consumer surface; the one-shot half, `omni events wait`, shipped in PR #972).

### 🚀 Features

- **api:** durable consumer surface — register, pull from cursor, ack, lag ([#989](https://github.com/automagik-dev/omni/pull/989))
- **api:** compile agent manifests into managed routing automations ([#986](https://github.com/automagik-dev/omni/pull/986))
- **api:** agent manifest read/write routes + manifest.updated event ([`5e10c8d`](https://github.com/automagik-dev/omni/commit/5e10c8df85fa87ad956dda9c1f10eeaaab4ed082))
- **api:** expose transactionalEmissions on automation create/update ([#988](https://github.com/automagik-dev/omni/pull/988))
- **api:** expose strictSchemas on webhook sources across API, SDK, and CLI ([#1000](https://github.com/automagik-dev/omni/pull/1000))
- **api:** platform credential bootstrap without direct SQL ([`383e0b2`](https://github.com/automagik-dev/omni/commit/383e0b25eeff25f2ac1b768c66e1b60c9f0a1130))
- **api:** expose multitenancy posture on auth validate ([`c0f9179`](https://github.com/automagik-dev/omni/commit/c0f91793aa5f6d5d265dcb757dbb4d92930c9519))
- **api:** expose platform root-key issuance route ([`6f71937`](https://github.com/automagik-dev/omni/commit/6f719379c9a33644cc70b27856e7bc04f1af17cc))
- **api:** auth-required harness channel routes — say, transcript, tap, reset ([#953](https://github.com/automagik-dev/omni/pull/953))
- **api:** dedupe webhook ingress via idempotency-key journal claim ([`587e876`](https://github.com/automagik-dev/omni/commit/587e87631973c476957decc09e946bed8b6195a0))
- **api:** event schema registry service, ingress/emit gates, source-type mapping ([#959](https://github.com/automagik-dev/omni/pull/959))
- **api:** connector heartbeat verb, liveness sweeper, stalled DLQ surfacing ([`9d343a2`](https://github.com/automagik-dev/omni/commit/9d343a2f93a0c4887aab8715a6002ed6874fe104))
- **cli:** omni events consumers + events follow ([#989](https://github.com/automagik-dev/omni/pull/989))
- **cli:** --event-type-mapping flag on omni webhooks create/update ([#1011](https://github.com/automagik-dev/omni/pull/1011))
- **cli:** surface compiled state in agents graph and automations list ([#986](https://github.com/automagik-dev/omni/pull/986))
- **cli:** omni agents manifest get/apply and omni agents graph ([`c63fc5e`](https://github.com/automagik-dev/omni/commit/c63fc5e69596d46c36324984c92b51b605c7e872))
- **cli:** --transactional-emissions on automations create/update ([#988](https://github.com/automagik-dev/omni/pull/988))
- **cli:** tenants keys issue-root subcommand ([`5b2eca7`](https://github.com/automagik-dev/omni/commit/5b2eca7538faecd390d8ab08425c1e14a2788dfd))
- **cli:** render server tenancy posture in status ([`1afcc72`](https://github.com/automagik-dev/omni/commit/1afcc72067e5cc82aefbdfca20a50c5529784b93))
- **cli:** omni tenants command group ([`7a6aec4`](https://github.com/automagik-dev/omni/commit/7a6aec408f13d40840872121bb3105d04c9c2019))
- **cli:** add omni events wait one-shot blocking subscription ([`9e9de38`](https://github.com/automagik-dev/omni/commit/9e9de3800248d72fc188fcac09be7beea4350864))
- **cli:** omni events schema register/list/get ([#959](https://github.com/automagik-dev/omni/pull/959))
- **channels/asc-flow:** carry who the beneficiary IS into the Genesys userdata ([`2e69275`](https://github.com/automagik-dev/omni/commit/2e692759374c589d5437da39c9ad0d590144ee6d))
- **channels/asc-flow:** send real interactives, with a description on every row ([`3cda2f9`](https://github.com/automagik-dev/omni/commit/3cda2f9d559428fcab336b6077b6a4abaa03a1d1))
- **channels/asc-flow:** outbound rico via POST /mensagem ([`7404840`](https://github.com/automagik-dev/omni/commit/7404840ea8f1d0d43cb725f666c745a45a76a9ae))
- **channels/asc-flow:** resolve inbound media off the atendimento ([`0efce4b`](https://github.com/automagik-dev/omni/commit/0efce4bf8f536d1b6baf454e06fe4686e0d7b590))
- **channels/asc-flow:** answer the api_rest poll in the HTTP body ([`bf738b3`](https://github.com/automagik-dev/omni/commit/bf738b3b8947a36ca845bbb6df07b984e3d385cd))
- **channels/asc-flow:** ASC platform Flow channel ([`814a67d`](https://github.com/automagik-dev/omni/commit/814a67d7638f1f4d8521d896ee4077e04e3f3819))
- **channels/gupshup:** per-instance handoff routing defaults and customerFields template ([`170d37c`](https://github.com/automagik-dev/omni/commit/170d37c8176a19eba0cdf99124bde77a7f0b5d3a))
- **channels/harness:** E2E agent-testing channel plugin ([#953](https://github.com/automagik-dev/omni/pull/953))
- **channels/slack:** record thread roots, reply counters and pin state (#889 tail) ([`e4574ad`](https://github.com/automagik-dev/omni/commit/e4574ad17fc85a0b04d1fcf02de2efb1834bab23))
- **events:** enforce the publishes allowlist on agent emissions ([#987](https://github.com/automagik-dev/omni/pull/987))
- **events:** enforce strict schema mode at webhook ingress and emit_event ([#1000](https://github.com/automagik-dev/omni/pull/1000))
- **events:** trailing-* glob type filters in list API and CLI stream ([`93f6345`](https://github.com/automagik-dev/omni/commit/93f634565ad276cc6e311fdd7bb4bb1d145ea2eb))
- **events:** causationId stamping + omni events trace ([`d00dd8d`](https://github.com/automagik-dev/omni/commit/d00dd8d7e8b39bd02938e3d72d5dae90987f5d29))
- **automations:** chatless call_agent dispatch — event→agent without a chat context ([#1010](https://github.com/automagik-dev/omni/pull/1010))
- **automations:** buffer a run's emissions, flush in order on success ([#988](https://github.com/automagik-dev/omni/pull/988))
- **automations:** forward the OmniEvent envelope in webhook/call_agent actions ([`0ad37f0`](https://github.com/automagik-dev/omni/commit/0ad37f015ec4dd214dc14f4051d1886f021867b4))
- **db:** journal_seq total order + durable_consumers registry ([#989](https://github.com/automagik-dev/omni/pull/989))
- **db:** add automations.managed_by_agent_id manifest provenance ([#986](https://github.com/automagik-dev/omni/pull/986))
- **db:** agents.event_manifest jsonb column (migration 0061) ([`ff5d5a3`](https://github.com/automagik-dev/omni/commit/ff5d5a38270be6542106be196318e2c4311e89a5))
- **db:** add automations.transactional_emissions flag ([#988](https://github.com/automagik-dev/omni/pull/988))
- **db:** add webhook_sources.strict_schemas policy flag ([#1000](https://github.com/automagik-dev/omni/pull/1000))
- **db:** add omni_events.causation_id column + index ([`f084716`](https://github.com/automagik-dev/omni/commit/f084716942b507992943ced11d5f1803e2166c98))
- **db:** connector lifecycle contract columns on webhook_sources ([`8a7ba92`](https://github.com/automagik-dev/omni/commit/8a7ba9255806c524d286191f736e69b3632497fc))
- **db:** ingress idempotency key on omni_events + per-source key template ([`e7a564e`](https://github.com/automagik-dev/omni/commit/e7a564e0c69262f42ad788b6ec58ab0f54a524ef))
- **db:** add event_schemas registry table and webhook_sources.event_type_mapping ([#959](https://github.com/automagik-dev/omni/pull/959))
- **core:** agent event manifest schema (accepts/publishes, RFC #925 G4a) ([`bc292f6`](https://github.com/automagik-dev/omni/commit/bc292f6d6907e67381593a7c53c93d804a922c2a))
- **core:** derive emit_event idempotency keys from execution provenance ([`c6984c9`](https://github.com/automagik-dev/omni/commit/c6984c93211fff362535d2a9c6076c8757d2d54a))
- **core:** event schema registry primitives and emit_event validation gate ([#959](https://github.com/automagik-dev/omni/pull/959))
- **core:** connector liveness sweep + system.connector.stalled/recovered events ([`9d0bb34`](https://github.com/automagik-dev/omni/commit/9d0bb3446c4460a2cc3e44f7036a374f2b26bd13))
- **sdk:** agents.getManifest/updateManifest + regenerated types ([`33fc250`](https://github.com/automagik-dev/omni/commit/33fc2503bd90e3b1f136cdcf77ab488b03fc59c5))
- **sdk:** issueRoot platform tenant key method ([`7b20c5f`](https://github.com/automagik-dev/omni/commit/7b20c5f0259d4515b14bc97ff24fb9f9b21fa2ce))
- **sdk:** carry server tenancy posture through auth validate ([`3536e74`](https://github.com/automagik-dev/omni/commit/3536e74c4e100ce425191a6470169684771e346d))
- **sdk:** platform tenant control-plane client methods ([`45e84e0`](https://github.com/automagik-dev/omni/commit/45e84e03af1c2bc782afdb9c5d570fe0dfc13448))
- **ci:** add static migration contract gate for drizzle migrations ([`1b78699`](https://github.com/automagik-dev/omni/commit/1b7869908fceb1af4aa8228d93526f63aad22bcd))
- **cli+sdk:** register the harness channel across distribution surfaces ([#953](https://github.com/automagik-dev/omni/pull/953))
- **make:** add check-all to run check and the pg-gate concurrently ([`f04661a`](https://github.com/automagik-dev/omni/commit/f04661abccbbec6402a66d3fbb1f19ed9a2ad67c))
- **scripts:** keep-warm wrapper for the pg-gate dev loop ([`6c0d063`](https://github.com/automagik-dev/omni/commit/6c0d063a100cd25b935e6e9113cce28c6e00d8d2))
- **sdk+cli:** expose idempotency_key_template on webhook sources ([`8ca8ebb`](https://github.com/automagik-dev/omni/commit/8ca8ebb74287af21cfdd595c8ab108e35e86211e))
- **sdk+cli:** heartbeat verb + liveness/semantics on the webhooks surface ([`106ccc6`](https://github.com/automagik-dev/omni/commit/106ccc62b89c6dcb6878ad05774796f5a2d77bd7))
- **sources:** ClickUp webhook source recipe — runbook, schemas, e2e proof ([#984](https://github.com/automagik-dev/omni/pull/984))
- **webhooks:** body-sourced eventTypeMapping + array indices in payload paths ([#984](https://github.com/automagik-dev/omni/pull/984))

### 🐛 Bug Fixes

- **api:** unexport internal pull clamps flagged by knip ([`f478e90`](https://github.com/automagik-dev/omni/commit/f478e90b48b47957e4afe81a2e6a66e81450cbb5))
- **api:** skip MinIO suites when Docker cannot publish ports ([#948](https://github.com/automagik-dev/omni/pull/948))
- **api:** validate OpenAI chat-lane STT output and default to gpt-4o-transcribe ([`02cd30c`](https://github.com/automagik-dev/omni/commit/02cd30c1c5a747f1094ef2759689d104eedc17d5))
- **api:** skip agent-authored echoes in dispatch self-check ([#938](https://github.com/automagik-dev/omni/pull/938))
- **api:** expose gupshupHandoffOptions in OpenAPI and the SDK types ([`e13f762`](https://github.com/automagik-dev/omni/commit/e13f7627badac91956a9e96c9877e41d46f5fdcc))
- **api:** thread persisted Gupshup credentials through instance restart ([`35fcc75`](https://github.com/automagik-dev/omni/commit/35fcc750b700b348ebba69047ac9c47952ecebaa))
- **cli:** pin the native fetch in the events-schema round-trip suite ([`f021d77`](https://github.com/automagik-dev/omni/commit/f021d77ae6ed115f8def3e8f06be0ede2636da3c))
- **cli:** accept --gupshup-handoff-options on instances update ([`5c5d00a`](https://github.com/automagik-dev/omni/commit/5c5d00a6efe06fe929728d9d226f21a60d139af0))
- **channels/asc-flow:** forward the empty identity fields — the store is all-or-nothing ([`e0bbb63`](https://github.com/automagik-dev/omni/commit/e0bbb6336c0199c4f78f03a0325f95e37169ac34))
- **channels/asc-flow:** never send a list — it contradicts the message it hangs under ([`f340afb`](https://github.com/automagik-dev/omni/commit/f340afb8e94a54bb004692d8a57f48153421e4c4))
- **channels/asc-flow:** the two halves of "is this a re-send" are complementary, not alternatives ([`d1a226e`](https://github.com/automagik-dev/omni/commit/d1a226eb2de383ef3cd3772945b472c005110d3b))
- **channels/asc-flow:** tell a re-sent input from a real turn by the body, not by asking ([`ffb9546`](https://github.com/automagik-dev/omni/commit/ffb9546551e64eaa5f266108ba1b560bf4fe2fa8))
- **channels/asc-flow:** transliterate the punctuation a latin-1 platform cannot carry ([`8e5254b`](https://github.com/automagik-dev/omni/commit/8e5254bd85652b50141e8ea955e64846657c1546))
- **channels/asc-flow:** take buttons over a requested list — a list never renders here ([`b1f6fb8`](https://github.com/automagik-dev/omni/commit/b1f6fb812727afbd2fa1eb3920272eef9fddafac))
- **channels/asc-flow:** hold the inbound under the node's real timeout ([`ade9f07`](https://github.com/automagik-dev/omni/commit/ade9f078af59306b7becb68b383c5ac4c7b72dbc))
- **channels/asc-flow:** drop the input a restarted flow replays ([`1ecc8e1`](https://github.com/automagik-dev/omni/commit/1ecc8e1f5a884334dc5bc85c0029845b36cdf545))
- **channels/asc-flow:** deliver the turn by push, and stop the flow's loop-back from replaying it ([`f011c49`](https://github.com/automagik-dev/omni/commit/f011c49b778775949c8a9227ef76ce93d49dff26))
- **channels/asc-flow:** answer one turn per agent reply, not per dispatched part ([`897bb45`](https://github.com/automagik-dev/omni/commit/897bb457872863964b9fbce3317b06a87f8c38b5))
- **channels/asc-flow:** correlate answers to their own turn (review round 2) ([`bf50314`](https://github.com/automagik-dev/omni/commit/bf5031483397e2729ede483a570ec461bfcce2d7))
- **channels/asc-flow:** fila_vq is mandatory in flow mode ([`8cb9cf6`](https://github.com/automagik-dev/omni/commit/8cb9cf64084b54786d48fbba9990fbd1dffc42f3))
- **channels/asc-flow:** bound the turn window and stop leaking a cache per reconnect ([`efa85fb`](https://github.com/automagik-dev/omni/commit/efa85fb8c7c7ec4f855262d0b0818f9405daec94))
- **channels/asc-flow:** guarantee every in-flight turn ends, and stop pausing the agent in flow mode ([`49d6ddf`](https://github.com/automagik-dev/omni/commit/49d6ddfeec2504dedab8087de84946e88a0d8892))
- **channels/asc-flow:** the two handoff destinations are exclusive, default to flow ([`a23c3f3`](https://github.com/automagik-dev/omni/commit/a23c3f3b499bf3930beb22adb1a4e2c7eaa60c5b))
- **channels/asc-flow:** read the handoff dialect the REST route forwards ([`6111e97`](https://github.com/automagik-dev/omni/commit/6111e979953859c9d13167eeeda677259270d644))
- **channels/asc-flow:** hand_off 'sim' only when the transfer was accepted ([`bb8272f`](https://github.com/automagik-dev/omni/commit/bb8272fde811cce09ffec57793fe740bce548026))
- **channels/asc-flow:** ship media bytes, never a foreign url_arquivo ([`8535e1b`](https://github.com/automagik-dev/omni/commit/8535e1b023aa81ab1c16db7930ef10aa4060ef88))
- **channels/asc-flow:** publish mediaUrl so the agent waits for the media ([`71965dc`](https://github.com/automagik-dev/omni/commit/71965dc3f813bb0d771a4df0e346a3b47d040bcf))
- **channels/asc-flow:** encode emoji as platform markers on outbound ([`862dcde`](https://github.com/automagik-dev/omni/commit/862dcde8019bb3dd92c5fde40c414faa1b6425b4))
- **channels/asc-flow:** decode the platform's transcoded emoji on inbound ([`78790c0`](https://github.com/automagik-dev/omni/commit/78790c06928611cda5fcb96690d6dda8122af1c9))
- **channels/asc-flow:** convert markdown to WhatsApp syntax on outbound ([`d1b52b3`](https://github.com/automagik-dev/omni/commit/d1b52b3fab87f6cc54ce15e1d5e7e14c7d0ddce9))
- **channels/asc-flow:** dedupe async api_rest re-polls by default ([`d1cedaa`](https://github.com/automagik-dev/omni/commit/d1cedaa65a4916868022c182660544812bce5606))
- **channels/slack:** verify the Socket Mode WebSocket instead of trusting app.start() ([#941](https://github.com/automagik-dev/omni/pull/941))
- **events:** map chatUuid/personId onto custom journal rows ([`14c874f`](https://github.com/automagik-dev/omni/commit/14c874fd127d227a49e27b38c6b5a1c14e6bad80))
- **events:** journal custom event types at the column's 255 chars ([`278bb1b`](https://github.com/automagik-dev/omni/commit/278bb1b1bd5f6d72146b11ebc83309dfec6c50d9))
- **events:** thread the triggering envelope so correlation survives automation hops ([`b31a76c`](https://github.com/automagik-dev/omni/commit/b31a76c6a0854870b1dc2add3580b373d94cfd9d))
- **db:** keep event_schemas global-only for now (RLS coverage gate, scheduled_messages precedent) ([`536e709`](https://github.com/automagik-dev/omni/commit/536e709c76c5c105de3c27a87e926c7b96291cf2))
- **core:** close the turn-window and pause-agent contracts (review #921) ([`6ad24e9`](https://github.com/automagik-dev/omni/commit/6ad24e961916880059f473b1f2c6884e93b352a1))
- **ci:** compare migration contract against dev, the deployment base ([`544f89a`](https://github.com/automagik-dev/omni/commit/544f89a96b7cb1ea5dc0e02ba26e38b75485f182))
- **deps:** unify Bun typings on @types/bun@1.3.14 across the workspace ([`6d1d4aa`](https://github.com/automagik-dev/omni/commit/6d1d4aae67bb00a18d98bf68e5c32c6bdfc71dbe))
- **helm:** set TRUSTED_PROXY_HEADER in proxied realms ([`e850d60`](https://github.com/automagik-dev/omni/commit/e850d60001aac56fc8a1b54d72ba651a922baba8))
- **lint:** ignore Obsidian vault config under brain/.obsidian ([`cf20836`](https://github.com/automagik-dev/omni/commit/cf20836eff86676adf098ca10155cdd4c887c3ff))
- **make:** scope make test to packages and apps/ui like CI ([`321d2a3`](https://github.com/automagik-dev/omni/commit/321d2a3e5cee87e41f6ec64aba55c3d6794ab61b))
- **media-processing:** stop accepting chat replies as audio transcriptions ([`aad1efb`](https://github.com/automagik-dev/omni/commit/aad1efb0f72cd3ba7c65786777f0c89230b7971b))
- **tenancy:** register the persons journal lookup with the db-access guard ([`e1fbfc2`](https://github.com/automagik-dev/omni/commit/e1fbfc27b8ef0fdfdf802df987528e4bf56ce32a))
- **test:** tolerate mid-scan vanished files in the repo-tree guards ([`254a298`](https://github.com/automagik-dev/omni/commit/254a298eca2825194c45f7881d534b5a5deae3f0))
- **test:** clear guard scratch dirs before the baseline scan ([`d582142`](https://github.com/automagik-dev/omni/commit/d582142fd48bdf671929fb5fa9d09799f2ab9efb))
- **test-harness:** stop shared MinIO container via bun:test lifecycle, reap non-running leaks ([#999](https://github.com/automagik-dev/omni/pull/999))
- **ts:** point the types array at @types/bun, not the removed bun-types ([`6548125`](https://github.com/automagik-dev/omni/commit/6548125d3ca21b5033c2697302562e758bafe20e))

### ⚡ Performance

- **db:** clone pg-gate suite databases from a migrated template ([`b03a4b8`](https://github.com/automagik-dev/omni/commit/b03a4b85c12dca24efed9ee50c071711af124e22))
- **core:** add a 'silent' log threshold and default test runs to it ([`ac7d43b`](https://github.com/automagik-dev/omni/commit/ac7d43b53f354517229b28cd6ea73fbfe2d1cc49))
- **release-tests:** clone the pinned release boundary from a template ([`d41c812`](https://github.com/automagik-dev/omni/commit/d41c812d73b6eb7770a89d1607bafb8224a6a17e))
- **test:** run the test gate per-package through the turbo cache ([`ddd5c82`](https://github.com/automagik-dev/omni/commit/ddd5c82a648a46f5d261812575aa5e4a8bd707e5))

### ♻️ Refactoring

- **api:** route compiler writes through AutomationService internal path ([`37204ff`](https://github.com/automagik-dev/omni/commit/37204ffa6cf7e41d22022102e35789f7cff3c045))

### 🧪 Testing

- **api:** fake GitHub deliveries end-to-end through the unmodified ingress ([#983](https://github.com/automagik-dev/omni/pull/983))
- **api:** reap stale MinIO containers leaked by SIGKILLed runs ([`3306701`](https://github.com/automagik-dev/omni/commit/330670123799cf37a4abf55e8b8f54807a5e1e04))
- **channels/sdk:** exclude channel-harness from transport compliance coverage ([#953](https://github.com/automagik-dev/omni/pull/953))
- **automations:** pin the native fetch in the webhook-envelope suite ([`4569307`](https://github.com/automagik-dev/omni/commit/45693079a30c7d60a75be74a24562e7ddc4fd060))
- **release:** pin the 2.260902.5 rehearsal to its own migration set ([`6597dd6`](https://github.com/automagik-dev/omni/commit/6597dd688ac7bab21c41db5ca2c6c186bf943f34))
- **tenancy:** cover the custom-event journal consumer in the G5 harness ([`0051fb5`](https://github.com/automagik-dev/omni/commit/0051fb5dfd2cd64e389012bbfae6c27a05760ce3))

### 📚 Documentation

- **channels/asc-flow:** operational runbook for the ASC integration ([`cf12726`](https://github.com/automagik-dev/omni/commit/cf12726293cb08c8c2ac4247a6030f619d95a055))
- **events:** durable consumers runbook ([#989](https://github.com/automagik-dev/omni/pull/989))
- **db:** officialize the hand-written migration precedent ([#962](https://github.com/automagik-dev/omni/pull/962))
- **architecture:** connector lifecycle contract ([#961](https://github.com/automagik-dev/omni/pull/961))
- **ci:** record the merge-queue decision and the one-time dev settings change ([`71a299b`](https://github.com/automagik-dev/omni/commit/71a299b097f1048360ae725e90ac78ef0575b1f5))
- **claude:** document the faster local gates ([`e5a30cd`](https://github.com/automagik-dev/omni/commit/e5a30cdd8f268c273865296436151c86186e72a2))
- **runbooks:** use --event-type-mapping instead of the PATCH curl ([#1011](https://github.com/automagik-dev/omni/pull/1011))
- **sources:** GitHub webhook source runbook + event schema artifacts ([#983](https://github.com/automagik-dev/omni/pull/983))

### ⚙️ CI/CD

- **commitlint:** pin checkout and commitlint actions to full commit SHAs ([`d9293e1`](https://github.com/automagik-dev/omni/commit/d9293e1b8e933b43be5c406f345071496bfe4e8b))
- **hooks:** run pre-push tests through turbo and bound concurrency ([`97cf1ad`](https://github.com/automagik-dev/omni/commit/97cf1ad5a5add9a017a4acdb60a9a65ae3a1fb01))
- **images:** build the dev image once per merged PR via a reusable call ([`c6731a1`](https://github.com/automagik-dev/omni/commit/c6731a17f9a5dddc135166d2767b27b3fb0064b1))
- **images:** publish an attested dev image channel on every dev push ([`710c701`](https://github.com/automagik-dev/omni/commit/710c7018a03467aff775decbefbd3f5371a97821))
- **migration-gate:** fall back to the base branch when HEAD^1 is unfetchable ([`24d292a`](https://github.com/automagik-dev/omni/commit/24d292a979879bf1c9685d2dbe9f0fb43a15aa9f))
- **migration-gate:** compare PRs against the merge commit's first parent ([`8a65a39`](https://github.com/automagik-dev/omni/commit/8a65a39b760f26d9be4ccba68dda840f555a2a16))
- **quality-gate:** run CI on merge_group so a dev merge queue tests combined state ([`d1ee7ea`](https://github.com/automagik-dev/omni/commit/d1ee7ea08862517de57739cbb94daf331a9b17ee))
- **quality-gate:** turbo-cache the PR test run, keep the sweep on pushes ([`2581d19`](https://github.com/automagik-dev/omni/commit/2581d19ad230f0210c9964ca13963420a31eed0a))
- **release:** sync image-build.yml with dev (fail-closed release lookup) ([`5f02f82`](https://github.com/automagik-dev/omni/commit/5f02f8237c7bf050aa5e9a5d3e6c8a14548182ef))
- **release:** sync image-build.yml with dev (cold build, raw OCI index check) ([`d37cd98`](https://github.com/automagik-dev/omni/commit/d37cd98c04aeceaf9200dc0d4944c34bdf55a0f8))
- **release:** register image-build.yml on main so it can be dispatched ([`ea92308`](https://github.com/automagik-dev/omni/commit/ea92308ed05a3748ba4436ada28b71b824e35305))
- **turbo:** give the test task an accurate fingerprint ([`f168c95`](https://github.com/automagik-dev/omni/commit/f168c953988518d8da94d5c41afb37b04695f298))

### 🔧 Miscellaneous

- **channels/asc-flow:** sync package version with the monorepo ([`525c141`](https://github.com/automagik-dev/omni/commit/525c141df125033632ece1910949d04b29472928))
- **core:** initialize project brain ([`4de1239`](https://github.com/automagik-dev/omni/commit/4de1239c1294fd153165d0f1a0c0fa154a5c5281))
- **license:** adopt Apache-2.0 repo-wide ([`4460b5d`](https://github.com/automagik-dev/omni/commit/4460b5db33aa62fcf637cb38993d5aa00704e59a))
- **pkg:** add npm keywords to @automagik/omni, mark @omni/api private ([`5fc554a`](https://github.com/automagik-dev/omni/commit/5fc554a00e0bc3b8b4d7b584b531c632054503ba))
- **release:** pin immutable candidate v2.260902.5 for the dev to main promotion ([`a9e56cc`](https://github.com/automagik-dev/omni/commit/a9e56ccb059e273ea97c6983e319fc0d35e1b54c))

### 👥 Contributors

- Cezar Vasconcelos
- namastex888
- moraisdev
- Sofia

### 🔐 Verifying release assets

Each platform tarball (`darwin-arm64`, `linux-arm64`, `linux-x64-glibc`, `linux-x64-musl`) ships with a
cosign keyless signature (`.bundle`) and GitHub-native build provenance (`.provenance.json`). Verify any
tarball with:

```sh
gh attestation verify omni-2.260908.12-<platform>.tar.gz --repo automagik-dev/omni
```

**Full changelog:** [v2.260902.5...v2.260908.12](https://github.com/automagik-dev/omni/compare/v2.260902.5...v2.260908.12)


</details>
