### PR TITLE
fix(automations): surface unmatched trigger conditions in execution logs

### DIFF
--- a/packages/api/src/routes/v2/automations.ts
+++ b/packages/api/src/routes/v2/automations.ts
@@ -15,7 +15,10 @@ const automationsRoutes = new Hono<{ Variables: AppVariables }>();
 
 // Condition schema
 const conditionSchema = z.object({
-  field: z.string().min(1).describe('Dot notation field path (e.g., payload.content.type)'),
+  field: z
+    .string()
+    .min(1)
+    .describe('Dot notation path into the event payload (e.g., content.type, pull_request.merged)'),
   operator: z
     .enum(['eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'contains', 'not_contains', 'exists', 'not_exists', 'regex'])
     .describe('Comparison operator'),

--- a/packages/core/src/automations/__tests__/conditions.test.ts
+++ b/packages/core/src/automations/__tests__/conditions.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { evaluateCondition, evaluateConditions, getNestedValue } from '../conditions';
+import {
+  describeUnmatchedConditions,
+  evaluateCondition,
+  evaluateConditions,
+  evaluateConditionsWithDetails,
+  getNestedValue,
+} from '../conditions';
 import type { AutomationCondition } from '../types';
 
 describe('getNestedValue', () => {
@@ -347,5 +353,28 @@ describe('evaluateConditions', () => {
       // With OR, should pass since a matches
       expect(evaluateConditions(conditions, { a: 1, b: 3 }, 'or')).toBe(true);
     });
+  });
+});
+
+describe('describeUnmatchedConditions (#1030)', () => {
+  test('names the failing condition and tags an unresolved dot path', () => {
+    const conditions: AutomationCondition[] = [
+      { field: 'action', operator: 'eq', value: 'closed' },
+      { field: 'pull_request.merged', operator: 'eq', value: true },
+    ];
+    const result = evaluateConditionsWithDetails(conditions, { action: 'closed', pull_request: {} });
+    expect(result.matched).toBe(false);
+    expect(describeUnmatchedConditions(result)).toBe(
+      'conditions_not_matched: pull_request.merged eq true (condition_field_unresolved)',
+    );
+  });
+
+  test('reports the resolved value when the field exists but differs', () => {
+    const result = evaluateConditionsWithDetails([{ field: 'pull_request.merged', operator: 'eq', value: true }], {
+      pull_request: { merged: false },
+    });
+    expect(describeUnmatchedConditions(result)).toBe(
+      'conditions_not_matched: pull_request.merged eq true (actual: false)',
+    );
   });
 });

--- a/packages/core/src/automations/__tests__/engine-nested-conditions.test.ts
+++ b/packages/core/src/automations/__tests__/engine-nested-conditions.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression for #1030 — trigger conditions on NESTED payload paths
+ * (`pull_request.merged`) must resolve through the real engine path
+ * (bus → handleEvent → executeAutomation), and a non-match must record WHY
+ * in the execution log instead of a silent `conditionsMatched: false`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { InMemoryEventBus } from '../../events/__tests__/memory-bus';
+import type { EventType, GenericEventPayload } from '../../events/types';
+import { createAutomationEngine } from '../engine';
+import type { Automation, NewAutomationLog } from '../types';
+
+const TRIGGER = 'custom.repro.pr';
+
+function automation(): Automation {
+  return {
+    id: 'auto-1030',
+    name: 'announce merged PRs',
+    enabled: true,
+    priority: 0,
+    triggerEventType: TRIGGER,
+    triggerConditions: [
+      { field: 'action', operator: 'eq', value: 'closed' },
+      { field: 'pull_request.merged', operator: 'eq', value: true },
+    ],
+    conditionLogic: 'and',
+    actions: [{ type: 'log', config: { level: 'info', message: 'matched' } }],
+    debounce: { mode: 'none' },
+  } as unknown as Automation;
+}
+
+async function run(payload: Record<string, unknown>): Promise<NewAutomationLog[]> {
+  const bus = new InMemoryEventBus();
+  const engine = createAutomationEngine({ reconcileIntervalMs: 0 });
+  const logs: NewAutomationLog[] = [];
+  engine.setLogger(async (log) => {
+    logs.push(log);
+  });
+  await engine.start(bus, [automation()]);
+  await bus.publishGeneric(TRIGGER as EventType, payload as GenericEventPayload, { source: 'manual-trigger' });
+  await bus.idle();
+  await engine.stop();
+  return logs;
+}
+
+describe('nested payload paths in trigger conditions (#1030)', () => {
+  test('action == closed && pull_request.merged == true matches and executes', async () => {
+    const logs = await run({ type: TRIGGER, action: 'closed', pull_request: { merged: true, number: 1 } });
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.status).toBe('success');
+    expect(logs[0]?.conditionsMatched).toBe(true);
+  });
+
+  test('a non-match records which condition failed and that the field was unresolved', async () => {
+    const logs = await run({ type: TRIGGER, action: 'closed', pull_request: { number: 1 } });
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.status).toBe('skipped');
+    expect(logs[0]?.error).toBe('conditions_not_matched: pull_request.merged eq true (condition_field_unresolved)');
+  });
+});

