### PR TITLE
docs: refresh README and docs for the event backbone + multitenancy + channels wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="Apache 2.0 License" /></a>
   <img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?style=flat-square&logo=bun" alt="Bun" />
-  <img src="https://img.shields.io/badge/version-2.260804.3-8b5cf6?style=flat-square" alt="v2.260804.3" />
+  <img src="https://img.shields.io/badge/version-2.260908.13-8b5cf6?style=flat-square" alt="v2.260908.13" />
   <img src="https://img.shields.io/badge/channels-10-25D366?style=flat-square" alt="10 channels" />
   <img src="https://img.shields.io/badge/event%20bus-NATS%20JetStream-27AAE1?style=flat-square" alt="NATS JetStream" />
 </p>
@@ -46,14 +46,16 @@ Think of Omni as a deep-sea octopus. Each **channel** is a tentacle reaching int
 |---------|--------|------------|
 | **WhatsApp** (Baileys) | ✅ Stable | QR/phone pairing, media, reactions, groups, contacts, presence |
 | **WhatsApp Cloud API** (Meta) | ✅ Available | Embedded Signup OAuth, templates HSM, webhook (HMAC-SHA256), media, location, reactions |
-| **Discord** | ✅ Stable | Bots, embeds, polls, buttons, threads, slash commands |
-| **Slack** | ✅ Available | Bot/App token support |
+| **Discord** | ✅ Stable | Bots, embeds, polls, buttons, threads, slash commands, voice channels |
+| **Slack** | ✅ Available | Socket Mode or HTTP, bot & user (xoxp) token modes, threads, scheduled messages, permalinks, pins, message search |
 | **Telegram** | ✅ Available | Bot API, inline keyboards, groups, channels, threads, polls |
 | **A2A** | ✅ Available | Agent-to-agent channel integrations |
 | **Gupshup** | ✅ Available | Custom Integration webhook support |
 | **H3rmes** (Mutant) | ✅ Available | Brazilian WhatsApp gateway — JWT auth, media, templates, interactive, Pix-ready webhook shapes |
 | **ASC Flow** | ✅ Available | Brazilian BSP via the ASC platform Flow — REST callbacks, URA buttons/lists, Genesys handoff |
 | **Twilio WhatsApp** | ✅ Available | Twilio sender, webhook, and signature validation support |
+
+Also in the box: **Harness** (`--channel harness`), an E2E agent-testing channel that captures outgoing messages verbatim so you can drive and assert on agent conversations from tests, and an internal channel used for agent-to-agent routing.
 
 ## Install
 
@@ -184,6 +186,28 @@ omni automations create --name "priority-route" \
 
 </details>
 
+## Event Backbone
+
+Every state change lands in a total-ordered PostgreSQL journal and is published over NATS. The journal is the source of truth — you can filter it, trace it, wait on it, and consume it durably:
+
+```bash
+omni events list --type "message.*" --since 2h        # trailing-* glob type filters
+omni events trace <event-id>                          # causation chain, rendered as a tree
+omni events wait --type "custom.github.*" --timeout 60  # block until a matching event arrives
+
+# Durable named consumers — resumable cursors over the journal
+omni events consumers create deploy-watcher --type "custom.github.*"
+omni events follow --consumer deploy-watcher          # at-least-once, acks as it goes
+```
+
+**Webhook sources** turn external systems into event emitters with configuration only — no code: raw-body signature verification (HMAC-SHA256/SHA1 or token match), per-source idempotency key templates, event-type mapping to `custom.<source>.<event>`, optional strict schema validation, and heartbeat-based connector liveness (`system.connector.stalled` / `recovered`). Working recipes: [GitHub](docs/runbooks/github-webhook-source.md) and [ClickUp](docs/runbooks/clickup-webhook-source.md).
+
+**Event schemas** are registered once (`omni events schema register`) and enforced at webhook ingress and automation `emit_event` — invalid payloads dead-letter instead of entering the journal.
+
+**Agent manifests** declare what each agent consumes and publishes (`omni agents manifest apply`, `omni agents graph`): the `publishes` list is enforced at emission time, and `accepts` compiles into managed routing automations. Automations can also buffer their emitted events and flush them in order only when the whole run succeeds (`--transactional-emissions`).
+
+Deep dives: [event system](docs/architecture/event-system.md) · [durable consumers](docs/runbooks/durable-consumers.md) · [agent publish governance](docs/runbooks/agent-publish-governance.md)
+
 ## Architecture
 
 ```text
@@ -221,8 +245,13 @@ packages/
 ├── channel-hermes/          # H3rmes (Brazilian WhatsApp gateway)
 ├── channel-twilio-whatsapp/ # Twilio WhatsApp
 ├── channel-a2a/             # A2A channel
+├── channel-asc-flow/        # ASC platform Flow (Brazilian BSP)
+├── channel-harness/         # E2E agent-testing channel
+├── channel-internal/        # In-process agent-to-agent routing
 ├── cli/                     # `omni` command
 ├── media-processing/        # Media sync and extraction
+├── plugin-openclaw/         # Omni as a channel inside OpenClaw
+├── voice-client/            # Voice transport/codec library (Discord voice)
 ├── sdk/                     # TypeScript SDK
 ├── sdk-go/                  # Go SDK
 └── sdk-python/              # Python SDK
@@ -293,7 +322,7 @@ omni persons presence <id>
 </details>
 
 <details>
-<summary><strong>Management</strong> — keys, providers, automations, access, webhooks</summary>
+<summary><strong>Management</strong> — keys, providers, automations, access, webhooks, schedule, tenants</summary>
 
 #### `keys` — API key management
 
@@ -337,9 +366,37 @@ Modes: `disabled` · `blocklist` · `allowlist`
 #### `webhooks` — External event sources
 
 ```bash
-omni webhooks create --name "github-events"
+omni webhooks create --name "github-events" \
+  --signature-algorithm hmac-sha256 --signature-header "X-Hub-Signature-256" --signature-prefix "sha256=" \
+  --signature-secret-env GITHUB_WEBHOOK_SECRET \
+  --event-type-mapping '{"source":"header","header":"X-GitHub-Event"}' \
+  --idempotency-key-template "github:{headers.x-github-delivery}"
+omni webhooks heartbeat github-events            # connector liveness check-in
 omni webhooks trigger --type "custom.event" --payload '{"key":"value"}'
 ```
+
+Sources receive on the public `POST /api/v2/webhooks/ingress/:source` endpoint (signature required). See the [GitHub](docs/runbooks/github-webhook-source.md) and [ClickUp](docs/runbooks/clickup-webhook-source.md) recipes.
+
+#### `schedule` — Scheduled messages
+
+```bash
+omni schedule send <instance> <chat-id> "Stand-up in 10" --at 2h   # ISO timestamp or 30m/2h/3d
+omni schedule list <instance>
+omni schedule cancel <id>
+```
+
+Delivery is native where the channel supports it (Slack, text-only); everywhere else a local sweeper sends at the scheduled time.
+
+#### `tenants` — Platform tenant control plane
+
+```bash
+omni tenants create --slug acme --name "Acme" --max-key-ttl 7776000 --max-key-rate 100 --max-key-budget 1000 --reason "onboarding"
+omni tenants keys issue-root <tenant-id> --principal <uuid> --membership <uuid> --role tenant-owner \
+  --name root --scopes "tenant:*" --expires 2026-12-01 --rate-limit 100 --budget 1000 --reason "bootstrap"
+omni multitenancy status
+```
+
+Requires a PLATFORM-class credential and `OMNI_MULTITENANCY_ENABLED=true`; every command takes an audited `--reason`. Omni runs single-tenant by default — see [platform credential bootstrap](docs/deployment/platform-credential-bootstrap.md).
 
 </details>
 
@@ -354,8 +411,14 @@ omni doctor                                     # diagnose embedded runtime issu
 omni doctor --fix                               # repair safe runtime drift in-place
 omni auth login --api-key <your-api-key>        # authenticate
 omni config set defaultInstance <id>            # CLI settings
-omni events list --type "message.*" --since 2h  # event history
+omni events list --type "message.*" --since 2h  # event history (trailing-* globs)
+omni events trace <event-id>                    # causation chain
+omni events wait --type "custom.x.*" --timeout 60  # block until a matching event
+omni events schema register <type> --file s.json   # register a payload schema
+omni events consumers create <name> --type "custom.x.*"  # durable cursor
+omni events follow --consumer <name>            # durable tail
 omni events replay --start --since 2024-01-01   # replay events
+omni journey show <correlation-id>              # per-message latency timeline
 omni batch create --instance <id> --type targeted_chat_sync --chat <chat-id>
 omni resync --instance <id>                     # history backfill
 omni logs list --level error --limit 50         # server logs
@@ -377,7 +440,7 @@ omni dead-letters list --limit 20               # failed events
 | **OpenAPI** | `/api/v2/openapi.json` |
 | **Auth** | `x-api-key` header |
 
-Main API groups include: `/auth`, `/instances`, `/messages`, `/chats`, `/events`, `/persons`, `/access`, `/settings`, `/providers`, `/automations`, `/webhooks`, `/keys`, `/logs`, `/batch-jobs`, `/dead-letters`, `/media`, `/metrics`, `/event-ops`, `/payloads`, `/agents`, `/agent-state`, `/agent-tasks`, `/conversations`, `/context`, `/turns`, `/trust`, `/voice`, `/follow-up`, and `/handoffs`.
+Main API groups include: `/auth`, `/instances`, `/messages`, `/chats`, `/events` (plus `/events/schemas`, `/events/consumers`, and per-event `/trace`), `/persons`, `/access`, `/settings`, `/providers`, `/automations`, `/webhooks`, `/scheduled-messages`, `/keys`, `/logs`, `/batch-jobs`, `/dead-letters`, `/media`, `/metrics`, `/event-ops`, `/payloads`, `/agents`, `/agent-state`, `/agent-tasks`, `/conversations`, `/context`, `/turns`, `/trust`, `/voice`, `/follow-up`, `/handoffs`, `/journeys`, `/instances/:id/whatsapp-templates`, and `/platform` (multitenancy control plane, flag-gated).
 
 ## SDKs
 
@@ -415,7 +478,7 @@ make dev-ui    # Dev → http://localhost:5173
 make build-ui  # Prod → served by API on :8882
 ```
 
-Pages: Dashboard · Instances · Chats · Chat View · Contacts · Persons · Providers · Automations · Access Rules · Batch Jobs · Dead Letters · Events · Logs · Settings
+Pages: Dashboard · Instances · Chats · Chat View · Contacts · Persons · Providers · Automations · Access Rules · Batch Jobs · Dead Letters · Events · Logs · Voices · Settings
 
 <details>
 <summary>🔐 API Keys & Security</summary>
@@ -446,11 +509,11 @@ Namespaces include: `messages`, `chats`, `instances`, `persons`, `events`, `acce
 
 Set `*_MANAGED=false` for external services. Full list: `.env.example`.
 
-| Service | PM2 Name | Port |
-|---------|----------|------|
-| PostgreSQL | `omni-pgserve` | 8432 |
-| NATS | `omni-nats` | 4222 |
-| API | `omni-api` | 8882 |
+| Service | PM2 Name (installer / source checkout) | Port |
+|---------|----------------------------------------|------|
+| API | `omni-api` / `omni-v2-api` | 8882 |
+| NATS | `omni-nats` / `omni-v2-nats` | 4222 |
+| PostgreSQL | `autopg-server` (canonical pgserve, managed by `omni install`) | 8432 |
 
 </details>
 
@@ -477,11 +540,11 @@ make sdk-generate  # Regenerate SDKs from OpenAPI
 
 Set `*_MANAGED=false` for external services. Full list in `.env.example`.
 
-| Service | PM2 Name | Port |
-|---------|----------|------|
-| PostgreSQL | `omni-pgserve` | 8432 |
-| NATS | `omni-nats` | 4222 |
-| API | `omni-api` | 8882 |
+| Service | PM2 Name (installer / source checkout) | Port |
+|---------|----------------------------------------|------|
+| API | `omni-api` / `omni-v2-api` | 8882 |
+| NATS | `omni-nats` / `omni-v2-nats` | 4222 |
+| PostgreSQL | `autopg-server` (canonical pgserve, managed by `omni install`) | 8432 |
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Omni v2 Knowledge Base"
 created: 2025-01-29
-updated: 2026-02-09
+updated: 2026-09-08
 tags: [index, docs]
 status: current
 ---
@@ -15,17 +15,24 @@ status: current
 ```
 docs/
 ├── api/                    # API design, endpoints, internal routes
-├── architecture/           # System architecture (events, identity, plugins)
+├── architecture/           # System architecture (events, identity, plugins, connectors)
+├── channels/               # Per-channel setup & internals (Slack, WhatsApp Business, Flows)
+├── channel-parity/         # Cross-channel feature parity notes
+├── ci/                     # CI / merge-queue decisions
 ├── cli/                    # CLI design & commands
 ├── deployment/             # Deployment modes, flags, upgrade checklists
+├── design/                 # Design explorations (installer, wireframes)
+├── examples/               # Ready-to-use artifacts (event schemas, automations)
+├── guides/                 # Task-oriented guides (install, multi-instance, integrations)
 ├── media/                  # Media processing pipeline
-├── migration/              # v1 → v2 migration docs
+├── migration/              # v1 → v2 migration docs (historical)
 ├── performance/            # Load tests, baselines
 ├── research/               # 🔬 Research findings
 │   ├── baileys/            # Baileys protocol internals, OpenClaw WhatsApp
 │   ├── omni-internals/     # Deep dives into Omni's own systems
 │   ├── whatsapp-business/  # WhatsApp Business API, Telegram analysis
 │   └── SQUAD.md            # Research squad roster
+├── runbooks/               # Operator recipes (webhook sources, consumers, governance)
 ├── sdk/                    # SDK generation & usage
 ├── templates/              # Note templates
 └── ui/                     # Dashboard components
@@ -37,32 +44,70 @@ docs/
 
 | Document | Description | Status |
 |----------|-------------|--------|
-| [[endpoints\|API Endpoints]] | Complete v2 REST API reference — all route modules | ✅ current |
-| [[design\|API Design]] | Design principles, versioning strategy | ✅ current |
-| [[internal\|Internal API]] | Localhost-only service-to-service endpoints | ✅ current |
-| [[v1-compatibility-layer\|V1 Compatibility Layer]] | v1 → v2 endpoint mapping for UI migration | ✅ current |
+| [[api/endpoints\|API Endpoints]] | Complete v2 REST API reference — all route modules | ✅ current |
+| [[api/design\|API Design]] | Design principles, auth/scopes, errors, pagination | ✅ current |
+| [[api/internal\|Internal API]] | Localhost-only service-to-service endpoints | ✅ current |
+| [[api/v1-compatibility-layer\|V1 Compatibility Layer]] | v1 → v2 endpoint mapping for UI migration | 🗄️ historical |
 
 ### Architecture
 
 | Document | Description | Status |
 |----------|-------------|--------|
 | [[overview\|Architecture Overview]] | System components, request flows, deployment | ✅ current |
-| [[event-system\|Event System]] | NATS JetStream events, types, handlers, replay | ✅ current |
+| [[event-system\|Event System]] | Event journal, schema registry, causality, durable consumers, replay | ✅ current |
+| [[connector-contract\|Connector Contract]] | Webhook-source lifecycle: signatures, idempotency, heartbeats | ✅ current |
 | [[identity-graph\|Identity Graph]] | Cross-platform identity resolution and merging | ✅ current |
+| [[adr-0003-lid-first-identity\|ADR-0003: LID-First Identity]] | Decision record for LID-first identity keying | ✅ current |
+| [[actor-model\|Actor Model]] | Actor-based concurrency notes | ✅ current |
+| [[a2a-implementation\|A2A Implementation]] | Agent-to-agent channel design | ✅ current |
 | [[plugin-system\|Plugin System]] | Channel plugin SDK, lifecycle, capabilities | ✅ current |
 | [[provider-system\|Provider System]] | AI agent provider configuration | ✅ current |
+
+### Channels
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [[slack\|Slack]] | Slack setup: Agent messaging experience, tokens, threads, scheduling | ✅ current |
+| [[channels/whatsapp-business\|WhatsApp Business (Meta)]] | Cloud API setup, webhooks, templates, alerts | ✅ current |
+| [[whatsapp-flows\|WhatsApp Flows]] | Meta WhatsApp Flows integration | ✅ current |
+| [[telegram-whatsapp\|Telegram ↔ WhatsApp Parity]] | Cross-channel feature parity notes | ✅ current |
 
 ### CLI
 
 | Document | Description | Status |
 |----------|-------------|--------|
