### PR TITLE
fix(events): resolve replyToEventId from replyToExternalId at persist time

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -166,6 +166,42 @@ describeWithDb('Event Persistence Handler', () => {
       }
     });
 
+    test('resolves replyToExternalId to the referenced journal event on the same instance (#1091)', async () => {
+      await setupEventPersistence(mockEventBus, db);
+
+      const [instance] = await db
+        .insert(instances)
+        .values({ name: `test-ep-reply-${Date.now()}`, channel: 'whatsapp-baileys' })
+        .returning();
+      if (!instance) throw new Error('Failed to create test instance');
+      const base = (externalId: string, replyToId: string | null) => ({
+        id: randomUUID(),
+        type: 'message.received',
+        timestamp: Date.now(),
+        payload: { externalId, chatId: 'chat-reply', from: 'user-1', content: { type: 'text', text: 'x' }, replyToId },
+        metadata: { correlationId: 'corr-reply', instanceId: instance.id, channelType: 'whatsapp' },
+      });
+      try {
+        await emitEvent('message.received', base('ext-reply-root', null));
+        await emitEvent('message.received', base('ext-reply-child', 'ext-reply-root'));
+        // Reply to a message that never reached the journal — stays null, no back-fill.
+        await emitEvent('message.received', base('ext-reply-orphan', 'ext-reply-missing'));
+
+        const byExt = async (externalId: string) =>
+          (await db.select().from(omniEvents).where(eq(omniEvents.externalId, externalId)).limit(1))[0];
+        const root = await byExt('ext-reply-root');
+        const child = await byExt('ext-reply-child');
+        const orphan = await byExt('ext-reply-orphan');
+        expect(child?.replyToExternalId).toBe('ext-reply-root');
+        expect(child?.replyToEventId).toBe(root?.id);
+        expect(orphan?.replyToExternalId).toBe('ext-reply-missing');
+        expect(orphan?.replyToEventId).toBeNull();
+      } finally {
+        await db.delete(omniEvents).where(eq(omniEvents.instanceId, instance.id));
+        await db.delete(instances).where(eq(instances.id, instance.id));
+      }
+    });
+
     test('journals own-device echo (rawPayload.isFromMe=true) as outbound (#1034)', async () => {
       await setupEventPersistence(mockEventBus, db);
 

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -84,6 +84,34 @@ async function resolveChatLink(
 }
 
 /**
+ * Resolve `replyToExternalId` → `replyToEventId` at persist time (#1091): the
+ * journal row of the quoted message on the same instance, so `events trace`
+ * can walk reply chains as a causal edge. Same best-effort contract as
+ * resolveChatLink. Not back-filled: a reply to a pre-journal message (or one
+ * whose row lands later) legitimately stays null — the referenced event
+ * arriving AFTER its reply is a redelivery/replay edge case, not the ingest
+ * order, and `replyToExternalId` still carries the raw link for those rows.
+ */
+async function resolveReplyToEventId(
+  db: Database,
+  instanceId: string | undefined,
+  replyToExternalId: string | null | undefined,
+): Promise<string | null> {
+  if (!instanceId || !replyToExternalId) return null;
+  try {
+    const [row] = await db
+      .select({ id: omniEvents.id })
+      .from(omniEvents)
+      .where(and(eq(omniEvents.instanceId, instanceId), eq(omniEvents.externalId, replyToExternalId)))
+      .orderBy(omniEvents.receivedAt)
+      .limit(1);
+    return row?.id ?? null;
+  } catch {
+    return null; // best-effort — never fail event persistence because of this
+  }
+}
+
+/**
  * Best-effort person resolution for custom journal rows (#966): accept a
  * personId claim only when it is a valid UUID AND the persons row exists —
  * person_id carries an FK, and a bogus claim must not fail the whole insert.
@@ -142,6 +170,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
           await runConsumerInTenantContext(db, event, async () => {
             const sdb = scopedHandle(db);
             const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
+            const replyToEventId = await resolveReplyToEventId(sdb, metadata.instanceId, payload.replyToId);
 
             const columns: Omit<NewOmniEvent, 'id'> = {
               externalId: payload.externalId,
@@ -160,6 +189,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               mediaMimeType: payload.content.mimeType,
               chatId: payload.chatId,
               replyToExternalId: payload.replyToId,
+              replyToEventId,
               status: 'received',
               receivedAt: new Date(event.timestamp),
               rawPayload: payload.rawPayload ? deepSanitize(payload.rawPayload) : undefined,
@@ -213,6 +243,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
           await runConsumerInTenantContext(db, event, async () => {
             const sdb = scopedHandle(db);
             const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
+            const replyToEventId = await resolveReplyToEventId(sdb, metadata.instanceId, payload.replyToId);
 
             const newEvent: NewOmniEvent = {
               ...eventIdInsert(event.id),
@@ -229,6 +260,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               mediaMimeType: payload.content.mimeType,
               chatId: payload.chatId,
               replyToExternalId: payload.replyToId,
+              replyToEventId,
               status: 'completed',
               receivedAt: new Date(event.timestamp),
               processedAt: new Date(),


### PR DESCRIPTION
Closes #1091

## What
Journal rows for reply messages carried `replyToExternalId` but `replyToEventId` stayed null, so `events trace` could not walk reply chains.

The `message.received` and `message.sent` consumers in `event-persistence.ts` now resolve the referenced journal row by `(instanceId, externalId = replyToId)` on the scoped tenant handle (same best-effort seam as the #1035 chat back-link) and stamp `replyToEventId`.

## Back-fill decision
None. A reply to a pre-journal message legitimately stays null, and `replyToExternalId` still carries the raw link for those rows. The referenced event arriving after its reply is a replay/redelivery edge case, not the ingest order. Documented in the helper's doc comment.

## Tenancy guard
No new `(file, table)` site: `event-persistence.ts` → `omni_events` is already registered in both `tenancy-db-access-guard.ts` and `tenancy-writer-coverage.ts`, and the lookup runs inside `runConsumerInTenantContext` via `scopedHandle`.

## Scope
Journal event link only. #1090 (quotedText/quotedSenderName on the message record) is handled in a sibling PR and touches `message-persistence.ts`, so the two should merge cleanly.

## Test
Regression test in `event-persistence.test.ts`: root → reply resolves to the root's event id; reply to an unjournaled id stays null. Ran against a disposable migrated cluster: suite green. Static gates (typecheck, lint, dead-code, verify-migrations, verify-versions) green. Four unrelated API suites (chat scoping, follow-up sweeper, media processor) fail identically on the base tree in a fresh cluster.