### PR TITLE
feat(release): derive the promotion candidate and automate the pin (#1057)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,20 +597,27 @@ jobs:
     name: Promotion Pin Gate (dev → main)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+      attestations: read
 
-    # A promotion PR (base main) must carry a candidate pin that matches the
-    # tree being merged. The read-only promotion verifier (image-publish.yml)
-    # only runs on push to main, so before this job a stale pin — dev moved
-    # on and nobody re-minted — was discovered AFTER the merge, leaving main
-    # red with "final image build-input drift" (the two promotions after
-    # v2.260902.5 both did exactly this). This job runs the same binding
-    # check, verify-promotion-candidate.sh, on the PR's merge commit so the
-    # stale pin blocks the merge with the same message instead.
+    # A promotion PR (base main) must carry a tree whose candidate was minted.
+    # The read-only promotion verifier (image-publish.yml) only runs on push to
+    # main, so before this job a stale candidate — dev moved on and nobody
+    # re-minted — was discovered AFTER the merge, leaving main red with "final
+    # image build-input drift". This job runs the same binding check,
+    # verify-promotion-candidate.sh, on the PR's merge commit so a missing or
+    # stale candidate blocks the merge with the recovery command instead.
+    #
+    # Nothing is hand-pinned (#1057): the candidate is derived from the tree
+    # (package version → immutable v<version> tag → attested registry alias),
+    # exactly as image-publish.yml derives it after the merge.
     #
     # github.base_ref is non-empty only on pull_request events (merge_group
     # and push leave it blank), so every non-promotion event skips this job;
-    # a skipped required check passes, which is correct — the pin is only a
-    # claim about main.
+    # a skipped required check passes, which is correct — the candidate is
+    # only a claim about main.
     if: github.base_ref == 'main'
 
     steps:
@@ -623,28 +630,19 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Bind the pinned candidate to the promotion merge commit
+      - name: Bind the tree's minted candidate to the promotion merge commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
         run: |
           set -euo pipefail
-          pin_file=".github/workflows/image-publish.yml"
-          candidate_version=$(sed -n 's/^[[:space:]]*CANDIDATE_VERSION:[[:space:]]*//p' "${pin_file}")
-          candidate_sha=$(sed -n 's/^[[:space:]]*CANDIDATE_SHA:[[:space:]]*//p' "${pin_file}")
-          candidate_digest=$(sed -n 's/^[[:space:]]*CANDIDATE_DIGEST:[[:space:]]*//p' "${pin_file}")
-          for value in "${candidate_version}" "${candidate_sha}" "${candidate_digest}"; do
-            if [[ -z "${value}" || "${value}" == *$'\n'* ]]; then
-              echo "::error::could not parse exactly one CANDIDATE_VERSION/CANDIDATE_SHA/CANDIDATE_DIGEST triple from ${pin_file}"
-              exit 1
-            fi
-          done
+          mint_hint="Mint a candidate for the current dev tip first: gh workflow run version.yml --ref dev -f candidate=true, then gh workflow run image-build.yml --ref refs/tags/v<version> -f version=<version>. The mint pins dev through pin-candidate.yml; nothing is pasted by hand. Then refresh the promotion PR."
 
-          # The cheap staleness check first, with the recovery procedure in
-          # the error: a promotion whose tree version outran the pin means
-          # nobody minted a candidate for what is about to become main.
-          tree_version=$(jq -r .version packages/cli/package.json)
-          if [[ "${candidate_version}" != "${tree_version}" ]]; then
-            echo "::error::stale promotion pin: ${pin_file} pins CANDIDATE_VERSION=${candidate_version} but this tree is version ${tree_version}. Mint a fresh candidate first (gh workflow run version.yml --ref dev -f candidate=true, then gh workflow run image-build.yml --ref refs/tags/v<version> -f version=<version>), then paste the CANDIDATE_* values from its receipt into image-publish.yml, .well-known/{latest,dev}.json, deploy/helm/omni/values.yaml image.tag, the contract test pins, and the upgrade runbook in a reviewed commit on dev, and reopen the promotion."
+          candidate_version=$(jq -r .version packages/cli/package.json)
+          candidate_sha=$(git rev-parse "refs/tags/v${candidate_version}^{commit}" 2>/dev/null) || {
+            echo "::error::no immutable tag v${candidate_version}: this tree's version was never cut as a candidate. ${mint_hint}"
             exit 1
-          fi
+          }
 
           # The full binding image-publish.yml will re-run on main: candidate
           # commit exists, is an ancestor, the immutable tag resolves to it,
@@ -653,8 +651,26 @@ jobs:
           scripts/release/verify-promotion-candidate.sh \
             --candidate-sha "${candidate_sha}" \
             --final-sha "$(git rev-parse 'HEAD^{commit}')" \
-            --version "${candidate_version}" \
-            --digest "${candidate_digest}" || {
-            echo "::error::the pinned candidate does not bind to this promotion tree (see the verifier output above). Re-mint a candidate for the current dev tip and update the pin files instead of merging."
+            --version "${candidate_version}" || {
+            echo "::error::the tree's candidate v${candidate_version} does not bind to this promotion tree (see the verifier output above). ${mint_hint}"
+            exit 1
+          }
+
+          # A tag alone is not a candidate: the registry alias for it must be
+          # attested from exactly that source by the minter, which is what
+          # image-publish.yml re-verifies by digest after the merge.
+          gh attestation verify "oci://${IMAGE}:v${candidate_version}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${candidate_sha}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/image-build.yml" || {
+            echo "::error::${IMAGE}:v${candidate_version} is not attested from ${candidate_sha} by image-build.yml: the candidate was never minted (or its mint did not finish). ${mint_hint}"
+            exit 1
+          }
+
+          # The public channel pins ride along in the tree; pin-candidate.yml
+          # writes them on dev right after the mint.
+          pinned_version=$(jq -r .version .well-known/latest.json)
+          [[ "${pinned_version}" == "${candidate_version}" ]] || {
+            echo "::error::.well-known/latest.json pins ${pinned_version} but this tree is ${candidate_version}; run gh workflow run pin-candidate.yml --ref dev -f version=${candidate_version} and refresh the promotion PR"
             exit 1
           }

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -23,9 +23,13 @@
 #     provenance; require the active v* tag ruleset; wait for any running
 #     release.yml run at the tag, refuse a dev prerelease at the tag; dispatch
 #     release.yml (channel=stable) and version.yml (stable_publish_only=true)
-#     at the same tag and wait for both; print the CANDIDATE_* values that the
-#     reviewed promotion pins (image-publish.yml, .well-known/*.json, Helm
-#     values, contract tests, upgrade runbook) are updated to.
+#     at the same tag and wait for both; write the candidate receipt as soon
+#     as the stable release exists (before the npm step, so a registry race
+#     never hides the digest); dispatch pin-candidate.yml, which commits the
+#     public channel pins (.well-known/*.json, Helm image.tag) to dev.
+#     image-publish.yml and the CI promotion gate derive the candidate from
+#     the tree (package version → v<version> tag → attested alias); nothing is
+#     hand-pasted.
 #
 # Recovery: if finalize fails after build-push succeeded (ruleset check,
 # run-resolution timeout, concurrent dispatch, a failed release.yml run), a
@@ -104,6 +108,37 @@ jobs:
             exit 1
           }
           [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]
+
+      # A tag that already carries a public dev prerelease (a merged-PR bump,
+      # or a dispatch without candidate=true) can never become stable: its
+      # channel classification is immutable. finalize re-checks this after
+      # waiting for in-flight release.yml runs; refusing here saves the full
+      # multi-arch build and attestation when the answer is already known.
+      - name: Refuse a tag that already carries a dev prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          lookup_status=$(curl -sS -o "${RUNNER_TEMP}/release.json" -w '%{http_code}' \
+            --retry 3 --retry-all-errors --connect-timeout 10 --max-time 60 \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}")
+          case "${lookup_status}" in
+            404) echo "no release at v${VERSION} yet; the tag is mintable" ;;
+            200)
+              release_state=$(jq -r '[.draft,.prerelease] | @tsv' "${RUNNER_TEMP}/release.json")
+              [[ "${release_state}" != $'false\ttrue' ]] || {
+                echo "::error::a dev prerelease already exists at v${VERSION}; this tag cannot become stable — cut a fresh candidate with \`gh workflow run version.yml --ref dev -f candidate=true\` and mint that tag instead"
+                exit 1
+              }
+              ;;
+            *)
+              echo "::error::release lookup for v${VERSION} returned HTTP ${lookup_status}; refusing to guess"
+              exit 1
+              ;;
+          esac
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -327,16 +362,11 @@ jobs:
             --remote origin --version "${VERSION}" --mode exact --expected-sha "${SOURCE_SHA}"
           echo "Verified remote tag target before publication"
 
