### PR TITLE
fix(channel-whatsapp): publish only unknown LID mappings and contact names

### DIFF
--- a/packages/channel-whatsapp/src/__tests__/lid-mapping-publish-delta.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/lid-mapping-publish-delta.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { WhatsAppPlugin } from '../plugin';
+
+const OWNER_LID = '111@lid';
+const OWNER_PHONE = '5511999@s.whatsapp.net';
+
+function createPlugin() {
+  const publishGeneric = mock(async (_event: string, _payload: unknown, _meta: unknown) => undefined);
+  const plugin = new WhatsAppPlugin();
+  (plugin as unknown as { eventBus: unknown }).eventBus = { publishGeneric };
+  (plugin as unknown as { logger: unknown }).logger = { info: mock(), debug: mock(), warn: mock(), error: mock() };
+  return { plugin, publishGeneric };
+}
+
+function eventsOf(publishGeneric: ReturnType<typeof createPlugin>['publishGeneric'], type: string) {
+  return publishGeneric.mock.calls.filter(([t]) => t === type).map(([, payload]) => payload);
+}
+
+describe('issue #1040: contacts.upsert publishes only unknown mappings/names', () => {
+  test('identical repeated upserts publish once', () => {
+    const { plugin, publishGeneric } = createPlugin();
+    const contact = { id: OWNER_PHONE, lid: OWNER_LID, name: 'Owner' };
+
+    for (let i = 0; i < 5; i++) plugin.handleContactsUpsert('inst', [contact]);
+
+    expect(eventsOf(publishGeneric, 'custom.lid-mapping.batch')).toEqual([
+      { mappings: [{ lidJid: OWNER_LID, phoneJid: OWNER_PHONE }] },
+    ]);
+    expect(eventsOf(publishGeneric, 'custom.contacts.names')).toEqual([
+      { names: [{ jid: OWNER_PHONE, name: 'Owner' }] },
+    ]);
+  });
+
+  test('new or changed entries publish only the delta', () => {
+    const { plugin, publishGeneric } = createPlugin();
+    plugin.handleContactsUpsert('inst', [{ id: OWNER_PHONE, lid: OWNER_LID, name: 'Owner' }]);
+    plugin.handleContactsUpsert('inst', [
+      { id: '222@lid', phoneNumber: '5511888', name: 'Friend' },
+      { id: OWNER_PHONE, lid: OWNER_LID, name: 'Owner Renamed' },
+    ]);
+
+    const batches = eventsOf(publishGeneric, 'custom.lid-mapping.batch');
+    expect(batches).toHaveLength(2);
+    expect(batches[1]).toEqual({ mappings: [{ lidJid: '222@lid', phoneJid: '5511888@s.whatsapp.net' }] });
+
+    const names = eventsOf(publishGeneric, 'custom.contacts.names');
+    expect(names).toHaveLength(2);
+    expect(names[1]).toEqual({
+      names: [
+        { jid: OWNER_PHONE, name: 'Owner Renamed' },
+        { jid: '222@lid', name: 'Friend' },
+      ],
+    });
+  });
+});

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -242,6 +242,15 @@ function summarizeContent(content: Record<string, unknown>): Record<string, unkn
   return summary;
 }
 
