### PR TITLE
fix(whatsapp): persist quotedText and quotedSenderName on inbound replies

### DIFF
--- a/packages/api/src/plugins/message-persistence.ts
+++ b/packages/api/src/plugins/message-persistence.ts
@@ -630,6 +630,26 @@ function resolveSenderDisplayName(
   );
 }
 
+/**
+ * Quoted sender name (#1090): the channel's contact lookup first, then the
+ * chat participant row the quoted sender already has from their own messages.
+ */
+async function resolveQuotedSenderName(
+  services: Services,
+  chatId: string,
+  quotedMessage: Record<string, unknown> | undefined,
+): Promise<string | undefined> {
+  const pushName = truncate(quotedMessage?.pushName as string | undefined, 255);
+  if (pushName) return pushName;
+  const participant = quotedMessage?.participant as string | undefined;
+  if (!participant) return undefined;
+  // ponytail: phone-jid only; an @lid quoted participant won't match a phone-keyed row.
+  const platformUserId = participant.split('@')[0]?.split(':')[0];
+  if (!platformUserId) return undefined;
+  const existing = await services.chats.findParticipant(chatId, platformUserId);
+  return truncate(existing?.displayName ?? undefined, 255);
+}
+
 async function maybeFindOrCreateParticipant(
   services: Services,
   chatId: string,
@@ -961,7 +981,7 @@ async function handleMessageReceived(
     mediaLocalPath: rawPayload?.mediaLocalPath as string | undefined,
     replyToExternalId: truncate(payload.replyToId, 255),
     quotedText: quotedMessage?.conversation as string | undefined,
-    quotedSenderName: truncate(quotedMessage?.pushName as string | undefined, 255),
+    quotedSenderName: await resolveQuotedSenderName(services, chat.id, quotedMessage),
     // Thread (#889) — previously dropped: threadId rode along in the payload
     // for per_thread session routing and was never persisted.
     threadExternalId: truncate(payload.threadId, 255),

--- a/packages/api/src/services/chats.ts
+++ b/packages/api/src/services/chats.ts
@@ -905,16 +905,21 @@ export class ChatService {
   /**
    * Find or create a participant
    */
-  async findOrCreateParticipant(
-    chatId: string,
-    platformUserId: string,
-    defaults: Partial<NewChatParticipant> = {},
-  ): Promise<{ participant: ChatParticipant; created: boolean }> {
+  async findParticipant(chatId: string, platformUserId: string): Promise<ChatParticipant | undefined> {
     const [existing] = await this.db
       .select()
       .from(chatParticipants)
       .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.platformUserId, platformUserId)))
       .limit(1);
+    return existing;
+  }
+
+  async findOrCreateParticipant(
+    chatId: string,
+    platformUserId: string,
+    defaults: Partial<NewChatParticipant> = {},
+  ): Promise<{ participant: ChatParticipant; created: boolean }> {
+    const existing = await this.findParticipant(chatId, platformUserId);
 
     if (existing) {
       // Update identity links if provided and missing on existing record

--- a/packages/channel-whatsapp/src/__tests__/quoted-context.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/quoted-context.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression for omni#1090: a WhatsApp reply carries the quoted stanza in
+ * `contextInfo.quotedMessage`; it must surface as quoted text + quoted sender so
+ * `messages.quoted_text` / `quoted_sender_name` stop landing null.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { WAMessage } from 'baileys';
+import fixtures from '../../test/fixtures/real-payloads.json';
+import { extractQuotedContext } from '../handlers/messages';
+
+const replyFixture = (fixtures.messages.extendedText as Array<{ payload: unknown }>).find(({ payload }) => {
+  const msg = payload as WAMessage;
+  return msg.message?.extendedTextMessage?.contextInfo?.quotedMessage;
+})?.payload as WAMessage;
+
+function wrap(message: Record<string, unknown>): WAMessage {
+  return {
+    key: { id: 'TEST', remoteJid: '5511999998888@s.whatsapp.net', fromMe: false },
+    message,
+  } as unknown as WAMessage;
+}
+
+describe('extractQuotedContext (omni#1090)', () => {
+  it('lifts quoted text, participant and stanzaId from a real reply fixture', () => {
+    expect(replyFixture).toBeDefined();
+    expect(extractQuotedContext(replyFixture)).toEqual({
+      stanzaId: 'AC23570AE54CCF58A8923E45CC6089E8',
+      participant: '5511999990001@s.whatsapp.net',
+      type: 'text',
+      conversation: 'Buenas como q tão as coisas aí',
+    });
+  });
+
+  it('uses the caption for quoted media, else a typed placeholder', () => {
+    const base = { stanzaId: 'S1', participant: '5511999990001@s.whatsapp.net' };
+    const captioned = wrap({
+      imageMessage: {
+        caption: 'look',
+        contextInfo: { ...base, quotedMessage: { imageMessage: { mimetype: 'image/jpeg', caption: 'old pic' } } },
+      },
+    });
+    expect(extractQuotedContext(captioned)?.conversation).toBe('old pic');
+
+    const media = wrap({
+      extendedTextMessage: {
+        text: 'reply',
+        contextInfo: { ...base, quotedMessage: { audioMessage: { mimetype: 'audio/ogg', ptt: true } } },
+      },
+    });
+    expect(extractQuotedContext(media)).toMatchObject({ type: 'audio', conversation: '[audio]' });
+  });
+
+  it('returns undefined when there is no quote', () => {
+    expect(extractQuotedContext(wrap({ conversation: 'hi' }))).toBeUndefined();
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -613,6 +613,34 @@ function getReplyToId(msg: WAMessage): string | undefined {
   return contextInfo?.stanzaId || undefined;
 }
 
+/**
+ * Quoted-message context of a reply, lifted out of `contextInfo` (#1090).
+ *
+ * Baileys nests the quoted stanza under `message.<type>.contextInfo.quotedMessage`;
+ * persistence and the agent plugins read a top-level `rawPayload.quotedMessage`
+ * with `conversation` / `participant` / `pushName`, so this is the bridge.
+ */
+export interface QuotedContext {
+  stanzaId?: string;
+  participant?: string;
+  type: ContentType;
+  /** Text, caption, or a `[type]` placeholder for media / non-text quotes. */
+  conversation?: string;
+}
+
+export function extractQuotedContext(msg: WAMessage): QuotedContext | undefined {
+  const contextInfo = getMessageContextInfo(msg);
+  if (!contextInfo?.quotedMessage) return undefined;
+  const content = extractContent({ key: msg.key, message: contextInfo.quotedMessage } as WAMessage);
+  const type = content?.type ?? ('unknown' as ContentType);
+  return {
+    stanzaId: contextInfo.stanzaId || undefined,
+    participant: contextInfo.participant || undefined,
+    type,
+    conversation: content?.text || content?.caption || `[${type}]`,
+  };
+}
+
 // Note: replaceMentionsWithNames removed - mention replacement now handled in
 // agent-dispatcher with database lookup for better reliability across API restarts
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -42,7 +42,7 @@ import {
   seedAuthenticated,
   setupConnectionHandlers,
 } from './handlers/connection';
-import { setupMessageHandlers, tryDownloadMedia } from './handlers/messages';
+import { extractQuotedContext, setupMessageHandlers, tryDownloadMedia } from './handlers/messages';
 import { fromJid, isGroupJid, isLidJid, isUserJid, toGroupJid, toJid } from './jid';
 import { buildMessageContent } from './senders/builders';
 import { computeWaid } from './senders/contact';
@@ -3146,6 +3146,8 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       }
     }
 
+    await this.enrichPayloadWithQuotedMessage(extendedPayload, instanceId, chatId, rawMessage);
+
     // Add structured extended fields if present
     if (content.poll) extendedPayload.poll = content.poll;
     if (content.pollVotes) extendedPayload.pollVotes = content.pollVotes;
@@ -4093,6 +4095,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
       };
       if (content.localPath) rawPayload.mediaLocalPath = content.localPath;
       this.enrichPayloadWithChatName(rawPayload, instanceId, chatId);
+      await this.enrichPayloadWithQuotedMessage(rawPayload, instanceId, chatId, msg);
 
       const historySenderName = (msg as { pushName?: string | null }).pushName ?? undefined;
 
@@ -4113,6 +4116,24 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         isHistorySync: true,
       });
     }
+  }
+
+  /**
+   * Lift the quoted stanza of a reply to `rawPayload.quotedMessage` and resolve
+   * the quoted sender's name the same way mentions are resolved (#1090).
+   */
+  private async enrichPayloadWithQuotedMessage(
+    rawPayload: Record<string, unknown>,
+    instanceId: string,
+    chatId: string,
+    msg: WAMessage,
+  ): Promise<void> {
+    const quoted = extractQuotedContext(msg);
+    if (!quoted) return;
+    const pushName = quoted.participant
+      ? (await this.getContactInfo(instanceId, quoted.participant, chatId))?.name
+      : undefined;
+    rawPayload.quotedMessage = { ...quoted, pushName };
   }
 
   /**


### PR DESCRIPTION
Closes #1090

## Root cause
The WhatsApp plugin spreads the raw `WAMessage` into `rawPayload`, so the quote stays nested under `message.<type>.contextInfo.quotedMessage`. Persistence, `agent-responder` and `message-context` all read a top-level `rawPayload.quotedMessage` (`conversation` / `participant` / `pushName`) that never existed, so `quotedText` and `quotedSenderName` were always null (and the reply-to-bot check never matched either).

## Fix
- `extractQuotedContext` (channel-whatsapp) lifts `stanzaId`, `participant` and the quoted text out of `contextInfo`. Text uses the quoted body, then caption, then a `[type]` placeholder for media.
- The plugin attaches it as `rawPayload.quotedMessage` on both the realtime and history-sync paths and resolves the quoted sender's name via the existing `getContactInfo` used for mentions.
- Persistence keeps reading the same keys and falls back to the chat participant row (`chats.findParticipant`, extracted from `findOrCreateParticipant`) when the channel had no name.
- Scope is limited to the quote fields; `replyToEventId` resolution (#1091) is untouched.

## Test
- `packages/channel-whatsapp/src/__tests__/quoted-context.test.ts` runs against the real quoted `contextInfo` fixture in `test/fixtures/real-payloads.json` plus media caption/placeholder cases.
- typecheck, lint, dead-code, verify-migrations, verify-versions green; `bun test` green in channel-whatsapp and api (PostgreSQL-backed suites skipped locally, no cluster).