### PR TITLE
fix(channels): stop journaling placeholder text for delete/unknown payloads

### DIFF
--- a/packages/api/src/plugins/__tests__/agent-dispatcher-reaction-dual-emit.test.ts
+++ b/packages/api/src/plugins/__tests__/agent-dispatcher-reaction-dual-emit.test.ts
@@ -121,6 +121,26 @@ describe('shouldProcessMessage vs reaction dual-emits', () => {
     expect(instance).toBeNull();
   });
 
+  for (const type of ['delete', 'unknown'] as const) {
+    test(`content.type='${type}' never dispatches (journal-only signal, #1041)`, async () => {
+      const h = harness({ triggerEvents: ['message.received'] });
+
+      const instance = await __test__.shouldProcessMessage(
+        h.agentRunner,
+        h.accessService,
+        h.chatsService,
+        h.messagesService,
+        h.routeResolver,
+        fakeDb(),
+        payloadOf({ type }),
+        METADATA,
+        undefined,
+      );
+
+      expect(instance).toBeNull();
+    });
+  }
+
   test('a plain text message still dispatches (guard is reaction-specific)', async () => {
     const h = harness({ triggerEvents: ['message.received'] });
 

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -1169,6 +1169,9 @@ async function extractMediaFiles(
 // Media Preprocessing for Agents
 // ============================================================================
 
+/** message.received content types that never dispatch an agent (#336, #1041) */
+const NON_DISPATCHABLE_CONTENT_TYPES = new Set(['reaction', 'delete', 'unknown']);
+
 /** Emoji icons for each media content type */
 const MEDIA_ICONS: Record<string, string> = {
   audio: '\u{1F3B5}',
@@ -5653,10 +5656,14 @@ async function shouldProcessMessage(
   // triggerReactions config. Without this skip, a reaction dispatches the
   // agent as if it were a text message regardless of that config (and
   // double-dispatches when reaction.received IS configured).
-  if (payload.content?.type === 'reaction') {
-    log.debug('Skipping reaction dual-emit on message path (reaction.received owns dispatch)', {
+  //
+  // 'delete' and 'unknown' are likewise journal-only signals, not user speech
+  // (#1041): dispatching them hands the agent a placeholder to answer.
+  if (payload.content?.type && NON_DISPATCHABLE_CONTENT_TYPES.has(payload.content.type)) {
+    log.debug('Skipping non-conversational content type on message path', {
       instanceId: metadata.instanceId,
       chatId: payload.chatId,
+      contentType: payload.content.type,
     });
     return null;
   }

--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -1652,10 +1652,8 @@ export class DiscordPlugin extends BaseChannelPlugin {
       externalId: `${messageId}-delete-${Date.now()}`,
       chatId,
       from: chatId,
-      content: {
-        type: 'delete',
-        text: fromMe ? 'Message deleted by bot' : 'Message deleted',
-      },
+      // No placeholder text: it is not user speech (#1041). Semantics live in rawPayload.
+      content: { type: 'delete' },
       rawPayload: {
         deletedMessageId: messageId,
         deletedAt: Date.now(),

--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -301,4 +301,10 @@ describe('extractContent — bot-interactive messages (omni#902)', () => {
     expect(content?.mediaUrl).toBeUndefined();
     expect(content?.text).toBe('Sem mídia\n[Ok]');
   });
+
+  it('unknown payloads carry no placeholder text (#1041)', () => {
+    const content = extractContent(wrap({ secretEncryptedMessage: { encIv: 'x' } }));
+    expect(content?.type).toBe('unknown');
+    expect(content?.text).toBeUndefined();
+  });
 });

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -567,13 +567,12 @@ function extractUnknownContent(message: MessageContent): ExtractedContent | null
     return null;
   }
 
-  // Log unknown types at debug level for future investigation
+  // Log unknown types at debug level for future investigation. The keys stay in
+  // the log + rawPayload only — never in `text`, which downstream consumers
+  // (agents, FTS) treat as user speech (#1041).
   log.debug('Unknown message type', { keys: messageKeys });
 
-  return {
-    type: 'unknown' as ContentType,
-    text: `Unknown message type: ${messageKeys.join(', ')}`,
-  };
+  return { type: 'unknown' as ContentType };
 }
 
 /**

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3304,10 +3304,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       externalId: `${externalId}-delete-${Date.now()}`,
       chatId,
       from: chatId,
-      content: {
-        type: 'delete',
-        text: fromMe ? 'Message deleted by sender' : 'Message deleted',
-      },
+      // No placeholder text: it is not user speech (#1041). Semantics live in rawPayload.
+      content: { type: 'delete' },
       rawPayload: {
         deletedMessageId: externalId,
         deletedAt: Date.now(),


### PR DESCRIPTION
Closes #1041

## Root cause
Channel plugins fabricated human-readable placeholder strings as `content.text` for non-message payload kinds. Everything downstream (persistence → `textContent`, agent dispatch, FTS) treats `text` as user speech, so agents replied to `Unknown message type: secretEncryptedMessage` and deletions journaled channel-specific wording.

## Fix
- `channel-whatsapp` `extractUnknownContent`: `{ type: 'unknown' }`, no text. Diagnostic keys remain in the debug log and `rawPayload`.
- `channel-whatsapp` / `channel-discord` `handleMessageDeleted`: `{ type: 'delete' }`, no text. `deletedMessageId` / `deletedByMe` remain in `rawPayload`, so every instance journals identical semantics.
- `agent-dispatcher` `shouldProcessMessage`: the #336 reaction guard becomes a `NON_DISPATCHABLE_CONTENT_TYPES` set (`reaction`, `delete`, `unknown`), so these never dispatch an agent regardless of `triggerEvents`.

Not changed: a dedicated `message.deleted` event type. Deletions already emit under a distinct externalId (`<id>-delete-<ts>`), so the #1032 idempotency-key collision does not apply to this path.

## Tests
- `extract-content.test.ts`: unknown payload has no `text`.
- `agent-dispatcher-reaction-dual-emit.test.ts`: `delete` / `unknown` return null from `shouldProcessMessage`.

## Verification
`make check` stages: typecheck, biome, knip, verify-migrations, and the full test suite green (pre-push hook ran the suite again on push).