### PR TITLE
fix(events): claim an ingress idempotency key for reaction.received/removed

### DIFF
--- a/packages/api/src/__tests__/event-persistence.test.ts
+++ b/packages/api/src/__tests__/event-persistence.test.ts
@@ -11,6 +11,7 @@ import type { EventBus } from '@omni/core';
 import type { Database } from '@omni/db';
 import { chatIdMappings, chats, instances, omniEvents } from '@omni/db';
 import { eq, sql } from 'drizzle-orm';
+import { createPluginContext } from '../plugins/context';
 import { setupEventPersistence } from '../plugins/event-persistence';
 import { describeWithDb, getTestDb } from './db-helper';
 
@@ -643,6 +644,57 @@ describeWithDb('Event Persistence Handler', () => {
       expect(persisted?.direction).toBe('inbound');
       expect(persisted?.chatId).toBe('chat-123');
       expect(persisted?.metadata).toMatchObject({ from: 'user-456' });
+    });
+
+    test('publishing the same reaction twice through the ingress claim journals one row with an idempotency key (#1096)', async () => {
+      await setupEventPersistence(mockEventBus, db);
+      const [instance] = await db
+        .insert(instances)
+        .values({ name: `test-ep-reaction-claim-${Date.now()}`, channel: 'whatsapp-baileys' })
+        .returning();
+      if (!instance) throw new Error('Failed to create test instance');
+      const claim = createPluginContext({ pluginId: 'whatsapp-baileys', eventBus: mockEventBus, db }).ingressClaim;
+      if (!claim) throw new Error('ingressClaim missing from plugin context');
+
+      const idempotencyKey = `whatsapp-baileys:${instance.id}:ext-reaction-claim:reaction.received:👍`;
+      const publish = async () => {
+        const eventId = await claim.claim({
+          idempotencyKey,
+          instanceId: instance.id,
+          channelType: 'whatsapp-baileys',
+          externalId: 'ext-reaction-claim',
+          eventType: 'reaction.received',
+        });
+        if (eventId === null) return; // duplicate: the plugin skips the publish
+        await emitEvent('reaction.received', {
+          id: eventId,
+          type: 'reaction.received',
+          timestamp: Date.now(),
+          payload: {
+            messageId: 'ext-reaction-claim-target',
+            chatId: 'chat-123',
+            from: 'user-456',
+            emoji: '👍',
+            rawPayload: { externalId: 'ext-reaction-claim', isFromMe: false },
+          },
+          metadata: { correlationId: eventId, instanceId: instance.id, channelType: 'whatsapp-baileys' },
+        });
+      };
+
+      try {
+        await publish();
+        await publish();
+        const rows = await db.select().from(omniEvents).where(eq(omniEvents.instanceId, instance.id));
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.idempotencyKey).toBe(idempotencyKey);
+        expect(rows[0]?.eventType).toBe('reaction.received');
+        expect(rows[0]?.contentType).toBe('reaction');
+        expect(rows[0]?.externalId).toBe('ext-reaction-claim-target');
+        expect(rows[0]?.textContent).toBe('👍');
+      } finally {
+        await db.delete(omniEvents).where(eq(omniEvents.instanceId, instance.id));
+        await db.delete(instances).where(eq(instances.id, instance.id));
+      }
     });
   });
 

