### PR TITLE
feat(automations): per-automation concurrency limit and partition key

### DIFF
--- a/packages/api/src/routes/v2/automations.ts
+++ b/packages/api/src/routes/v2/automations.ts
@@ -142,6 +142,25 @@ const createAutomationSchema = z.object({
       "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
         'only when every action succeeded; a failed run publishes zero. Default false = immediate publishing',
     ),
+  maxConcurrency: z
+    .number()
+    .int()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe(
+      'Per-automation concurrency limit (#1108). Omit/null = today’s per-instance queueing with the engine ' +
+        'default; 1 = strict single-flight, which is what a read-before-write action needs',
+    ),
+  concurrencyKey: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe(
+      'Template over the event payload partitioning this automation’s queue (#1108), e.g. ' +
+        '"{{payload.from.id}}" to serialize per chat; omit/null = one queue for the whole automation',
+    ),
 });
 
 // Update automation schema

--- a/packages/api/src/schemas/openapi/automations.ts
+++ b/packages/api/src/schemas/openapi/automations.ts
@@ -113,6 +113,23 @@ export const AutomationSchema = z.object({
       "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
       'only when every action succeeded; a failed run publishes zero',
   }),
+  maxConcurrency: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({
+      description:
+        'Per-automation concurrency limit (#1108). null = queued per instance with the engine default; ' +
+        'set = a queue private to this automation, 1 being strict single-flight',
+    }),
+  concurrencyKey: z
+    .string()
+    .nullable()
+    .openapi({
+      description:
+        'Template over the event payload partitioning this automation’s queue (#1108), e.g. ' +
+        '"{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation',
+    }),
   managedByAgentId: z
     .string()
     .uuid()
@@ -147,6 +164,27 @@ export const CreateAutomationSchema = z.object({
       description:
         "Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order " +
         'only when every action succeeded; a failed run publishes zero. Default false = immediate publishing',
+    }),
+  maxConcurrency: z
+    .number()
+    .int()
+    .min(1)
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        'Per-automation concurrency limit (#1108). Omit/null = today’s per-instance queueing with the engine ' +
+        'default; 1 = strict single-flight, which is what a read-before-write action needs',
+    }),
+  concurrencyKey: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        'Template over the event payload partitioning this automation’s queue (#1108), e.g. ' +
+        '"{{payload.from.id}}" to serialize per chat; omit/null = one queue for the whole automation',
     }),
 });
 
