### PR TITLE
fix(events): honor chatId filter on events list and stream

### DIFF
--- a/packages/api/src/__tests__/events.test.ts
+++ b/packages/api/src/__tests__/events.test.ts
@@ -11,7 +11,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { NotFoundError } from '@omni/core';
 import type { Database, NewOmniEvent } from '@omni/db';
-import { omniEvents } from '@omni/db';
+import { chats, omniEvents } from '@omni/db';
 import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { createServices } from '../services';
@@ -352,6 +352,40 @@ describeWithDb('Events API Routes', () => {
   }
 
   describe('GET /events', () => {
+    test('filters by chatId (chat UUID) and returns no rows from other chats (#1055)', async () => {
+      const [wanted] = await db
+        .insert(chats)
+        .values({ externalId: `chat-a-${Date.now()}`, chatType: 'group', channel: 'discord' })
+        .returning();
+      const [other] = await db
+        .insert(chats)
+        .values({ externalId: `chat-b-${Date.now()}`, chatType: 'dm', channel: 'discord' })
+        .returning();
+      if (!wanted || !other) throw new Error('chat fixtures not inserted');
+      try {
+        await insertTestEvent(createTestEvent({ chatUuid: wanted.id, textContent: 'wanted-1' }));
+        await insertTestEvent(createTestEvent({ chatUuid: wanted.id, textContent: 'wanted-2' }));
+        await insertTestEvent(createTestEvent({ chatUuid: other.id, textContent: 'other' }));
+        await insertTestEvent(createTestEvent({ chatUuid: null, textContent: 'orphan' }));
+
+        const res = await app.request(`/events?chatId=${wanted.id}&limit=50`);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { items: Array<{ chatUuid: string | null }> };
+        expect(body.items.length).toBe(2);
+        for (const event of body.items) {
+          expect(event.chatUuid).toBe(wanted.id);
+        }
+
+        const none = await app.request('/events?chatId=00000000-0000-4000-8000-000000000000&limit=50');
+        expect(((await none.json()) as { items: unknown[] }).items).toEqual([]);
+      } finally {
+        for (const id of insertedEventIds) await db.delete(omniEvents).where(eq(omniEvents.id, id));
+        insertedEventIds = [];
+        await db.delete(chats).where(eq(chats.id, wanted.id));
+        await db.delete(chats).where(eq(chats.id, other.id));
+      }
+    });
+
     test('returns events list', async () => {
       const res = await app.request('/events?limit=10');
       expect(res.status).toBe(200);

--- a/packages/api/src/routes/v2/events.ts
+++ b/packages/api/src/routes/v2/events.ts
@@ -53,6 +53,7 @@ const listQuerySchema = z.object({
     .transform((v) => v?.split(',') as z.infer<typeof ChannelTypeSchema>[] | undefined),
   instanceId: z.string().uuid().optional(),
   personId: z.string().uuid().optional(),
+  chatId: z.string().uuid().optional(),
   eventType: z
     .string()
     .optional()

--- a/packages/api/src/schemas/openapi/events.ts
+++ b/packages/api/src/schemas/openapi/events.ts
@@ -122,6 +122,7 @@ export function registerEventSchemas(registry: OpenAPIRegistry): void {
         channel: z.string().optional().openapi({ description: 'Channel types (comma-separated)' }),
         instanceId: z.string().uuid().optional().openapi({ description: 'Filter by instance' }),
         personId: z.string().uuid().optional().openapi({ description: 'Filter by person' }),
+        chatId: z.string().uuid().optional().openapi({ description: 'Filter by chat UUID' }),
         eventType: z.string().optional().openapi({ description: 'Event types (comma-separated)' }),
         contentType: z.string().optional().openapi({ description: 'Content types (comma-separated)' }),
         direction: z.enum(['inbound', 'outbound']).optional().openapi({ description: 'Direction' }),

--- a/packages/api/src/services/events.ts
+++ b/packages/api/src/services/events.ts
@@ -18,6 +18,8 @@ export interface ListEventsOptions {
   instanceId?: string;
   instanceIds?: string[];
   personId?: string;
+  /** Chat UUID (omni_events.chat_uuid), not the platform chat id. */
+  chatId?: string;
   eventType?: EventType[];
   contentType?: ContentType[];
   direction?: 'inbound' | 'outbound';
@@ -93,6 +95,7 @@ export class EventService {
       channel,
       instanceId,
       personId,
+      chatId,
       eventType,
       contentType,
       direction,
@@ -117,6 +120,11 @@ export class EventService {
 
     if (personId) {
       conditions.push(eq(omniEvents.personId, personId));
+    }
+
+    if (chatId) {
+      // #1055: filter on the chats FK, not the raw platform chatId column.
+      conditions.push(eq(omniEvents.chatUuid, chatId));
     }
 
     if (eventType?.length) {

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -639,6 +639,7 @@ async function fetchStreamBatch(
       instanceId: filters.instanceId,
       channel,
       eventType: type,
+      chatId: filters.chatId,
       since: sinceIso,
       limit: 100,
     });
@@ -1109,17 +1110,13 @@ export function createEventsCommand(): Command {
 
         try {
           const instanceId = options.instance ? await resolveInstanceId(options.instance) : undefined;
-          // Note: chatId resolution added, but SDK doesn't support it yet
-          // This will be a no-op until the SDK is updated
-          if (options.chatId) {
-            await resolveChatId(options.chatId);
-          }
+          const chatId = options.chatId ? await resolveChatId(options.chatId) : undefined;
 
           const result = await client.events.list({
             instanceId,
             channel: options.channel,
             eventType: options.type,
-            // chatId parameter not yet supported by SDK
+            chatId,
             since: options.since ? parseSinceTime(options.since) : undefined,
             until: options.until,
             limit: options.limit,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -340,6 +340,9 @@ export interface SendMessageBody {
 export interface ListEventsParams {
   channel?: string;
   instanceId?: string;
+  personId?: string;
+  /** Chat UUID */
+  chatId?: string;
   eventType?: string;
   since?: string;
   until?: string;

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -10581,6 +10581,7 @@ export interface operations {
                 channel?: string;
                 instanceId?: string;
                 personId?: string;
+                chatId?: string;
                 eventType?: string;
                 contentType?: string;
                 direction?: "inbound" | "outbound";


### PR DESCRIPTION
Closes #1055

## Root cause
`omni events list --chat-id` resolved the chat but never sent it. `events stream` filtered client-side only after fetching an unfiltered page, so with a limit of 100 the wanted rows were routinely pushed out. The filter was missing at every layer: SDK `ListEventsParams`, the API `GET /events` Zod query schema, and `EventsService.list()`.

## Fix
- **API service**: new `chatId` option filters on `omni_events.chat_uuid` (the chats FK, not the raw platform `chat_id` column).
- **API route + OpenAPI**: `chatId` (UUID) accepted on `GET /events`. Unknown UUID returns empty, not unfiltered.
- **SDK**: `chatId` and `personId` on `ListEventsParams`, generated types updated.
- **CLI**: `events list` and the `stream`/`wait` fetch now pass `chatId` server-side.

## Test
Regression test in `packages/api/src/__tests__/events.test.ts` inserts events for two chats plus one with null `chatUuid`, then asserts every returned row's `chatUuid` matches the requested chat and that an unknown UUID returns `[]`. Verified failing without the service fix, passing with it, on a migrated disposable PostgreSQL.

`make check` green (typecheck, lint, dead-code, verify-migrations, verify-versions, test: 26/26 tasks).