--- a/packages/api/src/plugins/context.ts
+++ b/packages/api/src/plugins/context.ts
@@ -35,17 +35,17 @@ function createPluginDatabase(db: Database): PluginDatabase {
 }
 
 /**
- * Inbound-message idempotency claim (#1032, parity with `WebhookService.
- * receive` from #958). The claim IS the journal row: inserting it makes the
+ * Inbound idempotency claim (#1032, parity with `WebhookService.receive`
+ * from #958; #1096 extends it to `reaction.received` / `reaction.removed`). The claim IS the journal row: inserting it makes the
  * `omni_events.idempotency_key` unique index the dedup authority. The plugin
- * then publishes UNDER this row's id, and the `message.received` persistence
- * consumer fills the row in (upsert on id). Fail-open: a claim that errors
+ * then publishes UNDER this row's id, and the persistence consumer for that
+ * event type fills the row in (upsert on id). Fail-open: a claim that errors
  * (e.g. the instance row is missing) mints an id and lets the publish proceed
  * undeduped rather than dropping a real message.
  */
 function createIngressClaim(db: Database): IngressClaim {
   return {
-    async claim({ idempotencyKey, instanceId, channelType, externalId }) {
+    async claim({ idempotencyKey, instanceId, channelType, externalId, eventType = 'message.received' }) {
       const id = randomUUID();
       try {
         const claimed = await db
@@ -57,7 +57,7 @@ function createIngressClaim(db: Database): IngressClaim {
               ? (channelType as ChannelType)
               : 'discord',
             instanceId,
-            eventType: 'message.received',
+            eventType,
             direction: 'inbound',
             status: 'received',
             idempotencyKey,

--- a/packages/api/src/plugins/event-persistence.ts
+++ b/packages/api/src/plugins/event-persistence.ts
@@ -516,8 +516,7 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
               const sdb = scopedHandle(db);
               const chatLink = await resolveChatLink(sdb, metadata.instanceId, payload.chatId);
               const personId = await resolvePersonId(sdb, metadata.personId);
-              const newEvent: NewOmniEvent = {
-                ...eventIdInsert(event.id),
+              const columns: Omit<NewOmniEvent, 'id'> = {
                 externalId: payload.messageId,
                 channel: mapChannelType(metadata.channelType),
                 instanceId: metadata.instanceId,
@@ -536,7 +535,14 @@ export async function setupEventPersistence(eventBus: EventBus, db: Database): P
                 conversationId: null,
                 ...chatLink,
               };
-              await sdb.insert(omniEvents).values(newEvent).onConflictDoNothing({ target: omniEvents.id });
+              // Upsert on id (#1096): the channel ingress claim inserted a skeletal
+              // row under this id before the publish (same discipline as
+              // message.received); fill it in here. A redelivery rewrites
+              // identical values — still one row.
+              await sdb
+                .insert(omniEvents)
+                .values({ ...eventIdInsert(event.id), ...columns })
+                .onConflictDoUpdate({ target: omniEvents.id, set: columns });
             });
             log.debug(`Persisted ${type}`, { messageId: payload.messageId, emoji: payload.emoji });
           } catch (error) {

--- a/packages/channel-sdk/src/base/BaseChannelPlugin.ts
+++ b/packages/channel-sdk/src/base/BaseChannelPlugin.ts
@@ -30,6 +30,7 @@ import type {
 } from '../helpers/events';
 import type { ChannelCapabilities } from '../types/capabilities';
 import type {
+  ClaimedEventType,
   GlobalConfig,
   IngressClaim,
   Logger,
@@ -394,31 +395,67 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
     // before publishing. The kind is part of the key because a platform can
     // reuse a message id for a different fact (a WhatsApp deletion carries
     // the deleted message's id). A duplicate claim skips the publish.
-    if (this.ingressClaim) {
-      const idempotencyKey = `${this.id}:${instanceId}:${payload.externalId}:${payload.content.type}`;
-      const eventId = await this.ingressClaim.claim({
-        idempotencyKey,
-        instanceId,
-        channelType: this.id,
-        externalId: payload.externalId,
-      });
-      if (eventId === null) {
-        this.logger.info('Skipping duplicate inbound message (idempotency key already journaled)', {
-          instanceId,
-          idempotencyKey,
-        });
-        return generateCorrelationId('evt');
-      }
-      options.publishEventId = eventId;
-      try {
-        return await this.publishEventInternal('message.received', payload, instanceId, options);
-      } catch (error) {
-        await this.ingressClaim.release(eventId).catch(() => {});
-        throw error;
-      }
-    }
+    return this.publishClaimed('message.received', payload, instanceId, {
+      idempotencyKey: `${this.id}:${instanceId}:${payload.externalId}:${payload.content.type}`,
+      externalId: payload.externalId,
+      options,
+    });
+  }
 
-    return this.publishEventInternal('message.received', payload, instanceId, options);
+  /**
+   * Claim an ingress idempotency key, then publish under the claimed journal
+   * row id so the persistence consumer upserts into that row. A duplicate
+   * claim skips the publish; a failed publish releases the claim so the retry
+   * is not treated as a duplicate. Without a claim provider (fail-open, or
+   * host without db) the event publishes undeduped.
+   */
+  private async publishClaimed<K extends ClaimedEventType>(
+    type: K,
+    payload: EventPayloadMap[K],
+    instanceId: string,
+    params: { idempotencyKey: string; externalId: string; options?: PublishEventInternalOptions },
+  ): Promise<string> {
+    const { idempotencyKey, externalId, options = {} } = params;
+    if (!this.ingressClaim) {
+      return this.publishEventInternal(type, payload, instanceId, options);
+    }
+    const eventId = await this.ingressClaim.claim({
+      idempotencyKey,
+      instanceId,
+      channelType: this.id,
+      externalId,
+      eventType: type,
+    });
+    if (eventId === null) {
+      this.logger.info(`Skipping duplicate inbound ${type} (idempotency key already journaled)`, {
+        instanceId,
+        idempotencyKey,
+      });
+      return generateCorrelationId('evt');
+    }
+    try {
+      return await this.publishEventInternal(type, payload, instanceId, { ...options, publishEventId: eventId });
+    } catch (error) {
+      await this.ingressClaim.release(eventId).catch(() => {});
+      throw error;
+    }
+  }
+
+  /**
+   * Reaction idempotency key (#1096): `{channel}:{instance}:{reactionId}:{kind}:{emoji}`.
+   * The reaction's own platform id (rawPayload.externalId) is used when the
+   * channel has one (WhatsApp); otherwise `{messageId}:{from}` stands in, so a
+   * double-fired handler or a second observing instance cannot journal the
+   * same reaction twice.
+   */
+  private reactionClaimParams(
+    kind: 'reaction.received' | 'reaction.removed',
+    instanceId: string,
+    payload: { messageId: string; from: string; emoji: string; rawPayload?: Record<string, unknown> },
+  ): { idempotencyKey: string; externalId: string } {
+    const raw = payload.rawPayload?.externalId;
+    const externalId = typeof raw === 'string' && raw.length > 0 ? raw : `${payload.messageId}:${payload.from}`;
+    return { idempotencyKey: `${this.id}:${instanceId}:${externalId}:${kind}:${payload.emoji}`, externalId };
   }
 
   /**
@@ -468,7 +505,12 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    */
   protected async emitReactionReceived(params: EmitReactionReceivedParams): Promise<void> {
     const { instanceId, ...payload } = params;
-    await this.publishEventInternal('reaction.received', payload, instanceId);
+    await this.publishClaimed(
+      'reaction.received',
+      payload,
+      instanceId,
+      this.reactionClaimParams('reaction.received', instanceId, payload),
+    );
   }
 
   /**
@@ -476,7 +518,12 @@ export abstract class BaseChannelPlugin implements ChannelPlugin {
    */
   protected async emitReactionRemoved(params: EmitReactionRemovedParams): Promise<void> {
     const { instanceId, ...payload } = params;
-    await this.publishEventInternal('reaction.removed', payload, instanceId);
+    await this.publishClaimed(
+      'reaction.removed',
+      payload,
+      instanceId,
+      this.reactionClaimParams('reaction.removed', instanceId, payload),
+    );
   }
 
   /**

--- a/packages/channel-sdk/src/helpers/events.ts
+++ b/packages/channel-sdk/src/helpers/events.ts
@@ -290,6 +290,9 @@ export interface EmitReactionRemovedParams {
 
   /** Whether emoji is platform-custom */
   isCustomEmoji?: boolean;
+
+  /** Raw platform payload */
+  rawPayload?: Record<string, unknown>;
 }
 
 /**

--- a/packages/channel-sdk/src/types/context.ts
+++ b/packages/channel-sdk/src/types/context.ts
@@ -92,6 +92,8 @@ export interface PluginDatabase {
  * publish is skipped, so a double-fired channel handler or a platform
  * redelivery cannot fan the same message out twice.
  */
+export type ClaimedEventType = 'message.received' | 'reaction.received' | 'reaction.removed';
+
 export interface IngressClaim {
   /** Returns the claimed event id, or null when the key is already journaled. */
   claim(params: {
@@ -99,6 +101,8 @@ export interface IngressClaim {
     instanceId: string;
     channelType: string;
     externalId: string;
+    /** Journal row type for the skeleton row; defaults to `message.received`. */
+    eventType?: ClaimedEventType;
   }): Promise<string | null>;
   /** Release a claim whose publish failed, so the retry is not a "duplicate". */
   release(eventId: string): Promise<void>;

--- a/packages/channel-sdk/test/base.test.ts
+++ b/packages/channel-sdk/test/base.test.ts
@@ -16,6 +16,7 @@ import {
 import type {
   ChannelCapabilities,
   EmitMessageReceivedParams,
+  EmitReactionReceivedParams,
   HealthCheck,
   InstanceConfig,
   Logger,
@@ -126,6 +127,10 @@ class TestChannelPlugin extends BaseChannelPlugin {
     return this.emitMessageReceived(params);
   }
 
+  react(params: EmitReactionReceivedParams) {
+    return this.emitReactionReceived(params);
+  }
+
   async connect(instanceId: string, config: InstanceConfig): Promise<void> {
     this.connectCalled = true;
     await this.updateInstanceStatus(instanceId, config, {
@@ -216,6 +221,39 @@ describe('BaseChannelPlugin', () => {
     expect(received.length).toBe(1);
     expect((received[0]?.metadata as { publishEventId?: string }).publishEventId).toBe(
       'a2b9c1d0-1111-4222-8333-444455556666',
+    );
+  });
+
+  it('should claim an ingress key for reactions and skip the duplicate (#1096)', async () => {
+    const claims: { idempotencyKey: string; eventType?: string }[] = [];
+    context.ingressClaim = {
+      claim: async ({ idempotencyKey, eventType }) => {
+        claims.push({ idempotencyKey, eventType });
+        return claims.length === 1 ? 'b3c0d1e2-2222-4333-8444-555566667777' : null;
+      },
+      release: async () => {},
+    };
+    await plugin.initialize(context);
+
+    const reaction = {
+      instanceId: 'wa-001',
+      messageId: 'MSG-1',
+      chatId: 'chat-1',
+      from: 'user-1',
+      emoji: '👍',
+      rawPayload: { externalId: 'REACT-1', isFromMe: false },
+    };
+    await plugin.react(reaction);
+    await plugin.react(reaction);
+
+    expect(claims).toEqual([
+      { idempotencyKey: 'whatsapp-baileys:wa-001:REACT-1:reaction.received:👍', eventType: 'reaction.received' },
+      { idempotencyKey: 'whatsapp-baileys:wa-001:REACT-1:reaction.received:👍', eventType: 'reaction.received' },
+    ]);
+    const received = eventBus.published.filter((e) => e.type === 'reaction.received');
+    expect(received.length).toBe(1);
+    expect((received[0]?.metadata as { publishEventId?: string }).publishEventId).toBe(
+      'b3c0d1e2-2222-4333-8444-555566667777',
     );
   });
 

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3220,6 +3220,7 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
         chatId,
         from,
         emoji: '', // WhatsApp doesn't tell us which emoji was removed
+        rawPayload: { externalId, isFromMe },
       });
     }
   }

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -683,6 +683,8 @@ export interface ReactionRemovedPayload {
   emojiName?: string;
   /** Whether emoji is platform-custom */
   isCustomEmoji?: boolean;
+  /** Raw platform payload (carries the reaction's own external id where the platform has one) */
+  rawPayload?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Closes #1096.

## Problem
The reaction publish path restored by #1067 (PR for #1059) bypassed the ingress idempotency claim that #1052 (#1032) added for `message.received`. One reaction produced duplicate `omni_events` rows per observing instance, all with `idempotency_key: null`.

## Fix
- **channel-sdk** `BaseChannelPlugin`: the claim-then-publish-under-claimed-id flow is extracted into `publishClaimed`; `emitReactionReceived` / `emitReactionRemoved` route through it. Key: `{channel}:{instance}:{reactionId}:{kind}:{emoji}` (`reactionId` = `rawPayload.externalId` when the platform has one, else `{messageId}:{from}`). Fail-open unchanged.
- **api** `ingressClaim.claim` takes the event type so the skeleton row is a reaction row.
- **api** reaction persistence consumer upserts on id (same as `message.received`) so it fills the claimed row instead of inserting a second one.
- **core / whatsapp**: `ReactionRemovedPayload` gains `rawPayload`; WhatsApp passes the reaction id on removals so remove → re-add → remove is not deduped.

## Tenancy guards
No new write site: `plugins/context.ts` and `plugins/event-persistence.ts` are already registered `omni_events` writers.

## Tests
- SDK: same reaction twice → one `reaction.received` publish under the claimed id, key shape asserted.
- API (real PostgreSQL): same reaction published twice through the real claim → one journal row, non-null `idempotencyKey`, `eventType: reaction.received`.

## Validation
`make typecheck`, `make lint`, `make verify-migrations` green. `make test-pg-gate-warm` has one pre-existing failure on origin/dev (release rehearsal 0053→0065, `webhook_sources` constraint fingerprint) unrelated to this change. `make test` has 4 pre-existing DB-state failures (chat-scoping, follow-up sweeper, media processor) that reproduce on clean origin/dev.