### PR TITLE
docs: document the 2.260910.5–2.260910.15 CLI/API additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Every state change lands in a total-ordered PostgreSQL journal and is published 
 
 ```bash
 omni events list --type "message.*" --since 2h        # trailing-* glob type filters
+omni events types --since 7d                          # what's flowing: volume, schema status, subscribers
+omni events stream --pretty --exclude "custom.chat.*" # live tail, one line per event, minus the noise
 omni events trace <event-id>                          # causation chain, rendered as a tree
 omni events wait --type "custom.github.*" --timeout 60  # block until a matching event arrives
 
@@ -350,7 +352,7 @@ Schemas: `agno` · `webhook` · `openclaw` · `ag-ui` · `claude-code` · `a2a` 
 omni automations create --name "Auto-reply" --trigger "message.received" \
   --action send_message --action-config '{"text":"Got it!"}'
 omni automations list --enabled
-omni automations test <id>
+omni automations test <id> --event <event-id>   # dry-run against a real journaled event: condition verdicts, no side effects
 ```
 
 Actions: `webhook` · `send_message` · `emit_event` · `log` · `call_agent`
@@ -414,6 +416,8 @@ omni doctor --fix                               # repair safe runtime drift in-p
 omni auth login --api-key <your-api-key>        # authenticate
 omni config set defaultInstance <id>            # CLI settings
 omni events list --type "message.*" --since 2h  # event history (trailing-* globs)
+omni events types                               # observed event types: volume, schema, subscribers
+omni events stream --pretty                     # live tail, one colored line per event
 omni events trace <event-id>                    # causation chain
 omni events wait --type "custom.x.*" --timeout 60  # block until a matching event
 omni events schema register <type> --file s.json   # register a payload schema

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,7 +1,7 @@
 ---
 title: "API Endpoints Reference"
 created: 2025-01-29
-updated: 2026-09-08
+updated: 2026-09-10
 tags: [api, endpoints, reference]
 status: current
 ---
@@ -422,11 +422,23 @@ Source: `packages/api/src/routes/v2/events.ts`
 
 ```yaml
 GET    /api/v2/events                         # List events
-  Query: channel[], instanceId?, personId?, eventType[], contentType[],
-         direction?, since?, until?, search?, limit?, cursor?
+  Query: channel[], instanceId?, personId?, chatId?, eventType[], excludeEventType[],
+         contentType[], direction?, since?, until?, search?, limit?, cursor?
+  Note: eventType/excludeEventType are comma-separated; trailing-* prefix globs.
+        Exclusion wins over inclusion (`custom.*` minus `custom.chat.*`).
 
 GET    /api/v2/events/analytics               # Get analytics summary
-  Query: since?, until?, instanceId?, allTime?
+  Query: since?, until?, instanceId?, granularity? (hourly|daily), allTime?
+  Response: { ..., totalCostUsd, messageTypes, errorStages, instances, byChannel, byDirection, timeline? }
+  Note: totalCostUsd = sum of `metadata.agentUsage.costUsd` over events in range
+        (stamped on the event that woke an agent — see event-system.md).
+
+GET    /api/v2/events/types                   # Inventory of observed event types
+  Query: since?
+  Response: { items[{ eventType, count, lastSeen, schemaVersion, schemaEnabled,
+                      consumers[], automations[] }], meta: { since } }
+  Note: schemaVersion/schemaEnabled are null for unregistered types; consumers =
+        durable consumer names, automations = enabled automations triggered by the type.
 
 GET    /api/v2/events/timeline/:personId      # Person timeline
   Query: channels[]?, since?, until?, limit?, cursor?
@@ -490,7 +502,10 @@ JetStream consumers. `lag` = journal head − cursor.
 GET    /api/v2/events/consumers               # List consumers (filter, cursor, live lag)
 
 POST   /api/v2/events/consumers               # Register a consumer
-  Note: Initial cursor 'now' = journal head (default), 'beginning' = full replay
+  Body: { name, eventType, excludeTypes[]? (max 20), filters[]?, from? }
+  Note: Initial cursor 'now' = journal head (default), 'beginning' = full replay.
+        excludeTypes use the same glob syntax as eventType and win over it;
+        the stored value is echoed back as `excludeTypes` (null = none).
 
 GET    /api/v2/events/consumers/:name         # Get consumer + cursor position + lag
 
@@ -713,8 +728,17 @@ DELETE /api/v2/automations/:id                # Delete automation
 
 POST   /api/v2/automations/:id/enable         # Enable automation
 POST   /api/v2/automations/:id/disable        # Disable automation
-POST   /api/v2/automations/:id/test           # Test with mock event
-POST   /api/v2/automations/:id/execute        # Execute with real event
+POST   /api/v2/automations/:id/test           # Dry run: verdicts, no side effects
+  Body: { event?: { type, payload }, eventId? }   (exactly one)
+  Response: { matched, triggerMatched, conditionsMatched, conditionLogic,
+              conditions[{ field, operator, expected, actual, resolved, matched }],
+              actions[{ type, wouldExecute, config }] }
+  Note: eventId loads a REAL omni_events row — rawPayload as payload, envelope
+        metadata merged for conditions. Nothing executes, no execution log.
+        `resolved: false` = the condition's dot path found nothing.
+
+POST   /api/v2/automations/:id/execute        # Execute (actually runs the actions)
+  Body: { event?: { type, payload }, eventId? }   (exactly one)
 
 GET    /api/v2/automation-logs                 # Get automation execution logs
   Query: automationId?, limit?
@@ -785,7 +809,9 @@ POST   /api/v2/webhooks/:source/heartbeat     # Connector liveness heartbeat (au
 
 ```yaml
 POST   /api/v2/events/trigger                 # Trigger a custom event
