### PR TITLE
fix(events): journal reaction.received/removed in omni_events

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -77,6 +77,8 @@ describeWithDb('Event Persistence Handler', () => {
       expect(subscriptions.has('message.delivered')).toBe(true);
       expect(subscriptions.has('message.read')).toBe(true);
       expect(subscriptions.has('message.failed')).toBe(true);
+      expect(subscriptions.has('reaction.received')).toBe(true);
+      expect(subscriptions.has('reaction.removed')).toBe(true);
     });
   });
 
@@ -542,6 +544,38 @@ describeWithDb('Event Persistence Handler', () => {
 
       expect(created).toBeDefined();
       expect(created?.eventType).toBe('message.delivered');
+    });
+  });
+
+  // #1059: reactions live on the REACTION stream; after #1045 dropped the
+  // message.received dual-emit they were never journaled at all.
+  describe('reaction handlers', () => {
+    test.each(['reaction.received', 'reaction.removed'] as const)('journals %s as an omni_events row', async (type) => {
+      await setupEventPersistence(mockEventBus, db);
+
+      const eventId = randomUUID();
+      await emitEvent(type, {
+        id: eventId,
+        type,
+        timestamp: Date.now(),
+        payload: {
+          messageId: `ext-reaction-target-${type}`,
+          chatId: 'chat-123',
+          from: 'user-456',
+          emoji: type === 'reaction.received' ? '👍' : '',
+          rawPayload: { externalId: 'ext-reaction-msg', isFromMe: false },
+        },
+        metadata: { correlationId: 'corr-reaction', instanceId: null, channelType: 'whatsapp-baileys' },
+      });
+
+      const [persisted] = await db.select().from(omniEvents).where(eq(omniEvents.id, eventId)).limit(1);
+      expect(persisted).toBeDefined();
+      expect(persisted?.eventType).toBe(type);
+      expect(persisted?.externalId).toBe(`ext-reaction-target-${type}`);
+      expect(persisted?.contentType).toBe('reaction');
+      expect(persisted?.direction).toBe('inbound');
+      expect(persisted?.chatId).toBe('chat-123');
+      expect(persisted?.metadata).toMatchObject({ from: 'user-456' });
     });
   });
 

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -19,7 +19,7 @@
  * BEFORE INSERT derivation trigger, so no column is added here.
  */
 
-import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
+import type { EventBus, MessageReceivedPayload, MessageSentPayload, ReactionReceivedPayload } from '@omni/core';
 import { JOURNEY_STAGES, createLogger, getJourneyTracker, isValidUuid } from '@omni/core';
 import type { Database, NewOmniEvent } from '@omni/db';
 import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents, persons } from '@omni/db';
@@ -460,6 +460,54 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
       },
       { ...CONSUMER_OPTIONS, durable: 'event-persistence-failed' },
     );
+
+    // Subscribe to reaction.received / reaction.removed (#1059). Reactions
+    // live on the REACTION stream, not MESSAGE, so none of the subscribers
+    // above ever saw them; once #1045 stopped dual-emitting them as
+    // message.received they vanished from the journal entirely. Each gets its
+    // own row (a reaction is a fact, not a mutation of the target row):
+    // externalId is the target message id so --message filters still match.
+    for (const type of ['reaction.received', 'reaction.removed'] as const) {
+      await eventBus.subscribe(
+        type,
+        async (event) => {
+          const payload = event.payload as ReactionReceivedPayload;
+          const metadata = event.metadata;
+          try {
+            await runConsumerInTenantContext(db, event, async () => {
+              const sdb = scopedHandle(db);
+              const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
+              const personId = await resolvePersonId(sdb, metadata.personId);
+              const newEvent: NewOmniEvent = {
+                ...eventIdInsert(event.id),
+                externalId: payload.messageId,
+                channel: mapChannelType(metadata.channelType),
+                instanceId: metadata.instanceId,
+                personId,
+                eventType: type,
+                chatId: payload.chatId,
+                contentType: 'reaction',
+                textContent: sanitizeText(payload.emoji),
+                // #1034 convention: own-account reactions (from the phone) are outbound
+                direction: payload.rawPayload?.isFromMe === true ? 'outbound' : 'inbound',
+                status: 'completed',
+                receivedAt: new Date(event.timestamp),
+                rawPayload: deepSanitize({ ...payload, rawPayload: payload.rawPayload ?? null }),
+                metadata: { correlationId: metadata.correlationId, from: payload.from, emoji: payload.emoji },
+                causationId: metadata.causationId ?? null,
+                conversationId: null,
+                ...chatLink,
+              };
+              await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+            });
+            log.debug(`Persisted ${type}`, { messageId: payload.messageId, emoji: payload.emoji });
+          } catch (error) {
+            log.error(`Failed to persist ${type}`, { messageId: payload.messageId, error: String(error) });
+          }
+        },
+        { ...CONSUMER_OPTIONS, durable: `event-persistence-${type.replace('.', '-')}` },
+      );
+    }
 
     // Subscribe to ALL custom events (#957). Webhook ingress roots and
     // automation emit_event hops live on the CUSTOM stream but were never


### PR DESCRIPTION
Closes #1059.

## Root cause
Reactions publish on the NATS `REACTION` stream (`reaction.>`), and `event-persistence.ts` only subscribed to `message.*` and `custom.>`. Before #1045 reactions still reached the journal through the `message.received` dual-emit; once that was removed, inbound reactions produced no `omni_events` row at all. The publish succeeded, the stream retained it, and nothing consumed it, so no dead-letter either.

Trace: `handleReactionReceived` → `emitReactionReceived` → `eventBus.publish('reaction.received')` → subject `reaction.received.{channel}.{instance}` on `REACTION` → `message-persistence` (attaches emoji to the message row, added in #1045) → **no `event-persistence` consumer** → no journal row.

## Fix
- `event-persistence` subscribes to `reaction.received` and `reaction.removed` (durables `event-persistence-reaction-received` / `-removed`, `startFrom: first` like the other message consumers) and journals each as its own row: `contentType: 'reaction'`, `externalId` = target message id, emoji in `text_content`, `from` in metadata, own-phone reactions journaled as outbound per the #1034 convention.
- Regression test: publishes both reaction types through the handler and asserts the `omni_events` row (real PostgreSQL suite, `describeWithDb`).

## Verification
- `make typecheck`, `make lint`, `make dead-code`, `make verify-migrations`, `make verify-versions`: green
- `bun run test` (turbo, 26 tasks): green
- `event-persistence.test.ts` on a migrated disposable cluster: 18 pass, 0 fail
- `make test-pg-gate-warm`: 395/396; the one failure is the pre-existing `upgrade-2.260902.5-to-2.260908.20` webhook_sources catalog fingerprint, unrelated to this change