### PR TITLE
fix(api): never echo raw SQL or bound params from database errors

### DIFF
--- a/packages/api/src/__tests__/middleware-error-db-leak.test.ts
+++ b/packages/api/src/__tests__/middleware-error-db-leak.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression for #1069: database errors must not echo SQL text or bound
+ * parameters (notably the api_keys lookup's key_hash) to API clients.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { DrizzleQueryError } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { errorHandler } from '../middleware/error';
+import type { AppVariables } from '../types';
+
+const KEY_HASH = 'a'.repeat(64);
+const SQL =
+  'select "id", "name", "key_hash", "scopes" from "api_keys" where ("api_keys"."key_hash" = $1 and "api_keys"."status" = $2)';
+
+function pgError(message: string, code: string): Error {
+  const err = new Error(message);
+  err.name = 'PostgresError';
+  Object.assign(err, { code });
+  return err;
+}
+
+function appThrowing(error: unknown): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.get('/events', () => {
+    throw error;
+  });
+  return app;
+}
+
+describe('error boundary — database error leakage (#1069)', () => {
+  test('drizzle query failure returns DB_QUERY_FAILED with no SQL or params', async () => {
+    const error = new DrizzleQueryError(SQL, [KEY_HASH, 'active'], pgError('connection is closed', 'XX000'));
+    const res = await appThrowing(error).request('/events');
+    const text = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(JSON.parse(text)).toEqual({
+      error: { code: 'DB_QUERY_FAILED', message: 'Database query failed', retryable: true },
+    });
+    expect(text).not.toContain(KEY_HASH);
+    expect(text).not.toContain('api_keys');
+    expect(text).not.toContain('Failed query');
+    expect(text).not.toContain('params');
+  });
+
+  test('connection-level failure maps to 503 DB_CONNECTION_FAILED', async () => {
+    const error = new DrizzleQueryError(SQL, [KEY_HASH], pgError('write CONNECT_TIMEOUT db:5432', 'CONNECT_TIMEOUT'));
+    const res = await appThrowing(error).request('/events');
+    const text = await res.text();
+
+    expect(res.status).toBe(503);
+    expect(JSON.parse(text).error.code).toBe('DB_CONNECTION_FAILED');
+    expect(text).not.toContain(KEY_HASH);
+    expect(text).not.toContain('db:5432');
+  });
+
+  test('unknown errors never echo their message, regardless of NODE_ENV', async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    try {
+      const res = await appThrowing(new Error(`secret detail ${KEY_HASH}`)).request('/events');
+      const text = await res.text();
+      expect(res.status).toBe(500);
+      expect(JSON.parse(text).error.code).toBe('INTERNAL_ERROR');
+      expect(text).not.toContain(KEY_HASH);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  test('unique violations still map to 409 CONFLICT through the wrapper', async () => {
+    const driver = Object.assign(pgError('duplicate key', '23505'), { detail: 'Key (name)=(foo) already exists.' });
+    const res = await appThrowing(new DrizzleQueryError('insert into x', ['foo'], driver)).request('/events');
+    expect(res.status).toBe(409);
+  });
+});

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -5,6 +5,7 @@
 import { ConflictError, ERROR_CODES, NotFoundError, OmniError, ValidationError, createLogger } from '@omni/core';
 import { unwrapDbError } from '@omni/db';
 import * as Sentry from '@sentry/bun';
+import { DrizzleQueryError } from 'drizzle-orm';
 import type { Context, ErrorHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { ZodError } from 'zod';
@@ -311,19 +312,88 @@ function handleDatabaseError(
 }
 
 /**
- * Handle unknown errors
+ * postgres-js socket/connection failure codes (string, not SQLSTATE) plus the
+ * SQLSTATE class 08 prefix. Anything else from the driver is a query failure.
  */
-function handleUnknownError(c: Context, error: unknown): Response {
-  const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+const PG_CONNECTION_CODES = new Set([
+  'CONNECT_TIMEOUT',
+  'CONNECTION_CLOSED',
+  'CONNECTION_DESTROYED',
+  'CONNECTION_ENDED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EPIPE',
+]);
+
+interface DbErrorInfo {
+  code: typeof ERROR_CODES.DB_QUERY_FAILED | typeof ERROR_CODES.DB_CONNECTION_FAILED;
+  /** Failed SQL text (no bound parameters) — server log only. */
+  query?: string;
+  driverCode?: string;
+  driverMessage: string;
+}
+
+/**
+ * Classify a database failure. Returns null for anything that is not a
+ * drizzle/postgres-js error. The result deliberately carries the SQL but
+ * NEVER the bound parameters: the api_keys lookup binds the caller's key_hash
+ * (#1069), so params must not reach logs, Sentry, or responses.
+ */
+export function describeDbError(error: unknown): DbErrorInfo | null {
+  const driver = unwrapDbError(error);
+  const rawCode = driver instanceof Error ? (driver as { code?: unknown }).code : undefined;
+  const driverCode = typeof rawCode === 'string' ? rawCode : undefined;
+  const isDriverError =
+    driver instanceof Error &&
+    (driver.name === 'PostgresError' || (driverCode !== undefined && PG_CONNECTION_CODES.has(driverCode)));
+  if (!(error instanceof DrizzleQueryError) && !isDriverError) return null;
+
+  const connection = driverCode !== undefined && (PG_CONNECTION_CODES.has(driverCode) || driverCode.startsWith('08'));
+  return {
+    code: connection ? ERROR_CODES.DB_CONNECTION_FAILED : ERROR_CODES.DB_QUERY_FAILED,
+    query: error instanceof DrizzleQueryError ? error.query : undefined,
+    driverCode,
+    driverMessage: driver instanceof Error ? driver.message : String(driver),
+  };
+}
+
+/**
+ * Client-safe message for an arbitrary caught error. Database errors reduce
+ * to a generic string; everything else keeps its message. Use this at every
+ * route-level catch that serializes an error message into a response.
+ */
+export function safeErrorMessage(error: unknown, fallback = 'Unknown error'): string {
+  const db = describeDbError(error);
+  if (db) return db.code === ERROR_CODES.DB_CONNECTION_FAILED ? 'Database unavailable' : 'Database query failed';
+  return error instanceof Error ? error.message : fallback;
+}
+
+/**
+ * Handle generic database failures (anything not mapped to a 4xx above).
+ * Clients get a code and a generic message; the SQL stays in the server log.
+ */
+function handleGenericDbError(c: Context, info: DbErrorInfo): Response {
   return c.json(
     {
       error: {
-        code: 'INTERNAL_ERROR',
-        message: process.env.NODE_ENV === 'production' ? 'Internal server error' : message,
+        code: info.code,
+        message: info.code === ERROR_CODES.DB_CONNECTION_FAILED ? 'Database unavailable' : 'Database query failed',
+        retryable: true,
       },
     },
-    500,
+    ERROR_STATUS_MAP[info.code],
   );
+}
+
+/**
+ * Handle unknown errors. The raw message is never echoed, in any NODE_ENV:
+ * unknown errors are exactly the ones whose messages were not written for
+ * clients (driver output, stack-adjacent detail, internal hostnames).
+ */
+function handleUnknownError(c: Context): Response {
+  return c.json({ error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } }, 500);
 }
 
 /**
@@ -362,7 +432,9 @@ function routeError(c: Context, error: unknown): Response {
     const dbResult = handleDatabaseError(c, dbError as Error & { code?: string; detail?: string; constraint?: string });
     if (dbResult) return dbResult;
   }
-  return handleUnknownError(c, error);
+  const dbInfo = describeDbError(error);
+  if (dbInfo) return handleGenericDbError(c, dbInfo);
+  return handleUnknownError(c);
 }
 
 /** PostgreSQL error codes that represent client mistakes (not server errors) */
@@ -415,10 +487,19 @@ export const errorHandler: ErrorHandler<{ Variables: AppVariables }> = (error, c
       error: error instanceof Error ? error.message : String(error),
     });
   } else {
-    // Server errors (5xx) - log at error level with stack trace
+    // Server errors (5xx) - log at error level with stack trace.
+    // DB errors are logged from the classified shape (SQL + driver code), never
+    // from the drizzle wrapper message, which embeds the bound parameters.
+    const dbInfo = describeDbError(error);
     log.error('Server error', {
       requestId,
-      error: error instanceof Error ? error.message : String(error),
+      error: dbInfo
+        ? `${dbInfo.code}: ${dbInfo.driverMessage}`
+        : error instanceof Error
+          ? error.message
+          : String(error),
+      dbCode: dbInfo?.driverCode,
+      query: dbInfo?.query,
       stack: error instanceof Error ? error.stack : undefined,
     });
 
@@ -438,7 +519,14 @@ export const errorHandler: ErrorHandler<{ Variables: AppVariables }> = (error, c
         }
       }
 
-      Sentry.captureException(error);
+      if (dbInfo) {
+        scope.setTag('error.code', dbInfo.code);
+        scope.setExtra('db.query', dbInfo.query);
+        // Report the driver error, not the drizzle wrapper (its message carries params)
+        Sentry.captureException(unwrapDbError(error));
+      } else {
+        Sentry.captureException(error);
+      }
     });
   }
 

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -38,6 +38,7 @@ import { consumerOffsets } from '@omni/db';
 import { sql } from 'drizzle-orm';
 import { type Context, Hono } from 'hono';
 import packageJson from '../../package.json';
