### PR TITLE
fix(automations): dedup redelivered events on the execution path

### DIFF
--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -36,7 +36,7 @@
 import type { AgentCallContext, AgentRunResult, CallAgentActionConfig } from '@omni/core';
 import { PUBLISH_NOT_DECLARED, SCHEMA_NOT_REGISTERED, checkPublishAllowed, createLogger, generateId } from '@omni/core';
 import type { Database, EventType } from '@omni/db';
-import { agents, omniEvents } from '@omni/db';
+import { agents, omniEvents, processedEvents } from '@omni/db';
 import { eq } from 'drizzle-orm';
 import type { Services } from '../services';
 import { releaseIdleTimeoutClaim } from '../services/follow-up-lifecycle';
@@ -257,6 +257,7 @@ export interface AutomationEngineDeps {
     trustedTenantId?: string | null,
   ) => Promise<boolean>;
   releaseEmittedEventClaim: (eventId: string) => Promise<void>;
+  claimExecution: (eventId: string, automationId: string, trustedTenantId?: string | null) => Promise<boolean>;
   validateEmitEvent: (
     eventType: string,
     payload: Record<string, unknown>,
@@ -424,6 +425,20 @@ export function buildAutomationEngineDeps(
     // journal consumer's insert lands here (ON CONFLICT (id) DO NOTHING) —
     // one row, carrying the causality fields `omni events trace` walks
     // (causation_id column + correlationId in the metadata jsonb).
+    // Per-(event, automation) execution claim (#1031) — the same
+    // `processed_events` PK `withIdempotency` uses for durable subscribers,
+    // with the automation id as the handler so sibling automations on one
+    // event each get their own slot. Never released: a failed run must not
+    // re-fire a side effect that may already have landed (see idempotency.ts).
+    claimExecution: async (eventId, automationId) => {
+      const claim = await db
+        .insert(processedEvents)
+        .values({ eventId, handler: `automation:${automationId}` })
+        .onConflictDoNothing()
+        .returning({ eventId: processedEvents.eventId });
+      return claim.length > 0;
+    },
+
     claimEmittedEvent: async (claim, trustedTenantId = null) => {
       const claimed = await runTenantWorkDb(db, trustedTenantId, () =>
         scopedHandle(db)

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -86,6 +86,8 @@ export class AutomationService {
       trustedTenantId?: string | null,
     ) => Promise<boolean>;
     releaseEmittedEventClaim?: (eventId: string) => Promise<void>;
+    // Execution claim per (event, automation) — redelivery dedup (#1031).
+    claimExecution?: (eventId: string, automationId: string, trustedTenantId?: string | null) => Promise<boolean>;
     // Emission gates for emit_event: the publish allowlist (issue #987, keyed
     // by the emitting automation's managing agent) and the schema registry
     // (issue #959) — see automation-actions.ts.

--- a/packages/core/src/automations/__tests__/engine-execution-claim.test.ts
+++ b/packages/core/src/automations/__tests__/engine-execution-claim.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Redelivery dedup for automation execution (#1031).
+ *
+ * A NATS redelivery of an event whose long-running action outlived the ack
+ * window must NOT re-run the actions: the engine claims the
+ * (eventId, automationId) slot before any side effect and skips when the
+ * claim is already taken.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus, SubscribeOptions, Subscription } from '../../events/bus';
+import type { OmniEvent } from '../../events/types';
+import { createAutomationEngine } from '../engine';
+import type { Automation } from '../types';
+
+function makeAutomation(): Automation {
+  return {
+    id: 'auto-1',
+    name: 'Announce PR',
+    enabled: true,
+    priority: 0,
+    triggerEventType: 'custom.github.pull_request',
+    triggerConditions: [],
+    conditionLogic: 'and',
+    actions: [{ type: 'send_message', config: { instanceId: 'inst-1', to: 'chat-1', contentTemplate: 'hi' } }],
+    debounce: { mode: 'none' },
+  } as unknown as Automation;
+}
+
+function prEvent(): OmniEvent {
+  return {
+    id: 'evt-1',
+    type: 'custom.github.pull_request',
+    payload: { action: 'closed' },
+    metadata: { correlationId: 'corr-1', instanceId: 'inst-1' },
+    timestamp: Date.now(),
+  } as unknown as OmniEvent;
+}
+
+function makeBus(): { bus: EventBus; deliver: (event: OmniEvent) => Promise<void> } {
+  let handler: ((event: OmniEvent) => Promise<void>) | null = null;
+  const subscription: Subscription = { id: 'sub', pattern: '*', unsubscribe: async () => {} };
+  const bus = {
+    connect: mock(async () => {}),
+    publish: mock(async () => ({ id: '', sequence: 0, stream: '' })),
+    publishGeneric: mock(async () => ({ id: '', sequence: 0, stream: '' })),
+    subscribe: mock(async () => subscription),
+    subscribePattern: mock(async (_p: string, h: (e: OmniEvent) => Promise<void>, _o?: SubscribeOptions) => {
+      handler = h;
+      return subscription;
+    }),
+    subscribeMany: mock(async () => subscription),
+    subscribeAll: mock(async () => subscription),
+    close: mock(async () => {}),
+    isConnected: mock(() => true),
+  } as unknown as EventBus;
+  return {
+    bus,
+    deliver: async (event) => {
+      if (!handler) throw new Error('engine never subscribed');
+      await handler(event);
+    },
+  };
+}
+
+describe('AutomationEngine — execution claim (#1031)', () => {
+  test('redelivered event runs actions once; second delivery is logged as skipped', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5 });
+    const { bus, deliver } = makeBus();
+    const claimed = new Set<string>();
+    const sendMessage = mock(async () => {});
+    const logs: Array<{ status: string; error?: string }> = [];
+    engine.setLogger(async (log) => {
+      logs.push({ status: log.status, error: log.error });
+    });
+
+    await engine.start(bus, [makeAutomation()], {
+      sendMessage,
+      claimExecution: async (eventId, automationId) => {
+        const key = `${eventId}:${automationId}`;
+        if (claimed.has(key)) return false;
+        claimed.add(key);
+        return true;
+      },
+    });
+
+    await deliver(prEvent());
+    await deliver(prEvent());
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(logs.map((l) => l.status)).toEqual(['success', 'skipped']);
+    expect(logs[1]?.error).toContain('duplicate delivery');
+    await engine.stop();
+  });
+
+  test('subscribes with an ack window long enough for multi-minute actions', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5 });
+    const { bus } = makeBus();
+    await engine.start(bus, [makeAutomation()], {});
+    const opts = (bus.subscribePattern as ReturnType<typeof mock>).mock.calls[0]?.[2] as SubscribeOptions;
+    expect(opts.ackWaitMs).toBeGreaterThanOrEqual(3 * 60 * 1000);
+    await engine.stop();
+  });
+});

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -151,6 +151,16 @@ export interface ActionDependencies {
    * leaving it would suppress the retry's emission forever.
    */
   releaseEmittedEventClaim?: (eventId: string) => Promise<void>;
+  /**
+   * Claim the (eventId, automationId) execution slot BEFORE any action runs
+   * (#1031). Returns false when the slot is already claimed — a NATS
+   * redelivery of an event whose long-running action (call_agent, 1–3 min)
+   * outlived the ack window — and the engine skips the run instead of
+   * re-firing side effects. At-most-once per (event, automation), same
+   * discipline as `claimEmittedEvent`. Absent (tests, older wiring) ⇒ every
+   * delivery executes, as before.
+   */
+  claimExecution?: (eventId: string, automationId: string, trustedTenantId?: string | null) => Promise<boolean>;
   sendMessage?: (instanceId: string, to: string, content: string, trustedTenantId?: string | null) => Promise<void>;
   /**
    * Call an AI agent and return the response.

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -139,6 +139,7 @@ export class AutomationEngine {
       releaseIdleTimeoutClaim: deps.releaseIdleTimeoutClaim,
       claimEmittedEvent: deps.claimEmittedEvent,
       releaseEmittedEventClaim: deps.releaseEmittedEventClaim,
+      claimExecution: deps.claimExecution,
       // #959 gate — threaded here so engine executions validate too; without
       // this line the dep is provided by the API but silently dropped.
       validateEmitEvent: deps.validateEmitEvent,
@@ -286,6 +287,10 @@ export class AutomationEngine {
         startFrom: 'new',
         maxRetries: 3,
         retryDelayMs: 1000,
+        // Actions routinely run 1–3 min (call_agent → claude-code). The bus
+        // default of 30s redelivered mid-run and re-executed (#1031); the
+        // execution claim below is the guarantee, this just avoids the churn.
+        ackWaitMs: 5 * 60 * 1000,
       },
     );
     logger.info(`Subscribed to ${eventType}.*`, { durable });
@@ -747,6 +752,28 @@ export class AutomationEngine {
           executionTimeMs: Date.now() - start,
         };
 
+        await this.logExecution(result, trustedTenantId);
+        return result;
+      }
+
+      // Claim this (event, automation) execution before any side effect runs
+      // (#1031). A redelivery — the first run's action outlived the ack
+      // window — collides here, is logged as skipped, and acks normally.
+      if (this.deps.claimExecution && !(await this.deps.claimExecution(event.id, automation.id, trustedTenantId))) {
+        logger.info('Skipping redelivered event: execution already claimed', {
+          automationId: automation.id,
+          eventId: event.id,
+        });
+        const result: ExecutionResult = {
+          automationId: automation.id,
+          automationName: automation.name,
+          eventId: event.id,
+          status: 'skipped',
+          conditionsMatched: true,
+          actionsExecuted: [],
+          error: 'duplicate delivery: execution already claimed for this event',
+          executionTimeMs: Date.now() - start,
+        };
         await this.logExecution(result, trustedTenantId);
         return result;
       }

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -576,7 +576,11 @@ export const PENDING_G4_CEILING = 7;
  *     `access.ts::access_rules` joined this group in run15: its two consumer
  *     callers were converted, and the caller trace then found the tRPC edge.
  */
-export const PENDING_G5_CEILING = 12;
+// 13 after #1031: the automation engine's per-(event, automation) execution
+// claim is a genuinely new `processed_events` write in
+// `automation-actions.ts` — the same G6 gate as `idempotency.ts`, not a
+// relabelling.
+export const PENDING_G5_CEILING = 13;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -645,7 +649,9 @@ export const PENDING_G5_CEILING = 12;
 // pending-G4 site (a bare getDb() in a credential-less webhook path — see its
 // registry entry). Nothing was reclassified; the raise is a real new site in
 // a new package, not movement between pending classes.
-export const TOTAL_PENDING_CEILING = 19;
+// 20 after #1031 (6 + 13): ONE new G6-gated `processed_events` claim site in
+// `automation-actions.ts` (see PENDING_G5_CEILING). Nothing was reclassified.
+export const TOTAL_PENDING_CEILING = 20;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -888,6 +894,18 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     file: 'packages/api/src/plugins/automation-actions.ts',
     table: 'omni_events',
     class: 'tenant-boundary',
+  },
+  {
+    // #1031: execution claim against the same `processed_events` PK that
+    // `idempotency.ts` uses, reached from the engine's NATS consumer callback.
+    // Same G6 gate as that site: the table derives through a G2-unowned root.
+    file: 'packages/api/src/plugins/automation-actions.ts',
+    table: 'processed_events',
+    class: 'pending-G5-conversion',
+    justification:
+      'Reached only from the automation engine NATS consumer callback (no HTTP request, no credential). Same ' +
+      'processed_events claim and same G6 gate as packages/api/src/lib/idempotency.ts; the async mechanism is the ' +
+      'ADR-0008 consumer context.',
   },
   {
     file: 'packages/api/src/plugins/automation-actions.ts',

--- a/packages/db/src/tenancy-writer-coverage.ts
+++ b/packages/db/src/tenancy-writer-coverage.ts
@@ -153,6 +153,8 @@ export const REGISTERED_WRITERS: readonly RegisteredWriter[] = [
     coverage: 'db-derived',
   },
   { file: 'packages/api/src/lib/idempotency.ts', table: 'processed_events', coverage: 'db-unowned' },
+  // #1031: per-(event, automation) execution claim — same PK discipline as idempotency.ts.
+  { file: 'packages/api/src/plugins/automation-actions.ts', table: 'processed_events', coverage: 'db-unowned' },
   { file: 'packages/api/src/plugins/agent-dispatcher.ts', table: 'agent_sessions', coverage: 'db-derived' },
   // #958: emit_event idempotency claim — the journal row IS the claim.
   { file: 'packages/api/src/plugins/automation-actions.ts', table: 'omni_events', coverage: 'db-derived' },


### PR DESCRIPTION
## Summary

Fixes #1031 — a redelivered event re-executed an automation whose `call_agent` action outlived the ack window, sending the same message 3x.

- **Execution claim (the guarantee).** New `claimExecution` action dependency: the engine claims the `(event_id, automation_id)` slot in `processed_events` (handler `automation:<id>`, the same PK `withIdempotency` uses) after conditions match and **before** any action runs. A redelivery collides, is logged as `skipped` with a `duplicate delivery` reason, and acks normally. Never released, matching `idempotency.ts` at-most-once semantics.
- **Ack window (the churn).** The `automation-engine-*` durable consumers now subscribe with a 5-minute `ackWaitMs` instead of the 30s bus default, so realistic action durations no longer trigger redelivery in the first place.
- Registered the new `processed_events` write site in the tenancy registries and raised the pending-G5 / total ceilings by one for the genuinely new G6-gated site (same gate as `idempotency.ts::processed_events`, whatsapp-business precedent).

## Test plan

- [x] New `engine-execution-claim.test.ts`: same event delivered twice → `sendMessage` called once, logs are `['success', 'skipped']`; subscription carries a ≥3 min ack window.
- [x] typecheck, biome, knip, verify-migrations, full `bun run test` (api/core/db/channels) green. `make check`'s final `_sync-db` step needs a `.env` + `drizzle push`, which this worktree does not have; tests were run directly instead.