### PR TITLE
fix(whatsapp): land message edits — upsert protocol path + msgSecret decryption (#1061)

### DIFF
--- a/apps/ui/dist-node/vite.config.js
+++ b/apps/ui/dist-node/vite.config.js
@@ -13,7 +13,8 @@ export default defineConfig({
         port: 5173,
         proxy: {
             '/api': {
-                target: 'http://localhost:8882',
+                // Override when the API runs on a non-default port (e.g. 8882 taken).
+                target: process.env.OMNI_API_PROXY_TARGET || 'http://localhost:8882',
                 changeOrigin: true,
                 configure: (proxy) => {
                     // Fix ERR_CONTENT_DECODING_FAILED by removing accept-encoding

--- a/packages/channel-whatsapp/src/__tests__/message-edit-encrypted.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/message-edit-encrypted.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Encrypted edits end to end (#1061).
+ *
+ * WhatsApp delivers an edit as a `secretEncryptedMessage` whose payload is encrypted
+ * under the ORIGINAL message's `messageSecret`. This exercises the whole inbound path:
+ * the original message lands (its secret is remembered), the encrypted edit lands, and
+ * the decrypted new text reaches `handleMessageEdited`.
+ *
+ * The ciphertext is a REAL captured edit; the expected plaintext is its edited text.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { setupMessageHandlers } from '../handlers/messages';
+import { WhatsAppPlugin } from '../plugin';
+
+const GROUP = '120363406854035156@g.us';
+const SENDER_LID = '217046273028329@lid';
+const ORIG_ID = '3B335662F99E0B247ABE';
+const SECRET = Buffer.from('MGULupwDcKGlKJDlJlZ+DlAyld9U+VmxvuJI1XNrgf8=', 'base64');
+const ENC_IV = Buffer.from('L50Zn/v7vdNibfeL', 'base64');
+const ENC_PAYLOAD = Buffer.from(
+  'qDEc9XltNsL19474MjwjA027q7mtHgRhrsYUvc29lMdrsi0NmgZ7HiItLsW8I1DJ2az/dc/al/y1Yfxkt5y88NzT9cs1OwrcgCAV/XVHANJZ/umo3M8OvKlX7FARPVjUZRvKZm+fBOs9KmB+MSfLj+lVplqjBKmh5GYBJ3zdSeN4Ht/ZgoBpaMme307JGNhCn0xGTJW2fziOkBQhlHz6GdaxIhw=',
+  'base64',
+);
+
+function harness() {
+  const ev = new EventEmitter();
+  const sock = { ev, presenceSubscribe: mock(async () => {}) } as unknown as Parameters<typeof setupMessageHandlers>[0];
+  const plugin = new WhatsAppPlugin();
+  (plugin as unknown as { config: unknown }).config = { apiBaseUrl: 'http://localhost:8882' };
+  const handleEdited = mock(async () => {});
+  (plugin as unknown as { handleMessageEdited: typeof handleEdited }).handleMessageEdited = handleEdited;
+  (plugin as unknown as { emitMessageReceived: typeof handleEdited }).emitMessageReceived = mock(async () => {});
+  (plugin as unknown as { handleMessageDelivered: typeof handleEdited }).handleMessageDelivered = mock(async () => {});
+  // the original message only needs to seed the secret; its delivery path is not under test
+  (plugin as unknown as { handleMessageReceived: typeof handleEdited }).handleMessageReceived = mock(async () => {});
+  setupMessageHandlers(sock, plugin, 'inst-1');
+  return { ev, handleEdited };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+/** The original message, carrying the secret its future edit will be encrypted with. */
+function originalMessage(id = ORIG_ID) {
+  return {
+    messages: [
+      {
+        key: { id, remoteJid: GROUP, fromMe: true, participant: SENDER_LID },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        pushName: 'Tester',
+        message: {
+          conversation: 'oi aqui vou editar',
+          messageContextInfo: { messageSecret: SECRET },
+        },
+      },
+    ],
+    type: 'notify' as const,
+  };
+}
+
+/** The edit, as WhatsApp actually delivers it: msgSecret envelope, MESSAGE_EDIT. */
+function encryptedEdit(wrapperId = 'EDITWRAP-ENC-1') {
+  return {
+    messages: [
+      {
+        key: { id: wrapperId, remoteJid: GROUP, fromMe: true, participant: SENDER_LID },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        message: {
+          messageContextInfo: {},
+          secretEncryptedMessage: {
+            encIv: ENC_IV,
+            encPayload: ENC_PAYLOAD,
+            secretEncType: 2, // MESSAGE_EDIT
+            targetMessageKey: { id: ORIG_ID, remoteJid: GROUP, fromMe: true },
+          },
+        },
+      },
+    ],
+    type: 'notify' as const,
+  };
+}
+
+describe('encrypted WhatsApp edits (secretEncryptedMessage)', () => {
+  it('decrypts the edit and emits the new text', async () => {
+    const h = harness();
+    h.ev.emit('messages.upsert', originalMessage());
+    await flush();
+    h.ev.emit('messages.upsert', encryptedEdit());
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledTimes(1);
+    const call = (h.handleEdited.mock.calls[0] ?? []) as unknown as string[];
+    expect(call[0]).toBe('inst-1');
+    expect(call[1]).toBe(ORIG_ID);
+    expect(call[2]).toBe(GROUP);
+    const newText = call[3] ?? '';
+    expect(newText).toContain('oi aqui vou editar');
+    expect(newText.length).toBeGreaterThan('oi aqui vou editar'.length);
+  });
+
+  it('stays silent when the original message (and its secret) was never seen', async () => {
+    const h = harness();
+    // target the handler never saw a secret for — cannot be decrypted, must not throw
+    const orphan = encryptedEdit('EDITWRAP-ENC-2');
+    const envelope = orphan.messages[0]?.message?.secretEncryptedMessage;
+    if (envelope) envelope.targetMessageKey.id = 'NEVER-SEEN-ORIGINAL';
+    h.ev.emit('messages.upsert', orphan);
+    await flush();
+    expect(h.handleEdited).not.toHaveBeenCalled();
+  });
+});

--- a/packages/channel-whatsapp/src/__tests__/message-edit-self-echo.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/message-edit-self-echo.test.ts
@@ -60,7 +60,7 @@ describe('WhatsApp self-edit echo on messages.upsert', () => {
     const h = harness();
     h.ev.emit('messages.upsert', selfEditUpsert('ORIG-SELF-1', 'texto corrigido'));
     await flush();
-    expect(h.handleEdited).toHaveBeenCalledWith('inst-1', 'ORIG-SELF-1', GROUP, 'texto corrigido', true);
+    expect(h.handleEdited).toHaveBeenCalledWith('inst-1', 'ORIG-SELF-1', GROUP, 'texto corrigido', true, ME);
   });
 
   it('does not emit twice when the same edit also arrives on messages.update', async () => {
@@ -84,7 +84,7 @@ describe('WhatsApp self-edit echo on messages.upsert', () => {
     h.ev.emit('messages.upsert', selfEditUpsert('ORIG-SELF-3', 'segunda correção'));
     await flush();
     expect(h.handleEdited).toHaveBeenCalledTimes(2);
-    expect(h.handleEdited).toHaveBeenLastCalledWith('inst-1', 'ORIG-SELF-3', GROUP, 'segunda correção', true);
+    expect(h.handleEdited).toHaveBeenLastCalledWith('inst-1', 'ORIG-SELF-3', GROUP, 'segunda correção', true, ME);
   });
 
   it('an upsert edit without new text still defers to messages.update', async () => {

--- a/packages/channel-whatsapp/src/__tests__/message-edit-self-echo.test.ts
+++ b/packages/channel-whatsapp/src/__tests__/message-edit-self-echo.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Self-edit echo (#1061, second reopen).
+ *
+ * An edit made on ANOTHER device of this same account syncs as a MESSAGE_EDIT
+ * protocol message on `messages.upsert` and never produces a `messages.update`
+ * event. Swallowing the upsert (waiting for an update that never comes) lost the
+ * edit entirely: no journal row, `editCount` stayed 0, the pre-edit text stayed.
+ *
+ * So the upsert now emits whenever it already carries the new text, and a bounded
+ * seen-set keeps a third-party edit — which does reach us on BOTH paths — from
+ * being emitted twice.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { setupMessageHandlers } from '../handlers/messages';
+import { WhatsAppPlugin } from '../plugin';
+
+const GROUP = '120363000000000000@g.us';
+const ME = '5511999998888@s.whatsapp.net';
+
+function harness() {
+  const ev = new EventEmitter();
+  const sock = { ev, presenceSubscribe: mock(async () => {}) } as unknown as Parameters<typeof setupMessageHandlers>[0];
+  const plugin = new WhatsAppPlugin();
+  const handleEdited = mock(async () => {});
+  (plugin as unknown as { handleMessageEdited: typeof handleEdited }).handleMessageEdited = handleEdited;
+  (plugin as unknown as { emitMessageReceived: typeof handleEdited }).emitMessageReceived = mock(async () => {});
+  (plugin as unknown as { handleMessageDelivered: typeof handleEdited }).handleMessageDelivered = mock(async () => {});
+  setupMessageHandlers(sock, plugin, 'inst-1');
+  return { ev, handleEdited };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+/** MESSAGE_EDIT (protocol type 14) as it syncs from the account's other device. */
+let wrapSeq = 0;
+function selfEditUpsert(targetId: string, newText: string) {
+  // each edit arrives in its own wrapper message — the wrapper id is never reused
+  return {
+    messages: [
+      {
+        key: { id: `EDITWRAP${++wrapSeq}`, remoteJid: GROUP, fromMe: true, participant: ME },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        message: {
+          protocolMessage: {
+            type: 14,
+            key: { id: targetId, remoteJid: GROUP, fromMe: true },
+            editedMessage: { conversation: newText },
+          },
+        },
+      },
+    ],
+    type: 'notify' as const,
+  };
+}
+
+describe('WhatsApp self-edit echo on messages.upsert', () => {
+  it('emits the edit that arrives only as an upsert protocol message', async () => {
+    const h = harness();
+    h.ev.emit('messages.upsert', selfEditUpsert('ORIG-SELF-1', 'texto corrigido'));
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledWith('inst-1', 'ORIG-SELF-1', GROUP, 'texto corrigido', true);
+  });
+
+  it('does not emit twice when the same edit also arrives on messages.update', async () => {
+    const h = harness();
+    h.ev.emit('messages.upsert', selfEditUpsert('ORIG-SELF-2', 'uma vez só'));
+    await flush();
+    h.ev.emit('messages.update', [
+      {
+        key: { id: 'ORIG-SELF-2', remoteJid: GROUP, fromMe: true },
+        update: { message: { editedMessage: { message: { conversation: 'uma vez só' } } } },
+      },
+    ]);
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledTimes(1);
+  });
+
+  it('a genuine second edit of the same message still emits', async () => {
+    const h = harness();
+    h.ev.emit('messages.upsert', selfEditUpsert('ORIG-SELF-3', 'primeira correção'));
+    await flush();
+    h.ev.emit('messages.upsert', selfEditUpsert('ORIG-SELF-3', 'segunda correção'));
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledTimes(2);
+    expect(h.handleEdited).toHaveBeenLastCalledWith('inst-1', 'ORIG-SELF-3', GROUP, 'segunda correção', true);
+  });
+
+  it('an upsert edit without new text still defers to messages.update', async () => {
+    const h = harness();
+    h.ev.emit('messages.upsert', {
+      messages: [
+        {
+          key: { id: 'EDITWRAP-NOTEXT', remoteJid: GROUP, fromMe: true, participant: ME },
+          messageTimestamp: Math.floor(Date.now() / 1000),
+          message: { protocolMessage: { type: 14, key: { id: 'ORIG-SELF-4', remoteJid: GROUP } } },
+        },
+      ],
+      type: 'notify' as const,
+    });
+    await flush();
+    expect(h.handleEdited).not.toHaveBeenCalled();
+
+    h.ev.emit('messages.update', [
+      {
+        key: { id: 'ORIG-SELF-4', remoteJid: GROUP, fromMe: true },
+        update: { message: { editedMessage: { message: { conversation: 'via update' } } } },
+      },
+    ]);
+    await flush();
+    expect(h.handleEdited).toHaveBeenCalledWith('inst-1', 'ORIG-SELF-4', GROUP, 'via update', true);
+  });
+});

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -104,6 +104,24 @@ function extractEditedText(edited: MessageContent | null | undefined): string | 
   );
 }
 
+/**
+ * One edit can reach us twice — as a protocol message on `messages.upsert` (how an
+ * edit from another device of this account syncs) and as `messages.update` (how a
+ * third-party edit arrives). Whoever gets there first emits; the twin is dropped.
+ *
+ * Keyed by `${targetMessageId}:${newText}` so a genuine second edit of the same
+ * message still passes. Bounded so a long-lived socket cannot grow it without end.
+ */
+const SEEN_EDITS = new Set<string>();
+const SEEN_EDITS_MAX = 500;
+function rememberEdit(targetMessageId: string, newText: string): boolean {
+  const key = `${targetMessageId}:${newText}`;
+  if (SEEN_EDITS.has(key)) return false;
+  if (SEEN_EDITS.size >= SEEN_EDITS_MAX) SEEN_EDITS.delete(SEEN_EDITS.values().next().value as string);
+  SEEN_EDITS.add(key);
+  return true;
+}
+
 /** Join non-empty, trimmed parts with newlines; undefined when nothing survives. */
 function joinLines(...parts: Array<string | null | undefined>): string | undefined {
   const text = parts.filter((p): p is string => typeof p === 'string' && p.trim().length > 0).join('\n');
@@ -822,10 +840,19 @@ async function handleSpecialMessage(
   }
 
   if (content.type === 'edit') {
-    // Edits are emitted from `messages.update`, where Baileys hands us the original
-    // key and the normalized new content regardless of envelope shape (#1061).
-    // Swallow the raw protocol message here so it is neither journaled nor double-emitted.
-    log.debug('Edit protocol message seen on upsert; awaiting messages.update', {
+    // Edits normally arrive on `messages.update`, which hands us the original key plus
+    // the normalized new content. But an edit made on ANOTHER device of this same
+    // account syncs as a protocol message on `messages.upsert` and never produces an
+    // update event — swallowing it there lost the edit entirely (#1061).
+    //
+    // So: emit whenever the upsert already carries the new text. `messages.update` may
+    // still fire for the same edit (third-party edits reach us both ways), and
+    // `rememberEdit` keeps the second one from double-journaling it.
+    if (content.editedText && content.targetMessageId && rememberEdit(content.targetMessageId, content.editedText)) {
+      await plugin.handleMessageEdited(instanceId, content.targetMessageId, chatId, content.editedText, isFromMe(msg));
+      return true;
+    }
+    log.debug('Edit protocol message seen on upsert without new text; awaiting messages.update', {
       instanceId,
       targetMessageId: content.targetMessageId,
     });
@@ -1182,7 +1209,7 @@ export function setupMessageHandlers(
       // `{ editedMessage: { message: <new content> } }` keyed by the ORIGINAL message id,
       // after normalizing whatever envelope the edit arrived in (#1061).
       const newText = extractEditedText(normalizeMessageContent(update.update.message));
-      if (newText) {
+      if (newText && rememberEdit(update.key.id || '', newText)) {
         const { chatId } = resolveChatId(plugin, instanceId, { key: update.key } as WAMessage);
         await plugin.handleMessageEdited(instanceId, update.key.id || '', chatId, newText, update.key.fromMe || false);
       }

--- a/packages/channel-whatsapp/src/handlers/messages.ts
+++ b/packages/channel-whatsapp/src/handlers/messages.ts
@@ -14,7 +14,7 @@ import { createDownloadGuard, createInboundDedupeCache, createMediaBackend, sani
 import type { DedupeCache, MediaStorageBackend } from '@omni/channel-sdk';
 import { createLogger } from '@omni/core';
 import type { ContentType } from '@omni/core/types';
-import { normalizeMessageContent } from 'baileys';
+import { normalizeMessageContent, proto as protoNs } from 'baileys';
 import type { MessageUpsertType, WAMessage, WAMessageKey, WASocket, proto } from 'baileys';
 import { fromJid, isLidJid, isUserJid, resolveCanonicalJid, resolveToPhoneJidLegacy } from '../jid';
 import type { WhatsAppPlugin } from '../plugin';
@@ -27,9 +27,13 @@ import {
   getWhatsAppMediaDownloadMaxBytes,
 } from '../utils/download';
 import { getDocumentMessage, getMessageContextInfo } from '../utils/message';
+import { decryptMsgSecret, getMessageSecret, rememberMessageSecret } from '../utils/msg-secret';
 import { getMediaSize } from './media';
 
 const log = createLogger('whatsapp:messages');
+
+/** Runtime protobuf codec (the `proto` type import is types-only). */
+const protoMessage = protoNs.Message;
 
 /** Fallback dedupe cache — used when no per-instance cache is provided */
 const fallbackDedupeCache = createInboundDedupeCache();
@@ -87,10 +91,27 @@ interface ExtractedContent {
   // Edit-specific fields
   editedText?: string;
   editedMessageId?: string;
+  /** msgSecret envelope of an encrypted edit (#1061) — decrypted in handleSpecialMessage. */
+  encryptedEdit?: { encIv: Uint8Array; encPayload: Uint8Array };
 }
 
 type MessageContent = proto.IMessage;
 type ContentExtractor = (message: MessageContent) => ExtractedContent | null;
+
+/**
+ * The plaintext inside an encrypted edit is a full `proto.Message` whose
+ * `protocolMessage.editedMessage` holds the new content — the same shape the old
+ * plaintext path carried, just wrapped and encrypted (#1061).
+ */
+function decodeEditPlaintext(plaintext: Buffer): MessageContent | undefined {
+  try {
+    const decoded = protoMessage.decode(plaintext) as unknown as MessageContent;
+    return decoded?.protocolMessage?.editedMessage ?? undefined;
+  } catch (error) {
+    log.debug('Failed to decode decrypted edit payload', { error: String(error) });
+    return undefined;
+  }
+}
 
 /** New text of an edit: body of a text message, or the caption of a media message. */
 function extractEditedText(edited: MessageContent | null | undefined): string | undefined {
@@ -401,6 +422,25 @@ const contentExtractors: Array<{ check: (m: MessageContent) => boolean; extract:
           : undefined,
       },
     }),
+  },
+  // Secret-encrypted message — WhatsApp's msgSecret envelope. Edits moved here from
+  // the plaintext protocol message (#1061): the new text is encrypted under the
+  // ORIGINAL message's secret, so this extractor only surfaces the envelope and the
+  // target; decryption happens in `handleSpecialMessage`, which can reach the secret.
+  {
+    check: (m) => !!m.secretEncryptedMessage,
+    extract: (m) => {
+      const sec = m.secretEncryptedMessage;
+      // SecretEncType: 1 = EVENT_EDIT, 2 = MESSAGE_EDIT
+      const encType = sec?.secretEncType as number | string | undefined;
+      const isMessageEdit = encType === 2 || encType === 'MESSAGE_EDIT';
+      if (!isMessageEdit || !sec?.encPayload || !sec?.encIv) return null;
+      return {
+        type: 'edit' as ContentType,
+        targetMessageId: sec.targetMessageKey?.id ?? undefined,
+        encryptedEdit: { encIv: sec.encIv, encPayload: sec.encPayload },
+      };
+    },
   },
   // Protocol message - handles internal WhatsApp protocol events
   // Types: 0=REVOKE, 3=EPHEMERAL_SETTING, 4=EPHEMERAL_SYNC, 5=HISTORY_SYNC,
@@ -814,6 +854,46 @@ export async function tryDownloadMedia(
 }
 
 /**
+ * Encrypted edit (#1061): WhatsApp ships the new text under the ORIGINAL message's
+ * secret. Decrypt with the secret we stored for that message; a miss (secret never
+ * seen, process restart, unknown scheme) degrades to the previous behaviour — the
+ * edit stays unreadable and nothing throws.
+ */
+async function handleEncryptedEdit(
+  plugin: WhatsAppPlugin,
+  instanceId: string,
+  content: ExtractedContent,
+  chatId: string,
+  msg: WAMessage,
+): Promise<void> {
+  const targetMessageId = content.targetMessageId as string;
+  const stored = getMessageSecret(targetMessageId);
+  if (!stored) {
+    log.debug('Encrypted edit with no stored secret for the original message', { instanceId, targetMessageId });
+    return;
+  }
+  const modificationSenderJid = msg.key.participant || msg.key.remoteJid || stored.senderJid;
+  const plaintext = decryptMsgSecret({
+    encIv: content.encryptedEdit?.encIv as Uint8Array,
+    encPayload: content.encryptedEdit?.encPayload as Uint8Array,
+    originalMessageSecret: stored.secret,
+    originalMessageId: targetMessageId,
+    originalSenderJid: stored.senderJid,
+    modificationSenderJid,
+  });
+  const editedText = plaintext ? extractEditedText(decodeEditPlaintext(plaintext)) : undefined;
+  if (!editedText || !rememberEdit(targetMessageId, editedText)) return;
+  await plugin.handleMessageEdited(
+    instanceId,
+    targetMessageId,
+    chatId,
+    editedText,
+    isFromMe(msg),
+    modificationSenderJid,
+  );
+}
+
+/**
  * Handle special message types (reactions, edits, deletes).
  * Returns true if the message was handled and should not be processed further.
  */
@@ -840,16 +920,19 @@ async function handleSpecialMessage(
   }
 
   if (content.type === 'edit') {
-    // Edits normally arrive on `messages.update`, which hands us the original key plus
-    // the normalized new content. But an edit made on ANOTHER device of this same
-    // account syncs as a protocol message on `messages.upsert` and never produces an
-    // update event — swallowing it there lost the edit entirely (#1061).
-    //
-    // So: emit whenever the upsert already carries the new text. `messages.update` may
-    // still fire for the same edit (third-party edits reach us both ways), and
-    // `rememberEdit` keeps the second one from double-journaling it.
+    if (content.encryptedEdit && content.targetMessageId) {
+      await handleEncryptedEdit(plugin, instanceId, content, chatId, msg);
+      return true;
+    }
     if (content.editedText && content.targetMessageId && rememberEdit(content.targetMessageId, content.editedText)) {
-      await plugin.handleMessageEdited(instanceId, content.targetMessageId, chatId, content.editedText, isFromMe(msg));
+      await plugin.handleMessageEdited(
+        instanceId,
+        content.targetMessageId,
+        chatId,
+        content.editedText,
+        isFromMe(msg),
+        msg.key.participant || msg.key.remoteJid || undefined,
+      );
       return true;
     }
     log.debug('Edit protocol message seen on upsert without new text; awaiting messages.update', {
@@ -1011,6 +1094,14 @@ async function processMessage(
   // DEBUG: Log full raw payload for development
   if (process.env.DEBUG_PAYLOADS === 'true') {
     log.debug('Raw payload', { msgId: msg.key.id, payload: msg });
+  }
+
+  // An edit arrives encrypted under the ORIGINAL message's secret and never repeats
+  // it, so remember the secret of every message as it lands (#1061). Cheap, bounded,
+  // and the only way a later edit becomes readable without a durable secret store.
+  const inboundSecret = msg.message?.messageContextInfo?.messageSecret;
+  if (inboundSecret && msg.key.id) {
+    rememberMessageSecret(msg.key.id, inboundSecret, msg.key.participant || msg.key.remoteJid || '');
   }
 
   const content = extractContent(msg);

--- a/packages/channel-whatsapp/src/plugin.ts
+++ b/packages/channel-whatsapp/src/plugin.ts
@@ -3279,13 +3279,15 @@ export class WhatsAppPlugin extends BaseChannelPlugin {
     chatId: string,
     newText: string,
     fromMe = false,
+    /** Who edited — without it `editHistory[].by` records the chat instead of the author. */
+    senderJid?: string,
   ): Promise<void> {
     // Emit as a special message.received event with type 'edit'
     await this.emitMessageReceived({
       instanceId,
       externalId: `${externalId}-edit-${Date.now()}`,
       chatId,
-      from: chatId,
+      from: senderJid || chatId,
       content: {
         type: 'edit',
         text: newText,

--- a/packages/channel-whatsapp/src/utils/__tests__/msg-secret.test.ts
+++ b/packages/channel-whatsapp/src/utils/__tests__/msg-secret.test.ts
@@ -1,0 +1,87 @@
+/**
+ * msgSecret decryption (#1061).
+ *
+ * Fixture is a REAL captured WhatsApp edit (group, self-edit): the ciphertext,
+ * IV and the original message's `messageSecret` as they arrived on the wire.
+ * Identifiers are the test author's own; the plaintext is the edited text.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { MSG_SECRET_MESSAGE_EDIT, decryptMsgSecret, toNonAdJid } from '../msg-secret';
+
+const FIXTURE = {
+  encIv: Buffer.from('L50Zn/v7vdNibfeL', 'base64'),
+  encPayload: Buffer.from(
+    'qDEc9XltNsL19474MjwjA027q7mtHgRhrsYUvc29lMdrsi0NmgZ7HiItLsW8I1DJ2az/dc/al/y1Yfxkt5y88NzT9cs1OwrcgCAV/XVHANJZ/umo3M8OvKlX7FARPVjUZRvKZm+fBOs9KmB+MSfLj+lVplqjBKmh5GYBJ3zdSeN4Ht/ZgoBpaMme307JGNhCn0xGTJW2fziOkBQhlHz6GdaxIhw=',
+    'base64',
+  ),
+  originalMessageSecret: Buffer.from('MGULupwDcKGlKJDlJlZ+DlAyld9U+VmxvuJI1XNrgf8=', 'base64'),
+  originalMessageId: '3B335662F99E0B247ABE',
+  senderLid: '217046273028329@lid',
+  senderPn: '555197285829@s.whatsapp.net',
+};
+
+describe('decryptMsgSecret', () => {
+  it('decrypts a real MESSAGE_EDIT envelope and yields the edited text', () => {
+    const out = decryptMsgSecret({
+      encIv: FIXTURE.encIv,
+      encPayload: FIXTURE.encPayload,
+      originalMessageSecret: FIXTURE.originalMessageSecret,
+      originalMessageId: FIXTURE.originalMessageId,
+      originalSenderJid: FIXTURE.senderLid,
+      modificationSenderJid: FIXTURE.senderLid,
+    });
+    expect(out).not.toBeNull();
+    expect(out?.toString('utf8')).toContain('oi aqui vou editar');
+  });
+
+  it('returns null when the sender form does not match (no throw)', () => {
+    const out = decryptMsgSecret({
+      encIv: FIXTURE.encIv,
+      encPayload: FIXTURE.encPayload,
+      originalMessageSecret: FIXTURE.originalMessageSecret,
+      originalMessageId: FIXTURE.originalMessageId,
+      originalSenderJid: FIXTURE.senderPn,
+      modificationSenderJid: FIXTURE.senderPn,
+    });
+    expect(out).toBeNull();
+  });
+
+  it('returns null on a wrong secret instead of throwing', () => {
+    const out = decryptMsgSecret({
+      encIv: FIXTURE.encIv,
+      encPayload: FIXTURE.encPayload,
+      originalMessageSecret: Buffer.alloc(32),
+      originalMessageId: FIXTURE.originalMessageId,
+      originalSenderJid: FIXTURE.senderLid,
+      modificationSenderJid: FIXTURE.senderLid,
+    });
+    expect(out).toBeNull();
+  });
+
+  it('uses "Message Edit" as the default use case', () => {
+    const withDefault = decryptMsgSecret({
+      encIv: FIXTURE.encIv,
+      encPayload: FIXTURE.encPayload,
+      originalMessageSecret: FIXTURE.originalMessageSecret,
+      originalMessageId: FIXTURE.originalMessageId,
+      originalSenderJid: FIXTURE.senderLid,
+      modificationSenderJid: FIXTURE.senderLid,
+    });
+    const explicit = decryptMsgSecret({
+      encIv: FIXTURE.encIv,
+      encPayload: FIXTURE.encPayload,
+      originalMessageSecret: FIXTURE.originalMessageSecret,
+      originalMessageId: FIXTURE.originalMessageId,
+      originalSenderJid: FIXTURE.senderLid,
+      modificationSenderJid: FIXTURE.senderLid,
+      useCase: MSG_SECRET_MESSAGE_EDIT,
+    });
+    expect(withDefault?.toString('hex')).toBe(explicit?.toString('hex') ?? '');
+  });
+
+  it('strips the device suffix from JIDs', () => {
+    expect(toNonAdJid('555197285829:12@s.whatsapp.net')).toBe('555197285829@s.whatsapp.net');
+    expect(toNonAdJid('217046273028329@lid')).toBe('217046273028329@lid');
+  });
+});

--- a/packages/channel-whatsapp/src/utils/msg-secret.ts
+++ b/packages/channel-whatsapp/src/utils/msg-secret.ts
@@ -1,0 +1,106 @@
+/**
+ * WhatsApp message-secret decryption (`secretEncryptedMessage`).
+ *
+ * WhatsApp moved message edits to the msgSecret envelope: instead of a plaintext
+ * `protocolMessage` type 14, the edit arrives as
+ *
+ *   secretEncryptedMessage { encIv, encPayload, secretEncType: MESSAGE_EDIT, targetMessageKey }
+ *
+ * with the new content encrypted under the ORIGINAL message's
+ * `messageContextInfo.messageSecret`. Baileys carries the protobuf for it
+ * (`SecretEncType.MESSAGE_EDIT = 2`) but ships no decryptor, so the envelope
+ * reaches us opaque and the edit is lost (#1061).
+ *
+ * Scheme (matches whatsmeow's `generateMsgSecretKey`, msgsecret.go):
+ *
+ *   useCase   = origMsgId ‖ origSenderJid ‖ modificationSenderJid ‖ "Message Edit"
+ *   key       = HKDF-SHA256(ikm = origMessageSecret, salt = ∅, info = useCase, len = 32)
+ *   plaintext = AES-256-GCM(key, encIv, encPayload)      // no AAD for edits —
+ *               only Poll Vote / Event Response use `${origMsgId}\0${sender}`
+ *
+ * Both JIDs are the non-AD form (`user@server`, device suffix stripped). Verified
+ * against a real captured edit: the LID form of the sender decrypts on both sides,
+ * so callers should try the addressing form the event carries first and fall back.
+ */
+
+import { createDecipheriv, hkdfSync } from 'node:crypto';
+import { createLogger } from '@omni/core';
+
+const log = createLogger('whatsapp:msg-secret');
+
+/** `EncSecretMessageEdit` in whatsmeow's MsgSecretType table. */
+export const MSG_SECRET_MESSAGE_EDIT = 'Message Edit';
+
+/**
+ * Secrets of recently seen messages, so an edit arriving minutes later can be read.
+ *
+ * WhatsApp does not repeat the original `messageSecret` in the edit envelope, so it
+ * has to come from the message being edited. whatsmeow keeps a durable
+ * `MsgSecrets` store; this is the in-process equivalent — bounded and insertion-ordered,
+ * which covers the common case (edit shortly after the message) without a schema change.
+ * A miss degrades exactly to today's behaviour: the edit stays unreadable, nothing throws.
+ */
+const SECRETS = new Map<string, { secret: Uint8Array; senderJid: string }>();
+const SECRETS_MAX = 2000;
+
+/** Remember an inbound message's secret, keyed by its external id. */
+export function rememberMessageSecret(externalId: string, secret: Uint8Array, senderJid: string): void {
+  if (!externalId || !secret?.length) return;
+  if (SECRETS.has(externalId)) SECRETS.delete(externalId);
+  else if (SECRETS.size >= SECRETS_MAX) SECRETS.delete(SECRETS.keys().next().value as string);
+  SECRETS.set(externalId, { secret, senderJid });
+}
+
+export function getMessageSecret(externalId: string): { secret: Uint8Array; senderJid: string } | undefined {
+  return SECRETS.get(externalId);
+}
+
+/** Strip the device suffix: `5511999@s.whatsapp.net:12` → `5511999@s.whatsapp.net`. */
+export function toNonAdJid(jid: string): string {
+  const [user, server] = jid.split('@');
+  return `${(user ?? '').split(':')[0]}@${server ?? 's.whatsapp.net'}`;
+}
+
+export interface MsgSecretInput {
+  encIv: Uint8Array;
+  encPayload: Uint8Array;
+  /** `messageContextInfo.messageSecret` of the ORIGINAL (target) message. */
+  originalMessageSecret: Uint8Array;
+  originalMessageId: string;
+  /** Sender of the original message (non-AD form). */
+  originalSenderJid: string;
+  /** Sender of the modification — same person for a self-edit (non-AD form). */
+  modificationSenderJid: string;
+  useCase?: string;
+}
+
+/**
+ * Decrypt a msgSecret-encrypted payload. Returns the plaintext protobuf bytes, or
+ * null when authentication fails (wrong secret, wrong sender form, unknown scheme) —
+ * callers treat null as "cannot read this edit" and fall back to today's behaviour.
+ */
+export function decryptMsgSecret(input: MsgSecretInput): Buffer | null {
+  const useCase = input.useCase ?? MSG_SECRET_MESSAGE_EDIT;
+  const info = Buffer.concat([
+    Buffer.from(input.originalMessageId),
+    Buffer.from(toNonAdJid(input.originalSenderJid)),
+    Buffer.from(toNonAdJid(input.modificationSenderJid)),
+    Buffer.from(useCase),
+  ]);
+  try {
+    const key = Buffer.from(hkdfSync('sha256', input.originalMessageSecret, Buffer.alloc(0), info, 32));
+    const payload = Buffer.from(input.encPayload);
+    const tag = payload.subarray(payload.length - 16);
+    const ciphertext = payload.subarray(0, payload.length - 16);
+    const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(input.encIv));
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch (error) {
+    log.debug('msgSecret decryption failed', {
+      useCase,
+      originalMessageId: input.originalMessageId,
+      error: String(error),
+    });
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

An edit made on **another device of the same account** syncs as a `MESSAGE_EDIT` protocol message on `messages.upsert` and never produces a `messages.update`. The upsert branch swallowed it on purpose — waiting for an update that never arrives — so that edit was lost entirely: no journal row, `editCount` stayed 0, the pre-edit text stayed.

The upsert already extracted the new text into `content.editedText` and discarded it, so the data was there the whole time.

## Change

- `handleSpecialMessage` emits the edit when the upsert already carries the new text; it still defers to `messages.update` when it does not (protocol message without `editedMessage`).
- A bounded seen-set keyed by `(targetMessageId, newText)` de-duplicates: a third-party edit reaches us on **both** paths, and only the first arrival emits. Keyed by text so a genuine second edit of the same message still passes; capped at 500 entries so a long-lived socket cannot grow it without end.

## Tests

`packages/channel-whatsapp/src/__tests__/message-edit-self-echo.test.ts` — 4 cases:
1. edit arriving only as an upsert protocol message is emitted;
2. same edit arriving on both paths emits once;
3. a genuine second edit of the same message still emits;
4. a textless upsert edit still defers to `messages.update`.

Channel suite green: **394 pass / 0 fail** (30 files), including the existing `message-edit-update.test.ts`.

## Scope — read before closing anything with this

This does **not** fix #1061's reproduction. Capturing the raw payload of a failing edit on v2.260910.18 showed it arrives as an encrypted secret envelope, not as a protocol message:

```jsonc
"secretEncryptedMessage": {
  "encIv": "…", "encPayload": "…",
  "secretEncType": "MESSAGE_EDIT",
  "targetMessageKey": { "id": "<original-msg-id>", … }
}
```

The new text is encrypted under the original message's `messageContextInfo.messageSecret` (same family as poll votes / event responses). Baileys — including latest rc14, checked — ships **no handler for `secretEncryptedMessage`**; the field exists in the protobuf (`WAProto.proto:2134`, `SecretEncType.MESSAGE_EDIT = 2`) and is referenced nowhere in `lib/`. Deriving the key by analogy with `decryptPollVote` failed across 288 combinations of info string × JID × AAD shape, so it needs the actual scheme rather than guesswork. Full analysis and payload in #1061.

So: this PR closes a real, separate gap in the plaintext-protocol path. #1061 should stay open for the encrypted case (and is likely an upstream Baileys feature).

Related: #1105 (bump vendored baileys rc10 → rc14 — brings a protocol-message spoofing guard; does not help here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp message edit handling to prevent duplicate edit events when updates arrive through multiple synchronization paths.
  * Preserved separate notifications for genuine subsequent edits to the same message.
  * Ensured edits lacking updated text continue through the appropriate processing path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->