### PR TITLE
fix(release): anchor candidate release notes at the last promoted tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,9 +250,13 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.pkg.outputs.tag }}
           PREVIOUS_TAG: ${{ steps.prev.outputs.tag }}
+          # stable: the generator anchors the range at the last release tag
+          # reachable from origin/main (the last promoted release) instead of
+          # PREVIOUS_TAG, which on dev is a bump-only commit (#1097).
+          CHANNEL: ${{ inputs.channel || 'stable' }}
         run: |
           set -euo pipefail
-          args=(--to "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --output /tmp/release-notes.md)
+          args=(--to "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --channel "${CHANNEL}" --output /tmp/release-notes.md)
           if [[ -n "${PREVIOUS_TAG}" ]]; then
             args+=(--from "${PREVIOUS_TAG}")
           fi

--- a/scripts/release/generate-release-notes.test.ts
+++ b/scripts/release/generate-release-notes.test.ts
@@ -10,6 +10,9 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   type ParsedCommit,
   type RawCommit,
@@ -314,6 +317,69 @@ describe('renderReleaseNotes', () => {
     });
     expect(body).toContain('- Sofia');
     expect(body).not.toContain('github-actions[bot]');
+  });
+});
+
+describe('candidate range (#1097)', () => {
+  const script = join(import.meta.dir, 'generate-release-notes.ts');
+
+  /**
+   * main: feat A → v1.0.0 (promoted). dev, off main: feat B (#5), bump → v1.0.1,
+   * fix C (#6), bump → v1.0.2 (the candidate). The previous tag v1.0.1 is a
+   * bump-only commit, so previous-tag notes for v1.0.2 would list only fix C.
+   */
+  function fixtureRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'release-notes-'));
+    const git = (...args: string[]) => {
+      const result = Bun.spawnSync(['git', ...args], { cwd: dir });
+      if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+    };
+    const commit = (subject: string) => {
+      writeFileSync(join(dir, 'f'), subject);
+      git('add', 'f');
+      git('-c', 'user.name=Alice', '-c', 'user.email=a@x', 'commit', '-q', '-m', subject);
+    };
+    git('init', '-q', '-b', 'main');
+    commit('feat(api): A');
+    git('tag', 'v1.0.0');
+    git('checkout', '-q', '-b', 'dev');
+    commit('feat(cli): B (#5)');
+    commit('chore(version): bump to 1.0.1');
+    git('tag', 'v1.0.1');
+    commit('fix(api): C (#6)');
+    commit('chore(version): bump to 1.0.2');
+    git('tag', 'v1.0.2');
+    return dir;
+  }
+
+  function run(dir: string, ...args: string[]): string {
+    const result = Bun.spawnSync(['bun', script, '--to', 'v1.0.2', '--repo', 'o/r', ...args], { cwd: dir });
+    expect(result.exitCode).toBe(0);
+    return result.stdout.toString();
+  }
+
+  test('stable compares against the last tag reachable from main, not the bump-only previous tag', () => {
+    const body = run(fixtureRepo(), '--from', 'v1.0.1', '--channel', 'stable', '--main-ref', 'main');
+    expect(body).toContain('### 🚀 Features');
+    expect(body).toContain('- **cli:** B ([#5](https://github.com/o/r/pull/5))');
+    expect(body).toContain('- **api:** C ([#6](https://github.com/o/r/pull/6))');
+    expect(body).not.toContain('feat(api): A');
+    expect(body).toContain('[v1.0.0...v1.0.2](https://github.com/o/r/compare/v1.0.0...v1.0.2)');
+    expect(body).toContain('### 🔐 Verifying release assets');
+  });
+
+  test('dev keeps the previous-tag range', () => {
+    const body = run(fixtureRepo(), '--from', 'v1.0.1', '--channel', 'dev');
+    expect(body).not.toContain('Features');
+    expect(body).toContain('- **api:** C ([#6](https://github.com/o/r/pull/6))');
+    expect(body).toContain('[v1.0.1...v1.0.2]');
+  });
+
+  test('stable falls back to --from when main has no release tag', () => {
+    const dir = fixtureRepo();
+    Bun.spawnSync(['git', 'tag', '-d', 'v1.0.0'], { cwd: dir });
+    const body = run(dir, '--from', 'v1.0.1', '--channel', 'stable', '--main-ref', 'main');
+    expect(body).toContain('[v1.0.1...v1.0.2]');
   });
 });
 

--- a/scripts/release/generate-release-notes.ts
+++ b/scripts/release/generate-release-notes.ts
@@ -17,8 +17,14 @@
  *
  * Usage:
  *   bun scripts/release/generate-release-notes.ts \