--- a/packages/core/src/automations/conditions.ts
+++ b/packages/core/src/automations/conditions.ts
@@ -219,3 +219,23 @@ export function evaluateConditionsWithDetails(
     conditions: results,
   };
 }
+
+/**
+ * One-line, log-friendly explanation of why a condition set did not match
+ * (#1030). Names every failing condition with the value the payload actually
+ * resolved to; a field that resolved to nothing is tagged
+ * `condition_field_unresolved` so a typo'd or mis-rooted dot path is visible
+ * in the automation log instead of a silent `conditionsMatched: false`.
+ */
+export function describeUnmatchedConditions(result: ConditionEvaluationResult): string {
+  const failed = result.conditions
+    .filter((c) => !c.matched)
+    .map((c) => {
+      const expected =
+        c.operator === 'exists' || c.operator === 'not_exists' ? '' : ` ${JSON.stringify(c.expectedValue)}`;
+      const actual =
+        c.actualValue === undefined ? 'condition_field_unresolved' : `actual: ${JSON.stringify(c.actualValue)}`;
+      return `${c.field} ${c.operator}${expected} (${actual})`;
+    });
+  return `conditions_not_matched: ${failed.join('; ')}`;
+}

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -15,7 +15,7 @@ import type { EventType, GenericEventPayload, OmniEvent } from '../events/types'
 import { generateId } from '../ids';
 import { createLogger } from '../logger';
 import { type ActionDependencies, executeActions } from './actions';
-import { evaluateConditionsWithDetails } from './conditions';
+import { describeUnmatchedConditions, evaluateConditionsWithDetails } from './conditions';
 import {
   type ConversationKey,
   type DebounceEnvelopeStamp,
@@ -737,6 +737,8 @@ export class AutomationEngine {
       );
 
       if (!conditionResult.matched) {
+        // Surface WHY in the log row (#1030): which condition failed and what
+        // its field resolved to, so a mis-rooted dot path is not a silent skip.
         const result: ExecutionResult = {
           automationId: automation.id,
           automationName: automation.name,
@@ -744,6 +746,7 @@ export class AutomationEngine {
           status: 'skipped',
           conditionsMatched: false,
           actionsExecuted: [],
+          error: describeUnmatchedConditions(conditionResult),
           executionTimeMs: Date.now() - start,
         };
 


### PR DESCRIPTION
Closes #1030

## Summary
- Every layer of the reported repro was traced and verified: the CLI request body, the `POST /api/v2/automations` route, the DB insert values, the engine, NATS encode/decode, and the condition evaluator all preserve nested dot paths such as `pull_request.merged`. A new engine-level regression test (`engine-nested-conditions.test.ts`) locks that path in end to end through the in-memory bus.
- The real gap was the silence the issue calls out: a non-match logged `status: skipped`, `conditionsMatched: false` and nothing else. Skipped executions now carry a reason in the log row, e.g. `conditions_not_matched: pull_request.merged eq true (condition_field_unresolved)` or `(actual: false)`, so a typo'd or mis-rooted path is diagnosable from `omni automations logs`.
- Corrected the API description that suggested a `payload.` prefix for condition fields (the engine evaluates against the payload root merged with metadata).

## Verification
- `make check`: typecheck, lint, dead-code, and migration contract pass.
- `bun test` in core, api, and cli packages all green (api skips are the real-PostgreSQL suites that run under the separate pg gate). One CLI basic test flaked once in the turbo run and passed on isolated and full reruns.