### PR TITLE
feat(agents): stamp cost/usage on agent-dispatched events (#1064)

### DIFF
--- a/packages/api/src/__tests__/agent-usage.test.ts
+++ b/packages/api/src/__tests__/agent-usage.test.ts
@@ -1,0 +1,86 @@
+/**
+ * #1064: cost/usage lands on the journal row of the event that woke the
+ * agent, in `metadata.agentUsage`, alongside `agent_latency_ms` — so
+ * cost-per-event is a plain aggregation over omni_events.
+ */
+
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import type { Database } from '@omni/db';
+import { omniEvents } from '@omni/db';
+import { eq, sql } from 'drizzle-orm';
+import { stampAgentUsage } from '../services/agent-usage';
+import { EventService } from '../services/events';
+import { describeWithDb, getTestDb } from './db-helper';
+
+const USAGE = { providerId: 'prov-1', runId: 'run-1', costUsd: 0.25, tokensIn: 10, tokensOut: 20, model: 'm' };
+
+describeWithDb('stampAgentUsage', () => {
+  let db: Database;
+  const ids: string[] = [];
+
+  const seed = async (metadata: Record<string, unknown> | null) => {
+    const id = randomUUID();
+    ids.push(id);
+    await db.insert(omniEvents).values({
+      id,
+      externalId: `ext-usage-${id}`,
+      channel: 'whatsapp-baileys',
+      eventType: 'message.received',
+      direction: 'inbound',
+      chatId: 'chat-usage',
+      status: 'received',
+      receivedAt: new Date(),
+      metadata,
+    });
+    return id;
+  };
+
+  const row = async (id: string) => (await db.select().from(omniEvents).where(eq(omniEvents.id, id)))[0];
+
+  beforeAll(() => {
+    db = getTestDb();
+  });
+
+  afterAll(async () => {
+    await db.delete(omniEvents).where(sql`${omniEvents.externalId} LIKE 'ext-usage-%'`);
+  });
+
+  it('merges agentUsage into existing metadata and sets agent_latency_ms', async () => {
+    const id = await seed({ correlationId: 'corr-1', from: 'someone' });
+
+    await stampAgentUsage(db, id, { usage: USAGE, latencyMs: 1234.6 });
+
+    const r = await row(id);
+    expect(r?.metadata).toEqual({ correlationId: 'corr-1', from: 'someone', agentUsage: USAGE });
+    expect(r?.agentLatencyMs).toBe(1235);
+  });
+
+  it('stamps a row whose metadata is null', async () => {
+    const id = await seed(null);
+    await stampAgentUsage(db, id, { usage: USAGE });
+    expect((await row(id))?.metadata).toEqual({ agentUsage: USAGE });
+  });
+
+  it('is a no-op for a missing or malformed event id', async () => {
+    await expect(stampAgentUsage(db, undefined, { usage: USAGE })).resolves.toBeUndefined();
+    await expect(stampAgentUsage(db, 'not-a-uuid', { usage: USAGE })).resolves.toBeUndefined();
+    await expect(stampAgentUsage(db, randomUUID(), { usage: USAGE })).resolves.toBeUndefined();
+  });
+
+  it('makes cost-per-event an analytics query', async () => {
+    const a = await seed(null);
+    const b = await seed(null);
+    await stampAgentUsage(db, a, { usage: { ...USAGE, costUsd: 0.1 } });
+    await stampAgentUsage(db, b, { usage: { ...USAGE, costUsd: 0.15 } });
+
+    const [agg] = await db
+      .select({ total: sql<number>`sum((${omniEvents.metadata}->'agentUsage'->>'costUsd')::numeric)::float` })
+      .from(omniEvents)
+      .where(sql`${omniEvents.id} in (${a}, ${b})`);
+    expect(agg?.total).toBeCloseTo(0.25, 6);
+
+    const analytics = await new EventService(db).getAnalytics({});
+    expect(analytics.totalCostUsd).toBeGreaterThanOrEqual(0.25);
+  });
+});

--- a/packages/api/src/plugins/agent-dispatcher.ts
+++ b/packages/api/src/plugins/agent-dispatcher.ts
@@ -35,6 +35,7 @@ import {
   AgUiAgentProvider,
   type AgentRunCancelRequestedPayload,
   type AgentTrigger,
+  type AgentTriggerResult,
   type AgentTriggerType,
   AgnoAgentProvider,
   type BeforeAgentStartContext,
@@ -58,6 +59,7 @@ import {
   type SessionResetConfig,
   type StreamDelta,
   WebhookAgentProvider,
+  agentUsageFromResult,
   checkSessionReset,
   classifyEnvelope,
   createLogger,
@@ -89,6 +91,7 @@ import {
   shouldAgentReply,
 } from '../services/agent-runner';
 import { resolveKhalSessionId } from '../services/agent-session-identity';
+import { stampAgentUsage } from '../services/agent-usage';
 import type { MediaStorageService } from '../services/media-storage';
 import { buildWhatsAppMessageContext, extractPhoneFromJid } from '../services/message-context';
 import type { ResolvedRoute } from '../services/route-resolver';
@@ -2782,6 +2785,25 @@ async function buildContextMessages(
   }
 }
 
+/**
+ * #1064: cost/usage lands on the journal row of the message that woke the
+ * agent (the LAST buffered message — the causation root of the reply).
+ * Best-effort and off the reply's critical path.
+ */
+function stampDispatchUsage(
+  db: Database,
+  messages: BufferedMessage[],
+  result: AgentTriggerResult | null | undefined,
+  latencyMs: number,
+): void {
+  const usage = result ? agentUsageFromResult(result.metadata) : null;
+  if (!usage) return;
+  const lastMsg = messages[messages.length - 1];
+  runDispatchDb(db, lastMsg?.metadata.trustedTenantId, () =>
+    stampAgentUsage(db, lastMsg?.metadata.eventId, { usage, latencyMs }),
+  ).catch((error) => log.warn('Agent usage stamp scope failed', { error: String(error) }));
+}
+
 /** Record a journey checkpoint when tracking is active for this correlationId. */
 function recordJourneyCheckpoint(correlationId: string | undefined, stage: string, stageName: string): void {
   if (!correlationId) return;
@@ -3191,6 +3213,8 @@ async function dispatchViaProvider(
       if (!triggerOutcome) return true;
       const { result, cancelled: runCancelled } = triggerOutcome;
       const dispatchDurationMs = Date.now() - dispatchStart;
+
+      stampDispatchUsage(db, messages, result, dispatchDurationMs);
 
       // Sentry metrics: agent dispatch count and latency
       if (sentryEnabled()) {

--- a/packages/api/src/plugins/automation-actions.ts
+++ b/packages/api/src/plugins/automation-actions.ts
@@ -33,12 +33,21 @@
  * pin a pooled connection for the duration (the G4 leg-2 trap).
  */
 
-import type { AgentCallContext, AgentRunResult, CallAgentActionConfig } from '@omni/core';
-import { PUBLISH_NOT_DECLARED, SCHEMA_NOT_REGISTERED, checkPublishAllowed, createLogger, generateId } from '@omni/core';
+import type { AgentCallContext, AgentRunResult, CallAgentActionConfig, ProviderMetrics } from '@omni/core';
+import {
+  PUBLISH_NOT_DECLARED,
+  SCHEMA_NOT_REGISTERED,
+  agentUsageFromResult,
+  checkPublishAllowed,
+  createLogger,
+  generateId,
+} from '@omni/core';
 import type { Database, EventType } from '@omni/db';
 import { agents, omniEvents, processedEvents } from '@omni/db';
 import { eq } from 'drizzle-orm';
 import type { Services } from '../services';
+import type { AgentRunResult as RunnerResult } from '../services/agent-runner';
+import { stampAgentUsage } from '../services/agent-usage';
 import { releaseIdleTimeoutClaim } from '../services/follow-up-lifecycle';
 import { scopedHandle } from '../tenancy/tenant-scope';
 import { runTenantWorkDb } from '../tenancy/worker-tenant-context';
@@ -113,6 +122,30 @@ async function runChatlessCallAgent(
     messages: ctx.messages,
     timeoutSeconds: cfg.timeoutMs ? Math.ceil(cfg.timeoutMs / 1000) : undefined,
   });
+  return toCallAgentResult(db, ctx, result, trustedTenantId);
+}
+
+/**
+ * Shape a runner result for the automation engine and stamp its cost/usage on
+ * the triggering event's journal row (#1064) — the same ledger the dispatcher
+ * writes, so `call_agent` runs cost the same query as routed dispatches.
+ */
+function toCallAgentResult(
+  db: Database,
+  ctx: AgentCallContext,
+  result: RunnerResult,
+  trustedTenantId: string | null,
+): AgentRunResult {
+  const usage = agentUsageFromResult({
+    providerId: result.metadata.providerId,
+    runId: result.metadata.runId,
+    cost: toCost(result.metadata.metrics),
+  });
+  if (usage) {
+    runTenantWorkDb(db, trustedTenantId, () =>
+      stampAgentUsage(db, ctx.event?.id, { usage, latencyMs: result.metadata.metrics?.durationMs }),
+    ).catch((error) => log.warn('call_agent: usage stamp scope failed', { error: String(error) }));
+  }
   return {
     parts: result.parts,
     fullResponse: result.parts.join('\n'),
@@ -120,8 +153,20 @@ async function runChatlessCallAgent(
       runId: result.metadata.runId,
       sessionId: result.metadata.sessionId,
       status: result.metadata.status,
+      ...(usage ? { usage } : {}),
     },
   };
+}
+
+function toCost(metrics: ProviderMetrics | undefined) {
+  return metrics
+    ? {
+        inputTokens: metrics.inputTokens,
+        outputTokens: metrics.outputTokens,
+        costUsd: metrics.costUsd,
+        model: metrics.model,
+      }
+    : undefined;
 }
 
 /**
@@ -385,15 +430,7 @@ export function buildAutomationEngineDeps(
         chatType: 'dm',
         messages: ctx.messages,
       });
-      return {
-        parts: result.parts,
-        fullResponse: result.parts.join('\n'),
-        metadata: {
-          runId: result.metadata.runId,
-          sessionId: result.metadata.sessionId,
-          status: result.metadata.status,
-        },
-      };
+      return toCallAgentResult(db, ctx, result, trustedTenantId);
     },
 
     // Consumer-side stale-event gate — see engine.handleEvent comment.

--- a/packages/api/src/schemas/openapi/events.ts
+++ b/packages/api/src/schemas/openapi/events.ts
@@ -46,6 +46,7 @@ export const EventAnalyticsSchema = z.object({
   successRate: z.number().openapi({ description: 'Success rate (%)' }),
   avgProcessingTimeMs: z.number().nullable().openapi({ description: 'Average processing time (ms)' }),
   avgAgentTimeMs: z.number().nullable().openapi({ description: 'Average agent time (ms)' }),
+  totalCostUsd: z.number().openapi({ description: 'Sum of agent run cost (USD) stamped on events in range' }),
   messageTypes: z.record(z.string(), z.number()).openapi({ description: 'Count by content type' }),
   errorStages: z.record(z.string(), z.number()).openapi({ description: 'Count by error stage' }),
   instances: z.record(z.string(), z.number()).openapi({ description: 'Count by instance' }),

--- a/packages/api/src/services/__tests__/agent-runner.test.ts
+++ b/packages/api/src/services/__tests__/agent-runner.test.ts
@@ -90,7 +90,7 @@ describe('AgentRunnerService.runOrStream', () => {
     const runner = new AgentRunnerService(fakeDb);
     const runResult: AgentRunResult = {
       parts: ['sync-response'],
-      metadata: { runId: 'run-sync', sessionId: 'chat-1', status: 'completed' },
+      metadata: { runId: 'run-sync', sessionId: 'chat-1', status: 'completed', providerId: 'prov-1' },
     };
     const runMock = mock(async () => runResult);
     const streamMock = mock(async function* () {

--- a/packages/api/src/services/agent-runner.ts
+++ b/packages/api/src/services/agent-runner.ts
@@ -12,6 +12,7 @@ import {
   type IAgentClient,
   ProviderError,
   type ProviderFile,
+  type ProviderMetrics,
   type ProviderSchema,
   type SessionStorage,
   type StreamChunk,
@@ -118,11 +119,9 @@ export interface AgentRunResult {
     runId: string;
     sessionId: string;
     status: 'completed' | 'failed';
-    metrics?: {
-      inputTokens: number;
-      outputTokens: number;
-      durationMs: number;
-    };
+    /** agent_providers.id the run went through (#1064 usage stamping). */
+    providerId: string;
+    metrics?: ProviderMetrics;
   };
 }
 
@@ -710,6 +709,7 @@ export class AgentRunnerService {
         runId: response.runId,
         sessionId: response.sessionId,
         status: response.status,
+        providerId: instance.agentProviderId,
         metrics: response.metrics,
       },
     };
