### PR TITLE
fix(channel-asc-flow): drop the invented length cap on fila_vq

### DIFF
--- a/packages/channel-asc-flow/src/__tests__/plugin.test.ts
+++ b/packages/channel-asc-flow/src/__tests__/plugin.test.ts
@@ -355,6 +355,20 @@ describe('outbound turn', () => {
     expect(of('/transferirHumano')).toHaveLength(0);
   });
 
+  // The operation's real queue is 34 characters. A length cap invented on
+  // 2026-09-03 (no source, and the comment that added it said the domain was
+  // unknown) refused EVERY flow-mode handoff on it, silently for the person.
+  it('accepts the real 34-character queue of the operation', async () => {
+    await boot();
+    const fila = 'VQ_WPP_PF_NTX_AGENDAR_CONSULTAS_HV';
+    expect(fila).toHaveLength(34);
+
+    const result = await send({ type: 'text', text: 'Vou te transferir.' }, { isHandoff: true, handoffQueue: fila });
+
+    expect(result.success).toBe(true);
+    expect(ready('42')).toMatchObject({ hand_off: 'sim', fila_vq: fila });
+  });
+
   it('sends the Genesys fields EMPTY when the turn does not hand off', async () => {
     await boot();
     await send({ type: 'text', text: 'ok' }, { handoffQueue: 'VQ_X' });

--- a/packages/channel-asc-flow/src/utils/handoff.ts
+++ b/packages/channel-asc-flow/src/utils/handoff.ts
@@ -20,10 +20,23 @@ import type { Logger } from '@omni/core';
 
 /**
  * The queue code the Genesys component reads. No domain exists yet (the
- * de-para is a known pendency on the Hapvida side), so this only enforces a
- * conservative SHAPE — enough to keep junk out of `u_cod_transf`.
+ * de-para is a known pendency on the Hapvida side), so this enforces the
+ * CHARACTER SET and nothing else — enough to keep junk out of `u_cod_transf`.
+ *
+ * The length cap left on 2026-09-09. It never had a source: it was written
+ * here on 03/09 as a "conservative shape", mirrored into hv-scheduling the
+ * next day, and the very comment that introduced it said the domain was
+ * unknown. The HANDOFF-GENESYS.md it cited does not exist in any repo.
+ *
+ * The operation's real queue is `VQ_WPP_PF_NTX_AGENDAR_CONSULTAS_HV` — 34
+ * characters. Under the cap EVERY handoff in `flow` mode was refused, and
+ * silently as far as the person could tell. A guessed bound protects nothing;
+ * it only rejects the legitimate value once reality outgrows the guess.
+ *
+ * Length becomes a check again when Hapvida gives the real limit — with the
+ * source cited here, the way the rest of this module does it.
  */
-const FILA_PATTERN = /^[A-Za-z0-9_.-]{1,32}$/;
+const FILA_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
 /** `u_bot_motivo_transf` is free text; cap it so a runaway prompt cannot flood it. */
 const MOTIVO_MAX_LENGTH = 255;


### PR DESCRIPTION
`FILA_PATTERN` required `{1,32}`. The operation's real queue is `VQ_WPP_PF_NTX_AGENDAR_CONSULTAS_HV` — **34 characters**. In `flow` mode a queue outside the shape makes `buildGenesysFields` return `null` and the handoff is refused, so **every transfer died on the real value** — silently, as far as the person could tell.

## The cap never had a source

| question | answer |
|---|---|
| from a Hapvida spec? | no |
| from Genesys docs? | no |
| from the `HANDOFF-GENESYS.md` the comment cites? | **that file does not exist in any repo** |
| from where, then? | this file, `bb8272fd` (2026-09-03), as a "conservative shape" |

The comment that introduced it says the domain is unknown — *"the de-para is a known pendency on the Hapvida side"*. We picked a bound while writing down that we had no way to know it, and reality came in 2 characters over the guess.

hv-scheduling mirrored the same regex a day later, so **both ends rejected the same legitimate value**.

## What stays

The **character set** is what keeps junk out of `u_cod_transf`, and it is untouched. Length becomes a check again when Hapvida gives the real limit — cited, the way the rest of the module cites its sources.

## Tests

**151 pass** in `channel-asc-flow`, including a new one asserting the 34-character queue reaches `fila_vq` with `hand_off: 'sim'`.

Paired with hv-scheduling PR #494 (same removal in `_FILA_RE`). **Both must land together** — either side alone keeps refusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queue codes longer than 32 characters are now accepted when they contain valid characters, allowing legitimate flow-mode handoffs to complete successfully.
  - Flow-mode handoffs correctly transmit the handoff indicator and selected queue code.

- **Tests**
  - Added coverage for successful handoff using a real 34-character queue code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->