-      # The dispatching identity must stay github.token: release.yml's stable
-      # authorize job and version.yml's publish-stable job both require the
-      # actor to be github-actions[bot] and re-verify this run by id.
-      - name: Verify or publish the stable release, then publish stable npm
-        env:
-          GH_TOKEN: ${{ github.token }}
+      # The run-resolution helpers are shared by the release and npm steps
+      # below; sourced per step because each `run:` is its own shell.
+      - name: Stage dispatch helpers
         run: |
-          set -euo pipefail
-          tag="v${VERSION}"
-
+          cat > "${RUNNER_TEMP}/dispatch-helpers.sh" <<'SH'
           # `gh workflow run` prints no run id. Snapshot the workflow's
           # dispatch runs on this tag before dispatching, then poll for
           # exactly one NEW run whose head SHA is the verified source.
@@ -367,6 +397,19 @@ jobs:
               exit 1
             }
           }
+          SH
+
+      # The dispatching identity must stay github.token: release.yml's stable
+      # authorize job and version.yml's publish-stable job both require the
+      # actor to be github-actions[bot] and re-verify this run by id.
+      - name: Verify or publish the stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          # shellcheck disable=SC1091
+          source "${RUNNER_TEMP}/dispatch-helpers.sh"
 
           # A release.yml run still in flight at this tag (a dev prerelease
           # cut without candidate=true, or a stable run from a re-run of this
@@ -473,6 +516,45 @@ jobs:
             --remote origin --version "${VERSION}" --mode exact --expected-sha "${SOURCE_SHA}"
           echo "Verified remote tag target after publication"
 
