### PR TITLE
fix(events): link @lid-addressed events to their chat and person in the journal

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'b
 import { randomUUID } from 'node:crypto';
 import type { EventBus } from '@omni/core';
 import type { Database } from '@omni/db';
-import { omniEvents } from '@omni/db';
+import { chatIdMappings, chats, instances, omniEvents } from '@omni/db';
 import { eq, sql } from 'drizzle-orm';
 import { setupEventPersistence } from '../plugins/event-persistence';
 import { describeWithDb, getTestDb } from './db-helper';
@@ -123,6 +123,47 @@ describeWithDb('Event Persistence Handler', () => {
       expect(persisted?.chatId).toBe('chat-123');
       expect(persisted?.status).toBe('received');
       expect(persisted?.rawPayload).toEqual({ foo: 'bar' });
+    });
+
+    test('links a @lid-addressed message.received to the phone-form chat via chat_id_mappings (#1035)', async () => {
+      await setupEventPersistence(mockEventBus, db);
+
+      const [instance] = await db
+        .insert(instances)
+        .values({ name: `test-ep-lid-${Date.now()}`, channel: 'whatsapp-baileys' })
+        .returning();
+      if (!instance) throw new Error('Failed to create test instance');
+      const lidJid = '123456789012345@lid';
+      const phoneJid = '5511999999999@s.whatsapp.net';
+      try {
+        const [chat] = await db
+          .insert(chats)
+          .values({
+            instanceId: instance.id,
+            externalId: phoneJid,
+            canonicalId: phoneJid,
+            chatType: 'dm',
+            channel: 'whatsapp-baileys',
+          })
+          .returning();
+        await db.insert(chatIdMappings).values({ instanceId: instance.id, lidId: lidJid, phoneId: phoneJid });
+
+        await emitEvent('message.received', {
+          id: randomUUID(),
+          type: 'message.received',
+          timestamp: Date.now(),
+          payload: { externalId: 'ext-lid-001', chatId: lidJid, from: lidJid, content: { type: 'text', text: 'hi' } },
+          metadata: { correlationId: 'corr-lid', instanceId: instance.id, channelType: 'whatsapp' },
+        });
+
+        const [persisted] = await db.select().from(omniEvents).where(eq(omniEvents.externalId, 'ext-lid-001')).limit(1);
+        expect(persisted?.chatId).toBe(lidJid);
+        expect(persisted?.chatUuid).toBe(chat?.id);
+        expect(persisted?.canonicalChatId).toBe(phoneJid);
+      } finally {
+        await db.delete(omniEvents).where(eq(omniEvents.externalId, 'ext-lid-001'));
+        await db.delete(instances).where(eq(instances.id, instance.id));
+      }
     });
 
     test('uses UUID event id as persisted omni_events primary key', async () => {

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -24,6 +24,7 @@ import { JOURNEY_STAGES, createLogger, getJourneyTracker, isValidUuid } from '@o
 import type { Database, NewOmniEvent } from '@omni/db';
 import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents, persons } from '@omni/db';
 import { and, eq } from 'drizzle-orm';
+import { ChatService } from '../services/chats';
 import { scopedHandle } from '../tenancy/tenant-scope';
 import { runConsumerInTenantContext } from '../tenancy/worker-tenant-context';
 import { deepSanitize, sanitizeText } from '../utils/utf8';
@@ -57,26 +58,28 @@ function eventIdInsert(eventId: string | undefined): Partial<Pick<NewOmniEvent, 
   return eventId && isValidUuid(eventId) ? { id: eventId } : {};
 }
 
+type ChatLink = { chatUuid: string | null; canonicalChatId: string | null };
+const NO_CHAT_LINK: ChatLink = { chatUuid: null, canonicalChatId: null };
+
 /**
- * Resolve the chats.id UUID for a given instance + platform JID (chatId).
- * Best-effort: returns null if the chat doesn't exist yet or the lookup fails.
- * Never throws — event persistence must not fail because of this lookup.
+ * Resolve the chats row for a given instance + platform JID (chatId).
+ * Goes through ChatService.findByExternalIdSmart so a WhatsApp `@lid` chat id
+ * links to the phone-form chat the message pipeline routed it to (via
+ * canonicalId or chat_id_mappings) instead of journaling unlinked (#1035).
+ * Best-effort: returns an empty link if the chat doesn't exist yet or the
+ * lookup fails. Never throws — event persistence must not fail because of this.
  */
