### PR TITLE
fix(channels): journal own-device edit/delete echoes as outbound

### DIFF
--- a/packages/channel-discord/src/plugin.ts
+++ b/packages/channel-discord/src/plugin.ts
@@ -1638,6 +1638,8 @@ export class DiscordPlugin extends BaseChannelPlugin {
         deletedMessageId: messageId,
         deletedAt: Date.now(),
         deletedByMe: fromMe,
+        // #1062: persistence journals rawPayload.isFromMe=true echoes as outbound.
+        isFromMe: fromMe,
       },
     });
 

--- a/packages/channel-whatsapp/src/__tests__/delete-echo.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/delete-echo.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Own-device edit/delete echoes must carry rawPayload.isFromMe so the
+ * persistence layer journals them as outbound, like regular echoes (#1034, #1062).
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { WhatsAppPlugin } from '../plugin';
+
+function createMockEventBus() {
+  const published: Array<{ type: string; payload: { rawPayload?: Record<string, unknown> } }> = [];
+  return {
+    published,
+    publish: mock(async (type: string, payload: unknown) => {
+      published.push({ type, payload: payload as { rawPayload?: Record<string, unknown> } });
+      return 'mock-correlation-id';
+    }),
+    subscribe: mock(async () => ({ unsubscribe: async () => {} })),
+  };
+}
+
+function createPlugin(eventBus: ReturnType<typeof createMockEventBus>): WhatsAppPlugin {
+  const plugin = new WhatsAppPlugin();
+  const noop = () => {};
+  const logger = { debug: noop, info: noop, warn: noop, error: noop };
+  plugin.initialize({
+    eventBus: eventBus as never,
+    logger: { ...logger, child: () => logger } as never,
+    storage: {} as never,
+    config: {} as never,
+    db: {} as never,
+  });
+  return plugin;
+}
+
+describe('Own-device edit/delete echoes carry isFromMe (#1062)', () => {
+  let eventBus: ReturnType<typeof createMockEventBus>;
+  let plugin: WhatsAppPlugin;
+
+  beforeEach(() => {
+    eventBus = createMockEventBus();
+    plugin = createPlugin(eventBus);
+  });
+
+  it.each([true, false])('handleMessageDeleted(fromMe=%p) sets rawPayload.isFromMe', async (fromMe) => {
+    await plugin.handleMessageDeleted('instance-1', 'ext-123', 'chat-456@s.whatsapp.net', fromMe);
+    const [event] = eventBus.published;
+    expect(event?.type).toBe('message.received');
+    expect(event?.payload.rawPayload?.isFromMe).toBe(fromMe);
+    expect(event?.payload.rawPayload?.deletedByMe).toBe(fromMe);
+  });
+
+  it.each([true, false])('handleMessageEdited(fromMe=%p) sets rawPayload.isFromMe', async (fromMe) => {
+    await plugin.handleMessageEdited('instance-1', 'ext-123', 'chat-456@s.whatsapp.net', 'new text', fromMe);
+    const [event] = eventBus.published;
+    expect(event?.type).toBe('message.received');
+    expect(event?.payload.rawPayload?.isFromMe).toBe(fromMe);
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -807,6 +807,7 @@ async function handleSpecialMessage(
       content.targetMessageId,
       chatId,
       content.editedText || content.text || '',
+      isFromMe(msg),
     );
     return true;
   }
@@ -1168,7 +1169,13 @@ export function setupMessageHandlers(
           null;
 
         if (newText) {
-          await plugin.handleMessageEdited(instanceId, update.key.id || '', update.key.remoteJid || '', newText);
+          await plugin.handleMessageEdited(
+            instanceId,
+            update.key.id || '',
+            update.key.remoteJid || '',
+            newText,
+            update.key.fromMe || false,
+          );
         }
       }
     }

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3270,7 +3270,13 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
    * Handle message edited
    * @internal
    */
-  async handleMessageEdited(instanceId: string, externalId: string, chatId: string, newText: string): Promise<void> {
+  async handleMessageEdited(
+    instanceId: string,
+    externalId: string,
+    chatId: string,
+    newText: string,
+    fromMe = false,
+  ): Promise<void> {
     // Emit as a special message.received event with type 'edit'
     await this.emitMessageReceived({
       instanceId,
@@ -3285,6 +3291,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         editedMessageId: externalId,
         newText,
         editedAt: Date.now(),
+        // #1062: persistence journals rawPayload.isFromMe=true echoes as outbound.
+        isFromMe: fromMe,
       },
     });
 
@@ -3308,6 +3316,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         deletedMessageId: externalId,
         deletedAt: Date.now(),
         deletedByMe: fromMe,
+        // #1062: persistence journals rawPayload.isFromMe=true echoes as outbound.
+        isFromMe: fromMe,
       },
     });
 


### PR DESCRIPTION
Closes #1062 (scope gap of #1034 / PR #1043).

## Root cause
`event-persistence.ts` maps `rawPayload.isFromMe === true` to `direction: 'outbound'`, but `handleMessageDeleted` only emitted `deletedByMe`, and `handleMessageEdited` emitted no ownership flag at all. So own-device deletions journaled as `inbound`.

## Fix
- WhatsApp + Discord `handleMessageDeleted`: add `isFromMe: fromMe` to `rawPayload` (`deletedByMe` kept for compat).
- WhatsApp `handleMessageEdited`: new optional `fromMe` param, passed from both callers (protocolMessage path via `isFromMe(msg)`, `messages.update` via `key.fromMe`).
- Reactions already carried `isFromMe`; no change.

## Test
`packages/channel-whatsapp/src/__tests__/delete-echo.test.ts` asserts delete/edit echoes carry `rawPayload.isFromMe` for both `fromMe` values.

## Validation
- typecheck, lint, dead-code, verify-migrations, verify-versions: green
- channel-whatsapp (405) and channel-discord (214) suites: green
- `make test` DB sync step skipped in this worktree (no `.env`); no DB-backed test touched.