-  Body: { eventType (custom.*), payload, correlationId?, instanceId? }
+  Body: { eventType (custom.*), payload, correlationId?, causationId?, instanceId? }
+  Note: causationId (uuid of an existing event) parents the emission in the
+        causality tree (GET /events/:id/trace) instead of creating a new root.
 ```
 
 ---

--- a/docs/architecture/event-system.md
+++ b/docs/architecture/event-system.md
@@ -881,6 +881,17 @@ reaction performs — however deep inside a channel plugin — is stamped withou
 threading parameters through every signature. Precedence: **explicit metadata
 wins, then the ambient context, then self-reference** (roots).
 
+Emissions made **outside** a reaction (a script, a CI step, a human) have no
+ambient context and would become roots. `POST /api/v2/events/trigger` accepts
+an explicit `causationId`, and `omni webhooks trigger --causation-id
+<event-id>` sets it, so a mid-flow emission stays attached to the event it
+answers:
+
+```bash
+omni webhooks trigger --type custom.deploy.finished \
+  --payload '{"sha":"abc123"}' --causation-id <event-id>
+```
+
 Tracing surfaces:
 
 - `GET /api/v2/events/:id/trace` — walks ancestors up to the root and
@@ -923,7 +934,8 @@ from outside.
 
 A durable consumer is a **Postgres-registered name with a cursor over the
 journal** — a row in `durable_consumers`: `name` (unique), an `event_type`
-filter (trailing-`*` prefix glob), `filters` jsonb (payload conditions), and
+filter (trailing-`*` prefix glob), `exclude_types` jsonb (globs dropped from
+the stream, null = none), `filters` jsonb (payload conditions), and
 a `cursor` bigint over `journal_seq`. These are **not NATS JetStream
 durables** — NATS offsets live in `consumer_offsets`, a different table used
 for gap detection.
@@ -951,6 +963,12 @@ syntax (`>` and mid-token `*` are not supported). The glob works in
 `events list`, `events stream`, `events wait`, and durable-consumer filters.
 It is **not** supported in automation triggers (exact type match) or agent
 event manifests (exact types only).
+
+The same syntax drives **exclusion**: `--exclude <glob>` (repeatable) on
+`events stream` / `events wait` / `events consumers create`, `excludeEventType`
+on `GET /events`, and `excludeTypes` on consumer registration. Exclusion wins
+over inclusion, so `--type "custom.*" --exclude "custom.chat.*"` keeps
+application events without the housekeeping noise.
 
 ## Webhook Event Sources (External Ingress)
 
@@ -1004,6 +1022,33 @@ with a deterministic idempotency key derived from
 `(event, automation, actionIndex)`, so retries and redeliveries of the same
 run skip already-journaled emissions. This is a journal-level claim, not a
 database outbox table.
+
+## Agent Usage & Cost
+
+When a routed dispatch or an automation `call_agent` action completes, the
+provider's usage is stamped on the journal row of the **event that woke the
+agent** — no dedicated columns:
+
+- `omni_events.metadata.agentUsage` = `{ providerId, runId, costUsd?,
+  tokensIn?, tokensOut?, model? }` (`AgentUsageSchema` in `@omni/core`).
+  Providers expose different surfaces: claude-code reports cost and model,
+  Agno reports tokens and model, webhook/A2A/AG-UI report nothing — then
+  nothing is stamped rather than a row of zeros.
+- `omni_events.agent_latency_ms` = provider round-trip.
+
+Cost per event type, agent, or chat is a plain aggregation over the JSONB
+path, grouped by whatever the row already carries:
+
+```sql
+SELECT event_type, sum((metadata->'agentUsage'->>'costUsd')::numeric) AS cost_usd
+FROM omni_events
+WHERE metadata ? 'agentUsage'
+GROUP BY event_type;
+```
+
+`GET /api/v2/events/analytics` returns the window's sum as `totalCostUsd`;
+`omni events analytics` prints it. Streaming and turn-based dispatch are not
+stamped (no provider result to read).
 
 ## Event Payload Storage
 

--- a/docs/cli/design.md
+++ b/docs/cli/design.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI Design"
 created: 2025-01-29
-updated: 2026-09-08
+updated: 2026-09-10
 tags: [cli, reference]
 status: current
 ---
@@ -287,16 +287,23 @@ omni events get <id>                       # Get one event
 omni events search "meeting"              # Search by content
 omni events timeline <person-id>          # Cross-channel timeline
 omni events metrics                       # Processing metrics
-omni events analytics                     # Aggregated analytics
+omni events analytics                     # Aggregated analytics (incl. totalCostUsd of agent runs)
+
+# Inventory of observed event types: volume, last seen, schema status, subscribers
+omni events types                          # Whole journal
+omni events types --since 7d               # Only count events in the window
 
 # Live tail (poll-based)
 omni events stream --type "message.*"      # Live tail
 omni events stream --ndjson --poll-ms 500  # NDJSON output, custom poll interval
 omni events stream -v                      # + sender, fromMe marker, contentType columns
 omni events stream --ids                   # raw uuid8 ids instead of instance/chat names
+omni events stream --pretty                # One colored `time type who: text` line per event
+omni events stream --type "custom.*" --exclude "custom.chat.*"  # Drop housekeeping types
 
 # One-shot blocking wait (exits non-zero on timeout)
 omni events wait --type message.received --filter instanceId=<id> --timeout 60
+omni events wait --type "custom.*" --exclude "custom.chat.*" --timeout 60
 
 # Causation tracing: walks the causationId chain up to the root and
 # breadth-first down, printed as an indented tree with corr= ids
@@ -308,6 +315,24 @@ omni events replay --status <id>           # Check a replay session
 omni events replay --cancel <id>           # Cancel a replay session
 ```
 
