### PR TITLE
fix(channels): claim an ingress idempotency key before publishing message.received

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -199,6 +199,43 @@ describeWithDb('Event Persistence Handler', () => {
       expect(persisted[0]?.externalId).toBe('ext-recv-redelivery');
     });
 
+    test('fills in the ingress idempotency claim row instead of leaving a skeleton (#1032)', async () => {
+      await setupEventPersistence(mockEventBus, db);
+
+      const eventId = randomUUID();
+      // The claim row `createIngressClaim` inserts before the plugin publishes.
+      await db.insert(omniEvents).values({
+        id: eventId,
+        externalId: 'ext-recv-claim',
+        channel: 'whatsapp-baileys',
+        eventType: 'message.received',
+        direction: 'inbound',
+        status: 'received',
+        idempotencyKey: `whatsapp-baileys:test:ext-recv-claim:text:${eventId}`,
+        receivedAt: new Date(),
+      });
+
+      await emitEvent('message.received', {
+        id: eventId,
+        type: 'message.received',
+        timestamp: Date.now(),
+        payload: {
+          externalId: 'ext-recv-claim',
+          chatId: 'chat-123',
+          from: 'user-456',
+          content: { type: 'text', text: 'claimed then journaled' },
+        },
+        metadata: { correlationId: eventId, instanceId: null, channelType: 'whatsapp-baileys' },
+      });
+
+      const rows = await db.select().from(omniEvents).where(eq(omniEvents.externalId, 'ext-recv-claim'));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe(eventId);
+      expect(rows[0]?.textContent).toBe('claimed then journaled');
+      expect(rows[0]?.contentType).toBe('text');
+      expect(rows[0]?.idempotencyKey).toBe(`whatsapp-baileys:test:ext-recv-claim:text:${eventId}`);
+    });
+
     test('handles image content type', async () => {
       await setupEventPersistence(mockEventBus, db);
 

--- a/packages/api/src/plugins/context.ts
+++ b/packages/api/src/plugins/context.ts
@@ -4,9 +4,12 @@
  * Creates the PluginContext required by channel plugins during initialization.
  */
 
-import type { PluginContext, PluginDatabase } from '@omni/channel-sdk';
-import { type EventBus, createLogger } from '@omni/core';
+import { randomUUID } from 'node:crypto';
+import type { IngressClaim, PluginContext, PluginDatabase } from '@omni/channel-sdk';
+import { type EventBus, createLogger, resolvePublishTenantId } from '@omni/core';
 import type { Database } from '@omni/db';
+import { type ChannelType, channelTypes, omniEvents } from '@omni/db';
+import { eq } from 'drizzle-orm';
 
 import { createPluginLogger } from './logger';
 import { getPluginStorage } from './storage';
@@ -27,6 +30,54 @@ function createPluginDatabase(db: Database): PluginDatabase {
     },
     getDrizzle(): unknown {
       return db;
+    },
+  };
+}
+
+/**
+ * Inbound-message idempotency claim (#1032, parity with `WebhookService.
+ * receive` from #958). The claim IS the journal row: inserting it makes the
+ * `omni_events.idempotency_key` unique index the dedup authority. The plugin
+ * then publishes UNDER this row's id, and the `message.received` persistence
+ * consumer fills the row in (upsert on id). Fail-open: a claim that errors
+ * (e.g. the instance row is missing) mints an id and lets the publish proceed
+ * undeduped rather than dropping a real message.
+ */
+function createIngressClaim(db: Database): IngressClaim {
+  return {
+    async claim({ idempotencyKey, instanceId, channelType, externalId }) {
+      const id = randomUUID();
+      try {
+        const claimed = await db
+          .insert(omniEvents)
+          .values({
+            id,
+            externalId,
+            channel: (channelTypes as readonly string[]).includes(channelType)
+              ? (channelType as ChannelType)
+              : 'discord',
+            instanceId,
+            eventType: 'message.received',
+            direction: 'inbound',
+            status: 'received',
+            idempotencyKey,
+            receivedAt: new Date(),
+            metadata: { correlationId: id, source: `channel:${channelType}`, idempotencyKey },
+            tenantId: resolvePublishTenantId(undefined, instanceId),
+          })
+          .onConflictDoNothing({ target: omniEvents.idempotencyKey })
+          .returning({ id: omniEvents.id });
+        return claimed.length > 0 ? id : null;
+      } catch (error) {
+        log.warn('Ingress idempotency claim failed; publishing without dedup', {
+          idempotencyKey,
+          error: String(error),
+        });
+        return id;
+      }
+    },
+    async release(eventId) {
+      await db.delete(omniEvents).where(eq(omniEvents.id, eventId));
     },
   };
 }
