### PR TITLE
feat(events): idempotency key for custom events on webhooks trigger

### DIFF
--- a/docs/architecture/event-system.md
+++ b/docs/architecture/event-system.md
@@ -892,6 +892,23 @@ omni webhooks trigger --type custom.deploy.finished \
   --payload '{"sha":"abc123"}' --causation-id <event-id>
 ```
 
+A custom event can also carry the **producer's own ingress key** so a cron
+retry, an overlapping run, or a backfill does not publish the same fact twice
+— the dedup channel and webhook ingress already get, instead of a ledger kept
+outside the journal by every connector:
+
+```bash
+omni webhooks trigger --type custom.deploy.finished \
+  --payload '{"sha":"abc123"}' --idempotency-key deploy:abc123
+```
+
+The key is claimed the same way channel ingress claims its own — the journal
+row IS the claim, so `omni_events.idempotency_key` is the authority — and it
+is namespaced per instance (else per tenant), so two connectors emitting a
+naive key like a bare timestamp cannot collide. A key already journaled
+publishes nothing and answers with the ORIGINAL event id and
+`{"duplicate": true}`; omitting the key publishes undeduped, as before.
+
 Tracing surfaces:
 
 - `GET /api/v2/events/:id/trace` — walks ancestors up to the root and

--- a/docs/cli/design.md
+++ b/docs/cli/design.md
@@ -496,6 +496,7 @@ omni webhooks get <id>                     # Get details
 omni webhooks delete <id>                 # Delete
 omni webhooks trigger --type custom.x --payload '{...}'  # Manual event emission
 omni webhooks trigger --type custom.x --payload '{...}' --causation-id <event-id>  # Parented mid-flow emission
+omni webhooks trigger --type custom.x --payload '{...}' --idempotency-key <key>    # Replay-safe emission (dedupes)
 omni webhooks heartbeat <source>          # Connector liveness ping
 
 # Create with signature verification
@@ -535,6 +536,7 @@ Create flags:
 | `--instance <id>` | Instance context |
 | `--correlation-id <id>` | Group the emission with an existing flow |
 | `--causation-id <event-id>` | Parent event id; the emission lands under that event in `omni events trace` instead of becoming a root |
+| `--idempotency-key <key>` | Producer's ingress key, scoped per instance (else per tenant). A key already journaled publishes nothing and returns the original event id, flagged `duplicate`; omit for undeduped emission |
 
 > Recipes: [[../runbooks/github-webhook-source|GitHub webhook source]],
 > [[../runbooks/clickup-webhook-source|ClickUp webhook source]].

--- a/packages/api/src/routes/v2/__tests__/webhooks-trigger-idempotency.test.ts
+++ b/packages/api/src/routes/v2/__tests__/webhooks-trigger-idempotency.test.ts
@@ -1,0 +1,97 @@
+/**
+ * POST /api/v2/events/trigger — `idempotencyKey` boundary contract (#1109).
+ *
+ * Custom events had no ingress key, so every producer reimplemented dedup
+ * outside the journal. The key rides the same path as `causationId` (CLI flag
+ * → SDK → OpenAPI/Zod → route → service claim) and the dedup verdict rides
+ * back out in the response.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import type { AppVariables } from '../../../types';
+import { webhooksRoutes } from '../webhooks';
+
+interface TriggerCall {
+  eventType: string;
+  metadata: { instanceId?: string; idempotencyKey?: string } | undefined;
+}
+
+/** Services fake whose trigger dedupes on the key it is handed, like the real one. */
+function buildApp() {
+  const triggered: TriggerCall[] = [];
+  const seen = new Map<string, string>();
+  const services = {
+    webhooks: {
+      trigger: async (eventType: string, _payload: Record<string, unknown>, metadata?: TriggerCall['metadata']) => {
+        triggered.push({ eventType, metadata });
+        const key = metadata?.idempotencyKey;
+        if (!key) return { eventId: crypto.randomUUID(), published: true };
+        const existing = seen.get(key);
+        if (existing) return { eventId: existing, published: false, duplicate: true };
+        const eventId = crypto.randomUUID();
+        seen.set(key, eventId);
+        return { eventId, published: true, duplicate: false };
+      },
+    },
+  } as unknown as AppVariables['services'];
+
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', services);
+    await next();
+  });
+  app.route('/api/v2', webhooksRoutes);
+  return { app, triggered };
+}
+
+function trigger(app: Hono<{ Variables: AppVariables }>, body: Record<string, unknown>) {
+  return app.request('/api/v2/events/trigger', {
+    method: 'POST',
+    body: JSON.stringify({ eventType: 'custom.connector.window', payload: { items: 3 }, ...body }),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST /api/v2/events/trigger idempotencyKey (#1109)', () => {
+  test('the key reaches the service and the replay answers with the same id, flagged', async () => {
+    const { app, triggered } = buildApp();
+
+    const first = await trigger(app, { idempotencyKey: 'window-1' });
+    const second = await trigger(app, { idempotencyKey: 'window-1' });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(triggered[0]?.metadata?.idempotencyKey).toBe('window-1');
+
+    const firstBody = (await first.json()) as { eventId: string; duplicate?: boolean };
+    const secondBody = (await second.json()) as { eventId: string; duplicate?: boolean };
+    expect(firstBody.duplicate).toBe(false);
+    expect(secondBody.duplicate).toBe(true);
+    expect(secondBody.eventId).toBe(firstBody.eventId);
+  });
+
+  test('omitting the key keeps the undeduped behaviour', async () => {
+    const { app, triggered } = buildApp();
+
+    const first = await trigger(app, {});
+    const second = await trigger(app, {});
+
+    expect(triggered[0]?.metadata?.idempotencyKey).toBeUndefined();
+    const firstBody = (await first.json()) as { eventId: string; duplicate?: boolean };
+    const secondBody = (await second.json()) as { eventId: string; duplicate?: boolean };
+    expect(secondBody.eventId).not.toBe(firstBody.eventId);
+    expect(secondBody.duplicate).toBeUndefined();
+  });
+
+  test('an empty key is rejected at the boundary, nothing triggered', async () => {
+    const { app, triggered } = buildApp();
+
+    const res = await trigger(app, { idempotencyKey: '' });
+
+    expect(res.status).toBe(400);
+    expect(triggered).toHaveLength(0);
+  });
+});

--- a/packages/api/src/routes/v2/webhooks.ts
+++ b/packages/api/src/routes/v2/webhooks.ts
@@ -175,13 +175,19 @@ const triggerEventSchema = z.object({
   correlationId: z.string().optional().describe('Optional correlation ID'),
   causationId: z.string().uuid().optional().describe('Optional parent event ID (causality tree, #1072)'),
   instanceId: z.string().uuid().optional().describe('Optional instance ID for context'),
+  idempotencyKey: z
+    .string()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe('Optional producer-supplied ingress key; a key already journaled returns the original event (#1109)'),
 });
 
 /**
  * POST /events/trigger - Manually trigger a custom event
  */
 webhooksRoutes.post('/events/trigger', zValidator('json', triggerEventSchema), async (c) => {
-  const { eventType, payload, correlationId, causationId, instanceId } = c.req.valid('json');
+  const { eventType, payload, correlationId, causationId, instanceId, idempotencyKey } = c.req.valid('json');
   const services = c.get('services');
   const apiKey = c.get('apiKey');
 
@@ -194,6 +200,7 @@ webhooksRoutes.post('/events/trigger', zValidator('json', triggerEventSchema), a
     correlationId,
     causationId,
     instanceId,
+    idempotencyKey,
   });
 
   return c.json(result, 201);

--- a/packages/api/src/schemas/openapi/webhooks.ts
+++ b/packages/api/src/schemas/openapi/webhooks.ts
@@ -225,6 +225,10 @@ export const TriggerEventSchema = z.object({
     .optional()
     .openapi({ description: 'Parent event ID; stamps causationId so the emission is parented in the causality tree' }),
   instanceId: z.string().uuid().optional().openapi({ description: 'Instance ID for context' }),
+  idempotencyKey: z.string().min(1).max(255).optional().openapi({
+    description:
+      'Producer-supplied ingress key (#1109). Unique per instance (else per tenant), not global. A key already journaled publishes nothing and returns the ORIGINAL event id with duplicate: true. Omit for undeduped publishing.',
+  }),
 });
 
 // Webhook receive response

--- a/packages/api/src/services/__tests__/webhook-idempotency-postgres.test.ts
+++ b/packages/api/src/services/__tests__/webhook-idempotency-postgres.test.ts
@@ -23,9 +23,9 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { EventBus } from '@omni/core';
+import type { CustomEventType, EventBus } from '@omni/core';
 import { executeActions } from '@omni/core';
-import { type Database, createDbHandle, omniEvents, webhookSources } from '@omni/db';
+import { type Database, type NewOmniEvent, createDbHandle, omniEvents, webhookSources } from '@omni/db';
 import { provisionMigratedDatabase } from '@omni/db/pg-migrated-template';
 import { eq } from 'drizzle-orm';
 import { buildAutomationEngineDeps } from '../../plugins/automation-actions';
@@ -60,6 +60,35 @@ function urlFor(base: string, database: string): string {
 interface PublishedEvent {
   type: string;
   payload: Record<string, unknown>;
+}
+
+/**
+ * A recording bus that ALSO does what the `custom.>` persistence consumer does
+ * with a published event: insert its journal row, `onConflictDoNothing` on id.
+ * Row counts asserted against it therefore mean what they mean in production —
+ * a claimed publish fills its own claim row, an unclaimed one adds a new row.
+ */
+function journalingBus(events: PublishedEvent[], db: Database): EventBus {
+  return {
+    publishGeneric: async (type: string, payload: Record<string, unknown>, metadata?: Record<string, unknown>) => {
+      const id = (metadata?.publishEventId as string | undefined) ?? crypto.randomUUID();
+      events.push({ type, payload });
+      await db
+        .insert(omniEvents)
+        .values({
+          id,
+          channel: 'internal',
+          eventType: type as NewOmniEvent['eventType'],
+          direction: 'internal',
+          status: 'completed',
+          receivedAt: new Date(),
+          rawPayload: payload,
+          metadata: { source: 'manual-trigger' },
+        })
+        .onConflictDoNothing({ target: omniEvents.id });
+      return { id, type, timestamp: Date.now(), payload, metadata };
+    },
+  } as unknown as EventBus;
 }
 
 /** An EventBus fake that records generic publishes (all this path uses). */
@@ -179,6 +208,46 @@ postgresDescribe('webhook ingress idempotency (real PostgreSQL)', () => {
     const retry = await service.receive('gh-flaky', payload, {}, { rawBody });
     expect(retry.duplicate).toBeUndefined();
     expect(published).toHaveLength(1);
+  });
+
+  test('manual trigger replayed with the same key → one journal row, same event id, hit reported (#1109)', async () => {
+    const before = await eventCount();
+    const published: PublishedEvent[] = [];
+    const service = new WebhookService(db, journalingBus(published, db));
+    const eventType = 'custom.connector.window' as CustomEventType;
+    const payload = { window: '2026-09-11', items: 3 };
+
+    const first = await service.trigger(eventType, payload, { idempotencyKey: 'window-2026-09-11' });
+    const second = await service.trigger(eventType, payload, { idempotencyKey: 'window-2026-09-11' });
+
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(true); // the hit is visible to the caller
+    expect(second.published).toBe(false);
+    expect(second.eventId).toBe(first.eventId); // ...and the retry still gets a usable id
+
+    expect(published).toHaveLength(1);
+    expect(await eventCount()).toBe(before + 1);
+
+    const rows = await db.select().from(omniEvents).where(eq(omniEvents.id, first.eventId));
+    expect(rows).toHaveLength(1);
+    // Scoped like channel ingress (per instance, else per tenant) — never the bare key.
+    expect(rows[0]?.idempotencyKey).toBe('manual:global:window-2026-09-11');
+  });
+
+  test('manual trigger with NO key → identical payloads still journal twice (#1109)', async () => {
+    const before = await eventCount();
+    const published: PublishedEvent[] = [];
+    const service = new WebhookService(db, journalingBus(published, db));
+    const eventType = 'custom.connector.window' as CustomEventType;
+    const payload = { window: '2026-09-11', items: 3 };
+
+    const first = await service.trigger(eventType, payload);
+    const second = await service.trigger(eventType, payload);
+
+    expect(first.eventId).not.toBe(second.eventId);
+    expect(second.duplicate).toBeUndefined();
+    expect(published).toHaveLength(2);
+    expect(await eventCount()).toBe(before + 2);
   });
 
   test('re-running an automation over the same event → no duplicate emission (derived key)', async () => {

--- a/packages/api/src/services/__tests__/webhooks.test.ts
+++ b/packages/api/src/services/__tests__/webhooks.test.ts
@@ -856,6 +856,59 @@ describe('WebhookService', () => {
 
       expect(mockEventBus._publishedEvents[0]?.metadata.source).toBe('manual-trigger');
     });
+
+    test('a replayed idempotency key publishes nothing and reports the hit (#1109)', async () => {
+      const eventType = 'custom.connector.window' as CustomEventType;
+      const payload = { window: '2026-09-11' };
+
+      const first = await service.trigger(eventType, payload, { idempotencyKey: 'w-1' });
+      const second = await service.trigger(eventType, payload, { idempotencyKey: 'w-1' });
+
+      expect(first.duplicate).toBe(false);
+      expect(first.published).toBe(true);
+      // The retrying caller is told it was a hit, not a fresh publish.
+      expect(second.duplicate).toBe(true);
+      expect(second.published).toBe(false);
+      expect(mockEventBus.publishGeneric).toHaveBeenCalledTimes(1);
+    });
+
+    test('the claimed key is scoped per instance, not global (#1109)', async () => {
+      const eventType = 'custom.connector.window' as CustomEventType;
+      const instanceId = crypto.randomUUID();
+
+      await service.trigger(eventType, {}, { idempotencyKey: 'w-1' });
+      await service.trigger(eventType, {}, { idempotencyKey: 'w-1', instanceId });
+
+      // Same naive key from two producers ⇒ two distinct claims, two publishes.
+      expect([...mockDb._journaledKeys.keys()]).toEqual(['manual:global:w-1', `manual:${instanceId}:w-1`]);
+      expect(mockEventBus.publishGeneric).toHaveBeenCalledTimes(2);
+    });
+
+    test('without a key, an identical payload publishes again (#1109)', async () => {
+      const eventType = 'custom.connector.window' as CustomEventType;
+      const payload = { window: '2026-09-11' };
+
+      const first = await service.trigger(eventType, payload);
+      const second = await service.trigger(eventType, payload);
+
+      expect(second.eventId).not.toBe(first.eventId);
+      expect(second.duplicate).toBeUndefined();
+      expect(mockEventBus.publishGeneric).toHaveBeenCalledTimes(2);
+      // No key ⇒ no claim row: the publish path is byte-identical to pre-#1109.
+      expect(mockDb._journaledKeys.size).toBe(0);
+    });
+
+    test('a failed publish releases the claim so the retry is not a duplicate (#1109)', async () => {
+      const eventType = 'custom.connector.window' as CustomEventType;
+      const failingBus = { publishGeneric: () => Promise.reject(new Error('bus down')) } as unknown as EventBus;
+      const serviceWithFailingBus = new WebhookService(mockDb, failingBus);
+
+      await expect(serviceWithFailingBus.trigger(eventType, {}, { idempotencyKey: 'w-1' })).rejects.toThrow('bus down');
+
+      // The claim row is deleted, so the retry is a first publish and not an
+      // ack of an event that never reached the bus.
+      expect(mockDb._calls.delete).toHaveLength(1);
+    });
   });
 });
 

--- a/packages/api/src/services/webhooks.ts
+++ b/packages/api/src/services/webhooks.ts
@@ -23,6 +23,7 @@ import type {
 import { generateId } from '@omni/core';
 import type { Database } from '@omni/db';
 import {
+  type NewOmniEvent,
   type NewWebhookSource,
   type WebhookEventTypeMapping,
   type WebhookSource,
@@ -68,6 +69,37 @@ export interface WebhookHeartbeatResult {
   /** Status BEFORE this heartbeat — the sweeper owns transitions, so a stalled source recovers on its next tick. */
   livenessStatus: WebhookSource['livenessStatus'];
   expectedIntervalSeconds: number | null;
+}
+
+export interface TriggerEventMetadata {
+  correlationId?: string;
+  causationId?: string;
+  instanceId?: string;
+  /**
+   * Producer-supplied ingress key (#1109). Present and unseen ⇒ publish;
+   * present and already journaled ⇒ no second publish and the ORIGINAL id
+   * comes back; absent ⇒ pre-#1109 behaviour, undeduped.
+   */
+  idempotencyKey?: string;
+}
+
+export interface TriggerEventResult {
+  /** The PUBLISHED event's id — on a dedup hit, the id of the event that was already journaled. */
+  eventId: string;
+  published: boolean;
+  /** True when the key was already journaled: nothing was published this call (#1109). */
+  duplicate?: boolean;
+}
+
+/**
+ * Namespace a manual trigger's key (#1109) the way channel ingress namespaces
+ * its own (`{channel}:{instance}:{externalId}:{kind}`): uniqueness is per
+ * instance, else per tenant, never global. Two connectors emitting a naive key
+ * (a bare timestamp) under different instances therefore cannot collide, while
+ * the same producer retrying the same fact still lands on the same key.
+ */
+function scopeTriggerKey(key: string, instanceId: string | undefined, tenantId: string | null): string {
+  return `manual:${instanceId ?? tenantId ?? 'global'}:${key}`;
 }
 
 /** Constant-time string comparison; a length mismatch short-circuits, which leaks only the length. */
@@ -401,23 +433,19 @@ export class WebhookService {
       headers,
     });
 
-    const claimed = await this.db
-      .insert(omniEvents)
-      .values({
-        id: eventId,
-        channel: 'internal',
-        eventType,
-        direction: 'inbound',
-        status: 'received',
-        rawPayload: payload,
-        idempotencyKey,
-        receivedAt: new Date(),
-        metadata: { correlationId: eventId, source: 'webhook', fullEventType: eventType, webhookSource: sourceName },
-      })
-      .onConflictDoNothing({ target: omniEvents.idempotencyKey })
-      .returning({ id: omniEvents.id });
+    const claim = await this.claimJournalRow({
+      id: eventId,
+      channel: 'internal',
+      eventType,
+      direction: 'inbound',
+      status: 'received',
+      rawPayload: payload,
+      idempotencyKey,
+      receivedAt: new Date(),
+      metadata: { correlationId: eventId, source: 'webhook', fullEventType: eventType, webhookSource: sourceName },
+    });
 
-    if (claimed.length === 0) {
+    if (claim.duplicate) {
       await this.db
         .update(webhookSources)
         .set({
@@ -426,18 +454,12 @@ export class WebhookService {
         })
         .where(eq(webhookSources.id, source.id));
 
-      const [original] = await this.db
-        .select({ id: omniEvents.id })
-        .from(omniEvents)
-        .where(eq(omniEvents.idempotencyKey, idempotencyKey))
-        .limit(1);
-
       log.info('Webhook redelivery acked without a second event', { sourceName, idempotencyKey });
 
       return {
         received: true,
         duplicate: true,
-        eventId: original?.id ?? eventId,
+        eventId: claim.eventId,
         source: sourceName,
         eventType,
       };
@@ -495,6 +517,36 @@ export class WebhookService {
       source: sourceName,
       eventType,
     };
+  }
+
+  /**
+   * Claim an ingress idempotency key by INSERTING the journal row (#958): the
+   * `omni_events.idempotency_key` unique index — not application logic — is the
+   * dedup authority. A conflict means the fact is already journaled; the
+   * ORIGINAL row's id comes back so a retrying producer still gets a usable id.
+   * The caller publishes UNDER the returned id, and releases the row if that
+   * publish fails.
+   */
+  private async claimJournalRow(
+    row: NewOmniEvent & { id: string; idempotencyKey: string },
+  ): Promise<{ eventId: string; duplicate: boolean }> {
+    const claimed = await this.db
+      .insert(omniEvents)
+      .values(row)
+      .onConflictDoNothing({ target: omniEvents.idempotencyKey })
+      .returning({ id: omniEvents.id });
+
+    if (claimed.length > 0) {
+      return { eventId: row.id, duplicate: false };
+    }
+
+    const [original] = await this.db
+      .select({ id: omniEvents.id })
+      .from(omniEvents)
+      .where(eq(omniEvents.idempotencyKey, row.idempotencyKey))
+      .limit(1);
+
+    return { eventId: original?.id ?? row.id, duplicate: true };
   }
 
   /**
@@ -601,13 +653,20 @@ export class WebhookService {
   }
 
   /**
-   * Manually trigger a custom event
+   * Manually trigger a custom event.
+   *
+   * With an `idempotencyKey` (#1109) the publish rides the SAME ingress-claim
+   * path as webhook ingress (`receive`) and channel ingress: the key is
+   * claimed as the journal row and the unique index does the deduping. A key
+   * already journaled publishes nothing and returns the original event's id,
+   * so a connector replaying a window gets a usable id instead of a second
+   * fact. Without a key the behaviour is unchanged — undeduped, as before.
    */
   async trigger(
     eventType: CustomEventType,
     payload: Record<string, unknown>,
-    metadata?: { correlationId?: string; causationId?: string; instanceId?: string },
-  ): Promise<{ eventId: string; published: boolean }> {
+    metadata?: TriggerEventMetadata,
+  ): Promise<TriggerEventResult> {
     // Provisional id for the schema gate's dead-letter reference and the
     // no-bus fallback; the publish path returns the PUBLISHED event's id (#956).
     const provisionalId = metadata?.correlationId ?? generateId();
@@ -616,25 +675,98 @@ export class WebhookService {
     // every publish path into the journal (issue #959).
     await this.enforceRegisteredSchema(eventType, payload, provisionalId, 'manual trigger');
 
-    if (this.eventBus) {
-      // A caller-supplied correlationId CONTINUES an existing flow; with none
-      // supplied the bus self-references (root event, fresh correlation).
-      // Either way the returned id is the published event's own id, not the
-      // correlation (#956 — the two used to be conflated, so the caller's id
-      // never matched the journal).
-      const result = await this.eventBus.publishGeneric(eventType, payload, {
-        correlationId: metadata?.correlationId,
-        // Parent event for agent/CLI emissions mid-flow (#1072) — the journal
-        // consumer persists it as causation_id, exactly like emit_event.
-        causationId: metadata?.causationId,
-        instanceId: metadata?.instanceId,
-        source: 'manual-trigger',
-      });
-
-      return { eventId: result.id, published: true };
+    const bus = this.eventBus;
+    if (!bus) {
+      return { eventId: provisionalId, published: false };
     }
 
-    return { eventId: provisionalId, published: false };
+    const key = metadata?.idempotencyKey;
+    if (key) {
+      return this.triggerClaimed(bus, eventType, payload, metadata ?? {}, key);
+    }
+
+    // A caller-supplied correlationId CONTINUES an existing flow; with none
+    // supplied the bus self-references (root event, fresh correlation).
+    // Either way the returned id is the published event's own id, not the
+    // correlation (#956 — the two used to be conflated, so the caller's id
+    // never matched the journal).
+    const result = await bus.publishGeneric(eventType, payload, {
+      correlationId: metadata?.correlationId,
+      // Parent event for agent/CLI emissions mid-flow (#1072) — the journal
+      // consumer persists it as causation_id, exactly like emit_event.
+      causationId: metadata?.causationId,
+      instanceId: metadata?.instanceId,
+      source: 'manual-trigger',
+    });
+
+    return { eventId: result.id, published: true };
+  }
+
+  /**
+   * Keyed manual trigger (#1109) — the `receive()` shape exactly: claim the
+   * key as the journal row, publish UNDER that row's id so row and event share
+   * one identity, and release the claim when the publish fails so the retry is
+   * not acked as a duplicate of an event that never reached the bus.
+   */
+  private async triggerClaimed(
+    bus: EventBus,
+    eventType: CustomEventType,
+    payload: Record<string, unknown>,
+    metadata: TriggerEventMetadata,
+    key: string,
+  ): Promise<TriggerEventResult> {
+    const idempotencyKey = scopeTriggerKey(key, metadata.instanceId, this.tenantId);
+    const eventId = generateId();
+
+    const claim = await this.claimJournalRow({
+      id: eventId,
+      channel: 'internal',
+      eventType,
+      // What the `custom.>` consumer would have written for this event, so a
+      // keyed trigger and an unkeyed one are indistinguishable in the journal.
+      direction: 'internal',
+      status: 'completed',
+      rawPayload: payload,
+      idempotencyKey,
+      causationId: metadata.causationId ?? null,
+      receivedAt: new Date(),
+      metadata: {
+        correlationId: metadata.correlationId ?? eventId,
+        source: 'manual-trigger',
+        fullEventType: eventType,
+        idempotencyKey,
+      },
+    });
+
+    if (claim.duplicate) {
+      log.info('Manual trigger deduped: idempotency key already journaled', { eventType, idempotencyKey });
+      return { eventId: claim.eventId, published: false, duplicate: true };
+    }
+
+    try {
+      await bus.publishGeneric(eventType, payload, {
+        correlationId: metadata.correlationId,
+        causationId: metadata.causationId,
+        instanceId: metadata.instanceId,
+        publishEventId: eventId,
+        source: 'manual-trigger',
+      });
+    } catch (error) {
+      await this.db
+        .delete(omniEvents)
+        .where(eq(omniEvents.id, eventId))
+        .catch((releaseError: unknown) => {
+          log.error('Failed to release trigger idempotency claim after publish failure', {
+            eventType,
+            eventId,
+            idempotencyKey,
+            error: String(releaseError),
+          });
+        });
+      throw error;
+    }
+
+    return { eventId, published: true, duplicate: false };
   }
 
   /**

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -6,7 +6,7 @@
  * omni webhooks create --name <name> [--description <desc>]
  * omni webhooks update <id> [--name <name>] [--enabled]
  * omni webhooks delete <id>
- * omni webhooks trigger --type <event-type> --payload <json> [--instance <id>]
+ * omni webhooks trigger --type <event-type> --payload <json> [--instance <id>] [--idempotency-key <key>]
  *
  * The signature secret can come from argv (`--signature-secret`, visible in
  * shell history and `ps`), an environment variable (`--signature-secret-env`),
@@ -559,6 +559,10 @@ export function createWebhooksCommand(): Command {
     .option('--instance <id>', 'Instance ID')
     .option('--correlation-id <id>', 'Correlation ID')
     .option('--causation-id <event-id>', 'Parent event ID (keeps the causality tree for mid-flow emissions, #1072)')
+    .option(
+      '--idempotency-key <key>',
+      'Ingress key (#1109): re-triggering with a key already journaled publishes nothing and returns the original event ID',
+    )
     .action(
       async (options: {
         type: string;
@@ -566,6 +570,7 @@ export function createWebhooksCommand(): Command {
         instance?: string;
         correlationId?: string;
         causationId?: string;
+        idempotencyKey?: string;
       }) => {
         const client = getClient();
 
@@ -584,11 +589,16 @@ export function createWebhooksCommand(): Command {
             instanceId: options.instance,
             correlationId: options.correlationId,
             causationId: options.causationId,
+            idempotencyKey: options.idempotencyKey,
           });
 
-          output.success(`Event triggered: ${result.eventId}`, {
+          // A dedup hit is not a publish — say so, and hand back the id of the
+          // event that already carries this key (#1109).
+          const headline = result.duplicate ? 'Event already published (idempotency key seen)' : 'Event triggered';
+          output.success(`${headline}: ${result.eventId}`, {
             eventId: result.eventId,
             eventType: result.eventType,
+            duplicate: result.duplicate,
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -843,6 +843,12 @@ export interface TriggerEventBody {
   /** Parent event id — stamps `causationId` so `events trace` parents this emission (#1072). */
   causationId?: string;
   instanceId?: string;
+  /**
+   * Producer-supplied ingress key (#1109), scoped per instance (else per
+   * tenant). A key already journaled publishes nothing and returns the
+   * ORIGINAL event id with `duplicate: true`; omitting it publishes undeduped.
+   */
+  idempotencyKey?: string;
 }
 
 /**
@@ -3294,9 +3300,10 @@ export function createOmniClient(config: OmniClientConfig) {
       },
 
       /**
-       * Trigger a custom event
+       * Trigger a custom event. With `idempotencyKey`, a replayed key comes
+       * back as `duplicate: true` carrying the original event id (#1109).
        */
-      async trigger(body: TriggerEventBody): Promise<{ eventId: string; eventType: string }> {
+      async trigger(body: TriggerEventBody): Promise<{ eventId: string; eventType: string; duplicate?: boolean }> {
         const { data, error, response } = await client.POST('/events/trigger', { body });
         throwIfError(response, error);
         return data ?? { eventId: '', eventType: body.eventType };

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -4592,6 +4592,8 @@ export interface components {
              * @description Instance ID for context
              */
             instanceId?: string;
+            /** @description Producer-supplied ingress key (#1109). Unique per instance (else per tenant), not global. A key already journaled publishes nothing and returns the ORIGINAL event id with duplicate: true. Omit for undeduped publishing. */
+            idempotencyKey?: string;
         };
         WebhookReceiveResponse: {
             /**
@@ -13195,6 +13197,8 @@ export interface operations {
                      * @description Instance ID for context
                      */
                     instanceId?: string;
+                    /** @description Producer-supplied ingress key (#1109). Unique per instance (else per tenant), not global. A key already journaled publishes nothing and returns the ORIGINAL event id with duplicate: true. Omit for undeduped publishing. */
+                    idempotencyKey?: string;
                 };
             };
         };


### PR DESCRIPTION
Closes #1109.

## What

`--idempotency-key` on `omni webhooks trigger` and the matching field on `POST /events/trigger`, so a producer of custom events can let omni own the dedup instead of reimplementing it outside.

- Key present and unseen → publish as today.
- Key present and already seen → no second journal row; the **existing** event id comes back, so a retrying caller still gets a usable id rather than an error. `trigger()` returns `{ eventId, published, duplicate }`.
- Key absent → the old branch, untouched.

## Why

Channel ingress has had an idempotency key derived from source identity for a long time; custom events had no way to supply one. Every producer therefore reimplements dedup outside omni — in the setup that motivated this, four connectors each keep a flat-file ledger of already-emitted source ids purely so a cron retry, an overlapping run, or a backfill does not publish the same fact twice. That is the same logic four times, living outside the journal that is meant to be the source of truth, and it is logic omni already owns for channels.

## Correction to the issue as filed

The issue claimed uniqueness should be scoped "per instance / tenant, not global". That was wrong about how this repo already works: `omni_events.idempotency_key` **is** globally unique (`packages/db/src/schema.ts:1869`) and scope comes from namespacing the key string — `{channel}:{instance}:{externalId}:{kind}` in `BaseChannelPlugin.emitMessageReceived`, `{source}:{sha256(body)}` in webhook `receive()`.

So this follows the existing convention instead: the caller's key is namespaced as `manual:{instanceId ?? tenantId ?? 'global'}:{key}`. No schema change, no migration.

Implementation follows `receive()` rather than paralleling it: the claim-insert + conflict-lookup that `receive()` had inline is extracted into a private `claimJournalRow()` that both paths now call, so keyed and unkeyed triggers are indistinguishable in the journal and there is one dedup mechanism, not two.

## Tests

Acceptance (a) and (b) are proven against real PostgreSQL. The unkeyed case needed the persistence consumer to exist for "two rows" to mean anything, so the pg suite's bus fake now also performs the consumer's insert — keyed ⇒ 1 row, unkeyed ⇒ 2 rows, through the production code path.

```
api unit + new route suite      60 pass / 0 fail
webhook-idempotency-postgres     7 pass / 0 fail  (real PostgreSQL)
@omni/api                     2297 pass / 688 skip / 0 fail
@automagik/omni (CLI)          747 pass / 0 fail
@omni/sdk                       47 pass / 0 fail
@omni/db                       220 pass / 144 skip / 0 fail