+`events types` flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--since <time>` | Only count events since (`24h`, `7d`, or ISO timestamp); default whole journal |
+
+Each row reports `eventType`, `count`, `lastSeen`, the registered
+`schemaVersion` / `schemaEnabled` (null = unregistered), and the durable
+`consumers` and enabled `automations` subscribed to that type.
+
+`events stream` / `events wait` filter and rendering flags added recently:
+
+| Flag | Purpose |
+|------|---------|
+| `--exclude <glob>` | Drop event types matching this glob; repeatable; wins over `--type` (`stream`, `wait`, `consumers create`) |
+| `--pretty` | One colored `time type who: text` line per event; no ANSI when piped or `NO_COLOR` (`stream`, `follow`) |
+| `--ids` | Raw ids instead of resolved instance/chat names (`stream`; `follow` only with `--pretty`) |
+
 ### Durable consumers
 
 Named, resumable cursors for tailing the event store. These are **Postgres
@@ -318,6 +343,7 @@ follower (no consumer groups).
 ```bash
 omni events consumers create my-bot --type "message.*" --filter instanceId=<id>
 omni events consumers create audit --type "*" --from-beginning
+omni events consumers create app --type "custom.*" --exclude "custom.chat.*" --exclude "custom.lid-mapping.*"
 omni events consumers ls                   # List consumers
 omni events consumers inspect my-bot       # Cursor position, lag
 omni events consumers rm my-bot            # Delete
