### PR TITLE
ci(versions): exempt files absent on the PR base from the version-sync gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,30 @@ jobs:
         run: bun install
 
       - name: Verify version sync
-        run: bun scripts/verify-versions.ts
+        # On PRs / merge queues, tracked files that don't exist on the base
+        # are reported NEW and exempt (#1020): dev's auto-bump rewrites every
+        # pre-existing file into the merge ref, but a file the PR introduces
+        # (new channel package.json) can only carry the author's last sync,
+        # so it re-drifts on every merge to dev. The base is resolved exactly
+        # like the migration gate below: HEAD^1 of the test merge commit,
+        # falling back to the base-branch tip when the PR merged mid-run.
+        # Pushes to dev/main keep the strict full check.
+        env:
+          VERSION_BASE_BRANCH: ${{ github.base_ref || 'dev' }}
+        run: |
+          bun test scripts/verify-versions.test.ts
+          if [ "${{ github.event_name }}" = "push" ]; then
+            bun scripts/verify-versions.ts
+          else
+            git fetch --no-tags --deepen=1 origin
+            if BASE=$(git rev-parse --verify -q HEAD^1); then
+              bun scripts/verify-versions.ts --base "$BASE"
+            else
+              echo "::notice::HEAD^1 unresolvable (PR merged mid-run?) — falling back to origin/${VERSION_BASE_BRANCH}"
+              git fetch --no-tags --depth=1 origin "+refs/heads/${VERSION_BASE_BRANCH}:refs/remotes/origin/${VERSION_BASE_BRANCH}"
+              bun scripts/verify-versions.ts --base "origin/${VERSION_BASE_BRANCH}"
+            fi
+          fi
 
       - name: Migration contract gate
         # Static check of packages/db/drizzle/ (journal ↔ files bijection,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,10 @@ jobs:
         # Pushes to dev/main keep the strict full check.
         env:
           VERSION_BASE_BRANCH: ${{ github.base_ref || 'dev' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           bun test scripts/verify-versions.test.ts
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${EVENT_NAME}" = "push" ]; then
             bun scripts/verify-versions.ts
           else
             git fetch --no-tags --deepen=1 origin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: help install dev dev-api dev-ui dev-services dev-stop build build-ui clean version \
         test test-sweep test-watch test-api test-db test-pg-gate test-pg-gate-warm pg-gate-warm-stop \
-        typecheck typecheck-ui lint lint-fix lint-ui format check check-all dead-code verify-migrations \
+        typecheck typecheck-ui lint lint-fix lint-ui format check check-all dead-code verify-migrations verify-versions \
         db-push db-migrate db-studio db-reset \
         ensure-nats ensure-ffmpeg check-ffmpeg check-deps start stop restart logs status \
         restart-api restart-nats restart-pgserve logs-api \
@@ -31,6 +31,7 @@ help:
 	@echo "  make check         Run all quality checks (typecheck + lint + dead-code + migrations + test)"
 	@echo "  make check-all     Run check AND the pg-gate concurrently (fastest full validation)"
 	@echo "  make verify-migrations  Static migration contract gate (journal/immutability/lint)"
+	@echo "  make verify-versions    Version sync gate (BASE=<ref> exempts files absent on ref)"
 	@echo "  make typecheck     TypeScript type checking"
 	@echo "  make lint          Run Biome linter"
 	@echo "  make lint-fix      Fix auto-fixable lint issues"
@@ -296,8 +297,14 @@ verify-migrations:
 	bun test scripts/verify-migration-contract.test.ts
 	bun scripts/verify-migration-contract.ts $(if $(BASE),--base $(BASE),)
 
+# Version sync gate: every tracked version field matches root package.json.
+# Pass BASE=<ref> to exempt files absent on that ref (what CI does on PRs, #1020).
+verify-versions:
+	bun test scripts/verify-versions.test.ts
+	bun scripts/verify-versions.ts $(if $(BASE),--base $(BASE),)
+
 # Run all quality checks
-check: typecheck lint dead-code verify-migrations test
+check: typecheck lint dead-code verify-migrations verify-versions test
 	@echo ""
 	@echo "All checks passed!"
 

--- a/scripts/verify-versions.test.ts
+++ b/scripts/verify-versions.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for scripts/verify-versions.ts — the NEW-file exemption (#1020).
+ *
+ * Run: bun test scripts/verify-versions.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { fieldStatus, readBasePaths } from './verify-versions';
+
+describe('fieldStatus', () => {
+  const base = new Set(['package.json', 'packages/api/package.json']);
+
+  test('matching version is OK regardless of base', () => {
+    expect(fieldStatus('1.0.0', '1.0.0', 'packages/api/package.json', base)).toBe('OK');
+    expect(fieldStatus('1.0.0', '1.0.0', 'packages/new/package.json', null)).toBe('OK');
+  });
+
+  test('drift in a file that exists on base is a MISMATCH', () => {
+    expect(fieldStatus('0.9.0', '1.0.0', 'packages/api/package.json', base)).toBe('MISMATCH');
+    expect(fieldStatus(null, '1.0.0', 'packages/api/package.json', base)).toBe('MISMATCH');
+  });
+
+  test('drift in a file absent from base is NEW (exempt)', () => {
+    expect(fieldStatus('0.9.0', '1.0.0', 'packages/new/package.json', base)).toBe('NEW');
+  });
+
+  test('without a base ref every drift is a MISMATCH', () => {
+    expect(fieldStatus('0.9.0', '1.0.0', 'packages/new/package.json', null)).toBe('MISMATCH');
+  });
+});
+
+describe('readBasePaths', () => {
+  test('null base means no exemption', () => {
+    expect(readBasePaths(null)).toBeNull();
+  });
+
+  test('lists the tracked tree of a real ref', () => {
+    const paths = readBasePaths('HEAD');
+    expect(paths?.has('package.json')).toBe(true);
+    expect(paths?.has('scripts/verify-versions.ts')).toBe(true);
+  });
+});

--- a/scripts/verify-versions.ts
+++ b/scripts/verify-versions.ts
@@ -3,12 +3,21 @@
 /**
  * Verify every tracked version field matches the root package.json.
  *
- * Usage: bun scripts/verify-versions.ts
+ * Usage: bun scripts/verify-versions.ts [--base <git-ref>]
  *
  * Reads the root package.json `version` as the reference value, then walks
  * every entry from scripts/lib/version-fields.ts and prints a per-file
  * status line. Exits 0 when all files match, 1 when any field drifts (or
  * is missing).
+ *
+ * With --base, tracked files that do NOT exist on the base ref are reported
+ * as NEW and exempt from the check (#1020). On a PR merge ref the auto-bump
+ * on dev has already rewritten every pre-existing file, but a file the PR
+ * introduces (a new channel package.json) can only carry the
+ * version the author last synced — so it re-drifts on every merge to dev
+ * and the author races the merge cadence. The first auto-bump after merge
+ * normalizes it anyway, so exempting it loses nothing. Files that exist on
+ * the base keep the strict check: a mismatch there is real drift.
  *
  * Wired into the Quality Gate job in .github/workflows/ci.yml as the
  * "Verify version sync" step so version drift fails CI fast.
@@ -27,34 +36,75 @@ function readRootVersion(): string {
   return data.version;
 }
 
+function resolveBaseRef(argv: readonly string[]): string | null {
+  const flagIndex = argv.indexOf('--base');
+  if (flagIndex === -1) return null;
+  const value = argv[flagIndex + 1];
+  if (!value) {
+    console.error('--base requires a git ref argument');
+    process.exit(2);
+  }
+  return value;
+}
+
+/** Repo-relative paths present in the base ref's tree, or null when no base was given. */
+export function readBasePaths(baseRef: string | null): Set<string> | null {
+  if (baseRef === null) return null;
+  const result = Bun.spawnSync(['git', 'ls-tree', '-r', '--name-only', '--full-tree', baseRef], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    console.error(`Cannot list base ref "${baseRef}": ${result.stderr.toString().trim()}`);
+    process.exit(2);
+  }
+  return new Set(result.stdout.toString().split('\n').filter(Boolean));
+}
+
+export function fieldStatus(
+  actual: string | null,
+  reference: string,
+  path: string,
+  basePaths: Set<string> | null,
+): 'OK' | 'NEW' | 'MISMATCH' {
+  if (actual === reference) return 'OK';
+  if (basePaths !== null && !basePaths.has(path)) return 'NEW';
+  return 'MISMATCH';
+}
+
 function main(): void {
   const reference = readRootVersion();
   console.log(`Reference version: ${reference}`);
 
+  const baseRef = resolveBaseRef(process.argv.slice(2));
+  const basePaths = readBasePaths(baseRef);
+  if (baseRef !== null) console.log(`Base ref: ${baseRef} (files absent there are exempt)`);
+
   const fields = getAllVersionFields();
   let mismatches = 0;
+  let fresh = 0;
 
   for (const field of fields) {
     const actual = field.read();
-    const matches = actual === reference;
-    const status = matches ? 'OK      ' : 'MISMATCH';
+    const status = fieldStatus(actual, reference, field.path, basePaths);
     const display = actual ?? '<missing>';
-    console.log(`${status} ${field.path} → ${display}`);
-    if (!matches) {
-      mismatches++;
-    }
+    console.log(`${status.padEnd(8)} ${field.path} → ${display}`);
+    if (status === 'MISMATCH') mismatches++;
+    if (status === 'NEW') fresh++;
   }
 
   const total = fields.length;
-  const matched = total - mismatches;
+  const matched = total - mismatches - fresh;
+  const newNote = fresh > 0 ? `, ${fresh} new (exempt — auto-bump normalizes after merge)` : '';
 
   if (mismatches === 0) {
-    console.log(`\nOK: ${matched}/${total} files match`);
+    console.log(`\nOK: ${matched}/${total} files match${newNote}`);
     process.exit(0);
   }
 
-  console.log(`\nFAIL: ${mismatches} mismatches found`);
+  console.log(`\nFAIL: ${mismatches} mismatches found${newNote}`);
   process.exit(1);
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
Closes #1020

## Problem
The Quality Gate's **Verify version sync** step checks the PR merge ref against root `package.json`. A file the PR *adds* (e.g. `packages/channel-<x>/package.json`) can't pick up dev's auto-bump, so every merge to dev between the author's last sync and the gate run re-fails the check (bit #910 twice in 18 minutes).

## Fix (the minimal one proposed in the issue)
- `scripts/verify-versions.ts` gains `--base <ref>`. Tracked files absent on the base tree print `NEW` and are exempt; files present on the base keep the strict `MISMATCH` check. Without `--base` behaviour is unchanged.
- `ci.yml`: on `pull_request` / `merge_group` the base is resolved exactly like the migration gate (HEAD^1 of the test merge commit, falling back to the base-branch tip if the PR merged mid-run). `push` events keep the strict full check.
- `make verify-versions` (with optional `BASE=`) added and wired into `make check`, mirroring `verify-migrations`.
- `scripts/verify-versions.test.ts` covers the status logic and the git listing.

## Verification
- `make check`: typecheck, lint, dead-code, verify-migrations, verify-versions all green; 25/26 test packages green. The one CLI failure is the pre-suite PM2 leak guard tripping on daemons from other sessions' concurrent test runs on the same host, unrelated to this diff.
- Manually simulated a new `packages/zz-fake/package.json` at `0.0.0`: `--base HEAD` reports `NEW` and exits 0; without `--base` it still fails.

Not done here: the optional "private workspace packages don't need real versions" cleanup from the issue — separate follow-up.