### PR TITLE
fix(whatsapp): emit message edits from messages.update and unwrap every envelope shape

### DIFF
--- a/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/extract-content.test.ts
@@ -345,3 +345,46 @@ describe('extractContent — bot-interactive messages (omni#902)', () => {
     expect(content?.text).toBeUndefined();
   });
 });
+
+describe('extractContent — envelope unwrapping (#1061 reopen)', () => {
+  const editProto = {
+    protocolMessage: {
+      key: { id: 'ORIG789', remoteJid: '120363000000000000@g.us', fromMe: true },
+      type: 14,
+      editedMessage: { extendedTextMessage: { text: 'edited in group' } },
+    },
+  };
+
+  it('own group edit synced from the phone: deviceSentMessage → editedMessage → protocolMessage', () => {
+    const content = extractContent(
+      wrap({
+        messageContextInfo: { deviceListMetadataVersion: 2 },
+        deviceSentMessage: {
+          destinationJid: '120363000000000000@g.us',
+          message: { editedMessage: { message: editProto } },
+        },
+      }),
+    );
+    expect(content?.type).toBe('edit');
+    expect(content?.targetMessageId).toBe('ORIG789');
+    expect(content?.editedText).toBe('edited in group');
+  });
+
+  it('bare protocolMessage edit (no envelope) still classifies as edit', () => {
+    const content = extractContent(wrap(editProto));
+    expect(content?.type).toBe('edit');
+    expect(content?.targetMessageId).toBe('ORIG789');
+  });
+
+  it('viewOnceMessageV2 envelope unwraps to the inner media instead of unknown', () => {
+    const content = extractContent(wrap({ viewOnceMessageV2: { message: { imageMessage: { caption: 'once' } } } }));
+    expect(content?.type).toBe('image');
+    expect(content?.text ?? content?.caption).toBe('once');
+  });
+
+  it('ephemeral text still extracts after the wrapper extractors were folded into unwrapEnvelopes', () => {
+    const content = extractContent(wrap({ ephemeralMessage: { message: { conversation: 'ttl' } } }));
+    expect(content?.type).toBe('text');
+    expect(content?.text).toBe('ttl');
+  });
+});

