### PR TITLE
feat(automations): dry-run test against a journaled event with condition verdicts

### DIFF
--- a/packages/api/src/routes/v2/__tests__/automations-test-event.test.ts
+++ b/packages/api/src/routes/v2/__tests__/automations-test-event.test.ts
@@ -1,0 +1,114 @@
+/**
+ * POST /automations/:id/test with `eventId` (#1073): the route loads the REAL
+ * journaled row, shapes it like the engine would have seen it (rawPayload as
+ * payload, envelope metadata merged for conditions), and returns the dry run.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import { NotFoundError } from '@omni/core';
+import type { Automation, Database } from '@omni/db';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import { AutomationService } from '../../../services/automations';
+import type { AppVariables } from '../../../types';
+import { automationsRoutes } from '../automations';
+
+const AUTOMATION_ID = '66666666-6666-4666-8666-666666666666';
+const EVENT_ID = '77777777-7777-4777-8777-777777777777';
+
+const row = {
+  id: AUTOMATION_ID,
+  tenantId: null,
+  name: 'gh',
+  triggerEventType: 'custom.webhook.github',
+  triggerConditions: [{ field: 'action', operator: 'eq', value: 'opened' }],
+  conditionLogic: 'and',
+  actions: [{ type: 'log', config: { level: 'info', message: '{{payload.action}} {{event.metadata.correlationId}}' } }],
+  enabled: true,
+  managedByAgentId: null,
+} as unknown as Automation;
+
+function buildApp() {
+  const db = {
+    select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([row]) }) }) }),
+  } as unknown as Database;
+  const getById = mock(async (id: string) => {
+    if (id !== EVENT_ID) throw new NotFoundError('Event', id);
+    return {
+      id: EVENT_ID,
+      eventType: 'custom.webhook.github',
+      rawPayload: { action: 'opened' },
+      metadata: { correlationId: 'corr-9' },
+      receivedAt: new Date(0),
+    };
+  });
+  const services = {
+    automations: new AutomationService(db, null),
+    events: { getById },
+  } as unknown as AppVariables['services'];
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', services);
+    await next();
+  });
+  app.route('/automations', automationsRoutes);
+  return { app, getById };
+}
+
+async function post(app: Hono<{ Variables: AppVariables }>, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /automations/:id/test with eventId (#1073)', () => {
+  test('dry-runs against the journaled row', async () => {
+    const { app, getById } = buildApp();
+    const res = await post(app, `/automations/${AUTOMATION_ID}/test`, { eventId: EVENT_ID });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      matched: boolean;
+      eventId: string;
+      actions: Array<{ config: { message: string } }>;
+    };
+    expect(getById).toHaveBeenCalledWith(EVENT_ID);
+    expect(body.matched).toBe(true);
+    expect(body.eventId).toBe(EVENT_ID);
+    expect(body.actions[0]?.config.message).toBe('opened corr-9');
+  });
+
+  test('unknown event id → 404', async () => {
+    const { app } = buildApp();
+    const res = await post(app, `/automations/${AUTOMATION_ID}/test`, {
+      eventId: '00000000-0000-4000-8000-000000000000',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test('event and eventId are mutually exclusive and one is required', async () => {
+    const { app } = buildApp();
+    expect((await post(app, `/automations/${AUTOMATION_ID}/test`, {})).status).toBe(400);
+    expect(
+      (
+        await post(app, `/automations/${AUTOMATION_ID}/test`, {
+          eventId: EVENT_ID,
+          event: { type: 'x', payload: {} },
+        })
+      ).status,
+    ).toBe(400);
+  });
+
+  test('inline event still works', async () => {
+    const { app } = buildApp();
+    const res = await post(app, `/automations/${AUTOMATION_ID}/test`, {
+      event: { type: 'custom.webhook.github', payload: { action: 'closed' } },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { matched: boolean; conditions: Array<{ actual: unknown }> };
+    expect(body.matched).toBe(false);
+    expect(body.conditions[0]?.actual).toBe('closed');
+  });
+});

--- a/packages/api/src/routes/v2/automations.ts
+++ b/packages/api/src/routes/v2/automations.ts
@@ -5,6 +5,7 @@
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import type { AutomationTestEvent } from '../../services/automations';
 import type { AppVariables } from '../../types';
 
 const automationsRoutes = new Hono<{ Variables: AppVariables }>();
@@ -151,13 +152,40 @@ const listQuerySchema = z.object({
   enabled: z.coerce.boolean().optional(),
 });
 
-// Test automation schema
-const testAutomationSchema = z.object({
-  event: z.object({
-    type: z.string().min(1).describe('Event type'),
-    payload: z.record(z.string(), z.unknown()).describe('Event payload'),
-  }),
-});
+// Test/execute automation schema: a hand-written event OR a journaled event id (#1073)
+const testAutomationSchema = z
+  .object({
+    event: z
+      .object({
+        type: z.string().min(1).describe('Event type'),
+        payload: z.record(z.string(), z.unknown()).describe('Event payload'),
+      })
+      .optional(),
+    eventId: z.string().uuid().optional().describe('Id of a journaled omni_events row to run against'),
+  })
+  .refine((b) => (b.event ? 1 : 0) + (b.eventId ? 1 : 0) === 1, {
+    message: 'Provide exactly one of "event" or "eventId"',
+  });
+
+/**
+ * Resolve the test/execute body to an event: the inline mock, or the REAL
+ * journaled row (#1073) shaped the way the engine would have seen it —
+ * `rawPayload` as payload, the envelope `metadata` alongside.
+ */
+async function resolveTestEvent(
+  services: AppVariables['services'],
+  body: z.infer<typeof testAutomationSchema>,
+): Promise<AutomationTestEvent> {
+  if (body.event) return body.event;
+  const row = await services.events.getById(body.eventId as string);
+  return {
+    id: row.id,
+    type: row.eventType,
+    payload: row.rawPayload ?? {},
+    metadata: row.metadata ?? undefined,
+    timestamp: row.receivedAt.getTime(),
+  };
+}
 
 // Logs query schema
 const logsQuerySchema = z.object({
@@ -296,8 +324,8 @@ automationsRoutes.post('/:id/disable', async (c) => {
  */
 automationsRoutes.post('/:id/test', zValidator('json', testAutomationSchema), async (c) => {
   const id = c.req.param('id');
-  const { event } = c.req.valid('json');
   const services = c.get('services');
+  const event = await resolveTestEvent(services, c.req.valid('json'));
 
   const result = await services.automations.test(id, event);
 
@@ -309,8 +337,8 @@ automationsRoutes.post('/:id/test', zValidator('json', testAutomationSchema), as
  */
 automationsRoutes.post('/:id/execute', zValidator('json', testAutomationSchema), async (c) => {
   const id = c.req.param('id');
-  const { event } = c.req.valid('json');
   const services = c.get('services');
+  const event = await resolveTestEvent(services, c.req.valid('json'));
 
   const result = await services.automations.execute(id, event);
 

--- a/packages/api/src/schemas/openapi/automations.ts
+++ b/packages/api/src/schemas/openapi/automations.ts
@@ -164,10 +164,53 @@ export const AutomationLogSchema = z.object({
 
 // Test automation request
 export const TestAutomationSchema = z.object({
-  event: z.object({
-    type: z.string().min(1).openapi({ description: 'Event type' }),
-    payload: z.record(z.string(), z.unknown()).openapi({ description: 'Event payload' }),
-  }),
+  event: z
+    .object({
+      type: z.string().min(1).openapi({ description: 'Event type' }),
+      payload: z.record(z.string(), z.unknown()).openapi({ description: 'Event payload' }),
+    })
+    .optional()
+    .openapi({ description: 'Hand-written event. Exactly one of event / eventId is required' }),
+  eventId: z
+    .string()
+    .uuid()
+    .optional()
+    .openapi({
+      description:
+        'Id of a REAL journaled event (omni_events) to run against (#1073): its rawPayload is the payload, ' +
+        'its envelope metadata is merged for conditions. Exactly one of event / eventId is required',
+    }),
+});
+
+// Dry-run result (#1073)
+export const AutomationTestResultSchema = z.object({
+  matched: z.boolean().openapi({ description: 'triggerMatched AND conditionsMatched' }),
+  triggerMatched: z.boolean().openapi({ description: 'Event type equals the automation trigger' }),
+  conditionsMatched: z.boolean().openapi({ description: 'Condition set verdict under conditionLogic' }),
+  conditionLogic: z.enum(['and', 'or']),
+  conditions: z
+    .array(
+      z.object({
+        field: z.string(),
+        operator: z.string(),
+        expected: z.unknown().optional(),
+        actual: z.unknown().optional(),
+        resolved: z.boolean().openapi({ description: 'false = the dot path resolved to nothing in the payload' }),
+        matched: z.boolean(),
+      }),
+    )
+    .openapi({ description: 'Per-condition verdicts' }),
+  actions: z
+    .array(
+      z.object({
+        type: z.string(),
+        wouldExecute: z.boolean(),
+        config: z.record(z.string(), z.unknown()).openapi({ description: 'Action config with templates rendered' }),
+      }),
+    )
+    .openapi({ description: 'Rendered actions — never executed' }),
+  eventId: z.string().uuid().nullable(),
+  dryRun: z.literal(true),
 });
 
 // Automation metrics
@@ -195,6 +238,7 @@ export function registerAutomationSchemas(registry: OpenAPIRegistry): void {
   registry.register('CreateAutomationRequest', CreateAutomationSchema);
   registry.register('AutomationLog', AutomationLogSchema);
   registry.register('TestAutomationRequest', TestAutomationSchema);
+  registry.register('AutomationTestResult', AutomationTestResultSchema);
   registry.register('AutomationMetrics', AutomationMetricsSchema);
 
   registry.registerPath({
@@ -320,24 +364,18 @@ export function registerAutomationSchemas(registry: OpenAPIRegistry): void {
     path: '/automations/{id}/test',
     operationId: 'testAutomation',
     tags: ['Automations'],
-    summary: 'Test automation',
-    description: 'Test automation against a sample event (dry run).',
+    summary: 'Test automation (dry run)',
+    description:
+      'Dry-run an automation against a hand-written event or a REAL journaled event (`eventId`, #1073): ' +
+      'trigger match, per-condition verdicts and rendered action templates. Executes nothing, writes no execution log.',
     request: {
       params: z.object({ id: z.string().uuid().openapi({ description: 'Automation UUID' }) }),
       body: { content: { 'application/json': { schema: TestAutomationSchema } } },
     },
     responses: {
       200: {
-        description: 'Test result',
-        content: {
-          'application/json': {
-            schema: z.object({
-              matched: z.boolean(),
-              conditionResults: z.array(z.object({ condition: ConditionSchema, passed: z.boolean() })).optional(),
-              wouldExecute: z.array(ActionSchema).optional(),
-            }),
-          },
-        },
+        description: 'Dry-run result',
+        content: { 'application/json': { schema: AutomationTestResultSchema } },
       },
       404: { description: 'Not found', content: { 'application/json': { schema: ErrorSchema } } },
     },
@@ -349,7 +387,8 @@ export function registerAutomationSchemas(registry: OpenAPIRegistry): void {
     operationId: 'executeAutomation',
     tags: ['Automations'],
     summary: 'Execute automation',
-    description: 'Execute automation with a provided event payload. Actually runs the actions (not a dry run).',
+    description:
+      'Execute automation with a provided event payload or a journaled event (`eventId`). Actually runs the actions (not a dry run).',
     request: {
       params: z.object({ id: z.string().uuid().openapi({ description: 'Automation UUID' }) }),
       body: { content: { 'application/json': { schema: TestAutomationSchema } } },

--- a/packages/api/src/services/__tests__/automations-dry-run.test.ts
+++ b/packages/api/src/services/__tests__/automations-dry-run.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `AutomationService.test()` dry run (#1073): trigger match, per-condition
+ * verdicts (#1030 wording — unresolved paths are visible), rendered action
+ * templates, and NO side effects (no action runs, no execution log row).
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus } from '@omni/core';
+import type { Automation, Database } from '@omni/db';
+import { AutomationService } from '../automations';
+
+const AUTOMATION_ID = '44444444-4444-4444-8444-444444444444';
+const EVENT_ID = '55555555-5555-4555-8555-555555555555';
+
+function automation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: AUTOMATION_ID,
+    tenantId: null,
+    name: 'gh-pr-opened',
+    description: null,
+    triggerEventType: 'custom.webhook.github',
+    triggerConditions: [
+      { field: 'action', operator: 'eq', value: 'opened' },
+      { field: 'pull_request.draft', operator: 'eq', value: false },
+    ],
+    conditionLogic: 'and',
+    actions: [
+      { type: 'log', config: { level: 'info', message: 'PR {{payload.pull_request.title}} via {{event.id}}' } },
+      {
+        type: 'emit_event',
+        config: { eventType: 'custom.pr', payloadTemplate: { title: '{{payload.pull_request.title}}' } },
+      },
+    ],
+    debounce: null,
+    enabled: true,
+    priority: 0,
+    transactionalEmissions: false,
+    managedByAgentId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Automation;
+}
+
+function harness(row: Automation) {
+  const insert = mock(() => ({ values: () => ({ returning: () => Promise.resolve([{ id: 'log' }]) }) }));
+  const db = {
+    select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([row]) }) }) }),
+    insert,
+  } as unknown as Database;
+  const publish = mock(async () => ({ id: 'evt', timestamp: Date.now() }));
+  const eventBus = { publish, publishGeneric: publish } as unknown as EventBus;
+  return { service: new AutomationService(db, eventBus), insert, publish };
+}
+
+const journaled = {
+  id: EVENT_ID,
+  type: 'custom.webhook.github',
+  payload: { action: 'opened', pull_request: { title: 'Add dry run', draft: false } },
+  metadata: { correlationId: 'corr-1', source: 'webhook' },
+  timestamp: 1_700_000_000_000,
+};
+
+describe('AutomationService.test() dry run (#1073)', () => {
+  test('matching event: trigger + verdicts + rendered templates, no side effects', async () => {
+    const { service, insert, publish } = harness(automation());
+    const result = await service.test(AUTOMATION_ID, journaled);
+
+    expect(result).toMatchObject({ matched: true, triggerMatched: true, conditionsMatched: true, dryRun: true });
+    expect(result.eventId).toBe(EVENT_ID);
+    expect(result.conditions).toEqual([
+      { field: 'action', operator: 'eq', expected: 'opened', actual: 'opened', resolved: true, matched: true },
+      { field: 'pull_request.draft', operator: 'eq', expected: false, actual: false, resolved: true, matched: true },
+    ]);
+    expect(result.actions[0]).toEqual({
+      type: 'log',
+      wouldExecute: true,
+      config: { level: 'info', message: `PR Add dry run via ${EVENT_ID}` },
+    });
+    expect(result.actions[1]?.config).toEqual({ eventType: 'custom.pr', payloadTemplate: { title: 'Add dry run' } });
+
+    expect(insert).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  test('unresolved dot path is reported as resolved=false, not a silent mismatch', async () => {
+    const { service } = harness(
+      automation({ triggerConditions: [{ field: 'pullRequest.draft', operator: 'eq', value: false }] }),
+    );
+    const result = await service.test(AUTOMATION_ID, journaled);
+
+    expect(result.matched).toBe(false);
+    expect(result.conditions[0]).toMatchObject({ field: 'pullRequest.draft', resolved: false, matched: false });
+    expect(result.actions.every((a) => a.wouldExecute === false)).toBe(true);
+  });
+
+  test('conditions can reference envelope metadata, like the engine merges it', async () => {
+    const { service } = harness(
+      automation({ triggerConditions: [{ field: 'correlationId', operator: 'eq', value: 'corr-1' }] }),
+    );
+    const result = await service.test(AUTOMATION_ID, journaled);
+    expect(result.conditions[0]).toMatchObject({ actual: 'corr-1', matched: true });
+  });
+
+  test('event type mismatch fails the trigger even when conditions pass', async () => {
+    const { service } = harness(automation());
+    const result = await service.test(AUTOMATION_ID, { ...journaled, type: 'message.received' });
+    expect(result).toMatchObject({ matched: false, triggerMatched: false, conditionsMatched: true });
+  });
+
+  test('"or" logic and legacy inline event without an id', async () => {
+    const { service } = harness(automation({ conditionLogic: 'or' }));
+    const result = await service.test(AUTOMATION_ID, {
+      type: 'custom.webhook.github',
+      payload: { action: 'opened', pull_request: { draft: true } },
+    });
+    expect(result).toMatchObject({ matched: true, conditionLogic: 'or', eventId: null });
+    expect(result.conditions.map((c) => c.matched)).toEqual([true, false]);
+  });
+});

--- a/packages/api/src/services/automations.ts
+++ b/packages/api/src/services/automations.ts
@@ -12,11 +12,14 @@ import {
   type CallAgentActionConfig,
   ConflictError,
   type Automation as CoreAutomation,
+  type EventMetadata,
   NotFoundError,
   ValidationError,
   createAutomationEngine,
   createTemplateContext,
+  evaluateConditionsWithDetails,
   executeActions,
+  substituteTemplateObject,
 } from '@omni/core';
 import type { EventBus } from '@omni/core';
 import type { Database } from '@omni/db';
@@ -31,10 +34,38 @@ import {
 import { and, desc, eq, gte, sql } from 'drizzle-orm';
 import { scopedHandle } from '../tenancy/tenant-scope';
 
+/**
+ * An event to test/execute an automation against. Either hand-written (the
+ * legacy `test` body) or a REAL journaled `omni_events` row mapped by the
+ * route (#1073) — then `id`, `metadata` and `timestamp` are the row's.
+ */
+export interface AutomationTestEvent {
+  type: string;
+  payload: Record<string, unknown>;
+  id?: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+}
+
 export interface AutomationTestResult {
+  /** triggerMatched && conditionsMatched */
   matched: boolean;
-  conditions: Array<{ field: string; operator: string; matched: boolean }>;
-  actions: Array<{ type: string; wouldExecute: boolean }>;
+  /** Event type equals the automation's trigger (the engine never delivers anything else). */
+  triggerMatched: boolean;
+  conditionsMatched: boolean;
+  conditionLogic: 'and' | 'or';
+  /** Per-condition verdicts (#1030 wording): `resolved: false` = the dot path found nothing. */
+  conditions: Array<{
+    field: string;
+    operator: string;
+    expected: unknown;
+    actual: unknown;
+    resolved: boolean;
+    matched: boolean;
+  }>;
+  /** Actions with their templates rendered against the event — never executed. */
+  actions: Array<{ type: string; wouldExecute: boolean; config: Record<string, unknown> }>;
+  eventId: string | null;
   dryRun: true;
 }
 
@@ -309,26 +340,54 @@ export class AutomationService {
   }
 
   /**
-   * Test an automation against a sample event (dry run)
+   * Dry-run an automation against an event (#1073): trigger match, condition
+   * verdicts and rendered action templates. Mirrors the engine's evaluation
+   * (metadata merged under the payload for conditions) but executes nothing
+   * and writes no execution log.
    */
-  async test(id: string, event: { type: string; payload: Record<string, unknown> }): Promise<AutomationTestResult> {
+  async test(id: string, event: AutomationTestEvent): Promise<AutomationTestResult> {
     const automation = await this.getById(id);
+    const triggerMatched = automation.triggerEventType === event.type;
+    const conditionLogic = automation.conditionLogic ?? 'and';
 
-    if (this.engine) {
-      return this.engine.testAutomation(automation as CoreAutomation, event);
-    }
+    const conditionResult = evaluateConditionsWithDetails(
+      automation.triggerConditions as Parameters<typeof evaluateConditionsWithDetails>[0],
+      { ...(event.metadata ?? {}), ...event.payload },
+      conditionLogic,
+    );
+    const matched = triggerMatched && conditionResult.matched;
 
-    // Manual test if engine not running
-    // Just check conditions
-    const matched = automation.triggerEventType === event.type;
+    const context = createTemplateContext(event.payload, {
+      event: event.id
+        ? {
+            id: event.id,
+            type: event.type,
+            timestamp: event.timestamp ?? Date.now(),
+            metadata: (event.metadata ?? {}) as unknown as EventMetadata,
+          }
+        : undefined,
+      automation: { id: automation.id, managedByAgentId: automation.managedByAgentId },
+    });
 
     return {
       matched,
-      conditions: [],
-      actions: (automation.actions as Array<{ type: string }>).map((a) => ({
+      triggerMatched,
+      conditionsMatched: conditionResult.matched,
+      conditionLogic,
+      conditions: conditionResult.conditions.map((c) => ({
+        field: c.field,
+        operator: c.operator,
+        expected: c.expectedValue,
+        actual: c.actualValue,
+        resolved: c.actualValue !== undefined,
+        matched: c.matched,
+      })),
+      actions: (automation.actions as AutomationAction[]).map((a) => ({
         type: a.type,
         wouldExecute: matched,
+        config: substituteTemplateObject((a.config ?? {}) as unknown as Record<string, unknown>, context),
       })),
+      eventId: event.id ?? null,
       dryRun: true,
     };
   }
@@ -339,7 +398,7 @@ export class AutomationService {
    */
   async execute(
     id: string,
-    event: { type: string; payload: Record<string, unknown> },
+    event: AutomationTestEvent,
     deps?: ActionDependencies,
   ): Promise<{
     automationId: string;
@@ -357,8 +416,8 @@ export class AutomationService {
       };
     }
 
-    // Build context from event
-    const correlationId = crypto.randomUUID();
+    // Build context from event. A journaled event (#1073) keeps its own id in the log row.
+    const correlationId = event.id ?? crypto.randomUUID();
     const context = createTemplateContext(event.payload);
 
     // Default dependencies (eventBus from service, others empty)

--- a/packages/cli/src/commands/__tests__/automations.test.ts
+++ b/packages/cli/src/commands/__tests__/automations.test.ts
@@ -162,3 +162,25 @@ describe('buildCreateBody', () => {
     );
   });
 });
+
+describe('parseEventOption (#1073)', () => {
+  const { parseEventOption } = __testables;
+
+  test('a UUID is a journaled event id', () => {
+    expect(parseEventOption(' 77777777-7777-4777-8777-777777777777 ')).toEqual({
+      eventId: '77777777-7777-4777-8777-777777777777',
+    });
+  });
+
+  test('inline JSON keeps the legacy body', () => {
+    expect(parseEventOption('{"type":"message.received","payload":{"text":"hi"}}')).toEqual({
+      event: { type: 'message.received', payload: { text: 'hi' } },
+    });
+  });
+
+  test('rejects garbage and JSON without type/payload', () => {
+    expect(parseEventOption('not-json')).toBeUndefined();
+    expect(parseEventOption('{"type":"x"}')).toBeUndefined();
+    expect(parseEventOption('{"payload":{}}')).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/automations.ts
+++ b/packages/cli/src/commands/automations.ts
@@ -29,10 +29,11 @@
  */
 
 import { readFileSync } from 'node:fs';
-import type { CreateAutomationBody } from '@omni/sdk';
+import type { CreateAutomationBody, OmniClient, TestAutomationBody } from '@omni/sdk';
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as output from '../output.js';
+import { getCurrentFormat } from '../output.js';
 import { resolveAutomationId } from '../resolve.js';
 
 // ============================================================================
@@ -188,7 +189,44 @@ function buildCreateBody(options: CreateOptions): CreateAutomationBody {
   return body as CreateAutomationBody;
 }
 
-export const __testables = { buildActions, buildDefinition, buildCreateBody, readDefinitionFile };
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * `--event` is either inline event JSON (legacy) or the id of a journaled
+ * event (#1073). Returns the API body, or undefined when it is neither.
+ */
+function parseEventOption(raw: string): TestAutomationBody | undefined {
+  const value = raw.trim();
+  if (UUID_RE.test(value)) return { eventId: value };
+  try {
+    const event = JSON.parse(value) as { type?: unknown; payload?: unknown };
+    if (typeof event.type !== 'string' || typeof event.payload !== 'object' || event.payload === null) return undefined;
+    return { event: event as TestAutomationBody['event'] };
+  } catch {
+    return undefined;
+  }
+}
+
+function reportExecution(result: Awaited<ReturnType<OmniClient['automations']['execute']>>): void {
+  if (!result.triggered) {
+    output.info('Automation not triggered (event type did not match)');
+    output.data({ triggered: false });
+    return;
+  }
+  const allSuccess = result.results.every((r) => r.status === 'success');
+  if (allSuccess) {
+    output.success('Automation executed successfully', {
+      automationId: result.automationId,
+      actionsExecuted: result.results.length,
+      results: result.results,
+    });
+  } else {
+    output.info('Automation executed with some failures');
+    output.data({ automationId: result.automationId, results: result.results });
+  }
+}
+
+export const __testables = { buildActions, buildDefinition, buildCreateBody, readDefinitionFile, parseEventOption };
 
 // ============================================================================
 // COMMANDS
@@ -398,36 +436,54 @@ export function createAutomationsCommand(): Command {
   // omni automations test <id>
   automations
     .command('test <id>')
-    .description('Test an automation with a mock event')
-    .requiredOption('--event <json>', 'Event JSON (e.g., \'{"type":"message.received","payload":{}}\')')
-    .action(async (id: string, options: { event: string }) => {
+    .description('Dry-run an automation against a mock event or a REAL journaled event: verdicts, no side effects')
+    .requiredOption(
+      '--event <json|event-id>',
+      'Event JSON (\'{"type":"message.received","payload":{}}\') or the id of a journaled event (omni events list)',
+    )
+    .option('--execute', 'Actually run the actions against the event (same as `execute`)', false)
+    .action(async (id: string, options: { event: string; execute: boolean }) => {
       const client = getClient();
 
       try {
         const automationId = await resolveAutomationId(id);
-        let event: { type: string; payload: Record<string, unknown> };
-        try {
-          event = JSON.parse(options.event);
-        } catch {
-          output.error('Invalid JSON for --event');
+        const body = parseEventOption(options.event);
+        if (!body) {
+          output.error('--event must be valid JSON with "type" and "payload" fields, or a journaled event UUID');
           return;
         }
 
-        if (!event.type || !event.payload) {
-          output.error('Event must have "type" and "payload" fields');
+        if (options.execute) {
+          reportExecution(await client.automations.execute(automationId, body));
+          return;
         }
 
-        const result = await client.automations.test(automationId, { event });
+        const result = await client.automations.test(automationId, body);
+        const verdicts = result.conditions.map((c) => ({
+          field: c.field,
+          operator: c.operator,
+          expected: c.expected === undefined ? '' : JSON.stringify(c.expected),
+          actual: c.resolved ? JSON.stringify(c.actual) : '(unresolved)',
+          matched: c.matched ? 'yes' : 'no',
+        }));
+        const summary = result.matched
+          ? 'Automation matched the event (dry run — nothing executed)'
+          : result.triggerMatched
+            ? `Conditions did not match (${result.conditionLogic})`
+            : 'Trigger did not match: event type differs from the automation trigger';
 
-        if (result.matched) {
-          output.success('Automation matched the event', {
-            matched: true,
-            wouldExecute: result.wouldExecute,
-          });
-        } else {
-          output.info('Automation did not match the event');
-          output.data({ matched: false });
+        if (result.matched) output.success(summary);
+        else output.info(summary);
+        if (getCurrentFormat() === 'json') {
+          output.data(result);
+          return;
         }
+        if (verdicts.length > 0) {
+          output.header('Conditions');
+          output.list(verdicts, { rawData: result.conditions });
+        }
+        output.header('Actions (templates rendered, not executed)');
+        output.data(result.actions);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to test automation: ${message}`);
@@ -437,47 +493,19 @@ export function createAutomationsCommand(): Command {
   // omni automations execute <id>
   automations
     .command('execute <id>')
-    .description('Execute an automation with a provided event (actually runs actions)')
-    .requiredOption('--event <json>', 'Event JSON (e.g., \'{"type":"message.received","payload":{...}}\')')
+    .description('Execute an automation with a provided or journaled event (actually runs actions)')
+    .requiredOption('--event <json|event-id>', 'Event JSON or the id of a journaled event')
     .action(async (id: string, options: { event: string }) => {
       const client = getClient();
 
       try {
         const automationId = await resolveAutomationId(id);
-        let event: { type: string; payload: Record<string, unknown> };
-        try {
-          event = JSON.parse(options.event);
-        } catch {
-          output.error('Invalid JSON for --event');
+        const body = parseEventOption(options.event);
+        if (!body) {
+          output.error('--event must be valid JSON with "type" and "payload" fields, or a journaled event UUID');
           return;
         }
-
-        if (!event.type || !event.payload) {
-          output.error('Event must have "type" and "payload" fields');
-          return;
-        }
-
-        const result = await client.automations.execute(automationId, { event });
-
-        if (result.triggered) {
-          const allSuccess = result.results.every((r: { status: string }) => r.status === 'success');
-          if (allSuccess) {
-            output.success('Automation executed successfully', {
-              automationId: result.automationId,
-              actionsExecuted: result.results.length,
-              results: result.results,
-            });
-          } else {
-            output.info('Automation executed with some failures');
-            output.data({
-              automationId: result.automationId,
-              results: result.results,
-            });
-          }
-        } else {
-          output.info('Automation not triggered (event type did not match)');
-          output.data({ triggered: false });
-        }
+        reportExecution(await client.automations.execute(automationId, body));
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         output.error(`Failed to execute automation: ${message}`);

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -693,11 +693,17 @@ export interface CreateAutomationBody {
  * Body for testing an automation
  */
 export interface TestAutomationBody {
-  event: {
+  /** Hand-written event. Exactly one of event / eventId. */
+  event?: {
     type: string;
     payload: Record<string, unknown>;
   };
+  /** Id of a REAL journaled event to run against (#1073). */
+  eventId?: string;
 }
+
+/** Dry-run result of `automations.test` (#1073). */
+export type AutomationTestResult = components['schemas']['AutomationTestResult'];
 
 /**
  * Query parameters for listing automation logs
@@ -3007,13 +3013,13 @@ export function createOmniClient(config: OmniClientConfig) {
       /**
        * Test an automation (dry run)
        */
-      async test(id: string, body: TestAutomationBody): Promise<{ matched: boolean; wouldExecute?: unknown[] }> {
+      async test(id: string, body: TestAutomationBody): Promise<AutomationTestResult> {
         const { data, error, response } = await client.POST('/automations/{id}/test', {
           params: { path: { id } },
           body,
         });
         throwIfError(response, error);
-        return data ?? { matched: false };
+        return data;
       },
 
       /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -90,6 +90,7 @@ export type {
   ListAutomationsParams,
   CreateAutomationBody,
   TestAutomationBody,
+  AutomationTestResult,
   ListAutomationLogsParams,
   // Dead letter types
   DeadLetter,

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -1898,8 +1898,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Test automation
-         * @description Test automation against a sample event (dry run).
+         * Test automation (dry run)
+         * @description Dry-run an automation against a hand-written event or a REAL journaled event (`eventId`, #1073): trigger match, per-condition verdicts and rendered action templates. Executes nothing, writes no execution log.
          */
         post: operations["testAutomation"];
         delete?: never;
@@ -1919,7 +1919,7 @@ export interface paths {
         put?: never;
         /**
          * Execute automation
-         * @description Execute automation with a provided event payload. Actually runs the actions (not a dry run).
+         * @description Execute automation with a provided event payload or a journaled event (`eventId`). Actually runs the actions (not a dry run).
          */
         post: operations["executeAutomation"];
         delete?: never;
@@ -3860,6 +3860,8 @@ export interface components {
             avgProcessingTimeMs: number | null;
             /** @description Average agent time (ms) */
             avgAgentTimeMs: number | null;
+            /** @description Sum of agent run cost (USD) stamped on events in range */
+            totalCostUsd: number;
             /** @description Count by content type */
             messageTypes: {
                 [key: string]: number;
@@ -5943,7 +5945,8 @@ export interface components {
             durationMs: number;
         };
         TestAutomationRequest: {
-            event: {
+            /** @description Hand-written event. Exactly one of event / eventId is required */
+            event?: {
                 /** @description Event type */
                 type: string;
                 /** @description Event payload */
@@ -5951,6 +5954,44 @@ export interface components {
                     [key: string]: unknown;
                 };
             };
+            /**
+             * Format: uuid
+             * @description Id of a REAL journaled event (omni_events) to run against (#1073): its rawPayload is the payload, its envelope metadata is merged for conditions. Exactly one of event / eventId is required
+             */
+            eventId?: string;
+        };
+        AutomationTestResult: {
+            /** @description triggerMatched AND conditionsMatched */
+            matched: boolean;
+            /** @description Event type equals the automation trigger */
+            triggerMatched: boolean;
+            /** @description Condition set verdict under conditionLogic */
+            conditionsMatched: boolean;
+            /** @enum {string} */
+            conditionLogic: "and" | "or";
+            /** @description Per-condition verdicts */
+            conditions: {
+                field: string;
+                operator: string;
+                expected?: unknown;
+                actual?: unknown;
+                /** @description false = the dot path resolved to nothing in the payload */
+                resolved: boolean;
+                matched: boolean;
+            }[];
+            /** @description Rendered actions — never executed */
+            actions: {
+                type: string;
+                wouldExecute: boolean;
+                /** @description Action config with templates rendered */
+                config: {
+                    [key: string]: unknown;
+                };
+            }[];
+            /** Format: uuid */
+            eventId: string | null;
+            /** @enum {boolean} */
+            dryRun: true;
         };
         AutomationMetrics: {
             /** @description Engine running */
@@ -10717,6 +10758,8 @@ export interface operations {
                         avgProcessingTimeMs: number | null;
                         /** @description Average agent time (ms) */
                         avgAgentTimeMs: number | null;
+                        /** @description Sum of agent run cost (USD) stamped on events in range */
+                        totalCostUsd: number;
                         /** @description Count by content type */
                         messageTypes: {
                             [key: string]: number;
@@ -18922,7 +18965,8 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": {
-                    event: {
+                    /** @description Hand-written event. Exactly one of event / eventId is required */
+                    event?: {
                         /** @description Event type */
                         type: string;
                         /** @description Event payload */
@@ -18930,106 +18974,53 @@ export interface operations {
                             [key: string]: unknown;
                         };
                     };
+                    /**
+                     * Format: uuid
+                     * @description Id of a REAL journaled event (omni_events) to run against (#1073): its rawPayload is the payload, its envelope metadata is merged for conditions. Exactly one of event / eventId is required
+                     */
+                    eventId?: string;
                 };
             };
         };
         responses: {
-            /** @description Test result */
+            /** @description Dry-run result */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": {
+                        /** @description triggerMatched AND conditionsMatched */
                         matched: boolean;
-                        conditionResults?: {
-                            condition: {
-                                /** @description Dot notation field path */
-                                field: string;
-                                /**
-                                 * @description Operator
-                                 * @enum {string}
-                                 */
-                                operator: "eq" | "neq" | "gt" | "lt" | "gte" | "lte" | "contains" | "not_contains" | "exists" | "not_exists" | "regex";
-                                /** @description Value to compare */
-                                value?: unknown;
-                            };
-                            passed: boolean;
+                        /** @description Event type equals the automation trigger */
+                        triggerMatched: boolean;
+                        /** @description Condition set verdict under conditionLogic */
+                        conditionsMatched: boolean;
+                        /** @enum {string} */
+                        conditionLogic: "and" | "or";
+                        /** @description Per-condition verdicts */
+                        conditions: {
+                            field: string;
+                            operator: string;
+                            expected?: unknown;
+                            actual?: unknown;
+                            /** @description false = the dot path resolved to nothing in the payload */
+                            resolved: boolean;
+                            matched: boolean;
                         }[];
-                        wouldExecute?: ({
-                            /** @enum {string} */
-                            type: "webhook";
+                        /** @description Rendered actions — never executed */
+                        actions: {
+                            type: string;
+                            wouldExecute: boolean;
+                            /** @description Action config with templates rendered */
                             config: {
-                                /** @description Webhook URL */
-                                url: string;
-                                /**
-                                 * @default POST
-                                 * @enum {string}
-                                 */
-                                method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-                                headers?: {
-                                    [key: string]: string;
-                                };
-                                bodyTemplate?: string;
-                                /** @default false */
-                                waitForResponse: boolean;
-                                /** @default 30000 */
-                                timeoutMs: number;
-                                responseAs?: string;
-                                /** @description Send the full OmniEvent envelope as the default body (default true) */
-                                includeEnvelope?: boolean;
+                                [key: string]: unknown;
                             };
-                        } | {
-                            /** @enum {string} */
-                            type: "send_message";
-                            config: {
-                                instanceId?: string;
-                                to?: string;
-                                contentTemplate: string;
-                            };
-                        } | {
-                            /** @enum {string} */
-                            type: "emit_event";
-                            config: {
-                                eventType: string;
-                                payloadTemplate?: {
-                                    [key: string]: unknown;
-                                };
-                            };
-                        } | {
-                            /** @enum {string} */
-                            type: "log";
-                            config: {
-                                /** @enum {string} */
-                                level: "debug" | "info" | "warn" | "error";
-                                message: string;
-                            };
-                        } | {
-                            /** @enum {string} */
-                            type: "call_agent";
-                            config: {
-                                /** @description Provider ID (template: {{instance.agentProviderId}}) */
-                                providerId?: string;
-                                /** @description Agent ID (required or template) */
-                                agentId: string;
-                                /**
-                                 * @description Agent type
-                                 * @enum {string}
-                                 */
-                                agentType?: "agent" | "team" | "workflow";
-                                /**
-                                 * @description Session strategy for agent memory
-                                 * @enum {string}
-                                 */
-                                sessionStrategy?: "per_user" | "per_chat" | "per_thread";
-                                /** @description Prefix messages with sender name */
-                                prefixSenderName?: boolean;
-                                /** @description Timeout in milliseconds */
-                                timeoutMs?: number;
-                                /** @description Store agent response as variable for chaining (e.g., "agentResponse") */
-                                responseAs?: string;
-                            };
-                        })[];
+                        }[];
+                        /** Format: uuid */
+                        eventId: string | null;
+                        /** @enum {boolean} */
+                        dryRun: true;
                     };
                 };
             };
@@ -19068,7 +19059,8 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/json": {
-                    event: {
+                    /** @description Hand-written event. Exactly one of event / eventId is required */
+                    event?: {
                         /** @description Event type */
                         type: string;
                         /** @description Event payload */
@@ -19076,6 +19068,11 @@ export interface operations {
                             [key: string]: unknown;
                         };
                     };
+                    /**
+                     * Format: uuid
+                     * @description Id of a REAL journaled event (omni_events) to run against (#1073): its rawPayload is the payload, its envelope metadata is merged for conditions. Exactly one of event / eventId is required
+                     */
+                    eventId?: string;
                 };
             };
         };


### PR DESCRIPTION
Closes #1073

## What
`omni automations test <id> --event <event-id>` runs an automation against a REAL journaled `omni_events` row as a dry run. `--execute` runs the actions for real (same as `execute`, which also accepts an event id now).

- **API** `POST /automations/:id/test` and `/execute` accept `eventId` (exactly one of `event` / `eventId`). The route loads the row and shapes it the way the engine would have seen it: `rawPayload` as payload, envelope `metadata` merged for conditions, `{{event.*}}` placeholders (#1071) populated from the row.
- **Service** `test()` now does the full dry run itself: trigger match, per-condition verdicts (`field`, `operator`, `expected`, `actual`, `resolved`, `matched` — the #1030 unresolved-path signal), and each action's config with templates rendered. Nothing executes, no execution log is written. `execute()` with a journaled event logs the real event id.
- **OpenAPI** new `AutomationTestResult` schema; SDK types regenerated, `automations.test()` typed.
- **CLI** `--event <json|event-id>` on `test` and `execute`, `--execute` on `test`; verdicts printed as a table.

## Tests
- `services/__tests__/automations-dry-run.test.ts`: verdicts, unresolved paths, metadata merge, trigger mismatch, `or` logic, and no insert/publish side effects.
- `routes/v2/__tests__/automations-test-event.test.ts`: eventId path, 404, body exclusivity, legacy inline event.
- CLI `parseEventOption` unit tests.

`make typecheck`, `lint`, `dead-code`, `verify-migrations`, `verify-versions` and the full `bun run test` sweep pass (the `make test` DB sync step needs a `.env` this worktree lacks).