@@ -775,6 +775,7 @@ export class AgentRunnerService {
         runId: response.runId,
         sessionId: response.sessionId,
         status: response.status,
+        providerId: context.agentProviderId,
         metrics: response.metrics,
       },
     };
@@ -809,6 +810,7 @@ export class AgentRunnerService {
         runId: crypto.randomUUID(),
         sessionId,
         status: 'completed',
+        providerId: context.instance.agentProviderId ?? '',
       },
     };
   }

--- a/packages/api/src/services/agent-usage.ts
+++ b/packages/api/src/services/agent-usage.ts
@@ -1,0 +1,48 @@
+/**
+ * Stamp cost/usage onto the journal row of the event that woke an agent (#1064).
+ *
+ * The dispatcher and the automation `call_agent` action both route through
+ * here, so the journal is the single ledger — no consumer has to parse
+ * provider output into a side table. Same shape as the #1035 back-link in
+ * message-persistence: an UPDATE on `omni_events` by id, inside the caller's
+ * worker tenant scope via `scopedHandle`, a no-op when the row is not there.
+ */
+
+import { AGENT_USAGE_METADATA_KEY, type AgentUsage, createLogger, isValidUuid } from '@omni/core';
+import type { Database } from '@omni/db';
+import { omniEvents } from '@omni/db';
+import { eq, sql } from 'drizzle-orm';
+import { scopedHandle } from '../tenancy/tenant-scope';
+
+const log = createLogger('agent-usage');
+
+export interface AgentUsageStamp {
+  usage: AgentUsage;
+  /** Provider round-trip; lands in the existing `agent_latency_ms` column. */
+  latencyMs?: number;
+}
+
+/**
+ * Merge `{ agentUsage }` into `metadata` and set `agent_latency_ms` on the
+ * `omni_events` row for `eventId`. Best-effort: the reply is already on its
+ * way, so a failure here is logged and never thrown.
+ */
+export async function stampAgentUsage(
+  db: Database,
+  eventId: string | undefined,
+  stamp: AgentUsageStamp,
+): Promise<void> {
+  if (!eventId || !isValidUuid(eventId)) return;
+  try {
+    const patch = JSON.stringify({ [AGENT_USAGE_METADATA_KEY]: stamp.usage });
+    await scopedHandle(db)
+      .update(omniEvents)
+      .set({
+        metadata: sql`coalesce(${omniEvents.metadata}, '{}'::jsonb) || ${patch}::jsonb`,
+        ...(stamp.latencyMs !== undefined ? { agentLatencyMs: Math.round(stamp.latencyMs) } : {}),
+      })
+      .where(eq(omniEvents.id, eventId));
+  } catch (error) {
+    log.warn('Failed to stamp agent usage on journal row', { eventId, error: String(error) });
+  }
+}

