### PR TITLE
feat(events): add --causation-id to webhooks trigger / causationId to POST /events/trigger

### DIFF
--- a/packages/api/src/routes/v2/__tests__/webhooks-trigger-causation.test.ts
+++ b/packages/api/src/routes/v2/__tests__/webhooks-trigger-causation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * POST /api/v2/events/trigger — `causationId` boundary contract (#1072).
+ *
+ * Agent/CLI emissions mid-flow used to journal as roots because the trigger
+ * body had no way to name a parent event. `causationId` is validated as a
+ * UUID at the boundary and handed to the service exactly like `correlationId`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import type { AppVariables } from '../../../types';
+import { webhooksRoutes } from '../webhooks';
+
+interface TriggerCall {
+  eventType: string;
+  metadata: { correlationId?: string; causationId?: string; instanceId?: string } | undefined;
+}
+
+function buildApp() {
+  const triggered: TriggerCall[] = [];
+  const services = {
+    webhooks: {
+      trigger: async (eventType: string, _payload: Record<string, unknown>, metadata?: TriggerCall['metadata']) => {
+        triggered.push({ eventType, metadata });
+        return { eventId: 'evt-1', published: true };
+      },
+    },
+  } as unknown as AppVariables['services'];
+
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', services);
+    await next();
+  });
+  app.route('/api/v2', webhooksRoutes);
+  return { app, triggered };
+}
+
+function trigger(app: Hono<{ Variables: AppVariables }>, body: Record<string, unknown>) {
+  return app.request('/api/v2/events/trigger', {
+    method: 'POST',
+    body: JSON.stringify({ eventType: 'custom.purchase.recorded', payload: {}, ...body }),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST /api/v2/events/trigger causationId (#1072)', () => {
+  test('a UUID causationId reaches the service alongside correlationId', async () => {
+    const { app, triggered } = buildApp();
+    const causationId = crypto.randomUUID();
+
+    const res = await trigger(app, { causationId, correlationId: 'flow-1' });
+
+    expect(res.status).toBe(201);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0]?.metadata?.causationId).toBe(causationId);
+    expect(triggered[0]?.metadata?.correlationId).toBe('flow-1');
+  });
+
+  test('a non-UUID causationId is rejected at the boundary, nothing published', async () => {
+    const { app, triggered } = buildApp();
+
+    const res = await trigger(app, { causationId: 'not-an-event-id' });
+
+    expect(res.status).toBe(400);
+    expect(triggered).toHaveLength(0);
+  });
+
+  test('omitting causationId still triggers a root event', async () => {
+    const { app, triggered } = buildApp();
+
+    const res = await trigger(app, {});
+
+    expect(res.status).toBe(201);
+    expect(triggered[0]?.metadata?.causationId).toBeUndefined();
+  });
+});

--- a/packages/api/src/routes/v2/webhooks.ts
+++ b/packages/api/src/routes/v2/webhooks.ts
@@ -173,6 +173,7 @@ const triggerEventSchema = z.object({
     .describe('Event type (must be custom.*)'),
   payload: z.record(z.string(), z.unknown()).describe('Event payload'),
   correlationId: z.string().optional().describe('Optional correlation ID'),
+  causationId: z.string().uuid().optional().describe('Optional parent event ID (causality tree, #1072)'),
   instanceId: z.string().uuid().optional().describe('Optional instance ID for context'),
 });
 
