### PR TITLE
feat(events): publish system.connector.stalled on the bus instead of the DLQ

### DIFF
--- a/docs/architecture/connector-contract.md
+++ b/docs/architecture/connector-contract.md
@@ -56,10 +56,10 @@ are persisted with guarded updates (`WHERE liveness_status = <previous>`), so:
   `send_message` action).
 - The unhealthy state is visible as `livenessStatus` in
   `GET /webhook-sources` / `omni webhooks list` (health column) and get/detail.
-- A stalled transition also files a **dead-letter entry** (manual-resolution
-  only, no auto-retry — retrying would republish the emitted-once event);
-  recovery auto-resolves it. This is the "zero-emission dead-letter": a dead
-  connector surfaces on the ops surface, not only in a log.
+- Both transitions are **journaled** like custom events (#1063), so
+  `omni events list --type 'system.connector.*'`, `omni events trace`, and
+  `omni events wait` see them. A stall is an alert, not a delivery failure —
+  it never lands in the dead-letter queue.
 
 Payloads are Zod-registered in `SystemEventSchemas`
 (`packages/core/src/events/nats/registry.ts`). `recoveredBy` on the recovered

--- a/docs/runbooks/clickup-webhook-source.md
+++ b/docs/runbooks/clickup-webhook-source.md
@@ -33,7 +33,7 @@ Every delivery ClickUp sends to `POST /api/v2/webhooks/ingress/clickup` is:
    the stable per-event history id, so a retry acks with `duplicate: true`
    and exactly ONE journal event (issue #958);
 5. **supervised** — a declared cadence means silence beyond the window emits
-   `system.connector.stalled` + a DLQ entry instead of failing silently
+   `system.connector.stalled` on the bus instead of failing silently
    (issue #961, see [[../architecture/connector-contract|Connector Lifecycle Contract]]).
 
 ## Prerequisites
@@ -194,8 +194,8 @@ omni webhooks heartbeat clickup
 ```
 
 Heartbeats create NO journal events — only the `system.connector.stalled` /
-`system.connector.recovered` **transitions** are journaled, once each, and a
-stall also files a manual-resolution dead-letter entry. Health is visible in
+`system.connector.recovered` **transitions** are journaled, once each
+(never as dead-letter entries — a stall is an alert, #1063). Health is visible in
 `omni webhooks list` / `omni webhooks get clickup` (`livenessStatus`). A
 stall is also your early warning that ClickUp auto-suspended the webhook
 (step 4).

--- a/docs/runbooks/github-webhook-source.md
+++ b/docs/runbooks/github-webhook-source.md
@@ -26,7 +26,7 @@ Every delivery GitHub sends to `POST /api/v2/webhooks/ingress/github` is:
    template makes every redelivery ack with `duplicate: true` and exactly ONE
    journal event (issue #958);
 5. **supervised** — a declared cadence means silence beyond the window emits
-   `system.connector.stalled` + a DLQ entry instead of failing silently
+   `system.connector.stalled` on the bus instead of failing silently
    (issue #961, see [[../architecture/connector-contract|Connector Lifecycle Contract]]).
 
 ## Prerequisites
@@ -179,8 +179,8 @@ jobs:
 
 (`omni webhooks heartbeat github` does the same from a cron box.) Heartbeats
 create NO journal events — only the `system.connector.stalled` /
-`system.connector.recovered` **transitions** are journaled, once each, and a
-stall also files a manual-resolution dead-letter entry. Health is visible in
+`system.connector.recovered` **transitions** are journaled, once each
+(never as dead-letter entries — a stall is an alert, #1063). Health is visible in
 `omni webhooks list` / `omni webhooks get github` (`livenessStatus`).
 
 ## Step 5 — a firing automation

--- a/packages/api/src/__tests__/connector-liveness.test.ts
+++ b/packages/api/src/__tests__/connector-liveness.test.ts
@@ -2,11 +2,10 @@
  * Connector liveness integration test (#961) — real PostgreSQL, short windows.
  *
  * Proves the acceptance flow end to end on the actual service + schema:
- *   declare a 1s cadence → go silent → sweep marks the source stalled, emits
- *   `system.connector.stalled` ONCE, files a manual-resolution DLQ entry →
+ *   declare a 1s cadence → go silent → sweep marks the source stalled and
+ *   emits `system.connector.stalled` ONCE on the bus (never the DLQ, #1063) →
  *   further sweeps stay silent → a heartbeat resets the window → the next
- *   sweep emits `system.connector.recovered` once and auto-resolves the DLQ
- *   entry.
+ *   sweep emits `system.connector.recovered` once.
  *
  * Uses the `describeWithDb` harness (follow-up sweeper precedent): skips
  * cleanly unless ENABLE_DB_TESTS=true and the test database is reachable.
@@ -110,15 +109,15 @@ describeWithDb('Connector liveness (integration, short windows)', () => {
   });
 
   test('a sweep within the window changes nothing', async () => {
-    await service.sweepLiveness({ deadLetters });
+    await service.sweepLiveness();
     expect(oursStalled()).toHaveLength(0);
     expect((await service.getById(source.id)).livenessStatus).toBe('healthy');
   });
 
-  test('silence beyond the window stalls once: event + unhealthy state + DLQ entry', async () => {
+  test('silence beyond the window stalls once: bus event + unhealthy state, no DLQ entry', async () => {
     await sleep(1300);
 
-    await service.sweepLiveness({ deadLetters });
+    await service.sweepLiveness();
 
     expect(oursStalled()).toHaveLength(1);
     const payload = oursStalled()[0]?.payload as { silentForSeconds: number; expectedIntervalSeconds: number };
@@ -129,20 +128,16 @@ describeWithDb('Connector liveness (integration, short windows)', () => {
     expect(row.livenessStatus).toBe('stalled');
     expect(row.stalledAt).toBeInstanceOf(Date);
 
-    // Zero-emission dead-letter: pending, manual-resolution only.
-    const entries = await ourDlqEntries();
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.status).toBe('pending');
-    expect(entries[0]?.nextAutoRetryAt).toBeNull();
-    expect(entries[0]?.error).toContain(SOURCE_NAME);
+    // #1063: a stall is an alert on the bus, not a delivery failure.
+    expect(oursStalled()[0]?.metadata?.source).toBe('connector-liveness');
+    expect(await ourDlqEntries()).toHaveLength(0);
   });
 
   test('further sweeps while still silent do not re-announce', async () => {
-    await service.sweepLiveness({ deadLetters });
-    await service.sweepLiveness({ deadLetters });
+    await service.sweepLiveness();
+    await service.sweepLiveness();
 
     expect(oursStalled()).toHaveLength(1);
-    expect(await ourDlqEntries()).toHaveLength(1);
   });
 
   test('a heartbeat resets the window without publishing anything', async () => {
@@ -158,8 +153,8 @@ describeWithDb('Connector liveness (integration, short windows)', () => {
     expect(row.heartbeatCount).toBe(1);
   });
 
-  test('the next sweep recovers once and auto-resolves the DLQ entry', async () => {
-    await service.sweepLiveness({ deadLetters });
+  test('the next sweep recovers once', async () => {
+    await service.sweepLiveness();
 
     expect(oursRecovered()).toHaveLength(1);
     const payload = oursRecovered()[0]?.payload as { recoveredBy: string };
@@ -169,11 +164,10 @@ describeWithDb('Connector liveness (integration, short windows)', () => {
     expect(row.livenessStatus).toBe('healthy');
     expect(row.stalledAt).toBeNull();
 
-    const entries = await ourDlqEntries();
-    expect(entries[0]?.status).toBe('resolved');
+    expect(await ourDlqEntries()).toHaveLength(0);
 
     // Recovered is emitted once too.
-    await service.sweepLiveness({ deadLetters });
+    await service.sweepLiveness();
     expect(oursRecovered()).toHaveLength(1);
   });
 });

--- a/packages/api/src/__tests__/consumer-config.test.ts
+++ b/packages/api/src/__tests__/consumer-config.test.ts
@@ -115,7 +115,7 @@ describe('Consumer startFrom Configuration', () => {
     expect(main?.value).toBe('new');
   });
 
-  test('event-persistence: message consumers use startFrom: first; custom journal consumer is forward-only', () => {
+  test('event-persistence: message consumers use startFrom: first; journal-only consumers are forward-only', () => {
     const values = extractStartFromValues(join(PLUGINS_DIR, 'event-persistence.ts'));
 
     expect(values.length).toBeGreaterThanOrEqual(1);
@@ -124,12 +124,16 @@ describe('Consumer startFrom Configuration', () => {
     // forward-only, and a 'first' durable would replay the entire CUSTOM
     // stream retention as journal rows that can never carry a causation
     // parent.
-    const custom = values.find((v) => v.context === 'event-persistence-custom');
-    expect(custom).toBeDefined();
-    expect(custom?.value).toBe('new');
+    // The connector liveness journal consumer (#1063) follows the same rule.
+    const forwardOnly = ['event-persistence-custom', 'event-persistence-connector'];
+    for (const context of forwardOnly) {
+      const entry = values.find((v) => v.context === context);
+      expect(entry).toBeDefined();
+      expect(entry?.value).toBe('new');
+    }
 
     for (const entry of values) {
-      if (entry.context === 'event-persistence-custom') continue;
+      if (forwardOnly.includes(entry.context)) continue;
       expect(entry.value).toBe('first');
     }
   });

--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -80,6 +80,37 @@ describeWithDb('Event Persistence Handler', () => {
     });
   });
 
+  describe('system.connector.> handler (#1063)', () => {
+    test('journals a connector stall alert so it is listable and traceable', async () => {
+      await setupEventPersistence(mockEventBus, db);
+      expect(subscriptions.has('system.connector.>')).toBe(true);
+
+      const eventId = randomUUID();
+      await emitEvent('system.connector.>', {
+        id: eventId,
+        type: 'system.connector.stalled',
+        payload: {
+          sourceId: randomUUID(),
+          sourceName: 'gmail-purchases',
+          expectedIntervalSeconds: 60,
+          lastReceivedAt: null,
+          lastHeartbeatAt: null,
+          silentForSeconds: 90,
+          stalledAt: Date.now(),
+        },
+        timestamp: Date.now(),
+        metadata: { correlationId: eventId, source: 'connector-liveness' },
+      });
+
+      const [row] = await db.select().from(omniEvents).where(eq(omniEvents.id, eventId));
+      await db.delete(omniEvents).where(eq(omniEvents.id, eventId));
+      expect(row?.eventType).toBe('system.connector.stalled');
+      expect(row?.channel).toBe('internal');
+      expect(row?.direction).toBe('internal');
+      expect((row?.rawPayload as { sourceName?: string })?.sourceName).toBe('gmail-purchases');
+    });
+  });
+
   describe('message.received handler', () => {
     test('persists message.received event to database', async () => {
       await setupEventPersistence(mockEventBus, db);

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -19,7 +19,7 @@
  * BEFORE INSERT derivation trigger, so no column is added here.
  */
 
-import type { EventBus, MessageReceivedPayload, MessageSentPayload } from '@omni/core';
+import type { EventBus, MessageReceivedPayload, MessageSentPayload, OmniEvent } from '@omni/core';
 import { JOURNEY_STAGES, createLogger, getJourneyTracker, isValidUuid } from '@omni/core';
 import type { Database, NewOmniEvent } from '@omni/db';
 import { type ChannelType, type ContentType, channelTypes, chats, contentTypes, omniEvents, persons } from '@omni/db';
@@ -474,74 +474,89 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
     // the column). chatUuid and personId are mapped best-effort from the
     // envelope metadata / payload (see the inline comment) so the CLI's
     // --chat-id / --person-id filters can match custom events too.
-    await eventBus.subscribePattern(
-      'custom.>',
-      async (event) => {
-        const metadata = event.metadata;
-        try {
-          await runConsumerInTenantContext(db, event, async () => {
-            const sdb = scopedHandle(db);
-            const payload =
-              typeof event.payload === 'object' && event.payload !== null
-                ? (event.payload as Record<string, unknown>)
-                : {};
-            const instanceId = metadata.instanceId && isValidUuid(metadata.instanceId) ? metadata.instanceId : null;
-            const payloadChatId = typeof payload.chatId === 'string' ? payload.chatId : undefined;
-
-            // #966: best-effort identity mapping so --chat-id/--person-id
-            // filters can match custom events. personId: metadata.personId
-            // (publisher claim) first, then payload.personId — either must
-            // reference an existing persons row (FK safety). chatUuid:
-            // payload.chatUuid (a chats.id UUID) first, then payload.chatId
-            // (a platform JID) resolved against the instance like the
-            // message subscribers do.
-            const personId =
-              (await resolvePersonId(sdb, metadata.personId)) ?? (await resolvePersonId(sdb, payload.personId));
-            const chatUuid = await resolveChatUuidById(sdb, payload.chatUuid);
-            const chatLink = chatUuid
-              ? { chatUuid, canonicalChatId: null }
-              : await resolveChatLink(sdb, instanceId ?? undefined, payloadChatId);
-
-            const newEvent: NewOmniEvent = {
-              ...eventIdInsert(event.id),
-              channel: 'internal',
-              instanceId,
-              personId,
-              eventType: event.type.slice(0, 255) as NewOmniEvent['eventType'],
-              direction: 'internal',
-              status: 'completed',
-              receivedAt: new Date(event.timestamp),
-              rawPayload: deepSanitize(payload),
-              metadata: {
-                correlationId: metadata.correlationId,
-                source: metadata.source,
-                fullEventType: event.type,
-              },
-              causationId: metadata.causationId ?? null,
-              conversationId: null,
-              chatId: payloadChatId,
-              ...chatLink,
-            };
-            await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
-          });
-        } catch (error) {
-          log.error('Failed to persist custom event', {
-            eventType: event.type,
-            eventId: event.id,
-            error: String(error),
-          });
-        }
-      },
-      // startFrom 'new', unlike the message subscribers: #957 is explicitly
-      // forward-only — replaying the whole CUSTOM stream retention on first
-      // deploy would journal thousands of historical events that can never
-      // carry a causation parent.
-      { ...CONSUMER_OPTIONS, durable: 'event-persistence-custom', startFrom: 'new' },
-    );
+    // #1063: connector liveness transitions (system.connector.stalled /
+    // recovered) are alerts, not delivery failures — journal them the same way
+    // so `omni events list --type 'system.connector.*'`, trace, and wait can see
+    // them instead of only the DLQ.
+    //
+    // startFrom 'new', unlike the message subscribers: #957 is explicitly
+    // forward-only — replaying the whole CUSTOM stream retention on first
+    // deploy would journal thousands of historical events that can never
+    // carry a causation parent.
+    await eventBus.subscribePattern('custom.>', (event) => journalInternalEvent(db, event), {
+      ...CONSUMER_OPTIONS,
+      durable: 'event-persistence-custom',
+      startFrom: 'new',
+    });
+    await eventBus.subscribePattern('system.connector.>', (event) => journalInternalEvent(db, event), {
+      ...CONSUMER_OPTIONS,
+      durable: 'event-persistence-connector',
+      startFrom: 'new',
+    });
 
     log.info('Event persistence initialized - listening for message events');
   } catch (error) {
     log.error('Failed to set up event persistence', { error: String(error) });
     throw error;
+  }
+}
+
+/**
+ * Journal a bus event that carries no channel-side fact (custom.> and
+ * system.connector.>) as a minimal `omni_events` row: identity, causality,
+ * payload. Shared by the pattern subscribers in `setupEventPersistence`.
+ */
+async function journalInternalEvent(db: Database, event: OmniEvent): Promise<void> {
+  const metadata = event.metadata;
+  try {
+    await runConsumerInTenantContext(db, event, async () => {
+      const sdb = scopedHandle(db);
+      const payload =
+        typeof event.payload === 'object' && event.payload !== null ? (event.payload as Record<string, unknown>) : {};
+      const instanceId = metadata.instanceId && isValidUuid(metadata.instanceId) ? metadata.instanceId : null;
+      const payloadChatId = typeof payload.chatId === 'string' ? payload.chatId : undefined;
+
+      // #966: best-effort identity mapping so --chat-id/--person-id
+      // filters can match custom events. personId: metadata.personId
+      // (publisher claim) first, then payload.personId — either must
+      // reference an existing persons row (FK safety). chatUuid:
+      // payload.chatUuid (a chats.id UUID) first, then payload.chatId
+      // (a platform JID) resolved against the instance like the
+      // message subscribers do.
+      const personId =
+        (await resolvePersonId(sdb, metadata.personId)) ?? (await resolvePersonId(sdb, payload.personId));
+      const chatUuid = await resolveChatUuidById(sdb, payload.chatUuid);
+      const chatLink = chatUuid
+        ? { chatUuid, canonicalChatId: null }
+        : await resolveChatLink(sdb, instanceId ?? undefined, payloadChatId);
+
+      const newEvent: NewOmniEvent = {
+        ...eventIdInsert(event.id),
+        channel: 'internal',
+        instanceId,
+        personId,
+        eventType: event.type.slice(0, 255) as NewOmniEvent['eventType'],
+        direction: 'internal',
+        status: 'completed',
+        receivedAt: new Date(event.timestamp),
+        rawPayload: deepSanitize(payload),
+        metadata: {
+          correlationId: metadata.correlationId,
+          source: metadata.source,
+          fullEventType: event.type,
+        },
+        causationId: metadata.causationId ?? null,
+        conversationId: null,
+        chatId: payloadChatId,
+        ...chatLink,
+      };
+      await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+    });
+  } catch (error) {
+    log.error('Failed to persist custom event', {
+      eventType: event.type,
+      eventId: event.id,
+      error: String(error),
+    });
   }
 }

--- a/packages/api/src/scheduler.ts
+++ b/packages/api/src/scheduler.ts
@@ -357,7 +357,7 @@ export function setupScheduler(services: Services, channelRegistry?: ChannelRegi
       await withCronMonitor('connector-liveness-sweeper', '*/30 * * * * *', 1, 1, async () => {
         const startTime = Date.now();
         try {
-          const stats = await services.webhooks.sweepLiveness({ deadLetters: services.deadLetters });
+          const stats = await services.webhooks.sweepLiveness();
           recordScheduledJob('connector-liveness-sweeper', 'success', (Date.now() - startTime) / 1000);
           if (stats.stalled > 0 || stats.recovered > 0) {
             log.info('Connector liveness sweep tick', { ...stats });

--- a/packages/api/src/services/webhooks.ts
+++ b/packages/api/src/services/webhooks.ts
@@ -14,13 +14,11 @@ import {
   sweepConnectorLiveness,
 } from '@omni/core';
 import type {
-  ConnectorLivenessDeps,
   ConnectorLivenessRepo,
   ConnectorLivenessRow,
   ConnectorLivenessSweepStats,
   CustomEventType,
   EventBus,
-  OmniEvent,
 } from '@omni/core';
 import { generateId } from '@omni/core';
 import type { Database } from '@omni/db';
@@ -685,28 +683,12 @@ export class WebhookService {
    * One liveness sweep tick (#961) — called by the scheduler. Lives on
    * WebhookService because this is the one file sanctioned to touch
    * `webhook_sources` (tenancy-db-access-guard); the transition semantics
-   * live in `@omni/core` (`sweepConnectorLiveness`).
-   *
-   * When a `DeadLetterService` is provided, a stalled transition also files a
-   * manual-resolution DLQ entry (the "zero-emission dead-letter" ops surface)
-   * and recovery auto-resolves it.
+   * live in `@omni/core` (`sweepConnectorLiveness`). Stalled/recovered
+   * transitions are ordinary bus events (#1063) — the DLQ stays reserved
+   * for genuine delivery failures.
    */
-  async sweepLiveness(options: { deadLetters?: DeadLetterService } = {}): Promise<ConnectorLivenessSweepStats> {
-    const { deadLetters } = options;
-    const hooks: Pick<ConnectorLivenessDeps, 'onStalled' | 'onRecovered'> = deadLetters
-      ? {
-          onStalled: (row, payload, publishedEventId) =>
-            fileStallDeadLetter(deadLetters, row, payload, publishedEventId),
-          onRecovered: (row) => resolveStallDeadLetters(deadLetters, row),
-        }
-      : {};
-
-    return sweepConnectorLiveness({
-      repo: this.livenessRepo(),
-      eventBus: this.eventBus,
-      logger: log,
-      ...hooks,
-    });
+  async sweepLiveness(): Promise<ConnectorLivenessSweepStats> {
+    return sweepConnectorLiveness({ repo: this.livenessRepo(), eventBus: this.eventBus, logger: log });
   }
 
   /**
@@ -755,51 +737,5 @@ export class WebhookService {
         return res.length > 0;
       },
     };
-  }
-}
-
-/**
- * File the stalled transition into the DLQ so a dead connector surfaces on
- * the ops surface, not only in a log (#961). Manual resolution only
- * (`autoRetry: false`): auto-retry would republish the stalled event and
- * break its emitted-once contract — recovery resolves the entry instead.
- */
-async function fileStallDeadLetter(
-  deadLetters: DeadLetterService,
-  row: ConnectorLivenessRow,
-  payload: Parameters<NonNullable<ConnectorLivenessDeps['onStalled']>>[1],
-  publishedEventId: string | null,
-): Promise<void> {
-  const event: OmniEvent = {
-    id: publishedEventId ?? generateId(),
-    type: 'system.connector.stalled',
-    payload: { ...payload },
-    metadata: {
-      correlationId: generateId(),
-      source: 'connector-liveness',
-      ...(row.tenantId ? { tenantId: row.tenantId } : {}),
-    },
-    timestamp: payload.stalledAt,
-  };
-  await deadLetters.create({
-    event,
-    subject: 'system.connector.stalled.internal.global',
-    error: new Error(
-      `Connector '${row.name}' declared >=1 event or heartbeat per ${row.expectedIntervalSeconds}s ` +
-        `but has been silent for ${payload.silentForSeconds}s`,
-    ),
-    retryCount: 0,
-    autoRetry: false,
-  });
-}
-
-/** Recovery auto-resolves the pending stall entries this sweeper filed for the source. */
-async function resolveStallDeadLetters(deadLetters: DeadLetterService, row: ConnectorLivenessRow): Promise<void> {
-  const { items } = await deadLetters.list({ status: ['pending'], eventType: ['system.connector.stalled'] });
-  for (const entry of items) {
-    const stored = entry.payload as { payload?: { sourceId?: unknown } };
-    if (stored.payload?.sourceId === row.id) {
-      await deadLetters.resolve(entry.id, 'connector-liveness: recovered');
-    }
   }
 }

--- a/packages/core/src/connectors/__tests__/liveness.test.ts
+++ b/packages/core/src/connectors/__tests__/liveness.test.ts
@@ -196,53 +196,6 @@ describe('sweepConnectorLiveness — recovery', () => {
 });
 
 describe('sweepConnectorLiveness — hooks and resilience', () => {
-  test('onStalled receives the payload and the published event id', async () => {
-    const seen: Array<{ payload: ConnectorStalledPayload; eventId: string | null }> = [];
-    const { deps, published } = makeDeps([makeRow()]);
-
-    await sweepConnectorLiveness({
-      ...deps,
-      now: () => at(120),
-      onStalled: async (_row, payload, eventId) => {
-        seen.push({ payload, eventId });
-      },
-    });
-
-    expect(seen).toHaveLength(1);
-    expect(seen[0]?.eventId).toBe('evt-1');
-    expect(seen[0]?.payload.sourceName).toBe('gmail-purchases');
-    expect(published).toHaveLength(1);
-  });
-
-  test('onRecovered fires after a recovery transition', async () => {
-    const recovered: ConnectorRecoveredPayload[] = [];
-    const { deps } = makeDeps([makeRow({ livenessStatus: 'stalled', stalledAt: at(100), lastHeartbeatAt: at(195) })]);
-
-    await sweepConnectorLiveness({
-      ...deps,
-      now: () => at(200),
-      onRecovered: async (_row, payload) => {
-        recovered.push(payload);
-      },
-    });
-
-    expect(recovered).toHaveLength(1);
-    expect(recovered[0]?.recoveredBy).toBe('heartbeat');
-  });
-
-  test('a throwing hook does not fail the sweep and the event is still published', async () => {
-    const { deps, published } = makeDeps([makeRow()]);
-    const stats = await sweepConnectorLiveness({
-      ...deps,
-      now: () => at(120),
-      onStalled: async () => {
-        throw new Error('dlq down');
-      },
-    });
-    expect(stats).toEqual({ scanned: 1, stalled: 1, recovered: 0, errors: 0 });
-    expect(published).toHaveLength(1);
-  });
-
   test('without an event bus the transition is still persisted', async () => {
     const { deps, repo } = makeDeps([makeRow()]);
     const stats = await sweepConnectorLiveness({ ...deps, eventBus: null, now: () => at(120) });

--- a/packages/core/src/connectors/liveness.ts
+++ b/packages/core/src/connectors/liveness.ts
@@ -103,18 +103,6 @@ export interface ConnectorLivenessDeps {
   logger: Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
   /** Override the wall clock — used in tests. */
   now?: () => Date;
-  /**
-   * Ops surfacing hook, invoked after a stalled transition is persisted and
-   * published (the API layer files the DLQ entry here). `publishedEventId` is
-   * null when there is no bus. Hook failures are logged, never fatal.
-   */
-  onStalled?: (
-    row: ConnectorLivenessRow,
-    payload: ConnectorStalledPayload,
-    publishedEventId: string | null,
-  ) => Promise<void>;
-  /** Counterpart of `onStalled` — the API layer resolves the DLQ entry here. */
-  onRecovered?: (row: ConnectorLivenessRow, payload: ConnectorRecoveredPayload) => Promise<void>;
 }
 
 export interface ConnectorLivenessSweepStats {
@@ -199,9 +187,8 @@ async function processRow(
       silentForSeconds,
       stalledAt: now.getTime(),
     };
-    const eventId = await publishTransition(deps, 'system.connector.stalled', { ...payload }, row);
+    await publishTransition(deps, 'system.connector.stalled', { ...payload }, row);
     stats.stalled += 1;
-    await runHook(deps.logger, 'onStalled', row, () => deps.onStalled?.(row, payload, eventId));
     return;
   }
 
@@ -219,7 +206,6 @@ async function processRow(
     };
     await publishTransition(deps, 'system.connector.recovered', { ...payload }, row);
     stats.recovered += 1;
-    await runHook(deps.logger, 'onRecovered', row, () => deps.onRecovered?.(row, payload));
   }
 }
 
@@ -228,34 +214,16 @@ async function publishTransition(
   type: 'system.connector.stalled' | 'system.connector.recovered',
   payload: Record<string, unknown>,
   row: ConnectorLivenessRow,
-): Promise<string | null> {
+): Promise<void> {
   if (!deps.eventBus) {
     deps.logger.warn('connector liveness: no event bus, transition persisted without event', {
       type,
       sourceName: row.name,
     });
-    return null;
+    return;
   }
-  const result = await deps.eventBus.publishGeneric(type, payload, {
+  await deps.eventBus.publishGeneric(type, payload, {
     source: 'connector-liveness',
     ...(row.tenantId ? { tenantId: row.tenantId } : {}),
   });
-  return result.id;
-}
-
-async function runHook(
-  logger: ConnectorLivenessDeps['logger'],
-  name: string,
-  row: ConnectorLivenessRow,
-  hook: () => Promise<void> | undefined,
-): Promise<void> {
-  try {
-    await hook();
-  } catch (err) {
-    logger.error(`connector liveness: ${name} hook failed`, {
-      sourceId: row.id,
-      sourceName: row.name,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
 }


### PR DESCRIPTION
Closes #1063

## What

- Journal `system.connector.>` (stalled / recovered) through the same forward-only consumer as `custom.>`, so `omni events list --type 'system.connector.*'`, `trace`, `wait`, and automations can see connector liveness alerts.
- Remove the stall-to-DLQ path (`fileStallDeadLetter` / `resolveStallDeadLetters` and the `onStalled` / `onRecovered` hooks). A stall is an alert, not a delivery failure; the DLQ stays reserved for genuine delivery failures.
- Schemas were already Zod-registered in `SystemEventSchemas`; no change needed there.
- Docs updated (connector contract + GitHub / ClickUp runbooks).

## Tests

- New regression: `event-persistence.test.ts` journals a `system.connector.stalled` event and asserts the row.
- `connector-liveness.test.ts` now asserts no DLQ entry is filed on stall.
- `consumer-config.test.ts` allows the connector journal consumer to be forward-only.
- Ran typecheck, lint, dead-code, verify-migrations, verify-versions, the full turbo test run, and the PostgreSQL gate on a disposable cluster. The only gate failure is `tests/release/upgrade-2.260902.5-to-2.260908.20-postgres.test.ts`, which sees PostgreSQL 18 `*_not_null` constraint rows in the `webhook_sources` catalog fingerprint; it is unrelated to this change (no schema or migration touched).