-| [[design\|CLI Design]] | All CLI commands, flags, and usage examples | ✅ current |
+| [[cli/design\|CLI Design]] | All CLI commands, flags, and usage examples | ✅ current |
+
+### Guides
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [[install\|Installation Guide]] | Step-by-step install, setup, verify, troubleshoot | ✅ current |
+| [[multi-instance\|Multi-Instance Deployments]] | Running multiple isolated Omni servers on one host | ✅ current |
+| [[streaming-responses\|Streaming Responses]] | Streaming agent replies into channels | ✅ current |
+| [[typing-debounce\|Typing & Debounce]] | Presence and message debouncing behavior | ✅ current |
+| [[idle-chat-follow-up\|Idle Chat Follow-Up]] | Automated follow-ups on idle conversations | ✅ current |
+| [[openclaw-integration\|OpenClaw Integration]] | Connecting OpenClaw as an agent provider | ✅ current |
+| [[openclaw-from-scratch\|OpenClaw From Scratch]] | Full OpenClaw + Omni walkthrough | ✅ current |
+
+### Runbooks
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [[github-webhook-source\|GitHub Webhook Source]] | Config-only GitHub → Omni event ingress recipe | ✅ current |
+| [[clickup-webhook-source\|ClickUp Webhook Source]] | Config-only ClickUp → Omni event ingress recipe | ✅ current |
+| [[durable-consumers\|Durable Consumers]] | Named journal cursors: create, follow, monitor lag | ✅ current |
+| [[agent-publish-governance\|Agent Publish Governance]] | Manifest `publishes` allowlist enforcement and DLQ semantics | ✅ current |
+| [[identity-reconciliation\|Identity Reconciliation]] | Reconciling split/orphaned identities | ✅ current |
 
 ### Deployment
 
 | Document | Description | Status |
 |----------|-------------|--------|
 | [[single-tenant-mode\|Single-Tenant (Master-Key) Mode]] | Default deployment mode: flags, what changed unconditionally, large-database upgrade checklist | ✅ current |
+| [[platform-credential-bootstrap\|Platform Credential Bootstrap]] | First PLATFORM-class credential without direct SQL | ✅ current |
+
+Release/upgrade runbooks (`upgrade-*.md`, `public-launch-readiness.md`) also live in `deployment/` and are maintained by the release process.
 
 ### Media
 
@@ -84,6 +129,14 @@ docs/
 | [[plan\|Migration Plan]] | v1 → v2 migration strategy (Strangler Fig) | 🗄️ historical |
 | [[ui-reuse\|UI Reuse Strategy]] | Reusing v1 React dashboard with v2 API | 🗄️ historical |
 | [[v1-features-analysis\|V1 Features Analysis]] | Feature parity analysis | 🗄️ historical |
+| [[nats-genie-sidecar-decommission\|NATS-Genie Sidecar Decommission]] | Sidecar removal notes | 🗄️ historical |
+
+### CI
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [[merge-queue\|Merge Queue]] | Why dev uses a merge queue and the settings change | ✅ current |
+| [[ci-quality-setup-guide\|CI Quality Setup Guide]] | Quality-gate workflow setup | ✅ current |
 
 ### Performance
 

--- a/docs/api/design.md
+++ b/docs/api/design.md
@@ -1,57 +1,61 @@
 ---
 title: "API Design"
 created: 2025-01-29
-updated: 2026-02-09
+updated: 2026-09-08
 tags: [api, design]
 status: current
 ---
 
 # API Design
 
-> The Omni v2 API is designed to be familiar to v1 users while adding new capabilities. It provides both REST endpoints for external use and tRPC for type-safe internal/SDK use.
+> The Omni v2 API is a REST + OpenAPI surface under `/api/v2`. Every route is described in the OpenAPI spec (`/api/v2/openapi.json`, Swagger UI at `/api/v2/docs`), and the TypeScript/Go/Python SDKs are generated from it.
 
 > Related: [[endpoints|API Endpoints]], [[internal|Internal API]], [[v1-compatibility-layer|V1 Compatibility]]
 
 ## Design Principles
 
-1. **Backward Compatible** - v1 endpoints still work
-2. **Type-Safe** - tRPC for SDK, Zod for REST validation
+1. **v2 is the API** - `/api/v2` is the only mounted surface; a thin v1-compatibility shim exists solely for the dashboard migration (see [[v1-compatibility-layer|V1 Compatibility]])
+2. **Type-Safe** - Zod validation on every external boundary; SDKs generated from OpenAPI
 3. **Consistent** - Same patterns across all resources
 4. **LLM-Friendly** - Structured responses, clear error messages
 5. **Performant** - Pagination, filtering, sparse fieldsets
+6. **Event-first** - State changes are journaled and published; the events surface (schemas, consumers, trace) is a first-class API
 
 ## API Structure
 
 ```
-/api/v1/                      # REST API (v1 compatible)
-├── instances/                # Instance management
-├── messages/                 # Send/receive messages
-├── events/                   # Event queries (new)
-├── persons/                  # Identity management (new)
-├── access/                   # Access rules
-├── settings/                 # Global settings
-└── webhooks/                 # Webhook configuration
+/api/v2/                           # REST API (x-api-key auth)
+├── instances/                     # Instance management (+ supported-channels)
+├── messages/                      # Send/receive, permalink, star, threads
+├── chats/                         # Conversations, pin/archive, participants
+├── events/                        # Journal queries, schemas, consumers, trace
+├── persons/                       # Identity graph
+├── automations/                   # Event-driven workflows
+├── webhooks/                      # Webhook source configuration
+├── scheduled-messages/            # Schedule for later delivery
+├── providers/ keys/ access/ ...   # See the endpoints reference for all modules
+└── platform/                      # Tenant control plane (flag-gated)
 
-/trpc/                        # tRPC API (SDK use)
-├── instances.*
-├── messages.*
-├── events.*
-├── persons.*
-└── ...
+/api/v2/webhooks/ingress/:source   # Public signed ingress for external sources
 
-/webhook/                     # Incoming webhooks from channels
-├── whatsapp-baileys/:id
-├── whatsapp-business
-├── discord
-└── slack
+/api/v2/channels/...               # Channel-specific webhook receivers:
+├── gupshup/:instanceId/webhook
+├── asc-flow/:instanceId/webhook
+├── hermes/:instanceId/webhook
+├── twilio-whatsapp/:instanceId/webhook
+└── whatsapp-business/webhook      # Meta Cloud API (GET verify + POST)
+
+/api/v2/instances/:id/telegram/webhook   # Telegram webhook receiver
 ```
+
+The full module-by-module reference lives in [[endpoints|API Endpoints]] — this page covers the cross-cutting design only.
 
 ## Authentication
 
 All API requests require the `x-api-key` header:
 
 ```bash
-curl -H "x-api-key: omni_sk_..." https://api.example.com/api/v2/instances
+curl -H "x-api-key: omni_sk_..." http://localhost:8882/api/v2/instances
 ```
 
 ### Multiple API Keys with Scoped Permissions