@@ -180,7 +181,7 @@ const triggerEventSchema = z.object({
  * POST /events/trigger - Manually trigger a custom event
  */
 webhooksRoutes.post('/events/trigger', zValidator('json', triggerEventSchema), async (c) => {
-  const { eventType, payload, correlationId, instanceId } = c.req.valid('json');
+  const { eventType, payload, correlationId, causationId, instanceId } = c.req.valid('json');
   const services = c.get('services');
   const apiKey = c.get('apiKey');
 
@@ -191,6 +192,7 @@ webhooksRoutes.post('/events/trigger', zValidator('json', triggerEventSchema), a
 
   const result = await services.webhooks.trigger(eventType as CustomEventType, payload, {
     correlationId,
+    causationId,
     instanceId,
   });
 

--- a/packages/api/src/schemas/openapi/webhooks.ts
+++ b/packages/api/src/schemas/openapi/webhooks.ts
@@ -219,6 +219,11 @@ export const TriggerEventSchema = z.object({
   eventType: z.string().min(1).openapi({ description: 'Event type (must start with custom.)' }),
   payload: z.record(z.string(), z.unknown()).openapi({ description: 'Event payload' }),
   correlationId: z.string().optional().openapi({ description: 'Correlation ID' }),
+  causationId: z
+    .string()
+    .uuid()
+    .optional()
+    .openapi({ description: 'Parent event ID; stamps causationId so the emission is parented in the causality tree' }),
   instanceId: z.string().uuid().optional().openapi({ description: 'Instance ID for context' }),
 });
 

--- a/packages/api/src/services/__tests__/webhooks.test.ts
+++ b/packages/api/src/services/__tests__/webhooks.test.ts
@@ -818,6 +818,18 @@ describe('WebhookService', () => {
       expect(mockEventBus._publishedEvents[0]?.metadata.correlationId).toBe(correlationId);
     });
 
+    test('stamps a caller-supplied causationId (#1072)', async () => {
+      const eventType = 'custom.purchase.recorded' as CustomEventType;
+      const causationId = crypto.randomUUID();
+
+      const result = await service.trigger(eventType, {}, { causationId });
+
+      // The emission is parented to the given event; the returned id stays
+      // the published event's own id.
+      expect(result.eventId).not.toBe(causationId);
+      expect(mockEventBus._publishedEvents[0]?.metadata.causationId).toBe(causationId);
+    });
+
     test('passes instance ID to event metadata', async () => {
       const eventType = 'custom.instance.event' as CustomEventType;
       const instanceId = 'wa-123';

--- a/packages/api/src/services/webhooks.ts
+++ b/packages/api/src/services/webhooks.ts
@@ -608,7 +608,7 @@ export class WebhookService {
   async trigger(
     eventType: CustomEventType,
     payload: Record<string, unknown>,
-    metadata?: { correlationId?: string; instanceId?: string },
+    metadata?: { correlationId?: string; causationId?: string; instanceId?: string },
   ): Promise<{ eventId: string; published: boolean }> {
     // Provisional id for the schema gate's dead-letter reference and the
     // no-bus fallback; the publish path returns the PUBLISHED event's id (#956).
@@ -626,6 +626,9 @@ export class WebhookService {
       // never matched the journal).
       const result = await this.eventBus.publishGeneric(eventType, payload, {
         correlationId: metadata?.correlationId,
+        // Parent event for agent/CLI emissions mid-flow (#1072) — the journal
+        // consumer persists it as causation_id, exactly like emit_event.
+        causationId: metadata?.causationId,
         instanceId: metadata?.instanceId,
         source: 'manual-trigger',
       });

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -558,34 +558,44 @@ export function createWebhooksCommand(): Command {
     .requiredOption('--payload <json>', 'Event payload as JSON')
     .option('--instance <id>', 'Instance ID')
     .option('--correlation-id <id>', 'Correlation ID')
-    .action(async (options: { type: string; payload: string; instance?: string; correlationId?: string }) => {
-      const client = getClient();
+    .option('--causation-id <event-id>', 'Parent event ID (keeps the causality tree for mid-flow emissions, #1072)')
+    .action(
+      async (options: {
+        type: string;
+        payload: string;
+        instance?: string;
+        correlationId?: string;
+        causationId?: string;
+      }) => {
+        const client = getClient();
 
-      try {
-        let payload: Record<string, unknown>;
         try {
-          payload = JSON.parse(options.payload);
-        } catch {
-          output.error('Invalid JSON for --payload');
-          return;
+          let payload: Record<string, unknown>;
+          try {
+            payload = JSON.parse(options.payload);
+          } catch {
+            output.error('Invalid JSON for --payload');
+            return;
+          }
+
+          const result = await client.webhooks.trigger({
+            eventType: options.type,
+            payload,
+            instanceId: options.instance,
+            correlationId: options.correlationId,
+            causationId: options.causationId,
+          });
+
+          output.success(`Event triggered: ${result.eventId}`, {
+            eventId: result.eventId,
+            eventType: result.eventType,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          output.error(`Failed to trigger event: ${message}`);
         }
-
-        const result = await client.webhooks.trigger({
-          eventType: options.type,
-          payload,
-          instanceId: options.instance,
-          correlationId: options.correlationId,
-        });
-
-        output.success(`Event triggered: ${result.eventId}`, {
-          eventId: result.eventId,
-          eventType: result.eventType,
-        });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        output.error(`Failed to trigger event: ${message}`);
-      }
-    });
+      },
+    );
 
   // omni webhooks heartbeat <source-name>
   webhooks

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -816,6 +816,8 @@ export interface TriggerEventBody {
   eventType: string;
   payload: Record<string, unknown>;
   correlationId?: string;
+  /** Parent event id — stamps `causationId` so `events trace` parents this emission (#1072). */
+  causationId?: string;
   instanceId?: string;
 }
 

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -4542,6 +4542,11 @@ export interface components {
             correlationId?: string;
             /**
              * Format: uuid
+             * @description Parent event ID; stamps causationId so the emission is parented in the causality tree
+             */
+            causationId?: string;
+            /**
+             * Format: uuid
              * @description Instance ID for context
              */
             instanceId?: string;
@@ -13020,6 +13025,11 @@ export interface operations {
                     };
                     /** @description Correlation ID */
                     correlationId?: string;
+                    /**
+                     * Format: uuid
+                     * @description Parent event ID; stamps causationId so the emission is parented in the causality tree
+                     */
+                    causationId?: string;
                     /**
                      * Format: uuid
                      * @description Instance ID for context


### PR DESCRIPTION
Closes #1072

## What
- `omni webhooks trigger --causation-id <event-id>`
- `POST /events/trigger` body accepts `causationId` (UUID, optional)
- Plumbed exactly like `correlationId`: CLI flag → SDK `TriggerEventBody` → OpenAPI/Zod schema → route → `publishGeneric` metadata
- The existing `custom.>` journal consumer already persists `metadata.causationId` to `omni_events.causation_id`, so `omni events trace` parents the emission with no persistence change.

## Tests
- Service: `stamps a caller-supplied causationId (#1072)`
- Route boundary: new `webhooks-trigger-causation.test.ts` — UUID accepted and forwarded, non-UUID → 400 with nothing published, omitted → root event.

## Notes
- Validated as a UUID at the boundary only (no existence lookup), per the ticket's implementation notes.
- SDK types regenerated via `bun run generate:sdk`.
- typecheck / lint / dead-code / verify-migrations / verify-versions / full test suite (708 pass, 26/26 packages) green.