### PR TITLE
fix(events): reconnect follow on dropped long-poll and exit non-zero on failure

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -280,6 +280,10 @@ function startBunServer(app: App) {
   return Bun.serve<{ params: ReturnType<typeof parseVoiceStreamParams> }>({
     port: PORT,
     hostname: HOST,
+    // Bun's default idleTimeout is 10s, which cut the socket under an idle
+    // `POST /events/consumers/:name/pull?waitMs=10000` long-poll (issue #1029).
+    // Must exceed PULL_MAX_WAIT_MS (30s) in services/event-consumers.ts.
+    idleTimeout: 60,
     fetch(req, server) {
       const url = new URL(req.url);
 

--- a/packages/cli/src/commands/__tests__/events-consumers.test.ts
+++ b/packages/cli/src/commands/__tests__/events-consumers.test.ts
@@ -270,6 +270,59 @@ describe('omni events consumers + follow', () => {
     expect(consumers.get('drainer')?.cursor).toBe(before as number);
   });
 
+  test('a dropped long-poll socket reconnects and resumes from the cursor (issue #1029)', async () => {
+    printed.length = 0;
+    const f = append('custom.drain.six');
+    const realFetch = globalThis.fetch;
+    let drops = 2;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      if (drops > 0 && String(input).includes('/pull?')) {
+        drops--;
+        return Promise.reject(new Error('The socket connection was closed unexpectedly.'));
+      }
+      return realFetch(input, init);
+    }) as typeof globalThis.fetch;
+    try {
+      await followConsumer({
+        consumer: 'drainer',
+        limit: 10,
+        waitMs: 0,
+        ack: true,
+        untilIdle: true,
+        retryBaseMs: 1,
+        emit: (line) => printed.push(line),
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(drops).toBe(0);
+    // Resumes from the stored cursor: the un-acked peek row (five) plus the new one, nothing re-delivered.
+    const ids = printed.map((line) => (JSON.parse(line) as { id: string }).id);
+    expect(ids[ids.length - 1]).toBe(f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(consumers.get('drainer')?.cursor).toBe(f.seq);
+  });
+
+  test('exhausted reconnects rethrow the transport error', async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() => Promise.reject(new Error('socket closed'))) as typeof globalThis.fetch;
+    try {
+      await expect(
+        followConsumer({
+          consumer: 'drainer',
+          limit: 10,
+          waitMs: 0,
+          ack: true,
+          untilIdle: true,
+          maxRetries: 2,
+          retryBaseMs: 1,
+        }),
+      ).rejects.toThrow(/socket closed/);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   test('an unknown consumer surfaces the API 404', async () => {
     await expect(
       followConsumer({ consumer: 'ghost', limit: 10, waitMs: 0, ack: true, untilIdle: true }),

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -799,6 +799,38 @@ export interface FollowParams {
   isStopped?: () => boolean;
   /** Line sink — defaults to output.raw (stdout). Injected by tests. */
   emit?: (line: string) => void;
+  /** Consecutive transport failures tolerated before giving up (default 5). */
+  maxRetries?: number;
+  /** First backoff delay; doubles per retry up to 30s (default 1000). */
+  retryBaseMs?: number;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** HTTP-level failures (4xx/5xx) are surfaced by consumersApiRequest as "API returned N"; everything else is transport. */
+const isTransportError = (err: unknown): boolean => !(err instanceof Error && err.message.startsWith('API returned '));
+
+/**
+ * Pull one page, reconnecting with exponential backoff when the long-poll
+ * socket drops (issue #1029). Safe to retry: the stored cursor only moves on
+ * ack, so a re-pull replays the same page at worst.
+ */
+async function pullWithRetry(params: FollowParams): Promise<ConsumerPullPage> {
+  const maxRetries = params.maxRetries ?? 5;
+  const baseMs = params.retryBaseMs ?? 1000;
+  const path = `/${encodeURIComponent(params.consumer)}/pull?limit=${params.limit}&waitMs=${params.waitMs}`;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await consumersApiRequest<ConsumerPullPage>(path, { method: 'POST' });
+    } catch (err) {
+      if (!isTransportError(err) || attempt >= maxRetries || params.isStopped?.()) throw err;
+      const delay = Math.min(baseMs * 2 ** attempt, 30000);
+      process.stderr.write(
+        `⚠ Pull failed (${errorMessage(err)}); reconnecting in ${delay}ms (${attempt + 1}/${maxRetries})\n`,
+      );
+      await sleep(delay);
+    }
+  }
 }
 
 /**
@@ -817,10 +849,7 @@ export async function followConsumer(params: FollowParams): Promise<void> {
   for (;;) {
     if (params.isStopped?.()) return;
 
-    const page = await consumersApiRequest<ConsumerPullPage>(
-      `/${encodeURIComponent(params.consumer)}/pull?limit=${params.limit}&waitMs=${params.waitMs}`,
-      { method: 'POST' },
-    );
+    const page = await pullWithRetry(params);
 
     for (const item of page.items) {
       emit(JSON.stringify(item));
@@ -854,7 +883,7 @@ export async function followConsumer(params: FollowParams): Promise<void> {
     // Idle pacing floor: the server long-poll (waitMs) is the primary pause,
     // but a short window must not turn an idle tail into a tight loop.
     if (!progressed && params.waitMs < 1000) {
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      await sleep(1000);
     }
   }
 }
@@ -1136,6 +1165,7 @@ export function createEventsCommand(): Command {
     )
     .option('--no-ack', 'Peek: print one page without advancing the cursor, then exit')
     .option('--until-idle', 'Exit 0 once caught up with the journal instead of tailing forever')
+    .option('--ndjson', 'Accepted for symmetry with `events stream` (follow is always JSON Lines)')
     .action(async (options: { consumer: string; limit: number; waitMs: number; ack: boolean; untilIdle?: boolean }) => {
       let stopped = false;
       const shutdown = (): void => {
@@ -1155,6 +1185,7 @@ export function createEventsCommand(): Command {
         });
       } catch (err) {
         output.error(`Failed to follow consumer: ${errorMessage(err)}`);
+        process.exitCode = 1;
       } finally {
         processEvents.off('SIGINT', shutdown);
         processEvents.off('SIGTERM', shutdown);


### PR DESCRIPTION
Closes #1029

## Root cause
`Bun.serve` defaults `idleTimeout` to 10s. `omni events follow` defaults `--wait-ms 10000`, so an idle long-poll sat on the socket for exactly the idle limit and the server closed it. The CLI caught the fetch error, printed it, and exited 0. `--wait-ms 5000` masked the collision, which matches the report.

## Changes
- **api**: `idleTimeout: 60` on `Bun.serve`, above `PULL_MAX_WAIT_MS` (30s).
- **cli**: `followConsumer` retries transport failures with exponential backoff (5 attempts, 1s doubling to a 30s cap), resuming from the durable cursor. HTTP errors (`API returned N`) still fail fast. Retry notices go to stderr so NDJSON stdout stays clean.
- **cli**: `process.exitCode = 1` when follow gives up.
- **cli**: `follow --ndjson` accepted as a no-op for symmetry with `events stream` (the nit from the issue).

## Tests
- New: a dropped socket on pull reconnects and resumes without re-delivery; exhausted retries rethrow.
- `make check` green (typecheck, lint, knip, migration gate, full suite via the pre-push hook).
- Note: `install.test.ts` (`detectReinstall`) flakes intermittently on the untouched base too; unrelated.