### PR TITLE
fix(cli): keep eventType in JSON output of events list/search/timeline

### DIFF
--- a/packages/cli/src/__tests__/events-stream.test.ts
+++ b/packages/cli/src/__tests__/events-stream.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { Event } from '@omni/sdk';
 import {
+  eventListRow,
   formatEventLine,
   isErrorEvent,
   isNoisyEvent,
@@ -152,5 +153,14 @@ describe('events stream formatter', () => {
     expect(image).toContain('a cat photo');
     const blank = formatEventLine(makeEvent({ textContent: null, transcription: null, imageDescription: null }));
     expect(blank).toContain('message.received');
+  });
+});
+
+describe('eventListRow (#1028)', () => {
+  test('table projection keeps the type column; raw rows keep eventType for JSON', () => {
+    const ev = makeEvent({ eventType: 'custom.repro.x' });
+    expect(eventListRow(ev).type).toBe('custom.repro.x');
+    // JSON mode must emit the raw row (via rawData), which carries eventType.
+    expect(ev.eventType).toBe('custom.repro.x');
   });
 });

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -426,6 +426,21 @@ function createSchemaCommand(): Command {
 
 export const __testables = { schemaApiRequest, loadSchemaArtifact, summarizeSchemaRow };
 
+/**
+ * Table projection for list-shaped event commands. Human-readable output only:
+ * JSON mode emits the raw API rows via `rawData` so `eventType` (and every
+ * other field) survives intact (#1028).
+ */
+export function eventListRow(e: Event): {
+  id: string;
+  type: string;
+  instanceId: string;
+  direction: string;
+  receivedAt: string;
+} {
+  return { id: e.id, type: e.eventType, instanceId: e.instanceId, direction: e.direction, receivedAt: e.receivedAt };
+}
+
 // ============================================================================
 // STREAM
 // ============================================================================
@@ -992,15 +1007,7 @@ export function createEventsCommand(): Command {
             limit: options.limit,
           });
 
-          const items = result.items.map((e) => ({
-            id: e.id,
-            type: e.eventType,
-            instanceId: e.instanceId,
-            direction: e.direction,
-            receivedAt: e.receivedAt,
-          }));
-
-          output.list(items, { emptyMessage: 'No events found.' });
+          output.list(result.items.map(eventListRow), { emptyMessage: 'No events found.', rawData: result.items });
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error';
           output.error(`Failed to list events: ${message}`);
@@ -1208,15 +1215,10 @@ export function createEventsCommand(): Command {
           limit: options.limit,
         });
 
-        const items = result.items.map((e) => ({
-          id: e.id,
-          type: e.eventType,
-          instanceId: e.instanceId,
-          direction: e.direction,
-          receivedAt: e.receivedAt,
-        }));
-
-        output.list(items, { emptyMessage: 'No matching events found.' });
+        output.list(result.items.map(eventListRow), {
+          emptyMessage: 'No matching events found.',
+          rawData: result.items,
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to search events: ${message}`);
@@ -1240,15 +1242,10 @@ export function createEventsCommand(): Command {
           limit: options.limit,
         });
 
-        const items = result.items.map((e) => ({
-          id: e.id,
-          type: e.eventType,
-          instanceId: e.instanceId,
-          direction: e.direction,
-          receivedAt: e.receivedAt,
-        }));
-
-        output.list(items, { emptyMessage: `No events found for person: ${personId}` });
+        output.list(result.items.map(eventListRow), {
+          emptyMessage: `No events found for person: ${personId}`,
+          rawData: result.items,
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to get timeline: ${message}`);


### PR DESCRIPTION
Closes #1028

## Root cause
`omni events list`, `search`, and `timeline` mapped API rows into a table projection that renamed `eventType` to `type`, and `output.list` serialized that projection in `--json` mode. So JSON consumers saw no `eventType` key at all (for every row, not only `custom.*`), while `events get` returned the raw event. The API and service were never dropping the field.

## Fix
- Pass the raw API rows as `rawData` to `output.list` (the existing pattern in chats/messages/history), so JSON mode emits full events.
- One shared `eventListRow` projection for the human-readable table; the TYPE column is unchanged.
- Regression test in `events-stream.test.ts`.

## Verification
`make check` green (typecheck, lint, knip, migration gate, tests).