+      # Written BEFORE the npm step: the stable release and the attested image
+      # are final at this point, and an npm registry race must never hide the
+      # digest (#1057). Re-running failed jobs re-emits the same receipt.
+      - name: Write candidate receipt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          published_at=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --jq .published_at)
+          [[ "${published_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || {
+            echo "::error::stable release v${VERSION} has no published_at timestamp"
+            exit 1
+          }
+          {
+            echo "### Omni release candidate v${VERSION}"
+            echo "- source: \`${SOURCE_SHA}\`"
+            echo "- version: \`${VERSION}\`"
+            echo "- OCI digest: \`${DIGEST}\`"
+            echo "- release published at: \`${published_at}\`"
+            echo "- next: pin-candidate.yml commits the public channel pins to dev once"
+            echo "  the stable npm step below succeeds; then open the dev → main promotion."
+            echo "  image-publish.yml and the CI promotion gate derive the candidate from"
+            echo "  the tree, so nothing is pasted by hand."
+            echo "- mutation boundary: no tag, branch, production pin, or cluster write"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "CANDIDATE_VERSION=${VERSION}"
+          echo "CANDIDATE_SHA=${SOURCE_SHA}"
+          echo "CANDIDATE_DIGEST=${DIGEST}"
+          echo "RELEASE_PUBLISHED_AT=${published_at}"
+
+      - name: Publish stable npm
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          # shellcheck disable=SC1091
+          source "${RUNNER_TEMP}/dispatch-helpers.sh"
+
           # Always dispatch the hardened npm reconciler — even when version and
           # latest already look correct — so existing package bytes, registry
           # signatures, and available provenance attestations are reverified.
@@ -500,29 +582,19 @@ jobs:
           scripts/release/verify-oci-alias.sh \
             --image "${IMAGE}" --version "${VERSION}" --expected-digest "${DIGEST}"
 
-      - name: Write candidate receipt
+      # The pin is a dev branch write, so it lives in its own workflow with its
+      # own credential; this job stays unable to move a Git ref. The dispatch
+      # resolves pin-candidate.yml on the default branch, so until the first
+      # promotion carrying that file lands it 404s: warn with the manual
+      # command instead of failing an otherwise complete mint.
+      - name: Dispatch the candidate pin to dev
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          published_at=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --jq .published_at)
-          [[ "${published_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || {
-            echo "::error::stable release v${VERSION} has no published_at timestamp"
-            exit 1
+          gh workflow run pin-candidate.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref dev \
+            --field version="${VERSION}" || {
+            echo "::warning::could not dispatch pin-candidate.yml (not on the default branch yet?); run: gh workflow run pin-candidate.yml --ref dev -f version=${VERSION}"
           }
-          {
-            echo "### Omni release candidate v${VERSION}"
-            echo "- source: \`${SOURCE_SHA}\`"
-            echo "- version: \`${VERSION}\`"
-            echo "- OCI digest: \`${DIGEST}\`"
-            echo "- release published at: \`${published_at}\`"
-            echo "- next: paste the CANDIDATE_* values below into image-publish.yml,"
-            echo "  .well-known/{latest,dev}.json, deploy/helm/omni/values.yaml image.tag,"
-            echo "  the contract test pins, and the upgrade runbook in a reviewed commit,"
-            echo "  then open the dev → main promotion."
-            echo "- mutation boundary: no tag, branch, production pin, or cluster write"
-          } >> "${GITHUB_STEP_SUMMARY}"
-          echo "CANDIDATE_VERSION=${VERSION}"
-          echo "CANDIDATE_SHA=${SOURCE_SHA}"
-          echo "CANDIDATE_DIGEST=${DIGEST}"
-          echo "RELEASE_PUBLISHED_AT=${published_at}"

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -2,6 +2,14 @@
 # GHCR, npm, GitHub Releases, aliases, or deployment state. Production
 # deployment authority lives outside this public repository; this workflow
 # emits only a verification receipt for the protected dev-to-main promotion.
+#
+# The candidate is derived from the main tree, never hand-pinned (#1057):
+# version from packages/cli/package.json, source SHA from the immutable
+# refs/tags/v<version> (ruleset-protected, update/delete blocked), and the OCI
+# digest from the registry alias for that tag. The digest is then bound by
+# GitHub provenance to that exact source SHA and to image-build.yml as the
+# signer, so a moved alias or a foreign image fails exactly as a wrong pasted
+# digest used to; every other immutability check is unchanged.
 name: Verify Production Promotion
 
 on:
@@ -20,14 +28,11 @@ permissions:
 
 jobs:
   verify-promotion:
-    name: Verify immutable v2.260910.4 candidate
+    name: Verify immutable candidate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
-      CANDIDATE_VERSION: 2.260910.4
-      CANDIDATE_SHA: b86db34fbb0ed55cb215e273d073464fa4690b19
-      CANDIDATE_DIGEST: sha256:508c625b124f2beac560dd48a2885ef2f8c4b2e5237099f69542a70f1e18e42f
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -35,6 +40,32 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+
+      - name: Derive the candidate from the main tree
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REF}" == "refs/heads/main" ]] || {
+            echo "::error::production promotion verification is restricted to main"
+            exit 1
+          }
+          candidate_version=$(jq -r .version packages/cli/package.json)
+          [[ "${candidate_version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+            echo "::error::packages/cli/package.json version '${candidate_version}' is not a canonical dotted version"
+            exit 1
+          }
+          candidate_sha=$(git rev-parse "refs/tags/v${candidate_version}^{commit}" 2>/dev/null) || {
+            echo "::error::no immutable tag v${candidate_version}: main carries a version that was never cut as a candidate (cut it with version.yml candidate=true, then mint it with image-build.yml at refs/tags/v<version>)"
+            exit 1
+          }
+          [[ "${candidate_sha}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(jq -r .version .well-known/latest.json)" == "${candidate_version}" ]] || {
+            echo "::error::.well-known/latest.json is not pinned to ${candidate_version}; pin-candidate.yml did not land on dev before this promotion"
+            exit 1
+          }
+          {
+            echo "CANDIDATE_VERSION=${candidate_version}"
+            echo "CANDIDATE_SHA=${candidate_sha}"
+          } >> "${GITHUB_ENV}"
 
       - name: Checkout immutable candidate source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -50,10 +81,6 @@ jobs:
           FINAL_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          [[ "${GITHUB_REF}" == "refs/heads/main" ]] || {
-            echo "::error::production promotion verification is restricted to main"
-            exit 1
-          }
           [[ "$(git rev-parse 'HEAD^{commit}')" == "${FINAL_SHA}" ]]
           git fetch --no-tags origin \
             '+refs/heads/main:refs/remotes/origin/main'
@@ -64,11 +91,23 @@ jobs:
           scripts/release/verify-promotion-candidate.sh \
             --candidate-sha "${CANDIDATE_SHA}" \
             --final-sha "${FINAL_SHA}" \
-            --version "${CANDIDATE_VERSION}" \
-            --digest "${CANDIDATE_DIGEST}"
+            --version "${CANDIDATE_VERSION}"
 
       - name: Set up Buildx for read-only OCI inspection
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      # The alias is what image-build.yml pushed exactly once; the provenance
+      # check below is what makes reading it back safe (digest ↔ source SHA ↔
+      # signer workflow), so a retagged alias cannot pass.
+      - name: Resolve the candidate digest from the immutable alias
+        run: |
+          set -euo pipefail
+          candidate_digest=$(docker buildx imagetools inspect "${IMAGE}:v${CANDIDATE_VERSION}" --format '{{.Manifest.Digest}}')
+          [[ "${candidate_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::${IMAGE}:v${CANDIDATE_VERSION} has no valid OCI index digest; the candidate was never minted"
+            exit 1
+          }
+          echo "CANDIDATE_DIGEST=${candidate_digest}" >> "${GITHUB_ENV}"
 
       - name: Verify exact OCI alias, index, and GitHub provenance
         env:

--- a/.github/workflows/pin-candidate.yml
+++ b/.github/workflows/pin-candidate.yml
@@ -1,0 +1,192 @@
+# =============================================================================
+# Pin a minted release candidate's public channel metadata on dev.
+# =============================================================================
+# Replaces the hand-paste ritual (#1057). image-build.yml dispatches this once
+# its stable publication finished (or an operator dispatches it for a candidate
+# that already minted). It re-verifies the candidate from public state alone —
+# the immutable v<version> tag, the attested registry alias, and the public
+# stable release — and then commits exactly three files to dev:
+#
+#   .well-known/latest.json        version, released_at, tarball_base
+#   .well-known/dev.json           same values (dev tracks the stable candidate)
+#   deploy/helm/omni/values.yaml   image.tag: v<version>
+#
+# image-publish.yml and the CI promotion gate derive the candidate identity
+# from the tree (package version → tag → alias), so no workflow or test pins
+# a version, SHA, or digest by hand any more.
+#
+# The push is a direct commit to dev with the same machine credential and the
+# same `version-dev` concurrency group version.yml uses: a PR would trigger
+# version.yml's merged-PR bump and move dev past the candidate again. The
+# github.token stays read-only.
+#
+# It refuses to pin when dev has already moved past the candidate: that
+# candidate can no longer be promoted, so cut and mint a fresh one.
+# =============================================================================
+name: Pin Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Exact minted candidate version without the v prefix'
+        required: true
+        type: string
+
+concurrency:
+  group: version-dev
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  pin:
+    name: Pin the minted candidate on dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+      attestations: read
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/omni-api
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Require protected version writer credential
+        env:
+          VERSION_WRITER_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
+        run: |
+          [[ -n "${VERSION_WRITER_TOKEN}" ]] || {
+            echo "::error::VERSION_BUMP_PAT is required so the pin push to dev triggers its CI"
+            exit 1
+          }
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Set up Buildx for read-only OCI inspection
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Verify the minted candidate from public state
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "${VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+            echo "::error::version must be a canonical numeric dotted version without the v prefix"
+            exit 1
+          }
+          tree_version=$(jq -r .version packages/cli/package.json)
+          [[ "${tree_version}" == "${VERSION}" ]] || {
+            echo "::error::dev is at ${tree_version}, past candidate ${VERSION}; that candidate can no longer be promoted. Cut and mint a fresh one: version.yml with candidate=true on dev, then image-build.yml at refs/tags/v<version>"
+            exit 1
+          }
+          candidate_sha=$(git rev-parse "refs/tags/v${VERSION}^{commit}" 2>/dev/null) || {
+            echo "::error::no immutable tag v${VERSION}; cut it with version.yml candidate=true and mint it with image-build.yml first"
+            exit 1
+          }
+          [[ "${candidate_sha}" =~ ^[0-9a-f]{40}$ ]]
+          scripts/release/verify-remote-tag.sh \
+            --remote origin --version "${VERSION}" --mode exact --expected-sha "${candidate_sha}"
+          git merge-base --is-ancestor "${candidate_sha}" HEAD || {
+            echo "::error::v${VERSION} (${candidate_sha}) is not on dev"
+            exit 1
+          }
+
+          digest=$(docker buildx imagetools inspect "${IMAGE}:v${VERSION}" --format '{{.Manifest.Digest}}')
+          [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::${IMAGE}:v${VERSION} has no valid OCI index digest; mint the candidate first"
+            exit 1
+          }
+          gh attestation verify "oci://${IMAGE}@${digest}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${candidate_sha}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/image-build.yml"
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" > "${RUNNER_TEMP}/release.json"
+          [[ "$(jq -r '[.draft,.prerelease] | @tsv' "${RUNNER_TEMP}/release.json")" == $'false\tfalse' ]] || {
+            echo "::error::release v${VERSION} is not public stable; the mint did not finish"
+            exit 1
+          }
+          published_at=$(jq -r .published_at "${RUNNER_TEMP}/release.json")
+          [[ "${published_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || {
+            echo "::error::stable release v${VERSION} has no published_at timestamp"
+            exit 1
+          }
+          {
+            echo "sha=${candidate_sha}"
+            echo "digest=${digest}"
+            echo "published_at=${published_at}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write the public channel pins
+        env:
+          PUBLISHED_AT: ${{ steps.candidate.outputs.published_at }}
+        run: |
+          set -euo pipefail
+          python3 - "${VERSION}" "${PUBLISHED_AT}" "${GITHUB_REPOSITORY}" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          version, published_at, repository = sys.argv[1:4]
+
+          def replace_once(text: str, pattern: str, replacement: str, path: str) -> str:
+              text, count = re.subn(pattern, replacement, text, flags=re.MULTILINE)
+              if count != 1:
+                  raise SystemExit(f"{path}: expected exactly one match for {pattern!r}, found {count}")
+              return text
+
+          for name in ("latest", "dev"):
+              path = Path(f".well-known/{name}.json")
+              text = path.read_text(encoding="utf-8")
+              text = replace_once(text, r'^(\s*"version":\s*")[^"]*(")', rf"\g<1>{version}\g<2>", str(path))
+              text = replace_once(text, r'^(\s*"released_at":\s*")[^"]*(")', rf"\g<1>{published_at}\g<2>", str(path))
+              text = replace_once(
+                  text,
+                  r'^(\s*"tarball_base":\s*")[^"]*(")',
+                  rf"\g<1>https://github.com/{repository}/releases/download/v{version}\g<2>",
+                  str(path),
+              )
+              path.write_text(text, encoding="utf-8")
+
+          values = Path("deploy/helm/omni/values.yaml")
+          values.write_text(
+              replace_once(values.read_text(encoding="utf-8"), r'^  tag: "v[0-9]+\.[0-9]+\.[0-9]+"$', f'  tag: "v{version}"', str(values)),
+              encoding="utf-8",
+          )
+          PY
+          git diff --stat
+
+      - name: Commit and push the pin to dev
+        env:
+          VERSION_WRITER_TOKEN: ${{ secrets.VERSION_BUMP_PAT }}
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
+          CANDIDATE_DIGEST: ${{ steps.candidate.outputs.digest }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .well-known/latest.json .well-known/dev.json deploy/helm/omni/values.yaml
+          if git diff --cached --quiet; then
+            echo "dev already pins candidate v${VERSION}; nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore(release): pin candidate v${VERSION}"
+          # Machine-account push (not github-actions[bot]) so the pin commit's
+          # CI runs and any open promotion PR is not held at action_required;
+          # same rationale and credential as version.yml's bump push.
+          git -c http.https://github.com/.extraheader= \
+            push "https://x-access-token:${VERSION_WRITER_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/dev"
+          {
+            echo "### Pinned Omni release candidate v${VERSION} on dev"
+            echo "- source: \`${CANDIDATE_SHA}\`"
+            echo "- OCI digest: \`${CANDIDATE_DIGEST}\`"
+            echo "- next: open (or refresh) the dev → main promotion PR"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/deployment/public-launch-readiness.md
+++ b/docs/deployment/public-launch-readiness.md
@@ -1,16 +1,42 @@
 # Public launch readiness
 
-This change preserves the release candidate already published as
-`v2.260910.4` and turns the public main-branch path into verification only.
-Production deployment authority and the canonical production digest are not
-owned by this public repository.
+This change preserves the already-published release candidate and turns the
+public main-branch path into verification only. Production deployment
+authority and the canonical production digest are not owned by this public
+repository.
+
+## The one true promotion path
+
+```bash
+gh workflow run version.yml --ref dev -f candidate=true          # cuts v<version> on dev
+gh workflow run image-build.yml --ref refs/tags/v<version> -f version=<version>
+# image-build.yml mints, publishes, writes its receipt, and dispatches
+# pin-candidate.yml, which commits the public channel pins to dev.
+# Then open the dev → main promotion PR. Nothing is pasted by hand.
+```
+
+Nothing else mints. A merged-PR bump (or a `version.yml` dispatch without
+`candidate=true`) publishes a dev prerelease at its tag, and that tag can never
+become stable: `image-build.yml` refuses it in its first step with the
+`candidate=true` hint. Any merge to `dev` after the mint bumps the version
+past the candidate, so the Promotion Pin Gate goes red again with the same
+hint: cut and mint again, then refresh the promotion PR.
 
 ## Immutable candidate
 
-- Source commit: `b86db34fbb0ed55cb215e273d073464fa4690b19`
-- Version tag: `v2.260910.4` (the tag resolves to the source commit above)
-- OCI index: `ghcr.io/automagik-dev/omni-api@sha256:508c625b124f2beac560dd48a2885ef2f8c4b2e5237099f69542a70f1e18e42f`
-- Public release timestamp: `2026-09-10T17:31:13Z`
+The candidate is **derived from the tree**, never hand-pinned (#1057):
+
+- Version: `packages/cli/package.json` `version` on the promoted tree
+- Source commit: what the immutable `refs/tags/v<version>` resolves to
+  (the active `v*` tag ruleset blocks update and deletion)
+- OCI index: what `ghcr.io/automagik-dev/omni-api:v<version>` resolves to,
+  accepted only when GitHub provenance binds that digest to the source commit
+  above with `image-build.yml` as the signer
+- Public release timestamp: `published_at` of the stable GitHub Release at
+  the tag, written into `.well-known/latest.json` and `.well-known/dev.json`
+  by `pin-candidate.yml`
+- Current values: `jq -r .version .well-known/latest.json` is the pinned
+  public candidate; `git rev-parse refs/tags/v<version>` its source
 - Protected image build inputs: `deploy/Dockerfile`,
   `deploy/Dockerfile.dockerignore`, root `package.json`, `bun.lock`,
   `packages/**`, and `apps/**` (the list in
@@ -60,14 +86,32 @@ OCI attestation signed by `image-build.yml`.
    (`channel=stable`) and `version.yml` (`stable_publish_only=true`) at the
    same tag, and waits for both. It never creates or moves a tag, pushes a
    branch, or writes a production pin.
-3. The run prints `CANDIDATE_VERSION=`, `CANDIDATE_SHA=`, `CANDIDATE_DIGEST=`,
-   and `RELEASE_PUBLISHED_AT=`. A reviewed commit copies those values into
-   `image-publish.yml`, `.well-known/latest.json` and `.well-known/dev.json`,
-   `deploy/helm/omni/values.yaml` `image.tag`, the contract test pins
-   (`scripts/release/release-workflow-contract.test.sh`), and the upgrade
-   runbook/rehearsal.
-4. The `dev` → `main` promotion PR carries that commit; on merge,
-   `image-publish.yml` verifies the pinned candidate read-only.
+3. As soon as the stable release exists — before the stable npm step, so an
+   npm registry race never hides the digest — the run writes its receipt
+   (`CANDIDATE_VERSION=`, `CANDIDATE_SHA=`, `CANDIDATE_DIGEST=`,
+   `RELEASE_PUBLISHED_AT=`). The stable npm reconciler
+   (`scripts/release/reconcile-npm-stable.sh`) then polls the registry for
+   roughly 15 minutes of backoff before declaring non-convergence, because
+   npm propagation has taken 5-10 minutes in practice.
+4. After the npm step, the run dispatches `pin-candidate.yml` on `dev`. That
+   workflow re-verifies the candidate from public state alone (immutable tag,
+   attested alias, public stable release), refuses a candidate `dev` has
+   already moved past, and commits `chore(release): pin candidate v<version>`
+   directly to `dev` — `.well-known/latest.json`, `.well-known/dev.json`, and
+   `deploy/helm/omni/values.yaml` `image.tag` — with the same machine
+   credential and `version-dev` concurrency group as `version.yml`'s bump. A
+   direct push, not a PR: a merged PR would trigger the merged-PR bump and
+   move `dev` past the candidate again. Until the first promotion carrying
+   `pin-candidate.yml` reaches `main`, the dispatch 404s and the mint prints
+   the manual command (`gh workflow run pin-candidate.yml --ref dev -f
+   version=<version>`) as a warning instead of failing.
+5. Open the `dev` → `main` promotion PR. The Promotion Pin Gate derives the
+   candidate from the PR tree (package version → tag → attested alias), binds
+   it to the merge commit with `verify-promotion-candidate.sh`, and requires
+   `.well-known/latest.json` to pin the same version. On merge,
+   `image-publish.yml` derives the same identity from `main` and verifies it
+   read-only. No workflow, test, or document pins a version, SHA, or digest by
+   hand.
 
 Stranded mint recovery: if `finalize` fails after `build-push` succeeded (the
 ruleset check, a run-resolution timeout, a concurrent dispatch, or a failed
@@ -164,10 +208,10 @@ The independent final-head review of `0db5804e93b97afc67be570a40a37b631d71ee8b`
 identified four additional blockers. They are closed as follows:
 
 - The final `main` checkout remains the root control tree, while
-  `image-publish.yml` creates a second `release-candidate` checkout pinned to
-  the candidate SHA (`b86db34fbb0ed55cb215e273d073464fa4690b19` for
-  `v2.260910.4`; `b8c1bf20cd42b1e30974fc8d67f2b7d0fb620031` when this
-  remediation landed for `v2.260830.2`). The root-owned OCI verifier now
+  `image-publish.yml` creates a second `release-candidate` checkout at the
+  candidate SHA (derived from the tree's version tag since #1057;
+  `b8c1bf20cd42b1e30974fc8d67f2b7d0fb620031` when this remediation landed for
+  `v2.260830.2`). The root-owned OCI verifier now
   requires an explicit source directory and changes into that historical
   checkout before checking `HEAD`, the immutable tag, package/chart versions,
   and the registry alias. Its integration fixture executes final control code
@@ -220,10 +264,9 @@ The final worktree passed the following local, non-mutating gates:
   `run: |  ` block-scalar case of the run-expression matcher self-test), which
   is exempt by design
 - `bun scripts/verify-versions.ts` — every tracked version field agrees with
-  `packages/cli/package.json`. The value itself follows each dev bump (it was
-  `2.260830.2` when this document was written and is `2.260910.4` at the
-  2026-09-10 candidate revision), so it is not a fixed claim of this
-  document; the immutable candidate above is `v2.260910.4`
+  `packages/cli/package.json`. The value itself follows each dev bump, so it
+  is not a fixed claim of this document; the pinned public candidate is
+  whatever `.well-known/latest.json` names
 - every `scripts/release/*.test.sh`
 - `scripts/ci/test-helm-image-digest.sh` with Helm `v3.16.4` pinned to the
   repository's CI checksum
@@ -236,6 +279,6 @@ The final worktree passed the following local, non-mutating gates:
 - `bun run build`
 
 The build gate's generated rewrite was discarded. A final Git comparison
-confirms that every protected image build input is byte-identical to
-`b86db34fbb0ed55cb215e273d073464fa4690b19`, and the legacy HML runtime paths
-are byte-identical to the merged baseline.
+confirms that every protected image build input is byte-identical to the
+candidate source, and the legacy HML runtime paths are byte-identical to the
+merged baseline.

--- a/scripts/release/reconcile-npm-stable.sh
+++ b/scripts/release/reconcile-npm-stable.sh
@@ -112,8 +112,12 @@ case "${action}" in
   *) fail "unexpected state action ${action}" ;;
 esac
 
+# npm propagation after a publish has taken 5-10 minutes in practice (#1057);
+# the readback polls for roughly 15 minutes before declaring non-convergence.
+# A fixed delay list, not a wall-clock deadline: the contract test mocks sleep.
+converge_delays=(0 5 10 20 40 60 60 60 60 60 60 60 60 60 60 60 60 60 60)
 final_state=""
-for delay in 0 1 2 4 8; do
+for delay in "${converge_delays[@]}"; do
   [[ "${delay}" -eq 0 ]] || sleep "${delay}"
   published_after="$(read_published "${error_file}")"
   latest_after="$(read_latest "${latest_error_file}")"
@@ -134,8 +138,18 @@ expected_url="https://registry.npmjs.org/@automagik/omni/-/omni-${expected}.tgz"
 [[ -n "${integrity}" && "${resolved}" == "${expected_url}" ]] || \
   fail "registry metadata is missing an approved npm tarball URL"
 registry_tarball="${pack_dir}/registry-omni-${expected}.tgz"
-curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-connrefused \
-  -o "${registry_tarball}" "${resolved}"
+# The tarball URL can still 404 for minutes after the packument converged
+# (CDN propagation); curl --retry does not cover 404, so poll it the same way.
+tarball_fetched=false
+for delay in "${converge_delays[@]}"; do
+  [[ "${delay}" -eq 0 ]] || sleep "${delay}"
+  if curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-connrefused \
+    -o "${registry_tarball}" "${resolved}"; then
+    tarball_fetched=true
+    break
+  fi
+done
+[[ "${tarball_fetched}" == "true" ]] || fail "registry tarball ${resolved} did not become downloadable"
 curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-connrefused \
   -o "${keys_file}" "https://registry.npmjs.org/-/npm/v1/keys"
 curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-connrefused \

--- a/scripts/release/reconcile-npm-stable.test.sh
+++ b/scripts/release/reconcile-npm-stable.test.sh
@@ -208,6 +208,10 @@ no_converge="${work}/no-converge"
 if MOCK_NO_CONVERGE=true run_case "${no_converge}" >"${work}/no-converge.out" 2>"${work}/no-converge.err"; then
   fail "publish succeeded without exact post-mutation readback convergence"
 fi
+# npm propagation takes minutes (#1057): the readback must keep polling for
+# at least ten minutes of accumulated backoff before giving up.
+waited="$(awk '{ total += $1 } END { print total + 0 }' "${no_converge}/sleeps")"
+(( waited >= 600 )) || fail "non-convergence was declared after only ${waited}s of backoff"
 
 eventual="${work}/eventual"
 out="$(MOCK_STALE_READS=2 run_case "${eventual}")"

--- a/scripts/release/release-workflow-contract.test.sh
+++ b/scripts/release/release-workflow-contract.test.sh
@@ -109,19 +109,20 @@ def effective_job_permissions(text: str) -> dict[str, dict[str, str]]:
 
 require(image, r"branches:\s*\[main\]", "promotion verification is not bound to main")
 require(image, r"timeout-minutes:\s*[0-9]+", "promotion verification has no finite job timeout")
-for exact in (
-    "2.260910.4",
-    "b86db34fbb0ed55cb215e273d073464fa4690b19",
-    "sha256:508c625b124f2beac560dd48a2885ef2f8c4b2e5237099f69542a70f1e18e42f",
-):
-    if exact not in image:
-        errors.append(f"promotion workflow does not pin existing candidate identity {exact}")
+# The candidate is derived from the main tree, never hand-pinned (#1057):
+# version from the package, SHA from the immutable tag, digest from the alias
+# that provenance then binds to that SHA and to image-build.yml.
+forbid(image, r"^\s+CANDIDATE_(?:VERSION|SHA|DIGEST):\s*\S", "promotion workflow hand-pins a candidate version, SHA, or digest")
+require(image, r"candidate_version=\$\(jq -r \.version packages/cli/package\.json\)", "promotion workflow does not derive the candidate version from the tree")
+require(image, r"candidate_sha=\$\(git rev-parse \"refs/tags/v\$\{candidate_version\}\^\{commit\}\"", "promotion workflow does not derive the candidate SHA from the immutable tag")
+require(image, r"candidate_digest=\$\(docker buildx imagetools inspect \"\$\{IMAGE\}:v\$\{CANDIDATE_VERSION\}\" --format '\{\{\.Manifest\.Digest\}\}'\)", "promotion workflow does not derive the candidate digest from the immutable alias")
+require(image, r"jq -r \.version \.well-known/latest\.json\)\" == \"\$\{candidate_version\}\"", "promotion workflow does not require the public channel pin to match the promoted version")
 require(image, r"verify-promotion-candidate\.sh", "final image build inputs are not compared to the candidate")
 require(image, r"verify-oci-release\.sh", "existing immutable OCI alias is not checked")
 require(image, r"name:\s*Checkout immutable candidate source[\s\S]{0,500}path:\s*release-candidate", "immutable OCI verification has no separate candidate checkout")
 require(image, r"--source-dir\s+\"\$\{GITHUB_WORKSPACE\}/release-candidate\"", "immutable OCI verification does not use the candidate checkout")
 require(image, r"gh attestation verify\s+\"oci://\$\{IMAGE\}@\$\{CANDIDATE_DIGEST\}\"", "exact OCI digest provenance is not verified")
-require(image, r"--source-digest\s+\"\$\{CANDIDATE_SHA\}\"", "OCI provenance is not bound to b86db34f")
+require(image, r"--source-digest\s+\"\$\{CANDIDATE_SHA\}\"", "OCI provenance is not bound to the derived candidate SHA")
 require(image, r"--signer-workflow\s+\"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-build\.yml\"", "OCI signer workflow identity is not constrained to the candidate minter")
 require(image, r"verify-release-assets\.py", "existing public release asset inventory is not verified read-only")
 require(image, r"cosign verify-blob", "existing release bundle signatures are not verified")
@@ -185,6 +186,28 @@ else:
     )
     forbid(image_build, r"--certificate-identity-regexp", "candidate minting accepts a regexp signer identity")
     require(image_build, r"echo \"CANDIDATE_VERSION=\$\{VERSION\}\"\n\s+echo \"CANDIDATE_SHA=\$\{SOURCE_SHA\}\"\n\s+echo \"CANDIDATE_DIGEST=\$\{DIGEST\}\"", "candidate minting does not print the exact promotion pin values")
+    # #1057: the receipt is written as soon as the stable release exists, BEFORE
+    # the npm publication, so a registry race can never hide the digest.
+    receipt_at = image_build.find("- name: Write candidate receipt")
+    npm_dispatch_at = image_build.find("--field stable_publish_only=true")
+    if receipt_at < 0 or npm_dispatch_at < 0 or receipt_at > npm_dispatch_at:
+        errors.append("candidate minting writes the receipt after the stable npm step instead of before it")
+    # #1057: a tag that already carries a dev prerelease is refused in the very
+    # first job step, before checkout and the multi-arch build.
+    first_checkout_at = image_build.find("- uses: actions/checkout@")
+    early_refusal_at = image_build.find("- name: Refuse a tag that already carries a dev prerelease")
+    if early_refusal_at < 0 or first_checkout_at < 0 or early_refusal_at > first_checkout_at:
+        errors.append("candidate minting does not refuse a dev-prerelease tag before its first checkout")
+    else:
+        early_refusal = image_build[early_refusal_at:first_checkout_at]
+        require(early_refusal, r"releases/tags/v\$\{VERSION\}", "the early prerelease refusal does not look up the release at the tag")
+        require(early_refusal, r"\[\[ \"\$\{release_state\}\" != \$'false\\ttrue' \]\] \|\| \{", "the early prerelease refusal does not test the dev-prerelease state")
+        require(early_refusal, r"candidate=true", "the early prerelease refusal does not name the candidate=true recovery")
+        require(early_refusal, r"refusing to guess", "the early prerelease refusal does not fail closed on lookup errors")
+    # #1057: the mint hands the public pin to pin-candidate.yml on dev instead
+    # of asking for a hand-paste; the dispatch must not fail a finished mint.
+    require(image_build, r"gh workflow run pin-candidate\.yml \\\n\s+--repo \"\$\{GITHUB_REPOSITORY\}\" \\\n\s+--ref dev \\\n\s+--field version=\"\$\{VERSION\}\" \|\| \{", "candidate minting does not dispatch pin-candidate.yml on dev without failing the mint")
+    forbid(image_build, r"paste the CANDIDATE_\* values", "candidate minting still asks for a hand-paste of the candidate pin")
     for pattern, message in (
         (r"values-prod-gitops|pin-production-image", "candidate minting still writes a public production pin"),
         (r"secrets:\s*inherit", "candidate minting inherits repository secrets"),
@@ -575,15 +598,20 @@ require(release, r"bare tag pushes do not release", "release workflow still miss
 
 latest = json.loads((root / ".well-known/latest.json").read_text(encoding="utf-8"))
 dev = json.loads((root / ".well-known/dev.json").read_text(encoding="utf-8"))
+# pin-candidate.yml writes both manifests from the verified release, so the
+# contract is structural and cross-checked, never a literal version (#1057).
 for channel, document in (("stable", latest), ("dev", dev)):
     if document.get("channel") != channel:
         errors.append(f"{channel} public manifest has the wrong channel")
-    if document.get("version") != "2.260910.4":
-        errors.append(f"{channel} public manifest is not reconciled to v2.260910.4")
-    if document.get("released_at") != "2026-09-10T17:31:13Z":
-        errors.append(f"{channel} public manifest does not use the authoritative release timestamp")
-    if not str(document.get("tarball_base", "")).endswith("/releases/download/v2.260910.4"):
-        errors.append(f"{channel} public manifest has the wrong immutable tarball base")
+    pinned_version = str(document.get("version", ""))
+    if re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", pinned_version) is None:
+        errors.append(f"{channel} public manifest version {pinned_version!r} is not a canonical dotted version")
+    if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", str(document.get("released_at", ""))) is None:
+        errors.append(f"{channel} public manifest does not carry the release's published_at timestamp")
+    if not str(document.get("tarball_base", "")).endswith(f"/releases/download/v{pinned_version}"):
+        errors.append(f"{channel} public manifest tarball base does not match its own pinned version")
+if latest.get("version") != dev.get("version") or latest.get("released_at") != dev.get("released_at"):
+    errors.append("stable and dev public manifests are pinned to different candidates")
 if (root / ".well-known/homolog.json").exists():
     errors.append("retired homolog public channel metadata still exists")
 
@@ -627,12 +655,64 @@ require(
     r"^  promotion-pin-gate:\n(?:(?:    [^\n]*)?\n)*?\s+fetch-depth: 0\n\s+fetch-tags: true\n\s+persist-credentials: false\n",
     "the promotion pin gate cannot resolve the candidate commit and immutable tag (full history, tags, no persisted credentials)",
 )
-require(ci, r"jq -r \.version packages/cli/package\.json", "the promotion pin gate does not compare the pin to the tree version")
+require(ci, r"candidate_version=\$\(jq -r \.version packages/cli/package\.json\)", "the promotion pin gate does not derive the candidate version from the tree")
+require(ci, r"candidate_sha=\$\(git rev-parse \"refs/tags/v\$\{candidate_version\}\^\{commit\}\"", "the promotion pin gate does not derive the candidate SHA from the immutable tag")
+forbid(ci, r"sed -n 's/\^\[\[:space:\]\]\*CANDIDATE_", "the promotion pin gate still parses a hand-pasted candidate pin")
 require(
     ci,
     r"verify-promotion-candidate\.sh \\\n\s+--candidate-sha \"\$\{candidate_sha\}\" \\\n\s+--final-sha \"\$\(git rev-parse 'HEAD\^\{commit\}'\)\"",
-    "the promotion pin gate does not bind the pinned candidate to the PR merge commit",
+    "the promotion pin gate does not bind the derived candidate to the PR merge commit",
 )
+require(
+    ci,
+    r"gh attestation verify \"oci://\$\{IMAGE\}:v\$\{candidate_version\}\" \\\n\s+--repo \"\$\{GITHUB_REPOSITORY\}\" \\\n\s+--source-digest \"\$\{candidate_sha\}\" \\\n\s+--signer-workflow \"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-build\.yml\"",
+    "the promotion pin gate does not require the alias to be attested from the tag's source by the minter",
+)
+require(ci, r"pinned_version=\$\(jq -r \.version \.well-known/latest\.json\)", "the promotion pin gate does not require the public channel pin to match the promoted version")
+require(ci, r"candidate=true", "the promotion pin gate error text does not name the one true minting path")
+
+# pin-candidate.yml is the only writer of the public channel pins: it
+# re-verifies the candidate from public state (tag, attested alias, stable
+# release), writes exactly three files, and pushes to dev with the same
+# machine credential and concurrency group as version.yml's bump. Its
+# github.token stays read-only and it never builds, tags, or publishes.
+pin_candidate = workflows.get("pin-candidate.yml")
+if pin_candidate is None:
+    errors.append("candidate pin workflow pin-candidate.yml is missing")
+else:
+    require(pin_candidate, r"^on:\n  workflow_dispatch:\n    inputs:\n      version:", "candidate pin is not a dispatch-only workflow keyed by an exact version input")
+    forbid(pin_candidate, r"^  (?:push|pull_request(?:_target)?|workflow_run|schedule|release):", "candidate pin has a trigger other than workflow_dispatch")
+    require(pin_candidate, r"^permissions:\s*\{\s*\}\s*$", "candidate pin does not clear top-level token permissions")
+    require(pin_candidate, r"^concurrency:\n  group: version-dev\n  cancel-in-progress: false", "candidate pin does not serialize with the dev version writer under the version-dev group")
+    require(pin_candidate, r"timeout-minutes:\s*[0-9]+", "candidate pin has no finite job timeout")
+    require(pin_candidate, r"actions/checkout@[0-9a-f]{40}[^\n]*\n\s+with:\n\s+ref: dev\n\s+fetch-depth: 0\n\s+fetch-tags: true\n\s+persist-credentials: false", "candidate pin does not check out dev with full history and tags and without persisted credentials")
+    require(pin_candidate, r"tree_version=\$\(jq -r \.version packages/cli/package\.json\)[\s\S]{0,120}\[\[ \"\$\{tree_version\}\" == \"\$\{VERSION\}\" \]\] \|\| \{", "candidate pin does not refuse a candidate dev has already moved past")
+    require(pin_candidate, r"candidate_sha=\$\(git rev-parse \"refs/tags/v\$\{VERSION\}\^\{commit\}\"", "candidate pin does not resolve the candidate from the immutable tag")
+    require(pin_candidate, r"verify-remote-tag\.sh[\s\S]{0,120}--mode exact", "candidate pin does not bind the remote tag to the candidate")
+    require(pin_candidate, r"gh attestation verify \"oci://\$\{IMAGE\}@\$\{digest\}\"[\s\S]{0,200}--source-digest \"\$\{candidate_sha\}\"[\s\S]{0,100}--signer-workflow \"\$\{GITHUB_REPOSITORY\}/\.github/workflows/image-build\.yml\"", "candidate pin does not require the alias to be attested from the candidate source by the minter")
+    require(pin_candidate, r"== \$'false\\tfalse' \]\] \|\| \{", "candidate pin does not require a public stable release at the tag")
+    require(pin_candidate, r"git add \.well-known/latest\.json \.well-known/dev\.json deploy/helm/omni/values\.yaml\n", "candidate pin does not commit exactly the three public channel pin files")
+    require(pin_candidate, r'git commit -m "chore\(release\): pin candidate v\$\{VERSION\}"', "candidate pin commit is not a conventional chore(release) commit")
+    require(pin_candidate, r"VERSION_WRITER_TOKEN\}@github\.com/\$\{GITHUB_REPOSITORY\}\.git\" \\\n\s+\"HEAD:refs/heads/dev\"", "candidate pin does not push to dev with the machine writer credential")
+    for pattern, message in (
+        (r"docker/build-push-action", "candidate pin can build an image"),
+        (r"(?:packages|actions|attestations|id-token|contents):\s*write", "candidate pin grants a mutating token permission"),
+        (r"\bgh\s+workflow\s+run\b", "candidate pin dispatches a publisher"),
+        (r"\bgh\s+release\b", "candidate pin touches a GitHub release"),
+        (r"\bnpm\s+(?:publish|dist-tag)\b", "candidate pin can publish or move an npm alias"),
+        (r"\bgit\s+tag\b", "candidate pin can create a tag"),
+        (r"\bgh\s+api\b[^\n]*(?:--method|-X)\s+(?:POST|PATCH|PUT|DELETE)", "candidate pin performs a mutating API call"),
+        (r"imagetools\s+create", "candidate pin can retag an OCI manifest"),
+        (r"refs/heads/main", "candidate pin can write main"),
+        (r"secrets:\s*inherit", "candidate pin inherits repository secrets"),
+        (r"persist-credentials:\s*true", "candidate pin persists checkout credentials"),
+        (r"\b(?:kubectl|helm\s+(?:upgrade|install)|docker\s+service\s+update|aws\s+)", "candidate pin can mutate infrastructure"),
+    ):
+        forbid(pin_candidate, pattern, message)
+    expected_pin_permissions = {"pin": {"contents": "read", "packages": "read", "attestations": "read"}}
+    pin_permissions = effective_job_permissions(pin_candidate)
+    if pin_permissions != expected_pin_permissions:
+        errors.append(f"candidate pin job permissions are {pin_permissions}, expected exactly {expected_pin_permissions}")
 
 if errors:
     for error in errors:

--- a/scripts/release/verify-promotion-candidate.sh
+++ b/scripts/release/verify-promotion-candidate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  printf 'Usage: verify-promotion-candidate.sh --candidate-sha FULL_SHA --final-sha FULL_SHA --version VERSION --digest sha256:...\n' >&2
+  printf 'Usage: verify-promotion-candidate.sh --candidate-sha FULL_SHA --final-sha FULL_SHA --version VERSION [--digest sha256:...]\n' >&2
   exit 2
 }
 
@@ -28,7 +28,12 @@ done
 [[ "${candidate_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "candidate SHA must be 40 lowercase hexadecimal characters"
 [[ "${final_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "final SHA must be 40 lowercase hexadecimal characters"
 [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "version must be numeric dotted form"
-[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "digest must be lowercase sha256 with 64 hexadecimal characters"
+# The digest is optional: the pre-merge promotion gate binds the tree to its
+# tag without touching the registry, and the post-merge verifier resolves the
+# digest from the attested alias itself. When given, it is validated and echoed.
+if [[ -n "${digest}" ]]; then
+  [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "digest must be lowercase sha256 with 64 hexadecimal characters"
+fi
 
 git cat-file -e "${candidate_sha}^{commit}" 2>/dev/null || fail "candidate commit does not exist"
 git cat-file -e "${final_sha}^{commit}" 2>/dev/null || fail "final commit does not exist"
@@ -66,5 +71,5 @@ output="${GITHUB_OUTPUT:-/dev/stdout}"
   printf 'candidate_sha=%s\n' "${candidate_sha}"
   printf 'final_sha=%s\n' "${final_sha}"
   printf 'version=%s\n' "${version}"
-  printf 'digest=%s\n' "${digest}"
+  [[ -z "${digest}" ]] || printf 'digest=%s\n' "${digest}"
 } >>"${output}"

--- a/scripts/release/verify-promotion-candidate.test.sh
+++ b/scripts/release/verify-promotion-candidate.test.sh
@@ -103,6 +103,7 @@ fi
 # The pre-merge promotion gate derives version and SHA from the tree and has no
 # registry access, so the digest is optional; the binding checks still run.
 (
+  unset GITHUB_OUTPUT
   cd "${repo}"
   "${SCRIPT}" \
     --candidate-sha "${candidate}" \

--- a/scripts/release/verify-promotion-candidate.test.sh
+++ b/scripts/release/verify-promotion-candidate.test.sh
@@ -100,6 +100,22 @@ if (
   fail "invalid candidate digest was accepted"
 fi
 
+# The pre-merge promotion gate derives version and SHA from the tree and has no
+# registry access, so the digest is optional; the binding checks still run.
+(
+  cd "${repo}"
+  "${SCRIPT}" \
+    --candidate-sha "${candidate}" \
+    --final-sha "${final}" \
+    --version 2.260830.2
+) >"${work}/no-digest.out" 2>"${work}/no-digest.err" || \
+  fail "digest-less binding was rejected"
+grep -q '^promotion_candidate_verified=true$' "${work}/no-digest.out" || \
+  fail "digest-less binding did not report success"
+if grep -q '^digest=' "${work}/no-digest.out"; then
+  fail "digest-less binding echoed a digest"
+fi
+
 # The root context has no .dockerignore; deploy/Dockerfile.dockerignore is the
 # Dockerfile-specific ignore file BuildKit honours for -f deploy/Dockerfile, so
 # it selects what enters the protected build context and must be drift-checked.


### PR DESCRIPTION
Closes #1057

## What changes

**Derive, don't pin.** `image-publish.yml` and the CI Promotion Pin Gate no longer carry a hand-pasted `CANDIDATE_VERSION / SHA / DIGEST` triple. Both derive the candidate from the tree: version from `packages/cli/package.json`, source SHA from the immutable `refs/tags/v<version>`, digest from the registry alias for that tag. The digest is accepted only when GitHub provenance binds it to that SHA with `image-build.yml` as the signer, so a moved alias or foreign image fails exactly as a wrong pasted digest did. Ancestor walk, tag ruleset, build-input drift, release asset, cosign, and npm checks are unchanged. The gate additionally requires `.well-known/latest.json` to pin the promoted version.

**Automate the remaining pin.** New `pin-candidate.yml` (dispatch-only, read-only `github.token`) re-verifies a minted candidate from public state (tag, attested alias, public stable release) and commits `chore(release): pin candidate v<version>` directly to `dev`: `.well-known/{latest,dev}.json` and Helm `image.tag`. Direct push with `VERSION_BUMP_PAT` under the `version-dev` concurrency group, same as `version.yml`'s bump; a PR would trigger the merged-PR bump and move dev past the candidate again. It refuses a candidate dev has already moved past. `image-build.yml` dispatches it after the npm step (warning, not failure, until the file reaches `main`).

**npm race.** `reconcile-npm-stable.sh` polls the registry for ~15 minutes of backoff (was 15 seconds) and polls the tarball URL the same way, since `curl --retry` does not cover a propagating 404. Test asserts ≥10 minutes of accumulated backoff.

**Receipt before npm.** `image-build.yml` writes the candidate receipt as soon as the stable release exists, before the npm publish step.

**Refuse prerelease tags early.** `image-build.yml` looks up the release in its first step and refuses a dev prerelease with the `candidate=true` hint before checkout and the multi-arch build. The post-wait check in `finalize` stays.

**Contract test + docs** updated together: literal candidate pins removed from `release-workflow-contract.test.sh`; it now requires the derived-identity steps, the early refusal, the receipt ordering, and the shape of `pin-candidate.yml`. `docs/deployment/public-launch-readiness.md` documents the one true path.

## Bootstrap note

`gh workflow run pin-candidate.yml` resolves the workflow on the default branch, so the first mint after this lands will print the manual dispatch command as a warning; run it once by hand, then it is automatic.

## Verification

- `make check` green (typecheck, lint, dead-code, migrations, versions, 708 tests)
- every `scripts/release/*.test.sh` passes except `verify-release-source.test.sh`, untouched here and failing locally only because git's default-branch config collides with its `main` fixture
- actionlint 1.7.7 clean on all workflows
- pin writer dry-run against the real `.well-known/*.json` and `values.yaml` produced the expected 3-value diff and was reverted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated workflow for validating and pinning release candidates to the development channel.
  - Release candidates now undergo stronger checks for source, image, attestation, and public release consistency.

- **Bug Fixes**
  - Improved release publishing reliability by retrying registry synchronization for up to approximately 15 minutes.
  - Prevented duplicate or invalid development prerelease tags from progressing through the release process.

- **Documentation**
  - Updated public launch-readiness guidance to reflect the current release and promotion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->