### PR TITLE
fix(events): publish reactions only as reaction.* events, never message.received

### DIFF
--- a/docs/architecture/event-system.md
+++ b/docs/architecture/event-system.md
@@ -231,6 +231,25 @@ interface MessageReceivedEvent extends BaseEvent<'message.received', {
   rawPayload?: unknown;
 }> {}
 
+// Reactions are NOT messages. Inbound reactions never arrive as
+// message.received — they have their own semantic types (#1033), so
+// message subscribers (automations, agent dispatch, `events wait`) never
+// see a 👍 as a new message, and reaction flows are directly subscribable.
+interface ReactionReceivedEvent extends BaseEvent<'reaction.received', {
+  messageId: string;   // target message (platform external id)
+  chatId: string;
+  from: string;        // platform user id of the reactor
+  emoji: string;
+  isCustomEmoji?: boolean;
+}> {}
+
+interface ReactionRemovedEvent extends BaseEvent<'reaction.removed', {
+  messageId: string;
+  chatId: string;
+  from: string;
+  emoji: string;       // '' on WhatsApp (platform does not say which emoji was removed)
+}> {}
+
 interface MessageContent {
   type: ContentType;
   text?: string;
@@ -267,7 +286,7 @@ type ContentType =
   | 'video'
   | 'document'
   | 'sticker'
-  | 'reaction'
+  | 'reaction' // outbound only — inbound reactions are `reaction.received` / `reaction.removed`, never `message.received` (#1033)
   | 'poll'
   | 'location'
   | 'contact'

--- a/packages/api/src/plugins/__tests__/message-persistence-reactions.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-reactions.test.ts
@@ -1,0 +1,60 @@
+/**
+ * reaction.received / reaction.removed persistence (#1033).
+ *
+ * Reactions are not messages: they attach to the target message's
+ * `reactions` column instead of creating a message row.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { Database } from '@omni/db';
+import type { Services } from '../../services';
+import { handleReactionState } from '../message-persistence';
+
+function harness(found: boolean) {
+  const addReaction = mock(async () => ({}));
+  const removeReaction = mock(async () => ({}));
+  const services = {
+    db: {} as Database,
+    chats: { findByExternalIdSmart: async () => (found ? { id: 'chat-1' } : null) },
+    messages: {
+      getByExternalId: async () => (found ? { id: 'msg-1' } : null),
+      addReaction,
+      removeReaction,
+    },
+  } as unknown as Services;
+  return { services, addReaction, removeReaction };
+}
+
+function eventOf(type: 'reaction.received' | 'reaction.removed', emoji: string) {
+  return {
+    id: 'evt-1',
+    type,
+    payload: { messageId: 'ext-msg', chatId: '5511999999999@s.whatsapp.net', from: '5511888888888', emoji },
+    metadata: { correlationId: 'c', timestamp: 0, instanceId: 'inst-1' },
+  } as never;
+}
+
+describe('handleReactionState', () => {
+  test('reaction.received attaches the emoji to the target message', async () => {
+    const h = harness(true);
+    await handleReactionState(h.services, eventOf('reaction.received', '👍'), true);
+    expect(h.addReaction).toHaveBeenCalledWith(
+      'msg-1',
+      { emoji: '👍', platformUserId: '5511888888888', isCustomEmoji: undefined, customEmojiId: undefined },
+      'evt-1',
+    );
+    expect(h.removeReaction).not.toHaveBeenCalled();
+  });
+
+  test('reaction.removed detaches it (empty emoji = all of that user)', async () => {
+    const h = harness(true);
+    await handleReactionState(h.services, eventOf('reaction.removed', ''), false);
+    expect(h.removeReaction).toHaveBeenCalledWith('msg-1', '5511888888888', '', 'evt-1');
+  });
+
+  test('unknown target message is a no-op', async () => {
+    const h = harness(false);
+    await handleReactionState(h.services, eventOf('reaction.received', '👍'), true);
+    expect(h.addReaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -5645,14 +5645,12 @@ async function shouldProcessMessage(
     return null;
   }
 
-  // Reaction dual-emits: channel-whatsapp and channel-discord republish an
-  // inbound reaction as message.received (content.type='reaction') for
-  // backward compatibility with non-dispatch consumers (persistence, UI).
-  // Agent dispatch for reactions is exclusively the reaction.received
-  // subscription's job — that path honors the instance's triggerEvents +
-  // triggerReactions config. Without this skip, a reaction dispatches the
-  // agent as if it were a text message regardless of that config (and
-  // double-dispatches when reaction.received IS configured).
+  // Reactions are not messages: official channels publish them only as
+  // reaction.received / reaction.removed (#1033). This guard keeps a
+  // third-party plugin that still emits content.type='reaction' on
+  // message.received from dispatching the agent as if the user typed the
+  // emoji — reaction dispatch is exclusively the reaction.received
+  // subscription's job (honors triggerEvents + triggerReactions).
   if (payload.content?.type === 'reaction') {
     log.debug('Skipping reaction dual-emit on message path (reaction.received owns dispatch)', {
       instanceId: metadata.instanceId,

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -1049,6 +1049,54 @@ async function handleMessagePinState(
   }
 }
 
+/**
+ * Handle reaction.received / reaction.removed — attach the reaction to the
+ * target message's `reactions` column (#1033). Reactions are NOT messages and
+ * never arrive as message.received; this is the only persistence path for them.
+ */
+export async function handleReactionState(
+  services: Services,
+  event: TypedOmniEvent<'reaction.received' | 'reaction.removed'>,
+  added: boolean,
+): Promise<void> {
+  const payload = event.payload;
+  const metadata = event.metadata;
+  if (!metadata.instanceId) return;
+  const instanceId = metadata.instanceId;
+
+  try {
+    await runConsumerInTenantContext(services.db, event, async () => {
+      const chat = await services.chats.findByExternalIdSmart(instanceId, payload.chatId);
+      const message = chat ? await services.messages.getByExternalId(chat.id, payload.messageId) : null;
+      if (!message) {
+        log.debug('Target message not found for reaction', { chatId: payload.chatId, messageId: payload.messageId });
+        return;
+      }
+
+      if (added) {
+        await services.messages.addReaction(
+          message.id,
+          {
+            emoji: payload.emoji,
+            platformUserId: payload.from,
+            isCustomEmoji: payload.isCustomEmoji,
+            customEmojiId: payload.isCustomEmoji ? payload.emoji : undefined,
+          },
+          event.id,
+        );
+      } else {
+        await services.messages.removeReaction(message.id, payload.from, payload.emoji, event.id);
+      }
+      log.debug('Updated message reactions', { messageId: message.id, emoji: payload.emoji, added });
+    });
+  } catch (error) {
+    log.error('Failed to update message reactions', {
+      messageId: payload.messageId,
+      error: String(error),
+    });
+  }
+}
+
 // ============================================================================
 // Main Setup
 // ============================================================================
@@ -1370,6 +1418,25 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
 
     await eventBus.subscribe('message.unpinned', (event) => handleMessagePinState(services, event, false), {
       durable: 'message-persistence-unpinned',
+      queue: 'message-persistence',
+      maxRetries: 2,
+      retryDelayMs: 500,
+      startFrom: 'first',
+      concurrency: 10,
+    });
+
+    // Subscribe to reaction.received / reaction.removed — per-message reactions (#1033)
+    await eventBus.subscribe('reaction.received', (event) => handleReactionState(services, event, true), {
+      durable: 'message-persistence-reaction-received',
+      queue: 'message-persistence',
+      maxRetries: 2,
+      retryDelayMs: 500,
+      startFrom: 'first',
+      concurrency: 10,
+    });
+
+    await eventBus.subscribe('reaction.removed', (event) => handleReactionState(services, event, false), {
+      durable: 'message-persistence-reaction-removed',
       queue: 'message-persistence',
       maxRetries: 2,
       retryDelayMs: 500,

--- a/packages/api/src/services/messages.ts
+++ b/packages/api/src/services/messages.ts
@@ -747,21 +747,28 @@ export class MessageService {
   }
 
   /**
-   * Remove a reaction from a message
+   * Remove a reaction from a message.
+   *
+   * An empty `emoji` removes every reaction by that user — WhatsApp reports a
+   * removal without saying which emoji went away.
    */
   async removeReaction(id: string, platformUserId: string, emoji: string, latestEventId?: string): Promise<Message> {
     const message = await this.getById(id);
 
     const currentReactions = (message.reactions as ReactionInfo[]) ?? [];
-    const newReactions = currentReactions.filter((r) => !(r.platformUserId === platformUserId && r.emoji === emoji));
+    const newReactions = currentReactions.filter(
+      (r) => !(r.platformUserId === platformUserId && (emoji === '' || r.emoji === emoji)),
+    );
 
     // Update reaction counts
     const currentCounts = (message.reactionCounts as Record<string, number>) ?? {};
     const newCounts = { ...currentCounts };
-    if (newCounts[emoji]) {
-      newCounts[emoji] = Math.max(0, newCounts[emoji] - 1);
-      if (newCounts[emoji] === 0) {
-        delete newCounts[emoji];
+    for (const removed of currentReactions.filter((r) => !newReactions.includes(r))) {
+      const count = (newCounts[removed.emoji] ?? 0) - 1;
+      if (count > 0) {
+        newCounts[removed.emoji] = count;
+      } else {
+        delete newCounts[removed.emoji];
       }
     }
 

--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -1596,26 +1596,6 @@ export class DiscordPlugin extends BaseChannelPlugin {
         isCustomEmoji: false,
       });
     }
-
-    // Dual-emit as message.received for backward compatibility
-    // Remove this once all consumers migrate to reaction.* events
-    if (process.env.OMNI_DUAL_EMIT_REACTIONS !== 'false') {
-      await this.emitMessageReceived({
-        instanceId,
-        externalId: `${messageId}-reaction-${Date.now()}`,
-        chatId,
-        from: userId,
-        content: {
-          type: 'reaction',
-          text: emoji,
-        },
-        rawPayload: {
-          targetMessageId: messageId,
-          action,
-          emoji,
-        },
-      });
-    }
   }
 
   /**

--- a/packages/channel-whatsapp/src/__tests__/reaction-echo.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/reaction-echo.test.ts
@@ -1,8 +1,9 @@
 /**
- * Tests for reaction echo prevention (#336).
+ * Tests for reaction event routing (#336, #1033).
  *
- * Verifies that the bot's own reactions (isFromMe=true) do NOT get
- * dual-emitted as message.received events, preventing dispatch loops.
+ * Reactions are published ONLY as reaction.received / reaction.removed —
+ * never as message.received — so message subscribers (agent dispatch,
+ * automations, `events wait`) never see a reaction as an inbound message.
  */
 
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
@@ -52,8 +53,6 @@ describe('Reaction echo prevention (#336)', () => {
   beforeEach(() => {
     eventBus = createMockEventBus();
     plugin = createPlugin(eventBus);
-    // Reset env
-    process.env.OMNI_DUAL_EMIT_REACTIONS = undefined;
   });
 
   describe('handleReactionReceived with isFromMe=true', () => {
@@ -91,7 +90,7 @@ describe('Reaction echo prevention (#336)', () => {
   });
 
   describe('handleReactionReceived with isFromMe=false', () => {
-    it('emits both reaction.received AND message.received (dual-emit)', async () => {
+    it('emits reaction.received only — never message.received (#1033)', async () => {
       await plugin.handleReactionReceived(
         'instance-1',
         'ext-123',
@@ -103,26 +102,7 @@ describe('Reaction echo prevention (#336)', () => {
       );
 
       const types = eventBus.published.map((e) => e.type);
-      expect(types).toContain('reaction.received');
-      expect(types).toContain('message.received');
-    });
-
-    it('skips message.received when OMNI_DUAL_EMIT_REACTIONS=false', async () => {
-      process.env.OMNI_DUAL_EMIT_REACTIONS = 'false';
-
-      await plugin.handleReactionReceived(
-        'instance-1',
-        'ext-123',
-        'chat-456@s.whatsapp.net',
-        '5511999999999',
-        '❤️',
-        'target-msg-789',
-        false,
-      );
-
-      const types = eventBus.published.map((e) => e.type);
-      expect(types).toContain('reaction.received');
-      expect(types).not.toContain('message.received');
+      expect(types).toEqual(['reaction.received']);
     });
   });
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3205,23 +3205,6 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         emoji: '', // WhatsApp doesn't tell us which emoji was removed
       });
     }
-
-    // Dual-emit as message.received for backward compatibility
-    // Remove this once all consumers migrate to reaction.* events
-    // Skip dual-emit for bot's own reactions (isFromMe) to prevent dispatch loops (#336)
-    if (process.env.OMNI_DUAL_EMIT_REACTIONS !== 'false' && !isFromMe) {
-      await this.emitMessageReceived({
-        instanceId,
-        externalId,
-        chatId,
-        from,
-        content: {
-          type: 'reaction',
-          text: emoji,
-        },
-        rawPayload: { targetMessageId, isFromMe },
-      });
-    }
   }
 
   /**


### PR DESCRIPTION
Closes #1033

## Problem
WhatsApp and Discord republished every inbound reaction as `message.received` with `content.type='reaction'` (a leftover "remove once consumers migrate" shim). Every `message.received` subscriber — automations, agent dispatch, `events wait`, analytics — therefore received reactions as if they were new inbound messages unless it filtered `contentType`. This is the same collapsed-type pattern #959 removed on the webhook side. The other five channels already emitted only `reaction.received` / `reaction.removed`.

## Fix
- Remove the dual-emit (and `OMNI_DUAL_EMIT_REACTIONS`) from channel-whatsapp and channel-discord. Reactions now flow exclusively through `reaction.received` / `reaction.removed`.
- `message-persistence` subscribes to `reaction.received` / `reaction.removed` and attaches the reaction to the target message's `reactions` column, replacing the hidden `reaction` message row (which the UI already dropped). Inbound reactions are now persisted for all seven channels, not just the two that dual-emitted.
- `removeReaction('')` removes all of that user's reactions, since WhatsApp does not say which emoji was removed.
- Dispatcher guard for `content.type='reaction'` kept as defense against third-party plugins; comment updated.
- Event-system doc now documents `ReactionReceivedEvent` / `ReactionRemovedEvent` and states that inbound reactions never arrive as `message.received`.

## Tests
- `reaction-echo.test.ts` now asserts reactions publish only `reaction.received`.
- New `message-persistence-reactions.test.ts` covers attach, detach, and unknown-target no-op.
- `make check`: typecheck, lint, dead-code, migration gate green. Per-package test run: 0 failures (real-PostgreSQL suites skipped in this worktree; no disposable cluster started).