@@ -82,32 +86,26 @@ interface ApiKey {
 - **Send-only keys** (`["messages:send"]`) - Send messages, nothing else
 - **Time-limited keys** - Auto-expire after set date
 
-**Available Scopes:**
+**Available Scopes** (`namespace:action` pattern):
 | Scope | Description |
 |-------|-------------|
 | `*` | Full admin access |
-| `instances:*` | All instance operations |
-| `instances:read` | Read instance info |
-| `instances:write` | Create/update instances |
-| `instances:delete` | Delete instances |
-| `messages:*` | All message operations |
-| `messages:send` | Send messages only |
-| `messages:read` | Read message history |
-| `events:read` | Read events/traces |
+| `instances:*` / `instances:read` / `instances:write` / `instances:delete` | Instance operations |
+| `messages:*` / `messages:send` / `messages:read` | Message operations |
+| `events:read` | Read events, traces, consumers |
 | `persons:*` | Identity management |
 | `access:*` | Access rule management |
 | `settings:*` | Settings management |
+| `keys:read` / `keys:write` | API key management |
 | `admin:*` | Admin operations (keys, services) |
+| `platform:*` | Platform tenant control plane (PLATFORM-class credentials only; see [[../deployment/platform-credential-bootstrap\|Platform Credential Bootstrap]]) |
 
 **Audit Logging:**
-Every API key usage is logged with:
-- Timestamp
-- Endpoint called
-- IP address
-- User agent
-- Response status code
+Every API key usage is logged with timestamp, endpoint, IP address, user agent, and response status. See `GET /api/v2/keys/:id/audit`.
 
-See `GET /api/v2/api-keys/:id/audit` for audit log access.
+### Tenancy posture
+
+`POST /api/v2/auth/validate` returns, for every authenticated caller, the server's tenancy posture (`multitenancyEnabled`, `controlPlaneMounted`, `dbEnforcement`) alongside the credential's class, tenant, role, and scopes. The CLI surfaces this in `omni status` and `omni multitenancy status`.
 
 ## Common Patterns
 
@@ -115,10 +113,10 @@ See `GET /api/v2/api-keys/:id/audit` for audit log access.
 
 ```typescript
 // Query parameters (GET)
-GET /api/v1/events?channel=whatsapp&limit=50&cursor=xxx
+GET /api/v2/events?channel=whatsapp&limit=50&cursor=xxx
 
 // JSON body (POST/PUT/PATCH)
-POST /api/v1/messages
+POST /api/v2/messages/send
 Content-Type: application/json
 {
   "instanceId": "...",
@@ -163,7 +161,7 @@ Cursor-based pagination for all list endpoints:
 
 ```typescript
 // First page
-GET /api/v1/events?limit=50
+GET /api/v2/events?limit=50
 
 // Response
 {
@@ -175,7 +173,7 @@ GET /api/v1/events?limit=50
 }
 
 // Next page
-GET /api/v1/events?limit=50&cursor=eyJpZCI6IjEyMyIsInRzIjoiMjAyNS0wMS0wMSJ9
+GET /api/v2/events?limit=50&cursor=eyJpZCI6IjEyMyIsInRzIjoiMjAyNS0wMS0wMSJ9
 ```
 
 ### Filtering
@@ -183,11 +181,11 @@ GET /api/v1/events?limit=50&cursor=eyJpZCI6IjEyMyIsInRzIjoiMjAyNS0wMS0wMSJ9
 Standard filter parameters:
 
 ```typescript
-GET /api/v1/events
+GET /api/v2/events
   ?channel=whatsapp,discord     // Multiple values
+  &eventType=message.*          // Comma lists; trailing-* prefix globs
   &since=2025-01-01T00:00:00Z   // ISO 8601
   &until=2025-01-31T23:59:59Z
-  &contentType=text,audio
   &personId=uuid
   &instanceId=uuid
   &limit=50
@@ -206,445 +204,28 @@ GET /api/v1/events
 | `CHANNEL_ERROR` | 502 | Channel (WhatsApp/Discord) error |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |
 
-## REST Endpoints
+## tRPC
 
-### Instances
+A tRPC router exists in `packages/api/src/trpc/` for type-safe internal use, but it is not mounted as a public HTTP surface. External consumers use REST + the generated SDKs; the OpenAPI spec is the contract.
 
-```yaml
-# List instances
-GET /api/v1/instances
-Query:
-  - channel: string[]  # Filter by channel type
-  - status: string[]   # Filter by status
-  - limit: number
-  - cursor: string
-Response: { items: Instance[], meta: PaginationMeta }
+## Real-time
 
-# Get instance
-GET /api/v1/instances/:id
-Response: { data: Instance }
+There is no general-purpose WebSocket subscription API. For real-time event consumption use:
 
-# Create instance
-POST /api/v1/instances
-Body:
-  - name: string (required)
-  - channel: ChannelType (required)
-  - channelConfig: object
-  - agent: AgentConfig
-  - messaging: MessagingConfig
-  - media: MediaConfig
-Response: { data: Instance }
+- `omni events stream` / `omni events wait` — poll-based live tail and one-shot blocking wait over the journal
+- **Durable consumers** — `POST /api/v2/events/consumers/:name/pull` supports server-side long-poll (`waitMs`), giving push-like latency with at-least-once delivery (see [[../runbooks/durable-consumers|Durable Consumers]])
+- **Automations** — react to events server-side (`webhook`, `send_message`, `emit_event`, `call_agent` actions)
 
-# Update instance
-PATCH /api/v1/instances/:id
-Body: Partial<InstanceConfig>
-Response: { data: Instance }
-
-# Delete instance
-DELETE /api/v1/instances/:id
-Response: { success: true }
-
-# Get instance status
-GET /api/v1/instances/:id/status
-Response: { data: ConnectionStatus }
-
-# Get QR code (WhatsApp)
-GET /api/v1/instances/:id/qr
-Response: { data: { qr: string, expiresAt: string } }
-
-# Restart instance
-POST /api/v1/instances/:id/restart
-Response: { data: ConnectionStatus }
-
-# Logout instance
-POST /api/v1/instances/:id/logout
-Response: { success: true }
-```
-
-### Messages
-
-```yaml
-# Send text message
-POST /api/v1/messages
-Body:
-  - instanceId: string (required)
-  - to: string (required)  # Phone number or platform ID
-  - text: string (required)
-  - replyTo?: string       # Message ID to reply to
-Response: {
-  data: {
-    messageId: string,
-    externalMessageId: string,
-    status: 'sent'
-  }
-}
-
-# Send media
-POST /api/v1/messages/media
-Body:
-  - instanceId: string (required)
-  - to: string (required)
-  - mediaType: 'image' | 'audio' | 'video' | 'document'
-  - mediaUrl?: string      # URL to fetch
-  - mediaBase64?: string   # Or base64 encoded
-  - filename?: string
-  - caption?: string
-  - voiceNote?: boolean    # For audio
-Response: { data: MessageResult }
-
-# Send reaction
-POST /api/v1/messages/reaction
-Body:
-  - instanceId: string (required)
-  - to: string (required)
-  - messageId: string (required)  # Message to react to
-  - emoji: string (required)
-Response: { success: true }
-
-# Get message by ID
-GET /api/v1/messages/:id
-Response: { data: Message }
-```
-
-### Events (New in v2)
-
-```yaml
-# List events
-GET /api/v1/events
-Query:
-  - channel: string[]
-  - instanceId: string
-  - personId: string
-  - eventType: string[]
-  - contentType: string[]
-  - since: datetime
-  - until: datetime
-  - search: string         # Full-text search
-  - limit: number
-  - cursor: string
-Response: { items: Event[], meta: PaginationMeta }
-
-# Get event by ID
-GET /api/v1/events/:id
-Response: { data: Event }
-
-# Get event timeline for a person (cross-channel)
-GET /api/v1/events/timeline/:personId
-Query:
-  - channels: string[]
-  - since: datetime
-  - until: datetime
-  - limit: number
-Response: {
-  personId: string,
-  channels: string[],
-  items: TimelineEvent[],
-  meta: PaginationMeta
-}
-
-# Search events (advanced)
-POST /api/v1/events/search
-Body:
-  - query?: string          # Natural language query
-  - filters?: EventFilters
-  - format?: 'full' | 'summary' | 'agent'
-  - limit?: number
-Response: {
-  items: Event[],
-  summary?: string,        # If format=agent
-  asContext?: string       # LLM-friendly format
-}
-```
-
-### Persons (Identity - New in v2)
-
-```yaml
-# Search persons
-GET /api/v1/persons
-Query:
-  - search: string         # Name, email, or phone
-  - limit: number
-Response: { items: Person[], meta: PaginationMeta }
-
-# Get person by ID
-GET /api/v1/persons/:id
-Response: { data: Person }
-
-# Get person presence (all identities)
-GET /api/v1/persons/:id/presence
-Response: {
-  data: {
-    person: Person,
-    identities: PlatformIdentity[],
-    summary: {
-      totalIdentities: number,
-      activeChannels: string[],
-      totalMessages: number,
-      lastSeenAt: datetime,
-      firstSeenAt: datetime
-    },
-    byChannel: Record<string, ChannelPresence>
-  }
-}
-
-# Get person timeline (cross-channel messages)
-GET /api/v1/persons/:id/timeline
-Query:
-  - channels: string[]
-  - since: datetime
-  - until: datetime
-  - limit: number
-  - cursor: string
-Response: { items: TimelineEvent[], meta: PaginationMeta }
-
-# Link two identities
-POST /api/v1/persons/link
-Body:
-  - identityA: string (required)
-  - identityB: string (required)
-Response: { data: Person }
-
-# Unlink identity
-POST /api/v1/persons/unlink
-Body:
-  - identityId: string (required)
-  - reason: string (required)
-Response: { data: { person: Person, identity: Identity } }
-```
-
-### Access Rules
-
-```yaml
-# List access rules
-GET /api/v1/access/rules
-Query:
-  - instanceId: string     # Filter by instance
-  - type: 'allow' | 'deny'
-Response: { items: AccessRule[] }
-
-# Create rule
-POST /api/v1/access/rules
-Body:
-  - instanceId?: string    # null = global
-  - type: 'allow' | 'deny'
-  - criteria: RuleCriteria
-  - priority: number
-  - action: RuleAction
-Response: { data: AccessRule }
-
-# Update rule
-PATCH /api/v1/access/rules/:id
-Body: Partial<AccessRule>
-Response: { data: AccessRule }
-
-# Delete rule
-DELETE /api/v1/access/rules/:id
-Response: { success: true }
-
-# Check access (test)
-POST /api/v1/access/check
-Body:
-  - instanceId: string
-  - platformUserId: string
-  - channel: string
-Response: {
-  data: {
-    allowed: boolean,
-    rule?: AccessRule,
-    reason: string
-  }
-}
-```
-
-### Settings
-
-```yaml
-# List settings
-GET /api/v1/settings
-Response: { items: Setting[] }
-
-# Get setting
-GET /api/v1/settings/:key
-Response: { data: Setting }
-
-# Update setting
-PUT /api/v1/settings/:key
-Body:
-  - value: any
-Response: { data: Setting }
-
-# Update multiple settings
-PATCH /api/v1/settings
-Body:
-  - settings: Record<string, any>
-Response: { data: Setting[] }
-```
-
-### Channels (New in v2)
-
-```yaml
-# List available channels
-GET /api/v1/channels
-Response: {
-  items: {
-    id: string,
-    name: string,
-    version: string,
-    capabilities: ChannelCapabilities
-  }[]
-}
-
-# Get channel info
-GET /api/v1/channels/:id
-Response: { data: ChannelInfo }
-```
-
-## tRPC Router
-
-For SDK and internal use, tRPC provides end-to-end type safety:
-
-```typescript
-// packages/api/src/trpc/router.ts
-
-import { initTRPC } from '@trpc/server';
-import { z } from 'zod';
-
-const t = initTRPC.context<Context>().create();
-
-export const appRouter = t.router({
-  instances: t.router({
-    list: t.procedure
-      .input(z.object({
-        channel: z.array(z.string()).optional(),
-        status: z.array(z.string()).optional(),
-        limit: z.number().default(50),
-        cursor: z.string().optional(),
-      }))
-      .query(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    get: t.procedure
-      .input(z.object({ id: z.string().uuid() }))
-      .query(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    create: t.procedure
-      .input(instanceCreateSchema)
-      .mutation(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    // ... more procedures
-  }),
-
-  messages: t.router({
-    send: t.procedure
-      .input(z.object({
-        instanceId: z.string().uuid(),
-        to: z.string(),
-        text: z.string(),
-        replyTo: z.string().optional(),
-      }))
-      .mutation(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    sendMedia: t.procedure
-      .input(sendMediaSchema)
-      .mutation(async ({ input, ctx }) => {
-        // Implementation
-      }),
-  }),
-
-  events: t.router({
-    list: t.procedure
-      .input(eventListSchema)
-      .query(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    timeline: t.procedure
-      .input(z.object({
-        personId: z.string().uuid(),
-        channels: z.array(z.string()).optional(),
-        since: z.string().datetime().optional(),
-        until: z.string().datetime().optional(),
-        limit: z.number().default(50),
-      }))
-      .query(async ({ input, ctx }) => {
-        // Implementation
-      }),
-  }),
-
-  persons: t.router({
-    search: t.procedure
-      .input(z.object({ query: z.string().min(2) }))
-      .query(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    presence: t.procedure
-      .input(z.object({ id: z.string().uuid() }))
-      .query(async ({ input, ctx }) => {
-        // Implementation
-      }),
-
-    link: t.procedure
-      .input(z.object({
-        identityA: z.string().uuid(),
-        identityB: z.string().uuid(),
-      }))
-      .mutation(async ({ input, ctx }) => {
-        // Implementation
-      }),
-  }),
-});
-
-export type AppRouter = typeof appRouter;
-```
-
-## WebSocket API
-
-Real-time updates via WebSocket:
-
-```typescript
-// Connect
-const ws = new WebSocket('wss://api.example.com/ws?apiKey=sk-...');
-
-// Subscribe to events
-ws.send(JSON.stringify({
-  type: 'subscribe',
-  channels: ['events', 'instances'],
-  filters: {
-    instanceId: '...',  // Optional
-  }
-}));
-
-// Receive events
-ws.onmessage = (event) => {
-  const data = JSON.parse(event.data);
-  // {
-  //   type: 'event',
-  //   channel: 'events',
-  //   payload: { ... }
-  // }
-};
-
-// Unsubscribe
-ws.send(JSON.stringify({
-  type: 'unsubscribe',
-  channels: ['events']
-}));
-```
+Scoped WebSocket endpoints exist for specific UI features (chat updates, log tailing, voice) — see `packages/api/src/ws/`.
 
 ## Rate Limiting
+
+Default limits by endpoint category (see `packages/api/src/middleware/rate-limit.ts` for the source of truth):
 
 | Endpoint | Limit | Window |
 |----------|-------|--------|
 | Messages (send) | 60 | 1 minute |
-| Events (list) | 100 | 1 minute |
+| Events (list) / webhook ingress | 100 | 1 minute |
 | Instances (CRUD) | 30 | 1 minute |
 | General | 1000 | 1 minute |
 
@@ -658,7 +239,7 @@ X-RateLimit-Reset: 1706745600
 ## Versioning
 
 The API uses URL versioning:
-- `/api/v1/` - Current stable
-- `/api/v2/` - Future (when breaking changes needed)
+- `/api/v2/` - Current stable (the only mounted surface)
+- The v1-compatibility layer maps legacy dashboard calls onto v2 — see [[v1-compatibility-layer|V1 Compatibility]]
 
-Breaking changes will be announced 6 months in advance.
+Breaking changes will be announced in advance via release notes.

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,7 +1,7 @@
 ---
 title: "API Endpoints Reference"
 created: 2025-01-29
-updated: 2026-02-09
+updated: 2026-09-08
 tags: [api, endpoints, reference]
 status: current
 ---
@@ -18,25 +18,48 @@ All v2 routes are defined in `packages/api/src/routes/v2/` and mounted in `index
 
 | Module | Mount Point | Description |
 |--------|-------------|-------------|
+| `a2a` | `/a2a` | A2A discovery: authenticated multi-agent catalog + Agent Card resolution |
+| `agents` | `/agents` | First-class agent entities, event manifests, identity links |
+| `agent-state` | `/agent-state` | Ephemeral agent state machine (SSE streams + one-shot get/set) |
+| `agent-tasks` | `/agent-tasks` | Persistent agent task history |
 | `auth` | `/auth` | API key validation |
 | `instances` | `/instances` | Instance CRUD, connection, sync, profile, groups |
 | `logs` | `/logs` | System log streaming |
 | `messages` | `/messages` | Message CRUD, send operations, TTS, presence |
-| `events` | `/events` | Event queries, analytics, timeline |
+| `scheduled-messages` | `/scheduled-messages` | Deferred sends (platform-native or local sweeper) |
+| `slack` | `/slack` | Slack-only: DM open + full-text message search |
+| `event-schemas` | `/` (routes at `/events/schemas`) | Event schema registry (draft-07 JSON Schema, validated at publish gates) |
+| `event-consumers` | `/` (routes at `/events/consumers`) | Durable pull consumers with Postgres journal cursors |
+| `events` | `/events` | Event queries, analytics, timeline, causality traces |
+| `journeys` | `/journeys` | Message journey tracing (per-correlation traces + aggregate metrics) |
 | `persons` | `/persons` | Identity search, presence, linking |
 | `access` | `/access` | Access control rules |
 | `settings` | `/settings` | Server settings management |
 | `providers` | `/providers` | AI agent provider management |
 | `dead-letters` | `/dead-letters` | Failed event management |
 | `event-ops` | `/event-ops` | Event replay, metrics |
+| `processed-events` | `/processed-events` | Placeholder reserving the path (clean 404 until #411 lands) |
 | `metrics` | `/metrics` | System metrics |
+| `conversations` | `/conversations` | Cross-channel conversation continuity |
 | `chats` | `/chats` | Chat CRUD, participants, archive/pin/mute |
+| `channel-harness` | `/channels/harness` | E2E agent-test harness driving/inspection (auth-required, unlike channel webhooks) |
 | `media` | `/media` | Media file serving |
 | `batch-jobs` | `/batch-jobs` | Batch operations |
 | `keys` | `/keys` | API key management |
+| `context` | `/context` | Per-API-key conversation context (active instance/chat/message) |
+| `turns` | `/turns` | Turn lifecycle for turn-based agents (close, admin list/stats) |
+| `trust` | `/trust` | Host fingerprint trust registration (idempotent handshake) |
+| `voice` | `/voice` | Voice session management (join/leave/sessions, any VoiceCapable channel) |
+| `follow-up` | `/follow-up` | Idle-chat follow-up config at agent/instance/chat scopes |
+| `handoffs` | `/handoffs` | Handoff audit log |
+| `whatsapp-business` | `/instances` (routes at `/instances/:id/whatsapp-business/*`) | WhatsApp Cloud (Meta) connection lifecycle, profile, analytics |
+| `templates` | `/` (routes at `/instances/:id/whatsapp-templates/*`) | WhatsApp Cloud HSM template management |
+| `whatsapp-flows` | `/` (routes at `/instances/:id/whatsapp-flows/*`) | WhatsApp Flows management + send |
 | `payloads` | `/` | Event payload storage and config |
-| `webhooks` | `/` | Webhook sources and event triggers |
-| `automations` | `/automations` | Event-driven automation workflows |
+| `webhooks` | `/` | Webhook sources, ingress, heartbeats, event triggers |
+| `automations` | `/automations` + `/` | Event-driven automation workflows (root mount for `/automation-logs`, `/automation-metrics`) |
+| `agent-routes` | `/` (routes at `/instances/:instanceId/routes`, `/routes/metrics`) | Agent routing configuration |
+| `platform-tenants` | `/platform` (mounted in `app.ts`, only when `OMNI_MULTITENANCY_ENABLED=true`) | Tenant lifecycle control plane (platform-class credentials only) |
 
 ---
 
@@ -213,11 +236,12 @@ PATCH  /api/v2/messages/:id/document-extraction # Update document extraction
 
 ```yaml
 POST   /api/v2/messages/send                  # Send text message
-  Body: { instanceId, to, text, replyTo?, mentions?[] }
+  Body: { instanceId, to, text, replyTo?, threadId?, mentions?[] }
+  Note: `threadId` targets a thread/topic (e.g. Telegram forum topic, Slack thread_ts)
 
 POST   /api/v2/messages/send/media            # Send media
   Body: { instanceId, to, type: image|audio|video|document,
-          url?, base64?, filename?, caption?, voiceNote? }
+          url?, base64?, filename?, caption?, voiceNote?, threadId? }
 
 POST   /api/v2/messages/send/reaction         # Send reaction
   Body: { instanceId, to, messageId, emoji }
@@ -240,7 +264,7 @@ POST   /api/v2/messages/send/forward          # Forward a message (WhatsApp)
   Body: { instanceId, to, messageId, fromChatId }
 
 POST   /api/v2/messages/send/presence         # Send typing/recording indicator
-  Body: { instanceId, to, type: typing|recording|paused, duration? }
+  Body: { instanceId, to, type: typing|recording|paused, duration?, threadId? }
 
 POST   /api/v2/messages/send/poll             # Send poll (Discord)
   Body: { instanceId, to, question, answers[], durationHours?, multiSelect?, replyTo? }
@@ -278,6 +302,45 @@ POST   /api/v2/messages/:id/star             # Star a message
 
 DELETE /api/v2/messages/:id/star             # Unstar a message
   Body: { instanceId, channelId, fromMe? }
+```
+
+### Permalink
+
+```yaml
+GET    /api/v2/messages/:id/permalink        # Resolve a stable deep link to the message
+  Query: instanceId, channelId
+  Response: { messageId, permalink, cached }
+  Note: Resolved lazily via the channel plugin and cached on the message row.
+        400 if the channel cannot resolve permalinks.
+```
+
+> Message-level **pin** state is populated from inbound platform events only —
+> there is no invokable pin endpoint (chat-level pin lives under `/chats/:id/pin`).
+
+---
+
+## Scheduled Messages
+
+Source: `packages/api/src/routes/v2/scheduled-messages.ts`
+
+Deferred sends. The server picks the delivery mode from the channel's
+`canScheduleMessage` capability: platform-native scheduling where the channel
+supports it (Slack, text-only), otherwise Omni's local sweeper (15s cron).
+Callers do not choose the mode.
+
+```yaml
+POST   /api/v2/scheduled-messages             # Schedule a message for later
+  Body: { instanceId, chatId, content, sendAt, threadId?, isThreadBroadcast? }
+  Note: `content` is OutgoingContent (e.g. { type: 'text', text: '...' });
+        `sendAt` is an ISO-8601 datetime
+
+GET    /api/v2/scheduled-messages             # List pending scheduled messages
+  Query: instanceId, limit (1-500, default 100)
+  Note: Only messages scheduled through Omni are listed
+
+GET    /api/v2/scheduled-messages/:id         # Get scheduled message
+
+DELETE /api/v2/scheduled-messages/:id         # Cancel a pending scheduled message
 ```
 
 ---
@@ -373,8 +436,74 @@ POST   /api/v2/events/search                  # Search events
 
 GET    /api/v2/events/:id                     # Get event by ID
 
+GET    /api/v2/events/:id/trace               # Walk the causality chain around an event
+  Response: { event, ancestors[], descendants[{ event, depth }], truncated }
+  Note: Walks causation_id ancestors up to the root ingress event, then
+        breadth-first through descendants (children = events whose
+        causation_id is this id). Instance access is gated on the focus event.
+
 GET    /api/v2/events/by-sender/:senderId     # Events by sender
   Query: limit?, instanceId?
+```
+
+---
+
+## Event Schemas
+
+Source: `packages/api/src/routes/v2/event-schemas.ts`
+
+Registry of draft-07 JSON Schemas per event type. Global (not tenant-scoped).
+Validation is enforced at the publish gates — webhook ingress and the
+automation `emit_event` action. Unregistered types pass through unless the
+webhook source sets `strictSchemas` (failures dead-letter as
+`schema_not_registered`) or `OMNI_STRICT_EMIT_EVENT_SCHEMAS=true` is set for
+`emit_event`.
+
+> Runbook examples: [[../runbooks/github-webhook-source|GitHub webhook source]],
+> [[../runbooks/clickup-webhook-source|ClickUp webhook source]]
+
+```yaml
+GET    /api/v2/events/schemas                 # List registered schemas
+  Query: enabled?
+
+GET    /api/v2/events/schemas/:eventType      # Get schema for an event type
+
+POST   /api/v2/events/schemas                 # Register or revise a schema
+  Body: { eventType, schema, description?, enabled? }
+  Note: Revising an existing type bumps `version`. Revisions must be
+        additive-optional; an incompatible replacement is refused with 409.
+```
+
+---
+
+## Durable Event Consumers
+
+Source: `packages/api/src/routes/v2/event-consumers.ts`
+
+Named pull consumers over the Postgres event journal — cursors over
+`omni_events.journal_seq`, delivered at-least-once. These are **not** NATS
+JetStream consumers. `lag` = journal head − cursor.
+
+> Runbook: [[../runbooks/durable-consumers|Durable consumers]]
+
+```yaml
+GET    /api/v2/events/consumers               # List consumers (filter, cursor, live lag)
+
+POST   /api/v2/events/consumers               # Register a consumer
+  Note: Initial cursor 'now' = journal head (default), 'beginning' = full replay
+
+GET    /api/v2/events/consumers/:name         # Get consumer + cursor position + lag
+
+DELETE /api/v2/events/consumers/:name         # Delete registration + cursor (journal untouched)
+
+POST   /api/v2/events/consumers/:name/pull    # Pull events after the stored cursor
+  Query: limit (1-500, default 100), waitMs (0-30000; long-poll wait for new events)
+  Note: Returns events in journal_seq order plus the highest SCANNED
+        journal_seq as `cursor` (not the last matching event's seq)
+
+POST   /api/v2/events/consumers/:name/ack     # Advance the cursor (monotonic)
+  Body: { cursor }
+  Note: Equal cursor = no-op; lower than stored = 400
 ```
 
 ---
@@ -540,6 +669,28 @@ GET    /api/v2/providers/:id/workflows        # List workflows
 
 ---
 
+## Agent Manifests
+
+Source: `packages/api/src/routes/v2/agents.ts`
+
+An agent's event manifest declares what it consumes and publishes:
+`{ accepts: [{ event, filter? }], publishes: [{ event }] }` — exact event
+types only, no globs. `publishes` is enforced at emit time (violations are
+dead-lettered as `publish_not_declared`); `accepts` compiles into managed
+automations.
+
+> Runbook: [[../runbooks/agent-publish-governance|Agent publish governance]]
+
+```yaml
+GET    /api/v2/agents/:id/manifest            # Get the agent's event manifest
+
+PUT    /api/v2/agents/:id/manifest            # Replace the manifest (full replacement)
+  Body: { accepts: [{ event, filter? }], publishes: [{ event }] }
+  Note: Publishes system.agent.manifest.updated
+```
+
+---
+
 ## Automations
 
 Source: `packages/api/src/routes/v2/automations.ts`
@@ -551,8 +702,12 @@ GET    /api/v2/automations                    # List automations
 GET    /api/v2/automations/:id                # Get automation
 
 POST   /api/v2/automations                    # Create automation
+  Note: Body accepts `transactionalEmissions` (default false) — buffer the
+        run's emit_event publishes and flush them in order only when every
+        action succeeded; a failed run publishes zero events.
 
 PATCH  /api/v2/automations/:id                # Update automation
+  Body: (same as create, all optional — including transactionalEmissions)
 
 DELETE /api/v2/automations/:id                # Delete automation
 
@@ -573,6 +728,9 @@ GET    /api/v2/automation-metrics              # Get automation metrics
 
 Source: `packages/api/src/routes/v2/webhooks.ts`
 
+> Runbook examples: [[../runbooks/github-webhook-source|GitHub webhook source]],
+> [[../runbooks/clickup-webhook-source|ClickUp webhook source]]
+
 ### Webhook Sources (Inbound)
 
 ```yaml
@@ -582,8 +740,23 @@ GET    /api/v2/webhook-sources                # List webhook sources
 GET    /api/v2/webhook-sources/:id            # Get source details
 
 POST   /api/v2/webhook-sources                # Create webhook source
+  Body: name, description?, enabled?,
+        signatureConfig?      # { algorithm: hmac-sha256|hmac-sha1|token-match, header, prefix? }
+        signatureSecret?      # Write-only — never echoed back (responses expose hasSignatureSecret)
+        idempotencyKeyTemplate?  # Default "{source}:{sha256(body)}"
+        eventTypeMapping?     # { source: "header", header } or { source: "body", path }
+        strictSchemas?        # Require a registered schema; else dead-letter schema_not_registered
+        expectedIntervalSeconds?  # Declared connector cadence for liveness detection
 
-PATCH  /api/v2/webhook-sources/:id            # Update source
+  Note: `idempotencyKeyTemplate` placeholders — {source}, {sha256(body)},
+        {headers.<name>}, {payload.<dot.path>} (dot paths support numeric
+        array indices). Dedup runs via a unique idempotency key on
+        omni_events; a duplicate delivery returns 200 { duplicate: true }.
+  Note: `eventTypeMapping` derives the published type as custom.<source>.<event>.
+  Note: `signatureConfig` and `signatureSecret` are paired — a config without
+        a stored secret is rejected (400).
+
+PATCH  /api/v2/webhook-sources/:id            # Update source (same fields as create)
 
 DELETE /api/v2/webhook-sources/:id            # Delete source
 ```
@@ -591,13 +764,28 @@ DELETE /api/v2/webhook-sources/:id            # Delete source
 ### Inbound Webhooks
 
 ```yaml
-POST   /api/v2/webhooks/:source               # Receive webhook event
+POST   /api/v2/webhooks/ingress/:source       # Public ingress (auth-exempt)
+  Note: Verified EXCLUSIVELY by the source's signature config — signature
+        verification is required. Unknown source, disabled source, and bad
+        signature all collapse to 401 (no oracle for probing source names).
+
+POST   /api/v2/webhooks/:source               # Receive webhook event (authenticated)
+  Note: Same body contract as the public ingress: empty body → {}; a
+        non-empty body that is not a JSON object is a 400. Unknown source is
+        a 404 unless OMNI_WEBHOOK_AUTOCREATE=true.
+
+POST   /api/v2/webhooks/:source/heartbeat     # Connector liveness heartbeat (authenticated, no body)
+  Note: Resets the liveness window for sources declaring
+        expectedIntervalSeconds. A missed window emits
+        system.connector.stalled; recovery emits system.connector.recovered.
+        Heartbeats themselves are not journaled — only the transitions are.
 ```
 
 ### Event Triggering
 
 ```yaml
 POST   /api/v2/events/trigger                 # Trigger a custom event
+  Body: { eventType (custom.*), payload, correlationId?, instanceId? }
 ```
 
 ---
@@ -675,4 +863,48 @@ Source: `packages/api/src/routes/v2/metrics.ts`
 
 ```yaml
 GET    /api/v2/metrics                        # System metrics (Prometheus format)
+```
+
+---
+
+## Platform Tenants
+
+Source: `packages/api/src/routes/v2/platform-tenants.ts`
+
+Mounted at `/api/v2/platform` **only when `OMNI_MULTITENANCY_ENABLED=true`**
+(otherwise the whole surface 404s). Every route requires a PLATFORM-class
+credential with explicit `platform:*` scopes — tenant credentials and normal
+data-plane keys are denied. Mutations take a `reason` in the body; audited
+reads take an `x-platform-reason` header. Every state change writes an
+append-only platform audit row.
+
+There are intentionally **no DELETE routes** — hard tenant delete is
+unavailable; `archive` is the terminal state.
+
+```yaml
+POST   /api/v2/platform/tenants                    # Create tenant
+GET    /api/v2/platform/tenants                    # List tenants
+  Header: x-platform-reason
+GET    /api/v2/platform/tenants/:id                # Get tenant
+  Header: x-platform-reason
+
+POST   /api/v2/platform/tenants/:id/suspend        # Suspend tenant
+  Body: { reason }
+POST   /api/v2/platform/tenants/:id/archive        # Archive tenant (terminal)
+  Body: { reason }
+
+GET    /api/v2/platform/tenants/:id/memberships    # List memberships
+  Header: x-platform-reason
+POST   /api/v2/platform/tenants/:id/memberships    # Attach membership
+  Body: { principalId, role, reason }
+
+POST   /api/v2/platform/tenants/:tenantId/memberships/:id/disable  # Disable membership
+  Body: { reason }
+POST   /api/v2/platform/tenants/:tenantId/memberships/:id/status   # Set membership status
+  Body: { status: active|disabled, reason }
+POST   /api/v2/platform/tenants/:tenantId/memberships/:id/role     # Change membership role
+  Body: { role, reason }
+
+POST   /api/v2/platform/tenants/:id/keys/root      # Issue tenant root API key
+  Note: The plaintext key is returned exactly once in the 201 body
 ```

--- a/docs/architecture/adr-0003-lid-first-identity.md
+++ b/docs/architecture/adr-0003-lid-first-identity.md
@@ -268,8 +268,9 @@ pass `isValidE164Phone` **and not** `isLidFormat` (`packages/api/src/utils/phone
 All schema edits land **with** their generated migration in the same commit
 (AGENTS.md; `.claude/CLAUDE.md` §Database). The latest migration is
 `packages/db/drizzle/0051_message_pin_star.sql`; the first new file here is
-`0052_identity_links.sql` (generate with `bunx drizzle-kit generate`, **never**
-`drizzle-kit push`). No already-deployed migration is edited.
+`0052_identity_links.sql` (hand-written following the additive/idempotent
+migration precedent — `drizzle-kit generate` is broken in this repo and
+`drizzle-kit push` is forbidden). No already-deployed migration is edited.
 
 ### 3.1 `platform_identities` — add a stable *anchor* concept, keep the raw handle
 
@@ -573,7 +574,7 @@ run repeatedly while the API serves traffic. Ordering matters:
 1. **Schema migration `0052_identity_links.sql`** — create `identity_links`; add
    `anchor_type` / `anchor_id` / `phone_e164` / `phone_verified` to
    `platform_identities`; add the new indexes. Additive only; no data moves.
-   (`bunx drizzle-kit generate`, commit SQL + schema together.)
+   (Hand-written SQL plus a journal entry; commit SQL + schema together.)
 2. **Normalize + collapse key-fragmentation (D6, ~1164 cases) FIRST.**
    Canonicalize `platform_user_id` (strip `whatsapp:` prefix / JID suffix /
    device `:NN`) and merge the bare-digits vs `<n>@s.whatsapp.net` twins in the

--- a/docs/architecture/event-system.md
+++ b/docs/architecture/event-system.md
@@ -1,8 +1,8 @@
 ---
 title: "Event System"
 created: 2025-01-29
-updated: 2026-02-09
-tags: [architecture, events, nats]
+updated: 2026-09-08
+tags: [architecture, events, nats, journal]
 status: current
 ---
 
@@ -10,7 +10,7 @@ status: current
 
 > The event system is the nervous system of Omni v2. Every action produces events, events trigger reactions, and events are persisted for audit and replay.
 
-> Related: [[overview|Architecture Overview]], [[plugin-system|Plugin System]]
+> Related: [[overview|Architecture Overview]], [[plugin-system|Plugin System]], [[connector-contract|Connector Contract]] · Runbooks: [Durable Consumers](../runbooks/durable-consumers.md), [Agent Publish Governance](../runbooks/agent-publish-governance.md), [GitHub Webhook Source](../runbooks/github-webhook-source.md), [ClickUp Webhook Source](../runbooks/clickup-webhook-source.md)
 
 ## Why Event-Driven?
 
@@ -37,13 +37,30 @@ POST /message  ──────►  Database     POST /message ─────
                                      Database Updated    Side Effects
 ```
 
+## The Journal Is the Source of Truth
+
+Since the event-backbone work (RFC #925), the **PostgreSQL journal — the
+`omni_events` table — is the durable record** of the event system. NATS
+JetStream is the transport that fans events out to live subscribers; the
+journal is what replay, causality tracing, and durable consumption read.
+This means NATS retention limits are a transport concern, not a data-loss
+concern.
+
+Three columns make `omni_events` a proper journal:
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `journal_seq` | `bigserial`, unique index | Total order over journaled events; durable-consumer cursors page strictly after it |
+| `causation_id` | `uuid`, indexed | The event this event reacted to — the edge of the causality tree |
+| `idempotency_key` | `text`, unique index | At-most-once journaling for retried, replayed, or redelivered ingress |
+
 ## NATS JetStream
 
-We use NATS JetStream as our event bus:
+We use NATS JetStream as our event transport:
 
 - **Lightweight** - Single binary, <20MB memory
-- **Persistent** - Events survive restarts
-- **Exactly-once** - No duplicate processing
+- **Persistent** - Events survive restarts (within stream retention; the journal outlives it)
+- **Deduplicated publish** - Within NATS; end-to-end processing is at-least-once, with the journal's idempotency key as the dedup backstop
 - **Fast** - <1ms latency
 - **Built-in KV** - For session state
 
@@ -468,6 +485,28 @@ interface ChannelQrCodeEvent extends BaseEvent<'channel.qr_code', {
 }> {}
 ```
 
+### System & Custom Events
+
+The event-backbone wave added families beyond the channel pipeline:
+
+| Type | Emitted when |
+|------|--------------|
+| `custom.<source>.<event>` | Webhook ingress or an automation `emit_event` action publishes a custom event |
+| `system.connector.stalled` / `system.connector.recovered` | The connector-liveness sweeper detects a missed / resumed heartbeat |
+| `system.consumer.created` / `system.consumer.deleted` | A durable consumer is registered / removed |
+| `system.agent.manifest.updated` | An agent's event manifest changes |
+| `channel.alert` | A channel raises an operational alert |
+| `template.status_changed` | A message template's approval status changes |
+| `agent.run.cancel_requested` | Cancellation is requested for an in-flight agent run |
+
+Journaling rules differ by family:
+
+- **`custom.*` events are journaled by a dedicated forward-only consumer**
+  (recorded with channel `internal`). Custom events published before that
+  consumer first ran are not in the journal.
+- **`system.*` events are deliberately NOT journaled** — they are operational
+  signals on the bus, not part of the durable record.
+
 ## Publishing Events
 
 ```typescript
@@ -592,7 +631,8 @@ export class EventBus {
   }
 
   /**
-   * Subscribe with automatic JSON schema validation.
+   * Subscribe with in-process Zod validation (typing convenience —
+   * see the schema registry note below for the persisted contract layer).
    */
   async subscribeValidated<E extends OmniEvent>(
     pattern: string,
@@ -611,12 +651,19 @@ export class EventBus {
 }
 ```
 
+> **`subscribeValidated()` is in-process typing, not the platform's
+> validation story.** The subscriber hands in a Zod schema and gets a typed
+> event (or a thrown `ValidationError`) — a convenience for consumers. The
+> persisted contract layer is the [event schema registry](#event-schema-registry)
+> below, which gates specific ingress points with stored JSON Schemas.
+
 ## Event Handlers
 
 ### Example: Identity Resolution Handler
 
 ```typescript
-// packages/core/src/identity/handler.ts
+// Illustrative subscriber — the subscribe API lives in
+// packages/core/src/events/bus.ts
 
 export class IdentityEventHandler {
   constructor(
@@ -664,7 +711,8 @@ export class IdentityEventHandler {
 ### Example: Media Processing Handler
 
 ```typescript
-// packages/core/src/media/handler.ts
+// Illustrative subscriber — the subscribe API lives in
+// packages/core/src/events/bus.ts
 
 export class MediaEventHandler {
   constructor(
@@ -751,77 +799,192 @@ export class MediaEventHandler {
 
 ## Event Replay
 
-Events can be replayed for debugging or reprocessing:
+**Replay reads the journal, not a NATS stream.** `omni_events` outlives NATS
+retention and carries a total order (`journal_seq`), so a replay session
+selects journal rows by time/type/instance filters and re-publishes them to
+the bus; the journal's unique idempotency key keeps a replayed event from
+being journaled twice. Durable consumers (below) read the same journal for
+resumable consumption — see the
+[durable consumers runbook](../runbooks/durable-consumers.md).
+
+Replay primitives live in `packages/core/src/events/replay.ts`; the API
+drives sessions (one at a time, running in the background) via
+`/api/v2/event-ops/replay`:
 
 ```typescript
 // packages/core/src/events/replay.ts
 
-export class EventReplayer {
-  constructor(private eventBus: EventBus) {}
-
-  /**
-   * Replay events from a specific time range.
-   */
-  async replay(options: {
-    stream: string;
-    startTime: Date;
-    endTime?: Date;
-    filter?: (event: OmniEvent) => boolean;
-    handler: (event: OmniEvent) => Promise<void>;
-  }): Promise<ReplayResult> {
-    const { stream, startTime, endTime, filter, handler } = options;
-
-    let processed = 0;
-    let skipped = 0;
-    let errors = 0;
-
-    const consumer = await this.eventBus.getReplayConsumer(stream, startTime);
-
-    for await (const msg of consumer) {
-      const event = JSON.parse(msg.data) as OmniEvent;
-      const eventTime = new Date(event.timestamp);
-
-      // Check end time
-      if (endTime && eventTime > endTime) {
-        break;
-      }
-
-      // Apply filter
-      if (filter && !filter(event)) {
-        skipped++;
-        continue;
-      }
-
-      try {
-        await handler(event);
-        processed++;
-      } catch (error) {
-        console.error(`Replay error for event ${event.id}:`, error);
-        errors++;
-      }
-    }
-
-    return { processed, skipped, errors };
-  }
-
-  /**
-   * Replay a specific event by ID.
-   */
-  async replayEvent(eventId: string): Promise<void> {
-    const event = await this.eventBus.getEventById(eventId);
-    if (!event) {
-      throw new Error(`Event not found: ${eventId}`);
-    }
-
-    // Re-publish with original timestamp
-    await this.eventBus.publish({
-      ...event,
-      id: crypto.randomUUID(),  // New ID
-      replayOf: eventId,        // Link to original
-    });
-  }
+export interface ReplayOptions {
+  since: Date;               // Start timestamp (inclusive)
+  until?: Date;              // End timestamp (exclusive)
+  eventTypes?: string[];     // Event type filter
+  instanceId?: string;       // Instance filter
+  limit?: number;            // Max events to replay
+  speedMultiplier?: number;  // 1 = real-time, 0 = instant
+  skipProcessed?: boolean;   // Skip already-processed events
+  dryRun?: boolean;          // Count without publishing
 }
 ```
+
+```bash
+POST   /api/v2/event-ops/replay      # start a session (body: ReplayOptions)
+GET    /api/v2/event-ops/replay      # list sessions
+GET    /api/v2/event-ops/replay/:id  # session progress
+DELETE /api/v2/event-ops/replay/:id  # cancel
+```
+
+## Causality & Tracing
+
+Every published event can carry two lineage fields:
+
+- **`correlationId`** (metadata) — groups an entire flow; root events
+  self-reference.
+- **`causationId`** (journal column) — the id of the event this one reacted
+  to; the parent edge of the causality tree.
+
+Propagation is **ambient** via `AsyncLocalStorage`
+(`packages/core/src/events/causality.ts`). A consumer about to react wraps
+its reaction in `runWithEventCausality`; the publish factory falls back to
+the ambient context for whichever field the publish did not set explicitly:
+
+```typescript
+import { runWithEventCausality } from '@omni/core';
+
+// Wrapped around automation runs and agent dispatch:
+await runWithEventCausality(
+  { correlationId: event.metadata?.correlationId, causationId: event.id },
+  () => automationEngine.run(event),
+);
+```
+
+Because `AsyncLocalStorage` follows the whole await chain, every publish the
+reaction performs — however deep inside a channel plugin — is stamped without
+threading parameters through every signature. Precedence: **explicit metadata
+wins, then the ambient context, then self-reference** (roots).
+
+Tracing surfaces:
+
+- `GET /api/v2/events/:id/trace` — walks ancestors up to the root and
+  descendants breadth-first (cycle-guarded, truncation-capped).
+- `omni events trace <id>` — renders the same trace as an indented tree.
+
+## Event Schema Registry
+
+Payload contracts are persisted in the `event_schemas` table: `event_type`
+(unique), a draft-07 JSON Schema stored as jsonb, a version, and an enabled
+flag. The registry is **global**, not tenant-scoped.
+
+```bash
+# Register / revise a schema
+POST /api/v2/events/schemas
+omni events schema register custom.github.push --file schema.json
+```
+
+Revisions must be **additive-optional**: removing fields, tightening types,
+or adding new required fields is incompatible and rejected with 409.
+
+Enforcement runs at exactly **two gates**:
+
+1. **Webhook ingress / manual trigger** — an invalid payload is dead-lettered
+   with reason `schema_validation_failed` and the request fails with 400;
+   nothing is journaled. An unregistered type passes, unless the source sets
+   `strictSchemas` — then it is dead-lettered as `schema_not_registered`.
+2. **Automation `emit_event`** — validated after the agent
+   publishes-allowlist gate. Strict mode for unregistered types is opt-in via
+   `OMNI_STRICT_EMIT_EVENT_SCHEMAS=true` (default off).
+
+The bus itself is **ungated**: channel and core events are not schema-checked
+at publish time — Zod types them in-process at the boundary
+(`subscribeValidated()` above); the registry exists for payloads crossing in
+from outside.
+
+## Durable Named Consumers
+
+> Operational guide: [durable consumers runbook](../runbooks/durable-consumers.md)
+
+A durable consumer is a **Postgres-registered name with a cursor over the
+journal** — a row in `durable_consumers`: `name` (unique), an `event_type`
+filter (trailing-`*` prefix glob), `filters` jsonb (payload conditions), and
+a `cursor` bigint over `journal_seq`. These are **not NATS JetStream
+durables** — NATS offsets live in `consumer_offsets`, a different table used
+for gap detection.
+
+Semantics:
+
+- **At-least-once.** Pulls page strictly after the cursor, with optional
+  long-poll; a client that crashes mid-page re-pulls the same page.
+- **Ack is monotonic** — acking an older sequence never moves the cursor back.
+- **Lag** = journal head − cursor.
+- **One follower per name** — no consumer groups; fan out with more names.
+
+Surfaces:
+
+- REST: `/api/v2/events/consumers[...]`
+- CLI: `omni events consumers create|ls|inspect|rm`,
+  `omni events follow --consumer <name>` (tail + ack as you go), and the
+  one-shot `omni events wait` (ephemeral, no registration).
+
+### Filter Glob Semantics
+
+Event-type filters are a **trailing-`*` prefix glob only** —
+`custom.github.*` matches `custom.github.push`. This is not NATS wildcard
+syntax (`>` and mid-token `*` are not supported). The glob works in
+`events list`, `events stream`, `events wait`, and durable-consumer filters.
+It is **not** supported in automation triggers (exact type match) or agent
+event manifests (exact types only).
+
+## Webhook Event Sources (External Ingress)
+
+Rows in `webhook_sources` configure a public, auth-exempt endpoint:
+
+```
+POST /api/v2/webhooks/ingress/:source
+```
+
+Each source defines:
+
+- **Signature verification** over the raw body — `hmac-sha256`, `hmac-sha1`,
+  or `token-match`, with an optional signature prefix and a constant-time
+  compare. Every verification failure returns the same 401.
+- **Idempotency** via a per-source key template — default
+  `{source}:{sha256(body)}`, with `{headers.<name>}` and `{payload.<path>}`
+  placeholders. The key dedupes on the journal's unique idempotency index;
+  duplicates return 200 with `{"duplicate": true}`.
+- **Semantic typing** via `eventTypeMapping` — a header- or body-sourced
+  value becomes `custom.<source>.<event>`.
+- Optional **`strictSchemas`** (see the schema registry gates above).
+- A **connector-liveness contract** — `expectedIntervalSeconds` plus
+  `POST /api/v2/webhooks/:source/heartbeat`; a sweeper emits
+  `system.connector.stalled` / `system.connector.recovered`.
+
+GitHub and ClickUp are **config-only recipes** over this one generic
+mechanism — no channel plugin involved. See
+[[connector-contract|Connector Contract]],
+[GitHub webhook source](../runbooks/github-webhook-source.md), and
+[ClickUp webhook source](../runbooks/clickup-webhook-source.md).
+
+## Agent Event Manifests & Governance
+
+Agents declare their event surface in `agents.event_manifest` — `accepts`
+and `publishes` lists of **exact** event types (no globs).
+
+- **`publishes` is enforced at emit time**: an `emit_event` for an undeclared
+  type is dead-lettered with reason `publish_not_declared`.
+- **`accepts` is compiled into managed automations** (provenance tracked via
+  `managed_by_agent_id`), so the wiring is data, not code.
+- `omni agents graph` renders the resulting event topology.
+
+See the [agent publish governance runbook](../runbooks/agent-publish-governance.md).
+
+## Transactional Emissions on Automations
+
+Automations with the `transactional_emissions` flag buffer their
+`emit_event` actions per run and flush them **in order, only if the run
+finishes with zero failed actions**. Each emission claims its journal row
+with a deterministic idempotency key derived from
+`(event, automation, actionIndex)`, so retries and redeliveries of the same
+run skip already-journaled emissions. This is a journal-level claim, not a
+database outbox table.
 
 ## Event Payload Storage
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Overview"
 created: 2025-01-29
-updated: 2026-02-09
+updated: 2026-09-08
 tags: [architecture, overview]
 status: current
 ---
@@ -10,15 +10,15 @@ status: current
 
 > Omni v2 is built on event-driven, plugin-based architecture designed for extensibility, reliability, and AI-native consumption.
 
-> Related: [[event-system|Event System]], [[plugin-system|Plugin System]], [[identity-graph|Identity Graph]], [[provider-system|Provider System]]
+> Related: [[event-system|Event System]], [[connector-contract|Connector Contract]], [[plugin-system|Plugin System]], [[identity-graph|Identity Graph]], [[provider-system|Provider System]]
 
 ## Design Principles
 
 ### 1. Event Sourcing Hybrid
 - All state changes are captured as events
-- Events are the source of truth for audit/replay
+- Events are journaled to PostgreSQL in a total order (`journal_seq`); NATS is the transport
+- The journal is the source of truth for audit, replay, tracing (`causationId`), and durable consumption
 - Materialized views provide fast queries
-- Can rebuild state from events if needed
 
 ### 2. Plugin-First Channels
 - Channels are external plugins, not core code
@@ -34,7 +34,7 @@ status: current
 ### 4. Type Safety End-to-End
 - TypeScript everywhere (no Python/JS split)
 - Drizzle ORM for type-safe database access
-- tRPC for type-safe API calls
+- OpenAPI-generated SDKs for type-safe API calls
 - Zod for runtime validation
 
 ## System Components
@@ -43,8 +43,8 @@ status: current
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                                 CLIENTS                                      │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │
-│  │  Dashboard  │  │   Omni SDK  │  │  Omni CLI   │  │  MCP Tools  │        │
-│  │  (React)    │  │ (TypeScript)│  │   (LLM)     │  │  (Claude)   │        │
+│  │  Dashboard  │  │   Omni SDK  │  │  Omni CLI   │  │  Webhook    │        │
+│  │  (React)    │  │ (TypeScript)│  │   (LLM)     │  │  Sources    │        │
 │  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘        │
 └─────────┼────────────────┼────────────────┼────────────────┼────────────────┘
           │                │                │                │
@@ -54,8 +54,8 @@ status: current
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
 │  │                         Hono HTTP Server                               │  │
 │  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │  │
-│  │  │  REST API   │  │  tRPC API   │  │  WebSocket  │  │  Webhooks   │  │  │
-│  │  │ /api/v1/*   │  │  /trpc/*    │  │   /ws/*     │  │ /webhook/*  │  │  │
+│  │  │  REST API   │  │  OpenAPI    │  │  Channel    │  │  Ingress    │  │  │
+│  │  │ /api/v2/*   │  │/api/v2/docs │  │  webhooks   │  │ /ingress/*  │  │  │
 │  │  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │  │
 │  └───────────────────────────────────────────────────────────────────────┘  │
 │                                    │                                         │
@@ -73,8 +73,10 @@ status: current
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                             EVENT BUS (NATS)                                 │
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
-│  │  Streams: MESSAGES | IDENTITY | MEDIA | AGENT | ACCESS | CHANNEL      │  │
-│  │  Features: Persistence | Exactly-once | Replay | Key-Value Store      │  │
+│  │  Streams: MESSAGE | REACTION | INSTANCE | IDENTITY | MEDIA | ACCESS  │  │
+│  │           SESSION | CUSTOM | SYSTEM | AGENT                           │  │
+│  │  Features: Persistence | At-least-once | Replay | Key-Value Store    │  │
+│  │  Journaled to PostgreSQL (omni_events) — the source of truth         │  │
 │  └───────────────────────────────────────────────────────────────────────┘  │
 └───────────┬───────────────────┬───────────────────┬───────────────────┬─────┘
             │                   │                   │                   │
@@ -99,9 +101,11 @@ status: current
 │  └───────────────────────────────────────────────────────────────────────┘  │
 │                                    │                                         │
 │  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐  │
-│  │WhatsApp │ │WhatsApp │ │ Discord │ │  Slack  │ │Telegram │ │ Custom  │  │
+│  │WhatsApp │ │WhatsApp │ │ Discord │ │  Slack  │ │Telegram │ │ +7 more │  │
 │  │Baileys  │ │ Cloud   │ │         │ │         │ │         │ │         │  │
 │  └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘  │
+│   (also: Gupshup, H3rmes, ASC Flow, Twilio WhatsApp, A2A, Harness,         │
+│    Internal — see the README channel table)                                │
 └─────────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -173,7 +177,7 @@ status: current
 ### Outbound Message Flow (API/CLI)
 
 ```
-1. API Request: POST /api/v1/messages
+1. API Request: POST /api/v2/messages/send
          │
          ▼
 2. Validation & Auth
@@ -205,108 +209,54 @@ status: current
 ```
 packages/
 ├── core/                          # Core domain logic
-│   ├── src/
-│   │   ├── events/               # Event bus, types, streams
-│   │   │   ├── bus.ts            # NATS JetStream wrapper
-│   │   │   ├── types.ts          # Event type definitions
-│   │   │   └── streams.ts        # Stream configuration
-│   │   │
-│   │   ├── identity/             # Identity graph
-│   │   │   ├── service.ts        # IdentityService
-│   │   │   ├── resolver.ts       # Identity resolution logic
-│   │   │   └── merger.ts         # Identity merging
-│   │   │
-│   │   ├── access/               # Access control
-│   │   │   ├── service.ts        # AccessControlService
-│   │   │   ├── rules.ts          # Rule engine
-│   │   │   └── patterns.ts       # Pattern matching
-│   │   │
-│   │   ├── media/                # Media processing
-│   │   │   ├── pipeline.ts       # Processing orchestration
-│   │   │   ├── processors/       # Processor implementations
-│   │   │   │   ├── whisper.ts    # Audio transcription
-│   │   │   │   ├── gemini.ts     # Image/video description
-│   │   │   │   └── document.ts   # Document extraction
-│   │   │   └── storage.ts        # Media storage
-│   │   │
-│   │   ├── router/               # Message routing
-│   │   │   ├── router.ts         # MessageRouter
-│   │   │   ├── agent-client.ts   # Agent API client
-│   │   │   └── splitter.ts       # Message splitting
-│   │   │
-│   │   ├── oauth/                # OAuth management
-│   │   │   ├── manager.ts        # OAuthManager
-│   │   │   └── providers/        # Provider implementations
-│   │   │
-│   │   └── db/                   # Database
-│   │       ├── schema.ts         # Drizzle schema
-│   │       ├── migrations/       # SQL migrations
-│   │       └── client.ts         # Database client
-│   │
-│   └── package.json
+│   └── src/
+│       ├── events/               # Event bus, causality, schema registry
+│       │   ├── bus.ts            # NATS JetStream wrapper
+│       │   ├── causality.ts      # correlationId/causationId propagation
+│       │   ├── schema-registry.ts # Event payload schema validation
+│       │   ├── replay.ts         # Journal replay
+│       │   ├── payload-store.ts  # Large payload offloading
+│       │   ├── dead-letter.ts    # DLQ handling
+│       │   ├── nats/             # Streams, consumers, registry
+│       │   └── types.ts          # Event type definitions
+│       ├── automations/          # Automation engine + actions
+│       ├── providers/            # Agent provider factory (webhook, openclaw, …)
+│       ├── schemas/              # Zod schemas (messages, agents, manifests, …)
+│       ├── connectors/           # Connector liveness contract
+│       ├── sessions/ scheduler/ secrets/ egress/ observability/ …
+│       └── types/                # Shared TypeScript types
 │
 ├── api/                           # HTTP API
-│   ├── src/
-│   │   ├── routes/               # Route handlers
-│   │   │   ├── instances.ts      # Instance CRUD
-│   │   │   ├── messages.ts       # Message operations
-│   │   │   ├── events.ts         # Event queries
-│   │   │   ├── identity.ts       # Identity management
-│   │   │   ├── access.ts         # Access rules
-│   │   │   ├── settings.ts       # Global settings
-│   │   │   └── webhooks.ts       # Webhook receivers
-│   │   │
-│   │   ├── trpc/                 # tRPC router
-│   │   │   ├── router.ts         # Main router
-│   │   │   └── procedures/       # Procedure definitions
-│   │   │
-│   │   ├── middleware/           # Middleware
-│   │   │   ├── auth.ts           # API key auth
-│   │   │   ├── rate-limit.ts     # Rate limiting
-│   │   │   └── logging.ts        # Request logging
-│   │   │
-│   │   ├── websocket/            # WebSocket handlers
-│   │   │   ├── server.ts         # WS server
-│   │   │   └── handlers.ts       # Event handlers
-│   │   │
-│   │   └── index.ts              # Server entry point
-│   │
-│   └── package.json
+│   └── src/
+│       ├── routes/v2/            # All /api/v2 route modules (~40)
+│       ├── services/             # Domain services (events, webhooks, tenants, …)
+│       ├── plugins/              # Agent dispatcher, event persistence, loader
+│       ├── middleware/           # Auth, rate limiting, webhook auth
+│       ├── tenancy/              # Multitenancy flags, posture, auth plane
+│       ├── ws/                   # Scoped WebSocket handlers (chats, logs, voice)
+│       └── index.ts              # Server entry point (auto-migrates on boot)
 │
-├── channel-sdk/                   # Plugin SDK
-│   ├── src/
-│   │   ├── types.ts              # Plugin interfaces
-│   │   ├── base-plugin.ts        # Base class
-│   │   ├── normalizer.ts         # Normalizer interface
-│   │   ├── testing/              # Test utilities
-│   │   └── index.ts              # Public API
-│   │
-│   └── package.json
-│
-├── channel-whatsapp/               # WhatsApp (Baileys)
-├── channel-discord/               # Discord
-│
-├── db/                            # Database package (Drizzle schema + migrations)
-│   └── package.json
-│
-├── media-processing/              # Media handling (transcription, vision, extraction)
-│   └── package.json
-│
+├── db/                            # Drizzle schema + hand-written SQL migrations
+├── channel-sdk/                   # Plugin SDK (interfaces, base class, discovery)
+├── channel-whatsapp/              # WhatsApp (Baileys)
+├── channel-whatsapp-business/     # WhatsApp Cloud API (Meta)
+├── channel-discord/               # Discord (incl. voice)
+├── channel-slack/                 # Slack
+├── channel-telegram/              # Telegram
+├── channel-gupshup/               # Gupshup
+├── channel-hermes/                # H3rmes (Brazilian WhatsApp gateway)
+├── channel-twilio-whatsapp/       # Twilio WhatsApp
+├── channel-a2a/                   # A2A protocol server
+├── channel-asc-flow/              # ASC platform Flow (Brazilian BSP)
+├── channel-harness/               # E2E agent-testing channel
+├── channel-internal/              # In-process agent-to-agent routing
+├── media-processing/              # Transcription, vision, extraction
+├── plugin-openclaw/               # Omni as a channel inside OpenClaw
+├── voice-client/                  # Voice transport/codec library
+├── cli/                           # LLM-optimized CLI (`omni`)
 ├── sdk/                           # Auto-generated TypeScript SDK
-│   └── package.json
-│
 ├── sdk-go/                        # Go SDK
-│   └── go.mod
-│
-├── sdk-python/                    # Python SDK
-│   └── pyproject.toml
-│
-└── cli/                           # LLM-optimized CLI
-    ├── src/
-    │   ├── commands/             # Command implementations
-    │   └── index.ts              # CLI entry point
-    │
-    └── package.json
+└── sdk-python/                    # Python SDK
 ```
 
 ## Configuration
@@ -315,12 +265,13 @@ packages/
 
 ```bash
 # Server
-OMNI_HOST=0.0.0.0
-OMNI_PORT=8881
-OMNI_API_KEY=sk-...
+API_HOST=0.0.0.0
+API_PORT=8882
+OMNI_API_KEY=omni_sk_...  # Override primary key (auto-generated on first boot)
 
-# Database
-DATABASE_URL=postgresql://user:pass@localhost:5432/omni
+# Database (the CLI installer manages PostgreSQL via canonical pgserve and
+# writes the URL; source checkouts read .env — see .env.example)
+DATABASE_URL=postgresql://postgres:postgres@localhost:8432/omni
 
 # NATS
 NATS_URL=nats://localhost:4222
@@ -330,16 +281,14 @@ GROQ_API_KEY=...          # Audio transcription (primary)
 OPENAI_API_KEY=...        # Fallback for audio + images
 GEMINI_API_KEY=...        # Images and video (primary)
 
-# OAuth (for channels that need it)
-SLACK_CLIENT_ID=...
-SLACK_CLIENT_SECRET=...
-WHATSAPP_BUSINESS_APP_ID=...
-WHATSAPP_BUSINESS_APP_SECRET=...
-
 # Feature Flags
-OMNI_EVENTS_REALTIME=true
-OMNI_LEGACY_WRITE=false   # Enable during migration
+A2A_ENABLED=true                     # Mount the A2A channel
+OMNI_MULTITENANCY_ENABLED=true       # Mount the /api/v2/platform control plane
+OMNI_DB_ENFORCEMENT=on               # Tenant isolation enforcement (RLS)
+OMNI_STRICT_EMIT_EVENT_SCHEMAS=true  # Refuse emit_event for unregistered types
 ```
+
+Set `*_MANAGED=false` for externally managed services. Full list in `.env.example`.
 
 ### Instance Configuration
 
@@ -450,72 +399,35 @@ interface InstanceConfig {
 
 ## Deployment (PM2)
 
-We use PM2 for production deployment. No containers required.
+We use PM2 for deployment. No containers required.
 
-### Prerequisites
+The easiest path is the CLI installer, which bootstraps the whole runtime
+(PostgreSQL via pgserve, NATS, and the API) under PM2:
 
 ```bash
-# Install NATS binary (one-time)
-curl -L https://github.com/nats-io/nats-server/releases/download/v2.10.22/nats-server-v2.10.22-linux-amd64.tar.gz | tar xz
-sudo mv nats-server-v2.10.22-linux-amd64/nats-server /usr/local/bin/
-
-# Create NATS data directory
-sudo mkdir -p /var/lib/nats
-sudo chown $USER:$USER /var/lib/nats
+bun add -g @automagik/omni
+omni install
 ```
 
-### PM2 Configuration
+The installer registers `omni-api` and `omni-nats` under PM2 and provisions
+PostgreSQL through the canonical pgserve backbone (its own PM2-supervised
+process, e.g. `autopg-server`).
 
-```javascript
-// ecosystem.config.js
-module.exports = {
-  apps: [
-    // NATS JetStream (message broker)
-    {
-      name: 'nats',
-      script: 'nats-server',
-      args: '--jetstream --store_dir /var/lib/nats',
-      interpreter: 'none',
-      autorestart: true,
-      watch: false,
-    },
+For source deployments, the repo ships `ecosystem.config.cjs`, which defines
+`omni-v2-nats` and `omni-v2-api` (PostgreSQL is external or pgserve-managed,
+per your `.env`):
 
-    // Omni API Server
-    {
-      name: 'omni-api',
-      script: 'bun',
-      args: 'run start:api',
-      cwd: '/path/to/omni-v2',
-      env: {
-        NODE_ENV: 'production',
-        PORT: 8881,
-      },
-      autorestart: true,
-      max_memory_restart: '500M',
-    },
-
-    // Media Processing Workers
-    {
-      name: 'omni-workers',
-      script: 'bun',
-      args: 'run start:workers',
-      cwd: '/path/to/omni-v2',
-      instances: 2,  // Scale based on load
-      env: {
-        NODE_ENV: 'production',
-      },
-      autorestart: true,
-      max_memory_restart: '1G',
-    },
-  ],
-};
-```
+| Service | PM2 Name (installer / source checkout) | Port |
+|---------|----------------------------------------|------|
+| API | `omni-api` / `omni-v2-api` | 8882 |
+| NATS | `omni-nats` / `omni-v2-nats` | 4222 |
+| PostgreSQL | `autopg-server` (canonical pgserve, via `omni install`) | 8432 |
 
 ### Commands
 
 ```bash
-# Start all services
-pm2 start ecosystem.config.js
+# Start all services (from a source checkout)
+pm2 start ecosystem.config.cjs
 
 # View status
 pm2 status
@@ -572,45 +484,18 @@ curl http://localhost:8882/api/v2/health
 - Immutable event log
 - Retention policies configurable
 
-## MCP Integration (Model Context Protocol)
+## LLM / Agent Integration
 
-Omni v2 includes an MCP server that enables AI assistants (Claude, Cursor, Windsurf, etc.) to interact with the platform.
+There is no MCP server in this repository. AI assistants and agents integrate
+with Omni through:
 
-### Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `omni_list_instances` | List all instances with status |
-| `omni_get_instance` | Get instance details |
-| `omni_send_message` | Send text/media message |
-| `omni_search_messages` | Search message history |
-| `omni_search_persons` | Find persons across channels |
-| `omni_get_person_presence` | Get cross-channel presence |
-| `omni_get_timeline` | Get conversation timeline |
-| `omni_create_instance` | Create new instance |
-| `omni_restart_instance` | Restart connection |
-
-### Running the MCP Server
-
-```bash
-# HTTP mode (for web clients)
-bun run mcp:http
-
-# Stdio mode (for Claude Desktop)
-bun run mcp:stdio
-```
-
-### Client Installation
-
-```bash
-# Claude Desktop
-npx @anthropic/install-mcp omni --url http://localhost:8882/mcp
-
-# Cursor / VSCode
-# Add to settings.json:
-{
-  "mcp.servers": {
-    "omni": { "url": "http://localhost:8882/mcp" }
-  }
-}
-```
+- **The CLI** (`omni`) — designed to be LLM-operable: grouped help, `--json`
+  output on every command, and one-shot verbs (`omni say`, `omni open`,
+  `omni events wait`)
+- **The REST API + SDKs** — OpenAPI-described, so agents can consume the spec
+  directly
+- **Agent providers** — bind an agent (webhook, OpenClaw, Claude Code, A2A,
+  and more) to an instance so it responds to messages; see
+  [[provider-system|Provider System]]
+- **Agent event manifests** — declare what an agent consumes/publishes and let
+  Omni compile the routing; see [[event-system|Event System]]

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -39,6 +39,8 @@ February 2027**; new Slack apps can only use `agent_view`, and the switch from
 3. For Socket Mode (default): an **app-level token** (`xapp-...`) with
    `connections:write`.
 4. A **bot token** (`xoxb-...`) issued on install.
+5. Optional: a **user token** (`xoxp-...`) if you want user-token mode —
+   required for message search (see below).
 
 ## Setup
 
@@ -98,8 +100,33 @@ Provide the tokens as instance credentials:
 ```
 
 See `SlackConfig` (`packages/channel-slack/src/types.ts`) for every option:
-DM policy, channel allow/blocklists, stream mode, reply-to mode, slash
-commands, and user-token mode (`authMode: 'user'`, #889).
+DM policy (`dmPolicy`, `dmAllowlist`), channel allow/blocklists, stream mode
+(`streamMode`, `streamThrottleMs`), reply-to mode, ack reactions
+(`ackReaction`, `removeAckAfterReply`), display defaults (`defaultUsername`,
+`defaultIconUrl`/`defaultIconEmoji`), HTTP mode (`httpPort`, `signingSecret`),
+retry config, and user-token mode (below).
+
+### User-token (`xoxp`) mode (#889)
+
+Set `authMode: 'user'` and provide a `userToken` (`xoxp-...`) to have the
+instance act as a user instead of (only) a bot:
+
+```jsonc
+{
+  "channel": "slack",
+  "config": {
+    "botToken": "xoxb-...",   // still required — Bolt authenticates with it
+    "appToken": "xapp-...",
+    "authMode": "user",
+    "userToken": "xoxp-..."   // prefix-validated; an xoxb here is rejected
+  }
+}
+```
+
+The **bot token stays mandatory** in user mode: it authenticates the Socket
+Mode connection and is the fallback for scopes the user token lacks. User mode
+is required for `search.messages` (the `search:read` scope only exists as a
+user scope).
 
 ### 3. Verify
 
@@ -111,6 +138,34 @@ configured. You should see:
   clears),
 - the streamed reply rendered word-by-word (native `chat.startStream` when the
   workspace supports it).
+
+## Messaging features (#889)
+
+Beyond send/receive, the Slack plugin supports:
+
+- **Threads** — `thread_ts` resolution via `replyToMode`, thread history
+  through `conversations.replies`, and thread roots/reply counters recorded on
+  messages.
+- **Scheduled messages** — native `chat.scheduleMessage` (text-only), surfaced
+  as `omni schedule send <instance> <chat> "..." --at 2h` and
+  `POST /api/v2/scheduled-messages`. Cancel with `omni schedule cancel <id>`.
+- **Permalinks** — `GET /api/v2/messages/:id/permalink` resolves via
+  `chat.getPermalink` and caches on the message row.
+- **Pins** — `pin_added`/`pin_removed` events populate `pinnedAt`/`pinnedBy`
+  on messages; agents get `pins.add`/`pins.remove` tools.
+- **Message search** — `omni slack search <instance> <query>` wraps
+  `search.messages`. Requires user-token mode (`search:read` is a user scope);
+  results are from the authorizing user's perspective.
+- **DM open** — `omni slack dm <instance> <userId>` resolves/opens the DM
+  channel for a `U…` user id and prints the follow-up send command.
+
+## Socket health (#941)
+
+A Slack instance can look "connected" while its WebSocket is deaf —
+`auth.test` is HTTPS and stays `ok` even when the Socket Mode WSS never
+opened. Omni therefore verifies the real WebSocket `readyState` on connect
+(waiting for the `connected` event with a timeout) and health checks fail
+first on a dead socket rather than trusting `app.start()`.
 
 ## Status & stop internals
 

--- a/docs/channels/whatsapp-business.md
+++ b/docs/channels/whatsapp-business.md
@@ -114,8 +114,9 @@ omni instances connect <instance-id> \
 
 For numbers added via Embedded Signup, Meta requires a 6-digit PIN registration before the number can send:
 
-```bash
-omni instances whatsapp-business:register <instance-id> --pin 123456
+```http
+POST /api/v2/instances/:id/whatsapp-business/register
+{ "pin": "123456" }
 ```
 
 The PIN is one you set during onboarding — it's also required if you ever de-register and re-register.
@@ -131,8 +132,8 @@ omni send --to +5511999998888 --text "Hi!" --instance <instance-id>
 Or via REST:
 
 ```http
-POST /api/v2/messages
-{ "instanceId": "...", "to": "+5511999998888", "content": { "type": "text", "text": "Hi!" } }
+POST /api/v2/messages/send
+{ "instanceId": "...", "to": "+5511999998888", "text": "Hi!" }
 ```
 
 ### Templates (outside 24h window or first contact)

--- a/docs/cli/design.md
+++ b/docs/cli/design.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI Design"
 created: 2025-01-29
-updated: 2026-02-09
+updated: 2026-09-08
 tags: [cli, reference]
 status: current
 ---
@@ -15,11 +15,11 @@ status: current
 ## Installation
 
 ```bash
-# Build and link globally
-make cli-link
+# End users: install globally with Bun
+bun add -g @automagik/omni
 
-# Binary location
-~/.omni/bin/omni
+# Repo development: build and link from source (symlinks into ~/.bun/bin)
+make cli-link
 ```
 
 ## Configuration
@@ -28,60 +28,125 @@ make cli-link
 # Set API key (stored in ~/.omni/config.json)
 omni config set apiKey sk-omni-...
 
-# Set base URL
-omni config set baseUrl https://api.example.com
+# Set API URL (the key is apiUrl, default http://localhost:8882)
+omni config set apiUrl https://api.example.com
 
 # Set default instance
-omni config set instance <instance-id>
+omni config set defaultInstance <instance-id>
 
 # View config
 omni config list
 
 # Environment variables (take precedence)
 export OMNI_API_KEY=sk-omni-...
-export OMNI_BASE_URL=https://api.example.com
+export OMNI_FORMAT=json
+```
+
+Valid config keys: `apiUrl`, `apiKey`, `defaultInstance`, `format` (`human`|`json`),
+`showCommands`, `telemetry`, `updateChannel` (`latest`|`next`), and the local-runtime
+namespace `server.port`, `server.databaseUrl`, `server.dataDir`, `server.logLevel`,
+`server.nodeEnv`. There is no `baseUrl` key and no `OMNI_BASE_URL` variable.
+
+### Multiple servers
+
+The CLI keeps a named registry of Omni servers (managed only via `omni server`,
+never `omni config set`):
+
+```bash
+omni server add prod https://api.example.com --api-key sk-omni-...
+omni server list                # List registered servers
+omni server use prod            # Switch the active server
+omni server current             # Show the active server
+omni server remove prod
+
+# One-off: target a named server for a single command
+omni instances list --server prod
 ```
 
 ## Command Structure
 
-Commands are grouped into three categories:
+Commands have a visibility **category** (`core`, `standard`, `advanced`, `debug`)
+and a help **group** (Core, Management, System). Grouped help shows everything
+except `debug` commands; `omni --all` reveals those too.
 
-### Core
+### Core — messaging & conversation context
 
 | Command | Description |
 |---------|-------------|
 | `send` | Send message (text, media, location, poll, embed, reaction, presence) |
+| `say` | Send text to the open chat (verb command) |
+| `react` | React to a message with an emoji (verb command) |
+| `listen` | Transcribe audio to text (verb command) |
+| `imagine` | Generate an image from a prompt (Gemini, verb command) |
+| `film` | Generate a video from a prompt (Gemini Veo, verb command) |
+| `music` | Generate music/audio from a prompt (Gemini Lyria, verb command) |
+| `speak` | Synthesize text to speech and send as a voice note (verb command) |
+| `see` | Describe an image or video via Gemini Vision (verb command) |
+| `history` | Show recent messages in the open chat (verb command) |
+| `open` / `close` | Set / clear the active chat context for verb commands |
+| `use` | Set the active instance for verb commands |
+| `where` | Show current context (instance, chat) |
+| `done` | Close turn (send final message + emit `turn.done`) |
 | `chats` | List and manage conversations |
-| `messages` | Message actions (search, read receipts) |
+| `messages` | Message actions (get, search, read, edit, delete, star/unstar) |
+| `tts` | Text-to-speech operations |
+| `voice` | Voice channel operations (join, stream, sessions) |
+| `a2a` | A2A agent registry and JSON-RPC helpers |
+| `schedule` | Schedule messages for later delivery |
+| `media` | Browse and download media items |
 
-### Management
+### Management — configuration and setup
 
 | Command | Description |
 |---------|-------------|
-| `instances` | Channel connections (WhatsApp, Discord) |
+| `channels` | Channel types, add instances, status overview |
+| `instances` | Channel connections (WhatsApp, Discord, Slack, …) |
 | `persons` | Contact directory |
+| `agents` | AI agent entity management (incl. event manifests) |
+| `providers` | AI/LLM provider configuration |
 | `automations` | Event-driven workflows |
-| `providers` | AI/LLM providers configuration |
+| `follow-up` | Idle-chat follow-up config (agents/instances/chats) |
+| `slack` | Slack-only: open a DM by user id, search messages |
+| `connect` | Connect an instance to a genie agent via NATS |
+| `setup` | Compound setup (agent → provider → instance, any schema) |
+| `routes` | Agent routing configuration |
+| `keys` | API key management |
+| `tenants` | Platform tenant control plane (multitenancy) |
+| `trust` | Genie host fingerprint trust |
 | `access` | Access control and permissions |
-| `webhooks` | Webhook management |
+| `webhooks` | External event sources (webhook ingress) |
+| `turns` | Admin turn management (list, close, stats) |
 
-### System
+### System — status, runtime, and observability
 
 | Command | Description |
 |---------|-------------|
 | `status` | API health and connection info |
 | `config` | CLI settings (default instance, format) |
-| `events` | Query message history |
 | `auth` | Authentication management |
+| `events` | Event store: query, tail, trace, durable consumers |
+| `server` | Registry of Omni servers to talk to (add, use, list) |
+| `multitenancy` | Server multitenancy posture (read-only) |
 | `settings` | Server settings |
 | `batch` | Batch operations |
-| `keys` | API key management (hidden) |
-| `logs` | System log viewer (hidden) |
-| `dead-letters` | Failed event management (hidden) |
-| `payloads` | Event payload inspection (hidden) |
-| `completions` | Shell completions (hidden) |
+| `start` / `stop` / `restart` | Manage local Omni services (API + NATS) |
+| `install` | Interactive setup wizard (bootstrap an Omni server) |
+| `update` | Update the CLI to the latest version |
+| `doctor` | Diagnose and repair the embedded omni runtime |
+| `requirements` | Show declared peer-version requirements (pgserve, genie) |
+| `prompts` | Manage LLM prompt overrides |
+| `resync` | Trigger history backfill for instances |
+| `replay` | Replay missed messages for an agent instance |
+| `journey` | Message journey tracing & latency |
 
-> Hidden commands are shown with `omni --all`
+### Debug (shown with `omni --all`)
+
+| Command | Description |
+|---------|-------------|
+| `logs` | System log viewer |
+| `dead-letters` | Failed event management |
+| `payloads` | Event payload inspection |
+| `completions` | Shell completions |
 
 ---
 
@@ -125,6 +190,23 @@ omni send --instance <id> --to +5511999 --text "Hi"
 
 # Reply to a message
 omni send --to +5511999 --text "Reply" --reply-to <message-id>
+```
+
+## Schedule
+
+Schedule messages for later delivery. `<chat>` is the platform chat id. Delivery
+is native when the channel supports it (Slack `chat.scheduleMessage`, text-only);
+otherwise a local sweeper (15s tick) sends it. Only messages scheduled through
+Omni are listed.
+
+```bash
+omni schedule send <instance> <chat> "Reminder" --at 2026-09-09T14:00:00Z
+omni schedule send <instance> <chat> "Soon" --at 30m          # 30m/2h/3d shorthand
+omni schedule send <instance> <chat> "Hi" --at 2h --thread <ts>
+omni schedule send <instance> <chat> "All" --at 1d --broadcast
+omni schedule list <instance>              # List scheduled messages
+omni schedule get <id>                     # Get one
+omni schedule cancel <id>                  # Cancel before delivery
 ```
 
 ## Chats
@@ -191,16 +273,76 @@ omni persons presence <id>                # Cross-channel presence
 
 ## Events
 
+The event store surface: query, live tail, tracing, durable consumers, and a
+JSON Schema registry for custom event types.
+
 ```bash
+# Query
 omni events list                           # List recent events
-omni events list --instance <id>           # Filter by instance
-omni events list --since 2025-01-01        # Date range
-omni events list --limit 100               # Limit results
+omni events list --instance <id> --channel whatsapp
+omni events list --type "message.*"        # Trailing-* prefix glob
+omni events list --type message.received,message.sent  # Comma list
+omni events list --since 2026-09-01 --until 2026-09-08 --limit 100
+omni events get <id>                       # Get one event
 omni events search "meeting"              # Search by content
 omni events timeline <person-id>          # Cross-channel timeline
 omni events metrics                       # Processing metrics
-omni events replay                        # Manage replay sessions
+omni events analytics                     # Aggregated analytics
+
+# Live tail (poll-based)
+omni events stream --type "message.*"      # Live tail
+omni events stream --ndjson --poll-ms 500  # NDJSON output, custom poll interval
+
+# One-shot blocking wait (exits non-zero on timeout)
+omni events wait --type message.received --filter instanceId=<id> --timeout 60
+
+# Causation tracing: walks the causationId chain up to the root and
+# breadth-first down, printed as an indented tree with corr= ids
+omni events trace <id>
+
+# Replay
+omni events replay --start --since 2026-09-01 --types "message.received" --dry-run  # exact types only, no globs
+omni events replay --status <id>           # Check a replay session
+omni events replay --cancel <id>           # Cancel a replay session
 ```
+
+### Durable consumers
+
+Named, resumable cursors for tailing the event store. These are **Postgres
+journal cursors** over `omni_events.journal_seq` — NOT NATS JetStream
+consumers. Delivery is at-least-once, and each consumer name supports a single
+follower (no consumer groups).
+
+```bash
+omni events consumers create my-bot --type "message.*" --filter instanceId=<id>
+omni events consumers create audit --type "*" --from-beginning
+omni events consumers ls                   # List consumers
+omni events consumers inspect my-bot       # Cursor position, lag
+omni events consumers rm my-bot            # Delete
+
+# Durable tail through the consumer's stored cursor (acks as it goes)
+omni events follow --consumer my-bot
+omni events follow --consumer my-bot --no-ack      # Peek one page, no ack
+omni events follow --consumer my-bot --until-idle  # Exit when caught up
+```
+
+### Schema registry
+
+Register JSON Schemas for custom event types (validated at ingress when a
+webhook source sets `--strict-schemas`).
+
+```bash
+omni events schema register custom.deploy --file ./deploy.schema.json --description "Deploy events"
+omni events schema register custom.ping --schema '{"type":"object"}' --disabled
+omni events schema list
+omni events schema get custom.deploy
+```
+
+> [!note] Glob and emission caveats
+> Type globs are trailing-`*` prefix only (`message.*`, not `*.received`), and
+> are NOT supported in automation triggers or agent manifests. There is no
+> `events emit` — manual emission goes through
+> `omni webhooks trigger --type custom.x --payload '{...}'`.
 
 ## Automations
 
@@ -217,6 +359,30 @@ omni automations execute <id>            # Execute with real event
 omni automations logs <id>               # Execution logs
 ```
 
+`create`/`update` support `--transactional-emissions`: `emit_event` actions are
+buffered and flushed in order only if the whole run succeeds. The `call_agent`
+action also works chatless — an event can dispatch an agent without any chat
+context.
+
+## Agents
+
+Agent entity CRUD plus event subscription manifests.
+
+```bash
+omni agents list|get|create|update|delete  # Entity management
+
+# Event manifests (accepts/publishes), JSON or YAML
+omni agents manifest get <agent-id>
+omni agents manifest apply <agent-id> --file ./manifest.yaml
+
+# Subscription graph: agent | consumes | produces | compiled
+omni agents graph
+omni agents graph --type message.received
+```
+
+Manifest semantics: `publishes` is enforced at emit time; `accepts` compiles
+into managed automations.
+
 ## Providers
 
 ```bash
@@ -225,18 +391,104 @@ omni providers get <id>                    # Get details
 omni providers create ...                 # Create provider
 omni providers update <id> ...            # Update
 omni providers delete <id>               # Delete
-omni providers health <id>              # Health check
+omni providers test <id>                 # Connectivity/health test
+omni providers setup openclaw ...        # Guided OpenClaw setup wizard (the only wizard today)
+omni providers agents <id>               # List provider agents
+omni providers teams <id>                # List provider teams
+omni providers workflows <id>            # List provider workflows
 ```
 
 ## Webhooks
 
+External event sources: inbound webhooks land on the public unauthenticated
+ingress endpoint `POST /api/v2/webhooks/ingress/:source` (signature required)
+and become events on the bus.
+
 ```bash
 omni webhooks list                         # List webhook sources
 omni webhooks get <id>                     # Get details
-omni webhooks create ...                  # Create source
-omni webhooks update <id> ...             # Update
-omni webhooks delete <id>                # Delete
-omni webhooks trigger ...                # Trigger custom event
+omni webhooks delete <id>                 # Delete
+omni webhooks trigger --type custom.x --payload '{...}'  # Manual event emission
+omni webhooks heartbeat <source>          # Connector liveness ping
+
+# Create with signature verification
+omni webhooks create --name github \
+  --signature-algorithm hmac-sha256 \
+  --signature-header X-Hub-Signature-256 \
+  --signature-prefix "sha256=" \
+  --signature-secret-env GITHUB_WEBHOOK_SECRET
+
+# Event type mapping: events are typed custom.<source>.<event>
+omni webhooks create --name github --event-type-mapping '{"source":"header","header":"X-GitHub-Event"}'
+omni webhooks create --name clickup --event-type-mapping '{"source":"body","path":"event"}'
+omni webhooks create --name foo --event-type-mapping @mapping.json
+```
+
+Create flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--signature-algorithm` | `hmac-sha256` \| `hmac-sha1` \| `token-match` |
+| `--signature-header` / `--signature-prefix` | Where/how the signature arrives |
+| `--signature-secret` / `--signature-secret-env` / `--signature-secret-stdin` | Secret delivery options |
+| `--idempotency-key-template` | Dedup key; placeholders `{source}`, `{sha256(body)}`, `{headers.<name>}`, `{payload.<dot.path>}` (numeric array indices OK); default `{source}:{sha256(body)}` |
+| `--strict-schemas` | Reject payloads failing the registered JSON Schema |
+| `--event-type-mapping <json\|@file>` | Derive event type from header or body path |
+| `--expected-interval` | Connector liveness cadence; missed heartbeats emit `system.connector.stalled` / `.recovered` |
+
+`update` adds the clearing flags `--clear-signature`, `--no-strict-schemas`,
+`--clear-event-type-mapping`, `--clear-cadence`.
+
+> Recipes: [[../runbooks/github-webhook-source|GitHub webhook source]],
+> [[../runbooks/clickup-webhook-source|ClickUp webhook source]].
+
+## Tenants
+
+Platform tenant control plane. Requires a PLATFORM-class credential and
+`OMNI_MULTITENANCY_ENABLED=true` on the server. All commands effectively
+require `--reason` (3–500 chars, audited).
+
+```bash
+omni tenants list --reason "quarterly review"
+omni tenants get <id> --reason "support case 123"
+omni tenants create --slug acme --name "Acme" \
+  --max-key-ttl 7776000 --max-key-rate 100 --max-key-budget 500 --reason "onboarding"  # TTL in seconds (90 days)
+omni tenants suspend <id> --reason "billing hold"
+omni tenants archive <id> --reason "offboarded"     # Terminal
+
+omni tenants memberships list <tenant-id> --reason "..."
+omni tenants memberships add|disable|status|role ...
+
+# Plaintext key is printed exactly once. All of --principal, --membership,
+# --role, --name, --scopes, --expires, --rate-limit, --budget are required,
+# and the scopes/expiry must fit the role ceiling and tenant TTL policy.
+omni tenants keys issue-root <tenant-id> \
+  --principal <uuid> --membership <uuid> --role tenant-owner \
+  --name root --scopes "tenant:*" --expires <iso-within-ttl> \
+  --rate-limit 100 --budget 500 --reason "root key rotation"
+```
+
+```bash
+# Read-only server tenancy posture (separate top-level command)
+omni multitenancy status
+```
+
+## Slack
+
+Slack-only helpers.
+
+```bash
+omni slack dm <instance> <userId>          # Resolve/open DM channel for a user (U…)
+omni slack search <instance> <query>       # Search messages (requires user-token authMode)
+```
+
+## Journey
+
+Message journey tracing with a T0–T11 latency breakdown.
+
+```bash
+omni journey show <correlationId>          # Timeline with timing bars
+omni journey summary                       # Aggregated journey metrics
 ```
 
 ## Access
@@ -264,6 +516,8 @@ omni settings set GROQ_API_KEY gsk_...    # Set setting
 ```bash
 omni status                                # API health check
 omni auth validate                        # Validate API key
+omni start / stop / restart               # Manage local services (API + NATS)
+omni doctor                               # Diagnose/repair embedded runtime
 omni logs                                 # View recent logs
 omni logs error                           # Filter by level
 omni logs --modules api,whatsapp          # Filter by module
@@ -281,10 +535,10 @@ omni dead-letters retry <id>             # Retry failed event
 # Default: human-readable with colors
 omni instances list
 
-# JSON (for parsing)
-omni instances list --format json
+# JSON (for parsing) — --json works with any command, in any position
+omni instances list --json
 
-# Use OMNI_FORMAT env var for default
+# Use OMNI_FORMAT env var or `omni config set format json` for a default
 export OMNI_FORMAT=json
 ```
 
@@ -293,19 +547,26 @@ export OMNI_FORMAT=json
 ```
 Options:
   -V, --version     Show version
+  --json            Output in JSON format (works with any command)
+  --server <name>   Target a named server from the registry for this command
   --no-color        Disable colored output
-  --all             Show all commands (including hidden)
+  --all             Show all commands (including debug commands)
   -h, --help        Show help
 ```
+
+There is no global `--api-url` / `--api-key` — targets come from the config
+file, the server registry (`omni server`), or environment variables.
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `OMNI_API_KEY` | API key for authentication |
-| `OMNI_BASE_URL` | Base URL of Omni server |
-| `OMNI_FORMAT` | Default output format |
-| `OMNI_NO_COLOR` | Disable colored output |
+| `OMNI_FORMAT` | Default output format (`human` \| `json`) |
+| `OMNI_INSTANCE` | Active instance for verb commands |
+| `OMNI_CHAT` | Active chat for verb commands |
+| `OMNI_CONFIG_DIR` | Config directory override (default `~/.omni`) |
+| `OMNI_TELEMETRY` | Enable/disable error telemetry (`true` \| `false`) |
 
 ## Configuration File
 
@@ -314,8 +575,11 @@ Located at `~/.omni/config.json`:
 ```json
 {
   "apiKey": "omni_sk_...",
-  "baseUrl": "http://localhost:8882",
-  "instance": "07a5178e-...",
+  "apiUrl": "http://localhost:8882",
+  "defaultInstance": "07a5178e-...",
   "format": "human"
 }
 ```
+
+Multi-server setups add a `servers` block (`active` pointer + named entries),
+managed exclusively by `omni server` — never edit it via `omni config set`.

--- a/docs/deployment/platform-credential-bootstrap.md
+++ b/docs/deployment/platform-credential-bootstrap.md
@@ -74,11 +74,20 @@ untouched.
 
 ## After bootstrapping
 
-Use the platform credential against the platform control plane (for example
-`POST /api/v2/platform/tenants` with an `x-platform-reason` header) to create
+Use the platform credential against the platform control plane to create
 tenants, attach memberships, and issue tenant root keys — the delegation chain
-the enforcement world expects. Day-to-day work should use tenant-scoped keys
-delegated from this credential, not the platform credential itself.
+the enforcement world expects. The control plane is only mounted when
+`OMNI_MULTITENANCY_ENABLED=true`; without it every `/api/v2/platform/**`
+request returns 404.
+
+The `omni tenants` command group wraps the whole surface (`tenants create`,
+`tenants memberships add`, `tenants keys issue-root`, …); every command takes
+an audited `--reason`. On the raw API, mutations carry a `reason` in the JSON
+body (for example `POST /api/v2/platform/tenants`), while the audited read
+endpoints take an `x-platform-reason` header instead.
+
+Day-to-day work should use tenant-scoped keys delegated from this credential,
+not the platform credential itself.
 
 ## Exit codes
 

--- a/docs/deployment/single-tenant-mode.md
+++ b/docs/deployment/single-tenant-mode.md
@@ -43,7 +43,8 @@ half-deactivate a security boundary.
 
 With both flags in their default state:
 
-- **No new control-plane surface.** The ten platform tenant/membership endpoints
+- **No new control-plane surface.** The eleven platform control-plane endpoints
+  (tenant/membership management plus tenant root-key issuance)
   are documented in the OpenAPI spec (tagged `Platform`) but are not mounted;
   a request to them returns 404, not 401.
 - **Master-key auth is unchanged.** A legacy key carries no tenant context.
@@ -97,6 +98,12 @@ check reading the removed fields will now see them missing. Migrate as follows:
   `freshness != "current"`.
 
 - **Per-consumer detail** → the authenticated event-ops surface.
+
+  Note: `/health/consumers` reports the **NATS processing offsets**
+  (`consumer_offsets`), not the named durable consumers registry
+  (`durable_consumers`). Lag for named consumers is per-consumer via
+  `omni events consumers ls` / `inspect` — see the
+  [durable consumers runbook](../runbooks/durable-consumers.md).
 
 A failing consumer health check now returns `{"status":"error"}` with HTTP 500
 and nothing else; the driver detail (host, port, database, role) goes to the
@@ -168,7 +175,7 @@ Run the online phase **before** upgrading:
 ```bash
 # 1. Preflight: which high-volume tables still need indexes, and how big are they.
 #    Reports and exits without changing anything.
-bun run db:online-ddl --url "postgres://…" --check
+cd packages/db && bun run db:online-ddl --url "postgres://…" --check
 
 # 2. Online phase: adds the nullable columns (catalog-only, instant) and builds
 #    every index with CREATE INDEX CONCURRENTLY — no long lock, and resumable.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -136,6 +136,12 @@ omni instances create --channel discord --name "my-discord" --discord-token "<BO
 omni instances create --channel slack --name "my-slack" --slack-app-token "<APP_TOKEN>" --slack-bot-token "<BOT_TOKEN>"
 ```
 
+Other supported channels: `whatsapp-business` (Meta Cloud API), `gupshup`,
+`hermes`, `asc-flow`, `twilio-whatsapp`, `a2a` (requires `A2A_ENABLED=true`),
+and `harness` (E2E agent-testing). List them with
+`omni channels list`, and see `omni instances create --help` for
+channel-specific flags.
+
 ## Post-Install: Connect an OpenClaw Agent
 
 ```bash
@@ -325,3 +331,9 @@ curl -fsSL https://bun.sh/install | bash \
 ```
 
 Requires: Linux or macOS, x64 or arm64, internet access.
+
+## Next Steps
+
+- Wire an external system in as an event source: [GitHub webhook source](../runbooks/github-webhook-source.md), [ClickUp webhook source](../runbooks/clickup-webhook-source.md)
+- Consume events durably: [durable consumers runbook](../runbooks/durable-consumers.md)
+- Run several isolated deployments on one host: [multi-instance guide](multi-instance.md)

--- a/docs/guides/multi-instance.md
+++ b/docs/guides/multi-instance.md
@@ -210,23 +210,34 @@ pm2 save
 
 ## CLI Usage Per Instance
 
-The `omni` CLI defaults to `http://localhost:8882`. When managing a non-default instance, specify the API URL and key:
+The `omni` CLI defaults to `http://localhost:8882`. To manage multiple deployments, register each one in the CLI's server registry and switch between them:
 
 ```bash
-# Talk to the staging instance
-omni instances list --api-url http://localhost:8883
+# Register each deployment once (verifies reachability and key before saving)
+omni server add prod http://localhost:8882
+omni server add staging http://localhost:8883
 
-# Set a per-instance API key for auth
-omni instances list --api-url http://localhost:8883 --api-key <staging-key>
+# List registered servers (keys are masked) and see which one is active
+omni server list
+omni server current
+
+# Target a server for a single command with the global --server flag
+omni --server staging instances list
+
+# Or switch the active server for all subsequent commands
+omni server use staging
+omni instances list
 
 # Tip: use shell aliases for convenience
-alias omni-prod='omni --api-url http://localhost:8882 --api-key $PROD_KEY'
-alias omni-staging='omni --api-url http://localhost:8883 --api-key $STAGING_KEY'
+alias omni-prod='omni --server prod'
+alias omni-staging='omni --server staging'
 
 # Then use naturally
 omni-staging instances list
 omni-prod routes list --instance <id>
 ```
+
+> There is no global `--api-url`/`--api-key` flag — those exist only on `omni auth login` / `omni auth recover`. The server registry above is the supported way to address multiple deployments.
 
 ## Environment Variable Reference
 
@@ -246,6 +257,13 @@ omni-prod routes list --instance <id>
 | `LOG_LEVEL` | Log verbosity | `debug` |
 
 ## Known Limitations
+
+### Independent Event Journals
+
+Each deployment has its own PostgreSQL event journal, so durable event
+consumers (`omni events consumers`) and their cursors are scoped to one
+deployment — a consumer registered on staging knows nothing about prod's
+journal.
 
 ### Multi-Device Routing Unpredictability
 

--- a/docs/runbooks/durable-consumers.md
+++ b/docs/runbooks/durable-consumers.md
@@ -48,7 +48,7 @@ projections); the default starts at the current head (like `events wait`).
 - **Cursor** = last acked `omni_events.journal_seq`, a monotonic journal
   position assigned at insert. (`receivedAt` carries the publisher's clock
   and can land out of order, so it cannot anchor an at-least-once cursor.)
-- **Pull** (`POST /v2/events/consumers/:name/pull`) pages rows strictly after
+- **Pull** (`POST /api/v2/events/consumers/:name/pull`) pages rows strictly after
   the cursor in `journal_seq` order, pre-filtered by the type glob (trailing
   `*` = prefix, the #966 contract) and payload conditions (the automation
   matcher — same as `events wait --filter`). It never moves the cursor.


### PR DESCRIPTION
Docs-only refresh so README + docs/ describe Omni as it exists at the dev tip (2.260908.13), after the event-backbone (RFC #925), multitenancy, and channels waves. Every claim below was verified against code before changing; a second adversarial pass re-verified the diff against the CLI/API sources.

## Claim-by-claim: what was stale → what changed

### README.md
- Version badge said `2.260804.3` → now `2.260908.13` (matches `package.json`).
- Slack channel row said only "Bot/App token support" → now lists Socket/HTTP modes, bot & user (`xoxp`) token modes, threads, scheduled messages, permalinks, pins, message search (#889/#914/#941). Discord row now mentions voice.
- Channel table omitted the harness channel entirely → added a note for `--channel harness` (E2E agent-testing) and the internal routing channel.
- No mention of the event backbone → new **Event Backbone** section: journal as source of truth, trailing-`*` glob filters, `events trace|wait|schema`, durable named consumers (`events consumers` / `events follow`), webhook sources (signatures, idempotency templates, event-type mapping, heartbeat liveness), agent manifests (`agents manifest` / `agents graph`), `--transactional-emissions`; links to the runbooks.
- `webhooks` CLI block showed only bare create/trigger → now shows signature verification, event-type mapping, idempotency template, heartbeat, and the public `POST /api/v2/webhooks/ingress/:source` endpoint.
- No `schedule` / `tenants` / `multitenancy` coverage → added CLI sections for scheduled messages (native Slack vs local sweeper) and the platform tenant control plane (flag-gated, `--reason`-audited, bootstrap doc link).
- Events CLI block listed only `list`/`replay` → now includes `trace`, `wait`, `schema register`, `consumers create`, `follow`, `journey show`.
- REST API group list was missing the new modules → added `/events/schemas`, `/events/consumers`, per-event `/trace`, `/scheduled-messages`, `/journeys`, `/instances/:id/whatsapp-templates`, `/platform`.
- Project-structure tree omitted six packages → added `channel-asc-flow`, `channel-harness`, `channel-internal`, `plugin-openclaw`, `voice-client`.
- PM2 service tables claimed a nonexistent `omni-pgserve` process → corrected to `omni-api`/`omni-nats` (installer) vs `omni-v2-api`/`omni-v2-nats` (source `ecosystem.config.cjs`), with PostgreSQL under canonical pgserve (`autopg-server`).
- Dashboard pages list was missing Voices → added.

### docs/README.md (index)
- Structure tree listed 9 directories; `channels/`, `guides/`, `runbooks/`, `ci/`, `examples/`, `design/`, `channel-parity/` were invisible → all listed now.
- 38 markdown files existed with no index entry → indexed the user-facing ones (channels, guides, runbooks, deployment additions, CI, new architecture docs incl. ADR-0003 and connector-contract).
- Ambiguous wikilinks (`[[design]]` resolved to one of two files) → path-qualified.
- `updated: 2026-02-09` → 2026-09-08; v1-compatibility-layer re-marked historical.

### docs/api/design.md
- The entire endpoint catalog was written against `/api/v1/*`, which is not mounted; "v1 endpoints still work" and "`/api/v1/` — Current stable" were false → rewritten around the real `/api/v2` surface; the duplicated catalog now defers to endpoints.md.
- Documented a general-purpose WebSocket subscription API (`wss://.../ws`) that does not exist → replaced with the real real-time options (events stream/wait, long-poll consumer pull, automations; scoped `ws/` handlers noted).
- tRPC presented as a public API → corrected: exists internally, not mounted; SDKs are OpenAPI-generated.
- Scope table was missing `keys:read/write` and `platform:*`; `GET /api/v2/api-keys/:id/audit` was the wrong path (`/keys/:id/audit`) → fixed; added the tenancy-posture note on `auth/validate`.
- Channel webhook list covered 4 channels → now lists all receivers (gupshup, asc-flow, hermes, twilio, whatsapp-business, telegram, plus generic ingress).

### docs/api/endpoints.md
- Route-module table covered 19 of 40 modules → now covers all of them (agents, agent-state/tasks/routes, scheduled-messages, slack, event-schemas, event-consumers, journeys, conversations, channel-harness, context, turns, trust, voice, follow-up, handoffs, whatsapp-business/flows, templates, platform-tenants…).
- None of the event backbone was documented → full sections for event schemas, durable consumers (pull/ack semantics, journal-cursor model — explicitly *not* JetStream), `GET /events/:id/trace`, the public signed ingress + heartbeat, webhook-source body fields (signatureConfig, idempotencyKeyTemplate, eventTypeMapping, strictSchemas, expectedIntervalSeconds).
- New sections for scheduled messages, the 11 platform-tenant routes (incl. root-key issuance, reason auditing, no-DELETE design), agent manifests, message permalink/star/threadId, and `transactionalEmissions` on automations.

### docs/architecture/event-system.md
- Framed NATS streams as the replay/source-of-truth model, contradicting the durable-consumers runbook → reframed: PostgreSQL journal (`journal_seq`) is the source of truth, NATS is transport; replay section rewritten to the real session API.
- Missing every backbone feature → new sections: causality & tracing (`causationId`, AsyncLocalStorage propagation), schema registry (the exactly-two enforcement gates + dead-letter reasons), durable named consumers, webhook event sources, agent manifests & publish governance, transactional emissions, glob semantics (trailing-`*` only; not in automation triggers or manifests).
- Event catalog was missing `custom.*`, `system.connector.*`, `system.consumer.*`, `system.agent.manifest.updated`, `channel.alert`, `template.status_changed`, `agent.run.cancel_requested` → added, with the "system.* not journaled" and forward-only custom-journal caveats.
- Cited nonexistent files (`core/src/identity/handler.ts`, `core/src/media/handler.ts`) → fixed.

### docs/architecture/overview.md + ADR-0003
- Advertised an MCP server with 9 tools and `bun run mcp:http|stdio` — pure fiction, nothing exists → replaced with the real LLM integration paths (CLI, OpenAPI SDKs, providers, manifests).
- `/api/v1/*` and `/ws/*` in the diagram and flows → `/api/v2`, OpenAPI, ingress.
- Package tree described directories that don't exist (`core/src/identity|access|media|router|oauth|db`) and listed 2 of 13 channel packages → replaced with the real tree.
- `OMNI_HOST`/`OMNI_PORT=8881` (wrong names, wrong port, self-contradicting with 8882 later in the same file) → `API_HOST`/`API_PORT=8882`; env block now shows the real feature flags (`A2A_ENABLED`, `OMNI_MULTITENANCY_ENABLED`, `OMNI_DB_ENFORCEMENT`, `OMNI_STRICT_EMIT_EVENT_SCHEMAS`).
- PM2 example referenced `ecosystem.config.js` and nonexistent `start:api`/`start:workers` scripts → points at `omni install` and the shipped `ecosystem.config.cjs` with the actual process names.
- Stream list said `MESSAGES|IDENTITY|MEDIA|AGENT|ACCESS|CHANNEL` → actual ten streams (`MESSAGE, REACTION, INSTANCE, IDENTITY, MEDIA, ACCESS, SESSION, CUSTOM, SYSTEM, AGENT`); "Exactly-once" → at-least-once + journal dedup.
- ADR-0003 instructed `bunx drizzle-kit generate` (broken in this repo, contradicts the migration contract) → corrected to the hand-written additive/idempotent migration flow.

### docs/cli/design.md
- Inventoried 21 of ~62 commands → full inventory grouped by the CLI's real help groups; events subcommand list rebuilt (was missing `schema`, `consumers`, `stream`, `wait`, `follow`, `get`, `trace`, `analytics`).
- `omni providers health` doesn't exist → `omni providers test` (+ `setup openclaw`, `agents`, `teams`, `workflows`).
- Config key documented as `baseUrl` + `OMNI_BASE_URL` (neither exists; contradicted install.md) → `apiUrl` and the real key/env-var lists.
- Global options implied `--api-url`/`--api-key` → corrected to `--json`/`--server`/`--no-color`/`--all` and a new multi-server registry section (`omni server`).
- New sections: tenants, multitenancy status, schedule, agents manifests/graph, slack dm/search, journey, webhooks (full flag surface), `--transactional-emissions`.

### docs/channels/
- slack.md covered only the #914 agent-messaging work → added user-token (`xoxp`) mode (bot token stays mandatory; `search:read` is user-only), messaging features (threads, scheduled messages, permalinks, pins, search, DM open, `omni slack` CLI), the #941 socket-health behavior, and a fuller config-option pointer.
- whatsapp-business.md: send example used `POST /api/v2/messages` with a `content` wrapper (wrong path and body) → `POST /api/v2/messages/send` with the flat body; `omni instances whatsapp-business:register` doesn't exist → the real `POST /api/v2/instances/:id/whatsapp-business/register`.

### docs/guides/
- multi-instance.md told users to pass global `--api-url`/`--api-key` flags that don't exist (both aliases in the doc were broken) → rewritten around the actual mechanism: `omni server add/use/current` + global `--server`; added the per-deployment journal/consumer caveat.
- install.md showed 4 of 12 channels → added the rest (+ `omni channels list`) and a Next Steps section linking the webhook-source and durable-consumer runbooks.

### docs/deployment/ + runbooks
- platform-credential-bootstrap.md claimed `POST /api/v2/platform/tenants` takes an `x-platform-reason` header (it takes body `reason`; the header is for audited reads), and never stated the `OMNI_MULTITENANCY_ENABLED=true` prerequisite → both fixed; now points at the `omni tenants` CLI instead of raw curl.
- single-tenant-mode.md said "ten platform endpoints" (there are 11 incl. root-key issuance); `bun run db:online-ddl` only works from `packages/db/` (added `cd`); `/health/consumers` conflated NATS offsets with the new durable-consumer registry → disambiguated with a runbook link.
- durable-consumers.md: pull path missed the `/api` prefix → fixed.

## Deliberately untouched
- README header image block (owned by another agent).
- `docs/deployment/upgrade-*.md` and `public-launch-readiness.md` (owned by the release process) — only referenced from the index, not modified.
- CLAUDE.md/AGENTS.md layer.
- No private infra anywhere: verified all examples use localhost defaults or `example.com` placeholders.

## Verification
- Every command/flag/path claim in the diff was checked against `packages/cli/src/**` and `packages/api/src/routes/v2/**`; an independent adversarial pass over the final diff found and fixed 12 residual errors (wrong flag forms, an invented PM2 process name, a role-ceiling-violating example, etc.) before this PR was opened.
- `make lint` green; docs-only change (no code touched).
