### PR TITLE
fix(channels): unwrap WhatsApp editedMessage envelope and persist edits on the original message

### DIFF
--- a/packages/api/src/plugins/__tests__/message-persistence-edit.test.ts
+++ b/packages/api/src/plugins/__tests__/message-persistence-edit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Message edit persistence (#1061).
+ *
+ * WhatsApp/Discord journal an edit as `content.type: 'edit'` under a fresh
+ * externalId with `rawPayload.editedMessageId` naming the original; the edit
+ * must land on the original row's edit history. Telegram re-uses the original
+ * externalId and flags `rawPayload.isEdited`.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { Services } from '../../services';
+import { maybeRecordMessageEdit } from '../message-persistence';
+
+function harness(found: boolean) {
+  const recordEdit = mock(async () => ({}));
+  const getByExternalId = mock(async () => (found ? { id: 'orig-uuid' } : null));
+  const services = { messages: { getByExternalId, recordEdit } } as unknown as Services;
+  return { services, recordEdit, getByExternalId };
+}
+
+const AT = new Date('2026-09-10T00:00:00Z');
+
+describe('maybeRecordMessageEdit', () => {
+  test("'edit' event applies the new text to the original message via editedMessageId", async () => {
+    const h = harness(true);
+    await maybeRecordMessageEdit(
+      h.services,
+      true,
+      { editedMessageId: 'ORIG123', editedAt: 1_700_000_000_000 },
+      'chat-1',
+      'edit-row-uuid',
+      'edit',
+      'corrected text',
+      AT,
+      '5511888888888',
+    );
+    expect(h.getByExternalId).toHaveBeenCalledWith('chat-1', 'ORIG123');
+    expect(h.recordEdit).toHaveBeenCalledWith(
+      'orig-uuid',
+      'corrected text',
+      new Date(1_700_000_000_000),
+      '5511888888888',
+    );
+  });
+
+  test("'edit' event whose original is unknown is a no-op", async () => {
+    const h = harness(false);
+    await maybeRecordMessageEdit(h.services, true, { editedMessageId: 'NOPE' }, 'chat-1', 'x', 'edit', 't', AT, 'u');
+    expect(h.recordEdit).not.toHaveBeenCalled();
+  });
+
+  test('Telegram isEdited on an existing row records the edit on that row', async () => {
+    const h = harness(true);
+    await maybeRecordMessageEdit(h.services, false, { isEdited: true }, 'chat-1', 'row-uuid', 'text', 'new', AT, 'u');
+    expect(h.getByExternalId).not.toHaveBeenCalled();
+    expect(h.recordEdit).toHaveBeenCalledWith('row-uuid', 'new', AT, 'u');
+  });
+
+  test('a freshly created ordinary message is not an edit', async () => {
+    const h = harness(true);
+    await maybeRecordMessageEdit(h.services, true, {}, 'chat-1', 'row-uuid', 'text', 'hi', AT, 'u');
+    expect(h.recordEdit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -649,21 +649,39 @@ async function maybeFindOrCreateParticipant(
   });
 }
 
-async function maybeRecordMessageEdit(
+export async function maybeRecordMessageEdit(
   services: Services,
   created: boolean,
   rawPayload: Record<string, unknown> | undefined,
+  chatId: string,
   messageId: string,
+  contentType: string,
   newText: string | undefined,
   platformTimestamp: Date,
   from: string | undefined,
 ): Promise<void> {
+  const editedBy = truncate(from, 255) ?? undefined;
+
+  // WhatsApp/Discord: a `content.type === 'edit'` event under a fresh externalId that
+  // names the original in rawPayload.editedMessageId (#1061).
+  if (contentType === 'edit') {
+    const targetExternalId = rawPayload?.editedMessageId;
+    if (typeof targetExternalId !== 'string') return;
+    const target = await services.messages.getByExternalId(chatId, targetExternalId);
+    if (!target) return;
+    const editedAtMs = rawPayload?.editedAt;
+    const editedAt = new Date(typeof editedAtMs === 'number' ? editedAtMs : platformTimestamp.getTime());
+    await services.messages.recordEdit(target.id, newText ?? '', editedAt, editedBy);
+    return;
+  }
+
+  // Telegram: the edit re-uses the original externalId and flags rawPayload.isEdited.
   if (created) return;
   if (rawPayload?.isEdited !== true) return;
 
   const editedAtMs = rawPayload.editDate;
   const editedAt = new Date(typeof editedAtMs === 'number' ? editedAtMs : platformTimestamp.getTime());
-  await services.messages.recordEdit(messageId, newText ?? '', editedAt, truncate(from, 255) ?? undefined);
+  await services.messages.recordEdit(messageId, newText ?? '', editedAt, editedBy);
 }
 
 async function maybeRecordParticipantActivity(
@@ -686,7 +704,7 @@ function maybeUpdateRecency(
   trustedTenantId: string | null,
 ): void {
   // Edits should not bump recency.
-  if (rawPayload?.isEdited === true) return;
+  if (rawPayload?.isEdited === true || payload.content.type === 'edit') return;
 
   const preview = sanitizeText(buildChatPreview(payload, rawPayload)) ?? '';
   const isFromMe = rawPayload?.isFromMe === true;
@@ -976,7 +994,9 @@ async function handleMessageReceived(
     services,
     created,
     rawPayload,
+    chat.id,
     message.id,
+    payload.content.type,
     sanitizeText(payload.content.text) ?? undefined,
     platformTimestamp ?? new Date(eventTimestamp),
     payload.from,

--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -302,6 +302,43 @@ describe('extractContent — bot-interactive messages (omni#902)', () => {
     expect(content?.text).toBe('Sem mídia\n[Ok]');
   });
 
+  it('unwraps the Baileys editedMessage envelope into an edit with its new text (#1061)', () => {
+    const content = extractContent(
+      wrap({
+        editedMessage: {
+          message: {
+            protocolMessage: {
+              key: { id: 'ORIG123', remoteJid: '5511999998888@s.whatsapp.net', fromMe: false },
+              type: 14,
+              editedMessage: { conversation: 'corrected text' },
+            },
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('edit');
+    expect(content?.targetMessageId).toBe('ORIG123');
+    expect(content?.editedText).toBe('corrected text');
+  });
+
+  it('edited media caption is carried as the edit text (#1061)', () => {
+    const content = extractContent(
+      wrap({
+        editedMessage: {
+          message: {
+            protocolMessage: {
+              key: { id: 'ORIG456' },
+              type: 14,
+              editedMessage: { imageMessage: { caption: 'new caption' } },
+            },
+          },
+        },
+      }),
+    );
+    expect(content?.type).toBe('edit');
+    expect(content?.editedText).toBe('new caption');
+  });
+
   it('unknown payloads carry no placeholder text (#1041)', () => {
     const content = extractContent(wrap({ secretEncryptedMessage: { encIv: 'x' } }));
     expect(content?.type).toBe('unknown');

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -91,6 +91,18 @@ interface ExtractedContent {
 type MessageContent = proto.IMessage;
 type ContentExtractor = (message: MessageContent) => ExtractedContent | null;
 
+/** New text of an edit: body of a text message, or the caption of a media message. */
+function extractEditedText(edited: MessageContent | null | undefined): string | undefined {
+  return (
+    edited?.conversation ||
+    edited?.extendedTextMessage?.text ||
+    edited?.imageMessage?.caption ||
+    edited?.videoMessage?.caption ||
+    edited?.documentMessage?.caption ||
+    undefined
+  );
+}
+
 /** Join non-empty, trimmed parts with newlines; undefined when nothing survives. */
 function joinLines(...parts: Array<string | null | undefined>): string | undefined {
   const text = parts.filter((p): p is string => typeof p === 'string' && p.trim().length > 0).join('\n');
@@ -386,8 +398,7 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
         return {
           type: 'edit' as ContentType,
           targetMessageId: proto?.key?.id ?? undefined,
-          editedText:
-            proto?.editedMessage?.conversation || proto?.editedMessage?.extendedTextMessage?.text || undefined,
+          editedText: extractEditedText(proto?.editedMessage),
         };
       }
 
@@ -501,6 +512,23 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
         }
       }
       return null; // Can't extract inner content
+    },
+  },
+  // Edited message (FutureProofMessage wrapper). Baileys delivers an incoming edit as
+  // `editedMessage.message.protocolMessage` (type 14); without this unwrap it fell through
+  // to extractUnknownContent and the new text was lost (#1061).
+  {
+    check: (m) => !!m.editedMessage,
+    extract: (m) => {
+      const innerMsg = m.editedMessage?.message as MessageContent | undefined;
+      if (innerMsg) {
+        for (const { check, extract } of contentExtractors.slice(0, -1)) {
+          if (check(innerMsg)) {
+            return extract(innerMsg);
+          }
+        }
+      }
+      return null;
     },
   },
   // Ephemeral message (disappearing messages wrapper - FutureProofMessage)
@@ -1157,20 +1185,8 @@ export function setupMessageHandlers(
         await processStatusUpdate(plugin, instanceId, update.key, update.update.status);
       }
 
-      // Handle message edits
-      if (update.update.message) {
-        const editedContent = update.update.message;
-        const newText =
-          editedContent.conversation ||
-          editedContent.extendedTextMessage?.text ||
-          editedContent.imageMessage?.caption ||
-          editedContent.videoMessage?.caption ||
-          null;
-
-        if (newText) {
-          await plugin.handleMessageEdited(instanceId, update.key.id || '', update.key.remoteJid || '', newText);
-        }
-      }
+      // Message edits are NOT handled here: the same edit also arrives via messages.upsert
+      // as an `editedMessage` envelope, which extractContent unwraps (#1061).
     }
   });
 


### PR DESCRIPTION
Closes #1061

## Root cause
Baileys delivers an incoming edit wrapped in a `FutureProofMessage` envelope: `message.editedMessage.message.protocolMessage` (type 14, `editedMessage` = new content). `extractContent` had unwraps for `ephemeralMessage` and `viewOnceMessage` but not `editedMessage`, so every edit fell through to `extractUnknownContent`. Before #1053 that journaled `Unknown message type: editedMessage`; after #1053 it journals `contentType: unknown` with empty text. #1053 changed the symptom, not the cause.

The `messages.update` edit branch was dead for the same reason: Baileys emits `update.message.editedMessage.message`, and the branch read `update.message.conversation` at the top level, so `newText` was always null.

Telegram (`edited_message` → same externalId + `rawPayload.isEdited`) and Discord (`messageUpdate` → `handleMessageEdited`) were already correct at the plugin layer.

## Fix
- `channel-whatsapp` `extractContent`: unwrap the `editedMessage` envelope, delegating to the existing `protocolMessage` extractor, which returns `{ type: 'edit', targetMessageId, editedText }`. `editedText` now also covers image/video/document caption edits.
- `channel-whatsapp` `messages.update`: removed the dead edit branch (the same edit arrives via `messages.upsert`; keeping both would double-emit).
- `message-persistence` `maybeRecordMessageEdit`: a `content.type === 'edit'` event (WhatsApp/Discord, fresh externalId + `rawPayload.editedMessageId`) now applies `recordEdit` to the original message row, so `textContent`, `editCount`, `originalText`, `editHistory` work for these channels too. Telegram's `isEdited` path is unchanged. Edit events no longer bump chat/instance recency.

Result: an edit journals `message.received` with `contentType: edit`, the new text in `textContent`, and the target id in `rawPayload.editedMessageId`; the original message row carries the edit history.

Not changed: a dedicated `message.edited` event type (the issue lists the `contentType: edit` shape as the minimal acceptable outcome; taxonomy follow-up can build on this).

## Tests
- `extract-content.test.ts`: `editedMessage` envelope → `edit` with `targetMessageId` and new text; caption edit variant.
- `message-persistence-edit.test.ts`: `edit` event applies to the original via `editedMessageId`; unknown original is a no-op; Telegram `isEdited` path; ordinary new message is not an edit.

## Verification
`make check` green: typecheck, biome, verify-migrations, full test suite (708 tests).