- *     --to v2.260908.12 [--from v2.260902.5] \
- *     [--repo automagik-dev/omni] [--output /tmp/release-notes.md]
+ *     --to v2.260908.12 [--from v2.260902.5] [--channel stable|dev] \
+ *     [--main-ref origin/main] [--repo automagik-dev/omni] [--output /tmp/release-notes.md]
+ *
+ * `--from` is the previous tag on dev, which is right for a dev prerelease
+ * (per-merge notes). For `--channel stable` (a promoted candidate) that tag is
+ * almost always a bare chore(version) bump, so the range is instead anchored at
+ * the last release tag reachable from `--main-ref` — the last promoted release
+ * (#1097). `--from` is only the fallback when main carries no release tag.
  *
  * The pure functions are exported for scripts/release/generate-release-notes.test.ts.
  */
@@ -448,6 +454,19 @@ function collectCommits(fromTag: string | null, toTag: string): ParsedCommit[] {
     .filter((commit): commit is ParsedCommit => commit !== null);
 }
 
+/**
+ * Last vX.Y.Z tag reachable from `mainRef` other than `toTag` itself — the
+ * previously promoted release. Null when main carries no release tag.
+ */
+function resolvePromotedBaseTag(mainRef: string, toTag: string): string | null {
+  try {
+    const tag = runGit(['describe', '--tags', '--abbrev=0', '--match', 'v[0-9]*', '--exclude', toTag, mainRef]).trim();
+    return TAG_PATTERN.test(tag) ? tag : null;
+  } catch {
+    return null;
+  }
+}
+
 function collectMigrations(fromTag: string | null, toTag: string): MigrationEntry[] {
   if (!fromTag) return [];
   const diff = runGit(['diff', '--name-status', `${fromTag}..${toTag}`, '--', 'packages/db/drizzle']);
@@ -464,15 +483,33 @@ function main(): void {
       to: { type: 'string' },
       repo: { type: 'string' },
       output: { type: 'string' },
+      channel: { type: 'string' },
+      'main-ref': { type: 'string' },
     },
   });
   const toTag = values.to ?? '';
   if (!TAG_PATTERN.test(toTag)) {
     throw new Error(`--to must be a vX.Y.Z release tag, got: ${toTag || '(missing)'}`);
   }
-  const fromTag = values.from ?? null;
+  let fromTag = values.from ?? null;
   if (fromTag !== null && !TAG_PATTERN.test(fromTag)) {
     throw new Error(`--from must be a vX.Y.Z release tag, got: ${fromTag}`);
+  }
+  const channel = values.channel ?? 'dev';
+  if (channel !== 'stable' && channel !== 'dev') {
+    throw new Error(`--channel must be stable or dev, got: ${channel}`);
+  }
+  if (channel === 'stable') {
+    const mainRef = values['main-ref'] ?? 'origin/main';
+    const promoted = resolvePromotedBaseTag(mainRef, toTag);
+    if (promoted) {
+      console.error(`stable channel: comparing against ${promoted}, the last release tag reachable from ${mainRef}`);
+      fromTag = promoted;
+    } else {
+      console.error(
+        `stable channel: no release tag reachable from ${mainRef}; falling back to ${fromTag ?? 'full history'}`,
+      );
+    }
   }
   const repo = values.repo ?? process.env.GITHUB_REPOSITORY ?? 'automagik-dev/omni';
   if (!REPO_PATTERN.test(repo)) {


### PR DESCRIPTION
Closes #1097

For a stable candidate the previous tag on dev is always a bare `chore(version)` bump, so promoted releases shipped empty notes (e.g. v2.260910.15 compared `v2.260910.14...v2.260910.15`).

- `generate-release-notes.ts` takes `--channel stable|dev` (and `--main-ref`, default `origin/main`). For `stable` it anchors the range at the last `vX.Y.Z` tag reachable from main (the last promoted release), falling back to `--from` when main carries no release tag. `dev` keeps the previous-tag range.
- `release.yml` passes `--channel` from the existing `inputs.channel || 'stable'` value. No other workflow behaviour changes; grouping by conventional type, PR/issue links, and the asset-verification section are unchanged.
- Tests: a temp-repo fixture with a bump-only previous tag covers stable, dev, and the no-tag-on-main fallback.

`make check` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Stable release notes now compare changes against the latest promoted release on the main branch, producing more accurate changelogs.
  * Development release notes continue to use the previous-tag comparison range.
  * Stable release generation falls back to the specified starting tag when no promoted release is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->