@@ -326,6 +352,7 @@ omni events consumers rm my-bot            # Delete
 omni events follow --consumer my-bot
 omni events follow --consumer my-bot --no-ack      # Peek one page, no ack
 omni events follow --consumer my-bot --until-idle  # Exit when caught up
+omni events follow --consumer my-bot --pretty      # Human one-liners instead of JSON lines
 ```
 
 ### Schema registry
@@ -352,20 +379,76 @@ omni events schema validate custom.deploy --file ./payload.json   # dry run: exi
 ```bash
 omni automations list                      # List automations
 omni automations get <id>                  # Get details
-omni automations create ...               # Create automation
-omni automations update <id> ...          # Update
+omni automations create --name <n> --trigger <event> --action <type> [--action-config <json>]
+omni automations create --file ./automation.json   # Full definition (get --json output works as-is)
+omni automations update <id> --name "New"          # PATCH: only given fields go on the wire
+omni automations update <id> --file ./automation.json
 omni automations delete <id>              # Delete
 omni automations enable <id>              # Enable
 omni automations disable <id>             # Disable
-omni automations test <id>               # Test with mock event
-omni automations execute <id>            # Execute with real event
+omni automations test <id> --event '{"type":"message.received","payload":{}}'  # Dry run, mock event
+omni automations test <id> --event <event-id>      # Dry run against a REAL journaled event
+omni automations test <id> --event <event-id> --execute  # Same as `execute`
+omni automations execute <id> --event <json|event-id>    # Actually runs the actions
 omni automations logs <id>               # Execution logs
 ```
 
-`create`/`update` support `--transactional-emissions`: `emit_event` actions are
-buffered and flushed in order only if the whole run succeeds. The `call_agent`
-action also works chatless — an event can dispatch an agent without any chat
-context.
+### Multi-action create and full update
+
+`--action` / `--action-config` are repeatable and ordered: the i-th config
+pairs with the i-th action. `update` accepts the same definition flags as
+`create` (`--trigger`, `--condition`, `--action`, …); passing `--action`
+replaces the whole actions list, and the id and execution logs are kept.
+
+```bash
+omni automations create --name "PR digest" --trigger custom.github.pull_request \
+  --action log --action-config '{"message":"{{payload.action}} #{{payload.number}}"}' \
+  --action webhook --action-config '{"url":"https://hooks.example.com/pr","bodyTemplate":"{{payload_json}}"}'
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--file <path>` | Full definition as JSON; explicit flags override its fields. `id`, timestamps, `managedByAgentId` and null fields from `get --json` are dropped |
+| `--action <type>` | `webhook` \| `send_message` \| `emit_event` \| `log` \| `call_agent`; repeat for ordered multi-action (on `update`: replaces the list) |
+| `--action-config <json>` | Config for the matching `--action` (count must match) |
+| `--condition <json>` / `--condition-logic and\|or` | Trigger conditions (on `update`: replaces them) |
+| `--agent-id` / `--provider-id` / `--response-as` | Shortcuts that target the **first** `call_agent` action |
+| `--transactional-emissions` / `--no-transactional-emissions` | Buffer `emit_event` publishes and flush in order only if every action succeeded (`--no-…` is `update`-only) |
+
+### Dry run against a journaled event
+
+`test` never executes actions or writes an execution log. With an event id it
+loads the `omni_events` row (`rawPayload` as payload, envelope metadata merged
+for conditions) and prints the trigger match, a per-condition verdict table
+(`field`, `operator`, `expected`, `actual`, `resolved`, `matched` — `resolved:
+false` means the dot path found nothing) and each action's config with
+templates rendered. `--execute` flips it into a real run.
+
+| Flag | Purpose |
+|------|---------|
+| `--event <json\|event-id>` | Hand-written event JSON, or the id of a journaled event (`omni events list`) |
+| `--execute` | Actually run the actions (same as `execute`) |
+
+### Template placeholders
+
+Action configs are templates. Besides `{{payload.<dot.path>}}`,
+`{{event.<field>}}`, `{{env.<NAME>}}` and stored variables, two whole-object
+placeholders render compact JSON (no whitespace) for pasting into prompts and
+webhook bodies:
+
+| Placeholder | Renders |
+|-------------|---------|
+| `{{payload_json}}` | The whole payload as compact JSON |
+| `{{event_json}}` | `{ id, type, timestamp, metadata, payload }`; envelope fields are `null` when no envelope was threaded |
+
+```bash
+omni automations create --name "Forward to agent" --trigger custom.clickup.taskstatusupdated \
+  --action call_agent --agent-id <agent-id> \
+  --action-config '{"promptOverride":"A ClickUp task changed. Event: {{event_json}}"}'
+```
+
+The `call_agent` action also works chatless — an event can dispatch an agent
+without any chat context.
 
 ## Agents
 
@@ -412,6 +495,7 @@ omni webhooks list                         # List webhook sources
 omni webhooks get <id>                     # Get details
 omni webhooks delete <id>                 # Delete
 omni webhooks trigger --type custom.x --payload '{...}'  # Manual event emission
+omni webhooks trigger --type custom.x --payload '{...}' --causation-id <event-id>  # Parented mid-flow emission
 omni webhooks heartbeat <source>          # Connector liveness ping
 
 # Create with signature verification
@@ -441,6 +525,16 @@ Create flags:
 
 `update` adds the clearing flags `--clear-signature`, `--no-strict-schemas`,
 `--clear-event-type-mapping`, `--clear-cadence`.
+
+`trigger` flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--type <type>` | Event type (`custom.*`) |
+| `--payload <json>` | Event payload |
+| `--instance <id>` | Instance context |
+| `--correlation-id <id>` | Group the emission with an existing flow |
+| `--causation-id <event-id>` | Parent event id; the emission lands under that event in `omni events trace` instead of becoming a root |
 
 > Recipes: [[../runbooks/github-webhook-source|GitHub webhook source]],
 > [[../runbooks/clickup-webhook-source|ClickUp webhook source]].