+function getOrCreate<K, V>(outer: Map<K, Map<string, V>>, key: K): Map<string, V> {
+  let inner = outer.get(key);
+  if (!inner) {
+    inner = new Map();
+    outer.set(key, inner);
+  }
+  return inner;
+}
+
 export class WhatsAppPlugin extends BaseChannelPlugin {
   readonly id: ChannelType = 'whatsapp-baileys';
   readonly name = 'WhatsApp (Baileys)';
@@ -467,6 +476,10 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    * Populated from contacts.upsert (c.lid + c.id) and lid-mapping.update events.
    */
   private lidMappingCache = new Map<string, Map<string, string>>();
+  /** lid→phone pairs already announced via custom.lid-mapping.batch (per instance). */
+  private publishedLidMappings = new Map<string, Map<string, string>>();
+  /** jid→name pairs already announced via custom.contacts.names (per instance). */
+  private publishedContactNames = new Map<string, Map<string, string>>();
 
   /**
    * Short-lived cache of recent message keys (externalId → { participant, fromMe }).
@@ -1079,6 +1092,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     this.decryptTrackers.delete(instanceId);
     this.lidFirstEnabledMap.delete(instanceId);
     this.lidMappingCache.delete(instanceId);
+    this.publishedLidMappings.delete(instanceId);
+    this.publishedContactNames.delete(instanceId);
     this.lastActionTime.delete(instanceId);
     this.historyPushFetchCount.delete(instanceId);
     // Dispose and remove per-instance dedup cache
@@ -3685,17 +3700,21 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   }
 
   /**
-   * Publish cached contact names for an instance to the event bus for chat name persistence
+   * Publish contact names not yet announced for an instance (issue #1040:
+   * only the delta — re-emitting the whole cache on every contacts.upsert
+   * flooded the journal with identical payloads).
    */
   private publishContactNames(instanceId: string): void {
     const contactCache = this.contactsCache.get(instanceId);
     if (!contactCache || contactCache.size === 0) return;
 
+    const published = getOrCreate(this.publishedContactNames, instanceId);
     const names: Array<{ jid: string; name: string }> = [];
     for (const [jid, contact] of contactCache) {
-      if (contact.name && !jid.includes('@g.us') && !jid.includes('@broadcast')) {
-        names.push({ jid, name: contact.name });
-      }
+      if (!contact.name || jid.includes('@g.us') || jid.includes('@broadcast')) continue;
+      if (published.get(jid) === contact.name) continue;
+      published.set(jid, contact.name);
+      names.push({ jid, name: contact.name });
     }
     if (names.length === 0) return;
 
@@ -3714,7 +3733,9 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
   }
 
   /**
-   * Publish all cached LID mappings for an instance to the event bus for DB persistence
+   * Publish LID mappings not yet announced for an instance to the event bus
+   * for DB persistence. A `{lidJid, phoneJid}` pair is its own identity, so
+   * known pairs are skipped (issue #1040).
    */
   private publishLidMappings(instanceId: string): void {
     const lidCache = this.lidMappingCache.get(instanceId);
@@ -3722,9 +3743,15 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
 
     // Cache stores both directions (lid→phone and phone→lid). Only the
     // lid-keyed direction belongs in DB persistence as the canonical mapping.
-    const mappings = Array.from(lidCache.entries())
-      .filter(([key]) => isLidJid(key))
-      .map(([lidJid, phoneJid]) => ({ lidJid, phoneJid }));
+    const published = getOrCreate(this.publishedLidMappings, instanceId);
+    const mappings: Array<{ lidJid: string; phoneJid: string }> = [];
+    for (const [lidJid, phoneJid] of lidCache) {
+      if (!isLidJid(lidJid) || published.get(lidJid) === phoneJid) continue;
+      published.set(lidJid, phoneJid);
+      mappings.push({ lidJid, phoneJid });
+    }
+    if (mappings.length === 0) return;
+
     this.eventBus
       .publishGeneric(
         'custom.lid-mapping.batch',


### PR DESCRIPTION
Fixes #1040

## Root cause
`handleContactsUpsert` called `publishLidMappings`/`publishContactNames`, which serialised the **entire** per-instance cache on every `contacts.upsert`. Baileys fires that event on routine device activity, so the same known mapping (typically the owner's own `lidJid -> phoneJid`) was republished at ~2.4 ev/s, bloating the journal and flooding every `custom.*` consumer.

## Fix
- Track already-published `lid->phone` pairs and `jid->name` pairs per instance; publish only new or changed entries. A `{lidJid, phoneJid}` pair is its own identity, so identical upserts now produce zero events.
- Clear the tracking maps on instance cleanup alongside the other per-instance caches.
- Consumers are unchanged (they already upsert per item), so partial batches are safe.

## Test
`lid-mapping-publish-delta.test.ts`: five identical upserts publish once; a later upsert with one new contact and one renamed contact publishes only that delta.

`make check` green (typecheck, lint, knip, migration gate, 702 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - WhatsApp contact synchronization now publishes only new or changed LID mappings and contact names.
  - Repeated contact updates no longer generate duplicate mapping or name events.
  - Contact changes now correctly include only the affected entries, reducing unnecessary update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->