### PR TITLE
chore(deps): upgrade drizzle-orm to 0.45.2 (#1021)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@sentry/bun": "^10.43.0",
         "@trpc/server": "^11.0.0-rc.608",
-        "drizzle-orm": "^0.38.4",
+        "drizzle-orm": "^0.45.2",
         "hono": "^4.6.17",
         "lru-cache": "^11.2.6",
         "nats": "^2.29.3",
@@ -384,7 +384,7 @@
       "version": "2.260908.20",
       "dependencies": {
         "@omni/core": "workspace:*",
-        "drizzle-orm": "^0.38.4",
+        "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.5",
       },
       "devDependencies": {
@@ -1510,7 +1510,7 @@
 
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 
-    "drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
     "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/semantic-conventions": "^1.30.0",
     "@sentry/bun": "^10.43.0",
     "@trpc/server": "^11.0.0-rc.608",
-    "drizzle-orm": "^0.38.4",
+    "drizzle-orm": "^0.45.2",
     "hono": "^4.6.17",
     "lru-cache": "^11.2.6",
     "nats": "^2.29.3",

--- a/packages/api/src/__tests__/event-consumers-postgres.test.ts
+++ b/packages/api/src/__tests__/event-consumers-postgres.test.ts
@@ -35,7 +35,7 @@ import {
   durableConsumers,
   omniEvents,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { setupEventPersistence } from '../plugins/event-persistence';
 import { EventConsumerService } from '../services/event-consumers';
 import { runInWorkerTenantScope } from '../tenancy/worker-tenant-context';
@@ -377,7 +377,9 @@ postgresDescribe('durable event consumers (#989, real PostgreSQL)', () => {
     test('a scope-less pull on the enforced runtime role fails closed rather than leaking', async () => {
       // No tenant GUC: the omni_events SELECT policy's context reader RAISES,
       // so the read errors instead of silently returning another tenant's rows.
-      await expect(runtimeService.pull('iso', { limit: 100 })).rejects.toThrow(/app\.tenant_id|insufficient/i);
+      await expect(driverRejection(runtimeService.pull('iso', { limit: 100 }))).rejects.toThrow(
+        /app\.tenant_id|insufficient/i,
+      );
     });
   });
 });

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -3,6 +3,7 @@
  */
 
 import { ConflictError, ERROR_CODES, NotFoundError, OmniError, ValidationError, createLogger } from '@omni/core';
+import { unwrapDbError } from '@omni/db';
 import * as Sentry from '@sentry/bun';
 import type { Context, ErrorHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -354,9 +355,11 @@ function routeError(c: Context, error: unknown): Response {
     const channelResult = handleChannelError(c, error as Error & { code?: string; retryable?: boolean });
     if (channelResult) return channelResult;
   }
-  // PostgreSQL errors (unique constraint, foreign key, etc.) — duck-typed by numeric code
-  if (error instanceof Error && 'code' in error) {
-    const dbResult = handleDatabaseError(c, error as Error & { code?: string; detail?: string; constraint?: string });
+  // PostgreSQL errors (unique constraint, foreign key, etc.) — duck-typed by numeric
+  // code on the driver error, which drizzle >= 0.44 hides behind DrizzleQueryError
+  const dbError = unwrapDbError(error);
+  if (dbError instanceof Error && 'code' in dbError) {
+    const dbResult = handleDatabaseError(c, dbError as Error & { code?: string; detail?: string; constraint?: string });
     if (dbResult) return dbResult;
   }
   return handleUnknownError(c, error);
@@ -389,9 +392,11 @@ function isClientError(error: unknown): boolean {
     const status = ERROR_STATUS_MAP[error.code] ?? 500;
     return status < 500;
   }
-  // Duck-typed errors with a string code (channel plugins, PostgreSQL)
-  if (error instanceof Error && 'code' in error && typeof (error as { code: unknown }).code === 'string') {
-    return isCodeClientError((error as { code: string }).code);
+  // Duck-typed errors with a string code (channel plugins, PostgreSQL — the
+  // latter arrives drizzle-wrapped since 0.44, so classify the driver error)
+  const cause = unwrapDbError(error);
+  if (cause instanceof Error && 'code' in cause && typeof (cause as { code: unknown }).code === 'string') {
+    return isCodeClientError((cause as { code: string }).code);
   }
   return false;
 }

--- a/packages/api/src/plugins/__tests__/automation-actions-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/automation-actions-two-tenant-postgres.test.ts
@@ -39,7 +39,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { createServices } from '../../services';
 import { buildAutomationEngineDeps } from '../automation-actions';
 
@@ -188,7 +188,7 @@ postgresDescribe('two-tenant automation-actions containment (real PostgreSQL)', 
     // the transaction rather than silently matching rows. Flag-off
     // byte-identity for the legacy world is asserted by the unit worker-scope
     // probes; under enforcement a scope-less read cannot succeed.
-    await expect(deps.sendMessage(INSTANCE_A, CHAT_A, 'legacy', undefined)).rejects.toThrow(
+    await expect(driverRejection(deps.sendMessage(INSTANCE_A, CHAT_A, 'legacy', undefined))).rejects.toThrow(
       /app\.tenant_id is not set|not found/i,
     );
     expect(sent).toEqual([]);

--- a/packages/api/src/plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/instance-monitor-two-tenant-postgres.test.ts
@@ -38,7 +38,7 @@ import {
   createDbHandle,
   instances,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { MULTITENANCY_FLAG_ENV } from '../../tenancy/feature-flag';
 import { __resetInstanceOwnerRegistry, rememberInstanceOwners } from '../../tenancy/instance-owner-registry';
@@ -165,7 +165,7 @@ postgresDescribe('instance-monitor sweeps under real RLS enforcement', () => {
     // Awaited inside an async thunk: a drizzle query builder is thenable but not
     // a Promise, and `expect(...).rejects` requires a real one.
     await expect(
-      (async () => runtimeDb.select().from(instances).where(eq(instances.isActive, true)))(),
+      driverRejection((async () => runtimeDb.select().from(instances).where(eq(instances.isActive, true)))()),
     ).rejects.toThrow(/app\.tenant_id/);
   });
 
@@ -220,6 +220,6 @@ postgresDescribe('instance-monitor sweeps under real RLS enforcement', () => {
     const monitor = new InstanceMonitor(runtimeDb, makeRegistry([], []));
     monitor.setAuthPlane(authPlaneDb, ENFORCED_ENV);
 
-    await expect(monitor.forceReconnect(INSTANCE_B)).rejects.toThrow(/app\.tenant_id/);
+    await expect(driverRejection(monitor.forceReconnect(INSTANCE_B))).rejects.toThrow(/app\.tenant_id/);
   });
 });

--- a/packages/api/src/plugins/__tests__/session-cluster-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/session-cluster-two-tenant-postgres.test.ts
@@ -36,7 +36,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { AgentRunnerService } from '../../services/agent-runner';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
 import { __test__ as sessionCleanerTest } from '../session-cleaner';
@@ -213,7 +213,7 @@ postgresDescribe('two-tenant session/dispatch-backend containment (real PostgreS
 
     // A write under B for A's instance cannot land: `agent_sessions` derives its
     // tenant from the required `instances` parent, so the WITH CHECK refuses it.
-    await expect(storeB.upsertSession(INSTANCE_A, 'stolen-key', 'sid-forged', null)).rejects.toThrow(
+    await expect(driverRejection(storeB.upsertSession(INSTANCE_A, 'stolen-key', 'sid-forged', null))).rejects.toThrow(
       /row-level security/i,
     );
 
@@ -233,6 +233,6 @@ postgresDescribe('two-tenant session/dispatch-backend containment (real PostgreS
     // LOUD — which is the proof that the converted path above is what carries
     // the tenant, not some incidental ambient visibility.
     const legacyStore = createSessionStorage(runtimeDb, 'p1');
-    await expect(legacyStore.getSession(INSTANCE_A, 'shared-key')).rejects.toThrow(/tenant/i);
+    await expect(driverRejection(legacyStore.getSession(INSTANCE_A, 'shared-key'))).rejects.toThrow(/tenant/i);
   });
 });

--- a/packages/api/src/plugins/__tests__/sync-worker-two-tenant-postgres.test.ts
+++ b/packages/api/src/plugins/__tests__/sync-worker-two-tenant-postgres.test.ts
@@ -29,7 +29,7 @@ import {
   createDbHandle,
   omniGroups,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { scopedHandle } from '../../tenancy/tenant-scope';
 import { runInWorkerTenantScope } from '../../tenancy/worker-tenant-context';
@@ -183,11 +183,13 @@ postgresDescribe('two-tenant sync-worker containment (real PostgreSQL)', () => {
     // belongs to A, so B's insert is rejected outright rather than landing a
     // stray B-row. (In the live consumer `onGroup` swallows this and continues.)
     await expect(
-      runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
-        syncWorkerTest.upsertSyncedGroup(runtimeDb, INSTANCE_A, 'whatsapp-baileys', {
-          externalId: 'group-a@g.us',
-          name: 'B overwrite attempt',
-        }),
+      driverRejection(
+        runInWorkerTenantScope(runtimeDb, TENANT_B, () =>
+          syncWorkerTest.upsertSyncedGroup(runtimeDb, INSTANCE_A, 'whatsapp-baileys', {
+            externalId: 'group-a@g.us',
+            name: 'B overwrite attempt',
+          }),
+        ),
       ),
     ).rejects.toThrow(/row-level security/i);
 

--- a/packages/api/src/services/__tests__/sync-jobs-two-tenant-postgres.test.ts
+++ b/packages/api/src/services/__tests__/sync-jobs-two-tenant-postgres.test.ts
@@ -41,7 +41,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { SyncJobService } from '../sync-jobs';
 
 const superUrl = process.env.OMNI_G4_POSTGRES_URL ?? '';
@@ -171,12 +171,14 @@ postgresDescribe('two-tenant sync-job containment (real PostgreSQL)', () => {
 
   test('a job for ANOTHER tenant’s instance is refused by RLS, not silently mis-stamped', async () => {
     await expect(
-      service.create({
-        instanceId: INSTANCE_A,
-        channelType: 'whatsapp-baileys',
-        type: 'groups',
-        tenantId: TENANT_B,
-      }),
+      driverRejection(
+        service.create({
+          instanceId: INSTANCE_A,
+          channelType: 'whatsapp-baileys',
+          type: 'groups',
+          tenantId: TENANT_B,
+        }),
+      ),
     ).rejects.toThrow(/row-level security/i);
   });
 

--- a/packages/api/src/services/chats.ts
+++ b/packages/api/src/services/chats.ts
@@ -18,6 +18,7 @@ import {
   chatParticipants,
   chats,
   omniGroups,
+  unwrapDbError,
 } from '@omni/db';
 import { and, asc, desc, eq, gt, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import { scopedHandle } from '../tenancy/tenant-scope';
@@ -101,7 +102,8 @@ export class ChatService {
     private eventBus: EventBus | null,
   ) {}
 
-  private isCanonicalUniqueViolation(error: unknown): boolean {
+  private isCanonicalUniqueViolation(rawError: unknown): boolean {
+    const error = unwrapDbError(rawError);
     if (!error || typeof error !== 'object') return false;
     if (!('code' in error) || (error as { code?: unknown }).code !== '23505') return false;
 

--- a/packages/api/src/services/routes.ts
+++ b/packages/api/src/services/routes.ts
@@ -5,7 +5,7 @@
 import { ConflictError, NotFoundError } from '@omni/core';
 import type { CreateAgentRoute, ListAgentRoutesQuery, UpdateAgentRoute } from '@omni/core';
 import type { Database } from '@omni/db';
-import { type AgentRoute, type NewAgentRoute, agentRoutes } from '@omni/db';
+import { type AgentRoute, type NewAgentRoute, agentRoutes, unwrapDbError } from '@omni/db';
 import { and, desc, eq } from 'drizzle-orm';
 import { invalidateProviderCacheForInstance } from '../plugins/agent-dispatcher';
 import { runAfterTenantCommit, scopedHandle } from '../tenancy/tenant-scope';
@@ -113,8 +113,10 @@ export class RouteService {
       }
 
       created = result;
-    } catch (error) {
-      // Check for unique constraint violation (PostgreSQL error code 23505)
+    } catch (rawError) {
+      // Check for unique constraint violation (PostgreSQL error code 23505);
+      // drizzle >= 0.44 wraps the driver error, so classify the unwrapped one
+      const error = unwrapDbError(rawError);
       if (error && typeof error === 'object' && 'code' in error && error.code === '23505') {
         const constraint = 'constraint' in error && typeof error.constraint === 'string' ? error.constraint : 'unknown';
 
@@ -137,7 +139,7 @@ export class RouteService {
         throw new ConflictError('AgentRoute', 'Route already exists', { constraint });
       }
 
-      throw error;
+      throw rawError;
     }
 
     // Best-effort cache invalidation outside try-catch

--- a/packages/api/src/tenancy/__tests__/tenant-boundary-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/tenant-boundary-postgres.test.ts
@@ -24,7 +24,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { sql } from 'drizzle-orm';
 import { type PlatformAuthContext, type TenantAuthContext, freezeContext } from '../auth-context';
 import { withPlatformTargetTenant } from '../platform-target-tenant';
@@ -190,9 +190,11 @@ postgresDescribe('tenant boundary end-to-end (real PostgreSQL)', () => {
       // Drizzle's `execute` returns a thenable builder, not a Promise, so it is
       // awaited inside an async wrapper before the rejection is asserted.
       await expect(
-        (async () => {
-          await runtimeDb.execute(sql`SELECT id FROM instances`);
-        })(),
+        driverRejection(
+          (async () => {
+            await runtimeDb.execute(sql`SELECT id FROM instances`);
+          })(),
+        ),
       ).rejects.toThrow(/app\.tenant_id is not set/);
     });
 
@@ -237,16 +239,20 @@ postgresDescribe('tenant boundary end-to-end (real PostgreSQL)', () => {
 
     test('an insert carrying another tenant id is rejected by WITH CHECK', async () => {
       await expect(
-        withTenantTransaction(runtimeDb, tenantContext(TENANT_A), (tx) =>
-          TenantInstanceRepository.create(tx, { name: 'cross', channel: 'whatsapp-baileys', tenantId: TENANT_B }),
+        driverRejection(
+          withTenantTransaction(runtimeDb, tenantContext(TENANT_A), (tx) =>
+            TenantInstanceRepository.create(tx, { name: 'cross', channel: 'whatsapp-baileys', tenantId: TENANT_B }),
+          ),
         ),
       ).rejects.toThrow(/row-level security policy/i);
     });
 
     test('re-tenanting an own row is rejected by WITH CHECK', async () => {
       await expect(
-        withTenantTransaction(runtimeDb, tenantContext(TENANT_A), (tx) =>
-          TenantInstanceRepository.setTenant(tx, INSTANCE_A, TENANT_B),
+        driverRejection(
+          withTenantTransaction(runtimeDb, tenantContext(TENANT_A), (tx) =>
+            TenantInstanceRepository.setTenant(tx, INSTANCE_A, TENANT_B),
+          ),
         ),
       ).rejects.toThrow(/row-level security policy/i);
     });

--- a/packages/api/src/tenancy/__tests__/two-tenant-adversarial-postgres.test.ts
+++ b/packages/api/src/tenancy/__tests__/two-tenant-adversarial-postgres.test.ts
@@ -42,7 +42,7 @@ import {
   applyTenantRlsEnforcement,
   createDbHandle,
 } from '@omni/db';
-import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
+import { driverRejection, provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { ChatService } from '../../services/chats';
 import { ConversationService } from '../../services/conversations';
 import { InstanceService } from '../../services/instances';
@@ -375,7 +375,7 @@ postgresDescribe('two-tenant adversarial containment (real PostgreSQL)', () => {
       // No scope is active here, so the service reaches the ambient pool and
       // the forced RLS policy denies it — the connection carries no leftover
       // tenant from the request that just finished.
-      await expect(instances.list()).rejects.toThrow(/app\.tenant_id is not set/);
+      await expect(driverRejection(instances.list())).rejects.toThrow(/app\.tenant_id is not set/);
     });
   });
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@omni/core": "workspace:*",
-    "drizzle-orm": "^0.38.4",
+    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/packages/db/src/errors.ts
+++ b/packages/db/src/errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Driver-error unwrapping for drizzle-orm >= 0.44.
+ *
+ * Since 0.44.0 drizzle wraps every driver error thrown by a query in
+ * `DrizzleQueryError` (`pg-core/session.ts`): the wrapper's message is the
+ * failed SQL + params, and the original `PostgresError` — the one carrying
+ * `code`, `constraint`, `detail`, and the server's message — moves to `cause`.
+ * Every consumer that classifies database failures by SQLSTATE (unique
+ * violations → 409, RLS denials, FK violations → 400) must therefore look
+ * through the wrapper.
+ */
+
+import { DrizzleQueryError } from 'drizzle-orm';
+
+/**
+ * Return the underlying driver error for a failed query, or the value itself
+ * when it is not a drizzle query wrapper. Callers keep duck-typing the result
+ * (`code`, `constraint`, …) exactly as they did before 0.44 — this helper only
+ * removes the wrapper, it does not assert what is underneath.
+ */
+export function unwrapDbError(error: unknown): unknown {
+  let current: unknown = error;
+  // Bounded walk: wrappers should never nest, but a cycle in `cause` must not
+  // hang the error path of all places.
+  for (let depth = 0; depth < 5 && current instanceof DrizzleQueryError && current.cause != null; depth++) {
+    current = current.cause;
+  }
+  return current;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,9 @@ export { and, asc, desc, eq, inArray, isNotNull, isNull, or, sql } from 'drizzle
 export { createDb, createDbHandle, createPostgresClient, getDb, closeDb, getDefaultDatabaseUrl } from './client';
 export type { Database, DbConfig } from './client';
 
+// Driver-error unwrapping (drizzle >= 0.44 wraps driver errors in DrizzleQueryError)
+export { unwrapDbError } from './errors';
+
 // Migration exports
 export { applyMigrations, assertOnlineDdlPreflight, BLOCKING_INDEX_OVERRIDE_ENV_VAR } from './migrate';
 export type { ApplyMigrationsOptions } from './migrate';

--- a/packages/db/src/pg-migrated-template.ts
+++ b/packages/db/src/pg-migrated-template.ts
@@ -31,6 +31,7 @@ import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { unwrapDbError } from './errors';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const drizzleDir = join(here, '..', 'drizzle');
@@ -166,3 +167,14 @@ export function provisionMigratedDatabase(access: PgSuperAccess, database: strin
   ensureSqlTemplate(access, templateName, chain.sql);
   createDatabaseFromTemplate(access, database, templateName);
 }
+
+/**
+ * drizzle >= 0.44 wraps driver errors in DrizzleQueryError; the server's
+ * refusal message (RLS policy, missing tenant GUC, WITH CHECK) lives on the
+ * PostgresError beneath. Wrap a rejecting promise in this so
+ * `expect(...).rejects.toThrow(pattern)` keeps matching the driver's message.
+ */
+export const driverRejection = <T>(p: Promise<T>): Promise<T> =>
+  p.catch((error) => {
+    throw unwrapDbError(error);
+  });


### PR DESCRIPTION
## Summary

Upgrades `drizzle-orm` `^0.38.4` → `^0.45.2` in `packages/api` and `packages/db` (runtime dependency, both manifests + `bun.lock` in one PR). Fixes Dependabot alerts #1 and #5 — HIGH: SQL injection via improperly escaped SQL identifiers (`sql.identifier()` / `sql.as()`, fixed upstream in 0.45.2, CWE-89).

`drizzle-kit` stays at `^0.30.1`: nothing dev-facing broke, and generate/snapshots are dead in this repo by design (hand-written migrations; see `.claude/CLAUDE.md`).

Closes #1021

## Identifier-injection exposure audit

**Verdict: no code path feeds request-derived input into an identifier position.** The vulnerable APIs are barely reachable here at all:

- **`sql.identifier()` / `sql.as()`: zero call sites** in the repository (the APIs the advisory is actually about).
- **`sql.raw()` production call sites, each with its input source:**
  - `packages/api/src/services/events.ts:410-416` — `date_trunc('${sql.raw(truncFunc)}', …)` where `truncFunc` is the literal `'hour'` or `'day'`, derived from a `granularity` query param validated as `z.enum(['hourly', 'daily'])` at the route boundary (`routes/v2/events.ts:96`). The user string itself never reaches SQL.
  - `packages/db/src/tenancy-rls.ts` — statements generated from the static `RLS_TENANT_TABLES` list and code-defined policy/function templates; applied only by operator scripts and tests, never on a request path.
  - `packages/db/src/online-ddl.ts` — DDL statements from static generators; table names in the row-count probe come from a code-defined entry list. Operator-invoked only.
  - `packages/db/src/tenancy-roles.ts` — role provisioning statements; role names come from defaults or the CLI flags of `apply-rls-enforcement.ts` (operator input on a superuser connection, not request data).
- Drizzle imports are confined to `packages/db` and `packages/api`; every other package gets query operators re-exported through `@omni/db`. The repo contract additionally bans raw SQL outside these audited sites.

So the advisory's attack vector (attacker-controlled identifier reaching `sql.identifier`) does not exist in this codebase; the upgrade is defense-in-depth plus staying inside supported versions.

## Changelog review (0.39 → 0.45) and what had to be adapted

Reviewed every release note for pg-dialect/postgres-js changes. Non-breaking for us: Bun SQL driver + Gel dialect (new, unused), `numeric`/`decimal` bigint-number modes (0.41, opt-in), removed in-driver mapping for `numeric[]`/`timestamp[]`/etc. arrays (0.41 — no such array columns in `schema.ts`), TS-enum `pgEnum` (0.42, additive), cross/lateral joins (0.43), cache module (0.44, opt-in), `$onUpdate` SQL-value fix (0.45). `tsc --noEmit` passed across all 26 packages with **zero source changes to `schema.ts` or any query call site**. No schema or migration changes were needed (and none were made — `packages/db/drizzle/` is untouched).

**The one real behavioral break: 0.44.0 wraps every driver error in `DrizzleQueryError`** (`pg-core/session.ts`), moving the original `postgres` `PostgresError` — the object carrying `code`, `constraint`, `detail` and the server's message — to `error.cause`. That silently broke SQLSTATE duck-typing (`error.code === '23505'` → 409, etc.) and every pg-gate assertion on driver messages. Adapted:

- **New `unwrapDbError()` helper** (`packages/db/src/errors.ts`, exported from `@omni/db`): returns the driver error beneath a `DrizzleQueryError`, or the value unchanged. Safe on the shared hoisted drizzle instance (`instanceof`-based, bounded cause walk).
- **Production consumers unwrap before classifying:** `packages/api/src/middleware/error.ts` (unique/FK violation → 409/400 mapping and client-vs-server log level), `services/chats.ts` (`isCanonicalUniqueViolation`), `services/routes.ts` (route-conflict 23505 → `ConflictError`). Without this, unique-constraint conflicts would have surfaced as 500s under 0.45.
- **Test adaptation:** new `driverRejection()` helper in `@omni/db/pg-migrated-template` (the shared pg-suite support module) rethrows the unwrapped cause so `expect(...).rejects.toThrow(/row-level security/…)` keeps asserting the server's actual refusal message; applied to the 12 pg-gate assertions that asserted driver messages (RLS/WITH CHECK/tenant-GUC refusals).

`migrateDb()` still uses drizzle's official postgres-js migrator; the full committed chain (66 migrations) applies cleanly under 0.45.2 and the `upgrade-2.260902.5-to-2.260908.20` rehearsal + pg-gate exercise it for real.

## Validation

- `make check` green (typecheck 26/26, biome, knip, migration contract gate, full test suite)
- `make test-pg-gate` green — 396 real-PostgreSQL tests, 0 fail (the true test of the query layer + migrator under 0.45)