--- a/packages/channel-whatsapp/src/__tests__/message-edit-update.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/message-edit-update.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Message edits (#1061, reopened).
+ *
+ * Baileys re-emits every MESSAGE_EDIT as `messages.update` with the ORIGINAL key
+ * and `{ editedMessage: { message: <new content> } }`. That is the single source
+ * for edit events; the raw protocol message on `messages.upsert` is swallowed so
+ * it is neither journaled as `unknown` nor emitted twice.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { setupMessageHandlers } from '../handlers/messages';
+import { WhatsAppPlugin } from '../plugin';
+
+const GROUP = '120363000000000000@g.us';
+
+function harness() {
+  const ev = new EventEmitter();
+  const sock = { ev, presenceSubscribe: mock(async () => {}) } as unknown as Parameters<typeof setupMessageHandlers>[0];
+  const plugin = new WhatsAppPlugin();
+  const handleEdited = mock(async () => {});
+  const emitReceived = mock(async () => {});
+  (plugin as unknown as { handleMessageEdited: typeof handleEdited }).handleMessageEdited = handleEdited;
+  (plugin as unknown as { emitMessageReceived: typeof emitReceived }).emitMessageReceived = emitReceived;
+  (plugin as unknown as { handleMessageDelivered: typeof handleEdited }).handleMessageDelivered = mock(async () => {});
+  setupMessageHandlers(sock, plugin, 'inst-1');
+  return { ev, handleEdited, emitReceived };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe('WhatsApp message edits via messages.update', () => {
+  it('text edit of own group message lands on the original id with the new text', async () => {
+    const h = harness();
+    h.ev.emit('messages.update', [
+      {
+        key: { id: 'ORIG789', remoteJid: GROUP, fromMe: true, participant: '5511999998888@s.whatsapp.net' },
+        update: { message: { editedMessage: { message: { extendedTextMessage: { text: 'edited in group' } } } } },
+      },
+    ]);
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledWith('inst-1', 'ORIG789', GROUP, 'edited in group', true);
+  });
+
+  it('media caption edit carries the caption', async () => {
+    const h = harness();
+    h.ev.emit('messages.update', [
+      {
+        key: { id: 'ORIG456', remoteJid: '5511999998888@s.whatsapp.net', fromMe: false },
+        update: { message: { editedMessage: { message: { imageMessage: { caption: 'new caption' } } } } },
+      },
+    ]);
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledWith(
+      'inst-1',
+      'ORIG456',
+      '5511999998888@s.whatsapp.net',
+      'new caption',
+      false,
+    );
+  });
+
+  it('status-only updates do not emit edits', async () => {
+    const h = harness();
+    h.ev.emit('messages.update', [{ key: { id: 'X', remoteJid: GROUP, fromMe: true }, update: { status: 3 } }]);
+    await flush();
+    expect(h.handleEdited).not.toHaveBeenCalled();
+  });
+
+  it('the raw edit protocol message on messages.upsert is swallowed (not unknown, not a second edit)', async () => {
+    const h = harness();
+    h.ev.emit('messages.upsert', {
+      type: 'notify',
+      messages: [
+        {
+          key: { id: 'EDITMSG1', remoteJid: GROUP, fromMe: true, participant: '5511999998888@s.whatsapp.net' },
+          messageTimestamp: 1_700_000_000,
+          message: {
+            deviceSentMessage: {
+              destinationJid: GROUP,
+              message: {
+                editedMessage: {
+                  message: {
+                    protocolMessage: {
+                      key: { id: 'ORIG789', remoteJid: GROUP, fromMe: true },
+                      type: 14,
+                      editedMessage: { conversation: 'edited in group' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+    await flush();
+    expect(h.handleEdited).not.toHaveBeenCalled();
+    expect(h.emitReceived).not.toHaveBeenCalled();
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -14,6 +14,7 @@ import { createDownloadGuard, createInboundDedupeCache, createMediaBackend, sani
 import type { DedupeCache, MediaStorageBackend } from '@omni/channel-sdk';
 import { createLogger } from '@omni/core';
 import type { ContentType } from '@omni/core/types';
+import { normalizeMessageContent } from 'baileys';
 import type { MessageUpsertType, WAMessage, WAMessageKey, WASocket, proto } from 'baileys';
 import { fromJid, isLidJid, isUserJid, resolveCanonicalJid, resolveToPhoneJidLegacy } from '../jid';
 import type { WhatsAppPlugin } from '../plugin';
@@ -459,9 +460,6 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
     }),
   },
   // Bot-sent interactive list menu (issue #902) — flatten to a text transcript.
-  // Must stay BEFORE the trailing wrapper extractors so the slice(0, -N) offsets
-  // below keep pointing at the wrappers (and so deviceSent/ephemeral/viewOnce
-  // re-extraction reaches these interactive types).
   {
     check: (m) => !!m.listMessage,
     extract: (m) => ({
@@ -495,71 +493,6 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
   {
     check: (m) => !!(m as Record<string, unknown>).messageHistoryBundle,
     extract: () => null, // History sync, don't emit
-  },
-  // Device sent message (multi-device sync)
-  {
-    check: (m) => !!(m as Record<string, unknown>).deviceSentMessage,
-    extract: (m) => {
-      // Extract the actual message from the device sync wrapper
-      const deviceMsg = (m as Record<string, unknown>).deviceSentMessage as Record<string, unknown> | undefined;
-      const innerMsg = deviceMsg?.message as MessageContent | undefined;
-      if (innerMsg) {
-        // Re-run extraction on the inner message
-        for (const { check, extract } of contentExtractors.slice(0, -3)) {
-          if (check(innerMsg)) {
-            return extract(innerMsg);
-          }
-        }
-      }
-      return null; // Can't extract inner content
-    },
-  },
-  // Edited message (FutureProofMessage wrapper). Baileys delivers an incoming edit as
-  // `editedMessage.message.protocolMessage` (type 14); without this unwrap it fell through
-  // to extractUnknownContent and the new text was lost (#1061).
-  {
-    check: (m) => !!m.editedMessage,
-    extract: (m) => {
-      const innerMsg = m.editedMessage?.message as MessageContent | undefined;
-      if (innerMsg) {
-        for (const { check, extract } of contentExtractors.slice(0, -1)) {
-          if (check(innerMsg)) {
-            return extract(innerMsg);
-          }
-        }
-      }
-      return null;
-    },
-  },
-  // Ephemeral message (disappearing messages wrapper - FutureProofMessage)
-  {
-    check: (m) => !!m.ephemeralMessage,
-    extract: (m) => {
-      const innerMsg = m.ephemeralMessage?.message as MessageContent | undefined;
-      if (innerMsg) {
-        for (const { check, extract } of contentExtractors.slice(0, -1)) {
-          if (check(innerMsg)) {
-            return extract(innerMsg);
-          }
-        }
-      }
-      return null;
-    },
-  },
-  // View-once message (FutureProofMessage wrapper)
-  {
-    check: (m) => !!m.viewOnceMessage,
-    extract: (m) => {
-      const innerMsg = m.viewOnceMessage?.message as MessageContent | undefined;
-      if (innerMsg) {
-        for (const { check, extract } of contentExtractors.slice(0, -1)) {
-          if (check(innerMsg)) {
-            return extract(innerMsg);
-          }
-        }
-      }
-      return null;
-    },
   },
 ];
 
@@ -607,9 +540,40 @@ function extractUnknownContent(message: MessageContent): ExtractedContent | null
  * Extract content from a Baileys message using handler map
  * Falls back to 'unknown' type for unrecognized messages to ensure nothing is lost
  */
+/**
+ * FutureProofMessage envelopes WhatsApp wraps real content in. Mirrors Baileys'
+ * `normalizeMessageContent` list plus `deviceSentMessage` (own-device sync).
+ * Envelopes nest in any order (e.g. own edit from the phone:
+ * deviceSentMessage → editedMessage → protocolMessage), so unwrap iteratively
+ * instead of special-casing each wrapper (#1061).
+ */
+const ENVELOPE_KEYS = [
+  'deviceSentMessage',
+  'ephemeralMessage',
+  'viewOnceMessage',
+  'viewOnceMessageV2',
+  'viewOnceMessageV2Extension',
+  'editedMessage',
+  'documentWithCaptionMessage',
+  'associatedChildMessage',
+  'groupStatusMessage',
+  'groupStatusMessageV2',
+] as const;
+
+function unwrapEnvelopes(message: MessageContent): MessageContent {
+  let current = message;
+  for (let depth = 0; depth < 5; depth++) {
+    const record = current as Record<string, { message?: MessageContent | null } | null | undefined>;
+    const key = ENVELOPE_KEYS.find((k) => record[k]?.message);
+    if (!key) break;
+    current = record[key]?.message as MessageContent;
+  }
+  return current;
+}
+
 export function extractContent(msg: WAMessage): ExtractedContent | null {
-  const message = msg.message;
-  if (!message) return null;
+  if (!msg.message) return null;
+  const message = unwrapEnvelopes(msg.message);
 
   for (const { check, extract } of contentExtractors) {
     if (check(message)) {
@@ -857,14 +821,14 @@ async function handleSpecialMessage(
     return true;
   }
 
-  if (content.type === 'edit' && content.targetMessageId) {
-    await plugin.handleMessageEdited(
+  if (content.type === 'edit') {
+    // Edits are emitted from `messages.update`, where Baileys hands us the original
+    // key and the normalized new content regardless of envelope shape (#1061).
+    // Swallow the raw protocol message here so it is neither journaled nor double-emitted.
+    log.debug('Edit protocol message seen on upsert; awaiting messages.update', {
       instanceId,
-      content.targetMessageId,
-      chatId,
-      content.editedText || content.text || '',
-      isFromMe(msg),
-    );
+      targetMessageId: content.targetMessageId,
+    });
     return true;
   }
 
@@ -1214,8 +1178,14 @@ export function setupMessageHandlers(
         await processStatusUpdate(plugin, instanceId, update.key, update.update.status);
       }
 
-      // Message edits are NOT handled here: the same edit also arrives via messages.upsert
-      // as an `editedMessage` envelope, which extractContent unwraps (#1061).
+      // Message edits: Baileys re-emits every MESSAGE_EDIT protocol message here as
+      // `{ editedMessage: { message: <new content> } }` keyed by the ORIGINAL message id,
+      // after normalizing whatever envelope the edit arrived in (#1061).
+      const newText = extractEditedText(normalizeMessageContent(update.update.message));
+      if (newText) {
+        const { chatId } = resolveChatId(plugin, instanceId, { key: update.key } as WAMessage);
+        await plugin.handleMessageEdited(instanceId, update.key.id || '', chatId, newText, update.key.fromMe || false);
+      }
     }
   });
 


### PR DESCRIPTION
Closes #1061 (reopened after #1066).

## What still failed

Re-test on v2.260910.15: editing an own message in a group still journaled `message.received` with `contentType: "unknown"` and empty `textContent`, and the original row never gained `editCount`.

## What #1066 missed

1. **Envelope order.** #1066 appended an `editedMessage` extractor at the *tail* of the extractor chain. The pre-existing `deviceSentMessage` extractor re-runs only `contentExtractors.slice(0, -3)`, which after the insertion excludes the new `editedMessage` extractor. An edit synced from the owner's own phone arrives as `deviceSentMessage → editedMessage → protocolMessage`, so it fell through to `extractUnknownContent` → `unknown`. Wrapper unwrapping via fixed slice offsets is fragile; every wrapper added shifts them.
2. **Wrong path removed.** #1066 deleted the `messages.update` edit handling. That is exactly where Baileys re-emits every `MESSAGE_EDIT` (`process-message.js`), keyed by the **original** message id with the new content under `{ editedMessage: { message } }`, after normalizing the envelope itself. That handler had never worked either: it read `.conversation` directly off the `editedMessage` wrapper.

## Fix

- `extractContent` unwraps every FutureProofMessage envelope Baileys knows (its `normalizeMessageContent` list) plus `deviceSentMessage`, iteratively, at any depth and order. The four ad-hoc wrapper extractors and their `slice(0, -N)` offsets are gone.
- Edits are emitted **once**, from `messages.update`, using Baileys' `normalizeMessageContent` plus the existing `extractEditedText` (text or media caption). Chat id goes through `resolveChatId` so LID chats resolve as on the upsert path.
- The raw protocol message on `messages.upsert` is still classified as `edit` but swallowed, so it is neither journaled as `unknown` nor emitted a second time.
- The API-side persistence from #1066 (`editedMessageId` → `recordEdit` on the original) is unchanged and now actually receives the event.

## Tests

- `extract-content.test.ts`: own group edit under `deviceSentMessage → editedMessage`, bare `protocolMessage` edit, `viewOnceMessageV2` and `ephemeralMessage` unwrap.
- `message-edit-update.test.ts` (new): `messages.update` text edit and caption edit call `handleMessageEdited` with the original id; status-only updates do not; the upsert envelope emits nothing.

`make typecheck`, `make lint`, knip, verify-migrations and the full turbo test suite pass (pre-push gate). The `make check` `_sync-db` step needs a local `.env` + PostgreSQL and was not runnable in this worktree.