--- a/packages/api/src/services/events.ts
+++ b/packages/api/src/services/events.ts
@@ -57,6 +57,8 @@ export interface EventAnalytics {
   successRate: number;
   avgProcessingTimeMs: number | null;
   avgAgentTimeMs: number | null;
+  /** Sum of `metadata.agentUsage.costUsd` over the range (#1064). */
+  totalCostUsd: number;
   messageTypes: Record<string, number>;
   errorStages: Record<string, number>;
   instances: Record<string, number>;
@@ -341,6 +343,8 @@ export class EventService {
         failed: sql<number>`count(*) filter (where ${omniEvents.status} = 'failed')::int`,
         avgProcessingTime: sql<number>`avg(${omniEvents.processingTimeMs})::int`,
         avgAgentTime: sql<number>`avg(${omniEvents.agentLatencyMs})::int`,
+        // #1064: cost stamped by the agent dispatcher in metadata.agentUsage
+        totalCostUsd: sql<number>`coalesce(sum((${omniEvents.metadata}->'agentUsage'->>'costUsd')::numeric), 0)::float`,
       })
       .from(omniEvents)
       .where(whereClause);
@@ -429,6 +433,7 @@ export class EventService {
       successRate: total > 0 ? (successful / total) * 100 : 0,
       avgProcessingTimeMs: counts?.avgProcessingTime ?? null,
       avgAgentTimeMs: counts?.avgAgentTime ?? null,
+      totalCostUsd: counts?.totalCostUsd ?? 0,
       messageTypes: Object.fromEntries(
         contentTypeCounts
           .filter((c): c is typeof c & { contentType: NonNullable<typeof c.contentType> } => c.contentType != null)

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -128,6 +128,7 @@ interface AnalyticsData {
   successRate: number;
   avgProcessingTimeMs: number | null;
   avgAgentTimeMs: number | null;
+  totalCostUsd?: number;
   messageTypes: Record<string, number>;
   errorStages: Record<string, number>;
   instances: Record<string, number>;
@@ -175,6 +176,7 @@ function displayAnalytics(data: AnalyticsData): void {
       successRate: data.successRate,
       avgProcessingMs: data.avgProcessingTimeMs,
       avgAgentMs: data.avgAgentTimeMs,
+      totalCostUsd: data.totalCostUsd ?? 0,
       messageTypes: data.messageTypes,
       instances: data.instances,
       errorStages: data.errorStages,
@@ -189,6 +191,7 @@ function displayAnalytics(data: AnalyticsData): void {
       successRate: `${data.successRate.toFixed(1)}%`,
       avgProcessingMs: data.avgProcessingTimeMs ?? '-',
       avgAgentMs: data.avgAgentTimeMs ?? '-',
+      totalCostUsd: `$${(data.totalCostUsd ?? 0).toFixed(4)}`,
     });
 
     displayRecordBreakdown('Message Types', data.messageTypes, 'type');

--- a/packages/core/src/automations/actions.ts
+++ b/packages/core/src/automations/actions.ts
@@ -11,6 +11,7 @@ import { SCHEMA_VALIDATION_FAILED } from '../events/schema-registry';
 import type { CustomEventType, GenericEventPayload } from '../events/types';
 import { generateId } from '../ids';
 import { createLogger } from '../logger';
+import type { AgentUsage } from '../schemas/agent-usage';
 import { type TemplateContext, substituteTemplate, substituteTemplateObject } from './templates';
 import type {
   ActionExecutionResult,
@@ -37,6 +38,8 @@ export interface AgentRunResult {
     runId: string;
     sessionId: string;
     status: 'completed' | 'failed';
+    /** Cost/usage the provider reported (#1064), when any. */
+    usage?: AgentUsage;
   };
 }
 

--- a/packages/core/src/providers/agno-client.ts
+++ b/packages/core/src/providers/agno-client.ts
@@ -302,6 +302,7 @@ export class AgnoClient implements IAgentClient {
       session_id: string;
       content: string;
       status: 'COMPLETED' | 'FAILED';
+      model?: string;
       metrics?: {
         input_tokens?: number;
         output_tokens?: number;
@@ -319,6 +320,7 @@ export class AgnoClient implements IAgentClient {
             inputTokens: data.metrics.input_tokens ?? 0,
             outputTokens: data.metrics.output_tokens ?? 0,
             durationMs: data.metrics.duration ?? 0,
+            model: data.model,
           }
         : undefined,
     };

--- a/packages/core/src/providers/agno-provider.ts
+++ b/packages/core/src/providers/agno-provider.ts
@@ -111,6 +111,8 @@ export class AgnoAgentProvider implements IAgentProvider {
           ? {
               inputTokens: response.metrics.inputTokens,
               outputTokens: response.metrics.outputTokens,
+              costUsd: response.metrics.costUsd,
+              model: response.metrics.model,
             }
           : undefined,
         customerErrorBlocked,

--- a/packages/core/src/providers/claude-code-client.ts
+++ b/packages/core/src/providers/claude-code-client.ts
@@ -90,6 +90,18 @@ export interface StreamRunMetrics {
   outputTokens: number;
   costUsd: number;
   durationMs: number;
+  /** Model reported by the SDK result message (`modelUsage` keys), when present. */
+  model?: string;
+}
+
+/**
+ * Model name from an SDK result message. The SDK reports per-model usage as
+ * `modelUsage: Record<model, usage>`; a single-model run has one key.
+ */
+function extractModel(msg: { modelUsage?: unknown }): string | undefined {
+  const usage = msg.modelUsage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  return Object.keys(usage)[0];
 }
 
 /**
@@ -413,6 +425,7 @@ function handleResult(
         outputTokens: tokens.output,
         costUsd: totalCost,
         durationMs,
+        model: extractModel(msg),
       },
       sessionId: sid,
     };
@@ -484,6 +497,7 @@ interface RunAccumulator {
   costUsd: number;
   inputTokens: number;
   outputTokens: number;
+  model?: string;
 }
 
 type SDKUsage =
@@ -510,6 +524,7 @@ function processRunMessage(
     errors?: string[];
     total_cost_usd?: number;
     usage?: SDKUsage;
+    modelUsage?: unknown;
   },
   acc: RunAccumulator,
   startTime: number,
@@ -524,6 +539,7 @@ function processRunMessage(
   if (message.subtype === 'success') {
     acc.content = message.result ?? '';
     acc.costUsd = message.total_cost_usd ?? 0;
+    acc.model = extractModel(message);
     const tokens = extractTokens(message.usage);
     acc.inputTokens = tokens.input;
     acc.outputTokens = tokens.output;
@@ -816,7 +832,13 @@ export class ClaudeCodeClient implements IAgentClient {
       runId: crypto.randomUUID(),
       sessionId: acc.sessionId,
       status: 'completed',
-      metrics: { inputTokens: acc.inputTokens, outputTokens: acc.outputTokens, durationMs },
+      metrics: {
+        inputTokens: acc.inputTokens,
+        outputTokens: acc.outputTokens,
+        durationMs,
+        costUsd: acc.costUsd,
+        model: acc.model,
+      },
     };
   }
 

--- a/packages/core/src/providers/claude-code-provider.ts
+++ b/packages/core/src/providers/claude-code-provider.ts
@@ -268,7 +268,12 @@ export class ClaudeCodeAgentProvider implements IAgentProvider {
         providerId: this.id,
         durationMs,
         cost: response.metrics
-          ? { inputTokens: response.metrics.inputTokens, outputTokens: response.metrics.outputTokens }
+          ? {
+              inputTokens: response.metrics.inputTokens,
+              outputTokens: response.metrics.outputTokens,
+              costUsd: response.metrics.costUsd,
+              model: response.metrics.model,
+            }
           : undefined,
       },
     };

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -128,6 +128,10 @@ export interface ProviderMetrics {
   inputTokens: number;
   outputTokens: number;
   durationMs: number;
+  /** Run cost in USD when the provider reports it (claude-code `total_cost_usd`). */
+  costUsd?: number;
+  /** Model that produced the response when the provider reports it. */
+  model?: string;
 }
 
 /**
@@ -522,6 +526,8 @@ export interface AgentTriggerResult {
     cost?: {
       inputTokens?: number;
       outputTokens?: number;
+      costUsd?: number;
+      model?: string;
     };
     /**
      * True when the response text was replaced by the customer-safe error

--- a/packages/core/src/schemas/agent-usage.test.ts
+++ b/packages/core/src/schemas/agent-usage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import { AgentUsageSchema, agentUsageFromResult } from './agent-usage';
+
+const base = { providerId: 'prov-1', runId: 'run-1' };
+
+describe('agentUsageFromResult (#1064)', () => {
+  it('maps provider cost fields onto the journal stamp', () => {
+    const usage = agentUsageFromResult({
+      ...base,
+      cost: { inputTokens: 120, outputTokens: 30, costUsd: 0.0042, model: 'claude-sonnet-5' },
+    });
+    expect(usage).toEqual({
+      providerId: 'prov-1',
+      runId: 'run-1',
+      tokensIn: 120,
+      tokensOut: 30,
+      costUsd: 0.0042,
+      model: 'claude-sonnet-5',
+    });
+    expect(AgentUsageSchema.safeParse(usage).success).toBe(true);
+  });
+
+  it('keeps partial surfaces (tokens without cost, cost without model)', () => {
+    expect(agentUsageFromResult({ ...base, cost: { inputTokens: 5, outputTokens: 7 } })).toEqual({
+      ...base,
+      tokensIn: 5,
+      tokensOut: 7,
+    });
+    expect(agentUsageFromResult({ ...base, cost: { costUsd: 0.01 } })).toEqual({ ...base, costUsd: 0.01 });
+  });
+
+  it('stamps nothing when the provider exposed no usage', () => {
+    expect(agentUsageFromResult(base)).toBeNull();
+    expect(agentUsageFromResult({ ...base, cost: {} })).toBeNull();
+  });
+
+  it('rejects malformed usage instead of journaling garbage', () => {
+    expect(agentUsageFromResult({ ...base, cost: { costUsd: -1 } })).toBeNull();
+    expect(agentUsageFromResult({ ...base, cost: { inputTokens: 1.5 } })).toBeNull();
+  });
+});

--- a/packages/core/src/schemas/agent-usage.ts
+++ b/packages/core/src/schemas/agent-usage.ts
@@ -1,0 +1,51 @@
+/**
+ * Cost/usage stamped on the journal row of the event that woke an agent (#1064).
+ *
+ * Lives in `omni_events.metadata.agentUsage` (JSONB) — no dedicated columns:
+ * cost-per-event is a `(metadata->'agentUsage'->>'costUsd')::numeric`
+ * aggregation, grouped by whatever the row already carries (event_type,
+ * agent_id, chat_uuid). Every field but `providerId`/`runId` is optional
+ * because providers expose different surfaces: claude-code reports cost and
+ * model, Agno reports tokens and model, webhook providers report nothing.
+ */
+
+import { z } from 'zod';
+
+export const AgentUsageSchema = z.object({
+  providerId: z.string(),
+  runId: z.string(),
+  costUsd: z.number().nonnegative().optional(),
+  tokensIn: z.number().int().nonnegative().optional(),
+  tokensOut: z.number().int().nonnegative().optional(),
+  model: z.string().min(1).optional(),
+});
+
+export type AgentUsage = z.infer<typeof AgentUsageSchema>;
+
+/** Metadata key under which {@link AgentUsage} is stored in `omni_events.metadata`. */
+export const AGENT_USAGE_METADATA_KEY = 'agentUsage';
+
+/**
+ * Build the stamp from a provider result's `metadata`. Returns null when the
+ * provider exposed no usage at all — nothing is stamped rather than a row of
+ * zeros that would skew averages.
+ */
+export function agentUsageFromResult(metadata: {
+  providerId: string;
+  runId: string;
+  cost?: { inputTokens?: number; outputTokens?: number; costUsd?: number; model?: string };
+}): AgentUsage | null {
+  const cost = metadata.cost;
+  if (!cost) return null;
+  const parsed = AgentUsageSchema.safeParse({
+    providerId: metadata.providerId,
+    runId: metadata.runId,
+    costUsd: cost.costUsd,
+    tokensIn: cost.inputTokens,
+    tokensOut: cost.outputTokens,
+    model: cost.model,
+  });
+  if (!parsed.success) return null;
+  const { providerId: _p, runId: _r, ...fields } = parsed.data;
+  return Object.values(fields).some((v) => v !== undefined) ? parsed.data : null;
+}

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -7,6 +7,7 @@ export * from './agent-manifest';
 export * from './agent-route';
 export * from './agent-state';
 export * from './agent-task';
+export * from './agent-usage';
 export * from './common';
 export * from './conversation';
 export * from './follow-up';

--- a/packages/db/src/tenancy-db-access-guard.test.ts
+++ b/packages/db/src/tenancy-db-access-guard.test.ts
@@ -327,6 +327,11 @@ describe('db-access guard', () => {
       // their own pending entries.
       'packages/api/src/services/webhooks.ts',
       'packages/api/src/plugins/automation-actions.ts',
+      // #1064: the agent-usage stamp on `omni_events` — an UPDATE by event id
+      // through `scopedHandle` inside the caller's worker scope
+      // (`runDispatchDb` / `runTenantWorkDb`), the message-persistence
+      // back-link shape. Consumer-only callers.
+      'packages/api/src/services/agent-usage.ts',
     ]);
     for (const entry of boundary) {
       expect(entry.file.startsWith('packages/api/src/tenancy/') || converted.has(entry.file)).toBe(true);

--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -1020,6 +1020,16 @@ export const REGISTERED_DB_ACCESS: readonly RegisteredDbAccess[] = [
     class: 'tenant-boundary',
   },
   {
+    // #1064: the agent-usage stamp (cost/tokens/model onto the triggering
+    // event's journal row). Runs through `scopedHandle(db)` inside the
+    // caller's worker tenant scope — `runDispatchDb` from the dispatcher,
+    // `runTenantWorkDb` from the call_agent action — the same ADR-0008 seam
+    // as the message-persistence back-link below. Consumer-only callers.
+    file: 'packages/api/src/services/agent-usage.ts',
+    table: 'omni_events',
+    class: 'tenant-boundary',
+  },
+  {
     // #1035: the message.received consumer back-links the journal row's
     // chatUuid/personId after chat resolution. The update runs inside
     // `runConsumerInTenantContext` through `scopedHandle(db)` — the same

--- a/packages/db/src/tenancy-writer-coverage.ts
+++ b/packages/db/src/tenancy-writer-coverage.ts
@@ -177,6 +177,7 @@ export const REGISTERED_WRITERS: readonly RegisteredWriter[] = [
   { file: 'packages/api/src/services/access.ts', table: 'access_rules', coverage: 'db-derived' },
   { file: 'packages/api/src/services/agent-replay.ts', table: 'instances', coverage: 'trusted-root' },
   { file: 'packages/api/src/services/agent-tasks.ts', table: 'agent_tasks', coverage: 'db-derived' },
+  { file: 'packages/api/src/services/agent-usage.ts', table: 'omni_events', coverage: 'db-derived' },
   { file: 'packages/api/src/services/agents.ts', table: 'agents', coverage: 'db-derived' },
   { file: 'packages/api/src/services/automations.ts', table: 'automation_logs', coverage: 'db-derived' },
   { file: 'packages/api/src/services/automations.ts', table: 'automations', coverage: 'db-unowned' },


### PR DESCRIPTION
Closes #1064

## What

Agent-dispatched events now carry cost/usage. When a routed dispatch or an automation `call_agent` completes, the provider's usage is stamped on the journal row of the event that woke the agent:

- `omni_events.metadata.agentUsage` = `{ providerId, runId, costUsd?, tokensIn?, tokensOut?, model? }` (Zod: `AgentUsageSchema` in `@omni/core`)
- `omni_events.agent_latency_ms` = provider round-trip (column existed, was never written)

Cost per event type / agent / chat is now a plain aggregation over `omni_events`, e.g.
`sum((metadata->'agentUsage'->>'costUsd')::numeric) ... group by event_type | agent_id | chat_uuid`.
`GET /v2/events/analytics` returns `totalCostUsd`; `omni events analytics` prints it.

## Design

- **No schema change.** Usage fits the existing `metadata` JSONB; the issue asks for aggregation, not indexed columns. If a per-tenant billing index is ever needed, a generated column over the JSONB path is an additive follow-up.
- **One write site.** `services/agent-usage.ts::stampAgentUsage` — an UPDATE by event id through `scopedHandle` inside the caller's worker scope (`runDispatchDb` / `runTenantWorkDb`), the #1035 back-link shape. Registered in `tenancy-writer-coverage.ts` and `tenancy-db-access-guard.ts`.
- **Provider plumbing.** `ProviderMetrics` and `AgentTriggerResult.metadata.cost` gain optional `costUsd` / `model`. claude-code already had `total_cost_usd` and dropped it at the boundary; it now flows through, with `model` from the SDK result's `modelUsage`. Agno passes through `model`. Webhook/A2A/AG-UI report nothing → nothing is stamped (no rows of zeros).
- **Stamped where the result is known:** dispatcher sync path (`dispatchViaProvider`) and `call_agent` (chatful + chatless, via `ctx.event.id`). The `AgentRunResult` handed back to the automation engine also carries `metadata.usage`, so a budget condition can read it later.

## Not covered (deliberately)

- **Streaming dispatch** — `StreamDelta` has no metrics channel; claude-code's stream metrics stop at a log line. Adding a `final` delta with metrics is a follow-up.
- **Turn-based dispatch** — fire-and-forget, no provider result to read.

## Tests

- `packages/core/src/schemas/agent-usage.test.ts` — mapping/validation (pure).
- `packages/api/src/__tests__/agent-usage.test.ts` — real PostgreSQL: merges into existing metadata, null metadata, no-op for missing/malformed ids, and the cost aggregation + analytics `totalCostUsd`. Verified locally on a disposable migrated cluster (20/20 pass with `event-persistence.test.ts`).
- Tenancy writer-coverage and db-access-guard suites pass with the new site.

`make typecheck`, `make lint`, `make verify-migrations` (no migrations), full `bun run test` (26/26 packages) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent runs now record provider, model, token usage, latency, and cost details.
  * Event analytics now include total agent-run cost.
  * CLI analytics output displays total cost in JSON and human-readable formats.
  * Provider results include expanded usage and model information.

* **Tests**
  * Added coverage for usage recording, cost aggregation, analytics totals, and invalid usage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->