@@ -219,7 +257,11 @@ export const AutomationMetricsSchema = z.object({
   instanceQueues: z
     .array(
       z.object({
-        instanceId: z.string().openapi({ description: 'Instance ID' }),
+        instanceId: z.string().openapi({
+          description:
+            'Queue key: the instance ID, or "<instanceId>:<automationId>[:<partition>]" for an automation ' +
+            'running on its own queue (#1108)',
+        }),
         activeCount: z.number().int().openapi({ description: 'Active jobs' }),
         pendingCount: z.number().int().openapi({ description: 'Pending jobs' }),
       }),

--- a/packages/api/src/services/__tests__/automations.test.ts
+++ b/packages/api/src/services/__tests__/automations.test.ts
@@ -42,6 +42,8 @@ function createMockAutomation(overrides: Partial<Automation> = {}): Automation {
     enabled: true,
     priority: 0,
     transactionalEmissions: false,
+    maxConcurrency: null,
+    concurrencyKey: null,
     managedByAgentId: null,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/packages/cli/src/commands/__tests__/automations.test.ts
+++ b/packages/cli/src/commands/__tests__/automations.test.ts
@@ -75,6 +75,15 @@ describe('buildDefinition (update)', () => {
     expect(buildDefinition({})).toEqual({});
   });
 
+  test('carries the concurrency flags, and omits them when unset (#1108)', () => {
+    expect(buildDefinition({ maxConcurrency: 1, concurrencyKey: '{{payload.from.id}}' })).toEqual({
+      maxConcurrency: 1,
+      concurrencyKey: '{{payload.from.id}}',
+    });
+    // Absent flags must not appear in the PATCH — the row keeps per-instance queueing.
+    expect(buildDefinition({ name: 'n' })).toEqual({ name: 'n' });
+  });
+
   test('carries trigger, conditions, logic and actions', () => {
     expect(
       buildDefinition({

--- a/packages/cli/src/commands/automations.ts
+++ b/packages/cli/src/commands/automations.ts
@@ -63,6 +63,10 @@ interface DefinitionOptions extends ActionOptions {
   // Transactional publication (G5, #988): true from --transactional-emissions,
   // undefined when the flag is not given (server default false applies).
   transactionalEmissions?: boolean;
+  // Per-automation concurrency (#1108): undefined when the flag is not given,
+  // so the field is omitted and the row keeps per-instance queueing.
+  maxConcurrency?: number;
+  concurrencyKey?: string;
 }
 
 interface CreateOptions extends DefinitionOptions {
@@ -173,6 +177,8 @@ function buildDefinition(options: DefinitionOptions): Partial<CreateAutomationBo
   if (logic !== undefined) body.conditionLogic = logic;
   if (options.priority !== undefined) body.priority = options.priority;
   if (options.transactionalEmissions !== undefined) body.transactionalEmissions = options.transactionalEmissions;
+  if (options.maxConcurrency !== undefined) body.maxConcurrency = options.maxConcurrency;
+  if (options.concurrencyKey !== undefined) body.concurrencyKey = options.concurrencyKey;
 
   return body;
 }
@@ -309,6 +315,17 @@ export function createAutomationsCommand(): Command {
       "Buffer the run's emit_event publishes and flush them in order only when every action succeeded; " +
         'a failed run publishes zero (#988). Defaults to off (immediate publishing)',
     )
+    .option(
+      '--max-concurrency <n>',
+      'Run at most N of THIS automation at a time on its own queue; 1 = strict single-flight, ' +
+        'which a read-before-write action needs (#1108). Default: queued per instance with the engine default',
+      (v) => Number.parseInt(v, 10),
+    )
+    .option(
+      '--concurrency-key <template>',
+      'Template over the event payload partitioning that queue, e.g. "{{payload.from.id}}" to serialize ' +
+        'per chat instead of globally (#1108)',
+    )
     // call_agent specific options
     .option('--agent-id <id>', 'Agent ID (for the first call_agent action)')
     .option('--provider-id <id>', 'Provider ID (for the first call_agent action)')
@@ -351,6 +368,15 @@ export function createAutomationsCommand(): Command {
         'a failed run publishes zero (#988)',
     )
     .option('--no-transactional-emissions', 'Return the automation to immediate mid-sequence publishing')
+    .option(
+      '--max-concurrency <n>',
+      'Run at most N of THIS automation at a time on its own queue; 1 = strict single-flight (#1108)',
+      (v) => Number.parseInt(v, 10),
+    )
+    .option(
+      '--concurrency-key <template>',
+      'Template over the event payload partitioning that queue, e.g. "{{payload.from.id}}" (#1108)',
+    )
     .option('--agent-id <id>', 'Agent ID (for the first call_agent action)')
     .option('--provider-id <id>', 'Provider ID (for the first call_agent action)')
     .option('--response-as <var>', 'Store agent response as variable (for the first call_agent action)')

--- a/packages/core/src/automations/__tests__/engine-concurrency.test.ts
+++ b/packages/core/src/automations/__tests__/engine-concurrency.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Per-automation concurrency control (#1108).
+ *
+ * Runs are queued per INSTANCE, so two events describing the same business
+ * fact both entered execution and both read the shared state before either
+ * had written it — a lost update. `maxConcurrency` moves the automation onto
+ * its own queue (1 = strict single-flight) and `concurrencyKey` partitions
+ * that queue by a template over the payload, so unrelated keys stay parallel.
+ *
+ * The probe below is exactly that race: the action READS a ledger, yields,
+ * then WRITES what it read. Serialized, the second run sees the first's row.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { EventBus, SubscribeOptions, Subscription } from '../../events/bus';
+import type { OmniEvent } from '../../events/types';
+import { createAutomationEngine } from '../engine';
+import type { Automation } from '../types';
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: 'auto-1',
+    name: 'Append to ledger',
+    enabled: true,
+    priority: 0,
+    triggerEventType: 'custom.order.confirmed',
+    triggerConditions: [],
+    conditionLogic: 'and',
+    actions: [
+      {
+        type: 'send_message',
+        config: { instanceId: 'inst-1', to: 'chat-1', contentTemplate: '{{payload.account}}|{{payload.ref}}' },
+      },
+    ],
+    debounce: { mode: 'none' },
+    ...overrides,
+  } as unknown as Automation;
+}
+
+function orderEvent(id: string, payload: Record<string, unknown>): OmniEvent {
+  return {
+    id,
+    type: 'custom.order.confirmed',
+    payload,
+    metadata: { correlationId: `corr-${id}`, instanceId: 'inst-1' },
+    timestamp: Date.now(),
+  } as unknown as OmniEvent;
+}
+
+function makeBus(): { bus: EventBus; deliver: (event: OmniEvent) => Promise<void> } {
+  let handler: ((event: OmniEvent) => Promise<void>) | null = null;
+  const subscription: Subscription = { id: 'sub', pattern: '*', unsubscribe: async () => {} };
+  const bus = {
+    connect: mock(async () => {}),
+    publish: mock(async () => ({ id: '', sequence: 0, stream: '' })),
+    publishGeneric: mock(async () => ({ id: '', sequence: 0, stream: '' })),
+    subscribe: mock(async () => subscription),
+    subscribePattern: mock(async (_p: string, h: (e: OmniEvent) => Promise<void>, _o?: SubscribeOptions) => {
+      handler = h;
+      return subscription;
+    }),
+    subscribeMany: mock(async () => subscription),
+    subscribeAll: mock(async () => subscription),
+    close: mock(async () => {}),
+    isConnected: mock(() => true),
+  } as unknown as EventBus;
+  return {
+    bus,
+    deliver: async (event) => {
+      if (!handler) throw new Error('engine never subscribed');
+      await handler(event);
+    },
+  };
+}
+
+type ActionDep = (instanceId: string, to: string, content: string) => Promise<void>;
+
+/**
+ * A read-before-write action, one ledger per account (the rendered
+ * `<account>|<ref>` content). Each entry records the ledger size the run SAW
+ * before writing, so `['a@0', 'b@0']` is the lost update and `['a@0', 'b@1']`
+ * is a run that observed its predecessor's side effect.
+ */
+function makeLedgerAction(): { rows: (account?: string) => string[]; sendMessage: ActionDep } {
+  const ledgers = new Map<string, string[]>();
+  const sendMessage = async (_instanceId: string, _to: string, content: string): Promise<void> => {
+    const [account = '', ref = ''] = content.split('|');
+    const seen = (ledgers.get(account) ?? []).length;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    ledgers.set(account, [...(ledgers.get(account) ?? []), `${ref}@${seen}`]);
+  };
+  return { rows: (account = '') => ledgers.get(account) ?? [], sendMessage };
+}
+
+describe('AutomationEngine — per-automation concurrency (#1108)', () => {
+  test('maxConcurrency 1 serializes two events in the same tick; the second sees the first write', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5 });
+    const { bus, deliver } = makeBus();
+    const { rows, sendMessage } = makeLedgerAction();
+
+    await engine.start(bus, [makeAutomation({ maxConcurrency: 1 })], { sendMessage });
+    await Promise.all([deliver(orderEvent('evt-a', { ref: 'a' })), deliver(orderEvent('evt-b', { ref: 'b' }))]);
+
+    expect(rows()).toEqual(['a@0', 'b@1']);
+    await engine.stop();
+  });
+
+  test('without the fields the same two events race on the shared per-instance queue', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5 });
+    const { bus, deliver } = makeBus();
+    const { rows, sendMessage } = makeLedgerAction();
+
+    await engine.start(bus, [makeAutomation()], { sendMessage });
+    await Promise.all([deliver(orderEvent('evt-a', { ref: 'a' })), deliver(orderEvent('evt-b', { ref: 'b' }))]);
+
+    // Both read the pre-write snapshot — the bug #1108 exists to fix. Kept as
+    // the regression guard that the default path was NOT quietly serialized.
+    expect(rows()).toEqual(['a@0', 'b@0']);
+    expect(engine.getMetrics().instanceQueues.map((q) => q.instanceId)).toEqual(['inst-1']);
+    await engine.stop();
+  });
+
+  test('an automation without the fields keeps sharing one queue with another automation', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 1 });
+    const { bus, deliver } = makeBus();
+    const { rows, sendMessage } = makeLedgerAction();
+
+    const other = makeAutomation({ id: 'auto-2', name: 'Other' });
+    await engine.start(bus, [makeAutomation(), other], { sendMessage });
+    await deliver(orderEvent('evt-a', { ref: 'a' }));
+
+    // One instance queue serving both automations, at the engine's default
+    // limit — unchanged from before the feature.
+    expect(engine.getMetrics().instanceQueues).toEqual([{ instanceId: 'inst-1', activeCount: 0, pendingCount: 0 }]);
+    expect(rows()).toEqual(['a@0', 'a@1']);
+    await engine.stop();
+  });
+
+  test('concurrencyKey renders over the payload: same key serializes, different keys stay parallel', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5 });
+    const { bus, deliver } = makeBus();
+    const { rows, sendMessage } = makeLedgerAction();
+    const automation = makeAutomation({ maxConcurrency: 1, concurrencyKey: '{{payload.account}}' });
+
+    // Queues are sampled from inside a run — a partitioned queue is evicted
+    // once idle, so after the last run the map is empty by design.
+    const liveKeys = new Set<string>();
+    const probe: ActionDep = async (instanceId, to, content) => {
+      for (const q of engine.getMetrics().instanceQueues) liveKeys.add(q.instanceId);
+      await sendMessage(instanceId, to, content);
+    };
+
+    await engine.start(bus, [automation], { sendMessage: probe });
+    await Promise.all([
+      deliver(orderEvent('evt-a', { ref: 'a', account: 'acct-1' })),
+      deliver(orderEvent('evt-b', { ref: 'b', account: 'acct-1' })),
+      deliver(orderEvent('evt-c', { ref: 'c', account: 'acct-2' })),
+    ]);
+
+    // acct-1 serialized behind itself — b read the ledger AFTER a wrote it —
+    // while acct-2 ran against its own queue, untouched by either.
+    expect(rows('acct-1')).toEqual(['a@0', 'b@1']);
+    expect(rows('acct-2')).toEqual(['c@0']);
+    expect([...liveKeys].sort()).toEqual(['inst-1:auto-1:acct-1', 'inst-1:auto-1:acct-2']);
+    expect(engine.getMetrics().instanceQueues).toEqual([]);
+    await engine.stop();
+  });
+
+  test('a concurrencyKey that renders empty falls back to the automation-wide queue', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5 });
+    const { bus, deliver } = makeBus();
+    const { rows, sendMessage } = makeLedgerAction();
+    const automation = makeAutomation({ maxConcurrency: 1, concurrencyKey: '{{payload.missing}}' });
+
+    await engine.start(bus, [automation], { sendMessage });
+    await Promise.all([deliver(orderEvent('evt-a', { ref: 'a' })), deliver(orderEvent('evt-b', { ref: 'b' }))]);
+
+    // Merging into ONE queue is the conservative direction: an unresolvable
+    // partition must never make a single-flight automation run in parallel.
+    expect(rows()).toEqual(['a@0', 'b@1']);
+    await engine.stop();
+  });
+
+  test('backpressure still applies on a per-automation queue', async () => {
+    const engine = createAutomationEngine({ defaultConcurrency: 5, maxQueueDepth: 1 });
+    const { bus, deliver } = makeBus();
+    const { sendMessage } = makeLedgerAction();
+
+    await engine.start(bus, [makeAutomation({ maxConcurrency: 1 })], { sendMessage });
+    // One running, one pending (depth 1 = full), the third is refused.
+    const settled = await Promise.allSettled([
+      deliver(orderEvent('evt-a', { ref: 'a' })),
+      deliver(orderEvent('evt-b', { ref: 'b' })),
+      deliver(orderEvent('evt-c', { ref: 'c' })),
+    ]);
+
+    const rejected = settled.filter((s) => s.status === 'rejected');
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      name: 'QueueFullError',
+      queueKey: 'inst-1:auto-1',
+      maxDepth: 1,
+    });
+    await engine.stop();
+  });
+});

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -2,7 +2,8 @@
  * Automation Engine
  *
  * Orchestrates event handling with:
- * - Per-instance queues with bounded concurrency
+ * - Per-instance queues with bounded concurrency, or a queue private to one
+ *   automation when it sets its own concurrency controls (#1108)
  * - Message debouncing per conversation
  * - Condition evaluation
  * - Action execution
@@ -23,16 +24,29 @@ import {
   type DebouncedMessage,
   buildConversationKey,
 } from './debounce';
-import { type TemplateContext, createTemplateContext } from './templates';
+import { type TemplateContext, createTemplateContext, substituteTemplate } from './templates';
 import type { ActionExecutionResult, Automation, AutomationLogStatus, DebounceConfig, NewAutomationLog } from './types';
 
 const logger = createLogger('automations:engine');
 
 /**
- * Per-instance queue for bounded concurrency
+ * A queue with bounded concurrency.
+ *
+ * The key is the instance id by default — one queue per instance, as it has
+ * always been. An automation that sets `maxConcurrency`/`concurrencyKey`
+ * (#1108) gets its own queue instead, keyed `${instanceId}:${automationId}`
+ * and optionally suffixed with its rendered partition.
  */
 interface InstanceQueue {
-  instanceId: string;
+  key: string;
+  /**
+   * Drop this queue from the map once it goes idle. True for the #1108
+   * per-automation queues: a `concurrencyKey` is rendered from payload
+   * content, so the map would otherwise grow one entry per chat/account and
+   * never shrink. Instance queues are bounded by the instance count and stay,
+   * as they always have.
+   */
+  evictWhenIdle: boolean;
   activeCount: number;
   maxConcurrency: number;
   pending: Array<{
@@ -94,11 +108,12 @@ export interface EngineConfig {
  */
 export class QueueFullError extends Error {
   constructor(
-    public readonly instanceId: string,
+    /** Queue key: the instance id, or `${instanceId}:${automationId}[:partition]` (#1108). */
+    public readonly queueKey: string,
     public readonly queueDepth: number,
     public readonly maxDepth: number,
   ) {
-    super(`Queue full for instance ${instanceId}: ${queueDepth}/${maxDepth} pending`);
+    super(`Queue full for ${queueKey}: ${queueDepth}/${maxDepth} pending`);
     this.name = 'QueueFullError';
   }
 }
@@ -108,7 +123,7 @@ export class QueueFullError extends Error {
  */
 export class AutomationEngine {
   private subscriptions = new Map<string, Subscription>();
-  private instanceQueues = new Map<string, InstanceQueue>();
+  private queues = new Map<string, InstanceQueue>();
   private debounceManagers = new Map<string, DebounceManager>(); // automationId -> manager
   private automations: Automation[] = [];
   private eventBus: EventBus | null = null;
@@ -631,7 +646,31 @@ export class AutomationEngine {
   }
 
   /**
-   * Queue an execution with per-instance concurrency control
+   * Which queue this run belongs to (#1108).
+   *
+   * Both concurrency fields absent = the instance id, today's shared
+   * per-instance queue. Either one set moves the run onto a queue private to
+   * the automation, optionally partitioned by `concurrencyKey` rendered over
+   * this event's payload — so `{{payload.from.id}}` serializes per chat while
+   * leaving unrelated chats parallel.
+   *
+   * A template that renders empty (missing field, unresolved path) falls back
+   * to the automation-wide queue rather than minting a `...:` bucket: merging
+   * into ONE queue is the conservative direction for a feature whose whole
+   * point is serialization.
+   */
+  private resolveQueueKey(automation: Automation, context: TemplateContext, instanceId: string): string {
+    if (automation.maxConcurrency == null && automation.concurrencyKey == null) return instanceId;
+
+    const base = `${instanceId}:${automation.id}`;
+    if (!automation.concurrencyKey) return base;
+
+    const partition = substituteTemplate(automation.concurrencyKey, context).trim();
+    return partition ? `${base}:${partition}` : base;
+  }
+
+  /**
+   * Queue an execution with bounded concurrency
    */
   private async queueExecution(
     automation: Automation,
@@ -639,18 +678,24 @@ export class AutomationEngine {
     context: TemplateContext,
     instanceId: string,
   ): Promise<ExecutionResult> {
-    // Get or create queue for this instance
-    let queue = this.instanceQueues.get(instanceId);
-    if (!queue) {
-      const maxConcurrency = this.config.instanceConcurrencyOverrides?.[instanceId] ?? this.config.defaultConcurrency;
-      queue = {
-        instanceId,
-        activeCount: 0,
-        maxConcurrency,
-        pending: [],
-      };
-      this.instanceQueues.set(instanceId, queue);
-    }
+    const key = this.resolveQueueKey(automation, context, instanceId);
+    // An automation's own limit wins over the instance's. Re-read on every run
+    // so an update that reaches the engine through `reload` is not shadowed by
+    // a queue minted under the previous limit.
+    const maxConcurrency =
+      automation.maxConcurrency ??
+      this.config.instanceConcurrencyOverrides?.[instanceId] ??
+      this.config.defaultConcurrency;
+
+    const queue = this.queues.get(key) ?? {
+      key,
+      evictWhenIdle: key !== instanceId,
+      activeCount: 0,
+      maxConcurrency,
+      pending: [],
+    };
+    queue.maxConcurrency = maxConcurrency;
+    this.queues.set(key, queue);
 
     // If under capacity, execute immediately
     if (queue.activeCount < queue.maxConcurrency) {
@@ -661,11 +706,11 @@ export class AutomationEngine {
     const maxQueueDepth = this.config.maxQueueDepth ?? 100;
     if (queue.pending.length >= maxQueueDepth) {
       logger.warn('Queue full, applying backpressure', {
-        instanceId,
+        queueKey: key,
         queueDepth: queue.pending.length,
         maxDepth: maxQueueDepth,
       });
-      throw new QueueFullError(instanceId, queue.pending.length, maxQueueDepth);
+      throw new QueueFullError(key, queue.pending.length, maxQueueDepth);
     }
 
     // Otherwise, queue it
@@ -680,7 +725,7 @@ export class AutomationEngine {
       });
       logger.debug('Execution queued', {
         automationId: automation.id,
-        instanceId,
+        queueKey: key,
         queueLength: queueRef.pending.length,
       });
     });
@@ -851,6 +896,13 @@ export class AutomationEngine {
           next.resolve(result);
         }
       }
+
+      // Idle per-automation queue: drop it so a payload-derived partition key
+      // cannot grow the map without bound (#1108). The identity check keeps a
+      // queue that was re-created for the same key while this frame unwound.
+      if (queue.evictWhenIdle && queue.activeCount === 0 && queue.pending.length === 0) {
+        if (this.queues.get(queue.key) === queue) this.queues.delete(queue.key);
+      }
     }
   }
 
@@ -885,11 +937,15 @@ export class AutomationEngine {
   }
 
   /**
-   * Get queue metrics
+   * Get queue metrics.
+   *
+   * `instanceId` carries the QUEUE KEY: the instance id for the default
+   * per-instance queues, or `${instanceId}:${automationId}[:partition]` for an
+   * automation running on its own queue (#1108).
    */
   getMetrics(): { instanceQueues: Array<{ instanceId: string; activeCount: number; pendingCount: number }> } {
-    const instanceQueues = Array.from(this.instanceQueues.values()).map((q) => ({
-      instanceId: q.instanceId,
+    const instanceQueues = Array.from(this.queues.values()).map((q) => ({
+      instanceId: q.key,
       activeCount: q.activeCount,
       pendingCount: q.pending.length,
     }));

--- a/packages/core/src/automations/types.ts
+++ b/packages/core/src/automations/types.ts
@@ -204,6 +204,20 @@ export interface Automation {
    */
   transactionalEmissions?: boolean;
   /**
+   * Per-automation concurrency limit (#1108). Absent/null = today's
+   * behaviour: the run is queued per INSTANCE with the engine's default
+   * limit. Set = a queue private to this automation with this limit; `1` is
+   * strict single-flight, which is what a read-before-write action needs so
+   * two events for the same fact cannot both read the pre-write snapshot.
+   */
+  maxConcurrency?: number | null;
+  /**
+   * Optional template over the event payload partitioning the per-automation
+   * queue (#1108) — e.g. `{{payload.from.id}}` serializes per chat rather
+   * than globally. Absent/null = one queue for the whole automation.
+   */
+  concurrencyKey?: string | null;
+  /**
    * Agent whose event manifest governs this automation (RFC #925 G4).
    * Stamped by the G4b compiler (#986) when the row is compiled from a
    * manifest's `accepts` entries; null/absent = hand-authored. Two consumers:

--- a/packages/db/drizzle/0067_automation_concurrency.sql
+++ b/packages/db/drizzle/0067_automation_concurrency.sql
@@ -1,0 +1,34 @@
+-- Per-automation concurrency control (issue #1108).
+--
+-- Runs are queued per INSTANCE with a shared default limit, so there is no way
+-- to say "only one run of THIS automation at a time". Any automation whose
+-- action reads shared state before writing it (webhook / call_agent) can
+-- therefore lose an update: two events for the same business fact both read
+-- the pre-write snapshot and both write. The key that identifies the duplicate
+-- is only knowable after the handler read the content, so serialization is the
+-- only primitive that helps.
+--
+--   automations.max_concurrency   NULL = unchanged: queue per instance with
+--                                 the engine's default limit. Set = the run
+--                                 moves to a queue private to this automation
+--                                 with this limit; 1 = strict single-flight.
+--
+--   automations.concurrency_key   NULL = one queue for the whole automation.
+--                                 Set = a template over the event payload
+--                                 (same engine as conditions/action configs)
+--                                 partitioning that queue, so a caller can
+--                                 serialize per account / chat / repo instead
+--                                 of globally.
+--
+-- Both NULL on every existing row, so current automations keep today's
+-- per-instance queueing byte-for-byte and there is no migration risk.
+--
+-- Hand-written following the 0043/0044/0052 precedent (additive, idempotent).
+-- No explicit BEGIN/COMMIT — the boot migrator executes this file on a pooled
+-- postgres-js connection, which rejects raw transaction control.
+
+ALTER TABLE "automations"
+  ADD COLUMN IF NOT EXISTS "max_concurrency" integer;
+
+ALTER TABLE "automations"
+  ADD COLUMN IF NOT EXISTS "concurrency_key" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1786600000000,
       "tag": "0066_consumer_exclude_types",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1786700000000,
+      "tag": "0067_automation_concurrency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3136,6 +3136,25 @@ export const automations = pgTable(
     transactionalEmissions: boolean('transactional_emissions').notNull().default(false),
 
     /**
+     * Per-automation concurrency limit (issue #1108). NULL = today's
+     * behaviour: the run is queued per INSTANCE with the engine's default
+     * limit. Set = the run gets a queue private to this automation with this
+     * limit; `1` is strict single-flight, which is what a read-before-write
+     * handler (webhook / call_agent mutating shared state) needs to avoid a
+     * lost update between two events describing the same fact.
+     */
+    maxConcurrency: integer('max_concurrency'),
+
+    /**
+     * Optional template over the event payload (same engine as conditions and
+     * action configs) partitioning the per-automation queue — e.g.
+     * `{{payload.from.id}}` serializes per chat instead of globally. NULL =
+     * one queue for the whole automation. Only consulted once this row opts
+     * into per-automation queueing.
+     */
+    concurrencyKey: text('concurrency_key'),
+
+    /**
      * G4b manifest-compilation provenance (RFC #925, issue #986): set when
      * this automation was COMPILED from `agents.event_manifest` by the
      * manifest compiler; NULL = hand-made. Managed rows reject manual

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -690,6 +690,18 @@ export interface CreateAutomationBody {
    * failed run publishes zero. Default false = immediate publishing.
    */
   transactionalEmissions?: boolean;
+  /**
+   * Per-automation concurrency limit (#1108). Omit/null = today's
+   * per-instance queueing with the engine default; 1 = strict single-flight,
+   * which is what a read-before-write action needs.
+   */
+  maxConcurrency?: number | null;
+  /**
+   * Template over the event payload partitioning this automation's queue
+   * (#1108), e.g. `{{payload.from.id}}` to serialize per chat. Omit/null =
+   * one queue for the whole automation.
+   */
+  concurrencyKey?: string | null;
 }
 
 /**

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -1708,6 +1708,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/events/schemas/{eventType}/validate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Validate a payload against a registered event schema (dry run)
+         * @description Check a payload against the registered schema with the same validator and error strings as the webhook ingress and emit_event gates, without publishing an event or writing anything (no dead letter). Returns 200 whether the payload is valid or not; read the `valid` flag and `errors`.
+         */
+        post: operations["validateEventPayload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/events/consumers": {
         parameters: {
             query?: never;
@@ -5591,6 +5611,22 @@ export interface components {
             /** @description Whether the validation gate is active (default true) */
             enabled?: boolean;
         };
+        ValidateEventPayloadRequest: {
+            /** @description The event payload to validate (any JSON value) */
+            payload?: unknown;
+        };
+        EventPayloadValidation: {
+            /** @description Event type the payload was checked against */
+            eventType: string;
+            /** @description Schema revision used */
+            version: number;
+            /** @description Whether the gate is active for this type (a disabled schema is still checked) */
+            enabled: boolean;
+            /** @description True when the payload satisfies the schema */
+            valid: boolean;
+            /** @description Violations as `instancePath: message`, identical to the ingress gate; empty when valid */
+            errors: string[];
+        };
         DurableConsumer: {
             /**
              * Format: uuid
@@ -5792,6 +5828,10 @@ export interface components {
             priority: number;
             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
             transactionalEmissions: boolean;
+            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+            maxConcurrency: number | null;
+            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+            concurrencyKey: string | null;
             /**
              * Format: uuid
              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -5934,6 +5974,10 @@ export interface components {
              * @default false
              */
             transactionalEmissions: boolean;
+            /** @description Per-automation concurrency limit (#1108). Omit/null = today’s per-instance queueing with the engine default; 1 = strict single-flight, which is what a read-before-write action needs */
+            maxConcurrency?: number | null;
+            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; omit/null = one queue for the whole automation */
+            concurrencyKey?: string | null;
         };
         AutomationLog: {
             /**
@@ -6022,7 +6066,7 @@ export interface components {
             running: boolean;
             /** @description Instance queue stats */
             instanceQueues?: {
-                /** @description Instance ID */
+                /** @description Queue key: the instance ID, or "<instanceId>:<automationId>[:<partition>]" for an automation running on its own queue (#1108) */
                 instanceId: string;
                 /** @description Active jobs */
                 activeCount: number;
@@ -17158,6 +17202,69 @@ export interface operations {
             };
         };
     };
+    validateEventPayload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                eventType: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description The event payload to validate (any JSON value) */
+                    payload?: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Validation verdict */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            /** @description Event type the payload was checked against */
+                            eventType: string;
+                            /** @description Schema revision used */
+                            version: number;
+                            /** @description Whether the gate is active for this type (a disabled schema is still checked) */
+                            enabled: boolean;
+                            /** @description True when the payload satisfies the schema */
+                            valid: boolean;
+                            /** @description Violations as `instancePath: message`, identical to the ingress gate; empty when valid */
+                            errors: string[];
+                        };
+                    };
+                };
+            };
+            /** @description No schema registered for this type */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            /**
+                             * @description Error code
+                             * @example NOT_FOUND
+                             */
+                            code: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error details */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
     listEventConsumers: {
         parameters: {
             query?: never;
@@ -17803,6 +17910,10 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+                            maxConcurrency: number | null;
+                            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+                            concurrencyKey: string | null;
                             /**
                              * Format: uuid
                              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -17959,6 +18070,10 @@ export interface operations {
                      * @default false
                      */
                     transactionalEmissions?: boolean;
+                    /** @description Per-automation concurrency limit (#1108). Omit/null = today’s per-instance queueing with the engine default; 1 = strict single-flight, which is what a read-before-write action needs */
+                    maxConcurrency?: number | null;
+                    /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; omit/null = one queue for the whole automation */
+                    concurrencyKey?: string | null;
                 };
             };
         };
@@ -18091,6 +18206,10 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+                            maxConcurrency: number | null;
+                            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+                            concurrencyKey: string | null;
                             /**
                              * Format: uuid
                              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -18272,6 +18391,10 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+                            maxConcurrency: number | null;
+                            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+                            concurrencyKey: string | null;
                             /**
                              * Format: uuid
                              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -18499,6 +18622,10 @@ export interface operations {
                      * @default false
                      */
                     transactionalEmissions?: boolean;
+                    /** @description Per-automation concurrency limit (#1108). Omit/null = today’s per-instance queueing with the engine default; 1 = strict single-flight, which is what a read-before-write action needs */
+                    maxConcurrency?: number | null;
+                    /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; omit/null = one queue for the whole automation */
+                    concurrencyKey?: string | null;
                 };
             };
         };
@@ -18631,6 +18758,10 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+                            maxConcurrency: number | null;
+                            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+                            concurrencyKey: string | null;
                             /**
                              * Format: uuid
                              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -18812,6 +18943,10 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+                            maxConcurrency: number | null;
+                            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+                            concurrencyKey: string | null;
                             /**
                              * Format: uuid
                              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -18993,6 +19128,10 @@ export interface operations {
                             priority: number;
                             /** @description Transactional publication (G5, #988): buffer the run's emit_event publishes and flush them in order only when every action succeeded; a failed run publishes zero */
                             transactionalEmissions: boolean;
+                            /** @description Per-automation concurrency limit (#1108). null = queued per instance with the engine default; set = a queue private to this automation, 1 being strict single-flight */
+                            maxConcurrency: number | null;
+                            /** @description Template over the event payload partitioning this automation’s queue (#1108), e.g. "{{payload.from.id}}" to serialize per chat; null = one queue for the whole automation */
+                            concurrencyKey: string | null;
                             /**
                              * Format: uuid
                              * @description Set when this automation was compiled from an agent event manifest (RFC #925 G4b, #986); null = hand-made. Managed automations reject manual mutation — edit the owning agent’s manifest instead
@@ -19356,7 +19495,7 @@ export interface operations {
                         running: boolean;
                         /** @description Instance queue stats */
                         instanceQueues?: {
-                            /** @description Instance ID */
+                            /** @description Queue key: the instance ID, or "<instanceId>:<automationId>[:<partition>]" for an automation running on its own queue (#1108) */
                             instanceId: string;
                             /** @description Active jobs */
                             activeCount: number;


### PR DESCRIPTION
Closes #1108.

## What

Exposes per-automation concurrency control, reusing the queue machinery that already existed in the engine rather than adding a second one. Two optional fields:

- `maxConcurrency` — when set, the run is queued against `${instanceId}:${automation.id}` with that limit. `1` = strict single-flight.
- `concurrencyKey` — an optional template over the event payload, so a caller can serialize per account / per chat / per repo instead of across the whole automation.

Both absent = today's exact behaviour (per-instance queue, `defaultConcurrency`), so existing rows are untouched.

Threaded end to end following the `transactionalEmissions` (#988) precedent, file for file: core type, schema + migration 0067, engine keying, CLI flags on `automations create|update`, API schemas, SDK.

## Why

Automation runs are serialized per *instance*, never per automation. Any automation whose action reads shared state before writing it can therefore lose an update, and `call_agent` makes read-before-write the normal shape rather than an exotic one.

The motivating case: two different source events describing one business fact (an order confirmation, then the invoice for that order) each triggered an agent that greps a ledger for an existing entry before appending. They arrived ~60s apart, both entered execution, both read the pre-write snapshot, both wrote. The handler's dedup logic was correct — it just ran twice against the same state. This is not reachable by an idempotency key: the key that identifies the duplicate is only knowable *after* the agent reads the content. Serialization is the only primitive that helps.

## Two decisions the issue did not specify

1. **A `concurrencyKey` that renders empty falls back to the automation-wide queue**, rather than minting a `...:` bucket. For a serialization feature the safe direction is to merge: an unresolvable partition must never let a single-flight automation run in parallel.
2. **Partitioned queues are evicted when idle.** The key is rendered from payload content and the intended use is per-account/per-chat, so the map would otherwise grow one entry per chat for the lifetime of the process. Instance queues are bounded by instance count and are left as they were. The delete is identity-guarded so a queue re-created for the same key while a frame unwinds survives.

## Tests

New `packages/core/src/automations/__tests__/engine-concurrency.test.ts` — 6 tests. The probe is the actual race: the action reads a ledger, yields the loop, then writes what it read, so `['a@0','b@0']` is the lost update and `['a@0','b@1']` is a run observing its predecessor.

```
@omni/core   1078 pass / 0 fail
@omni/api    2290 pass / 686 skip / 0 fail
@omni/db      220 pass / 144 skip / 0 fail
@omni/sdk      47 pass / 0 fail
@automagik/omni  automations.test.ts  20 pass / 0 fail

bunx biome check .  → no fixes applied
bun run typecheck   → 26/26 successful
```

## Note for the reviewer

`packages/sdk/src/types.generated.ts` carries unrelated drift. Running the repo's own `bun scripts/generate-sdk.ts` pulls in ~100 lines for a `/events/schemas/{eventType}/validate` endpoint that was added to the API without regenerating (absent from the file on `dev`, present after regeneration). Hand-editing a generated file seemed worse than flagging it; it deserves its own regeneration commit.

`packages/cli`'s full suite reports failures on this branch — they are pre-existing and need a live server; the automations file touched here passes in full.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-automation concurrency limits.
  * Added payload-based queue partitioning to serialize matching events while allowing different partitions to run concurrently.
  * Added CLI options for configuring maximum concurrency and concurrency keys when creating or updating automations.
  * Expanded automation API and SDK support for these settings.
  * Queue metrics and errors now identify automation-specific and partitioned queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->