--- a/docs/runbooks/clickup-webhook-source.md
+++ b/docs/runbooks/clickup-webhook-source.md
@@ -210,11 +210,27 @@ omni automations create \
   --name "ClickUp status change notifier" \
   --trigger custom.clickup.taskstatusupdated \
   --action send_message \
-  --config '{
+  --action-config '{
     "instanceId": "<instance uuid>",
     "chatId": "<chat id>",
     "message": "task {{payload.task_id}}: {{payload.history_items.0.before.status}} → {{payload.history_items.0.after.status}} (by {{payload.history_items.0.user.username}})"
   }'
+```
+
+To hand the whole delivery to an agent instead of picking fields, use the
+`{{payload_json}}` / `{{event_json}}` placeholders (compact JSON), and repeat
+`--action` for an ordered multi-action automation:
+
+```bash
+omni automations create \
+  --name "ClickUp status change → agent" \
+  --trigger custom.clickup.taskstatusupdated \
+  --action log --action-config '{"message":"clickup {{payload.task_id}}"}' \
+  --action call_agent --agent-id <agent id> \
+  --action-config '{"promptOverride":"A ClickUp task changed status. Event: {{event_json}}"}'
+
+# Dry-run against a real delivery before enabling (verdicts, no side effects):
+omni automations test <automation id> --event <event id>
 ```
 
 Because retry dedup happens **before** publish, a ClickUp retry can never

--- a/docs/runbooks/durable-consumers.md
+++ b/docs/runbooks/durable-consumers.md
@@ -41,7 +41,24 @@ omni events consumers rm deploy-tracker
 
 `--from-beginning` on create starts the cursor at 0 (full journal replay —
 projections); the default starts at the current head (like `events wait`).
-`--no-ack` on follow peeks one page without moving the cursor.
+`--no-ack` on follow peeks one page without moving the cursor. `--pretty` on
+follow prints one `time type who: text` line per event instead of JSON lines.
+
+### Excluding noisy types
+
+`--exclude <glob>` (repeatable, same trailing-`*` syntax as `--type`) drops
+types from the consumer's stream and **wins over `--type`**, so a broad
+subscription does not flood the follower with housekeeping events:
+
+```bash
+omni events consumers create app-events \
+  --type 'custom.*' \
+  --exclude 'custom.chat.*' --exclude 'custom.lid-mapping.*'
+```
+
+The globs are stored on the consumer (`excludeTypes`, shown by `ls` /
+`inspect`), so every follower of that name sees the same sieve. The same flag
+exists on `events stream` and `events wait`.
 
 ## The model
 

--- a/docs/runbooks/github-webhook-source.md
+++ b/docs/runbooks/github-webhook-source.md
@@ -193,11 +193,28 @@ omni automations create \
   --name "GitHub push notifier" \
   --trigger custom.github.push \
   --action send_message \
-  --config '{
+  --action-config '{
     "instanceId": "<instance uuid>",
     "chatId": "<chat id>",
     "message": "push to {{payload.repository.full_name}} ({{payload.ref}}) by {{payload.sender.login}}"
   }'
+```
+
+`--action` / `--action-config` repeat for an ordered multi-action automation,
+and `{{payload_json}}` / `{{event_json}}` render the whole payload or event as
+compact JSON — handy for forwarding the delivery to an agent or another hook:
+
+```bash
+omni automations create \
+  --name "GitHub push notifier + agent" \
+  --trigger custom.github.push \
+  --action send_message \
+  --action-config '{"instanceId":"<instance uuid>","chatId":"<chat id>","message":"push by {{payload.sender.login}}"}' \
+  --action call_agent --agent-id <agent id> \
+  --action-config '{"promptOverride":"Summarize this GitHub push: {{payload_json}}"}'
+
+# Dry-run against a real delivery before enabling (verdicts, no side effects):
+omni automations test <automation id> --event <event id>
 ```
 
 Because redelivery dedup happens **before** publish, a GitHub redelivery can