+import { safeErrorMessage } from '../middleware/error';
 import { arePluginsDegraded, getPluginsDegradedReason } from '../plugin-state';
 import type { AppVariables, HealthCheck, HealthResponse } from '../types';
 
@@ -64,7 +65,7 @@ export const getHealth = async (c: Context<{ Variables: AppVariables }>) => {
     dbCheck = {
       status: 'error',
       latency: Date.now() - dbStart,
-      error: error instanceof Error ? error.message : 'Unknown error',
+      error: safeErrorMessage(error),
     };
   }
 

--- a/packages/api/src/routes/v2/event-ops.ts
+++ b/packages/api/src/routes/v2/event-ops.ts
@@ -9,6 +9,7 @@
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { describeDbError } from '../../middleware/error';
 import { optionalDateParam, requiredDateParam } from '../../schemas/date-query';
 import { ApiKeyService } from '../../services/api-keys';
 import type { AppVariables } from '../../types';
@@ -78,6 +79,7 @@ eventOpsRoutes.post('/replay', zValidator('json', replayOptionsSchema), async (c
     const session = await services.eventOps.startReplay(options);
     return c.json({ data: session }, 202);
   } catch (err) {
+    if (describeDbError(err)) throw err; // let the error boundary map it (#1069)
     return c.json({ error: String(err) }, 400);
   }
 });

