### PR TITLE
fix(db): tolerate sources vanishing mid-walk in tenancy scanners

### DIFF
--- a/packages/db/src/tenancy-db-access-guard.ts
+++ b/packages/db/src/tenancy-db-access-guard.ts
@@ -59,9 +59,9 @@
  * test run.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { relative } from 'node:path';
 import { RLS_EXCLUSIONS, RLS_TENANT_TABLES, type RlsExclusion } from './tenancy-rls';
+import { readSources } from './tenancy-scan-sources';
 
 export type DbAccessClass =
   | 'tenant-boundary'
@@ -87,8 +87,6 @@ export interface RegisteredDbAccess extends DbAccessSite {
   readonly justification?: string;
 }
 
-const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.turbo', '__tests__', 'coverage']);
-
 /**
  * Contract modules that mention table names and query verbs as DATA rather than
  * as queries: the ownership spec, the generated-SQL builders, and this guard's
@@ -109,37 +107,6 @@ const SKIP_FILES = new Set([
   'packages/db/scripts/check-writer-coverage.ts',
   'packages/db/scripts/check-db-access.ts',
 ]);
-
-function isTestFile(path: string): boolean {
-  return path.includes('/__tests__/') || /\.(test|spec)\.ts$/.test(path);
-}
-
-/**
- * Sibling suites create and delete scratch sources inside the scanned tree
- * while this scan runs (the egress guard's `__g5_egress_scratch__` under the
- * parallel test runner), so any path listed by the walk may be gone by the
- * time it is stat'ed or read. A vanished path has no call sites: skip it.
- * Every other error still throws.
- */
-function isEnoent(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException).code === 'ENOENT';
-}
-
-function walk(dir: string, out: string[]): void {
-  for (const entry of readdirSync(dir)) {
-    if (SKIP_DIRS.has(entry)) continue;
-    const full = join(dir, entry);
-    let isDirectory: boolean;
-    try {
-      isDirectory = statSync(full).isDirectory();
-    } catch (error) {
-      if (isEnoent(error)) continue;
-      throw error;
-    }
-    if (isDirectory) walk(full, out);
-    else if (full.endsWith('.ts') && !isTestFile(full)) out.push(full);
-  }
-}
 
 /** Drizzle export name -> SQL table, for every RLS-covered table. */
 function drizzleNameFor(table: string): string {
@@ -203,8 +170,7 @@ function stripComments(source: string): string {
  * site do not churn the registry.
  */
 export function scanDbAccessSites(packagesDir: string, repoRoot: string): DbAccessSite[] {
-  const files: string[] = [];
-  walk(packagesDir, files);
+  const files = readSources(packagesDir);
 
   const drizzleNames = [...RLS_DRIZZLE_TO_TABLE.keys()];
   const builder = new RegExp(`\\.(?:from|insert|update|delete)\\(\\s*(${drizzleNames.join('|')})\\s*[),]`, 'g');
@@ -218,16 +184,9 @@ export function scanDbAccessSites(packagesDir: string, repoRoot: string): DbAcce
   );
 
   const sites = new Map<string, DbAccessSite>();
-  for (const file of files) {
+  for (const { file, source: raw } of files) {
     const rel = relative(repoRoot, file);
     if (SKIP_FILES.has(rel)) continue;
-    let raw: string;
-    try {
-      raw = readFileSync(file, 'utf-8');
-    } catch (error) {
-      if (isEnoent(error)) continue;
-      throw error;
-    }
     const source = stripComments(raw);
 
     for (const match of source.matchAll(builder)) {

--- a/packages/db/src/tenancy-scan-sources.test.ts
+++ b/packages/db/src/tenancy-scan-sources.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readSources } from './tenancy-scan-sources';
+
+const root = mkdtempSync(join(tmpdir(), 'tenancy-scan-'));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe('readSources', () => {
+  test('tolerates entries that vanish between listing and read (issue #1080)', () => {
+    mkdirSync(join(root, '__g5_egress_scratch__'), { recursive: true });
+    writeFileSync(join(root, 'kept.ts'), 'export const kept = 1;');
+    writeFileSync(join(root, 'kept.test.ts'), 'export const test = 1;');
+    // A dangling symlink is listed by readdir but fails stat/read with ENOENT —
+    // the same shape as a sibling test deleting its scratch file mid-walk.
+    symlinkSync(join(root, 'gone.ts'), join(root, '__g5_egress_scratch__', 'rogue-egress.ts'));
+    symlinkSync(join(root, 'gone-dir'), join(root, 'vanished-dir'));
+
+    const files = readSources(root).map((s) => s.file);
+    expect(files).toEqual([join(root, 'kept.ts')]);
+  });
+
+  test('returns nothing for a root that no longer exists', () => {
+    expect(readSources(join(root, 'never-existed'))).toEqual([]);
+  });
+});

--- a/packages/db/src/tenancy-scan-sources.ts
+++ b/packages/db/src/tenancy-scan-sources.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared source walker for the tenancy static guards (writer coverage, DB
+ * access guard).
+ *
+ * Sibling suites create and delete scratch directories (`__g3_access_scratch__`,
+ * `__g5_egress_scratch__`) inside the scanned tree while a scan runs under the
+ * parallel test runner, so any path listed by the walk may be gone by the time
+ * it is listed, stat'ed, or read. A vanished path has no call sites: skip it.
+ * Every other error still throws. See issue #1080.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface SourceFile {
+  readonly file: string;
+  readonly source: string;
+}
+
+/** Directories excluded from the scan. */
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.turbo', '__tests__', 'coverage']);
+
+function isTestFile(path: string): boolean {
+  return path.includes('/__tests__/') || /\.(test|spec)\.ts$/.test(path);
+}
+
+function isEnoent(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function walk(dir: string, out: SourceFile[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (error) {
+    if (isEnoent(error)) return;
+    throw error;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    try {
+      if (statSync(full).isDirectory()) walk(full, out);
+      else if (full.endsWith('.ts') && !isTestFile(full)) out.push({ file: full, source: readFileSync(full, 'utf-8') });
+    } catch (error) {
+      if (!isEnoent(error)) throw error;
+    }
+  }
+}
+
+/** Every non-test `.ts` source under `dir`, tolerating files that vanish mid-walk. */
+export function readSources(dir: string): SourceFile[] {
+  const out: SourceFile[] = [];
+  walk(dir, out);
+  return out;
+}

--- a/packages/db/src/tenancy-writer-coverage.ts
+++ b/packages/db/src/tenancy-writer-coverage.ts
@@ -33,9 +33,9 @@
  * unrelated edits do not churn them.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { relative } from 'node:path';
 import { TENANT_OWNERSHIP_SPECS, getOwnershipSpec } from './tenancy-ownership';
+import { readSources } from './tenancy-scan-sources';
 
 /** Drizzle export name -> SQL table name, for the 29 tenant tables. @public */
 export const DRIZZLE_TO_TABLE: ReadonlyMap<string, string> = new Map(
@@ -61,22 +61,6 @@ export interface RegisteredWriter extends WriteSite {
   readonly coverage: WriterCoverage;
 }
 
-/** Directories excluded from the scan. */
-const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.turbo', '__tests__', 'coverage']);
-
-function isTestFile(path: string): boolean {
-  return path.includes('/__tests__/') || /\.(test|spec)\.ts$/.test(path);
-}
-
-function walk(dir: string, out: string[]): void {
-  for (const entry of readdirSync(dir)) {
-    if (SKIP_DIRS.has(entry)) continue;
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) walk(full, out);
-    else if (full.endsWith('.ts') && !isTestFile(full)) out.push(full);
-  }
-}
-
 /**
  * Scan `packagesDir` for Drizzle writes to any of the 29 tenant tables.
  *
@@ -85,8 +69,7 @@ function walk(dir: string, out: string[]): void {
  * use. Raw SQL writes are matched separately so a future one cannot slip past.
  */
 export function scanWriteSites(packagesDir: string, repoRoot: string): WriteSite[] {
-  const files: string[] = [];
-  walk(packagesDir, files);
+  const files = readSources(packagesDir);
 
   const sites = new Map<string, WriteSite>();
   const drizzleNames = [...DRIZZLE_TO_TABLE.keys()];
@@ -96,8 +79,7 @@ export function scanWriteSites(packagesDir: string, repoRoot: string): WriteSite
     'gi',
   );
 
-  for (const file of files) {
-    const source = readFileSync(file, 'utf-8');
+  for (const { file, source } of files) {
     const rel = relative(repoRoot, file);
 
     for (const match of source.matchAll(builder)) {


### PR DESCRIPTION
Closes #1080

## Problem
`scanWriteSites` and `scanDbAccessSites` walk `packages/` while the sibling G3/G5 guard tests create and delete `__g3_access_scratch__` / `__g5_egress_scratch__` under the same tree. Under bun's parallel runner a listed file can vanish before it is read, crashing the scan with ENOENT (CI runs 34437442494, 34519395095).

## Fix
- One shared walker, `readSources()` in `packages/db/src/tenancy-scan-sources.ts`, tolerates ENOENT on readdir, stat, and read. Both scanners use it; the duplicated walkers and the access guard's partial ENOENT handling are removed.
- No `__*_scratch__` skip rule: `tenancy-db-access-guard.test.ts` asserts the scan finds its scratch files under `packages/db/src`, so a skip would break it.
- Regression test `tenancy-scan-sources.test.ts` uses dangling symlinks (listed by readdir, ENOENT on stat/read) to reproduce the vanished-file shape deterministically.

## Verification
- `make typecheck`, `make lint`, `make dead-code`, `make verify-migrations` green.
- Full turbo test suite green via the pre-push hook. The `make test` wrapper itself needs a local `.env` + Postgres for its `_sync-db` step, which this worktree lacks.