### PR TITLE
feat(automations): add {{payload_json}} and {{event_json}} template placeholders

### DIFF
--- a/packages/core/src/automations/__tests__/templates.test.ts
+++ b/packages/core/src/automations/__tests__/templates.test.ts
@@ -13,6 +13,47 @@ import {
 describe('substituteTemplate', () => {
   const baseContext = createTemplateContext({ name: 'Alice', age: 30, email: 'alice@example.com' });
 
+  describe('whole-object JSON placeholders (#1071)', () => {
+    const payload = { pull_request: { title: 'Fix', user: { login: 'octo' } }, action: 'opened' };
+    const event = { id: 'evt_1', type: 'github.pr', timestamp: 1700000000000, metadata: { correlationId: 'c1' } };
+
+    test('{{payload_json}} renders the full payload as compact JSON', () => {
+      const out = substituteTemplate('PR: {{payload_json}}', createTemplateContext(payload));
+      expect(out).toBe(`PR: ${JSON.stringify(payload)}`);
+      expect(JSON.parse(out.slice(4))).toEqual(payload);
+    });
+
+    test('{{event_json}} renders envelope + payload, including the event id', () => {
+      const out = substituteTemplate('{{event_json}}', createTemplateContext(payload, { event }));
+      expect(out).toBe(JSON.stringify({ ...event, payload }));
+      expect(JSON.parse(out).id).toBe('evt_1');
+    });
+
+    test('{{event_json}} renders null envelope fields when no event was threaded', () => {
+      const out = JSON.parse(substituteTemplate('{{event_json}}', createTemplateContext(payload)));
+      expect(out).toEqual({ id: null, type: null, timestamp: null, metadata: null, payload });
+    });
+
+    test('output is deterministic and compact', () => {
+      const ctx = createTemplateContext(payload, { event });
+      const a = substituteTemplate('{{payload_json}}|{{event_json}}', ctx);
+      const b = substituteTemplate('{{payload_json}}|{{event_json}}', ctx);
+      expect(a).toBe(b);
+      expect(a).not.toMatch(/\n| {2}/);
+    });
+
+    test('are not shadowed by stored variables', () => {
+      const ctx = createTemplateContext(payload, { variables: { payload_json: 'nope', event_json: 'nope' } });
+      expect(substituteTemplate('{{payload_json}}', ctx)).toBe(JSON.stringify(payload));
+      expect(substituteTemplate('{{event_json}}', ctx)).not.toBe('nope');
+    });
+
+    test('work inside substituteTemplateObject (action configs)', () => {
+      const cfg = substituteTemplateObject({ promptOverride: 'ctx={{payload_json}}' }, createTemplateContext(payload));
+      expect(cfg.promptOverride).toBe(`ctx=${JSON.stringify(payload)}`);
+    });
+  });
+
   test('substitutes simple payload fields', () => {
     expect(substituteTemplate('Hello {{payload.name}}!', baseContext)).toBe('Hello Alice!');
   });

--- a/packages/core/src/automations/templates.ts
+++ b/packages/core/src/automations/templates.ts
@@ -20,6 +20,13 @@
  * - {{event.metadata.correlationId}} - Envelope: correlation of the flow
  *   (any `event.metadata.*` field resolves; absent for envelope-less
  *   invocations, where `{{event.*}}` renders empty)
+ * - {{payload_json}} - Whole payload as compact JSON (#1071)
+ * - {{event_json}} - Whole event (envelope + payload) as compact JSON (#1071);
+ *   `{ id, type, timestamp, metadata, payload }` — the envelope fields render
+ *   `null` when no envelope was threaded. Output is compact (no whitespace)
+ *   because it is pasted into prompts/bodies inline; key order is fixed for
+ *   the envelope and insertion order for the payload, so equal inputs render
+ *   byte-identical strings.
  */
 
 import type { EventMetadata } from '../events/types';
@@ -191,6 +198,14 @@ function resolveTemplatePath(path: string, context: TemplateContext): unknown {
 
   const specialValue = resolveSpecialValue(trimmed, root, rest, context);
   if (specialValue !== undefined) return specialValue;
+
+  // Whole-object JSON placeholders (#1071) — pre-serialized so they never
+  // collide with a stored variable and always render as compact JSON.
+  if (trimmed === 'payload_json') return JSON.stringify(context.payload);
+  if (trimmed === 'event_json') {
+    const { id = null, type = null, timestamp = null, metadata = null } = context.event ?? {};
+    return JSON.stringify({ id, type, timestamp, metadata, payload: context.payload });
+  }
 
   // Handle payload access
   if (root === 'payload') return rest ? getNestedValue(context.payload, rest) : context.payload;


### PR DESCRIPTION
Closes #1071

Adds two whole-object placeholders to the automation template resolver, so every templated action config (`promptOverride`, `bodyTemplate`, `contentTemplate`, `payloadTemplate`) gets them:

- `{{payload_json}}` — the full payload as JSON.
- `{{event_json}}` — `{ id, type, timestamp, metadata, payload }`; envelope fields are `null` when no envelope was threaded (manual `execute`).

Output is **compact** JSON (no whitespace) since it is pasted inline into prompts and bodies. Envelope key order is fixed and payload keys keep insertion order, so equal inputs render byte-identical strings. Resolved before variable lookup, so stored variables cannot shadow them.

`{{event.id}}` / `{{event.type}}` already existed from #960 and are unchanged.

## Verification
- typecheck, lint, dead-code, verify-migrations: green
- core automation tests: 360 pass
- full `bun run test`: one unrelated failure in the CLI pre-suite leak guard (stale PM2 daemon on the dev box), not touched by this change