### PR TITLE
fix(api): journal own-device echoes as outbound in omni_events

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -125,6 +125,39 @@ describeWithDb('Event Persistence Handler', () => {
       expect(persisted?.rawPayload).toEqual({ foo: 'bar' });
     });
 
+    test('journals own-device echo (rawPayload.isFromMe=true) as outbound (#1034)', async () => {
+      await setupEventPersistence(mockEventBus, db);
+
+      await emitEvent('message.received', {
+        id: randomUUID(),
+        type: 'message.received',
+        timestamp: Date.now(),
+        payload: {
+          externalId: 'ext-recv-echo-001',
+          chatId: 'chat-123',
+          from: 'me',
+          content: { type: 'text', text: 'typed on my phone' },
+          replyToId: null,
+          rawPayload: { isFromMe: true },
+        },
+        metadata: {
+          correlationId: 'corr-echo',
+          instanceId: null,
+          channelType: 'whatsapp',
+          personId: null,
+          platformIdentityId: null,
+        },
+      });
+
+      const [persisted] = await db
+        .select()
+        .from(omniEvents)
+        .where(eq(omniEvents.externalId, 'ext-recv-echo-001'))
+        .limit(1);
+      expect(persisted?.eventType).toBe('message.received');
+      expect(persisted?.direction).toBe('outbound');
+    });
+
     test('uses UUID event id as persisted omni_events primary key', async () => {
       await setupEventPersistence(mockEventBus, db);
 

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -148,7 +148,10 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               personId: metadata.personId,
               platformIdentityId: metadata.platformIdentityId,
               eventType: 'message.received',
-              direction: 'inbound',
+              // #1034: own-device echoes (owner typing on their phone) arrive as
+              // message.received with rawPayload.isFromMe=true. Journal them as
+              // outbound so `message.received` + `inbound` means "someone else wrote to us".
+              direction: payload.rawPayload?.isFromMe === true ? 'outbound' : 'inbound',
               contentType: mapContentType(payload.content.type),
               textContent: sanitizeText(payload.content.text),
               mediaUrl: payload.content.mediaUrl,


### PR DESCRIPTION
Closes #1034

## Root cause
`packages/api/src/plugins/event-persistence.ts` hard-coded `direction: 'inbound'` for every `message.received`, even when the channel payload carried `rawPayload.isFromMe: true` (owner typing on their own phone, echoed via multi-device sync).

## Fix
Derive `direction` from `rawPayload.isFromMe`: echoes are journaled as `outbound`. The event type stays `message.received` on purpose — the agent dispatcher still needs to see owner-typed messages (#344) and already distinguishes agent echoes durably (#938). Consumers can now trust `message.received` + `inbound` = someone else wrote to us.

## Verification
- New regression test in `event-persistence.test.ts` (run on a disposable migrated cluster: 14 pass)
- typecheck, biome, knip, verify-migrations: green
- full `bun run test`: 0 failures in all 26 packages