### PR TITLE
feat(events): validate a payload against a registered schema without emitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ omni events list --type "message.*" --since 2h  # event history (trailing-* glob
 omni events trace <event-id>                    # causation chain
 omni events wait --type "custom.x.*" --timeout 60  # block until a matching event
 omni events schema register <type> --file s.json   # register a payload schema
+omni events schema validate <type> --file p.json   # dry-run a payload, no event emitted
 omni events consumers create <name> --type "custom.x.*"  # durable cursor
 omni events follow --consumer <name>            # durable tail
 omni events replay --start --since 2024-01-01   # replay events

--- a/docs/cli/design.md
+++ b/docs/cli/design.md
@@ -338,6 +338,7 @@ omni events schema register custom.deploy --file ./deploy.schema.json --descript
 omni events schema register custom.ping --schema '{"type":"object"}' --disabled
 omni events schema list
 omni events schema get custom.deploy
+omni events schema validate custom.deploy --file ./payload.json   # dry run: exit 1 + violations, no event emitted
 ```
 
 > [!note] Glob and emission caveats

--- a/packages/api/src/constants/scopes.ts
+++ b/packages/api/src/constants/scopes.ts
@@ -162,6 +162,7 @@ export const SCOPE_MAP: Record<string, string> = {
   'GET /events/schemas': 'events:read',
   'GET /events/schemas/:eventType': 'events:read',
   'POST /events/schemas': 'events:write',
+  'POST /events/schemas/:eventType/validate': 'events:read', // dry run, read-only (#1076)
   'GET /events/consumers/:name': 'events:read',
   'POST /events/consumers': 'events:write',
   'DELETE /events/consumers/:name': 'events:write',

--- a/packages/api/src/routes/v2/__tests__/event-schemas.test.ts
+++ b/packages/api/src/routes/v2/__tests__/event-schemas.test.ts
@@ -22,6 +22,7 @@ interface RegisteredCall {
 
 function buildApp() {
   const registered: RegisteredCall[] = [];
+  const validated: { eventType: string; payload: unknown }[] = [];
   const row = {
     id: '11111111-1111-4111-8111-111111111111',
     eventType: 'custom.github.push',
@@ -41,6 +42,17 @@ function buildApp() {
       register: async (input: RegisteredCall) => {
         registered.push(input);
         return { ...row, eventType: input.eventType, schema: input.schema };
+      },
+      validatePayload: async (eventType: string, payload: unknown) => {
+        validated.push({ eventType, payload });
+        const valid = typeof payload === 'object' && payload !== null && 'ref' in payload;
+        return {
+          eventType,
+          version: 1,
+          enabled: true,
+          valid,
+          errors: valid ? [] : ["/: must have required property 'ref'"],
+        };
       },
     },
     // The events catch-all must never be reached by /events/schemas paths.
@@ -63,7 +75,7 @@ function buildApp() {
   // Production mount order (routes/v2/index.ts): registry first, then /events.
   app.route('/api/v2', eventSchemasRoutes);
   app.route('/api/v2/events', eventsRoutes);
-  return { app, registered };
+  return { app, registered, validated };
 }
 
 describe('event schema registry routes', () => {
@@ -121,5 +133,45 @@ describe('event schema registry routes', () => {
     });
     expect(res.status).toBe(400);
     expect(registered.length).toBe(0);
+  });
+
+  test('POST /events/schemas/:eventType/validate returns the verdict without registering anything', async () => {
+    const { app, registered, validated } = buildApp();
+    const res = await app.request('/api/v2/events/schemas/custom.github.push/validate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ payload: { commits: [] } }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { valid: boolean; errors: string[] } };
+    expect(json.data.valid).toBe(false);
+    expect(json.data.errors).toEqual(["/: must have required property 'ref'"]);
+    expect(validated).toEqual([{ eventType: 'custom.github.push', payload: { commits: [] } }]);
+    expect(registered.length).toBe(0);
+  });
+
+  test('POST /events/schemas/:eventType/validate accepts a valid payload with 200 and no errors', async () => {
+    const { app } = buildApp();
+    const res = await app.request('/api/v2/events/schemas/custom.github.push/validate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ payload: { ref: 'refs/heads/main' } }),
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { data: { valid: boolean; errors: string[] } }).data).toMatchObject({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  test('POST /events/schemas/:eventType/validate refuses a body without payload at the boundary', async () => {
+    const { app, validated } = buildApp();
+    const res = await app.request('/api/v2/events/schemas/custom.github.push/validate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ref: 'refs/heads/main' }),
+    });
+    expect(res.status).toBe(400);
+    expect(validated.length).toBe(0);
   });
 });

--- a/packages/api/src/routes/v2/event-schemas.ts
+++ b/packages/api/src/routes/v2/event-schemas.ts
@@ -14,7 +14,7 @@
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { RegisterEventSchemaSchema } from '../../schemas/openapi/event-schemas';
+import { RegisterEventSchemaSchema, ValidateEventPayloadSchema } from '../../schemas/openapi/event-schemas';
 import type { AppVariables } from '../../types';
 
 const eventSchemasRoutes = new Hono<{ Variables: AppVariables }>();
@@ -58,5 +58,23 @@ eventSchemasRoutes.post('/events/schemas', zValidator('json', RegisterEventSchem
 
   return c.json({ data }, 201);
 });
+
+/**
+ * POST /events/schemas/:eventType/validate - Dry-run a payload against the
+ * registered schema (issue #1076). Read-only: nothing is published or written.
+ */
+eventSchemasRoutes.post(
+  '/events/schemas/:eventType/validate',
+  zValidator('json', ValidateEventPayloadSchema),
+  async (c) => {
+    const eventType = c.req.param('eventType');
+    const { payload } = c.req.valid('json');
+    const services = c.get('services');
+
+    const data = await services.eventSchemas.validatePayload(eventType, payload);
+
+    return c.json({ data });
+  },
+);
 
 export { eventSchemasRoutes };

--- a/packages/api/src/schemas/openapi/event-schemas.ts
+++ b/packages/api/src/schemas/openapi/event-schemas.ts
@@ -38,9 +38,30 @@ export const RegisterEventSchemaSchema = z.object({
   enabled: z.boolean().optional().openapi({ description: 'Whether the validation gate is active (default true)' }),
 });
 
+export const ValidateEventPayloadSchema = z
+  .object({
+    payload: z.unknown().openapi({ description: 'The event payload to validate (any JSON value)' }),
+  })
+  // z.unknown() makes the key optional; the dry run must not silently validate `undefined`.
+  .refine((body) => 'payload' in body, { message: 'payload is required', path: ['payload'] });
+
+export const EventPayloadValidationSchema = z.object({
+  eventType: z.string().openapi({ description: 'Event type the payload was checked against' }),
+  version: z.number().int().openapi({ description: 'Schema revision used' }),
+  enabled: z
+    .boolean()
+    .openapi({ description: 'Whether the gate is active for this type (a disabled schema is still checked)' }),
+  valid: z.boolean().openapi({ description: 'True when the payload satisfies the schema' }),
+  errors: z
+    .array(z.string())
+    .openapi({ description: 'Violations as `instancePath: message`, identical to the ingress gate; empty when valid' }),
+});
+
 export function registerEventSchemaSchemas(registry: OpenAPIRegistry): void {
   registry.register('EventSchema', EventSchemaSchema);
   registry.register('RegisterEventSchemaRequest', RegisterEventSchemaSchema);
+  registry.register('ValidateEventPayloadRequest', ValidateEventPayloadSchema);
+  registry.register('EventPayloadValidation', EventPayloadValidationSchema);
 
   registry.registerPath({
     method: 'get',
@@ -106,6 +127,32 @@ export function registerEventSchemaSchemas(registry: OpenAPIRegistry): void {
       400: { description: 'Not a valid JSON Schema', content: { 'application/json': { schema: ErrorSchema } } },
       409: {
         description: 'Incompatible schema change refused (evolution rule)',
+        content: { 'application/json': { schema: ErrorSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/events/schemas/{eventType}/validate',
+    operationId: 'validateEventPayload',
+    tags: ['Events'],
+    summary: 'Validate a payload against a registered event schema (dry run)',
+    description:
+      'Check a payload against the registered schema with the same validator and error strings as the ' +
+      'webhook ingress and emit_event gates, without publishing an event or writing anything (no dead letter). ' +
+      'Returns 200 whether the payload is valid or not; read the `valid` flag and `errors`.',
+    request: {
+      params: z.object({ eventType: z.string().openapi({ description: 'Event type (e.g. custom.github.push)' }) }),
+      body: { content: { 'application/json': { schema: ValidateEventPayloadSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'Validation verdict',
+        content: { 'application/json': { schema: z.object({ data: EventPayloadValidationSchema }) } },
+      },
+      404: {
+        description: 'No schema registered for this type',
         content: { 'application/json': { schema: ErrorSchema } },
       },
     },

--- a/packages/api/src/services/__tests__/event-schema-gates-postgres.test.ts
+++ b/packages/api/src/services/__tests__/event-schema-gates-postgres.test.ts
@@ -232,6 +232,25 @@ postgresDescribe('event schema registry gates (real PostgreSQL)', () => {
     expect((await dlqRows()).length).toBe(3);
   });
 
+  test('dry run (#1076): same errors as the gate, no DLQ row, nothing published', async () => {
+    const dlqBefore = (await dlqRows()).length;
+    const journalBefore = journal.length;
+
+    const bad = await eventSchemas.validatePayload('custom.github.push', { ref: 7 });
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.length).toBeGreaterThan(0);
+    expect(bad.version).toBe(1);
+
+    const good = await eventSchemas.validatePayload('custom.github.push', { ref: 'refs/heads/main', commits: [] });
+    expect(good.valid).toBe(true);
+    expect(good.errors).toEqual([]);
+
+    await expect(eventSchemas.validatePayload('custom.not.registered', {})).rejects.toThrow(/not found/i);
+
+    expect((await dlqRows()).length).toBe(dlqBefore);
+    expect(journal.length).toBe(journalBefore);
+  });
+
   test('evolution: an additive-optional revision is accepted and bumps the version', async () => {
     const v2 = {
       ...PUSH_SCHEMA_V1,

--- a/packages/api/src/services/event-schemas.ts
+++ b/packages/api/src/services/event-schemas.ts
@@ -52,6 +52,16 @@ export interface EventSchemaGateVerdict {
   errors: string[];
 }
 
+/** Read-only verdict for `validatePayload` (issue #1076): no event, no DLQ row. */
+export interface EventSchemaDryRunVerdict {
+  eventType: string;
+  version: number;
+  enabled: boolean;
+  valid: boolean;
+  /** Same `instancePath: message` lines the ingress gate dead-letters with. */
+  errors: string[];
+}
+
 export class EventSchemaService {
   /**
    * The handle every query in this service uses.
@@ -178,6 +188,18 @@ export class EventSchemaService {
     }
     const verdict = validateEventPayload(row.schema, payload);
     return { registered: true, valid: verdict.valid, errors: verdict.errors };
+  }
+
+  /**
+   * Dry-run validation (issue #1076): the ingress gate's engine and error
+   * strings, without publishing, dead-lettering, or the gate cache. Throws
+   * 404 for an unregistered type (a dry run against nothing is a mistake,
+   * not a pass-through); a disabled schema is still checked and reported.
+   */
+  async validatePayload(eventType: string, payload: unknown): Promise<EventSchemaDryRunVerdict> {
+    const row = await this.getByTypeOrThrow(eventType);
+    const verdict = validateEventPayload(row.schema, payload);
+    return { eventType: row.eventType, version: row.version, enabled: row.enabled, ...verdict };
   }
 
   private async lookupForGate(eventType: string): Promise<EventSchemaRow | null> {

--- a/packages/api/src/tenancy/route-ownership.ts
+++ b/packages/api/src/tenancy/route-ownership.ts
@@ -671,6 +671,7 @@ const TENANT_SCOPED_ROUTES: readonly RouteKey[] = [
   'POST /api/v2/events/consumers/:name/ack',
   'POST /api/v2/events/consumers/:name/pull',
   'POST /api/v2/events/schemas',
+  'POST /api/v2/events/schemas/:eventType/validate',
   'POST /api/v2/events/search',
   'POST /api/v2/events/trigger',
   'POST /api/v2/instances',

--- a/packages/cli/src/commands/__tests__/events-schema.test.ts
+++ b/packages/cli/src/commands/__tests__/events-schema.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { __testables } from '../events';
 
-const { schemaApiRequest, loadSchemaArtifact, summarizeSchemaRow } = __testables;
+const { schemaApiRequest, loadSchemaArtifact, loadPayload, summarizeSchemaRow } = __testables;
 
 // The round-trip talks to a REAL in-process server, so it needs the REAL
 // fetch. `bun test` runs every package's files in ONE process, and a file
@@ -46,6 +46,43 @@ interface StoredSchema {
   updatedAt: string;
 }
 
+/** Stand-in for POST /events/schemas: insert at v1, bump on re-register. */
+function registerRow(rows: Map<string, StoredSchema>, body: unknown): Response {
+  const input = body as { eventType: string; schema: Record<string, unknown>; description?: string };
+  const existing = rows.get(input.eventType);
+  const row: StoredSchema = {
+    id: '22222222-2222-4222-8222-222222222222',
+    eventType: input.eventType,
+    version: existing ? existing.version + 1 : 1,
+    schema: input.schema,
+    description: input.description ?? null,
+    enabled: true,
+    createdAt: existing?.createdAt ?? new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  rows.set(input.eventType, row);
+  return Response.json({ data: row }, { status: 201 });
+}
+
+/** Stand-in for POST /events/schemas/:type/validate: required-key check, same error shape as the gate. */
+function dryRunValidate(rows: Map<string, StoredSchema>, eventType: string, body: unknown): Response {
+  const row = rows.get(eventType);
+  if (!row) {
+    return Response.json(
+      { error: { code: 'NOT_FOUND', message: `EventSchema not found: ${eventType}` } },
+      { status: 404 },
+    );
+  }
+  const { payload } = body as { payload: unknown };
+  const required = (row.schema.required as string[] | undefined) ?? [];
+  const errors = required
+    .filter((key) => typeof payload !== 'object' || payload === null || !(key in payload))
+    .map((key) => `/: must have required property '${key}'`);
+  return Response.json({
+    data: { eventType, version: row.version, enabled: row.enabled, valid: errors.length === 0, errors },
+  });
+}
+
 /** In-memory registry speaking the /api/v2/events/schemas contract. */
 function startRegistryServer() {
   const rows = new Map<string, StoredSchema>();
@@ -61,20 +98,10 @@ function startRegistryServer() {
       const rest = decodeURIComponent(url.pathname.slice(prefix.length).replace(/^\//, ''));
 
       if (req.method === 'POST' && rest === '') {
-        const body = (await req.json()) as { eventType: string; schema: Record<string, unknown>; description?: string };
-        const existing = rows.get(body.eventType);
-        const row: StoredSchema = {
-          id: '22222222-2222-4222-8222-222222222222',
-          eventType: body.eventType,
-          version: existing ? existing.version + 1 : 1,
-          schema: body.schema,
-          description: body.description ?? null,
-          enabled: true,
-          createdAt: existing?.createdAt ?? new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        };
-        rows.set(body.eventType, row);
-        return Response.json({ data: row }, { status: 201 });
+        return registerRow(rows, await req.json());
+      }
+      if (req.method === 'POST' && rest.endsWith('/validate')) {
+        return dryRunValidate(rows, rest.slice(0, -'/validate'.length), await req.json());
       }
       if (req.method === 'GET' && rest === '') {
         return Response.json({ items: [...rows.values()] });
@@ -135,6 +162,29 @@ describe('omni events schema round-trip', () => {
     expect(fetched.data.schema).toEqual(artifact);
   });
 
+  test('validate dry-runs a payload through the API without touching the registry', async () => {
+    const path = `/${encodeURIComponent('custom.github.push')}/validate`;
+    const versionBefore = rows.get('custom.github.push')?.version;
+
+    const bad = await schemaApiRequest<{ data: { valid: boolean; errors: string[] } }>(path, {
+      method: 'POST',
+      body: JSON.stringify({ payload: { commits: [] } }),
+    });
+    expect(bad.data.valid).toBe(false);
+    expect(bad.data.errors).toEqual(["/: must have required property 'ref'"]);
+
+    const good = await schemaApiRequest<{ data: { valid: boolean; errors: string[] } }>(path, {
+      method: 'POST',
+      body: JSON.stringify({ payload: { ref: 'refs/heads/main' } }),
+    });
+    expect(good.data).toMatchObject({ valid: true, errors: [] });
+
+    expect(rows.get('custom.github.push')?.version).toBe(versionBefore);
+    await expect(
+      schemaApiRequest('/custom.not.registered/validate', { method: 'POST', body: JSON.stringify({ payload: {} }) }),
+    ).rejects.toThrow(/API returned 404/);
+  });
+
   test('a non-2xx response surfaces the API status and body', async () => {
     await expect(schemaApiRequest('/custom.not.registered')).rejects.toThrow(/API returned 404/);
   });
@@ -165,5 +215,25 @@ describe('loadSchemaArtifact', () => {
   test('refuses a non-object artifact', () => {
     expect(() => loadSchemaArtifact({ schema: '[1,2]' })).toThrow(/JSON object/);
     expect(() => loadSchemaArtifact({ schema: '"str"' })).toThrow(/JSON object/);
+  });
+});
+
+describe('loadPayload', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omni-cli-payload-'));
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('reads any JSON value from --file or --payload', () => {
+    const file = join(dir, 'payload.json');
+    writeFileSync(file, JSON.stringify({ ref: 'x' }));
+    expect(loadPayload({ file })).toEqual({ ref: 'x' });
+    expect(loadPayload({ payload: '[1,2]' })).toEqual([1, 2]);
+  });
+
+  test('requires exactly one source', () => {
+    expect(() => loadPayload({})).toThrow(/exactly one/);
+    expect(() => loadPayload({ file: 'x.json', payload: '{}' })).toThrow(/exactly one/);
   });
 });

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -343,6 +343,23 @@ function loadSchemaArtifact(options: { file?: string; schema?: string }): Record
   return parsed as Record<string, unknown>;
 }
 
+/** Load the payload to validate from --file or inline --payload (exactly one); any JSON value. */
+function loadPayload(options: { file?: string; payload?: string }): unknown {
+  if ((options.file ? 1 : 0) + (options.payload ? 1 : 0) !== 1) {
+    throw new Error('Provide the payload via exactly one of --file <path> or --payload <json>');
+  }
+  return JSON.parse(options.file ? readFileSync(options.file, 'utf-8') : (options.payload as string)) as unknown;
+}
+
+/** Verdict of the dry-run validate endpoint (issue #1076). */
+interface PayloadValidation {
+  eventType: string;
+  version: number;
+  enabled: boolean;
+  valid: boolean;
+  errors: string[];
+}
+
 function summarizeSchemaRow(row: EventSchemaData): Record<string, unknown> {
   return {
     eventType: row.eventType,
@@ -421,10 +438,42 @@ function createSchemaCommand(): Command {
       }
     });
 
+  schema
+    .command('validate <eventType>')
+    .description('Validate a payload against the registered schema without emitting an event (exit 1 on violations)')
+    .option('--file <path>', 'Path to a JSON payload file')
+    .option('--payload <json>', 'Inline JSON payload')
+    .action(async (eventType: string, options: { file?: string; payload?: string }) => {
+      let result: PayloadValidation;
+      try {
+        const payload = loadPayload(options);
+        const res = await schemaApiRequest<{ data: PayloadValidation }>(`/${encodeURIComponent(eventType)}/validate`, {
+          method: 'POST',
+          body: JSON.stringify({ payload }),
+        });
+        result = res.data;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        output.error(`Failed to validate payload: ${message}`, undefined, 2);
+      }
+
+      if (result.valid) {
+        output.success(`Payload is valid for ${result.eventType} (schema version ${result.version})`, result);
+        return;
+      }
+      if (output.getCurrentFormat() === 'human') {
+        for (const line of result.errors) output.raw(`  - ${line}`);
+      }
+      output.error(
+        `Payload violates the schema for ${result.eventType} (schema version ${result.version}): ${result.errors.length} issue(s)`,
+        output.getCurrentFormat() === 'json' ? result : undefined,
+      );
+    });
+
   return schema;
 }
 
-export const __testables = { schemaApiRequest, loadSchemaArtifact, summarizeSchemaRow };
+export const __testables = { schemaApiRequest, loadSchemaArtifact, loadPayload, summarizeSchemaRow };
 
 /**
  * Table projection for list-shaped event commands. Human-readable output only:


### PR DESCRIPTION
Closes #1076

## What
- `POST /api/v2/events/schemas/:eventType/validate` with body `{ "payload": <any JSON> }`. Read-only: same `validateEventPayload` engine and `instancePath: message` strings the ingress and `emit_event` gates use, but nothing is published, no dead letter, no gate cache. 200 with `{ valid, errors, version, enabled }`; 404 when the type is unregistered. OpenAPI path + scope (`events:read`) + route ownership declared.
- `omni events schema validate <type> --file <path> | --payload <json>`. Human mode prints one line per violation; `--json` prints the verdict. Exit 0 valid, 1 violations, 2 request/parse failure.
- Service method `EventSchemaService.validatePayload`.

## Tests
- Route contract (mocked service): verdict, valid, and a body without `payload` refused at the boundary.
- Real-PostgreSQL gate suite: dry run reports the same errors as the gate with no DLQ row and nothing in the journal.
- CLI round-trip against an in-process API stub, plus payload loader rules.

## Verification
- `make typecheck`, `make lint`, `make dead-code`, `make verify-migrations`, `make verify-versions`: green.
- Full unit suite (pre-push hook run): green, all packages.
- `make test-pg-gate`: the event-schema suite passes; one pre-existing failure in `tests/release/upgrade-2.260902.5-to-2.260908.20-postgres.test.ts` (catalog fingerprint diff on local PostgreSQL 18 NOT NULL constraints), untouched by this change.