@@ -64,5 +115,6 @@ export function createPluginContext(options: CreatePluginContextOptions): Plugin
       },
     },
     db: createPluginDatabase(db),
+    ingressClaim: createIngressClaim(db),
   };
 }

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -140,8 +140,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
             const sdb = scopedHandle(db);
             const chatUuid = await resolveChatUuid(sdb, metadata.instanceId, payload.chatId);
 
-            const newEvent: NewOmniEvent = {
-              ...eventIdInsert(event.id),
+            const columns: Omit<NewOmniEvent, 'id'> = {
               externalId: payload.externalId,
               channel: mapChannelType(metadata.channelType),
               instanceId: metadata.instanceId,
@@ -168,7 +167,13 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               chatUuid,
             };
 
-            await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            // Upsert on id (#1032): the channel ingress claim (`createIngressClaim`)
+            // inserted a skeletal row under this id before the publish; fill it
+            // in here. A NATS redelivery rewrites identical values — still one row.
+            await sdb
+              .insert(omniEvents)
+              .values({ ...eventIdInsert(event.id), ...columns })
+              .onConflictDoUpdate({ target: omniEvents.id, set: columns });
           });
 
           // T4: Message stored in database — record journey checkpoint

--- a/packages/channel-sdk/src/base/BaseChannelPlugin.ts
+++ b/packages/channel-sdk/src/base/BaseChannelPlugin.ts
@@ -29,7 +29,14 @@ import type {
   InstanceConnectedMetadata,
 } from '../helpers/events';
 import type { ChannelCapabilities } from '../types/capabilities';
-import type { GlobalConfig, Logger, PluginContext, PluginDatabase, PluginStorage } from '../types/context';
+import type {
+  GlobalConfig,
+  IngressClaim,
+  Logger,
+  PluginContext,
+  PluginDatabase,
+  PluginStorage,
+} from '../types/context';
 import type { ConnectionStatus, InstanceConfig } from '../types/instance';
 import type { OutgoingMessage, SendResult } from '../types/messaging';
 import type { ChannelPlugin, HealthCheck, HealthStatus } from '../types/plugin';