--- a/packages/api/src/routes/v2/scheduled-messages.ts
+++ b/packages/api/src/routes/v2/scheduled-messages.ts
@@ -18,6 +18,7 @@ import type { ChannelType } from '@omni/core';
 import { ERROR_CODES, OmniError } from '@omni/core';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { safeErrorMessage } from '../../middleware/error';
 import { ScheduledMessageService, createPluginResolver } from '../../services/scheduled-messages';
 import type { AppVariables } from '../../types';
 
@@ -80,7 +81,7 @@ scheduledMessagesRoutes.post('/', zValidator('json', scheduleSchema), async (c) 
     if (error instanceof OmniError) throw error;
     throw new OmniError({
       code: ERROR_CODES.UNKNOWN,
-      message: error instanceof Error ? error.message : String(error),
+      message: safeErrorMessage(error, String(error)),
       recoverable: false,
       cause: error instanceof Error ? error : undefined,
     });

--- a/packages/api/src/routes/v2/voice.ts
+++ b/packages/api/src/routes/v2/voice.ts
@@ -14,6 +14,7 @@ import { zValidator } from '@hono/zod-validator';
 import { isVoiceCapable } from '@omni/channel-sdk';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { safeErrorMessage } from '../../middleware/error';
 import type { AppVariables } from '../../types';
 
 export const voiceRoutes = new Hono<{ Variables: AppVariables }>();
@@ -77,7 +78,7 @@ voiceRoutes.post('/join', zValidator('json', joinSchema), async (c) => {
       201,
     );
   } catch (err) {
-    return c.json({ error: { code: 'VOICE_JOIN_FAILED', message: String(err) } }, 500);
+    return c.json({ error: { code: 'VOICE_JOIN_FAILED', message: safeErrorMessage(err) } }, 500);
   }
 });
 
@@ -99,7 +100,7 @@ voiceRoutes.post('/leave', zValidator('json', leaveSchema), async (c) => {
 
     return c.json({ success: true });
   } catch (err) {
-    return c.json({ error: { code: 'VOICE_LEAVE_FAILED', message: String(err) } }, 500);
+    return c.json({ error: { code: 'VOICE_LEAVE_FAILED', message: safeErrorMessage(err) } }, 500);
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes #1069. Database errors were echoed to API clients with the raw SQL and bound parameters, including the `api_keys` lookup with the caller's `key_hash`.

**Root cause:** Drizzle >= 0.44 wraps driver failures in `DrizzleQueryError`, whose message is `Failed query: <sql>\nparams: <values>`. The shared Hono error boundary (`packages/api/src/middleware/error.ts`) fell through to `handleUnknownError`, which echoed `error.message` whenever `NODE_ENV !== 'production'`. The CLI's `events stream` polls `GET /events`; the auth middleware's api_keys lookup failed during a Postgres blip, and the wrapper message went straight into the response body.

**Fix (in the shared boundary):**
- `describeDbError()` classifies drizzle / postgres-js errors. Clients get `{ code: DB_QUERY_FAILED | DB_CONNECTION_FAILED, message: <generic>, retryable: true }` with 500 / 503. Unique / FK violations still map to 409 / 400.
- Server log gets the failed SQL and driver SQLSTATE, never the bound params. Sentry receives the unwrapped driver error with the SQL as an extra, not the wrapper.
- Unknown errors no longer echo their message in any environment.
- Route-level catch sites that serialized `error.message` into a response (`event-ops` replay, `voice` join/leave, `health` DB probe, `scheduled-messages`) now go through `safeErrorMessage()` or rethrow to the boundary.

The tRPC router is exported but not mounted, so there is no tRPC error formatter path to fix. The existing `output-redactor` middleware is a per-profile denylist for send-route bodies and does not apply here.

## Test plan

- [x] New `middleware-error-db-leak.test.ts`: throws a `DrizzleQueryError` carrying the api_keys SQL and a 64-hex key hash; asserts the body contains neither the SQL, the table name, `params`, nor the hash. Also covers connection-level 503 mapping, dev-mode unknown errors, and that 23505 still yields 409.
- [x] typecheck, lint, dead-code, verify-migrations, verify-versions green
- [x] Full turbo test suite (pre-push hook): 26/26 packages, 0 fail