### PR TITLE
feat(automations): generalize the debounce grouping key

### DIFF
--- a/packages/api/src/routes/v2/__tests__/automations-debounce-key.test.ts
+++ b/packages/api/src/routes/v2/__tests__/automations-debounce-key.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `debounce.key` validation at the API boundary (#1110).
+ *
+ * `presence` mode extends an open window when a CONTACT starts typing or
+ * recording — a statement about a conversation. A custom key says the window
+ * is not a conversation, so the two cannot both be true. Accepting the pair and
+ * ignoring one of them would leave a caller believing their `extendOnEvents`
+ * does something, so the request is refused with a message that names the
+ * conflict.
+ *
+ * Everything here is rejected (or accepted) by `zValidator` before any service
+ * is touched, so the app needs no database double.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import { errorHandler } from '../../../middleware/error';
+import type { AppVariables } from '../../../types';
+import { automationsRoutes } from '../automations';
+
+/** The create payload reaches the service only if validation passed. */
+function buildApp(): { app: Hono<{ Variables: AppVariables }>; created: unknown[] } {
+  const created: unknown[] = [];
+  const services = {
+    automations: {
+      create: async (data: unknown) => {
+        created.push(data);
+        return { id: 'auto-1', ...(data as Record<string, unknown>) };
+      },
+    },
+  } as unknown as AppVariables['services'];
+
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('services', services);
+    await next();
+  });
+  app.route('/automations', automationsRoutes);
+  return { app, created };
+}
+
+async function createAutomation(debounce: Record<string, unknown>): Promise<Response> {
+  const { app } = buildApp();
+  return await app.request('/automations', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      name: 'pr coalescer',
+      triggerEventType: 'custom.repo.pull_request',
+      actions: [{ type: 'log', config: { level: 'info', message: 'pr changed' } }],
+      debounce,
+    }),
+  });
+}
+
+describe('POST /automations debounce.key (#1110)', () => {
+  test('presence + key is REJECTED, with the conflict named', async () => {
+    const res = await createAutomation({
+      mode: 'presence',
+      baseDelayMs: 1000,
+      extendOnEvents: ['presence.composing'],
+      key: '{{payload.pull_request.id}}',
+    });
+
+    expect(res.status).toBe(400);
+    // A clear error, not a silent drop of one of the two.
+    const body = (await res.json()) as { error: { issues: Array<{ message: string; path: string[] }> } };
+    expect(body.error.issues[0]?.path).toEqual(['debounce', 'key']);
+    expect(body.error.issues[0]?.message).toBe(
+      'debounce.key cannot be combined with mode "presence": presence extension only applies to conversations',
+    );
+  });
+
+  test('presence without a key is still accepted', async () => {
+    const res = await createAutomation({
+      mode: 'presence',
+      baseDelayMs: 1000,
+      extendOnEvents: ['presence.composing'],
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test('fixed + key is accepted and reaches the service unchanged', async () => {
+    const { app, created } = buildApp();
+    const res = await app.request('/automations', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'pr coalescer',
+        triggerEventType: 'custom.repo.pull_request',
+        actions: [{ type: 'log', config: { level: 'info', message: 'pr changed' } }],
+        debounce: { mode: 'fixed', delayMs: 5000, key: '{{payload.pull_request.id}}' },
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect((created[0] as { debounce: Record<string, unknown> }).debounce).toEqual({
+      mode: 'fixed',
+      delayMs: 5000,
+      key: '{{payload.pull_request.id}}',
+    });
+  });
+
+  test('an empty key is rejected rather than stored as a window that never renders', async () => {
+    const res = await createAutomation({ mode: 'fixed', delayMs: 5000, key: '' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/api/src/routes/v2/automations.ts
+++ b/packages/api/src/routes/v2/automations.ts
@@ -101,25 +101,47 @@ const actionSchema = z.discriminatedUnion('type', [
   callAgentActionSchema,
 ]);
 
+// What the debounce window groups by (#1110): a template over the event
+// payload. Omitted = the conversation, which is what every pre-#1110 row means.
+const debounceKeySchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    'Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; ' +
+      'omit to group by conversation (instance + sender) as before. Not allowed with mode "presence"',
+  );
+
 // Debounce config schema
-const debounceSchema = z.discriminatedUnion('mode', [
-  z.object({ mode: z.literal('none') }),
-  z.object({
-    mode: z.literal('fixed'),
-    delayMs: z.number().int().min(100).max(300000).describe('Fixed delay in milliseconds'),
-  }),
-  z.object({
-    mode: z.literal('range'),
-    minMs: z.number().int().min(100).describe('Minimum delay'),
-    maxMs: z.number().int().max(300000).describe('Maximum delay'),
-  }),
-  z.object({
-    mode: z.literal('presence'),
-    baseDelayMs: z.number().int().min(100).describe('Base delay'),
-    maxWaitMs: z.number().int().max(300000).optional().describe('Maximum total wait'),
-    extendOnEvents: z.array(z.string()).describe('Events that extend the timer'),
-  }),
-]);
+const debounceSchema = z
+  .discriminatedUnion('mode', [
+    z.object({ mode: z.literal('none'), key: debounceKeySchema }),
+    z.object({
+      mode: z.literal('fixed'),
+      delayMs: z.number().int().min(100).max(300000).describe('Fixed delay in milliseconds'),
+      key: debounceKeySchema,
+    }),
+    z.object({
+      mode: z.literal('range'),
+      minMs: z.number().int().min(100).describe('Minimum delay'),
+      maxMs: z.number().int().max(300000).describe('Maximum delay'),
+      key: debounceKeySchema,
+    }),
+    z.object({
+      mode: z.literal('presence'),
+      baseDelayMs: z.number().int().min(100).describe('Base delay'),
+      maxWaitMs: z.number().int().max(300000).optional().describe('Maximum total wait'),
+      extendOnEvents: z.array(z.string()).describe('Events that extend the timer'),
+      key: debounceKeySchema,
+    }),
+  ])
+  // Rejected rather than silently ignored (#1110): `extendOnEvents` extends a
+  // window on a contact typing or recording, which says nothing about a window
+  // keyed on something that is not a conversation.
+  .refine((debounce) => !(debounce.mode === 'presence' && debounce.key), {
+    message: 'debounce.key cannot be combined with mode "presence": presence extension only applies to conversations',
+    path: ['key'],
+  });
 
 // Create automation schema
 const createAutomationSchema = z.object({

--- a/packages/api/src/schemas/openapi/automations.ts
+++ b/packages/api/src/schemas/openapi/automations.ts
@@ -94,6 +94,13 @@ const DebounceSchema = z.object({
   baseDelayMs: z.number().int().optional(),
   maxWaitMs: z.number().int().optional(),
   extendOnEvents: z.array(z.string()).optional(),
+  key: z
+    .string()
+    .optional()
+    .describe(
+      'Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; ' +
+        'absent = grouped by conversation (instance + sender). Not allowed with mode "presence"',
+    ),
 });
 
 // Automation schema

--- a/packages/core/src/automations/__tests__/debounce-custom-key.test.ts
+++ b/packages/core/src/automations/__tests__/debounce-custom-key.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Custom debounce grouping key (#1110).
+ *
+ * The debounce window already coalesced well — but only ever around a
+ * CONVERSATION, because the key was hardcoded to `${instanceId}:${personId}`.
+ * Any event that is not a chat message from a person could not use the
+ * primitive at all, even when several of its events describe one underlying
+ * fact (the motivating case: `opened`/`synchronize`/`enqueued`/`closed` for one
+ * pull request).
+ *
+ * `debounce.key` is a template over the event payload naming the window. What
+ * this file pins down:
+ *   1. one flush per distinct rendered key per window, for an event type with
+ *      no sender at all — the whole point of the issue;
+ *   2. a row WITHOUT `key` still groups by conversation, byte-for-byte as
+ *      before, including the senderless payload falling through to immediate;
+ *   3. causal identity (#956) survives the flush of a custom-keyed window,
+ *      exactly as it does for a conversation window — that guarantee is not
+ *      conversation-shaped and must not quietly become so. Its ADR-0008 twin
+ *      (the tenant envelope) is pinned alongside the conversation-window
+ *      cases it mirrors, in `engine-tenant-threading.test.ts`;
+ *   4. two instances never share a window.
+ *
+ * Runs the REAL engine over the in-memory bus (the same harness
+ * `causation-chain.test.ts` uses), so the assertions are about what NATS and
+ * the action callbacks actually see.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { InMemoryEventBus } from '../../events/__tests__/memory-bus';
+import { AutomationEngine } from '../engine';
+import type { Automation } from '../types';
+
+/** An event type with NO `from` in its payload — unreachable before #1110. */
+const PR_EVENT = 'custom.repo.pull_request';
+
+function makeAutomation(
+  partial: Partial<Automation> & Pick<Automation, 'id' | 'triggerEventType' | 'actions'>,
+): Automation {
+  return {
+    name: `automation-${partial.id}`,
+    description: null,
+    triggerConditions: [],
+    conditionLogic: 'and',
+    debounce: null,
+    enabled: true,
+    priority: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...partial,
+  } as Automation;
+}
+
+/** Re-emits one event per flush, so the journal counts the windows for us. */
+function loggingAutomation(partial: Partial<Automation> & Pick<Automation, 'id' | 'triggerEventType'>): Automation {
+  return makeAutomation({
+    actions: [{ type: 'emit_event', config: { eventType: 'custom.repo.flushed' } }],
+    ...partial,
+  });
+}
+
+const DELAY_MS = 25;
+const SETTLE_MS = 120;
+
+async function settle(bus: InMemoryEventBus): Promise<void> {
+  await bus.idle();
+  await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+  await bus.idle();
+}
+
+describe('debounce.key: coalescing beyond a conversation (#1110)', () => {
+  let bus: InMemoryEventBus;
+  let engine: AutomationEngine;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    engine = new AutomationEngine({ defaultConcurrency: 5, reconcileIntervalMs: 0 });
+  });
+
+  afterEach(async () => {
+    await engine.stop();
+    await bus.close();
+  });
+
+  test('fires once per distinct rendered key, for events that carry no sender', async () => {
+    await engine.start(
+      bus,
+      [
+        loggingAutomation({
+          id: 'auto-pr',
+          triggerEventType: PR_EVENT,
+          debounce: { mode: 'fixed', delayMs: DELAY_MS, key: '{{payload.pull_request.id}}' },
+        }),
+      ],
+      {},
+    );
+
+    // Five events, two pull requests, NO `from` anywhere.
+    for (const [prId, action] of [
+      [7, 'opened'],
+      [7, 'synchronize'],
+      [9, 'opened'],
+      [7, 'closed'],
+      [9, 'closed'],
+    ] as const) {
+      await bus.publishGeneric(PR_EVENT, { pull_request: { id: prId }, action }, { instanceId: 'inst-1' });
+    }
+    await settle(bus);
+
+    const flushes = bus.journal.filter((e) => e.type === 'custom.repo.flushed');
+    expect(flushes).toHaveLength(2);
+    // Each flush carries the LAST payload of its window.
+    const flushed = flushes
+      .map((e) => (e.payload as { pull_request: { id: number }; action: string }).pull_request.id)
+      .sort();
+    expect(flushed).toEqual([7, 9]);
+  });
+
+  test('two instances never share a window for the same rendered key', async () => {
+    await engine.start(
+      bus,
+      [
+        loggingAutomation({
+          id: 'auto-pr-ns',
+          triggerEventType: PR_EVENT,
+          debounce: { mode: 'fixed', delayMs: DELAY_MS, key: '{{payload.pull_request.id}}' },
+        }),
+      ],
+      {},
+    );
+
+    await bus.publishGeneric(PR_EVENT, { pull_request: { id: 1 } }, { instanceId: 'inst-1' });
+    await bus.publishGeneric(PR_EVENT, { pull_request: { id: 1 } }, { instanceId: 'inst-2' });
+    await settle(bus);
+
+    expect(bus.journal.filter((e) => e.type === 'custom.repo.flushed')).toHaveLength(2);
+  });
+
+  test('a key template that renders empty coalesces nothing — every event goes through', async () => {
+    await engine.start(
+      bus,
+      [
+        loggingAutomation({
+          id: 'auto-pr-empty',
+          triggerEventType: PR_EVENT,
+          // Nothing in the payload resolves this path.
+          debounce: { mode: 'fixed', delayMs: DELAY_MS, key: '{{payload.missing.id}}' },
+        }),
+      ],
+      {},
+    );
+
+    await bus.publishGeneric(PR_EVENT, { action: 'opened' }, { instanceId: 'inst-1' });
+    await bus.publishGeneric(PR_EVENT, { action: 'closed' }, { instanceId: 'inst-1' });
+    await settle(bus);
+
+    // Losing an event to a bucket with no shared fact is worse than not
+    // grouping, so an unrenderable key must not group.
+    expect(bus.journal.filter((e) => e.type === 'custom.repo.flushed')).toHaveLength(2);
+  });
+
+  test('causal identity survives the flush: the parent is the LAST REAL event, not the synthetic id', async () => {
+    await engine.start(
+      bus,
+      [
+        loggingAutomation({
+          id: 'auto-pr-causal',
+          triggerEventType: PR_EVENT,
+          debounce: { mode: 'fixed', delayMs: DELAY_MS, key: '{{payload.pull_request.id}}' },
+        }),
+      ],
+      {},
+    );
+
+    const FLOW = 'flow-1110';
+    await bus.publishGeneric(
+      PR_EVENT,
+      { pull_request: { id: 42 }, action: 'opened' },
+      { instanceId: 'inst-1', correlationId: FLOW },
+    );
+    const last = await bus.publishGeneric(
+      PR_EVENT,
+      { pull_request: { id: 42 }, action: 'closed' },
+      { instanceId: 'inst-1', correlationId: FLOW },
+    );
+    await settle(bus);
+
+    const flush = bus.journal.find((e) => e.type === 'custom.repo.flushed');
+    // Parent is a PUBLISHED event, never the id the flush minted for itself.
+    expect(flush?.metadata.causationId).toBe(last.id);
+    // And the debounced hop continues the flow instead of minting a fresh
+    // correlation and breaking the chain here.
+    expect(flush?.metadata.correlationId).toBe(FLOW);
+  });
+});
+
+describe('no debounce.key: conversation grouping is untouched (#1110)', () => {
+  let bus: InMemoryEventBus;
+  let engine: AutomationEngine;
+
+  beforeEach(() => {
+    bus = new InMemoryEventBus();
+    engine = new AutomationEngine({ defaultConcurrency: 5, reconcileIntervalMs: 0 });
+  });
+
+  afterEach(async () => {
+    await engine.stop();
+    await bus.close();
+  });
+
+  test('still groups per sender, and the payload sender is still what keys the window', async () => {
+    await engine.start(
+      bus,
+      [
+        loggingAutomation({
+          id: 'auto-chat',
+          triggerEventType: PR_EVENT,
+          debounce: { mode: 'fixed', delayMs: DELAY_MS },
+        }),
+      ],
+      {},
+    );
+
+    for (const [userId, text] of [
+      ['user-1', 'a'],
+      ['user-1', 'b'],
+      ['user-2', 'c'],
+    ] as const) {
+      await bus.publishGeneric(
+        PR_EVENT,
+        { from: { id: userId }, content: { type: 'text', text } },
+        { instanceId: 'inst-1' },
+      );
+    }
+    await settle(bus);
+
+    const flushes = bus.journal.filter((e) => e.type === 'custom.repo.flushed');
+    expect(flushes).toHaveLength(2);
+    expect(flushes.map((e) => (e.payload as { from: { id: string } }).from.id).sort()).toEqual(['user-1', 'user-2']);
+  });
+
+  test('a payload with no sender still falls through to immediate execution', async () => {
+    await engine.start(
+      bus,
+      [
+        loggingAutomation({
+          id: 'auto-chat-nosender',
+          triggerEventType: PR_EVENT,
+          debounce: { mode: 'fixed', delayMs: DELAY_MS },
+        }),
+      ],
+      {},
+    );
+
+    await bus.publishGeneric(PR_EVENT, { pull_request: { id: 1 } }, { instanceId: 'inst-1' });
+    await bus.publishGeneric(PR_EVENT, { pull_request: { id: 1 } }, { instanceId: 'inst-1' });
+    await settle(bus);
+
+    expect(bus.journal.filter((e) => e.type === 'custom.repo.flushed')).toHaveLength(2);
+  });
+});

--- a/packages/core/src/automations/__tests__/engine-tenant-threading.test.ts
+++ b/packages/core/src/automations/__tests__/engine-tenant-threading.test.ts
@@ -264,6 +264,45 @@ describe('automation engine threads the envelope tenant (G5, ADR-0008)', () => {
     }
   });
 
+  test('debounce: a CUSTOM-keyed window carries the stamp the same way (#1110)', async () => {
+    // Generalizing the grouping key must not generalize away the envelope:
+    // the events have NO sender at all, so nothing about this window is a
+    // conversation, and the flush still has to land in the producer's world.
+    const h = await startEngine([
+      automation({
+        actions: [SEND_ACTION],
+        debounce: { mode: 'fixed', delayMs: 5, key: '{{payload.pull_request.id}}' } as Automation['debounce'],
+      }),
+    ]);
+    try {
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }, { from: undefined, pull_request: { id: 7 } }));
+      await h.fire(event({ envelopeVersion: 1, tenantId: TENANT_A }, { from: undefined, pull_request: { id: 7 } }));
+      await new Promise((r) => setTimeout(r, 40));
+
+      expect(h.sendCalls.length).toBe(1); // one window, keyed on the PR
+      expect(h.sendCalls[0]?.trustedTenantId).toBe(TENANT_A);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
+  test('debounce: a legacy CUSTOM-keyed window flushes with null — no stamp is invented (#1110)', async () => {
+    const h = await startEngine([
+      automation({
+        actions: [SEND_ACTION],
+        debounce: { mode: 'fixed', delayMs: 5, key: '{{payload.pull_request.id}}' } as Automation['debounce'],
+      }),
+    ]);
+    try {
+      await h.fire(event({}, { from: undefined, pull_request: { id: 7 } }));
+      await new Promise((r) => setTimeout(r, 40));
+      expect(h.sendCalls.length).toBe(1);
+      expect(h.sendCalls[0]?.trustedTenantId).toBe(null);
+    } finally {
+      await h.engine.stop();
+    }
+  });
+
   test('webhook action: the egress broker context binds the trusted tenant (legacy stays unbound)', async () => {
     const seenTenants: string[] = [];
     setEgressPolicyResolver((context) => {

--- a/packages/core/src/automations/debounce.ts
+++ b/packages/core/src/automations/debounce.ts
@@ -60,7 +60,9 @@ export function stampsEqual(a: DebounceEnvelopeStamp | null, b: DebounceEnvelope
 }
 
 /**
- * Key for grouping messages: instanceId + personId
+ * Key a window groups by. `${instanceId}:${personId}` by default, or
+ * `${instanceId}:${renderedTemplate}` when the automation sets `debounce.key`
+ * (#1110) — the manager only ever compares it, never parses it.
  */
 export type ConversationKey = string;
 
@@ -87,10 +89,18 @@ interface DebounceWindow {
   firstMessageAt: number;
   lastActivityAt: number;
   timer: ReturnType<typeof setTimeout> | null;
-  from: {
-    id: string;
-    name?: string;
-  };
+  /**
+   * Sender of the LAST message in the window — undefined for a custom-keyed
+   * window (#1110), whose events need not be chat messages at all. Held on the
+   * window rather than parsed back out of the key, which only a conversation
+   * key could ever support.
+   */
+  from:
+    | {
+        id: string;
+        name?: string;
+      }
+    | undefined;
   instanceId: string;
   /** Envelope world of every message in this window — see DebounceEnvelopeStamp. */
   stamp: DebounceEnvelopeStamp | null;
@@ -102,7 +112,8 @@ interface DebounceWindow {
 export type DebounceCallback = (
   key: ConversationKey,
   messages: DebouncedMessage[],
-  from: { id: string; name?: string },
+  /** Sender of the last event in the window; undefined when it had none. */
+  from: { id: string; name?: string } | undefined,
   instanceId: string,
   /** The window's envelope stamp; `null` when the window is legacy. */
   stamp: DebounceEnvelopeStamp | null,
@@ -132,7 +143,7 @@ export class DebounceManager {
   addMessage(
     key: ConversationKey,
     message: DebouncedMessage,
-    from: { id: string; name?: string },
+    from: { id: string; name?: string } | undefined,
     instanceId: string,
     stamp: DebounceEnvelopeStamp | null = null,
   ): void {
@@ -167,8 +178,13 @@ export class DebounceManager {
       this.windows.set(key, window);
     }
 
-    // Add message
+    // Add message. `from`/`instanceId` track the LAST event (#1110): a custom
+    // key is not parseable back into them, and for a conversation key both are
+    // components of the key itself, so following the last event changes
+    // nothing there beyond picking up a fresher display name.
     window.messages.push(message);
+    window.from = from;
+    window.instanceId = instanceId;
     window.lastActivityAt = Date.now();
 
     // Reset timer

--- a/packages/core/src/automations/engine.ts
+++ b/packages/core/src/automations/engine.ts
@@ -504,6 +504,46 @@ export class AutomationEngine {
   }
 
   /**
+   * Which window this event joins (#1110); `null` = there is nothing to group
+   * by, so the caller processes the event immediately.
+   *
+   * No `debounce.key` = the conversation `${instanceId}:${personId}`, and a
+   * payload with no sender has always fallen through to the immediate path —
+   * byte-identical to the behaviour every existing row has today.
+   *
+   * `debounce.key` set = the template rendered over this event's payload,
+   * namespaced by the instance so two instances cannot share a window (two
+   * automations already cannot: each owns its own manager). That lets ANY
+   * event type coalesce on the fact it describes rather than on a chat.
+   *
+   * A template that renders EMPTY also returns `null` rather than minting an
+   * `${instanceId}:` bucket. Coalescing keeps only the last payload of a
+   * window, so merging events with no shared fact would silently drop them;
+   * for a feature whose failure mode is data loss, not grouping is the
+   * conservative direction (#1108's concurrencyKey merges instead, because
+   * over-serializing loses nothing).
+   */
+  private resolveDebounceKey(automation: Automation, event: OmniEvent, instanceId: string): ConversationKey | null {
+    const payload = event.payload as Record<string, unknown>;
+    const template = automation.debounce?.key;
+
+    if (!template) {
+      const from = payload.from as { id?: string } | undefined;
+      return from?.id ? buildConversationKey(instanceId, from.id) : null;
+    }
+
+    const rendered = substituteTemplate(template, createTemplateContext(payload)).trim();
+    if (!rendered) {
+      logger.debug('Debounce key template rendered empty — processing immediately', {
+        automationId: automation.id,
+        eventId: event.id,
+      });
+      return null;
+    }
+    return `${instanceId}:${rendered}`;
+  }
+
+  /**
    * Handle an event with debouncing
    */
   private async handleDebounced(automation: Automation, event: OmniEvent): Promise<void> {
@@ -517,15 +557,17 @@ export class AutomationEngine {
     const payload = event.payload as Record<string, unknown>;
     const instanceId = event.metadata.instanceId ?? 'global';
 
-    // Extract person/sender ID from payload
+    // Sender rides along for the template context; it is only the GROUPING key
+    // when the automation has no `debounce.key` of its own (#1110).
     const from = payload.from as { id: string; name?: string } | undefined;
-    if (!from?.id) {
-      // No sender info, can't debounce per-conversation
+
+    const key = this.resolveDebounceKey(automation, event, instanceId);
+    if (!key) {
+      // Nothing to group by — process immediately, as a payload without a
+      // sender always has.
       await this.handleImmediate(automation, event);
       return;
     }
-
-    const key = buildConversationKey(instanceId, from.id);
 
     // Check if this is a presence event (for presence-based debounce)
     if (event.type.startsWith('presence.')) {
@@ -587,7 +629,9 @@ export class AutomationEngine {
     const callback = async (
       key: ConversationKey,
       messages: DebouncedMessage[],
-      from: { id: string; name?: string },
+      // From the LAST event in the window, not parsed back out of the key — a
+      // custom key (#1110) carries neither a sender nor an instance.
+      from: { id: string; name?: string } | undefined,
       instanceId: string,
       stamp: DebounceEnvelopeStamp | null,
     ) => {

--- a/packages/core/src/automations/templates.ts
+++ b/packages/core/src/automations/templates.ts
@@ -98,7 +98,12 @@ export interface TemplateContext {
       text?: string;
       timestamp: number;
     }>;
-    from: {
+    /**
+     * Sender of the last event in the window. Absent for a custom-keyed
+     * window (#1110), whose events need not be chat messages — `{{from}}` and
+     * `{{from.*}}` then render empty, as they do for any unresolved path.
+     */
+    from?: {
       id: string;
       name?: string;
     };

--- a/packages/core/src/automations/types.ts
+++ b/packages/core/src/automations/types.ts
@@ -160,11 +160,28 @@ export type AutomationAction =
 /**
  * Debounce configuration for message grouping.
  */
-export type DebounceConfig =
+export type DebounceConfig = (
   | { mode: 'none' }
   | { mode: 'fixed'; delayMs: number }
   | { mode: 'range'; minMs: number; maxMs: number }
-  | { mode: 'presence'; baseDelayMs: number; maxWaitMs?: number; extendOnEvents: string[] };
+  | { mode: 'presence'; baseDelayMs: number; maxWaitMs?: number; extendOnEvents: string[] }
+) & {
+  /**
+   * What the window groups by (#1110) — a template over the event payload,
+   * rendered with the same engine as conditions and action configs, e.g.
+   * `{{payload.pull_request.id}}`.
+   *
+   * Absent = the conversation `${instanceId}:${personId}`, which is all this
+   * primitive could ever group by before, so every existing row is unchanged.
+   * Set = the rendered string namespaced by instance, which lets ANY event
+   * type coalesce on the fact it describes, not on a chat.
+   *
+   * Rejected at validation with `mode: 'presence'`: `extendOnEvents` extends a
+   * window on a contact's typing/recording, which has no meaning once the
+   * window is not a conversation.
+   */
+  key?: string;
+};
 
 /**
  * Action execution result.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3094,11 +3094,23 @@ export type AutomationAction =
 /**
  * Debounce configuration for message grouping.
  */
-export type DebounceConfig =
+export type DebounceConfig = (
   | { mode: 'none' }
   | { mode: 'fixed'; delayMs: number }
   | { mode: 'range'; minMs: number; maxMs: number }
-  | { mode: 'presence'; baseDelayMs: number; maxWaitMs?: number; extendOnEvents: string[] };
+  | { mode: 'presence'; baseDelayMs: number; maxWaitMs?: number; extendOnEvents: string[] }
+) & {
+  /**
+   * What the window groups by (#1110) — a template over the event payload.
+   * Absent = the conversation `${instanceId}:${personId}` (every existing row,
+   * unchanged); set = the rendered string namespaced by instance, so a
+   * non-chat event can coalesce on the fact it describes. Lives inside the
+   * existing `debounce` jsonb, so there is no column and no migration.
+   * Rejected at validation together with `mode: 'presence'`.
+   */
+  // no-migration-needed: a new field INSIDE the existing `debounce` jsonb column (#1110). No DDL: the column, its type and every stored row are unchanged, and a row without the field means what it always meant (group by conversation).
+  key?: string;
+};
 
 /**
  * Automation rules - "When event X with conditions Y, execute actions Z."

--- a/packages/sdk/src/types.generated.ts
+++ b/packages/sdk/src/types.generated.ts
@@ -5823,6 +5823,8 @@ export interface components {
                 baseDelayMs?: number;
                 maxWaitMs?: number;
                 extendOnEvents?: string[];
+                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                key?: string;
             } | null;
             /** @description Whether enabled */
             enabled: boolean;
@@ -5960,6 +5962,8 @@ export interface components {
                 baseDelayMs?: number;
                 maxWaitMs?: number;
                 extendOnEvents?: string[];
+                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                key?: string;
             };
             /**
              * @description Whether enabled
@@ -17907,6 +17911,8 @@ export interface operations {
                                 baseDelayMs?: number;
                                 maxWaitMs?: number;
                                 extendOnEvents?: string[];
+                                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                                key?: string;
                             } | null;
                             /** @description Whether enabled */
                             enabled: boolean;
@@ -18058,6 +18064,8 @@ export interface operations {
                         baseDelayMs?: number;
                         maxWaitMs?: number;
                         extendOnEvents?: string[];
+                        /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                        key?: string;
                     };
                     /**
                      * @description Whether enabled
@@ -18203,6 +18211,8 @@ export interface operations {
                                 baseDelayMs?: number;
                                 maxWaitMs?: number;
                                 extendOnEvents?: string[];
+                                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                                key?: string;
                             } | null;
                             /** @description Whether enabled */
                             enabled: boolean;
@@ -18388,6 +18398,8 @@ export interface operations {
                                 baseDelayMs?: number;
                                 maxWaitMs?: number;
                                 extendOnEvents?: string[];
+                                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                                key?: string;
                             } | null;
                             /** @description Whether enabled */
                             enabled: boolean;
@@ -18610,6 +18622,8 @@ export interface operations {
                         baseDelayMs?: number;
                         maxWaitMs?: number;
                         extendOnEvents?: string[];
+                        /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                        key?: string;
                     };
                     /**
                      * @description Whether enabled
@@ -18755,6 +18769,8 @@ export interface operations {
                                 baseDelayMs?: number;
                                 maxWaitMs?: number;
                                 extendOnEvents?: string[];
+                                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                                key?: string;
                             } | null;
                             /** @description Whether enabled */
                             enabled: boolean;
@@ -18940,6 +18956,8 @@ export interface operations {
                                 baseDelayMs?: number;
                                 maxWaitMs?: number;
                                 extendOnEvents?: string[];
+                                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                                key?: string;
                             } | null;
                             /** @description Whether enabled */
                             enabled: boolean;
@@ -19125,6 +19143,8 @@ export interface operations {
                                 baseDelayMs?: number;
                                 maxWaitMs?: number;
                                 extendOnEvents?: string[];
+                                /** @description Template over the event payload naming the debounce window (#1110), e.g. "{{payload.pull_request.id}}"; absent = grouped by conversation (instance + sender). Not allowed with mode "presence" */
+                                key?: string;
                             } | null;
                             /** @description Whether enabled */
                             enabled: boolean;


### PR DESCRIPTION
Closes #1110. Stacked on #1112 (→ #1111); review those first.

## What

Generalizes the debounce grouping key so coalescing is available to events that are not chat messages from a person. `DebounceConfig` gains an optional `key` — a template over the event payload:

- Absent → `buildConversationKey(instanceId, from.id)`, today's exact behaviour for every existing row.
- Present → the window is keyed by `${instanceId}:${rendered}`, namespaced so two automations cannot collide.
- `presence` + `key` is rejected at validation with an explicit error rather than silently ignored.

## Why

The debounce system already does coalescing well — windows, presence extension, causal identity carried through the synthetic flush (#956), tenant envelope carried through (ADR-0008). Its only limitation was that the key was hardcoded to a conversation (`debounce.ts:63-73`), which put the primitive out of reach of every non-chat event.

The motivating case: a repository webhook publishes `opened`, `synchronize`, `enqueued`, `closed`, `dequeued` for one pull request. On the bus that prompted this they are roughly 70% of total volume, and an automation that only cares about "this PR changed" pays for all five. The natural key — the PR id — is right there in the payload and had nowhere to go.

## Decisions worth a reviewer's attention

**An empty render coalesces nothing** (returns no key, every event goes through), which is the *opposite* of the `concurrencyKey` fallback in #1111 — deliberately. Over-serializing loses nothing, but a debounce window keeps only the last payload, so bucketing unrelated events under one degenerate key would silently drop them.

**The flush now takes `from`/`instanceId` from the last event in the window**, not the first. This is the assumption the issue flagged: with a conversation key both are components of the key itself, so nothing moves there except a fresher display name; with a custom key they are not derivable at all. `DebounceCallback.from` and `TemplateContext.debounce.from` became optional to match, so `{{from.*}}` renders empty on a senderless window like any unresolved path.

**No migration, and that is not an omission.** `debounce` is a `jsonb` column (`packages/db/src/schema.ts:3124`) and `key` is a new field *inside* it — no DDL. The changed `schema.ts` line carries the migration gate's documented escape hatch (`// no-migration-needed:`); without it the contract check fails with "schema.ts changed but no new migration was added".

**`DebounceConfig` became an intersection** of the existing mode union with `{ key?: string }` rather than adding the field to four mode shapes. Discriminated narrowing on `mode` still works — TS distributes the intersection.

## Tests

`packages/core/src/automations/__tests__/debounce-custom-key.test.ts` — one flush per distinct `{{payload.pull_request.id}}` across five senderless events; instance namespacing; empty render coalescing nothing; causal identity (parent is the last real event id, the flush continues the flow's `correlationId`); plus two no-key tests proving conversation grouping and the senderless fall-through are unchanged.

`packages/api/src/routes/v2/__tests__/automations-debounce-key.test.ts` — presence+key rejected on exact message and path, presence alone still accepted, fixed+key reaching the service unchanged, empty key rejected.

ADR-0008 coverage went into `engine-tenant-threading.test.ts` beside the existing conversation-window cases rather than into the new file. Written against `InMemoryEventBus` it passed alone but failed in the full package run — another suite leaks a process-wide ambient tenant through the publisher seam, so a "legacy" publish is not reliably legacy in a shared process. Pre-existing pollution, not caused here; the existing ADR-0008 tests dodge it by firing the handler directly, which is the harness mirrored.

```
packages/core (full)                    1086 pass / 0 fail
touched suites (core + api + cli, 30)    430 pass / 0 fail
debounce-custom-key                        6 pass / 0 fail
engine-tenant-threading                   11 pass / 0 fail
automations-debounce-key (api)             4 pass / 0 fail

bunx biome check .      → no fixes applied
make typecheck          → 26/26 successful
make verify-migrations  → 38 pass / 0 fail; contract OK vs origin/dev
make dead-code (knip)   → clean
```

## Not done

No CLI flag for `debounce.key` — the CLI has no debounce surface at all today (`grep debounce packages/cli/src/commands/automations.ts` is empty), so there was nothing to extend. Add when the CLI grows debounce flags generally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional custom debounce keys based on event payload templates.
  * Events can now share debounce windows based on a payload value, while remaining isolated between instances.
  * Existing conversation-based grouping remains unchanged when no custom key is provided.
* **Validation**
  * Custom keys are rejected for presence-based debounce mode and when empty.
  * Unrenderable keys execute immediately instead of being grouped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->