bunx biome check .        → no fixes applied
make typecheck            → 26/26 successful
bunx knip                 → clean
make verify-migrations    → 38 pass / 0 fail; contract OK vs origin/dev
make verify-versions      → 27/27 match
make test-pg-gate         → 400 pass / 1 fail
```

The single pg-gate failure is **pre-existing**, verified rather than assumed: the same gate on a clean `origin/dev` worktree gives 399 pass / 1 fail in the same file (`tests/release/upgrade-2.260902.5-to-2.260908.20-postgres.test.ts` — a `webhook_sources` catalog-fingerprint assertion short four NOT NULL constraints). This branch adds no migration and touches no schema.

## Two pieces of pre-existing debt found, deliberately left alone

1. `packages/sdk/src/types.generated.ts` is hand-edited here (only the two relevant hunks), matching what #1072 did, because a full regeneration also pulls in ~100 unrelated lines for an endpoint added without regenerating. Worth its own commit.
2. **OpenAPI drift on this endpoint**: `POST /events/trigger`'s 201 is documented as `WebhookReceiveResponse` (`eventId`/`source`/`eventType`/`duplicate`) while the service returns `{eventId, published, duplicate}` — `source` and `eventType` are never actually sent, and the CLI reads `result.eventType`. `duplicate` was already in that schema so this PR's flag is documented; fixing the rest changes the generated SDK response type and belongs in its own change.

skipped: rate-limiting and cleanup of claim rows — add when the drift above gets its own issue.