@@ -48,6 +55,7 @@ const NO_ACTIVITY_EVENTS = new Set<string>([
 interface PublishEventInternalOptions {
   timings?: Record<string, number>;
   ingestMode?: 'realtime' | 'history-sync';
+  publishEventId?: string;
 }
 
 /**
@@ -95,6 +103,7 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
   // ─────────────────────────────────────────────────────────────
 
   protected eventBus!: EventBus;
+  protected ingressClaim?: IngressClaim;
   protected logger!: Logger;
   protected storage!: PluginStorage;
   protected config!: GlobalConfig;
@@ -120,6 +129,7 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
     this.storage = context.storage;
     this.config = context.config;
     this.db = context.db;
+    this.ingressClaim = context.ingressClaim;
 
     await this.onInitialize(context);
   }
@@ -375,10 +385,40 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    */
   protected async emitMessageReceived(params: EmitMessageReceivedParams): Promise<string> {
     const { instanceId, timings, isHistorySync, ...payload } = params;
-    return this.publishEventInternal('message.received', payload, instanceId, {
+    const options: PublishEventInternalOptions = {
       timings,
       ingestMode: isHistorySync ? 'history-sync' : 'realtime',
-    });
+    };
+
+    // Ingress idempotency (#1032): claim `{channel}:{instance}:{externalId}:{kind}`
+    // before publishing. The kind is part of the key because a platform can
+    // reuse a message id for a different fact (a WhatsApp deletion carries
+    // the deleted message's id). A duplicate claim skips the publish.
+    if (this.ingressClaim) {
+      const idempotencyKey = `${this.id}:${instanceId}:${payload.externalId}:${payload.content.type}`;
+      const eventId = await this.ingressClaim.claim({
+        idempotencyKey,
+        instanceId,
+        channelType: this.id,
+        externalId: payload.externalId,
+      });
+      if (eventId === null) {
+        this.logger.info('Skipping duplicate inbound message (idempotency key already journaled)', {
+          instanceId,
+          idempotencyKey,
+        });
+        return generateCorrelationId('evt');
+      }
+      options.publishEventId = eventId;
+      try {
+        return await this.publishEventInternal('message.received', payload, instanceId, options);
+      } catch (error) {
+        await this.ingressClaim.release(eventId).catch(() => {});
+        throw error;
+      }
+    }
+
+    return this.publishEventInternal('message.received', payload, instanceId, options);
   }
 
   /**

--- a/packages/channel-sdk/src/types/context.ts
+++ b/packages/channel-sdk/src/types/context.ts
@@ -85,6 +85,26 @@ export interface PluginDatabase {
 }
 
 /**
+ * Ingress idempotency claim for inbound messages (#1032, parity with the
+ * webhook path from #958). The host claims the key by inserting the journal
+ * row BEFORE the plugin publishes; the `omni_events.idempotency_key` unique
+ * index is the dedup authority. A duplicate claim returns null and the
+ * publish is skipped, so a double-fired channel handler or a platform
+ * redelivery cannot fan the same message out twice.
+ */
+export interface IngressClaim {
+  /** Returns the claimed event id, or null when the key is already journaled. */
+  claim(params: {
+    idempotencyKey: string;
+    instanceId: string;
+    channelType: string;
+    externalId: string;
+  }): Promise<string | null>;
+  /** Release a claim whose publish failed, so the retry is not a "duplicate". */
+  release(eventId: string): Promise<void>;
+}
+
+/**
  * Context provided to channel plugins during initialization
  */
 export interface PluginContext {
@@ -102,4 +122,7 @@ export interface PluginContext {
 
   /** Database access (use sparingly - prefer storage) */
   db: PluginDatabase;
+
+  /** Optional inbound-message idempotency claim (#1032); absent = no dedup. */
+  ingressClaim?: IngressClaim;
 }

--- a/packages/channel-sdk/test/base.test.ts
+++ b/packages/channel-sdk/test/base.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src';
 import type {
   ChannelCapabilities,
+  EmitMessageReceivedParams,
   HealthCheck,
   InstanceConfig,
   Logger,
@@ -121,6 +122,10 @@ class TestChannelPlugin extends BaseChannelPlugin {
   connectCalled = false;
   disconnectCalled = false;
 
+  receive(params: EmitMessageReceivedParams) {
+    return this.emitMessageReceived(params);
+  }
+
   async connect(instanceId: string, config: InstanceConfig): Promise<void> {
     this.connectCalled = true;
     await this.updateInstanceStatus(instanceId, config, {
@@ -174,6 +179,44 @@ describe('BaseChannelPlugin', () => {
       },
       db: { execute: async () => [], getDrizzle: () => null },
     };
+  });
+
+  it('should skip the publish when the ingress claim reports a duplicate (#1032)', async () => {
+    const keys: string[] = [];
+    let claims = 0;
+    context.ingressClaim = {
+      claim: async ({ idempotencyKey }) => {
+        keys.push(idempotencyKey);
+        claims += 1;
+        return claims === 1 ? 'a2b9c1d0-1111-4222-8333-444455556666' : null;
+      },
+      release: async () => {},
+    };
+    await plugin.initialize(context);
+
+    const message = {
+      instanceId: 'wa-001',
+      externalId: 'MSG-1',
+      chatId: 'chat-1',
+      from: 'user-1',
+      content: { type: 'text' as const, text: 'hi' },
+    };
+    await plugin.receive(message);
+    await plugin.receive(message);
+    // Same platform id, different semantic kind (a WhatsApp deletion reuses
+    // the deleted message's id) — must NOT collide.
+    await plugin.receive({ ...message, content: { type: 'delete' as const } });
+
+    expect(keys).toEqual([
+      'whatsapp-baileys:wa-001:MSG-1:text',
+      'whatsapp-baileys:wa-001:MSG-1:text',
+      'whatsapp-baileys:wa-001:MSG-1:delete',
+    ]);
+    const received = eventBus.published.filter((e) => e.type === 'message.received');
+    expect(received.length).toBe(1);
+    expect((received[0]?.metadata as { publishEventId?: string }).publishEventId).toBe(
+      'a2b9c1d0-1111-4222-8333-444455556666',
+    );
   });
 
   it('should initialize with context', async () => {

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -580,7 +580,10 @@ export const PENDING_G4_CEILING = 7;
 // claim is a genuinely new `processed_events` write in
 // `automation-actions.ts` — the same G6 gate as `idempotency.ts`, not a
 // relabelling.
-export const PENDING_G5_CEILING = 13;
+// 14 after #1032: the channel ingress idempotency claim in `plugins/context.ts`
+// is a genuinely new `omni_events` write reached from a channel socket
+// callback on the ambient pool — the same G6 gate as `idempotency.ts`.
+export const PENDING_G5_CEILING = 14;
 
 /**
  * Ceiling on `pending-G4-conversion` + `pending-G5-conversion` combined.
@@ -651,7 +654,9 @@ export const PENDING_G5_CEILING = 13;
 // a new package, not movement between pending classes.
 // 20 after #1031 (6 + 13): ONE new G6-gated `processed_events` claim site in
 // `automation-actions.ts` (see PENDING_G5_CEILING). Nothing was reclassified.
-export const TOTAL_PENDING_CEILING = 20;
+// 21 after #1032 (6 + 14): ONE new G6-gated `omni_events` claim site in
+// `plugins/context.ts` (see PENDING_G5_CEILING). Nothing was reclassified.
+export const TOTAL_PENDING_CEILING = 21;
 
 /**
  * Committed inventory of every database access site in the repository.
@@ -894,6 +899,21 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     file: 'packages/api/src/plugins/automation-actions.ts',
     table: 'omni_events',
     class: 'tenant-boundary',
+  },
+  {
+    // #1032: channel ingress idempotency claim (`ingressClaim.claim` /
+    // `release`): the `omni_events` insert IS the dedup claim, reached from a
+    // channel plugin's socket callback which has no HTTP request and therefore
+    // no credential to open a tenant scope. Runs on the ambient pool; row
+    // ownership is the 0041 derivation trigger's job (db-derived). Flips to
+    // tenant-boundary when G6 lands, same gate as `idempotency.ts`.
+    file: 'packages/api/src/plugins/context.ts',
+    table: 'omni_events',
+    class: 'pending-G5-conversion',
+    justification:
+      'Reached only from a channel plugin socket consumer callback (the Baileys/Discord/Telegram inbound listener), ' +
+      'which has no HTTP request and therefore no credential to open an ADR-0008 tenant scope; the journal row is ' +
+      'the idempotency claim itself and its ownership is db-derived.',
   },
   {
     // #1031: execution claim against the same `processed_events` PK that

--- a/packages/db/src/tenancy-writer-coverage.ts
+++ b/packages/db/src/tenancy-writer-coverage.ts
@@ -158,6 +158,8 @@ export const REGISTERED_WRITERS: readonly RegisteredWriter[] = [
   { file: 'packages/api/src/plugins/agent-dispatcher.ts', table: 'agent_sessions', coverage: 'db-derived' },
   // #958: emit_event idempotency claim — the journal row IS the claim.
   { file: 'packages/api/src/plugins/automation-actions.ts', table: 'omni_events', coverage: 'db-derived' },
+  // #1032: channel ingress idempotency claim — the journal row IS the claim (parity with #958).
+  { file: 'packages/api/src/plugins/context.ts', table: 'omni_events', coverage: 'db-derived' },
   { file: 'packages/api/src/plugins/agent-dispatcher.ts', table: 'handoff_logs', coverage: 'db-derived' },
   { file: 'packages/api/src/plugins/event-listeners.ts', table: 'chat_id_mappings', coverage: 'db-derived' },
   { file: 'packages/api/src/plugins/event-listeners.ts', table: 'chats', coverage: 'db-derived' },


### PR DESCRIPTION
## Summary

Closes #1032. Channel ingest stamped no idempotency key, so a double-fired channel handler or a platform redelivery journaled the same inbound message twice and fanned it out twice. This gives channel ingress the same claim-before-publish discipline the webhook path got in #958.

- **channel-sdk**: `PluginContext` gains an optional `ingressClaim` hook. `emitMessageReceived` claims `{channel}:{instanceId}:{externalId}:{kind}` before publishing and skips the publish when the key is already journaled. The content kind is part of the key because a WhatsApp deletion reuses the deleted message's `externalId` (see the issue's design caveat).
- **api**: `createPluginContext` implements the claim by inserting the journal row (`omni_events.idempotency_key` unique index is the dedup authority), the plugin publishes under that row's id (`publishEventId`), and the claim is released when the publish fails. The claim fails open (mints an id, no dedup) if the insert itself errors, so a real message is never dropped by a DB hiccup.
- **api**: the `message.received` persistence consumer now upserts on id so it fills in the skeletal claim row instead of leaving it.

No schema change: the `idempotency_key` column and unique index already exist from #958.

## Tests

- `channel-sdk/test/base.test.ts`: duplicate claim skips the publish; same `externalId` with a different kind (`text` vs `delete`) yields distinct keys; the published event carries the claimed id.
- `api/src/__tests__/event-persistence.test.ts`: a pre-inserted claim row is filled in by the consumer (one row, key preserved). Verified on a disposable migrated PostgreSQL cluster.

## Validation

`make check`: typecheck, lint, dead-code, and migration gate green. Test run: 25 of 26 packages green; the CLI package failed only on its pre-suite PM2 leak guard (stale daemons from other test sessions on the host), unrelated to this change.