### PR DESCRIPTION
Closes #1098

Documentation only — no code changes.

Each row of the issue table is now covered in the listed files, matching the real `--help` output and the OpenAPI schemas:

| PR | Documented in |
|---|---|
| #1081 `--causation-id` / `causationId` | `docs/cli/design.md` (webhooks trigger flags), `docs/api/endpoints.md`, `docs/architecture/event-system.md` (causality) |
| #1084 `{{payload_json}}` / `{{event_json}}` | `docs/cli/design.md` (automations → template placeholders), GitHub + ClickUp runbooks |
| #1087 `omni events types` / `GET /events/types` | `docs/cli/design.md`, `docs/api/endpoints.md`, README |
| #1088 `--exclude` / `excludeEventType` / `excludeTypes` | `docs/cli/design.md`, `docs/runbooks/durable-consumers.md`, `docs/api/endpoints.md`, `docs/architecture/event-system.md` (glob semantics) |
| #1089 `automations test --event <id>` / `--execute`, dry-run result | `docs/cli/design.md`, `docs/api/endpoints.md`, README, runbooks |
| #1095 `--pretty` on `events stream` / `follow` | `docs/cli/design.md`, README, durable-consumers runbook |
| #1082 multi-action create / full update (`--file`, repeatable `--action`) | `docs/cli/design.md`, GitHub + ClickUp runbooks |
| #1070 `metadata.agentUsage`, `totalCostUsd` | `docs/architecture/event-system.md` (new "Agent Usage & Cost"), `docs/api/endpoints.md` |

Also fixed while there: the GitHub/ClickUp runbook examples used `--config`, which is not a flag — the real one is `--action-config`.

Verified: help output captured from `bun packages/cli/src/index.ts <cmd> --help` on dev; `make lint` (biome) and the pre-push typecheck + test gate green.