-async function resolveChatUuid(
+async function resolveChatLink(
   db: Database,
   instanceId: string | undefined,
   chatId: string | undefined,
-): Promise<string | null> {
-  if (!instanceId || !chatId) return null;
+): Promise<ChatLink> {
+  if (!instanceId || !chatId) return NO_CHAT_LINK;
   try {
-    const [chat] = await db
-      .select({ id: chats.id })
-      .from(chats)
-      .where(and(eq(chats.instanceId, instanceId), eq(chats.externalId, chatId)))
-      .limit(1);
-    return chat?.id ?? null;
+    const chat = await new ChatService(db, null).findByExternalIdSmart(instanceId, chatId);
+    return chat ? { chatUuid: chat.id, canonicalChatId: chat.canonicalId ?? null } : NO_CHAT_LINK;
   } catch {
-    return null; // best-effort — never fail event persistence because of this
+    return NO_CHAT_LINK; // best-effort — never fail event persistence because of this
   }
 }
 
@@ -138,7 +141,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         try {
           await runConsumerInTenantContext(db, event, async () => {
             const sdb = scopedHandle(db);
-            const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+            const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
 
             const newEvent: NewOmniEvent = {
               ...eventIdInsert(event.id),
@@ -165,7 +168,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               agentId: metadata.agentId ?? null,
               causationId: metadata.causationId ?? null,
               conversationId: null,
-              chatUuid,
+              ...chatLink,
             };
 
             await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
@@ -201,7 +204,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
         try {
           await runConsumerInTenantContext(db, event, async () => {
             const sdb = scopedHandle(db);
-            const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+            const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
 
             const newEvent: NewOmniEvent = {
               ...eventIdInsert(event.id),
@@ -231,7 +234,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               agentId: metadata.agentId ?? null,
               causationId: metadata.causationId ?? null,
               conversationId: null,
-              chatUuid,
+              ...chatLink,
             };
 
             await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
@@ -272,7 +275,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
 
             if (updated.length === 0) {
               // No existing event found, create a new record
-              const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+              const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
               const newEvent: NewOmniEvent = {
                 ...eventIdInsert(event.id),
                 externalId: payload.externalId,
@@ -287,7 +290,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
                 agentId: metadata.agentId ?? null,
                 causationId: metadata.causationId ?? null,
                 conversationId: null,
-                chatUuid,
+                ...chatLink,
               };
               await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
             }
@@ -326,7 +329,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
 
             if (updated.length === 0) {
               // No existing event found, create a new record
-              const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+              const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
               const newEvent: NewOmniEvent = {
                 ...eventIdInsert(event.id),
                 externalId: payload.externalId,
@@ -341,7 +344,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
                 agentId: metadata.agentId ?? null,
                 causationId: metadata.causationId ?? null,
                 conversationId: null,
-                chatUuid,
+                ...chatLink,
               };
               await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
             }
@@ -406,7 +409,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               // Insert a fresh failed row, mirroring the message.read subscriber
               // pattern (eventIdInsert for replay-safe deterministic id +
               // onConflictDoNothing on id for idempotency).
-              const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
+              const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
               const newEvent: NewOmniEvent = {
                 ...eventIdInsert(event.id),
                 externalId: payload.externalId,
@@ -427,7 +430,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
                 agentId: metadata.agentId ?? null,
                 causationId: metadata.causationId ?? null,
                 conversationId: null,
-                chatUuid,
+                ...chatLink,
               };
               await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
             }
@@ -486,9 +489,10 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             // message subscribers do.
             const personId =
               (await resolvePersonId(sdb, metadata.personId)) ?? (await resolvePersonId(sdb, payload.personId));
-            const chatUuid =
-              (await resolveChatUuidById(sdb, payload.chatUuid)) ??
-              (await resolveChatUuid(sdb, instanceId ?? undefined, payloadChatId));
+            const chatUuid = await resolveChatUuidById(sdb, payload.chatUuid);
+            const chatLink = chatUuid
+              ? { chatUuid, canonicalChatId: null }
+              : await resolveChatLink(sdb, instanceId ?? undefined, payloadChatId);
 
             const newEvent: NewOmniEvent = {
               ...eventIdInsert(event.id),
@@ -508,7 +512,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               causationId: metadata.causationId ?? null,
               conversationId: null,
               chatId: payloadChatId,
-              chatUuid,
+              ...chatLink,
             };
             await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
           });

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -57,11 +57,14 @@
  */
 
 import type { EventBus, MessageReceivedPayload, MessageSentPayload, TypedOmniEvent } from '@omni/core';
-import { classifyEnvelope, createLogger } from '@omni/core';
-import type { ChannelType, ChatType, MessageType } from '@omni/db';
+import { classifyEnvelope, createLogger, isValidUuid } from '@omni/core';
+import type { ChannelType, ChatType, Database, MessageType } from '@omni/db';
+import { omniEvents } from '@omni/db';
 import * as Sentry from '@sentry/bun';
+import { eq, sql } from 'drizzle-orm';
 import { sentryEnabled } from '../lib/sentry-scrub';
 import type { Services } from '../services';
+import { scopedHandle } from '../tenancy/tenant-scope';
 import {
   WorkerTenantContextError,
   runConsumerInTenantContext,
@@ -702,6 +705,26 @@ function maybeUpdateRecency(
   });
 }
 
+/** Chat/person linkage message-persistence resolved for an inbound event. */
+type JournalLink = { chatUuid: string; canonicalChatId: string | null; personId: string | null };
+
+/**
+ * Backfill chatUuid/canonicalChatId/personId onto the omni_events row for
+ * `eventId`. Idempotent; a no-op when the journal row does not exist yet
+ * (then event-persistence resolves the link itself at insert time).
+ */
+async function linkJournalRow(db: Database, eventId: string, link: JournalLink): Promise<void> {
+  if (!isValidUuid(eventId)) return;
+  await scopedHandle(db)
+    .update(omniEvents)
+    .set({
+      chatUuid: link.chatUuid,
+      canonicalChatId: link.canonicalChatId,
+      personId: sql`coalesce(${omniEvents.personId}, ${link.personId})`,
+    })
+    .where(eq(omniEvents.id, eventId));
+}
+
 /**
  * Find or create the chat for an inbound message.
  *
@@ -835,7 +858,7 @@ async function handleMessageReceived(
   eventTimestamp: number,
   trustedTenantId: string | null,
   identity: IdentityResult,
-): Promise<void> {
+): Promise<JournalLink | undefined> {
   const channel = (metadata.channelType ?? 'whatsapp') as ChannelType;
   const isHistorySync = metadata.ingestMode === 'history-sync';
 
@@ -986,6 +1009,7 @@ async function handleMessageReceived(
     platformTimestamp ?? new Date(eventTimestamp),
     trustedTenantId,
   );
+  return { chatUuid: chat.id, canonicalChatId: chat.canonicalId ?? null, personId: personId ?? null };
 }
 
 /**
@@ -1102,9 +1126,19 @@ export async function setupMessagePersistence(eventBus: EventBus, services: Serv
             (metadata.channelType ?? 'whatsapp') as ChannelType,
             trustedTenantId,
           );
-          await runConsumerInTenantContext(services.db, event, () =>
+          const journalLink = await runConsumerInTenantContext(services.db, event, () =>
             handleMessageReceived(services, payload, workMetadata, event.timestamp, trustedTenantId, identity),
           );
+          // After commit: the event-persistence consumer races this one, so its
+          // journal row may have been written before the chat/person existed
+          // (#1035). Own work scope, never the handler's transaction.
+          if (journalLink) {
+            await runTenantWorkDb(services.db, trustedTenantId, () =>
+              linkJournalRow(services.db, event.id, journalLink),
+            ).catch((err) => {
+              log.debug('Failed to link journal row (non-critical)', { eventId: event.id, error: String(err) });
+            });
+          }
           // Sentry metric: message received count by channel
           if (sentryEnabled()) {
             Sentry.metrics.count('messages.received', 1, {

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -192,6 +192,9 @@ describe('db-access guard', () => {
       // any DB work. Its only callers are those consumers, so every caller is
       // now scoped.
       'packages/api/src/plugins/event-persistence.ts',
+      // #1035: the message-persistence consumer back-links the journal row
+      // inside `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers.
+      'packages/api/src/plugins/message-persistence.ts',
       // G5 leg B: the media-processor consumer threads its versioned envelope
       // into `processMessageMedia`, whose DB blocks run through
       // `runConsumerInTenantContext` + `scopedHandle`. Consumer-only callers.

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -1000,6 +1000,15 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     class: 'tenant-boundary',
   },
   {
+    // #1035: the message.received consumer back-links the journal row's
+    // chatUuid/personId after chat resolution. The update runs inside
+    // `runConsumerInTenantContext` through `scopedHandle(db)` — the same
+    // ADR-0008 worker-scope seam as the event-persistence.ts siblings above.
+    file: 'packages/api/src/plugins/message-persistence.ts',
+    table: 'omni_events',
+    class: 'tenant-boundary',
+  },
+  {
     file: 'packages/api/src/plugins/instance-monitor.ts',
     table: 'instances',
     class: 'tenant-boundary',

--- a/packages/db/src/tenancy-writer-coverage.ts
+++ b/packages/db/src/tenancy-writer-coverage.ts
@@ -163,6 +163,8 @@ export const REGISTERED_WRITERS: readonly RegisteredWriter[] = [
   { file: 'packages/api/src/plugins/event-listeners.ts', table: 'chats', coverage: 'db-derived' },
   { file: 'packages/api/src/plugins/event-listeners.ts', table: 'instances', coverage: 'trusted-root' },
   { file: 'packages/api/src/plugins/event-persistence.ts', table: 'omni_events', coverage: 'db-derived' },
+  // #1035: message.received consumer back-links the journal row (chatUuid/personId) once the chat is resolved.
+  { file: 'packages/api/src/plugins/message-persistence.ts', table: 'omni_events', coverage: 'db-derived' },
   { file: 'packages/api/src/plugins/instance-monitor.ts', table: 'instances', coverage: 'trusted-root' },
   { file: 'packages/api/src/plugins/media-processor.ts', table: 'media_content', coverage: 'db-derived' },
   { file: 'packages/api/src/plugins/media-processor.ts', table: 'messages', coverage: 'db-derived' },


### PR DESCRIPTION
Closes #1035

## Root cause
`event-persistence` resolved `chatUuid` by exact `chats.externalId` match on the platform chat id. For a WhatsApp LID DM the message pipeline routes to the phone-form chat (via `canonicalId` or `chat_id_mappings`), so the exact match missed and the event journaled with `chatUuid`, `canonicalChatId` and `personId` null. Independently, the event-persistence and message-persistence consumers race on the same event, so the journal row is often inserted before the chat row or the sender person exists. `canonicalChatId` was never written anywhere.

## Fix
- `event-persistence`: resolve the chat through the existing `ChatService.findByExternalIdSmart` (externalId, canonicalId, LID<->phone mapping) and populate `canonicalChatId`.
- `message-persistence`: after the inbound handler's transaction commits, backfill `chatUuid` / `canonicalChatId` / `personId` onto the `omni_events` row for that event id. This is the async backfill the issue asked for and covers the race for every channel, not only LID.

## Verification
- New test: phone-form chat + `chat_id_mappings` LID row, `message.received` with an `@lid` chat id journals with the chat's UUID and canonical id. Ran green on a disposable migrated Postgres cluster.
- `make typecheck`, `make lint`, `make dead-code`, `make verify-migrations`: green. `bun run test` (the `make test` body): 26/26 tasks green. `make test` itself needs a `.env` this worktree lacks, so its schema-sync step was not run.

## Not addressed
The `custom.*` vs `system.*` namespace note in the issue comment is a docs/design question, out of scope here.